### PR TITLE
feat(stt): bring parakeet-mlx parity and preserve timed artifacts

### DIFF
--- a/Docs/Design/STT_Parakeet_MLX_Parity.md
+++ b/Docs/Design/STT_Parakeet_MLX_Parity.md
@@ -1,0 +1,57 @@
+# STT Parakeet MLX Parity Design
+
+## Scope
+This design captures the Parakeet MLX parity upgrades added to the server STT stack, including:
+- Structured MLX transcription artifacts (text, timed segments, tokens).
+- Native MLX streaming session integration for incremental decode.
+- Long-audio chunk merge improvements using token/timestamp-aware stitching.
+- Configurable MLX decoding and sentence-splitting controls.
+
+## Goals
+- Preserve upstream `parakeet-mlx` alignment metadata through ingestion and API formatting.
+- Keep backward compatibility for existing string-based transcription call paths.
+- Reduce duplicate/omitted text in overlap regions for buffered and streaming paths.
+- Avoid runtime dependency installation side effects in request paths.
+
+## Non-Goals
+- Replacing existing non-MLX providers.
+- Introducing new API response schemas.
+- Altering authentication or quota behavior for audio endpoints.
+
+## Architecture
+### Batch/Buffered
+- `Audio_Transcription_Parakeet_MLX.py` now normalizes MLX outputs into a structured artifact.
+- `Audio_Buffered_Transcription.py` merges chunk outputs with overlap-aware token logic.
+- `Audio_Transcription_Lib.py` converts structured artifacts into provider-neutral segment outputs.
+
+### Streaming
+- `Parakeet_Core_Streaming/transcriber.py` uses MLX streaming sessions when available.
+- Session lifecycle hooks are exposed (`reset_session`, `close`) and called from transcriber reset/close and WS teardown paths.
+- Fallback remains functional if MLX streaming session creation fails.
+
+### API Formatting
+- `/audio/transcriptions` can consume provider-timed segments beyond faster-whisper-only handling.
+- SRT/VTT/verbose JSON formats use real provider timing when available.
+
+## Configuration
+The `[STT-Settings]` section adds/uses:
+- `mlx_model_id`, `mlx_cache_dir`
+- `mlx_decoding_mode`
+- `mlx_beam_size`, `mlx_length_penalty`, `mlx_patience`, `mlx_duration_reward`
+- `mlx_sentence_max_words`, `mlx_sentence_silence_gap`, `mlx_sentence_max_duration`
+- `mlx_stream_context_left`, `mlx_stream_context_right`, `mlx_stream_depth`
+- `mlx_stream_keep_original_attention`
+- `streaming_fallback_to_whisper`
+
+## Error Handling
+- MLX load/decode failures return explicit error text in wrapper paths.
+- Core STT library raises a dedicated `STTTranscriptionError` for provider failures in Parakeet paths.
+- Optional MLX imports in unified streaming degrade gracefully to no-op fallbacks.
+
+## Verification
+Targeted tests cover:
+- Structured artifact propagation and timing normalization.
+- Streaming session lifecycle and fallback behavior.
+- Non-16kHz structured long-audio resampling.
+- Timed segment API formatting for SRT/VTT/verbose JSON.
+- Deterministic model default selection behavior in MLX tests.

--- a/tldw_Server_API/Config_Files/README.md
+++ b/tldw_Server_API/Config_Files/README.md
@@ -278,6 +278,7 @@ Common: `max_tokens`, `local_api_timeout`, `local_api_retries`, `local_api_retry
 - `transcript_cache_max_total_mb` (float): Cap total transcript cache size (MB) per directory; oldest files are evicted when exceeded. Leave empty for defaults or set 0/negative to disable.
 - `skip_audio_prevalidation` (bool): When true, skip `ffprobe`-based audio validation and rely on `ffmpeg` + STT to surface bad files (useful for high-throughput deployments).
 - Runtime transcription requests do not auto-install `parakeet-mlx`; install dependencies during setup/deployment.
+- Design reference: `Docs/Design/STT_Parakeet_MLX_Parity.md`
 
 ## [external_providers]
 - Reserved for plugging in external providers (YAML/INI sub-configs).

--- a/tldw_Server_API/Config_Files/README.md
+++ b/tldw_Server_API/Config_Files/README.md
@@ -260,16 +260,24 @@ Common: `max_tokens`, `local_api_timeout`, `local_api_retries`, `local_api_retry
 - `nemo_model_variant` (str), `nemo_device` (str), `nemo_cache_dir` (path)
 - `nemo_chunk_duration|nemo_overlap_duration` (sec)
 - `streaming_fallback_to_whisper` (bool)
+- `mlx_model_id` (str): default `mlx-community/parakeet-tdt-0.6b-v3`
+- `mlx_cache_dir` (path): optional local cache override for model artifacts
 - `mlx_chunk_duration|mlx_overlap_duration|buffered_chunk_duration|buffered_total_buffer` (sec)
 - `buffered_merge_algo` (str): e.g., `lcs`.
+- `mlx_decoding_mode` (str): `greedy|beam`
+- `mlx_beam_size|mlx_length_penalty|mlx_patience|mlx_duration_reward` (beam controls)
+- `mlx_sentence_max_words|mlx_sentence_silence_gap|mlx_sentence_max_duration` (sentence splitting controls)
+- `mlx_stream_context_left|mlx_stream_context_right|mlx_stream_depth` (native MLX streaming context/cache controls)
+- `mlx_stream_keep_original_attention` (bool): keep upstream full attention model during MLX streaming
 - `whisper_compute_type` (str): Optional faster-whisper compute type override; when unset or `"auto"` the server uses `float16` on CUDA and `int8` on CPU; examples: `float16`, `int8`, `int8_float16`.
 - Transcript cache toggles:
   - `disable_transcript_cache` (bool): When true, do not write `.segments.json` transcript cache files at all.
   - `disable_transcript_cache_pruning` (bool): When true, keep writing cache files but skip age/size-based pruning (cache may grow without bound).
   - `transcript_cache_max_files_per_source` (int): Max cached transcript files per base source; newest files are kept first. Leave empty for defaults or set 0/negative to disable this limit.
   - `transcript_cache_max_age_days` (int): Delete cached transcripts older than this many days. Leave empty for defaults or set 0/negative to disable.
-  - `transcript_cache_max_total_mb` (float): Cap total transcript cache size (MB) per directory; oldest files are evicted when exceeded. Leave empty for defaults or set 0/negative to disable.
+- `transcript_cache_max_total_mb` (float): Cap total transcript cache size (MB) per directory; oldest files are evicted when exceeded. Leave empty for defaults or set 0/negative to disable.
 - `skip_audio_prevalidation` (bool): When true, skip `ffprobe`-based audio validation and rely on `ffmpeg` + STT to surface bad files (useful for high-throughput deployments).
+- Runtime transcription requests do not auto-install `parakeet-mlx`; install dependencies during setup/deployment.
 
 ## [external_providers]
 - Reserved for plugging in external providers (YAML/INI sub-configs).

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -183,7 +183,7 @@ def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> l
     for segment in raw_segments:
         if not isinstance(segment, dict):
             continue
