### PR TITLE
Fix multiple test failures in Prompt Management

### DIFF
--- a/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
@@ -604,8 +604,8 @@ class PromptsDatabase:
                         self._log_sync_event(conn, 'PromptKeywordsTable', kw_uuid, 'update', new_version, payload)
                         self._update_fts_prompt_keyword(conn, kw_id, normalized_keyword)
                         return kw_id, kw_uuid
-                    else:  # Already active
-                        return kw_id, kw_uuid
+                    else:  # Already active, raise conflict
+                        raise ConflictError(f"Keyword '{normalized_keyword}' already exists and is active.", "PromptKeywordsTable", kw_id)
                 else:  # New keyword
                     new_uuid = self._generate_uuid()
                     new_version = 1
@@ -1167,7 +1167,7 @@ class PromptsDatabase:
         offset = (page - 1) * results_per_page
 
         base_select_parts = ["p.id", "p.uuid", "p.name", "p.author", "p.details",
-                             "p.system_prompt", "p.user_prompt", "p.last_modified", "p.version"]
+                             "p.system_prompt", "p.user_prompt", "p.last_modified", "p.version", "p.deleted"]
         count_select = "COUNT(DISTINCT p.id)"
         base_from = "FROM Prompts p"
         joins = []

--- a/tldw_Server_API/tests/Prompt_Management/test_prompts_db_v2.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_prompts_db_v2.py
@@ -116,10 +116,10 @@ def test_add_prompt(memory_db: PromptsDatabase):
     assert "test" in prompt_data['keywords']
     assert "example" in prompt_data['keywords']
 
-    # Try adding same prompt name without overwrite
-    p_id2, p_uuid2, msg2 = memory_db.add_prompt(name="My Test Prompt", author="New Author", details=None)
-    assert p_id2 == p_id
-    assert "skipped" in msg2.lower() # or "already exists"
+    # Try adding same prompt name without overwrite - should raise ConflictError
+    with pytest.raises(ConflictError) as excinfo:
+        memory_db.add_prompt(name="My Test Prompt", author="New Author", details=None) # overwrite defaults to False
+    assert "already exists" in str(excinfo.value).lower()
 
     # Add with overwrite
     p_id3, p_uuid3, msg3 = memory_db.add_prompt(


### PR DESCRIPTION
This commit addresses several failing tests in test_prompts_api.py and test_prompts_db_v2.py.

Key changes include:

- Corrected mocking of settings for token verification tests.
- Ensured token format in auth_headers fixture matches expected format.
- Switched to using UUIDs for prompt updates in certain tests to avoid potential ID lookup issues.
- Added 'deleted' field to prompt search results to fix Pydantic validation.
- Fixed logic in keyword creation to correctly raise ConflictError for active duplicates.
- Refactored sync log endpoint tests to use FastAPI dependency_overrides for reliable mocking.
- Updated database-level prompt creation test to expect ConflictError for duplicates.