### PR TITLE
Fixed nvida-docker file, and also fixed whisper model downloading

### DIFF
--- a/App_Function_Libraries/Gradio_Related.py
+++ b/App_Function_Libraries/Gradio_Related.py
@@ -361,6 +361,6 @@ def launch_ui(share_public=None, server_mode=False):
         iface.launch(share=False, server_name="0.0.0.0", server_port=server_port_variable, )
     else:
         try:
-            iface.launch(share=False)
+            iface.launch(share=False, server_name="0.0.0.0", server_port=server_port_variable, )
         except Exception as e:
             logging.error(f"Error launching interface: {str(e)}")

--- a/Helper_Scripts/Dockerfiles/tldw-nvidia_amd64_Dockerfile
+++ b/Helper_Scripts/Dockerfiles/tldw-nvidia_amd64_Dockerfile
@@ -71,5 +71,8 @@ VOLUME /tldw
 # Make port 7860 available to the world outside this container
 EXPOSE 7860
 
+# Set listening to all interfaces
+ENV GRADIO_SERVER_NAME="0.0.0.0"
+
 # Run the application
 CMD ["python", "summarize.py", "-gui"]

--- a/Helper_Scripts/Dockerfiles/tldw-nvidia_amd64_Dockerfile
+++ b/Helper_Scripts/Dockerfiles/tldw-nvidia_amd64_Dockerfile
@@ -1,6 +1,16 @@
 # Usage
 # docker build -t tldw-nvidia_amd64_Dockerfile .
 # docker run --gpus=all -p 7860:7860 -v tldw_volume:/tldw tldw-nvidia_amd64_Dockerfile
+#
+# If the above command doesn't work and it hangs on start, use the following command:
+#
+#   sudo docker run -it -p 7860:7860 -v tldw_volume:/tdlw nvidia_tldw bash
+#
+# Once in the container, run the following command:
+#
+#   python summarize.py -gui
+#
+# And you should be good.
 
 # Use Nvidia image:
 FROM nvidia/cuda:12.6.1-cudnn-runtime-ubuntu24.04

--- a/Helper_Scripts/Dockerfiles/tldw_Debian_cpu-Dockerfile
+++ b/Helper_Scripts/Dockerfiles/tldw_Debian_cpu-Dockerfile
@@ -1,10 +1,19 @@
 # Usage
 # docker build -t tldw-app_debian --build-arg GPU_SUPPORT=cpu .
 # docker run -p 7860:7860 -v tldw_volume:/tldw tldw-app_debian
+#
+# If the above command doesn't work and it hangs on start, use the following command:
+#
+#   sudo docker run -it -p 7860:7860 -v tldw_volume:/tdlw tldw-app_debian bash
+#
+# Once in the container, run the following command:
+#
+#   python summarize.py -gui
+#
+# And you should be good.
 
 # Use an official Python runtime as a parent image
 FROM python:3.10.15-slim-bookworm
-
 
 # Set build arguments
 ARG REPO_URL=https://github.com/rmusser01/tldw.git

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ None of these companies exist to provide AI services in 2024. They’re only doi
 ### <a name="quickstart">Quickstart</a>
 
 #### Automatic Quickstart
+- Docker: Dockerfiles in the `Helper_Scripts/Dockerfiles` directory. 
+  - There's a docker build for GPU use and plain CPU use.
 1. **Download the Installer Script for your OS:**
    - **Linux:** `wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh && wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh`
    - **Windows:** `wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat && wget wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat`
@@ -300,21 +302,6 @@ None of these companies exist to provide AI services in 2024. They’re only doi
         - Download and install from: https://pandoc.org/installing.html
 - **Converting Epub to markdown**
     - `pandoc -f epub -t markdown -o output.md input.epub`
-- **Setting up PDF to Markdown conversion with Marker** (Optional - Necessary to do PDF ingestion/conversion)
-    - **Linux**
-        1. `sudo apt install python3-venv`
-        2. `python3 -m venv ./Helper_Scripts/marker_venv`
-        3. `source ./Helper_Scripts/marker_venv/bin/activate`  
-        4. `pip install marker`
-    - **Windows**
-        1. Install python3 from https://www.python.org/downloads/
-        2. `python Helper_Scripts\marker_venv\Scripts\activate\activate.ps1`
-        3. `pip install marker`
-- **Converting PDF to markdown**
-    - Convert a Single PDF to Markdown:
-        * `marker_single /path/to/file.pdf /path/to/output/folder --batch_multiplier 2 --langs English`
-    - Convert a Folder of PDFs to Markdown:
-        * `marker /path/to/folder/with/pdfs /path/to/output/folder --batch_multiplier 2 --langs English`
 - **Ingest Converted text files en-masse**
     - `python summarize.py <path_to_text_file> --ingest_text_file --text_title "Title" --text_author "Author Name" -k additional,keywords`
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ None of these companies exist to provide AI services in 2024. They’re only doi
 
 #### Automatic Quickstart
 - Docker: Dockerfiles in the `Helper_Scripts/Dockerfiles` directory. 
-  - There's a docker build for GPU use and plain CPU use.
+  - There's a docker build for GPU use: https://github.com/rmusser01/tldw/blob/main/Helper_Scripts/Dockerfiles/tldw-nvidia_amd64_Dockerfile 
+  - and plain CPU use: https://github.com/rmusser01/tldw/blob/main/Helper_Scripts/Dockerfiles/tldw_Debian_cpu-Dockerfile
 1. **Download the Installer Script for your OS:**
    - **Linux:** `wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Linux_Install_Update.sh && wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Linux_Run_tldw.sh`
    - **Windows:** `wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Windows_Install_Update.bat && wget wget https://raw.githubusercontent.com/rmusser01/tldw/main/Helper_Scripts/Installer_Scripts/Windows_Run_tldw.bat`


### PR DESCRIPTION
Nvidia-docker now works.
Debian should also work.
Whisper models now download to `tldw/App_Function_Libraries/models/Whisper/` - This should make using docker a lot less painful, as this means whisper models will be downloaded to the persistent volume.