-        text = str(segment.get("Text") or segment.get("text") or "").strip()
+        text = str(segment.get("text") or "").strip()
         if not text:
             continue
         try:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -177,6 +177,26 @@ def _stt_provider_availability(
 
 
 def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Normalize provider segment payloads into a canonical timed-segment schema.
+
+    Args:
+        raw_segments: Optional provider segment list. Each element is expected to
+            be a mapping with text and timing fields (`Text`/`text`,
+            `start_seconds`/`start`, `end_seconds`/`end`).
+
+    Returns:
+        A list of normalized segment dictionaries. Every returned segment
+        includes `text`, `start_seconds`, and `end_seconds`; optional `words`
+        are preserved when provided as a list.
+
+    Notes:
+        - Non-dict entries and empty-text segments are dropped.
+        - Start/end values are parsed defensively and default to `0.0` / start
+          time when parsing fails.
+        - End time is clamped so `end_seconds >= start_seconds`.
+        - Numeric coercion failures are handled via
+          `_AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS`.
+    """
     normalized: list[dict[str, Any]] = []
     if not isinstance(raw_segments, list):
         return normalized

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -191,7 +191,7 @@ def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> l
         except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
             start = 0.0
         try:
-            end = float(segment.get("end_seconds", segment.get("end", start)) or start)
+            end = float(segment.get("end_seconds", start) or start)
         except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
             end = start
         if end < start:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -177,25 +177,25 @@ def _stt_provider_availability(
 
 
 def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> list[dict[str, Any]]:
-    """Normalize provider segment payloads into a canonical timed-segment schema.
+    """Normalize raw segment mappings into cleaned timed segment dictionaries.
 
     Args:
-        raw_segments: Optional provider segment list. Each element is expected to
-            be a mapping with text and timing fields (`Text`/`text`,
-            `start_seconds`/`start`, `end_seconds`/`end`).
+        raw_segments: Optional ``list[dict[str, Any]]`` containing provider
+            segment payloads.
 
     Returns:
-        A list of normalized segment dictionaries. Every returned segment
-        includes `text`, `start_seconds`, and `end_seconds`; optional `words`
-        are preserved when provided as a list.
+        list[dict[str, Any]]: Normalized segments shaped as
+        ``{"text": str, "start_seconds": float, "end_seconds": float}``.
+        ``"words"`` is included when the source segment provides it as a list.
 
     Notes:
-        - Non-dict entries and empty-text segments are dropped.
-        - Start/end values are parsed defensively and default to `0.0` / start
-          time when parsing fails.
-        - End time is clamped so `end_seconds >= start_seconds`.
-        - Numeric coercion failures are handled via
-          `_AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS`.
+        - Filters out entries that are not dictionaries or have empty ``text``.
+        - Extracts ``text``, ``start_seconds``, and ``end_seconds`` with
+          defensive float parsing fallbacks (``start`` defaults to ``0.0`` and
+          ``end`` defaults to ``start`` when parsing fails or fields are empty).
+        - Clamps ``end_seconds`` to ``start_seconds`` when ``end < start``.
+        - Non-critical coercion errors are caught via
+          ``_AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS``.
     """
     normalized: list[dict[str, Any]] = []
     if not isinstance(raw_segments, list):

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -187,7 +187,7 @@ def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> l
         if not text:
             continue
         try:
-            start = float(segment.get("start_seconds", segment.get("start", 0.0)) or 0.0)
+            start = float(segment.get("start_seconds", 0.0) or 0.0)
         except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
             start = 0.0
         try:

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_transcriptions.py
@@ -176,6 +176,38 @@ def _stt_provider_availability(
     return "unknown"
 
 
+def _normalize_timed_segments(raw_segments: Optional[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    if not isinstance(raw_segments, list):
+        return normalized
+    for segment in raw_segments:
+        if not isinstance(segment, dict):
+            continue
+        text = str(segment.get("Text") or segment.get("text") or "").strip()
+        if not text:
+            continue
+        try:
+            start = float(segment.get("start_seconds", segment.get("start", 0.0)) or 0.0)
+        except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
+            start = 0.0
+        try:
+            end = float(segment.get("end_seconds", segment.get("end", start)) or start)
+        except _AUDIO_TRANSCRIPTIONS_NONCRITICAL_EXCEPTIONS:
+            end = start
+        if end < start:
+            end = start
+        norm_seg: dict[str, Any] = {
+            "text": text,
+            "start_seconds": start,
+            "end_seconds": end,
+        }
+        words = segment.get("words")
+        if isinstance(words, list):
+            norm_seg["words"] = words
+        normalized.append(norm_seg)
+    return normalized
+
+
 _PROVIDER_LANGUAGE_HINT_POLICY: dict[str, str] = {
     "faster-whisper": "iso639_base",
     "parakeet": "iso639_base",
@@ -805,12 +837,14 @@ async def create_transcription(
                 rid,
             )
 
+        timed_segments = _normalize_timed_segments(segments_for_timing)
+
         if response_format == "text":
             return Response(content=transcribed_text, media_type="text/plain")
 
         if response_format == "srt":
             _raise_on_transcription_error(transcribed_text)
-            if provider == "faster-whisper" and segments_for_timing:
+            if timed_segments:
                 lines: list[str] = []
 
                 def _fmt_srt_timestamp(total_seconds: float) -> str:
@@ -826,12 +860,8 @@ async def create_transcription(
                     return f"{hours:02d}:{minutes:02d}:{seconds:02d},{ms:03d}"
 
                 idx = 1
-                for seg in segments_for_timing:
-                    if not isinstance(seg, dict):
-                        continue
-                    text_seg = str(seg.get("Text", "")).strip()
-                    if not text_seg:
-                        continue
+                for seg in timed_segments:
+                    text_seg = str(seg.get("text", "")).strip()
                     start = seg.get("start_seconds", 0.0)
                     end = seg.get("end_seconds", start)
                     start_ts = _fmt_srt_timestamp(start)
@@ -852,7 +882,7 @@ async def create_transcription(
 
         if response_format == "vtt":
             _raise_on_transcription_error(transcribed_text)
-            if provider == "faster-whisper" and segments_for_timing:
+            if timed_segments:
                 lines_vtt: list[str] = ["WEBVTT", ""]
 
                 def _fmt_vtt_timestamp(total_seconds: float) -> str:
@@ -867,12 +897,8 @@ async def create_transcription(
                     minutes, seconds = divmod(seconds, 60)
                     return f"{hours:02d}:{minutes:02d}:{seconds:02d}.{ms:03d}"
 
-                for seg in segments_for_timing:
-                    if not isinstance(seg, dict):
-                        continue
-                    text_seg = str(seg.get("Text", "")).strip()
-                    if not text_seg:
-                        continue
+                for seg in timed_segments:
+                    text_seg = str(seg.get("text", "")).strip()
                     start = seg.get("start_seconds", 0.0)
                     end = seg.get("end_seconds", start)
                     start_ts = _fmt_vtt_timestamp(start)
@@ -897,18 +923,16 @@ async def create_transcription(
         response_data["duration"] = duration
 
         if "segment" in granularity_tokens:
-            if provider == "faster-whisper" and segments_for_timing:
+            if timed_segments:
                 segs = []
-                for i, seg in enumerate(segments_for_timing):
-                    if not isinstance(seg, dict):
-                        continue
+                for i, seg in enumerate(timed_segments):
                     start = float(seg.get("start_seconds", 0.0))
                     end = float(seg.get("end_seconds", duration))
                     seg_obj: dict[str, Any] = {
                         "id": i,
                         "start": start,
                         "end": end,
-                        "text": seg.get("Text", ""),
+                        "text": seg.get("text", ""),
                     }
                     if "word" in granularity_tokens and isinstance(seg.get("words"), list):
                         seg_obj["words"] = seg["words"]

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
@@ -19,12 +19,264 @@ import math
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 from loguru import logger
 
 logger = logger
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: int = -1) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _token_from_mapping(token: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(token, dict):
+        return None
+    text = str(token.get("text", "") or "")
+    start = _safe_float(token.get("start"), 0.0)
+    end = _safe_float(token.get("end"), start)
+    if end < start:
+        end = start
+    duration = _safe_float(token.get("duration"), max(end - start, 0.0))
+    token_id = _safe_int(token.get("id"), -1)
+    if token_id < 0:
+        token_id = _safe_int(token.get("token_id"), -1)
+    return {
+        "id": token_id,
+        "text": text,
+        "start": start,
+        "end": end,
+        "duration": duration,
+        "confidence": _safe_float(token.get("confidence"), 1.0),
+    }
+
+
+def _extract_tokens_from_mlx_artifact(artifact: Any) -> list[dict[str, Any]]:
+    if not isinstance(artifact, dict):
+        return []
+    tokens: list[dict[str, Any]] = []
+    raw_tokens = artifact.get("tokens")
+    if isinstance(raw_tokens, list):
+        for token in raw_tokens:
+            token_norm = _token_from_mapping(token)
+            if token_norm is not None:
+                tokens.append(token_norm)
+    if tokens:
+        return tokens
+
+    raw_sentences = artifact.get("sentences")
+    if isinstance(raw_sentences, list):
+        for sentence in raw_sentences:
+            if not isinstance(sentence, dict):
+                continue
+            for token in sentence.get("tokens", []):
+                token_norm = _token_from_mapping(token)
+                if token_norm is not None:
+                    tokens.append(token_norm)
+    return tokens
+
+
+def _token_match(a: dict[str, Any], b: dict[str, Any], overlap_duration: float) -> bool:
+    return (
+        _safe_int(a.get("id"), -1) >= 0
+        and _safe_int(a.get("id"), -1) == _safe_int(b.get("id"), -1)
+        and abs(_safe_float(a.get("start")) - _safe_float(b.get("start"))) < (overlap_duration / 2.0)
+    )
+
+
+def _merge_tokens_midpoint(
+    existing: list[dict[str, Any]],
+    incoming: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if not existing:
+        return incoming
+    if not incoming:
+        return existing
+    cutoff_time = (_safe_float(existing[-1].get("end")) + _safe_float(incoming[0].get("start"))) / 2.0
+    return [token for token in existing if _safe_float(token.get("end")) <= cutoff_time] + [
+        token for token in incoming if _safe_float(token.get("start")) >= cutoff_time
+    ]
+
+
+def _merge_tokens_longest_contiguous(
+    existing: list[dict[str, Any]],
+    incoming: list[dict[str, Any]],
+    *,
+    overlap_duration: float,
+) -> list[dict[str, Any]]:
+    if not existing or not incoming:
+        return incoming if not existing else existing
+
+    existing_end = _safe_float(existing[-1].get("end"))
+    incoming_start = _safe_float(incoming[0].get("start"))
+    if existing_end <= incoming_start:
+        return existing + incoming
+
+    overlap_existing = [
+        token for token in existing if _safe_float(token.get("end")) > incoming_start - overlap_duration
+    ]
+    overlap_incoming = [
+        token for token in incoming if _safe_float(token.get("start")) < existing_end + overlap_duration
+    ]
+    enough_pairs = len(overlap_existing) // 2
+    if len(overlap_existing) < 2 or len(overlap_incoming) < 2:
+        return _merge_tokens_midpoint(existing, incoming)
+
+    best_contiguous: list[tuple[int, int]] = []
+    for i in range(len(overlap_existing)):
+        for j in range(len(overlap_incoming)):
+            if _token_match(overlap_existing[i], overlap_incoming[j], overlap_duration):
+                current: list[tuple[int, int]] = []
+                k, l = i, j
+                while (
+                    k < len(overlap_existing)
+                    and l < len(overlap_incoming)
+                    and _token_match(overlap_existing[k], overlap_incoming[l], overlap_duration)
+                ):
+                    current.append((k, l))
+                    k += 1
+                    l += 1
+                if len(current) > len(best_contiguous):
+                    best_contiguous = current
+
+    if len(best_contiguous) < enough_pairs or not best_contiguous:
+        return _merge_tokens_midpoint(existing, incoming)
+
+    existing_overlap_start_idx = len(existing) - len(overlap_existing)
+    overlap_indices_existing = [existing_overlap_start_idx + pair[0] for pair in best_contiguous]
+    overlap_indices_incoming = [pair[1] for pair in best_contiguous]
+
+    merged: list[dict[str, Any]] = []
+    merged.extend(existing[: overlap_indices_existing[0]])
+    for idx in range(len(best_contiguous)):
+        idx_existing = overlap_indices_existing[idx]
+        idx_incoming = overlap_indices_incoming[idx]
+        merged.append(existing[idx_existing])
+        if idx < len(best_contiguous) - 1:
+            next_existing = overlap_indices_existing[idx + 1]
+            next_incoming = overlap_indices_incoming[idx + 1]
+            gap_existing = existing[idx_existing + 1 : next_existing]
+            gap_incoming = incoming[idx_incoming + 1 : next_incoming]
+            merged.extend(gap_incoming if len(gap_incoming) > len(gap_existing) else gap_existing)
+    merged.extend(incoming[overlap_indices_incoming[-1] + 1 :])
+    return merged
+
+
+def _merge_tokens_longest_common_subsequence(
+    existing: list[dict[str, Any]],
+    incoming: list[dict[str, Any]],
+    *,
+    overlap_duration: float,
+) -> list[dict[str, Any]]:
+    if not existing or not incoming:
+        return incoming if not existing else existing
+
+    existing_end = _safe_float(existing[-1].get("end"))
+    incoming_start = _safe_float(incoming[0].get("start"))
+    if existing_end <= incoming_start:
+        return existing + incoming
+
+    overlap_existing = [
+        token for token in existing if _safe_float(token.get("end")) > incoming_start - overlap_duration
+    ]
+    overlap_incoming = [
+        token for token in incoming if _safe_float(token.get("start")) < existing_end + overlap_duration
+    ]
+    if len(overlap_existing) < 2 or len(overlap_incoming) < 2:
+        return _merge_tokens_midpoint(existing, incoming)
+
+    dp = [[0 for _ in range(len(overlap_incoming) + 1)] for _ in range(len(overlap_existing) + 1)]
+    for i in range(1, len(overlap_existing) + 1):
+        for j in range(1, len(overlap_incoming) + 1):
+            if _token_match(overlap_existing[i - 1], overlap_incoming[j - 1], overlap_duration):
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+
+    pairs: list[tuple[int, int]] = []
+    i = len(overlap_existing)
+    j = len(overlap_incoming)
+    while i > 0 and j > 0:
+        if _token_match(overlap_existing[i - 1], overlap_incoming[j - 1], overlap_duration):
+            pairs.append((i - 1, j - 1))
+            i -= 1
+            j -= 1
+        elif dp[i - 1][j] > dp[i][j - 1]:
+            i -= 1
+        else:
+            j -= 1
+
+    pairs.reverse()
+    if not pairs:
+        return _merge_tokens_midpoint(existing, incoming)
+
+    existing_overlap_start_idx = len(existing) - len(overlap_existing)
+    overlap_indices_existing = [existing_overlap_start_idx + pair[0] for pair in pairs]
+    overlap_indices_incoming = [pair[1] for pair in pairs]
+
+    merged: list[dict[str, Any]] = []
+    merged.extend(existing[: overlap_indices_existing[0]])
+    for idx in range(len(pairs)):
+        idx_existing = overlap_indices_existing[idx]
+        idx_incoming = overlap_indices_incoming[idx]
+        merged.append(existing[idx_existing])
+        if idx < len(pairs) - 1:
+            next_existing = overlap_indices_existing[idx + 1]
+            next_incoming = overlap_indices_incoming[idx + 1]
+            gap_existing = existing[idx_existing + 1 : next_existing]
+            gap_incoming = incoming[idx_incoming + 1 : next_incoming]
+            merged.extend(gap_incoming if len(gap_incoming) > len(gap_existing) else gap_existing)
+    merged.extend(incoming[overlap_indices_incoming[-1] + 1 :])
+    return merged
+
+
+def _tokens_to_sentence_dicts(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not tokens:
+        return []
+    sentences: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    for token in tokens:
+        current.append(token)
+        token_text = str(token.get("text", ""))
+        is_sentence_boundary = any(symbol in token_text for symbol in ("!", "?", "。", "？", "！")) or "." in token_text
+        if is_sentence_boundary:
+            sentences.append(current)
+            current = []
+    if current:
+        sentences.append(current)
+
+    out: list[dict[str, Any]] = []
+    for sentence_tokens in sentences:
+        text = "".join(str(token.get("text", "")) for token in sentence_tokens).strip()
+        if not text:
+            continue
+        start = _safe_float(sentence_tokens[0].get("start"))
+        end = _safe_float(sentence_tokens[-1].get("end"), start)
+        confidences = np.array([max(_safe_float(token.get("confidence"), 1.0), 1e-10) for token in sentence_tokens])
+        confidence = float(np.exp(np.mean(np.log(confidences)))) if confidences.size else 1.0
+        out.append(
+            {
+                "text": text,
+                "start": start,
+                "end": max(end, start),
+                "duration": max(end - start, 0.0),
+                "confidence": confidence,
+                "tokens": sentence_tokens,
+            }
+        )
+    return out
 
 
 class MergeAlgorithm(Enum):
@@ -378,8 +630,20 @@ def transcribe_long_audio(
     total_buffer: Optional[float] = None,
     merge_algo: str = 'middle',
     device: str = 'cpu',
-    progress_callback: Optional[Callable[[int, int], None]] = None
-) -> str:
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+    *,
+    return_structured: bool = False,
+    model_path: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    decoding_mode: Optional[str] = None,
+    beam_size: Optional[int] = None,
+    length_penalty: Optional[float] = None,
+    patience: Optional[float] = None,
+    duration_reward: Optional[float] = None,
+    sentence_max_words: Optional[int] = None,
+    sentence_silence_gap: Optional[float] = None,
+    sentence_max_duration: Optional[float] = None,
+) -> Union[str, dict[str, Any]]:
     """
     Transcribe long audio files using buffered/chunked processing.
 
@@ -428,13 +692,27 @@ def transcribe_long_audio(
         transcriber = BufferedTranscriber(config)
 
     # Create transcribe function
-    def transcribe_chunk(chunk_audio: np.ndarray) -> str:
+    def transcribe_chunk(chunk_audio: np.ndarray) -> Union[str, dict[str, Any]]:
         # Import appropriate transcription function
         if variant == 'mlx':
             from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX import (
                 transcribe_with_parakeet_mlx,
             )
-            return transcribe_with_parakeet_mlx(chunk_audio, sample_rate=16000)
+            return transcribe_with_parakeet_mlx(
+                chunk_audio,
+                sample_rate=16000,
+                return_structured=return_structured,
+                model_path=model_path,
+                cache_dir=cache_dir,
+                decoding_mode=decoding_mode,
+                beam_size=beam_size,
+                length_penalty=length_penalty,
+                patience=patience,
+                duration_reward=duration_reward,
+                sentence_max_words=sentence_max_words,
+                sentence_silence_gap=sentence_silence_gap,
+                sentence_max_duration=sentence_max_duration,
+            )
         elif variant == 'onnx':
             from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX import (
                 transcribe_with_parakeet_onnx,
@@ -451,15 +729,83 @@ def transcribe_long_audio(
                 variant=variant
             )
 
-    # Process audio
-    result = transcriber.process_audio(
+    if variant == "mlx" and return_structured:
+        chunks = transcriber._create_chunks(audio_data)
+        total_chunks = len(chunks)
+        merged_tokens: list[dict[str, Any]] = []
+        fallback_text_chunks: list[str] = []
+
+        for idx, chunk in enumerate(chunks):
+            chunk_result = transcribe_chunk(chunk["audio"])
+            if progress_callback:
+                progress_callback(idx + 1, total_chunks)
+
+            if isinstance(chunk_result, dict):
+                tokens = _extract_tokens_from_mlx_artifact(chunk_result)
+                if tokens:
+                    chunk_start = _safe_float(chunk.get("start"), 0.0)
+                    for token in tokens:
+                        token["start"] = _safe_float(token.get("start"), 0.0) + chunk_start
+                        token["end"] = _safe_float(token.get("end"), token["start"]) + chunk_start
+                        if token["end"] < token["start"]:
+                            token["end"] = token["start"]
+                        token["duration"] = max(token["end"] - token["start"], 0.0)
+
+                    if not merged_tokens:
+                        merged_tokens = tokens
+                    else:
+                        overlap_for_merge = max(
+                            _safe_float(chunk.get("overlap_start"), 0.0),
+                            _safe_float(chunk.get("overlap_end"), 0.0),
+                            0.0,
+                        )
+                        if config.merge_algo == MergeAlgorithm.LCS:
+                            merged_tokens = _merge_tokens_longest_common_subsequence(
+                                merged_tokens,
+                                tokens,
+                                overlap_duration=overlap_for_merge,
+                            )
+                        elif config.merge_algo == MergeAlgorithm.SIMPLE:
+                            merged_tokens.extend(tokens)
+                        else:
+                            merged_tokens = _merge_tokens_longest_contiguous(
+                                merged_tokens,
+                                tokens,
+                                overlap_duration=overlap_for_merge,
+                            )
+                else:
+                    chunk_text = str(chunk_result.get("text", "")).strip()
+                    if chunk_text:
+                        fallback_text_chunks.append(chunk_text)
+            else:
+                chunk_text = str(chunk_result).strip()
+                if chunk_text:
+                    fallback_text_chunks.append(chunk_text)
+
+        if merged_tokens:
+            sentences = _tokens_to_sentence_dicts(merged_tokens)
+            text = "".join(str(token.get("text", "")) for token in merged_tokens).strip()
+            if not text and sentences:
+                text = " ".join(str(sentence.get("text", "")) for sentence in sentences).strip()
+            return {
+                "text": text,
+                "sentences": sentences,
+                "tokens": merged_tokens,
+            }
+
+        return {
+            "text": " ".join(fallback_text_chunks).strip(),
+            "sentences": [],
+            "tokens": [],
+        }
+
+    # Process audio with legacy text merge
+    return transcriber.process_audio(
         audio_data,
         sample_rate,
         transcribe_chunk,
         progress_callback
     )
-
-    return result
 
 
 #######################################################################################################################

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
@@ -28,6 +28,7 @@ logger = logger
 
 
 def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Safely coerce a value to float, returning ``default`` on failure."""
     try:
         return float(value)
     except (TypeError, ValueError):
@@ -35,6 +36,7 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
 
 
 def _safe_int(value: Any, default: int = -1) -> int:
+    """Safely coerce a value to int, returning ``default`` on failure."""
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -42,6 +44,7 @@ def _safe_int(value: Any, default: int = -1) -> int:
 
 
 def _token_from_mapping(token: Any) -> Optional[dict[str, Any]]:
+    """Normalize a token-like mapping into the internal token schema."""
     if not isinstance(token, dict):
         return None
     text = str(token.get("text", "") or "")
@@ -64,6 +67,7 @@ def _token_from_mapping(token: Any) -> Optional[dict[str, Any]]:
 
 
 def _extract_tokens_from_mlx_artifact(artifact: Any) -> list[dict[str, Any]]:
+    """Extract normalized token dictionaries from a Parakeet MLX artifact payload."""
     if not isinstance(artifact, dict):
         return []
     tokens: list[dict[str, Any]] = []
@@ -89,6 +93,7 @@ def _extract_tokens_from_mlx_artifact(artifact: Any) -> list[dict[str, Any]]:
 
 
 def _token_match(a: dict[str, Any], b: dict[str, Any], overlap_duration: float) -> bool:
+    """Return ``True`` when two tokens are considered the same overlap token."""
     return (
         _safe_int(a.get("id"), -1) >= 0
         and _safe_int(a.get("id"), -1) == _safe_int(b.get("id"), -1)
@@ -100,6 +105,7 @@ def _merge_tokens_midpoint(
     existing: list[dict[str, Any]],
     incoming: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Merge token lists by splitting at the midpoint of overlap boundaries."""
     if not existing:
         return incoming
     if not incoming:
@@ -117,19 +123,24 @@ def _merge_tokens_longest_contiguous(
     *,
     overlap_duration: float,
 ) -> list[dict[str, Any]]:
+    """Merge token lists using the longest contiguous overlap run."""
     if not existing or not incoming:
-        return incoming if not existing else existing
+        return existing if existing else incoming
 
-    existing_end = _safe_float(existing[-1].get("end"))
-    incoming_start = _safe_float(incoming[0].get("start"))
+    existing_end = _safe_float(existing[-1].get("end"), float("-inf"))
+    incoming_start = _safe_float(incoming[0].get("start"), float("inf"))
     if existing_end <= incoming_start:
         return existing + incoming
 
     overlap_existing = [
-        token for token in existing if _safe_float(token.get("end")) > incoming_start - overlap_duration
+        token
+        for token in existing
+        if _safe_float(token.get("end"), float("-inf")) > incoming_start - overlap_duration
     ]
     overlap_incoming = [
-        token for token in incoming if _safe_float(token.get("start")) < existing_end + overlap_duration
+        token
+        for token in incoming
+        if _safe_float(token.get("start"), float("inf")) < existing_end + overlap_duration
     ]
     enough_pairs = len(overlap_existing) // 2
     if len(overlap_existing) < 2 or len(overlap_incoming) < 2:
@@ -140,15 +151,15 @@ def _merge_tokens_longest_contiguous(
         for j in range(len(overlap_incoming)):
             if _token_match(overlap_existing[i], overlap_incoming[j], overlap_duration):
                 current: list[tuple[int, int]] = []
-                k, l = i, j
+                k, incoming_idx = i, j
                 while (
                     k < len(overlap_existing)
-                    and l < len(overlap_incoming)
-                    and _token_match(overlap_existing[k], overlap_incoming[l], overlap_duration)
+                    and incoming_idx < len(overlap_incoming)
+                    and _token_match(overlap_existing[k], overlap_incoming[incoming_idx], overlap_duration)
                 ):
-                    current.append((k, l))
+                    current.append((k, incoming_idx))
                     k += 1
-                    l += 1
+                    incoming_idx += 1
                 if len(current) > len(best_contiguous):
                     best_contiguous = current
 
@@ -181,19 +192,24 @@ def _merge_tokens_longest_common_subsequence(
     *,
     overlap_duration: float,
 ) -> list[dict[str, Any]]:
+    """Merge token lists by aligning the overlap region with LCS matching."""
     if not existing or not incoming:
-        return incoming if not existing else existing
+        return existing if existing else incoming
 
-    existing_end = _safe_float(existing[-1].get("end"))
-    incoming_start = _safe_float(incoming[0].get("start"))
+    existing_end = _safe_float(existing[-1].get("end"), float("-inf"))
+    incoming_start = _safe_float(incoming[0].get("start"), float("inf"))
     if existing_end <= incoming_start:
         return existing + incoming
 
     overlap_existing = [
-        token for token in existing if _safe_float(token.get("end")) > incoming_start - overlap_duration
+        token
+        for token in existing
+        if _safe_float(token.get("end"), float("-inf")) > incoming_start - overlap_duration
     ]
     overlap_incoming = [
-        token for token in incoming if _safe_float(token.get("start")) < existing_end + overlap_duration
+        token
+        for token in incoming
+        if _safe_float(token.get("start"), float("inf")) < existing_end + overlap_duration
     ]
     if len(overlap_existing) < 2 or len(overlap_incoming) < 2:
         return _merge_tokens_midpoint(existing, incoming)
@@ -244,6 +260,7 @@ def _merge_tokens_longest_common_subsequence(
 
 
 def _tokens_to_sentence_dicts(tokens: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Group token timing into sentence-like segments with aggregate confidence."""
     if not tokens:
         return []
     sentences: list[list[dict[str, Any]]] = []
@@ -731,6 +748,10 @@ def transcribe_long_audio(
             )
 
     if variant == "mlx" and return_structured:
+        if sample_rate != 16000:
+            audio_data = transcriber._resample(audio_data, sample_rate, 16000)
+            sample_rate = 16000
+
         chunks = transcriber._create_chunks(audio_data)
         total_chunks = len(chunks)
         merged_tokens: list[dict[str, Any]] = []

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Buffered_Transcription.py
@@ -104,9 +104,10 @@ def _merge_tokens_midpoint(
         return incoming
     if not incoming:
         return existing
-    cutoff_time = (_safe_float(existing[-1].get("end")) + _safe_float(incoming[0].get("start"))) / 2.0
-    return [token for token in existing if _safe_float(token.get("end")) <= cutoff_time] + [
-        token for token in incoming if _safe_float(token.get("start")) >= cutoff_time
+    cutoff_time = (existing[-1].get("end", 0.0) + incoming[0].get("start", 0.0)) / 2.0
+    return [token for token in existing if token.get("end", 0.0) <= cutoff_time] + [
+        token for token in incoming if token.get("start", 0.0) >= cutoff_time
+    ]
     ]
 
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
@@ -1333,8 +1333,7 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                     length_penalty=_cfg_float("mlx_length_penalty", 0.0) if stt_cfg.get("mlx_length_penalty") is not None else None,
                     patience=_cfg_float("mlx_patience", 0.0) if stt_cfg.get("mlx_patience") is not None else None,
                     duration_reward=_cfg_float("mlx_duration_reward", 0.0) if stt_cfg.get("mlx_duration_reward") is not None else None,
-                    sentence_max_words=_cfg_int("mlx_sentence_max_words", 0) or None,
-                    sentence_silence_gap=_cfg_float("mlx_sentence_silence_gap", 0.0) if stt_cfg.get("mlx_sentence_silence_gap") is not None else None,
+                    duration_reward=_cfg_float("mlx_duration_reward", 0.0) if stt_cfg.get("mlx_duration_reward") is not None else None,
                     sentence_max_duration=_cfg_float("mlx_sentence_max_duration", 0.0) if stt_cfg.get("mlx_sentence_max_duration") is not None else None,
                 )
                 if self._mlx_stream_session is not None:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
@@ -46,6 +46,18 @@ from .Audio_Transcription_Nemo import (
     transcribe_with_canary,
     transcribe_with_parakeet,
 )
+try:  # pragma: no cover - optional on non-macOS or minimal test envs
+    from .Audio_Transcription_Parakeet_MLX import (
+        create_parakeet_mlx_streaming_session,
+        transcribe_with_parakeet_mlx,
+    )
+except Exception:  # pragma: no cover - provide safe fallbacks
+    def create_parakeet_mlx_streaming_session(*_args, **_kwargs):  # type: ignore[override]
+        return None
+
+    def transcribe_with_parakeet_mlx(*_args, **_kwargs):  # type: ignore[override]
+        return ""
+
 from .model_utils import normalize_model_and_variant
 
 _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS = (
@@ -1253,6 +1265,9 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
         self._rnnt_streamer: Optional[_ParakeetRNNTStreamer] = None
         self._rnnt_last_partial: str = ""
         self._rnnt_last_final: str = ""
+        self._mlx_stream_session: Any = None
+        self._mlx_last_partial: str = ""
+        self._mlx_last_final: str = ""
 
         if variant == 'mlx':
             # MLX model is loaded on-demand in transcribe function
@@ -1263,6 +1278,69 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                 )
                 logger.info("Using Parakeet MLX variant (lazy loading)")
                 self.model = "mlx"  # Placeholder to indicate MLX is ready
+                try:
+                    from tldw_Server_API.app.core.config import get_stt_config
+
+                    stt_cfg = get_stt_config() or {}
+                except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                    stt_cfg = {}
+
+                def _cfg_int(key: str, default: int) -> int:
+                    try:
+                        value = stt_cfg.get(key, default)
+                        return int(value)
+                    except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                        return default
+
+                def _cfg_float(key: str, default: float) -> float:
+                    try:
+                        value = stt_cfg.get(key, default)
+                        return float(value)
+                    except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                        return default
+
+                def _cfg_str(key: str) -> Optional[str]:
+                    value = stt_cfg.get(key)
+                    if value is None:
+                        return None
+                    value_str = str(value).strip()
+                    return value_str if value_str else None
+
+                def _cfg_bool(key: str, default: bool = False) -> bool:
+                    value = stt_cfg.get(key)
+                    if value is None:
+                        return default
+                    if isinstance(value, bool):
+                        return value
+                    value_str = str(value).strip().lower()
+                    if value_str in {"1", "true", "yes", "on"}:
+                        return True
+                    if value_str in {"0", "false", "no", "off"}:
+                        return False
+                    return default
+
+                self._mlx_stream_session = create_parakeet_mlx_streaming_session(
+                    model_path=_cfg_str("mlx_model_id"),
+                    cache_dir=_cfg_str("mlx_cache_dir"),
+                    context_size=(
+                        _cfg_int("mlx_stream_context_left", 256),
+                        _cfg_int("mlx_stream_context_right", 256),
+                    ),
+                    depth=max(_cfg_int("mlx_stream_depth", 1), 1),
+                    keep_original_attention=_cfg_bool("mlx_stream_keep_original_attention", False),
+                    decoding_mode=_cfg_str("mlx_decoding_mode"),
+                    beam_size=_cfg_int("mlx_beam_size", 0) or None,
+                    length_penalty=_cfg_float("mlx_length_penalty", 0.0) if stt_cfg.get("mlx_length_penalty") is not None else None,
+                    patience=_cfg_float("mlx_patience", 0.0) if stt_cfg.get("mlx_patience") is not None else None,
+                    duration_reward=_cfg_float("mlx_duration_reward", 0.0) if stt_cfg.get("mlx_duration_reward") is not None else None,
+                    sentence_max_words=_cfg_int("mlx_sentence_max_words", 0) or None,
+                    sentence_silence_gap=_cfg_float("mlx_sentence_silence_gap", 0.0) if stt_cfg.get("mlx_sentence_silence_gap") is not None else None,
+                    sentence_max_duration=_cfg_float("mlx_sentence_max_duration", 0.0) if stt_cfg.get("mlx_sentence_max_duration") is not None else None,
+                )
+                if self._mlx_stream_session is not None:
+                    logger.info("Initialized Parakeet MLX native streaming session")
+                else:
+                    logger.info("Parakeet MLX native streaming unavailable; using legacy chunk decode path")
                 return  # Success
             except ImportError as e:
                 logger.error(f"Failed to import Parakeet MLX: {e}")
@@ -1359,6 +1437,15 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
         # Clear RNNT-specific tracking so partial/final comparisons start fresh
         self._rnnt_last_partial = ""
         self._rnnt_last_final = ""
+        mlx_session = getattr(self, "_mlx_stream_session", None)
+        if mlx_session is not None and hasattr(mlx_session, "close"):
+            try:
+                mlx_session.close()
+            except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                pass
+        self._mlx_stream_session = None
+        self._mlx_last_partial = ""
+        self._mlx_last_final = ""
 
     async def process_audio_chunk(self, audio_data: bytes) -> Optional[dict[str, Any]]:
         """
@@ -1440,6 +1527,72 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
 
             return None
 
+        if self.config.model_variant == "mlx" and self._mlx_stream_session is not None:
+            try:
+                artifact = self._mlx_stream_session.add_audio(audio_np, sample_rate=self.config.sample_rate)
+                full_text = str((artifact or {}).get("text", "")).strip()
+            except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS as mlx_stream_err:
+                logger.warning(f"Parakeet MLX native streaming failed, falling back to legacy chunking: {mlx_stream_err}")
+                try:
+                    self._mlx_stream_session.close()
+                except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                    pass
+                self._mlx_stream_session = None
+                full_text = ""
+
+            if full_text:
+                try:
+                    from .Audio_Custom_Vocabulary import postprocess_text_if_enabled
+
+                    full_text = postprocess_text_if_enabled(full_text)
+                except _AUDIO_UNIFIED_NONCRITICAL_EXCEPTIONS:
+                    pass
+
+            if (
+                self.config.enable_partial
+                and current_time - self.last_partial_time > self.config.partial_interval
+                and buffer_duration > max(self.config.min_partial_duration, 0.1)
+                and full_text
+                and full_text != self._mlx_last_partial
+            ):
+                self._mlx_last_partial = full_text
+                self.last_partial_time = current_time
+                metadata = self._prepare_partial_metadata(buffer_duration)
+                result = {
+                    "type": "partial",
+                    "text": full_text,
+                    "timestamp": current_time,
+                    "is_final": False,
+                    "model": f"parakeet-{self.config.model_variant}",
+                }
+                result.update(metadata)
+                return result
+
+            if buffer_duration >= self.config.chunk_duration:
+                audio_chunk = self.buffer.get_audio(self.config.chunk_duration)
+                if audio_chunk is not None:
+                    self.buffer.consume(
+                        self.config.chunk_duration,
+                        self.config.overlap_duration
+                    )
+                    if full_text and full_text != self._mlx_last_final:
+                        self._mlx_last_final = full_text
+                        self.transcription_history.append(full_text)
+                        chunk_duration = float(len(audio_chunk)) / float(self.config.sample_rate or 1)
+                        metadata = self._prepare_final_metadata(chunk_duration)
+                        result = {
+                            "type": "final",
+                            "text": full_text,
+                            "timestamp": current_time,
+                            "is_final": True,
+                            "model": f"parakeet-{self.config.model_variant}",
+                        }
+                        result.update(metadata)
+                        result["_audio_chunk"] = np.array(audio_chunk, copy=True)
+                        return result
+
+            return None
+
         # Check if we should send a partial result
         if (self.config.enable_partial and
             current_time - self.last_partial_time > self.config.partial_interval and
@@ -1450,8 +1603,6 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
             if audio_for_partial is not None and len(audio_for_partial) > 0:
                 # Transcribe partial audio
                 if self.config.model_variant == 'mlx':
-                    # Use MLX implementation
-                    from .Audio_Transcription_Parakeet_MLX import transcribe_with_parakeet_mlx
                     text = transcribe_with_parakeet_mlx(
                         audio_for_partial,
                         sample_rate=self.config.sample_rate
@@ -1492,7 +1643,6 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
             if audio_chunk is not None:
                 # Transcribe the chunk
                 if self.config.model_variant == 'mlx':
-                    from .Audio_Transcription_Parakeet_MLX import transcribe_with_parakeet_mlx
                     text = transcribe_with_parakeet_mlx(
                         audio_chunk,
                         sample_rate=self.config.sample_rate

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Streaming_Unified.py
@@ -51,11 +51,15 @@ try:  # pragma: no cover - optional on non-macOS or minimal test envs
         create_parakeet_mlx_streaming_session,
         transcribe_with_parakeet_mlx,
     )
-except Exception:  # pragma: no cover - provide safe fallbacks
-    def create_parakeet_mlx_streaming_session(*_args, **_kwargs):  # type: ignore[override]
+except ImportError as exc:  # pragma: no cover - provide safe fallbacks
+    logger.debug("Parakeet MLX import unavailable; using no-op fallbacks: {}", exc)
+
+    def create_parakeet_mlx_streaming_session(*_args: Any, **_kwargs: Any) -> None:  # type: ignore[override]
+        """Return no streaming session when the MLX backend is unavailable."""
         return None
 
-    def transcribe_with_parakeet_mlx(*_args, **_kwargs):  # type: ignore[override]
+    def transcribe_with_parakeet_mlx(*_args: Any, **_kwargs: Any) -> str:  # type: ignore[override]
+        """Return an empty transcription when the MLX backend is unavailable."""
         return ""
 
 from .model_utils import normalize_model_and_variant
@@ -1286,6 +1290,7 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                     stt_cfg = {}
 
                 def _cfg_int(key: str, default: int) -> int:
+                    """Return an integer config value with safe fallback coercion."""
                     try:
                         value = stt_cfg.get(key, default)
                         return int(value)
@@ -1293,6 +1298,7 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                         return default
 
                 def _cfg_float(key: str, default: float) -> float:
+                    """Return a float config value with safe fallback coercion."""
                     try:
                         value = stt_cfg.get(key, default)
                         return float(value)
@@ -1300,13 +1306,15 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                         return default
 
                 def _cfg_str(key: str) -> Optional[str]:
+                    """Return a non-empty string config value or ``None``."""
                     value = stt_cfg.get(key)
                     if value is None:
                         return None
                     value_str = str(value).strip()
                     return value_str if value_str else None
 
-                def _cfg_bool(key: str, default: bool = False) -> bool:
+                def _cfg_bool(key: str, *, default: bool = False) -> bool:
+                    """Return a boolean config value with string/number normalization."""
                     value = stt_cfg.get(key)
                     if value is None:
                         return default
@@ -1327,7 +1335,10 @@ class ParakeetStreamingTranscriber(BaseStreamingTranscriber):
                         _cfg_int("mlx_stream_context_right", 256),
                     ),
                     depth=max(_cfg_int("mlx_stream_depth", 1), 1),
-                    keep_original_attention=_cfg_bool("mlx_stream_keep_original_attention", False),
+                    keep_original_attention=_cfg_bool(
+                        "mlx_stream_keep_original_attention",
+                        default=False,
+                    ),
                     decoding_mode=_cfg_str("mlx_decoding_mode"),
                     beam_size=_cfg_int("mlx_beam_size", 0) or None,
                     length_penalty=_cfg_float("mlx_length_penalty", 0.0) if stt_cfg.get("mlx_length_penalty") is not None else None,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -67,7 +67,11 @@ from tldw_Server_API.app.core.config import (
     loaded_config_data,
 )
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
-from tldw_Server_API.app.core.exceptions import CancelCheckError, TranscriptionCancelled
+from tldw_Server_API.app.core.exceptions import (
+    CancelCheckError,
+    STTTranscriptionError,
+    TranscriptionCancelled,
+)
 from tldw_Server_API.app.core.Ingestion_Media_Processing.path_utils import resolve_safe_local_path
 from tldw_Server_API.app.core.Metrics.metrics_logger import log_counter, log_histogram, timeit
 from tldw_Server_API.app.core.testing import is_truthy
@@ -189,7 +193,6 @@ def _looks_like_error_text(text: Any) -> bool:
     if not isinstance(text, str):
         return False
     return text.strip().startswith("[Error:")
-
 
 # Conservative defaults to prevent unbounded cache growth unless explicitly
 # disabled via `disable_transcript_cache_pruning` or environment variables.
@@ -2893,7 +2896,7 @@ def speech_to_text_parakeet(
                             )
 
                     if isinstance(mlx_result, str) and _looks_like_error_text(mlx_result):
-                        raise RuntimeError(mlx_result)
+                        raise STTTranscriptionError(mlx_result)
 
                     return create_segments_from_parakeet_mlx_artifact(mlx_result, audio_duration)
 
@@ -2918,7 +2921,7 @@ def speech_to_text_parakeet(
 
     except _AUDIO_TRANSCRIPTION_NONCRITICAL_EXCEPTIONS as e:
         logging.error(f"Parakeet transcription failed: {e}")
-        raise RuntimeError(f"Parakeet transcription error: {str(e)}") from e
+        raise STTTranscriptionError(f"Parakeet transcription error: {str(e)}") from e
 
 def speech_to_text_canary(
     audio_file_path: str,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -2687,11 +2687,9 @@ def create_segments_from_parakeet_mlx_artifact(
         if not sentence_text:
             continue
 
-        sentence_start = _coerce_float(sentence.get("start"))
-        sentence_end = _coerce_float(sentence.get("end"))
-        if sentence_start is None:
-            sentence_start = 0.0
-        if sentence_end is None or sentence_end < sentence_start:
+        sentence_start = _coerce_float(sentence.get("start"), 0.0)
+        sentence_end = _coerce_float(sentence.get("end"), sentence_start)
+        if sentence_end < sentence_start:
             sentence_end = sentence_start
 
         segment: dict[str, Any] = {

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Lib.py
@@ -2647,6 +2647,97 @@ def create_segments_from_text(text: str, audio_duration: float = None, segmentat
 
     return segments
 
+
+def create_segments_from_parakeet_mlx_artifact(
+    artifact: Any,
+    audio_duration: Optional[float] = None,
+) -> list[dict[str, Any]]:
+    """
+    Convert a Parakeet MLX structured artifact into whisper-compatible segments.
+
+    Expected artifact shape:
+    {
+      "text": str,
+      "sentences": [
+        {
+          "text": str,
+          "start": float,
+          "end": float,
+          "confidence": float,
+          "tokens": [{"text": str, "start": float, "end": float, ...}]
+        },
+      ],
+      "tokens": [...]
+    }
+    """
+    if not isinstance(artifact, dict):
+        text = str(artifact or "").strip()
+        return create_segments_from_text(text, audio_duration, segmentation="sentence")
+
+    text = str(artifact.get("text", "") or "").strip()
+    raw_sentences = artifact.get("sentences")
+    if not isinstance(raw_sentences, list):
+        return create_segments_from_text(text, audio_duration, segmentation="sentence")
+
+    segments: list[dict[str, Any]] = []
+    for sentence in raw_sentences:
+        if not isinstance(sentence, dict):
+            continue
+        sentence_text = str(sentence.get("text", "") or "").strip()
+        if not sentence_text:
+            continue
+
+        sentence_start = _coerce_float(sentence.get("start"))
+        sentence_end = _coerce_float(sentence.get("end"))
+        if sentence_start is None:
+            sentence_start = 0.0
+        if sentence_end is None or sentence_end < sentence_start:
+            sentence_end = sentence_start
+
+        segment: dict[str, Any] = {
+            "start_seconds": float(sentence_start),
+            "end_seconds": float(sentence_end),
+            "text": sentence_text,
+            "Text": sentence_text,
+            "start": format_time(float(sentence_start)),
+            "end": format_time(float(sentence_end)),
+            "Time_Start": float(sentence_start),
+            "Time_End": float(sentence_end),
+        }
+        sentence_confidence = _coerce_float(sentence.get("confidence"))
+        if sentence_confidence is not None:
+            segment["confidence"] = float(sentence_confidence)
+
+        raw_tokens = sentence.get("tokens")
+        words: list[dict[str, Any]] = []
+        if isinstance(raw_tokens, list):
+            for token in raw_tokens:
+                if not isinstance(token, dict):
+                    continue
+                token_text = str(token.get("text", "") or "").strip()
+                token_start = _coerce_float(token.get("start"))
+                token_end = _coerce_float(token.get("end"))
+                if not token_text or token_start is None or token_end is None:
+                    continue
+                if token_end < token_start:
+                    token_end = token_start
+                words.append(
+                    {
+                        "start": float(token_start),
+                        "end": float(token_end),
+                        "word": token_text,
+                    }
+                )
+        if words:
+            segment["words"] = words
+
+        segments.append(segment)
+
+    if not segments:
+        return create_segments_from_text(text, audio_duration, segmentation="sentence")
+    return segments
+
+
 def speech_to_text_parakeet(
     audio_file_path: str,
     variant: str = "standard",
@@ -2701,8 +2792,20 @@ def speech_to_text_parakeet(
                     stt_cfg = get_stt_config() or {}
                     raw_chunk_duration = stt_cfg.get("mlx_chunk_duration")
                     raw_overlap_duration = stt_cfg.get("mlx_overlap_duration")
+                    mlx_model_id = str(stt_cfg.get("mlx_model_id", "")).strip() or None
+                    mlx_cache_dir = str(stt_cfg.get("mlx_cache_dir", "")).strip() or None
+                    mlx_decoding_mode = str(stt_cfg.get("mlx_decoding_mode", "")).strip() or None
+                    mlx_beam_size = _coerce_int(stt_cfg.get("mlx_beam_size"))
+                    mlx_length_penalty = _coerce_float(stt_cfg.get("mlx_length_penalty"))
+                    mlx_patience = _coerce_float(stt_cfg.get("mlx_patience"))
+                    mlx_duration_reward = _coerce_float(stt_cfg.get("mlx_duration_reward"))
+                    mlx_sentence_max_words = _coerce_int(stt_cfg.get("mlx_sentence_max_words"))
+                    mlx_sentence_silence_gap = _coerce_float(stt_cfg.get("mlx_sentence_silence_gap"))
+                    mlx_sentence_max_duration = _coerce_float(stt_cfg.get("mlx_sentence_max_duration"))
 
                     chunk_duration = _coerce_float(raw_chunk_duration)
+                    if chunk_duration is None:
+                        chunk_duration = _coerce_float(stt_cfg.get("buffered_chunk_duration"))
                     if chunk_duration is None:
                         chunk_duration = 30.0
 
@@ -2710,11 +2813,23 @@ def speech_to_text_parakeet(
                     if overlap_duration is None:
                         overlap_duration = 5.0
 
+                    mlx_result: Union[str, dict[str, Any]]
                     if chunk_duration <= 0:
-                        text = transcribe_with_parakeet_mlx(
+                        mlx_result = transcribe_with_parakeet_mlx(
                             audio_file_path,
                             chunk_duration=None,
                             overlap_duration=15.0,
+                            return_structured=True,
+                            model_path=mlx_model_id,
+                            cache_dir=mlx_cache_dir,
+                            decoding_mode=mlx_decoding_mode,
+                            beam_size=mlx_beam_size,
+                            length_penalty=mlx_length_penalty,
+                            patience=mlx_patience,
+                            duration_reward=mlx_duration_reward,
+                            sentence_max_words=mlx_sentence_max_words,
+                            sentence_silence_gap=mlx_sentence_silence_gap,
+                            sentence_max_duration=mlx_sentence_max_duration,
                         )
                     else:
                         use_buffered = audio_duration is None or audio_duration > chunk_duration
@@ -2742,26 +2857,47 @@ def speech_to_text_parakeet(
                                 if total_buffer <= chunk_duration or total_buffer >= 3.0 * chunk_duration:
                                     total_buffer = None
 
-                            text = transcribe_long_audio(
+                            mlx_result = transcribe_long_audio(
                                 audio_file_path,
                                 model_name="parakeet",
                                 variant="mlx",
                                 chunk_duration=chunk_duration,
                                 total_buffer=total_buffer,
                                 merge_algo=merge_algo,
+                                return_structured=True,
+                                model_path=mlx_model_id,
+                                cache_dir=mlx_cache_dir,
+                                decoding_mode=mlx_decoding_mode,
+                                beam_size=mlx_beam_size,
+                                length_penalty=mlx_length_penalty,
+                                patience=mlx_patience,
+                                duration_reward=mlx_duration_reward,
+                                sentence_max_words=mlx_sentence_max_words,
+                                sentence_silence_gap=mlx_sentence_silence_gap,
+                                sentence_max_duration=mlx_sentence_max_duration,
                             )
                         else:
-                            text = transcribe_with_parakeet_mlx(
+                            mlx_result = transcribe_with_parakeet_mlx(
                                 audio_file_path,
                                 chunk_duration=chunk_duration,
                                 overlap_duration=overlap_duration,
+                                return_structured=True,
+                                model_path=mlx_model_id,
+                                cache_dir=mlx_cache_dir,
+                                decoding_mode=mlx_decoding_mode,
+                                beam_size=mlx_beam_size,
+                                length_penalty=mlx_length_penalty,
+                                patience=mlx_patience,
+                                duration_reward=mlx_duration_reward,
+                                sentence_max_words=mlx_sentence_max_words,
+                                sentence_silence_gap=mlx_sentence_silence_gap,
+                                sentence_max_duration=mlx_sentence_max_duration,
                             )
 
-                    if _looks_like_error_text(text):
-                        raise RuntimeError(text)
+                    if isinstance(mlx_result, str) and _looks_like_error_text(mlx_result):
+                        raise RuntimeError(mlx_result)
 
-                    # Default to sentence-level segmentation
-                    return create_segments_from_text(text, audio_duration, segmentation="sentence")
+                    return create_segments_from_parakeet_mlx_artifact(mlx_result, audio_duration)
 
             except ImportError as e:
                 logging.warning(f"Could not import Parakeet MLX: {e}. Falling back to standard.")
@@ -2862,6 +2998,10 @@ def speech_to_text_qwen2audio(
             label="Audio input path",
         )
         audio_file_path = str(audio_path)
+
+        # Validate provider availability/config before decoding audio so
+        # disabled Qwen routes can fall back cleanly without decode errors.
+        load_qwen2audio()
 
         # Load audio data
         import librosa

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_MLX.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_MLX.py
@@ -16,11 +16,13 @@
 ####################
 
 import importlib.util
+import inspect
 import logging
 import os
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
@@ -32,6 +34,181 @@ IS_MACOS = sys.platform == 'darwin'
 
 # Global model cache
 _mlx_model_cache: Optional[Any] = None
+_DEFAULT_MLX_MODEL_ID = "mlx-community/parakeet-tdt-0.6b-v3"
+
+
+def _safe_float(value: Any, default: Optional[float] = None) -> Optional[float]:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _supports_kwarg(callable_obj: Any, kwarg_name: str) -> bool:
+    try:
+        return kwarg_name in inspect.signature(callable_obj).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _token_to_dict(token: Any) -> dict[str, Any]:
+    start = _safe_float(getattr(token, "start", None), 0.0) or 0.0
+    duration = _safe_float(getattr(token, "duration", None), None)
+    end_from_attr = _safe_float(getattr(token, "end", None), None)
+    end = end_from_attr if end_from_attr is not None else (start + (duration or 0.0))
+    if duration is None:
+        duration = max(end - start, 0.0)
+    return {
+        "id": getattr(token, "id", None),
+        "text": str(getattr(token, "text", "") or ""),
+        "start": float(start),
+        "end": float(end),
+        "duration": float(duration),
+        "confidence": float(_safe_float(getattr(token, "confidence", None), 1.0) or 1.0),
+    }
+
+
+def _sentence_to_dict(sentence: Any) -> dict[str, Any]:
+    tokens_raw = getattr(sentence, "tokens", None)
+    token_dicts: list[dict[str, Any]] = []
+    if isinstance(tokens_raw, list):
+        token_dicts = [_token_to_dict(token) for token in tokens_raw]
+
+    start = _safe_float(getattr(sentence, "start", None), None)
+    end = _safe_float(getattr(sentence, "end", None), None)
+    duration = _safe_float(getattr(sentence, "duration", None), None)
+    if start is None and token_dicts:
+        start = token_dicts[0]["start"]
+    if end is None and token_dicts:
+        end = token_dicts[-1]["end"]
+    if start is None:
+        start = 0.0
+    if end is None:
+        end = start
+    if duration is None:
+        duration = max(end - start, 0.0)
+
+    return {
+        "text": str(getattr(sentence, "text", "") or ""),
+        "start": float(start),
+        "end": float(end),
+        "duration": float(duration),
+        "confidence": float(_safe_float(getattr(sentence, "confidence", None), 1.0) or 1.0),
+        "tokens": token_dicts,
+    }
+
+
+def _as_structured_artifact(result: Any) -> dict[str, Any]:
+    if isinstance(result, dict):
+        text = str(result.get("text", "") or "")
+        raw_sentences = result.get("sentences") if isinstance(result.get("sentences"), list) else []
+        raw_tokens = result.get("tokens") if isinstance(result.get("tokens"), list) else []
+        sentences = [dict(sentence) for sentence in raw_sentences if isinstance(sentence, dict)]
+        tokens = [dict(token) for token in raw_tokens if isinstance(token, dict)]
+        if not tokens and sentences:
+            for sentence in sentences:
+                words = sentence.get("tokens")
+                if isinstance(words, list):
+                    for token in words:
+                        if isinstance(token, dict):
+                            tokens.append(dict(token))
+        return {
+            "text": text,
+            "sentences": sentences,
+            "tokens": tokens,
+        }
+
+    text = str(getattr(result, "text", result) or "")
+    sentences_raw = getattr(result, "sentences", None)
+    sentences: list[dict[str, Any]] = []
+    if isinstance(sentences_raw, list):
+        sentences = [_sentence_to_dict(sentence) for sentence in sentences_raw]
+
+    tokens_raw = getattr(result, "tokens", None)
+    tokens: list[dict[str, Any]] = []
+    if isinstance(tokens_raw, list):
+        tokens = [_token_to_dict(token) for token in tokens_raw]
+    elif sentences:
+        for sentence in sentences:
+            for token in sentence.get("tokens", []):
+                tokens.append(token)
+
+    return {
+        "text": text,
+        "sentences": sentences,
+        "tokens": tokens,
+    }
+
+
+def _build_decoding_config(
+    *,
+    decoding_mode: Optional[str] = None,
+    beam_size: Optional[int] = None,
+    length_penalty: Optional[float] = None,
+    patience: Optional[float] = None,
+    duration_reward: Optional[float] = None,
+    sentence_max_words: Optional[int] = None,
+    sentence_silence_gap: Optional[float] = None,
+    sentence_max_duration: Optional[float] = None,
+) -> Optional[Any]:
+    has_sentence_overrides = any(
+        value is not None
+        for value in (sentence_max_words, sentence_silence_gap, sentence_max_duration)
+    )
+    mode = str(decoding_mode or "").strip().lower()
+    has_beam_overrides = mode == "beam" or any(
+        value is not None for value in (beam_size, length_penalty, patience, duration_reward)
+    )
+    if not has_sentence_overrides and not has_beam_overrides and mode != "greedy":
+        return None
+
+    try:
+        import parakeet_mlx
+    except Exception as exc:
+        logging.debug(f"Unable to import parakeet_mlx for decoding config construction: {exc}")
+        return None
+
+    SentenceConfig = getattr(parakeet_mlx, "SentenceConfig", None)
+    DecodingConfig = getattr(parakeet_mlx, "DecodingConfig", None)
+    Greedy = getattr(parakeet_mlx, "Greedy", None)
+    Beam = getattr(parakeet_mlx, "Beam", None)
+    if SentenceConfig is None or DecodingConfig is None or Greedy is None or Beam is None:
+        logging.debug("parakeet_mlx decoding classes unavailable; skipping decoding config")
+        return None
+
+    sentence_obj = SentenceConfig()
+    if sentence_max_words is not None:
+        sentence_obj.max_words = int(sentence_max_words)
+    if sentence_silence_gap is not None:
+        sentence_obj.silence_gap = float(sentence_silence_gap)
+    if sentence_max_duration is not None:
+        sentence_obj.max_duration = float(sentence_max_duration)
+
+    if mode == "beam" or has_beam_overrides:
+        beam_kwargs: dict[str, Any] = {}
+        if beam_size is not None:
+            beam_kwargs["beam_size"] = int(beam_size)
+        if length_penalty is not None:
+            beam_kwargs["length_penalty"] = float(length_penalty)
+        if patience is not None:
+            beam_kwargs["patience"] = float(patience)
+        if duration_reward is not None:
+            beam_kwargs["duration_reward"] = float(duration_reward)
+        decode_obj = Beam(**beam_kwargs) if beam_kwargs else Beam()
+    else:
+        decode_obj = Greedy()
+    return DecodingConfig(decoding=decode_obj, sentence=sentence_obj)
 
 #######################################################################################################################
 # Installation and Setup
@@ -115,7 +292,11 @@ def install_parakeet_mlx() -> bool:
 # Model Loading and Management
 #
 
-def load_parakeet_mlx_model(force_reload: bool = False, model_path: Optional[str] = None):
+def load_parakeet_mlx_model(
+    force_reload: bool = False,
+    model_path: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+):
     """
     Load the Parakeet MLX model.
 
@@ -140,15 +321,23 @@ def load_parakeet_mlx_model(force_reload: bool = False, model_path: Optional[str
         logging.error("MLX is not available. Install with: pip install mlx")
         return None
 
-    # Check/install parakeet-mlx
+    # Check parakeet-mlx
     if not check_parakeet_mlx_installed():
-        logging.info("parakeet-mlx not found, attempting to install...")
-        if not install_parakeet_mlx():
-            logging.error("Failed to install parakeet-mlx")
-            return None
+        logging.error(
+            "parakeet-mlx is not installed. Install during setup/deploy (runtime auto-install is disabled)."
+        )
+        return None
 
     try:
         import parakeet_mlx
+        stt_cfg: dict[str, Any] = {}
+        try:
+            from tldw_Server_API.app.core.config import get_stt_config
+
+            stt_cfg = get_stt_config() or {}
+        except Exception:
+            stt_cfg = {}
+
         # dtype is optional for tests; if mlx is unavailable, proceed without dtype
         try:
             import mlx.core as mx
@@ -161,25 +350,29 @@ def load_parakeet_mlx_model(force_reload: bool = False, model_path: Optional[str
         # Initialize the model
         # The parakeet-mlx library handles model downloading and caching
         # Try to load from Hugging Face model ID
-        # Default model from the parakeet-mlx CLI
-        model_id = model_path or "mlx-community/parakeet-tdt-0.6b-v2"
+        # Default model from the parakeet-mlx CLI (v3)
+        model_id = (
+            model_path
+            or str(stt_cfg.get("mlx_model_id", "")).strip()
+            or _DEFAULT_MLX_MODEL_ID
+        )
+        model_cache_dir = cache_dir or str(stt_cfg.get("mlx_cache_dir", "")).strip() or None
+        from_pretrained_kwargs: dict[str, Any] = {}
+        if _dtype is not None and _supports_kwarg(parakeet_mlx.from_pretrained, "dtype"):
+            from_pretrained_kwargs["dtype"] = _dtype
+        if model_cache_dir and _supports_kwarg(parakeet_mlx.from_pretrained, "cache_dir"):
+            from_pretrained_kwargs["cache_dir"] = model_cache_dir
 
         try:
             # Try to load the model from Hugging Face
             logging.info(f"Loading model from: {model_id}")
-            if _dtype is not None:
-                model = parakeet_mlx.from_pretrained(model_id, dtype=_dtype)
-            else:
-                model = parakeet_mlx.from_pretrained(model_id)
+            model = parakeet_mlx.from_pretrained(model_id, **from_pretrained_kwargs)
         except FileNotFoundError:
             # Model might need to be downloaded first
             logging.info("Model not found locally, downloading from Hugging Face...")
             try:
                 # The model will be downloaded automatically
-                if _dtype is not None:
-                    model = parakeet_mlx.from_pretrained(model_id, dtype=_dtype)
-                else:
-                    model = parakeet_mlx.from_pretrained(model_id)
+                model = parakeet_mlx.from_pretrained(model_id, **from_pretrained_kwargs)
             except Exception as e2:
                 logging.exception(f"Failed to download/load model: {e2}")
                 return None
@@ -213,8 +406,20 @@ def transcribe_with_parakeet_mlx(
     verbose: bool = False,
     chunk_duration: Optional[float] = None,
     overlap_duration: float = 15.0,
-    chunk_callback: Optional[Callable[[int, int], None]] = None
-) -> str:
+    chunk_callback: Optional[Callable[[int, int], None]] = None,
+    *,
+    return_structured: bool = False,
+    model_path: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    decoding_mode: Optional[str] = None,
+    beam_size: Optional[int] = None,
+    length_penalty: Optional[float] = None,
+    patience: Optional[float] = None,
+    duration_reward: Optional[float] = None,
+    sentence_max_words: Optional[int] = None,
+    sentence_silence_gap: Optional[float] = None,
+    sentence_max_duration: Optional[float] = None,
+) -> Union[str, dict[str, Any]]:
     """
     Transcribe audio using Parakeet MLX model.
 
@@ -231,8 +436,9 @@ def transcribe_with_parakeet_mlx(
     Returns:
         Transcribed text string
     """
+    _ = (language, batch_size)
     # Attempt to load the model first (tests may monkeypatch loader)
-    model = load_parakeet_mlx_model()
+    model = load_parakeet_mlx_model(model_path=model_path, cache_dir=cache_dir)
     if model is None:
         # Preserve the original platform check semantics only when loading fails
         if not IS_MACOS:
@@ -240,37 +446,16 @@ def transcribe_with_parakeet_mlx(
         return "[Error: Failed to load Parakeet MLX model]"
 
     try:
-        import soundfile as sf
-
         # Handle different input types
-        audio_file_path = None
+        audio_file_path: Optional[str] = None
+        audio_np: Optional[np.ndarray] = None
 
         if isinstance(audio_data, (str, Path)):
             # Already a file path
             audio_path = Path(audio_data)
             if not audio_path.exists():
                 return f"[Error: Audio file not found: {audio_path}]"
-
-            # Check if we need to resample
-            audio_np, file_sr = sf.read(str(audio_path))
-
-            # Convert to mono if stereo
-            if len(audio_np.shape) > 1:
-                audio_np = np.mean(audio_np, axis=1)
-
-            # Only create new file if resampling is needed
-            if file_sr != 16000:
-                import librosa
-                audio_np = librosa.resample(
-                    audio_np,
-                    orig_sr=file_sr,
-                    target_sr=16000
-                )
-                audio_data = audio_np  # Will be saved to temp file later
-            else:
-                # Can use the original file directly
-                audio_file_path = str(audio_path)
-                audio_data = None  # Clear audio_data to avoid processing it later
+            audio_file_path = str(audio_path)
 
         elif isinstance(audio_data, np.ndarray):
             # Ensure float32
@@ -284,41 +469,90 @@ def transcribe_with_parakeet_mlx(
             # Resample if needed
             if sample_rate != 16000:
                 import librosa
+
                 audio_data = librosa.resample(
-                    audio_data,
+                    audio_data,  # type: ignore[arg-type]
                     orig_sr=sample_rate,
                     target_sr=16000
                 )
+            audio_np = np.asarray(audio_data, dtype=np.float32)
         else:
             return "[Error: Invalid audio data type]"
 
         # Normalize audio to [-1, 1] range (only if we have numpy array)
-        if isinstance(audio_data, np.ndarray) and np.abs(audio_data).max() > 1.0:
-            audio_data = audio_data / np.abs(audio_data).max()
+        if isinstance(audio_np, np.ndarray) and audio_np.size > 0 and np.abs(audio_np).max() > 1.0:
+            audio_np = audio_np / np.abs(audio_np).max()
 
         # Transcribe using parakeet-mlx
         if verbose:
-            if isinstance(audio_data, np.ndarray):
-                logging.info(f"Transcribing audio of length {len(audio_data)/16000:.2f} seconds")
+            if isinstance(audio_np, np.ndarray):
+                logging.info(f"Transcribing audio of length {len(audio_np)/16000:.2f} seconds")
             else:
                 logging.info("Transcribing audio file")
 
-        transcribe_kwargs = {}
+        try:
+            from tldw_Server_API.app.core.config import get_stt_config
+
+            stt_cfg = get_stt_config() or {}
+        except Exception:
+            stt_cfg = {}
+
+        transcribe_kwargs: dict[str, Any] = {}
         if chunk_duration is not None:
             transcribe_kwargs['chunk_duration'] = chunk_duration
             transcribe_kwargs['overlap_duration'] = overlap_duration
         if chunk_callback is not None:
             transcribe_kwargs['chunk_callback'] = chunk_callback
 
+        decoding_mode = decoding_mode or str(stt_cfg.get("mlx_decoding_mode", "")).strip() or None
+        beam_size = beam_size if beam_size is not None else _safe_int(stt_cfg.get("mlx_beam_size"))
+        length_penalty = (
+            length_penalty if length_penalty is not None else _safe_float(stt_cfg.get("mlx_length_penalty"))
+        )
+        patience = patience if patience is not None else _safe_float(stt_cfg.get("mlx_patience"))
+        duration_reward = (
+            duration_reward if duration_reward is not None else _safe_float(stt_cfg.get("mlx_duration_reward"))
+        )
+        sentence_max_words = (
+            sentence_max_words
+            if sentence_max_words is not None
+            else _safe_int(stt_cfg.get("mlx_sentence_max_words"))
+        )
+        sentence_silence_gap = (
+            sentence_silence_gap
+            if sentence_silence_gap is not None
+            else _safe_float(stt_cfg.get("mlx_sentence_silence_gap"))
+        )
+        sentence_max_duration = (
+            sentence_max_duration
+            if sentence_max_duration is not None
+            else _safe_float(stt_cfg.get("mlx_sentence_max_duration"))
+        )
+
+        decoding_config = _build_decoding_config(
+            decoding_mode=decoding_mode,
+            beam_size=beam_size,
+            length_penalty=length_penalty,
+            patience=patience,
+            duration_reward=duration_reward,
+            sentence_max_words=sentence_max_words,
+            sentence_silence_gap=sentence_silence_gap,
+            sentence_max_duration=sentence_max_duration,
+        )
+        if decoding_config is not None and _supports_kwarg(model.transcribe, "decoding_config"):
+            transcribe_kwargs["decoding_config"] = decoding_config
+
         temp_audio_path: Optional[str] = None
         try:
             if audio_file_path:
                 result = model.transcribe(audio_file_path, **transcribe_kwargs)
-            elif isinstance(audio_data, np.ndarray):
+            elif isinstance(audio_np, np.ndarray):
+                import soundfile as sf
+
                 # Persist numpy audio to a temp file so downstream callers (and tests)
                 # receive a filesystem path consistently.
                 with tempfile.NamedTemporaryFile(suffix='.wav', delete=False) as tmp_file:
-                    sf.write(tmp_file.name, audio_data, 16000, format='WAV')
+                    sf.write(tmp_file.name, audio_np, 16000, format='WAV')
                     temp_audio_path = tmp_file.name
                 result = model.transcribe(temp_audio_path, **transcribe_kwargs)
             else:
@@ -330,20 +564,14 @@ def transcribe_with_parakeet_mlx(
                 except Exception as rm_err:
                     logging.debug(f"Failed to remove temp audio file (Parakeet_MLX): path={temp_audio_path}, error={rm_err}")
 
-        # The transcribe method returns an AlignedResult object
-        # Extract the text from it
-        transcription = result.text if hasattr(result, 'text') else result
-
-        if isinstance(transcription, dict):
-            # Handle structured output
-            text = transcription.get('text', '')
-        else:
-            # Direct text output
-            text = str(transcription)
+        artifact = _as_structured_artifact(result)
+        text = artifact["text"]
 
         if verbose:
             logging.info(f"Transcription complete: {text[:100]}...")
 
+        if return_structured:
+            return artifact
         return text
 
     except ImportError as e:
@@ -354,6 +582,97 @@ def transcribe_with_parakeet_mlx(
         logging.exception(f"Error during Parakeet MLX transcription: {e}")
         logging.exception(f"Traceback: {traceback.format_exc()}")
         return f"[Error: Transcription failed: {str(e)}]"
+
+
+@dataclass
+class ParakeetMLXStreamingSession:
+    """Thin wrapper around parakeet-mlx StreamingParakeet."""
+
+    model: Any
+    streamer: Any
+    _closed: bool = False
+
+    def add_audio(self, audio_np: np.ndarray, sample_rate: int = 16000) -> dict[str, Any]:
+        if self._closed:
+            return {"text": "", "sentences": [], "tokens": []}
+        if not isinstance(audio_np, np.ndarray):
+            return {"text": "", "sentences": [], "tokens": []}
+        if audio_np.dtype != np.float32:
+            audio_np = audio_np.astype(np.float32)
+        if audio_np.ndim > 1:
+            audio_np = np.mean(audio_np, axis=1).astype(np.float32)
+        if sample_rate != 16000:
+            import librosa
+
+            audio_np = librosa.resample(audio_np, orig_sr=sample_rate, target_sr=16000)
+        if audio_np.size == 0:
+            return {"text": "", "sentences": [], "tokens": []}
+
+        import mlx.core as mx
+
+        self.streamer.add_audio(mx.array(audio_np, dtype=mx.float32))
+        return _as_structured_artifact(self.streamer.result)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self.streamer.__exit__(None, None, None)
+        except Exception as exc:
+            logging.debug(f"Parakeet MLX streaming session close warning: {exc}")
+
+
+def create_parakeet_mlx_streaming_session(
+    *,
+    model_path: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    context_size: tuple[int, int] = (256, 256),
+    depth: int = 1,
+    keep_original_attention: bool = False,
+    decoding_mode: Optional[str] = None,
+    beam_size: Optional[int] = None,
+    length_penalty: Optional[float] = None,
+    patience: Optional[float] = None,
+    duration_reward: Optional[float] = None,
+    sentence_max_words: Optional[int] = None,
+    sentence_silence_gap: Optional[float] = None,
+    sentence_max_duration: Optional[float] = None,
+) -> Optional[ParakeetMLXStreamingSession]:
+    model = load_parakeet_mlx_model(model_path=model_path, cache_dir=cache_dir)
+    if model is None:
+        return None
+    if not hasattr(model, "transcribe_stream"):
+        logging.warning("Loaded Parakeet MLX model does not expose transcribe_stream; streaming session unavailable")
+        return None
+
+    try:
+        decoding_config = _build_decoding_config(
+            decoding_mode=decoding_mode,
+            beam_size=beam_size,
+            length_penalty=length_penalty,
+            patience=patience,
+            duration_reward=duration_reward,
+            sentence_max_words=sentence_max_words,
+            sentence_silence_gap=sentence_silence_gap,
+            sentence_max_duration=sentence_max_duration,
+        )
+        stream_kwargs: dict[str, Any] = {
+            "context_size": context_size,
+            "depth": depth,
+        }
+        if decoding_config is not None and _supports_kwarg(model.transcribe_stream, "decoding_config"):
+            stream_kwargs["decoding_config"] = decoding_config
+        if _supports_kwarg(model.transcribe_stream, "keep_original_attention"):
+            stream_kwargs["keep_original_attention"] = keep_original_attention
+
+        streamer = model.transcribe_stream(**stream_kwargs)
+        if hasattr(streamer, "__enter__"):
+            streamer = streamer.__enter__()
+        return ParakeetMLXStreamingSession(model=model, streamer=streamer)
+    except Exception as exc:
+        logging.warning(f"Failed to create Parakeet MLX streaming session: {exc}")
+        return None
 
 
 def transcribe_streaming_mlx(
@@ -378,10 +697,12 @@ def transcribe_streaming_mlx(
         yield "[Error: Parakeet MLX is only supported on macOS]"
         return
 
-    model = load_parakeet_mlx_model()
-    if model is None:
-        yield "[Error: Failed to load model]"
-        return
+    session = create_parakeet_mlx_streaming_session()
+    if session is None:
+        model = load_parakeet_mlx_model()
+        if model is None:
+            yield "[Error: Failed to load model]"
+            return
 
     buffer = np.array([], dtype=np.float32)
     overlap_size = int(chunk_size * overlap)
@@ -397,11 +718,15 @@ def transcribe_streaming_mlx(
                 chunk = buffer[:chunk_size]
 
                 # Transcribe chunk
-                text = transcribe_with_parakeet_mlx(
-                    chunk,
-                    sample_rate=16000,
-                    verbose=verbose
-                )
+                if session is not None:
+                    artifact = session.add_audio(chunk, sample_rate=16000)
+                    text = artifact.get("text", "")
+                else:
+                    text = transcribe_with_parakeet_mlx(
+                        chunk,
+                        sample_rate=16000,
+                        verbose=verbose
+                    )
 
                 if text and not text.startswith("[Error"):
                     yield text
@@ -411,17 +736,24 @@ def transcribe_streaming_mlx(
 
         # Process remaining buffer
         if len(buffer) > 0:
-            text = transcribe_with_parakeet_mlx(
-                buffer,
-                sample_rate=16000,
-                verbose=verbose
-            )
+            if session is not None:
+                artifact = session.add_audio(buffer, sample_rate=16000)
+                text = artifact.get("text", "")
+            else:
+                text = transcribe_with_parakeet_mlx(
+                    buffer,
+                    sample_rate=16000,
+                    verbose=verbose
+                )
             if text and not text.startswith("[Error"):
                 yield text
 
     except Exception as e:
         logging.exception(f"Error in streaming transcription: {e}")
         yield f"[Error: {str(e)}]"
+    finally:
+        if session is not None:
+            session.close()
 
 
 def unload_parakeet_mlx_model():

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_MLX.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Transcription_Parakeet_MLX.py
@@ -17,7 +17,6 @@
 
 import importlib.util
 import inspect
-import logging
 import os
 import subprocess
 import sys
@@ -38,6 +37,7 @@ _DEFAULT_MLX_MODEL_ID = "mlx-community/parakeet-tdt-0.6b-v3"
 
 
 def _safe_float(value: Any, default: Optional[float] = None) -> Optional[float]:
+    """Safely coerce a value to ``float`` and return ``default`` on failure."""
     if value is None:
         return default
     try:
@@ -47,6 +47,7 @@ def _safe_float(value: Any, default: Optional[float] = None) -> Optional[float]:
 
 
 def _safe_int(value: Any, default: Optional[int] = None) -> Optional[int]:
+    """Safely coerce a value to ``int`` and return ``default`` on failure."""
     if value is None:
         return default
     try:
@@ -56,6 +57,7 @@ def _safe_int(value: Any, default: Optional[int] = None) -> Optional[int]:
 
 
 def _supports_kwarg(callable_obj: Any, kwarg_name: str) -> bool:
+    """Return ``True`` when a callable accepts a keyword argument."""
     try:
         return kwarg_name in inspect.signature(callable_obj).parameters
     except (TypeError, ValueError):
@@ -63,6 +65,7 @@ def _supports_kwarg(callable_obj: Any, kwarg_name: str) -> bool:
 
 
 def _token_to_dict(token: Any) -> dict[str, Any]:
+    """Normalize a Parakeet token object to the server token schema."""
     start = _safe_float(getattr(token, "start", None), 0.0) or 0.0
     duration = _safe_float(getattr(token, "duration", None), None)
     end_from_attr = _safe_float(getattr(token, "end", None), None)
@@ -80,6 +83,7 @@ def _token_to_dict(token: Any) -> dict[str, Any]:
 
 
 def _sentence_to_dict(sentence: Any) -> dict[str, Any]:
+    """Normalize a Parakeet sentence object to a serializable sentence dictionary."""
     tokens_raw = getattr(sentence, "tokens", None)
     token_dicts: list[dict[str, Any]] = []
     if isinstance(tokens_raw, list):
@@ -110,6 +114,7 @@ def _sentence_to_dict(sentence: Any) -> dict[str, Any]:
 
 
 def _as_structured_artifact(result: Any) -> dict[str, Any]:
+    """Convert MLX transcription output into a normalized structured artifact."""
     if isinstance(result, dict):
         text = str(result.get("text", "") or "")
         raw_sentences = result.get("sentences") if isinstance(result.get("sentences"), list) else []
@@ -162,6 +167,7 @@ def _build_decoding_config(
     sentence_silence_gap: Optional[float] = None,
     sentence_max_duration: Optional[float] = None,
 ) -> Optional[Any]:
+    """Build an optional ``parakeet_mlx.DecodingConfig`` from user/config overrides."""
     has_sentence_overrides = any(
         value is not None
         for value in (sentence_max_words, sentence_silence_gap, sentence_max_duration)
@@ -176,7 +182,7 @@ def _build_decoding_config(
     try:
         import parakeet_mlx
     except Exception as exc:
-        logging.debug(f"Unable to import parakeet_mlx for decoding config construction: {exc}")
+        logger.debug("Unable to import parakeet_mlx for decoding config construction: {}", exc)
         return None
 
     SentenceConfig = getattr(parakeet_mlx, "SentenceConfig", None)
@@ -184,7 +190,7 @@ def _build_decoding_config(
     Greedy = getattr(parakeet_mlx, "Greedy", None)
     Beam = getattr(parakeet_mlx, "Beam", None)
     if SentenceConfig is None or DecodingConfig is None or Greedy is None or Beam is None:
-        logging.debug("parakeet_mlx decoding classes unavailable; skipping decoding config")
+        logger.debug("parakeet_mlx decoding classes unavailable; skipping decoding config")
         return None
 
     sentence_obj = SentenceConfig()
@@ -293,6 +299,7 @@ def install_parakeet_mlx() -> bool:
 #
 
 def load_parakeet_mlx_model(
+    *,
     force_reload: bool = False,
     model_path: Optional[str] = None,
     cache_dir: Optional[str] = None,
@@ -318,12 +325,12 @@ def load_parakeet_mlx_model(
 
     # Check MLX availability (tests may monkeypatch this to True)
     if not check_mlx_available():
-        logging.error("MLX is not available. Install with: pip install mlx")
+        logger.error("MLX is not available. Install with: pip install mlx")
         return None
 
     # Check parakeet-mlx
     if not check_parakeet_mlx_installed():
-        logging.error(
+        logger.error(
             "parakeet-mlx is not installed. Install during setup/deploy (runtime auto-install is disabled)."
         )
         return None
@@ -345,7 +352,7 @@ def load_parakeet_mlx_model(
         except Exception:
             _dtype = None
 
-        logging.info("Loading Parakeet MLX model...")
+        logger.info("Loading Parakeet MLX model...")
 
         # Initialize the model
         # The parakeet-mlx library handles model downloading and caching
@@ -365,32 +372,32 @@ def load_parakeet_mlx_model(
 
         try:
             # Try to load the model from Hugging Face
-            logging.info(f"Loading model from: {model_id}")
+            logger.info(f"Loading model from: {model_id}")
             model = parakeet_mlx.from_pretrained(model_id, **from_pretrained_kwargs)
         except FileNotFoundError:
             # Model might need to be downloaded first
-            logging.info("Model not found locally, downloading from Hugging Face...")
+            logger.info("Model not found locally, downloading from Hugging Face...")
             try:
                 # The model will be downloaded automatically
                 model = parakeet_mlx.from_pretrained(model_id, **from_pretrained_kwargs)
             except Exception as e2:
-                logging.exception(f"Failed to download/load model: {e2}")
+                logger.exception(f"Failed to download/load model: {e2}")
                 return None
         except Exception as e:
-            logging.exception(f"Failed to load model {model_id}: {e}")
+            logger.exception(f"Failed to load model {model_id}: {e}")
             return None
 
         _mlx_model_cache = model
-        logging.info("Successfully loaded Parakeet MLX model")
+        logger.info("Successfully loaded Parakeet MLX model")
 
         return model
 
     except ImportError as e:
-        logging.exception(f"Failed to import parakeet: {e}")
-        logging.info("Try installing manually: pip install git+https://github.com/senstella/parakeet-mlx.git")
+        logger.exception(f"Failed to import parakeet: {e}")
+        logger.info("Try installing manually: pip install git+https://github.com/senstella/parakeet-mlx.git")
         return None
     except Exception as e:
-        logging.exception(f"Failed to load Parakeet MLX model: {e}")
+        logger.exception(f"Failed to load Parakeet MLX model: {e}")
         return None
 
 
@@ -486,9 +493,9 @@ def transcribe_with_parakeet_mlx(
         # Transcribe using parakeet-mlx
         if verbose:
             if isinstance(audio_np, np.ndarray):
-                logging.info(f"Transcribing audio of length {len(audio_np)/16000:.2f} seconds")
+                logger.info(f"Transcribing audio of length {len(audio_np)/16000:.2f} seconds")
             else:
-                logging.info("Transcribing audio file")
+                logger.info("Transcribing audio file")
 
         try:
             from tldw_Server_API.app.core.config import get_stt_config
@@ -562,25 +569,25 @@ def transcribe_with_parakeet_mlx(
                 try:
                     os.remove(temp_audio_path)
                 except Exception as rm_err:
-                    logging.debug(f"Failed to remove temp audio file (Parakeet_MLX): path={temp_audio_path}, error={rm_err}")
+                    logger.debug(f"Failed to remove temp audio file (Parakeet_MLX): path={temp_audio_path}, error={rm_err}")
 
         artifact = _as_structured_artifact(result)
         text = artifact["text"]
 
         if verbose:
-            logging.info(f"Transcription complete: {text[:100]}...")
+            logger.info(f"Transcription complete: {text[:100]}...")
 
         if return_structured:
             return artifact
         return text
 
     except ImportError as e:
-        logging.exception(f"Missing required library: {e}")
+        logger.exception(f"Missing required library: {e}")
         return f"[Error: Missing required library: {e}]"
     except Exception as e:
         import traceback
-        logging.exception(f"Error during Parakeet MLX transcription: {e}")
-        logging.exception(f"Traceback: {traceback.format_exc()}")
+        logger.exception(f"Error during Parakeet MLX transcription: {e}")
+        logger.exception(f"Traceback: {traceback.format_exc()}")
         return f"[Error: Transcription failed: {str(e)}]"
 
 
@@ -620,7 +627,7 @@ class ParakeetMLXStreamingSession:
         try:
             self.streamer.__exit__(None, None, None)
         except Exception as exc:
-            logging.debug(f"Parakeet MLX streaming session close warning: {exc}")
+            logger.debug(f"Parakeet MLX streaming session close warning: {exc}")
 
 
 def create_parakeet_mlx_streaming_session(
@@ -643,7 +650,7 @@ def create_parakeet_mlx_streaming_session(
     if model is None:
         return None
     if not hasattr(model, "transcribe_stream"):
-        logging.warning("Loaded Parakeet MLX model does not expose transcribe_stream; streaming session unavailable")
+        logger.warning("Loaded Parakeet MLX model does not expose transcribe_stream; streaming session unavailable")
         return None
 
     try:
@@ -671,7 +678,7 @@ def create_parakeet_mlx_streaming_session(
             streamer = streamer.__enter__()
         return ParakeetMLXStreamingSession(model=model, streamer=streamer)
     except Exception as exc:
-        logging.warning(f"Failed to create Parakeet MLX streaming session: {exc}")
+        logger.warning(f"Failed to create Parakeet MLX streaming session: {exc}")
         return None
 
 
@@ -749,7 +756,7 @@ def transcribe_streaming_mlx(
                 yield text
 
     except Exception as e:
-        logging.exception(f"Error in streaming transcription: {e}")
+        logger.exception(f"Error in streaming transcription: {e}")
         yield f"[Error: {str(e)}]"
     finally:
         if session is not None:
@@ -771,15 +778,15 @@ def unload_parakeet_mlx_model():
                 import mlx.core as mx
                 mx.metal.clear_cache()
             except Exception as cache_err:
-                logging.debug(f"Failed to clear MLX cache: error={cache_err}")
+                logger.debug(f"Failed to clear MLX cache: error={cache_err}")
 
             # Force garbage collection
             import gc
             gc.collect()
 
-            logging.info("Unloaded Parakeet MLX model from memory")
+            logger.info("Unloaded Parakeet MLX model from memory")
         except Exception as e:
-            logging.exception(f"Error unloading model: {e}")
+            logger.exception(f"Error unloading model: {e}")
 
 
 #######################################################################################################################
@@ -813,7 +820,7 @@ def get_mlx_device_info() -> dict[str, Any]:
     except ImportError:
         pass
     except Exception as e:
-        logging.debug(f"Error getting MLX device info: {e}")
+        logger.debug(f"Error getting MLX device info: {e}")
 
     return info
 
@@ -892,11 +899,11 @@ def integrate_with_nemo_module():
         # Patch the function
         Audio_Transcription_Nemo._load_parakeet_mlx = _load_parakeet_mlx_patched
 
-        logging.info("Successfully integrated Parakeet MLX with main Nemo module")
+        logger.info("Successfully integrated Parakeet MLX with main Nemo module")
         return True
 
     except Exception as e:
-        logging.exception(f"Failed to integrate with Nemo module: {e}")
+        logger.exception(f"Failed to integrate with Nemo module: {e}")
         return False
 
 
@@ -905,8 +912,6 @@ def integrate_with_nemo_module():
 #
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-
     print("Parakeet MLX Module Information:")
     print("-" * 40)
 

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/transcriber.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/transcriber.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import binascii
+import contextlib
 import time
 from dataclasses import dataclass
 from typing import Any, Callable
@@ -84,12 +85,33 @@ def _variant_decode_fn(model: str, variant: str) -> DecodeFn | None:
         try:
             from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX import (
                 create_parakeet_mlx_streaming_session as _create_mlx_stream,
+            )
+            from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX import (
                 transcribe_with_parakeet_mlx as _tx_mlx,
             )
 
-            session = _create_mlx_stream()
+            session = None
+            try:
+                session = _create_mlx_stream()
+            except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS as session_err:
+                logger.debug("MLX streaming session unavailable; using stateless fallback decode: {}", session_err)
             last_audio = np.array([], dtype=np.float32)
             last_text = ""
+
+            def _close_session() -> None:
+                nonlocal session, last_audio, last_text
+                if session is not None:
+                    with contextlib.suppress(_PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS):
+                        session.close()
+                session = None
+                last_audio = np.array([], dtype=np.float32)
+                last_text = ""
+
+            def _reset_session() -> None:
+                nonlocal session
+                _close_session()
+                with contextlib.suppress(_PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS):
+                    session = _create_mlx_stream()
 
             def _fn(audio_np: np.ndarray, sr: int) -> str:
                 """
@@ -119,11 +141,7 @@ def _variant_decode_fn(model: str, variant: str) -> DecodeFn | None:
                 else:
                     # Audio buffer was rewound/trimmed (final chunk consume path).
                     # Reset session and continue from current window.
-                    try:
-                        session.close()
-                    except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS:
-                        pass
-                    session = _create_mlx_stream()
+                    _reset_session()
                     if session is None:
                         return _tx_mlx(audio_arr, sample_rate=sr)
                     delta = audio_arr
@@ -136,6 +154,8 @@ def _variant_decode_fn(model: str, variant: str) -> DecodeFn | None:
                 last_text = str((artifact or {}).get("text", "")).strip()
                 return last_text
 
+            _fn.close = _close_session
+            _fn.reset_session = _reset_session
             return _fn
         except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS as e:
             logger.debug("Failed to import MLX backend: {}", e)
@@ -197,6 +217,22 @@ class ParakeetCoreTranscriber:
         self._last_partial_time = 0.0
         self._total_processed_seconds = 0.0
         self._segment_index = 0
+        reset_hook = getattr(self.decode_fn, "reset_session", None)
+        if callable(reset_hook):
+            with contextlib.suppress(_PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS):
+                reset_hook()
+
+    def close(self) -> None:
+        """
+        Release decoder-associated resources, if the active decode function exposes a close hook.
+
+        This is primarily used by long-lived streaming backends (for example MLX)
+        that hold session-level resources beyond a single decode call.
+        """
+        close_hook = getattr(self.decode_fn, "close", None)
+        if callable(close_hook):
+            with contextlib.suppress(_PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS):
+                close_hook()
 
     def get_full_transcript(self) -> str:
         """

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/transcriber.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/transcriber.py
@@ -83,8 +83,13 @@ def _variant_decode_fn(model: str, variant: str) -> DecodeFn | None:
     elif v == "mlx":
         try:
             from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX import (
+                create_parakeet_mlx_streaming_session as _create_mlx_stream,
                 transcribe_with_parakeet_mlx as _tx_mlx,
             )
+
+            session = _create_mlx_stream()
+            last_audio = np.array([], dtype=np.float32)
+            last_text = ""
 
             def _fn(audio_np: np.ndarray, sr: int) -> str:
                 """
@@ -93,7 +98,43 @@ def _variant_decode_fn(model: str, variant: str) -> DecodeFn | None:
                 Returns:
                     The transcription text produced by the MLX model.
                 """
-                return _tx_mlx(audio_np, sample_rate=sr)
+                nonlocal session, last_audio, last_text
+                if session is None:
+                    return _tx_mlx(audio_np, sample_rate=sr)
+
+                try:
+                    audio_arr = np.asarray(audio_np, dtype=np.float32).flatten()
+                except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS:
+                    return _tx_mlx(audio_np, sample_rate=sr)
+
+                if audio_arr.size == 0:
+                    return last_text
+
+                if (
+                    last_audio.size > 0
+                    and audio_arr.size >= last_audio.size
+                    and np.array_equal(audio_arr[: last_audio.size], last_audio)
+                ):
+                    delta = audio_arr[last_audio.size :]
+                else:
+                    # Audio buffer was rewound/trimmed (final chunk consume path).
+                    # Reset session and continue from current window.
+                    try:
+                        session.close()
+                    except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS:
+                        pass
+                    session = _create_mlx_stream()
+                    if session is None:
+                        return _tx_mlx(audio_arr, sample_rate=sr)
+                    delta = audio_arr
+
+                last_audio = audio_arr
+                if delta.size == 0:
+                    return last_text
+
+                artifact = session.add_audio(delta, sample_rate=sr)
+                last_text = str((artifact or {}).get("text", "")).strip()
+                return last_text
 
             return _fn
         except _PARAKEET_TRANSCRIBER_NONCRITICAL_EXCEPTIONS as e:

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/ws_server.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Parakeet_Core_Streaming/ws_server.py
@@ -149,6 +149,8 @@ async def websocket_parakeet_core(
 
                 if (config.model != old_model) or (config.model_variant != old_variant):
                     # reset state and rebuild transcriber for new model selection
+                    with contextlib.suppress(_PARAKEET_WS_NONCRITICAL_EXCEPTIONS):
+                        transcriber.close()
                     transcriber = ParakeetCoreTranscriber(config=config, decode_fn=decode_fn)
                     if getattr(transcriber, 'decode_fn', None) is None:
                         await websocket.send_json({
@@ -369,6 +371,10 @@ async def websocket_parakeet_core(
             await websocket.send_json({"type": "error", "message": str(e)})
     finally:
         try:
+            with contextlib.suppress(_PARAKEET_WS_NONCRITICAL_EXCEPTIONS):
+                await transcriber.flush()
+            with contextlib.suppress(_PARAKEET_WS_NONCRITICAL_EXCEPTIONS):
+                transcriber.close()
             if insights_engine:
                 with contextlib.suppress(_PARAKEET_WS_NONCRITICAL_EXCEPTIONS):
                     await insights_engine.close()

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -471,9 +471,10 @@ class Qwen2AudioAdapter(SttProviderAdapter):
             cancel_check=cancel_check,
         )
         text = " ".join(
-            str(seg.get("Text") or seg.get("text") or "").strip()
+            str(seg.get("text") or "").strip()
             for seg in segments_list
             if isinstance(seg, dict)
+        )
         )
         return {
             "text": text,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -249,7 +249,11 @@ class FasterWhisperAdapter(SttProviderAdapter):
         segments_list, detected_lang = result
         # Strip Whisper metadata header so callers see only user content
         segments_for_response = strip_whisper_metadata_header(segments_list)
-        text = " ".join(str(seg.get("Text", "")).strip() for seg in segments_for_response if isinstance(seg, dict))
+        text = " ".join(
+            str(seg.get("Text") or seg.get("text") or "").strip()
+            for seg in segments_for_response
+            if isinstance(seg, dict)
+        )
 
         return {
             "text": text,
@@ -320,7 +324,11 @@ class ParakeetAdapter(SttProviderAdapter):
             base_dir=base_dir,
             cancel_check=cancel_check,
         )
-        text = " ".join(str(seg.get("Text", "")).strip() for seg in segments_list if isinstance(seg, dict))
+        text = " ".join(
+            str(seg.get("Text") or seg.get("text") or "").strip()
+            for seg in segments_list
+            if isinstance(seg, dict)
+        )
         return {
             "text": text,
             "language": language or lang,
@@ -461,7 +469,11 @@ class Qwen2AudioAdapter(SttProviderAdapter):
             base_dir=base_dir,
             cancel_check=cancel_check,
         )
-        text = " ".join(str(seg.get("Text", "")).strip() for seg in segments_list if isinstance(seg, dict))
+        text = " ".join(
+            str(seg.get("Text") or seg.get("text") or "").strip()
+            for seg in segments_list
+            if isinstance(seg, dict)
+        )
         return {
             "text": text,
             "language": language or lang,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -325,9 +325,10 @@ class ParakeetAdapter(SttProviderAdapter):
             cancel_check=cancel_check,
         )
         text = " ".join(
-            str(seg.get("Text") or seg.get("text") or "").strip()
+            str(seg.get("text") or "").strip()
             for seg in segments_list
             if isinstance(seg, dict)
+        )
         )
         return {
             "text": text,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/stt_provider_adapter.py
@@ -250,9 +250,10 @@ class FasterWhisperAdapter(SttProviderAdapter):
         # Strip Whisper metadata header so callers see only user content
         segments_for_response = strip_whisper_metadata_header(segments_list)
         text = " ".join(
-            str(seg.get("Text") or seg.get("text") or "").strip()
+            str(seg.get("text") or "").strip()
             for seg in segments_for_response
             if isinstance(seg, dict)
+        )
         )
 
         return {

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -3527,6 +3527,7 @@ def load_and_log_configs():
             return s if s != "" else default
 
         def _to_optional_int(raw: str | None) -> int | None:
+            """Parse an optional integer config value, returning ``None`` when absent/invalid."""
             if raw is None:
                 return None
             try:
@@ -3535,6 +3536,7 @@ def load_and_log_configs():
                 return None
 
         def _to_optional_float(raw: str | None) -> float | None:
+            """Parse an optional float config value, returning ``None`` when absent/invalid."""
             if raw is None:
                 return None
             try:
@@ -3549,8 +3551,12 @@ def load_and_log_configs():
         mlx_overlap_duration = _get_float('STT-Settings', 'mlx_overlap_duration', 5.0)
         buffered_chunk_duration = _get_float('STT-Settings', 'buffered_chunk_duration', mlx_chunk_duration)
         buffered_total_buffer = _to_optional_float(_get_str('STT-Settings', 'buffered_total_buffer', None))
-        buffered_merge_algo = _get_str('STT-Settings', 'buffered_merge_algo', 'middle')
-        streaming_fallback_to_whisper = _get_bool('STT-Settings', 'streaming_fallback_to_whisper', True)
+        buffered_merge_algo = _get_str('STT-Settings', 'buffered_merge_algo', 'middle') or 'middle'
+        streaming_fallback_to_whisper = _get_bool(
+            'STT-Settings',
+            'streaming_fallback_to_whisper',
+            default=True,
+        )
 
         mlx_decoding_mode = _get_str('STT-Settings', 'mlx_decoding_mode', '') or ''
         mlx_beam_size = _to_optional_int(_get_str('STT-Settings', 'mlx_beam_size', None))
@@ -3563,7 +3569,11 @@ def load_and_log_configs():
         mlx_stream_context_left = _get_int('STT-Settings', 'mlx_stream_context_left', 256)
         mlx_stream_context_right = _get_int('STT-Settings', 'mlx_stream_context_right', 256)
         mlx_stream_depth = _get_int('STT-Settings', 'mlx_stream_depth', 1)
-        mlx_stream_keep_original_attention = _get_bool('STT-Settings', 'mlx_stream_keep_original_attention', False)
+        mlx_stream_keep_original_attention = _get_bool(
+            'STT-Settings',
+            'mlx_stream_keep_original_attention',
+            default=False,
+        )
 
         def _env_or_cfg_bool(env_key: str, section: str, key: str, default: bool) -> bool:
             env_val = os.getenv(env_key)
@@ -3588,13 +3598,13 @@ def load_and_log_configs():
             return _get_str(section, key, default)
 
         # VibeVoice-ASR settings (local inference + optional vLLM HTTP path)
-        vibevoice_enabled = _get_bool('STT-Settings', 'vibevoice_enabled', False)
+        vibevoice_enabled = _get_bool('STT-Settings', 'vibevoice_enabled', default=False)
         vibevoice_model_id = _get_str('STT-Settings', 'vibevoice_model_id', 'microsoft/VibeVoice-ASR') or 'microsoft/VibeVoice-ASR'
         vibevoice_device = _get_str('STT-Settings', 'vibevoice_device', 'cuda') or 'cuda'
         vibevoice_dtype = _get_str('STT-Settings', 'vibevoice_dtype', 'bfloat16') or 'bfloat16'
         vibevoice_cache_dir = _get_str('STT-Settings', 'vibevoice_cache_dir', './models/vibevoice') or './models/vibevoice'
-        vibevoice_allow_download = _get_bool('STT-Settings', 'vibevoice_allow_download', True)
-        vibevoice_vllm_enabled = _get_bool('STT-Settings', 'vibevoice_vllm_enabled', False)
+        vibevoice_allow_download = _get_bool('STT-Settings', 'vibevoice_allow_download', default=True)
+        vibevoice_vllm_enabled = _get_bool('STT-Settings', 'vibevoice_vllm_enabled', default=False)
         vibevoice_vllm_base_url = _get_str('STT-Settings', 'vibevoice_vllm_base_url', '') or ''
         vibevoice_vllm_model_id = _get_str('STT-Settings', 'vibevoice_vllm_model_id', vibevoice_model_id) or vibevoice_model_id
         vibevoice_vllm_api_key = _get_str('STT-Settings', 'vibevoice_vllm_api_key', None)

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -3543,7 +3543,7 @@ def load_and_log_configs():
                 return None
 
         # Parakeet MLX settings
-        mlx_model_id = _get_str('STT-Settings', 'mlx_model_id', 'mlx-community/parakeet-tdt-0.6b-v3') or 'mlx-community/parakeet-tdt-0.6b-v3'
+        mlx_model_id = _get_str('STT-Settings', 'mlx_model_id', 'mlx-community/parakeet-tdt-0.6b-v3')
         mlx_cache_dir = _get_str('STT-Settings', 'mlx_cache_dir', '') or ''
         mlx_chunk_duration = _get_float('STT-Settings', 'mlx_chunk_duration', 30.0)
         mlx_overlap_duration = _get_float('STT-Settings', 'mlx_overlap_duration', 5.0)

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -3549,7 +3549,7 @@ def load_and_log_configs():
         mlx_overlap_duration = _get_float('STT-Settings', 'mlx_overlap_duration', 5.0)
         buffered_chunk_duration = _get_float('STT-Settings', 'buffered_chunk_duration', mlx_chunk_duration)
         buffered_total_buffer = _to_optional_float(_get_str('STT-Settings', 'buffered_total_buffer', None))
-        buffered_merge_algo = _get_str('STT-Settings', 'buffered_merge_algo', 'middle') or 'middle'
+        buffered_merge_algo = _get_str('STT-Settings', 'buffered_merge_algo', 'middle')
         streaming_fallback_to_whisper = _get_bool('STT-Settings', 'streaming_fallback_to_whisper', True)
 
         mlx_decoding_mode = _get_str('STT-Settings', 'mlx_decoding_mode', '') or ''

--- a/tldw_Server_API/app/core/config.py
+++ b/tldw_Server_API/app/core/config.py
@@ -3526,6 +3526,45 @@ def load_and_log_configs():
             s = str(raw).strip()
             return s if s != "" else default
 
+        def _to_optional_int(raw: str | None) -> int | None:
+            if raw is None:
+                return None
+            try:
+                return int(str(raw).strip())
+            except _CONFIG_NONCRITICAL_EXCEPTIONS:
+                return None
+
+        def _to_optional_float(raw: str | None) -> float | None:
+            if raw is None:
+                return None
+            try:
+                return float(str(raw).strip())
+            except _CONFIG_NONCRITICAL_EXCEPTIONS:
+                return None
+
+        # Parakeet MLX settings
+        mlx_model_id = _get_str('STT-Settings', 'mlx_model_id', 'mlx-community/parakeet-tdt-0.6b-v3') or 'mlx-community/parakeet-tdt-0.6b-v3'
+        mlx_cache_dir = _get_str('STT-Settings', 'mlx_cache_dir', '') or ''
+        mlx_chunk_duration = _get_float('STT-Settings', 'mlx_chunk_duration', 30.0)
+        mlx_overlap_duration = _get_float('STT-Settings', 'mlx_overlap_duration', 5.0)
+        buffered_chunk_duration = _get_float('STT-Settings', 'buffered_chunk_duration', mlx_chunk_duration)
+        buffered_total_buffer = _to_optional_float(_get_str('STT-Settings', 'buffered_total_buffer', None))
+        buffered_merge_algo = _get_str('STT-Settings', 'buffered_merge_algo', 'middle') or 'middle'
+        streaming_fallback_to_whisper = _get_bool('STT-Settings', 'streaming_fallback_to_whisper', True)
+
+        mlx_decoding_mode = _get_str('STT-Settings', 'mlx_decoding_mode', '') or ''
+        mlx_beam_size = _to_optional_int(_get_str('STT-Settings', 'mlx_beam_size', None))
+        mlx_length_penalty = _to_optional_float(_get_str('STT-Settings', 'mlx_length_penalty', None))
+        mlx_patience = _to_optional_float(_get_str('STT-Settings', 'mlx_patience', None))
+        mlx_duration_reward = _to_optional_float(_get_str('STT-Settings', 'mlx_duration_reward', None))
+        mlx_sentence_max_words = _to_optional_int(_get_str('STT-Settings', 'mlx_sentence_max_words', None))
+        mlx_sentence_silence_gap = _to_optional_float(_get_str('STT-Settings', 'mlx_sentence_silence_gap', None))
+        mlx_sentence_max_duration = _to_optional_float(_get_str('STT-Settings', 'mlx_sentence_max_duration', None))
+        mlx_stream_context_left = _get_int('STT-Settings', 'mlx_stream_context_left', 256)
+        mlx_stream_context_right = _get_int('STT-Settings', 'mlx_stream_context_right', 256)
+        mlx_stream_depth = _get_int('STT-Settings', 'mlx_stream_depth', 1)
+        mlx_stream_keep_original_attention = _get_bool('STT-Settings', 'mlx_stream_keep_original_attention', False)
+
         def _env_or_cfg_bool(env_key: str, section: str, key: str, default: bool) -> bool:
             env_val = os.getenv(env_key)
             if env_val is not None:
@@ -4246,6 +4285,26 @@ def load_and_log_configs():
                 'nemo_model_variant': nemo_model_variant,
                 'nemo_device': nemo_device,
                 'nemo_cache_dir': nemo_cache_dir,
+                'streaming_fallback_to_whisper': streaming_fallback_to_whisper,
+                'mlx_model_id': mlx_model_id,
+                'mlx_cache_dir': mlx_cache_dir,
+                'mlx_chunk_duration': mlx_chunk_duration,
+                'mlx_overlap_duration': mlx_overlap_duration,
+                'buffered_chunk_duration': buffered_chunk_duration,
+                'buffered_total_buffer': buffered_total_buffer,
+                'buffered_merge_algo': buffered_merge_algo,
+                'mlx_decoding_mode': mlx_decoding_mode,
+                'mlx_beam_size': mlx_beam_size,
+                'mlx_length_penalty': mlx_length_penalty,
+                'mlx_patience': mlx_patience,
+                'mlx_duration_reward': mlx_duration_reward,
+                'mlx_sentence_max_words': mlx_sentence_max_words,
+                'mlx_sentence_silence_gap': mlx_sentence_silence_gap,
+                'mlx_sentence_max_duration': mlx_sentence_max_duration,
+                'mlx_stream_context_left': mlx_stream_context_left,
+                'mlx_stream_context_right': mlx_stream_context_right,
+                'mlx_stream_depth': mlx_stream_depth,
+                'mlx_stream_keep_original_attention': mlx_stream_keep_original_attention,
                 # VibeVoice-ASR settings
                 'vibevoice_enabled': vibevoice_enabled,
                 'vibevoice_model_id': vibevoice_model_id,
@@ -4274,6 +4333,26 @@ def load_and_log_configs():
                 'nemo_model_variant': nemo_model_variant,
                 'nemo_device': nemo_device,
                 'nemo_cache_dir': nemo_cache_dir,
+                'streaming_fallback_to_whisper': streaming_fallback_to_whisper,
+                'mlx_model_id': mlx_model_id,
+                'mlx_cache_dir': mlx_cache_dir,
+                'mlx_chunk_duration': mlx_chunk_duration,
+                'mlx_overlap_duration': mlx_overlap_duration,
+                'buffered_chunk_duration': buffered_chunk_duration,
+                'buffered_total_buffer': buffered_total_buffer,
+                'buffered_merge_algo': buffered_merge_algo,
+                'mlx_decoding_mode': mlx_decoding_mode,
+                'mlx_beam_size': mlx_beam_size,
+                'mlx_length_penalty': mlx_length_penalty,
+                'mlx_patience': mlx_patience,
+                'mlx_duration_reward': mlx_duration_reward,
+                'mlx_sentence_max_words': mlx_sentence_max_words,
+                'mlx_sentence_silence_gap': mlx_sentence_silence_gap,
+                'mlx_sentence_max_duration': mlx_sentence_max_duration,
+                'mlx_stream_context_left': mlx_stream_context_left,
+                'mlx_stream_context_right': mlx_stream_context_right,
+                'mlx_stream_depth': mlx_stream_depth,
+                'mlx_stream_keep_original_attention': mlx_stream_keep_original_attention,
                 # VibeVoice-ASR settings
                 'vibevoice_enabled': vibevoice_enabled,
                 'vibevoice_model_id': vibevoice_model_id,

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -70,6 +70,10 @@ class CancelCheckError(RuntimeError):
     """Raised when a cancellation check fails unexpectedly."""
 
 
+class STTTranscriptionError(RuntimeError):
+    """Raised when an STT backend fails to produce a valid transcription."""
+
+
 class SecurityAlertWebhookError(Exception):
     """Raised when delivery of a security alert to a webhook fails.
 

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
@@ -1,0 +1,184 @@
+import io
+
+import numpy as np
+import pytest
+import soundfile as sf
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
+
+TEST_API_KEY = "test-api-key-1234567890"
+
+
+def _make_wav_bytes(duration_sec: float = 0.1, sr: int = 16000) -> bytes:
+    buf = io.BytesIO()
+    data = np.zeros(int(sr * duration_sec), dtype=np.float32)
+    sf.write(buf, data, sr, format="WAV")
+    return buf.getvalue()
+
+
+def _setup_stubbed_audio_app(monkeypatch):
+    monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
+    monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
+
+    from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+    import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
+
+    async def _fake_get_request_user() -> User:
+        return User(id=1, username="single_user")
+
+    async def _allow_job(*_args, **_kwargs):
+        return True, None
+
+    async def _noop_async(*_args, **_kwargs):
+        return None
+
+    class _StubAdapter:
+        def transcribe_batch(
+            self,
+            _audio_path,
+            *,
+            model=None,
+            language=None,
+            task="transcribe",
+            word_timestamps=False,
+            prompt=None,
+            hotwords=None,
+            base_dir=None,
+        ):
+            _ = (task, word_timestamps, prompt, hotwords, base_dir)
+            return {
+                "text": "first line second line",
+                "language": language or "en",
+                "segments": [
+                    {
+                        "start_seconds": 1.0,
+                        "end_seconds": 2.5,
+                        "Text": "first line",
+                        "words": [
+                            {"start": 1.0, "end": 1.4, "word": "first"},
+                            {"start": 1.4, "end": 2.5, "word": "line"},
+                        ],
+                    },
+                    {
+                        "start_seconds": 2.5,
+                        "end_seconds": 4.0,
+                        "Text": "second line",
+                        "words": [
+                            {"start": 2.5, "end": 3.2, "word": "second"},
+                            {"start": 3.2, "end": 4.0, "word": "line"},
+                        ],
+                    },
+                ],
+                "diarization": {"enabled": False, "speakers": None},
+                "usage": {"duration_ms": None, "tokens": None},
+                "metadata": {"provider": "parakeet", "model": model or "parakeet-mlx"},
+            }
+
+    class _StubRegistry:
+        def resolve_provider_for_model(self, _model):
+            return "parakeet", "parakeet-mlx", "mlx"
+
+        def get_adapter(self, _provider):
+            return _StubAdapter()
+
+    monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
+    monkeypatch.setattr(audio_ep, "increment_jobs_started", _noop_async)
+    monkeypatch.setattr(audio_ep, "finish_job", _noop_async)
+    monkeypatch.setattr(audio_ep, "check_daily_minutes_allow", _allow_job)
+    monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
+    monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
+    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: path)
+
+    app = FastAPI()
+    app.dependency_overrides[get_request_user] = _fake_get_request_user
+    app.include_router(audio_router, prefix="/api/v1/audio")
+    return app
+
+
+@pytest.mark.unit
+def test_audio_transcriptions_uses_provider_timed_segments_for_srt(monkeypatch, bypass_api_limits):
+    app = _setup_stubbed_audio_app(monkeypatch)
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        wav_bytes = _make_wav_bytes()
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.wav", io.BytesIO(wav_bytes), "audio/wav")}
+        data = {
+            "model": "parakeet-mlx",
+            "response_format": "srt",
+        }
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        assert resp.status_code == 200, resp.text
+        assert "00:00:01,000 --> 00:00:02,500" in resp.text
+        assert "00:00:02,500 --> 00:00:04,000" in resp.text
+        assert "00:00:00,000 --> 00:00:10,000" not in resp.text
+
+
+@pytest.mark.unit
+def test_audio_transcriptions_uses_provider_timed_segments_for_vtt(monkeypatch, bypass_api_limits):
+    app = _setup_stubbed_audio_app(monkeypatch)
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        wav_bytes = _make_wav_bytes()
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.wav", io.BytesIO(wav_bytes), "audio/wav")}
+        data = {
+            "model": "parakeet-mlx",
+            "response_format": "vtt",
+        }
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        assert resp.status_code == 200, resp.text
+        assert resp.text.startswith("WEBVTT")
+        assert "00:00:01.000 --> 00:00:02.500" in resp.text
+        assert "00:00:02.500 --> 00:00:04.000" in resp.text
+
+
+@pytest.mark.unit
+def test_audio_transcriptions_verbose_json_exposes_timed_segments_for_parakeet(monkeypatch, bypass_api_limits):
+    app = _setup_stubbed_audio_app(monkeypatch)
+
+    with bypass_api_limits(app), TestClient(app) as client:
+        wav_bytes = _make_wav_bytes()
+        headers = {"X-API-KEY": TEST_API_KEY}
+        files = {"file": ("sample.wav", io.BytesIO(wav_bytes), "audio/wav")}
+        data = {
+            "model": "parakeet-mlx",
+            "response_format": "verbose_json",
+            "timestamp_granularities": "segment,word",
+        }
+        resp = client.post(
+            "/api/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data=data,
+        )
+        if resp.status_code == 404:
+            pytest.skip("audio/transcriptions endpoint not mounted in this build")
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["segments"][0]["start"] == pytest.approx(1.0)
+        assert payload["segments"][0]["end"] == pytest.approx(2.5)
+        assert payload["segments"][0]["text"] == "first line"
+        assert payload["segments"][0]["words"][0]["word"] == "first"
+        assert payload["segments"][1]["start"] == pytest.approx(2.5)
+

--- a/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
+++ b/tldw_Server_API/tests/Audio/test_audio_transcriptions_timed_segments.py
@@ -1,56 +1,216 @@
 import io
+import importlib
+import os
+import sys
+import types
 
 import numpy as np
 import pytest
 import soundfile as sf
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from typing import Any
 
-from tldw_Server_API.app.api.v1.endpoints.audio.audio import router as audio_router
-
-TEST_API_KEY = "test-api-key-1234567890"
+TEST_API_KEY = os.getenv("TLDW_TEST_AUDIO_API_KEY", "unit-test-auth-token")
 
 
 def _make_wav_bytes(duration_sec: float = 0.1, sr: int = 16000) -> bytes:
+    """Return a short silent WAV payload for upload tests."""
     buf = io.BytesIO()
     data = np.zeros(int(sr * duration_sec), dtype=np.float32)
     sf.write(buf, data, sr, format="WAV")
     return buf.getvalue()
 
 
-def _setup_stubbed_audio_app(monkeypatch):
+def _setup_stubbed_audio_app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    """Create a FastAPI app wired to stubbed transcription dependencies."""
     monkeypatch.setenv("TEST_MODE", "true")
     monkeypatch.setenv("AUTH_MODE", "single_user")
     monkeypatch.setenv("SINGLE_USER_API_KEY", TEST_API_KEY)
     monkeypatch.setenv("SINGLE_USER_FIXED_ID", "1")
 
+    # Keep the test import path independent from optional redis dependency.
+    if "redis" not in sys.modules:
+        class _RedisError(Exception):
+            pass
+
+        class _RedisConnectionError(_RedisError):
+            pass
+
+        redis_mod = types.ModuleType("redis")
+        redis_asyncio_mod = types.ModuleType("redis.asyncio")
+        redis_exceptions_mod = types.ModuleType("redis.exceptions")
+        redis_asyncio_mod.Redis = object  # type: ignore[attr-defined]
+        redis_asyncio_mod.from_url = lambda *_args, **_kwargs: None  # type: ignore[attr-defined]
+        redis_exceptions_mod.RedisError = _RedisError  # type: ignore[attr-defined]
+        redis_exceptions_mod.ConnectionError = _RedisConnectionError  # type: ignore[attr-defined]
+        redis_mod.RedisError = _RedisError  # type: ignore[attr-defined]
+        redis_mod.asyncio = redis_asyncio_mod  # type: ignore[attr-defined]
+        redis_mod.exceptions = redis_exceptions_mod  # type: ignore[attr-defined]
+        sys.modules["redis"] = redis_mod
+        sys.modules["redis.asyncio"] = redis_asyncio_mod
+        sys.modules["redis.exceptions"] = redis_exceptions_mod
+
+    if "argon2" not in sys.modules:
+        class _FakeVerificationError(Exception):
+            pass
+
+        class _FakeVerifyMismatchError(_FakeVerificationError):
+            pass
+
+        class _FakePasswordHasher:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                _ = (args, kwargs)
+
+            def hash(self, password: str) -> str:
+                return f"fake-hash::{password}"
+
+            def verify(self, password_hash: str, password: str) -> bool:
+                return password_hash == f"fake-hash::{password}"
+
+            def check_needs_rehash(self, _password_hash: str) -> bool:
+                return False
+
+        argon2_mod = types.ModuleType("argon2")
+        argon2_exc_mod = types.ModuleType("argon2.exceptions")
+        argon2_mod.PasswordHasher = _FakePasswordHasher  # type: ignore[attr-defined]
+        argon2_exc_mod.VerificationError = _FakeVerificationError  # type: ignore[attr-defined]
+        argon2_exc_mod.VerifyMismatchError = _FakeVerifyMismatchError  # type: ignore[attr-defined]
+        argon2_mod.exceptions = argon2_exc_mod  # type: ignore[attr-defined]
+        sys.modules["argon2"] = argon2_mod
+        sys.modules["argon2.exceptions"] = argon2_exc_mod
+
+    if "passlib" not in sys.modules:
+        class _FakeCryptContext:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                _ = (args, kwargs)
+
+            def hash(self, password: str) -> str:
+                return f"fake-hash::{password}"
+
+            def verify(self, _password: str, _password_hash: str) -> bool:
+                return True
+
+        passlib_mod = types.ModuleType("passlib")
+        passlib_context_mod = types.ModuleType("passlib.context")
+        passlib_context_mod.CryptContext = _FakeCryptContext  # type: ignore[attr-defined]
+        passlib_mod.context = passlib_context_mod  # type: ignore[attr-defined]
+        sys.modules["passlib"] = passlib_mod
+        sys.modules["passlib.context"] = passlib_context_mod
+
+    if "PIL" not in sys.modules:
+        pil_mod = types.ModuleType("PIL")
+        pil_image_mod = types.ModuleType("PIL.Image")
+        pil_image_mod.Image = type("Image", (), {})  # type: ignore[attr-defined]
+        pil_mod.Image = pil_image_mod  # type: ignore[attr-defined]
+        sys.modules["PIL"] = pil_mod
+        sys.modules["PIL.Image"] = pil_image_mod
+
+    if "jinja2" not in sys.modules:
+        class _FakeTemplate:
+            def __init__(self, template: str) -> None:
+                self._template = template
+
+            def render(self, **_kwargs: Any) -> str:
+                return self._template
+
+        class _FakeSandboxedEnvironment:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                _ = (args, kwargs)
+
+            def from_string(self, template: str) -> _FakeTemplate:
+                return _FakeTemplate(template)
+
+        jinja2_mod = types.ModuleType("jinja2")
+        jinja2_sandbox_mod = types.ModuleType("jinja2.sandbox")
+        jinja2_sandbox_mod.SandboxedEnvironment = _FakeSandboxedEnvironment  # type: ignore[attr-defined]
+        jinja2_mod.sandbox = jinja2_sandbox_mod  # type: ignore[attr-defined]
+        jinja2_mod.__spec__ = importlib.machinery.ModuleSpec("jinja2", loader=None)
+        jinja2_sandbox_mod.__spec__ = importlib.machinery.ModuleSpec("jinja2.sandbox", loader=None)
+        sys.modules["jinja2"] = jinja2_mod
+        sys.modules["jinja2.sandbox"] = jinja2_sandbox_mod
+
+    atlib_mod_name = (
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib"
+    )
+    if atlib_mod_name not in sys.modules:
+        fake_atlib = types.ModuleType(atlib_mod_name)
+
+        class _FakeConversionError(Exception):
+            pass
+
+        def _convert_to_wav(path: str, *_args: Any, **_kwargs: Any) -> str:
+            return path
+
+        def _is_transcription_error_message(_text: Any) -> bool:
+            return False
+
+        def _validate_whisper_model_identifier(model_id: str) -> str:
+            return model_id
+
+        fake_atlib.ConversionError = _FakeConversionError  # type: ignore[attr-defined]
+        fake_atlib.convert_to_wav = _convert_to_wav  # type: ignore[attr-defined]
+        fake_atlib.is_transcription_error_message = _is_transcription_error_message  # type: ignore[attr-defined]
+        fake_atlib.validate_whisper_model_identifier = _validate_whisper_model_identifier  # type: ignore[attr-defined]
+        fake_atlib.__spec__ = importlib.machinery.ModuleSpec(atlib_mod_name, loader=None)
+        sys.modules[atlib_mod_name] = fake_atlib
+
+    audio_files_mod_name = (
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Files"
+    )
+    if audio_files_mod_name not in sys.modules:
+        fake_audio_files = types.ModuleType(audio_files_mod_name)
+
+        def _check_transcription_model_status(model_name: str) -> dict[str, Any]:
+            return {"available": True, "model": model_name}
+
+        fake_audio_files.check_transcription_model_status = _check_transcription_model_status  # type: ignore[attr-defined]
+        fake_audio_files.__spec__ = importlib.machinery.ModuleSpec(audio_files_mod_name, loader=None)
+        sys.modules[audio_files_mod_name] = fake_audio_files
+
     from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
-    import tldw_Server_API.app.api.v1.endpoints.audio.audio as audio_ep
-    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.api.v1.endpoints.audio.audio_transcriptions as audio_ep
     import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.stt_provider_adapter as stt_adapter
 
     async def _fake_get_request_user() -> User:
         return User(id=1, username="single_user")
 
-    async def _allow_job(*_args, **_kwargs):
+    async def _allow_job(*_args: Any, **_kwargs: Any) -> tuple[bool, None]:
+        """Allow all quota/job checks in this test harness."""
         return True, None
 
-    async def _noop_async(*_args, **_kwargs):
+    async def _noop_async(*_args: Any, **_kwargs: Any) -> None:
+        """No-op async hook used to bypass job side effects in tests."""
         return None
 
+    async def _get_limits_for_user(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        """Return permissive in-memory quota limits for endpoint tests."""
+        return {
+            "daily_minutes": 30.0,
+            "concurrent_streams": 1,
+            "concurrent_jobs": 1,
+            "max_file_size_mb": 25,
+        }
+
+    def _heartbeat_interval_seconds() -> int:
+        """Disable heartbeat loop in unit tests."""
+        return 0
+
     class _StubAdapter:
+        """Minimal STT adapter that returns fixed timed segments."""
+
         def transcribe_batch(
             self,
-            _audio_path,
+            _audio_path: str,
             *,
-            model=None,
-            language=None,
-            task="transcribe",
-            word_timestamps=False,
-            prompt=None,
-            hotwords=None,
-            base_dir=None,
-        ):
+            model: str | None = None,
+            language: str | None = None,
+            task: str = "transcribe",
+            word_timestamps: bool = False,
+            prompt: str | None = None,
+            hotwords: str | None = None,
+            base_dir: str | None = None,
+        ) -> dict[str, Any]:
             _ = (task, word_timestamps, prompt, hotwords, base_dir)
             return {
                 "text": "first line second line",
@@ -81,24 +241,40 @@ def _setup_stubbed_audio_app(monkeypatch):
             }
 
     class _StubRegistry:
-        def resolve_provider_for_model(self, _model):
+        """Registry stub that always routes to Parakeet MLX."""
+
+        def resolve_provider_for_model(self, _model: str) -> tuple[str, str, str]:
             return "parakeet", "parakeet-mlx", "mlx"
 
-        def get_adapter(self, _provider):
+        def get_adapter(self, _provider: str) -> _StubAdapter:
             return _StubAdapter()
 
-    monkeypatch.setattr(audio_ep, "can_start_job", _allow_job)
-    monkeypatch.setattr(audio_ep, "increment_jobs_started", _noop_async)
-    monkeypatch.setattr(audio_ep, "finish_job", _noop_async)
-    monkeypatch.setattr(audio_ep, "check_daily_minutes_allow", _allow_job)
-    monkeypatch.setattr(audio_ep, "add_daily_minutes", _noop_async)
+    shim_values: dict[str, Any] = {
+        "can_start_job": _allow_job,
+        "increment_jobs_started": _noop_async,
+        "finish_job": _noop_async,
+        "check_daily_minutes_allow": _allow_job,
+        "add_daily_minutes": _noop_async,
+        "get_limits_for_user": _get_limits_for_user,
+        "get_job_heartbeat_interval_seconds": _heartbeat_interval_seconds,
+        "heartbeat_jobs": _noop_async,
+        "sf": sf,
+    }
+    monkeypatch.setattr(audio_ep, "_audio_shim_attr", lambda name: shim_values[name])
     monkeypatch.setattr(stt_adapter, "get_stt_provider_registry", lambda: _StubRegistry())
-    monkeypatch.setattr(atlib, "convert_to_wav", lambda path, *args, **kwargs: path)
 
+    audio_router = audio_ep.router
     app = FastAPI()
     app.dependency_overrides[get_request_user] = _fake_get_request_user
     app.include_router(audio_router, prefix="/api/v1/audio")
     return app
+
+
+@pytest.mark.unit
+def test_setup_stubbed_audio_app_has_type_hints() -> None:
+    annotations = _setup_stubbed_audio_app.__annotations__
+    assert annotations.get("monkeypatch") is pytest.MonkeyPatch
+    assert annotations.get("return") is FastAPI
 
 
 @pytest.mark.unit
@@ -181,4 +357,3 @@ def test_audio_transcriptions_verbose_json_exposes_timed_segments_for_parakeet(m
         assert payload["segments"][0]["text"] == "first line"
         assert payload["segments"][0]["words"][0]["word"] == "first"
         assert payload["segments"][1]["start"] == pytest.approx(2.5)
-

--- a/tldw_Server_API/tests/Audio/test_parakeet_core_buffer_and_metadata.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_core_buffer_and_metadata.py
@@ -127,7 +127,15 @@ def test_variant_decode_selection(monkeypatch):
     )
 
     mod_mlx = types.ModuleType("Audio_Transcription_Parakeet_MLX")
-    mod_mlx.transcribe_with_parakeet_mlx = lambda audio_np, sample_rate: "mlx:ok"
+    class _FakeMlxSession:
+        def add_audio(self, audio_np, sample_rate=16000):
+            return {"text": "mlx:ok"}
+
+        def close(self):
+            return None
+
+    mod_mlx.create_parakeet_mlx_streaming_session = lambda: _FakeMlxSession()
+    mod_mlx.transcribe_with_parakeet_mlx = lambda audio_np, sample_rate: "mlx:fallback"
     monkeypatch.setitem(
         sys.modules,
         "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX",
@@ -158,6 +166,117 @@ def test_variant_decode_selection(monkeypatch):
     tr_mlx = ParakeetCoreTranscriber(config=StreamingConfig(sample_rate=sr, model_variant="mlx"))
     assert tr_mlx.decode_fn is not None
     assert tr_mlx._decode(audio) == "mlx:ok"
+
+
+@pytest.mark.unit
+def test_mlx_decode_closure_hooks_reset_and_close(monkeypatch):
+    mod_mlx = types.ModuleType("Audio_Transcription_Parakeet_MLX")
+    created_sessions = []
+
+    class _FakeMlxSession:
+        def __init__(self):
+            self.close_calls = 0
+
+        def add_audio(self, audio_np, sample_rate=16000):
+            return {"text": "mlx:hooked"}
+
+        def close(self):
+            self.close_calls += 1
+
+    def _create_session():
+        session = _FakeMlxSession()
+        created_sessions.append(session)
+        return session
+
+    mod_mlx.create_parakeet_mlx_streaming_session = _create_session
+    mod_mlx.transcribe_with_parakeet_mlx = lambda audio_np, sample_rate: "mlx:fallback"
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX",
+        mod_mlx,
+    )
+
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.transcriber import (
+        ParakeetCoreTranscriber,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.config import (
+        StreamingConfig,
+    )
+
+    tr_mlx = ParakeetCoreTranscriber(config=StreamingConfig(sample_rate=10, model_variant="mlx"))
+    assert tr_mlx.decode_fn is not None
+    assert callable(getattr(tr_mlx.decode_fn, "close", None))
+    assert callable(getattr(tr_mlx.decode_fn, "reset_session", None))
+    assert tr_mlx._decode(np.zeros(5, dtype=np.float32)) == "mlx:hooked"
+
+    # reset() should invoke decode reset_session hook and close active session
+    tr_mlx.reset()
+    assert created_sessions
+    assert created_sessions[0].close_calls == 1
+
+    # close() should invoke decode close hook for current session
+    tr_mlx.close()
+    assert sum(s.close_calls for s in created_sessions) >= 2
+
+
+@pytest.mark.unit
+def test_transcriber_close_invokes_decode_close_hook():
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.transcriber import (
+        ParakeetCoreTranscriber,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.config import (
+        StreamingConfig,
+    )
+
+    calls = {"close": 0}
+
+    def _decode(audio_np, sr):
+        return "ok"
+
+    def _close():
+        calls["close"] += 1
+
+    setattr(_decode, "close", _close)
+    tr = ParakeetCoreTranscriber(config=StreamingConfig(sample_rate=10), decode_fn=_decode)
+    tr.close()
+    assert calls["close"] == 1
+
+
+@pytest.mark.unit
+def test_mlx_decode_falls_back_when_stream_session_creation_fails(monkeypatch):
+    mod_mlx = types.ModuleType("Audio_Transcription_Parakeet_MLX")
+    fallback_calls = {"count": 0}
+
+    def _create_session():
+        raise RuntimeError("session init failed")
+
+    def _fallback_decode(audio_np, sample_rate=16000):
+        fallback_calls["count"] += 1
+        return f"mlx:fallback:{sample_rate}"
+
+    mod_mlx.create_parakeet_mlx_streaming_session = _create_session
+    mod_mlx.transcribe_with_parakeet_mlx = _fallback_decode
+    monkeypatch.setitem(
+        sys.modules,
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX",
+        mod_mlx,
+    )
+
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.transcriber import (
+        ParakeetCoreTranscriber,
+    )
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.config import (
+        StreamingConfig,
+    )
+
+    transcriber = ParakeetCoreTranscriber(config=StreamingConfig(sample_rate=10, model_variant="mlx"))
+    assert transcriber.decode_fn is not None
+    assert transcriber._decode(np.zeros(8, dtype=np.float32)) == "mlx:fallback:10"
+    assert fallback_calls["count"] == 1
+
+    # No-op when session could not be initialized.
+    transcriber.reset()
+    transcriber.close()
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Audio/test_parakeet_core_ws_diarization_insights.py
+++ b/tldw_Server_API/tests/Audio/test_parakeet_core_ws_diarization_insights.py
@@ -286,3 +286,83 @@ async def test_core_ws_with_diarization_and_insights(monkeypatch):
     assert any(o.get("type") == "full_transcript" for o in outs)
     # Expect diarization summary
     assert any(o.get("type") == "diarization_summary" for o in outs)
+
+
+@pytest.mark.asyncio
+async def test_core_ws_finally_flushes_and_closes_transcriber(monkeypatch):
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.ws_server as wsmod
+
+    calls = []
+
+    class _FakeTranscriber:
+        def __init__(self, config, decode_fn=None):
+            self.decode_fn = decode_fn or (lambda _a, _b: "ok")
+
+        async def process_audio_chunk(self, audio):
+            return None
+
+        async def flush(self):
+            calls.append("flush")
+            return None
+
+        def close(self):
+            calls.append("close")
+
+        def reset(self):
+            calls.append("reset")
+
+        def get_full_transcript(self):
+            return ""
+
+    monkeypatch.setattr(wsmod, "ParakeetCoreTranscriber", _FakeTranscriber, raising=True)
+
+    ws = DummyWebSocket([json.dumps({"type": "stop"})])
+    await wsmod.websocket_parakeet_core(ws, decode_fn=lambda _a, _b: "ok")
+
+    assert "flush" in calls
+    assert "close" in calls
+    assert calls.index("flush") < calls.index("close")
+
+
+@pytest.mark.asyncio
+async def test_core_ws_model_reconfigure_closes_previous_transcriber(monkeypatch):
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Parakeet_Core_Streaming.ws_server as wsmod
+
+    closes = []
+
+    class _FakeTranscriber:
+        _next_id = 0
+
+        def __init__(self, config, decode_fn=None):
+            type(self)._next_id += 1
+            self.transcriber_id = type(self)._next_id
+            self.decode_fn = decode_fn or (lambda _a, _b: "ok")
+
+        async def process_audio_chunk(self, audio):
+            return None
+
+        async def flush(self):
+            return None
+
+        def close(self):
+            closes.append(self.transcriber_id)
+
+        def reset(self):
+            return None
+
+        def get_full_transcript(self):
+            return ""
+
+    monkeypatch.setattr(wsmod, "ParakeetCoreTranscriber", _FakeTranscriber, raising=True)
+
+    ws = DummyWebSocket(
+        [
+            json.dumps({"type": "config", "model": "parakeet", "model_variant": "standard"}),
+            json.dumps({"type": "config", "model": "parakeet", "model_variant": "onnx"}),
+            json.dumps({"type": "stop"}),
+        ]
+    )
+    await wsmod.websocket_parakeet_core(ws, decode_fn=lambda _a, _b: "ok")
+
+    # Old transcriber should be closed during model swap, and active one on teardown.
+    assert len(closes) >= 2

--- a/tldw_Server_API/tests/Audio/test_streaming_metadata.py
+++ b/tldw_Server_API/tests/Audio/test_streaming_metadata.py
@@ -53,3 +53,58 @@ async def test_transcriber_emits_segment_metadata(monkeypatch):
     assert result2["segment_start"] == pytest.approx(expected_start, abs=1e-6)
     assert result2["segment_end"] == pytest.approx(expected_end, abs=1e-6)
     assert result2["overlap"] == pytest.approx(config.overlap_duration, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_mlx_transcriber_uses_native_stream_session_when_available(monkeypatch):
+    class _StubSession:
+        def __init__(self):
+            self.calls = 0
+
+        def add_audio(self, _audio_np, sample_rate=16000):
+            self.calls += 1
+            return {
+                "text": f"mlx stream {self.calls}",
+                "sentences": [
+                    {
+                        "text": f"mlx stream {self.calls}",
+                        "start": 0.0,
+                        "end": 1.0,
+                        "duration": 1.0,
+                        "confidence": 0.9,
+                        "tokens": [],
+                    }
+                ],
+            }
+
+        def close(self):
+            return None
+
+    session = _StubSession()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Streaming_Unified.create_parakeet_mlx_streaming_session",
+        lambda **kwargs: session,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Streaming_Unified.transcribe_with_parakeet_mlx",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy MLX path should not be used")),
+    )
+
+    config = StreamingConfig(
+        model_variant="mlx",
+        sample_rate=16000,
+        chunk_duration=1.0,
+        overlap_duration=0.25,
+        enable_partial=False,
+    )
+    transcriber = ParakeetStreamingTranscriber(config)
+    transcriber.initialize()
+
+    chunk_samples = int(config.sample_rate * config.chunk_duration)
+    audio_chunk = np.zeros(chunk_samples, dtype=np.float32).tobytes()
+
+    result = await transcriber.process_audio_chunk(audio_chunk)
+    assert result is not None
+    assert result["type"] == "final"
+    assert result["text"] == "mlx stream 1"

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py
@@ -603,6 +603,60 @@ def test_speech_to_text_qwen2audio_disabled_falls_back_to_whisper(monkeypatch, t
 
 
 @pytest.mark.unit
+def test_speech_to_text_qwen2audio_disabled_skips_audio_decode(monkeypatch, tmp_path):
+    """When Qwen2Audio is disabled, route directly to Whisper fallback without decoding via librosa."""
+    audio_file = tmp_path / "sample.wav"
+    audio_file.write_bytes(b"\x00" * 2048)
+
+    import sys
+    import types
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+
+    monkeypatch.setattr(
+        atlib,
+        "load_and_log_configs",
+        lambda: {"STT-Settings": {"qwen2audio_enabled": "false"}},
+    )
+
+    class _Seg:
+        start = 0.0
+        end = 1.0
+        text = "fallback whisper"
+
+    class _Info:
+        language = "en"
+        language_probability = 0.9
+
+    class _Model:
+        def transcribe(self, *args, **kwargs):
+            return [_Seg()], _Info()
+
+    monkeypatch.setattr(atlib, "get_whisper_model", lambda *args, **kwargs: _Model())
+    monkeypatch.setattr(atlib, "processing_choice", "cpu")
+
+    decode_calls = {"count": 0}
+
+    def _unexpected_decode(*_args, **_kwargs):
+        decode_calls["count"] += 1
+        raise AssertionError("librosa.load should not be called when Qwen2Audio is disabled")
+
+    fake_librosa = types.SimpleNamespace(
+        load=_unexpected_decode,
+        get_duration=lambda **_kwargs: 0.0,
+    )
+    monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
+
+    segments = atlib.speech_to_text(
+        str(audio_file),
+        whisper_model="qwen2audio-test",
+        selected_source_lang="en",
+    )
+    assert isinstance(segments, list)
+    assert segments
+    assert decode_calls["count"] == 0
+
+
+@pytest.mark.unit
 def test_speech_to_text_parakeet_failure_falls_back_to_valid_whisper_model(monkeypatch, tmp_path):
     """Parakeet fallback should use a valid faster-whisper model identifier."""
     audio_file = tmp_path / "sample.wav"
@@ -877,6 +931,137 @@ def test_speech_to_text_parakeet_mlx_passes_chunk_duration_when_short(monkeypatc
     assert captured["chunk_duration"] == 30.0
     assert captured["overlap_duration"] == 5.0
     assert segments[0]["Text"] == "short text"
+
+
+@pytest.mark.unit
+def test_speech_to_text_parakeet_mlx_uses_structured_timing_when_available(monkeypatch, tmp_path):
+    pytest.importorskip("librosa")
+
+    audio_file = tmp_path / "sample.wav"
+    audio_file.write_bytes(b"\x00" * 2048)
+
+    import librosa
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX as mlx_mod
+
+    monkeypatch.setattr(atlib, "get_stt_config", lambda: {
+        "mlx_chunk_duration": "30.0",
+        "mlx_overlap_duration": "5.0",
+    })
+    monkeypatch.setattr(librosa, "get_duration", lambda path: 10.0)
+    monkeypatch.setattr(mlx_mod, "check_mlx_available", lambda: True)
+
+    captured = {}
+
+    def fake_transcribe_with_parakeet_mlx(audio_path, **kwargs):
+        captured.update(kwargs)
+        return {
+            "text": "hello world",
+            "sentences": [
+                {
+                    "text": "hello world",
+                    "start": 1.1,
+                    "end": 2.4,
+                    "duration": 1.3,
+                    "confidence": 0.88,
+                    "tokens": [
+                        {
+                            "id": 1,
+                            "text": "hello",
+                            "start": 1.1,
+                            "end": 1.6,
+                            "duration": 0.5,
+                            "confidence": 0.91,
+                        },
+                        {
+                            "id": 2,
+                            "text": " world",
+                            "start": 1.6,
+                            "end": 2.4,
+                            "duration": 0.8,
+                            "confidence": 0.85,
+                        },
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(mlx_mod, "transcribe_with_parakeet_mlx", fake_transcribe_with_parakeet_mlx)
+
+    segments = atlib.speech_to_text_parakeet(
+        str(audio_file),
+        variant="mlx",
+        selected_source_lang="en",
+        vad_filter=False,
+    )
+
+    assert captured.get("return_structured") is True
+    assert len(segments) == 1
+    assert segments[0]["start_seconds"] == pytest.approx(1.1)
+    assert segments[0]["end_seconds"] == pytest.approx(2.4)
+    assert segments[0]["Text"] == "hello world"
+    assert isinstance(segments[0].get("words"), list)
+    assert segments[0]["words"][0]["word"] == "hello"
+    assert segments[0]["words"][0]["start"] == pytest.approx(1.1)
+    assert segments[0]["words"][0]["end"] == pytest.approx(1.6)
+
+
+@pytest.mark.unit
+def test_speech_to_text_parakeet_mlx_buffered_prefers_structured_merge_output(monkeypatch, tmp_path):
+    pytest.importorskip("librosa")
+
+    audio_file = tmp_path / "sample.wav"
+    audio_file.write_bytes(b"\x00" * 2048)
+
+    import librosa
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Buffered_Transcription as buffered_mod
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Lib as atlib
+    import tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX as mlx_mod
+
+    monkeypatch.setattr(atlib, "get_stt_config", lambda: {
+        "mlx_chunk_duration": "30.0",
+        "mlx_overlap_duration": "5.0",
+    })
+    monkeypatch.setattr(librosa, "get_duration", lambda path: 120.0)
+    monkeypatch.setattr(mlx_mod, "check_mlx_available", lambda: True)
+
+    captured = {}
+
+    def fake_transcribe_long_audio(*_args, **kwargs):
+        captured.update(kwargs)
+        return {
+            "text": "chunked hello world",
+            "sentences": [
+                {
+                    "text": "chunked hello world",
+                    "start": 2.0,
+                    "end": 4.0,
+                    "duration": 2.0,
+                    "confidence": 0.9,
+                    "tokens": [
+                        {"id": 1, "text": "chunked", "start": 2.0, "end": 2.6, "duration": 0.6, "confidence": 0.92},
+                        {"id": 2, "text": " hello", "start": 2.6, "end": 3.2, "duration": 0.6, "confidence": 0.89},
+                        {"id": 3, "text": " world", "start": 3.2, "end": 4.0, "duration": 0.8, "confidence": 0.88},
+                    ],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(buffered_mod, "transcribe_long_audio", fake_transcribe_long_audio)
+
+    segments = atlib.speech_to_text_parakeet(
+        str(audio_file),
+        variant="mlx",
+        selected_source_lang="en",
+        vad_filter=False,
+    )
+
+    assert captured.get("return_structured") is True
+    assert len(segments) == 1
+    assert segments[0]["start_seconds"] == pytest.approx(2.0)
+    assert segments[0]["end_seconds"] == pytest.approx(4.0)
+    assert segments[0]["Text"] == "chunked hello world"
+    assert segments[0]["words"][1]["word"] == "hello"
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_transcription.py
@@ -644,6 +644,7 @@ def test_speech_to_text_qwen2audio_disabled_skips_audio_decode(monkeypatch, tmp_
         load=_unexpected_decode,
         get_duration=lambda **_kwargs: 0.0,
     )
+    monkeypatch.setattr(atlib, "librosa", fake_librosa, raising=False)
     monkeypatch.setitem(sys.modules, "librosa", fake_librosa)
 
     segments = atlib.speech_to_text(

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_buffered_transcription.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_buffered_transcription.py
@@ -193,6 +193,50 @@ class TestBufferedTranscription:
 
         assert lcs_len == 2  # "world" and "test" are common
 
+    def test_merge_longest_contiguous_ignores_missing_timestamp_overlap_tokens(self):
+        """Malformed overlap tokens without timestamps should not drive contiguous-match splicing."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Buffered_Transcription import (
+            _merge_tokens_longest_contiguous,
+        )
+
+        existing = [
+            {"id": 1, "text": "A", "start": 0.0, "end": 0.4},
+            {"id": 2, "text": "B", "start": 0.4, "end": 0.8},
+            {"id": 3, "text": "C", "start": 0.8, "end": 1.2},
+        ]
+        incoming = [
+            {"id": 10, "text": "X", "start": 0.6, "end": 1.0},
+            {"id": 1, "text": "BAD", "start": None, "end": 1.1},
+            {"id": 11, "text": "Y", "start": 1.0, "end": 1.4},
+        ]
+
+        merged = _merge_tokens_longest_contiguous(existing, incoming, overlap_duration=1.0)
+        merged_texts = [token["text"] for token in merged]
+
+        assert merged_texts == ["A", "B", "Y"]
+
+    def test_merge_lcs_ignores_missing_timestamp_overlap_tokens(self):
+        """Malformed overlap tokens without timestamps should not drive LCS overlap matching."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Buffered_Transcription import (
+            _merge_tokens_longest_common_subsequence,
+        )
+
+        existing = [
+            {"id": 1, "text": "A", "start": 0.0, "end": 0.4},
+            {"id": 2, "text": "B", "start": 0.4, "end": 0.8},
+            {"id": 3, "text": "C", "start": 0.8, "end": 1.2},
+        ]
+        incoming = [
+            {"id": 10, "text": "X", "start": 0.6, "end": 1.0},
+            {"id": 1, "text": "BAD", "start": None, "end": 1.1},
+            {"id": 11, "text": "Y", "start": 1.0, "end": 1.4},
+        ]
+
+        merged = _merge_tokens_longest_common_subsequence(existing, incoming, overlap_duration=1.0)
+        merged_texts = [token["text"] for token in merged]
+
+        assert merged_texts == ["A", "B", "Y"]
+
     def test_process_audio_with_mock_transcriber(self, sample_audio_data, config):
 
         """Test full audio processing with mocked transcription."""
@@ -257,6 +301,70 @@ class TestBufferedTranscription:
         finally:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
+
+    @patch('soundfile.read')
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.transcribe_with_parakeet_mlx')
+    def test_transcribe_long_audio_mlx_structured_resamples_non_16k_audio(self, mock_transcribe_mlx, mock_sf_read):
+        """Structured MLX long-audio path should resample non-16kHz input before chunking."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Buffered_Transcription import (
+            BufferedTranscriber,
+            transcribe_long_audio,
+        )
+
+        original_audio = np.zeros(22050, dtype=np.float32)
+        resampled_audio = np.ones(16000, dtype=np.float32)
+        mock_sf_read.return_value = (original_audio, 22050)
+        mock_transcribe_mlx.return_value = {
+            "text": "hello",
+            "sentences": [],
+            "tokens": [{"text": "hello", "start": 0.0, "end": 0.5}],
+        }
+
+        captured = {}
+
+        def _fake_create_chunks(_self, audio: np.ndarray):
+            captured["audio"] = audio
+            return [{
+                "audio": audio,
+                "start": 0.0,
+                "end": 1.0,
+                "overlap_start": 0.0,
+                "overlap_end": 0.0,
+            }]
+
+        with patch.object(
+            BufferedTranscriber,
+            "_resample",
+            autospec=True,
+            return_value=resampled_audio,
+        ) as mock_resample, patch.object(
+            BufferedTranscriber,
+            "_create_chunks",
+            autospec=True,
+            side_effect=_fake_create_chunks,
+        ):
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+                tmp_path = tmp_file.name
+
+            try:
+                result = transcribe_long_audio(
+                    tmp_path,
+                    variant="mlx",
+                    chunk_duration=1.0,
+                    total_buffer=1.5,
+                    return_structured=True,
+                )
+            finally:
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+
+        mock_resample.assert_called_once()
+        resample_args = mock_resample.call_args[0]
+        assert resample_args[2] == 22050
+        assert resample_args[3] == 16000
+        assert captured["audio"] is resampled_audio
+        assert mock_transcribe_mlx.call_args.kwargs["sample_rate"] == 16000
+        assert result["tokens"]
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_ONNX.transcribe_with_parakeet_onnx')
     def test_transcribe_long_audio_onnx(self, mock_transcribe_onnx, long_audio_data):

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
@@ -6,6 +6,7 @@ import pytest
 import numpy as np
 import tempfile
 import os
+import builtins
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock, call
 import soundfile as sf
@@ -89,6 +90,31 @@ class TestParakeetMLX:
         # Test when MLX is not available
         mock_check.return_value = False
         assert check_mlx_available() == False
+
+    def test_build_decoding_config_uses_loguru_on_import_error(self, monkeypatch):
+        """Decoding config import errors should log through Loguru, not stdlib logging."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+
+        loguru_calls = {"count": 0}
+
+        def _capture_loguru(*args, **kwargs):
+            loguru_calls["count"] += 1
+
+        monkeypatch.setattr(mlx_mod.logger, "debug", _capture_loguru, raising=True)
+        assert not hasattr(mlx_mod, "logging")
+
+        original_import = builtins.__import__
+
+        def _fake_import(name, *args, **kwargs):
+            if name == "parakeet_mlx":
+                raise ImportError("boom")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import, raising=True)
+
+        cfg = mlx_mod._build_decoding_config(decoding_mode="beam")
+        assert cfg is None
+        assert loguru_calls["count"] >= 1
 
     def test_model_loading(self, monkeypatch):
 
@@ -263,8 +289,11 @@ class TestParakeetMLX:
         monkeypatch.setitem(sys.modules, 'parakeet_mlx', mock_parakeet_mlx)
 
         from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+        import tldw_Server_API.app.core.config as config_mod
+
         monkeypatch.setattr(mlx_mod, 'IS_MACOS', True)
         monkeypatch.setattr(mlx_mod, 'check_mlx_available', lambda: True)
+        monkeypatch.setattr(config_mod, "get_stt_config", lambda: {})
         mlx_mod._mlx_model_cache = None
 
         model = mlx_mod.load_parakeet_mlx_model(force_reload=True)

--- a/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
+++ b/tldw_Server_API/tests/Media_Ingestion_Modification/test_parakeet_mlx.py
@@ -143,6 +143,23 @@ class TestParakeetMLX:
         assert model == mock_model
         mock_parakeet_mlx.from_pretrained.assert_called_once()
 
+    def test_model_loading_does_not_runtime_install_when_package_missing(self, monkeypatch):
+        """Runtime requests should fail fast when parakeet-mlx is not installed."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+
+        monkeypatch.setattr(mlx_mod, "IS_MACOS", True)
+        monkeypatch.setattr(mlx_mod, "check_mlx_available", lambda: True)
+        monkeypatch.setattr(mlx_mod, "check_parakeet_mlx_installed", lambda: False)
+
+        def _unexpected_install():
+            raise AssertionError("Runtime installation should not be attempted")
+
+        monkeypatch.setattr(mlx_mod, "install_parakeet_mlx", _unexpected_install)
+        mlx_mod._mlx_model_cache = None
+
+        model = mlx_mod.load_parakeet_mlx_model(force_reload=True)
+        assert model is None
+
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.load_parakeet_mlx_model')
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.check_mlx_available')
     def test_transcribe_simple(self, mock_check_mlx, mock_load_model, sample_audio_data):
@@ -170,6 +187,90 @@ class TestParakeetMLX:
         # Check that audio was saved to temp file
         call_args = mock_model.transcribe.call_args
         assert call_args[0][0].endswith('.wav')
+
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.load_parakeet_mlx_model')
+    @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.check_mlx_available')
+    def test_transcribe_returns_structured_artifact_when_requested(self, mock_check_mlx, mock_load_model, sample_audio_data):
+        """MLX wrapper should expose sentence/token timing metadata when requested."""
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX import (
+            transcribe_with_parakeet_mlx
+        )
+
+        audio_data, sample_rate = sample_audio_data
+        mock_check_mlx.return_value = True
+        mock_model = MagicMock()
+
+        token1 = MagicMock()
+        token1.id = 101
+        token1.text = "Hello"
+        token1.start = 0.5
+        token1.end = 0.8
+        token1.duration = 0.3
+        token1.confidence = 0.93
+
+        token2 = MagicMock()
+        token2.id = 102
+        token2.text = " world"
+        token2.start = 0.8
+        token2.end = 1.2
+        token2.duration = 0.4
+        token2.confidence = 0.91
+
+        sentence = MagicMock()
+        sentence.text = "Hello world"
+        sentence.start = 0.5
+        sentence.end = 1.2
+        sentence.duration = 0.7
+        sentence.confidence = 0.92
+        sentence.tokens = [token1, token2]
+
+        aligned_result = MagicMock()
+        aligned_result.text = "Hello world"
+        aligned_result.sentences = [sentence]
+        aligned_result.tokens = [token1, token2]
+        mock_model.transcribe.return_value = aligned_result
+        mock_load_model.return_value = mock_model
+
+        artifact = transcribe_with_parakeet_mlx(
+            audio_data,
+            sample_rate,
+            return_structured=True,
+        )
+
+        assert isinstance(artifact, dict)
+        assert artifact["text"] == "Hello world"
+        assert len(artifact["sentences"]) == 1
+        assert artifact["sentences"][0]["start"] == pytest.approx(0.5)
+        assert artifact["sentences"][0]["end"] == pytest.approx(1.2)
+        assert artifact["sentences"][0]["confidence"] == pytest.approx(0.92)
+        assert artifact["tokens"][0]["id"] == 101
+        assert artifact["tokens"][0]["text"] == "Hello"
+        assert artifact["tokens"][0]["confidence"] == pytest.approx(0.93)
+
+    def test_model_loading_defaults_to_parakeet_v3(self, monkeypatch):
+        """Default MLX model id should align with upstream parakeet-mlx default."""
+        import sys, types
+        mock_parakeet_mlx = types.ModuleType('parakeet_mlx')
+        mock_model = MagicMock()
+        captured = {}
+
+        def _from_pretrained(model_id, **kwargs):
+            captured["model_id"] = model_id
+            captured["kwargs"] = kwargs
+            return mock_model
+
+        mock_parakeet_mlx.from_pretrained = MagicMock(side_effect=_from_pretrained)
+        monkeypatch.setitem(sys.modules, 'parakeet_mlx', mock_parakeet_mlx)
+
+        from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import Audio_Transcription_Parakeet_MLX as mlx_mod
+        monkeypatch.setattr(mlx_mod, 'IS_MACOS', True)
+        monkeypatch.setattr(mlx_mod, 'check_mlx_available', lambda: True)
+        mlx_mod._mlx_model_cache = None
+
+        model = mlx_mod.load_parakeet_mlx_model(force_reload=True)
+
+        assert model == mock_model
+        assert captured["model_id"] == "mlx-community/parakeet-tdt-0.6b-v3"
 
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.load_parakeet_mlx_model')
     @patch('tldw_Server_API.app.core.Ingestion_Media_Processing.Audio.Audio_Transcription_Parakeet_MLX.check_mlx_available')


### PR DESCRIPTION
Updates to parakeet-mlx from the base repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MLX-based speech-to-text engine with native streaming support
  * Introduced structured transcription output with sentence and word-level timestamps
  * Added configurable decoding modes (beam/greedy) with runtime parameter control
  * Extended configuration for model caching and sentence-splitting tuning

* **Bug Fixes**
  * Improved transcription segment text extraction with robust fallback handling

* **Documentation**
  * Updated STT configuration documentation with new MLX parameters and cache settings

* **Tests**
  * Added comprehensive test coverage for MLX streaming and structured output functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->