### PR TITLE
feat(kanban): comprehensive UX improvements

### DIFF
--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
@@ -5,6 +5,7 @@ import { Archive, RotateCcw, Trash2 } from "lucide-react"
 
 import {
   listBoards,
+  getBoard,
   unarchiveBoard,
   deleteBoard,
   unarchiveList,
@@ -17,13 +18,13 @@ import type { Board, KanbanList, Card, BoardWithLists } from "@/types/kanban"
 interface ArchivedItemsDrawerProps {
   open: boolean
   onClose: () => void
-  board?: BoardWithLists | null
+  boardId?: number | null
 }
 
 export const ArchivedItemsDrawer = ({
   open,
   onClose,
-  board
+  boardId
 }: ArchivedItemsDrawerProps) => {
   const queryClient = useQueryClient()
 
@@ -35,13 +36,21 @@ export const ArchivedItemsDrawer = ({
     staleTime: 15 * 1000
   })
 
+  // Fetch board data WITH archived items included
+  const { data: boardWithArchived, isLoading: boardArchiveLoading } = useQuery({
+    queryKey: ["kanban-board-archived", boardId],
+    queryFn: () => getBoard(boardId!, { includeArchived: true }),
+    enabled: open && boardId != null,
+    staleTime: 15 * 1000
+  })
+
   const archivedBoards = (boardsData?.boards ?? []).filter((b) => b.archived)
 
-  // Collect archived lists and cards from current board data
+  // Collect archived lists and cards from board data fetched with include_archived
   const archivedLists: KanbanList[] = []
   const archivedCards: Card[] = []
-  if (board) {
-    for (const list of board.lists) {
+  if (boardWithArchived) {
+    for (const list of boardWithArchived.lists) {
       if (list.archived) archivedLists.push(list)
       for (const card of list.cards) {
         if (card.archived) archivedCards.push(card)
@@ -74,11 +83,18 @@ export const ArchivedItemsDrawer = ({
     }
   })
 
+  const invalidateBoardQueries = () => {
+    if (boardId != null) {
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", boardId] })
+      queryClient.invalidateQueries({ queryKey: ["kanban-board-archived", boardId] })
+    }
+  }
+
   const restoreListMutation = useMutation({
     mutationFn: (listId: number) => unarchiveList(listId),
     onSuccess: () => {
       message.success("List restored")
-      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      invalidateBoardQueries()
     },
     onError: () => {
       message.error("Failed to restore. Please try again.")
@@ -89,7 +105,7 @@ export const ArchivedItemsDrawer = ({
     mutationFn: (listId: number) => deleteList(listId),
     onSuccess: () => {
       message.success("List deleted")
-      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      invalidateBoardQueries()
     },
     onError: () => {
       message.error("Failed to delete. Please try again.")
@@ -100,7 +116,7 @@ export const ArchivedItemsDrawer = ({
     mutationFn: (cardId: number) => unarchiveCard(cardId),
     onSuccess: () => {
       message.success("Card restored")
-      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      invalidateBoardQueries()
     },
     onError: () => {
       message.error("Failed to restore. Please try again.")
@@ -111,7 +127,7 @@ export const ArchivedItemsDrawer = ({
     mutationFn: (cardId: number) => deleteCard(cardId),
     onSuccess: () => {
       message.success("Card deleted")
-      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      invalidateBoardQueries()
     },
     onError: () => {
       message.error("Failed to delete. Please try again.")
@@ -248,7 +264,7 @@ export const ArchivedItemsDrawer = ({
       onClose={onClose}
       width={400}
     >
-      {boardsLoading ? (
+      {boardsLoading || boardArchiveLoading ? (
         <div className="flex justify-center py-10">
           <Spin />
         </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
@@ -70,7 +70,7 @@ export const ArchivedItemsDrawer = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
     },
     onError: (err) => {
-      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+      message.error(`Failed to delete board: ${err instanceof Error ? err.message : "Unknown error"}`)
     }
   })
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { Drawer, Button, Popconfirm, Empty, Spin, Collapse, message } from "antd"
+import { Archive, RotateCcw, Trash2 } from "lucide-react"
+
+import {
+  listBoards,
+  unarchiveBoard,
+  deleteBoard,
+  unarchiveList,
+  deleteList,
+  unarchiveCard,
+  deleteCard
+} from "@/services/kanban"
+import type { Board, KanbanList, Card, BoardWithLists } from "@/types/kanban"
+
+interface ArchivedItemsDrawerProps {
+  open: boolean
+  onClose: () => void
+  board?: BoardWithLists | null
+}
+
+export const ArchivedItemsDrawer = ({
+  open,
+  onClose,
+  board
+}: ArchivedItemsDrawerProps) => {
+  const queryClient = useQueryClient()
+
+  // Fetch all boards including archived
+  const { data: boardsData, isLoading: boardsLoading } = useQuery({
+    queryKey: ["kanban-boards-archived"],
+    queryFn: () => listBoards({ limit: 200, includeArchived: true }),
+    enabled: open,
+    staleTime: 15 * 1000
+  })
+
+  const archivedBoards = (boardsData?.boards ?? []).filter((b) => b.archived)
+
+  // Collect archived lists and cards from current board data
+  const archivedLists: KanbanList[] = []
+  const archivedCards: Card[] = []
+  if (board) {
+    for (const list of board.lists) {
+      if (list.archived) archivedLists.push(list)
+      for (const card of list.cards) {
+        if (card.archived) archivedCards.push(card)
+      }
+    }
+  }
+
+  // Mutations
+  const restoreBoardMutation = useMutation({
+    mutationFn: (boardId: number) => unarchiveBoard(boardId),
+    onSuccess: () => {
+      message.success("Board restored")
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
+    },
+    onError: (err) => {
+      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const deleteBoardMutation = useMutation({
+    mutationFn: (boardId: number) => deleteBoard(boardId),
+    onSuccess: () => {
+      message.success("Board deleted permanently")
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
+    },
+    onError: (err) => {
+      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const restoreListMutation = useMutation({
+    mutationFn: (listId: number) => unarchiveList(listId),
+    onSuccess: () => {
+      message.success("List restored")
+      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    },
+    onError: (err) => {
+      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const deleteListMutation = useMutation({
+    mutationFn: (listId: number) => deleteList(listId),
+    onSuccess: () => {
+      message.success("List deleted permanently")
+      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    },
+    onError: (err) => {
+      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const restoreCardMutation = useMutation({
+    mutationFn: (cardId: number) => unarchiveCard(cardId),
+    onSuccess: () => {
+      message.success("Card restored")
+      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    },
+    onError: (err) => {
+      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const deleteCardMutation = useMutation({
+    mutationFn: (cardId: number) => deleteCard(cardId),
+    onSuccess: () => {
+      message.success("Card deleted permanently")
+      if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    },
+    onError: (err) => {
+      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const renderItemActions = (
+    onRestore: () => void,
+    onDelete: () => void,
+    name: string
+  ) => (
+    <div className="flex gap-1">
+      <Button
+        type="text"
+        size="small"
+        icon={<RotateCcw className="w-3.5 h-3.5" />}
+        onClick={(e) => {
+          e.stopPropagation()
+          onRestore()
+        }}
+      >
+        Restore
+      </Button>
+      <Popconfirm
+        title={`Delete "${name}" permanently?`}
+        description="This cannot be undone."
+        onConfirm={onDelete}
+        okText="Delete"
+        okType="danger"
+      >
+        <Button
+          type="text"
+          size="small"
+          danger
+          icon={<Trash2 className="w-3.5 h-3.5" />}
+          onClick={(e) => e.stopPropagation()}
+        />
+      </Popconfirm>
+    </div>
+  )
+
+  const collapseItems = [
+    ...(archivedBoards.length > 0
+      ? [
+          {
+            key: "boards",
+            label: `Archived Boards (${archivedBoards.length})`,
+            children: (
+              <div className="space-y-2">
+                {archivedBoards.map((b) => (
+                  <div
+                    key={b.id}
+                    className="flex items-center justify-between p-2 rounded bg-surface"
+                  >
+                    <span className="text-sm truncate">{b.name}</span>
+                    {renderItemActions(
+                      () => restoreBoardMutation.mutate(b.id),
+                      () => deleteBoardMutation.mutate(b.id),
+                      b.name
+                    )}
+                  </div>
+                ))}
+              </div>
+            )
+          }
+        ]
+      : []),
+    ...(archivedLists.length > 0
+      ? [
+          {
+            key: "lists",
+            label: `Archived Lists (${archivedLists.length})`,
+            children: (
+              <div className="space-y-2">
+                {archivedLists.map((l) => (
+                  <div
+                    key={l.id}
+                    className="flex items-center justify-between p-2 rounded bg-surface"
+                  >
+                    <span className="text-sm truncate">{l.name}</span>
+                    {renderItemActions(
+                      () => restoreListMutation.mutate(l.id),
+                      () => deleteListMutation.mutate(l.id),
+                      l.name
+                    )}
+                  </div>
+                ))}
+              </div>
+            )
+          }
+        ]
+      : []),
+    ...(archivedCards.length > 0
+      ? [
+          {
+            key: "cards",
+            label: `Archived Cards (${archivedCards.length})`,
+            children: (
+              <div className="space-y-2">
+                {archivedCards.map((c) => (
+                  <div
+                    key={c.id}
+                    className="flex items-center justify-between p-2 rounded bg-surface"
+                  >
+                    <span className="text-sm truncate">{c.title}</span>
+                    {renderItemActions(
+                      () => restoreCardMutation.mutate(c.id),
+                      () => deleteCardMutation.mutate(c.id),
+                      c.title
+                    )}
+                  </div>
+                ))}
+              </div>
+            )
+          }
+        ]
+      : [])
+  ]
+
+  const isEmpty =
+    archivedBoards.length === 0 &&
+    archivedLists.length === 0 &&
+    archivedCards.length === 0
+
+  return (
+    <Drawer
+      title={
+        <div className="flex items-center gap-2">
+          <Archive className="w-4 h-4" />
+          <span>Archived Items</span>
+        </div>
+      }
+      open={open}
+      onClose={onClose}
+      width={400}
+    >
+      {boardsLoading ? (
+        <div className="flex justify-center py-10">
+          <Spin />
+        </div>
+      ) : isEmpty ? (
+        <Empty description="No archived items" />
+      ) : (
+        <Collapse
+          items={collapseItems}
+          defaultActiveKey={collapseItems.map((i) => i.key)}
+          ghost
+        />
+      )}
+    </Drawer>
+  )
+}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
@@ -58,7 +58,7 @@ export const ArchivedItemsDrawer = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
     },
     onError: (err) => {
-      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+      message.error(`Failed to restore board: ${err instanceof Error ? err.message : "Unknown error"}`)
     }
   })
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ArchivedItemsDrawer.tsx
@@ -57,20 +57,20 @@ export const ArchivedItemsDrawer = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
       queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
     },
-    onError: (err) => {
-      message.error(`Failed to restore board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to restore. Please try again.")
     }
   })
 
   const deleteBoardMutation = useMutation({
     mutationFn: (boardId: number) => deleteBoard(boardId),
     onSuccess: () => {
-      message.success("Board deleted permanently")
+      message.success("Board deleted")
       queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
       queryClient.invalidateQueries({ queryKey: ["kanban-boards-archived"] })
     },
-    onError: (err) => {
-      message.error(`Failed to delete board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete. Please try again.")
     }
   })
 
@@ -80,19 +80,19 @@ export const ArchivedItemsDrawer = ({
       message.success("List restored")
       if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to restore. Please try again.")
     }
   })
 
   const deleteListMutation = useMutation({
     mutationFn: (listId: number) => deleteList(listId),
     onSuccess: () => {
-      message.success("List deleted permanently")
+      message.success("List deleted")
       if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete. Please try again.")
     }
   })
 
@@ -102,19 +102,19 @@ export const ArchivedItemsDrawer = ({
       message.success("Card restored")
       if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to restore: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to restore. Please try again.")
     }
   })
 
   const deleteCardMutation = useMutation({
     mutationFn: (cardId: number) => deleteCard(cardId),
     onSuccess: () => {
-      message.success("Card deleted permanently")
+      message.success("Card deleted")
       if (board) queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to delete: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete. Please try again.")
     }
   })
 
@@ -136,7 +136,7 @@ export const ArchivedItemsDrawer = ({
         Restore
       </Button>
       <Popconfirm
-        title={`Delete "${name}" permanently?`}
+        title={`Delete "${name}"?`}
         description="This cannot be undone."
         onConfirm={onDelete}
         okText="Delete"

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardGallery.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardGallery.tsx
@@ -54,7 +54,12 @@ export const BoardGallery = ({
               </p>
             )}
             <div className="text-xs text-text-subtle">
-              Updated {new Date(board.updated_at).toLocaleDateString()}
+              Updated{" "}
+              {new Date(board.updated_at).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric"
+              })}
             </div>
           </button>
         ))}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardGallery.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardGallery.tsx
@@ -1,0 +1,100 @@
+import { Button, Empty } from "antd"
+import { Plus, Kanban } from "lucide-react"
+
+import type { Board } from "@/types/kanban"
+
+interface BoardGalleryProps {
+  boards: Board[]
+  onSelectBoard: (boardId: number) => void
+  onCreateBoard: () => void
+}
+
+export const BoardGallery = ({
+  boards,
+  onSelectBoard,
+  onCreateBoard
+}: BoardGalleryProps) => {
+  const activeBoards = boards.filter((b) => !b.archived)
+  const archivedBoards = boards.filter((b) => b.archived)
+
+  if (activeBoards.length === 0 && archivedBoards.length === 0) {
+    return (
+      <Empty
+        description="Organize research tasks, track projects with boards and cards."
+        className="mt-20"
+      >
+        <Button
+          type="primary"
+          icon={<Plus className="w-4 h-4" />}
+          onClick={onCreateBoard}
+        >
+          Create Board
+        </Button>
+      </Empty>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Active boards grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {activeBoards.map((board) => (
+          <button
+            key={board.id}
+            onClick={() => onSelectBoard(board.id)}
+            className="text-left bg-surface hover:bg-surface2 rounded-lg p-4 border border-transparent hover:border-primary/30 transition-colors cursor-pointer"
+          >
+            <div className="flex items-start gap-2 mb-2">
+              <Kanban className="w-4 h-4 text-primary mt-0.5 flex-shrink-0" />
+              <h3 className="font-medium text-sm line-clamp-2">{board.name}</h3>
+            </div>
+            {board.description && (
+              <p className="text-xs text-text-muted line-clamp-2 mb-2">
+                {board.description}
+              </p>
+            )}
+            <div className="text-xs text-text-subtle">
+              Updated {new Date(board.updated_at).toLocaleDateString()}
+            </div>
+          </button>
+        ))}
+
+        {/* Create board card */}
+        <button
+          onClick={onCreateBoard}
+          className="flex items-center justify-center gap-2 bg-transparent border-2 border-dashed border-border hover:border-primary/50 rounded-lg p-4 text-text-muted hover:text-text transition-colors cursor-pointer min-h-[100px]"
+        >
+          <Plus className="w-4 h-4" />
+          <span className="text-sm">New Board</span>
+        </button>
+      </div>
+
+      {/* Archived boards (collapsed) */}
+      {archivedBoards.length > 0 && (
+        <details className="text-sm">
+          <summary className="text-text-muted cursor-pointer hover:text-text">
+            {archivedBoards.length} archived board
+            {archivedBoards.length !== 1 ? "s" : ""}
+          </summary>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 mt-3">
+            {archivedBoards.map((board) => (
+              <button
+                key={board.id}
+                onClick={() => onSelectBoard(board.id)}
+                className="text-left bg-surface/50 hover:bg-surface rounded-lg p-4 opacity-60 hover:opacity-100 transition-opacity cursor-pointer"
+              >
+                <div className="flex items-start gap-2 mb-1">
+                  <Kanban className="w-4 h-4 text-text-muted mt-0.5 flex-shrink-0" />
+                  <h3 className="font-medium text-sm line-clamp-1">
+                    {board.name}
+                  </h3>
+                </div>
+                <div className="text-xs text-text-subtle">Archived</div>
+              </button>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
@@ -126,19 +126,27 @@ export const BoardView = ({
               if (!a) return
               undoRef.current = null
               if (a.type === "archive-card") {
-                unarchiveCard(a.entityId).then(() => {
-                  queryClient.invalidateQueries({
-                    queryKey: ["kanban-board", board.id]
+                unarchiveCard(a.entityId)
+                  .then(() => {
+                    queryClient.invalidateQueries({
+                      queryKey: ["kanban-board", board.id]
+                    })
+                    message.success("Card restored")
                   })
-                  message.success("Card restored")
-                })
+                  .catch(() => {
+                    message.error("Failed to restore card. Please try again.")
+                  })
               } else if (a.type === "archive-list") {
-                unarchiveList(a.entityId).then(() => {
-                  queryClient.invalidateQueries({
-                    queryKey: ["kanban-board", board.id]
+                unarchiveList(a.entityId)
+                  .then(() => {
+                    queryClient.invalidateQueries({
+                      queryKey: ["kanban-board", board.id]
+                    })
+                    message.success("List restored")
                   })
-                  message.success("List restored")
-                })
+                  .catch(() => {
+                    message.error("Failed to restore list. Please try again.")
+                  })
               }
             }}
           >
@@ -160,8 +168,8 @@ export const BoardView = ({
       setAddingList(false)
       setNewListName("")
     },
-    onError: (err) => {
-      message.error(`Failed to create list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to create list. Please try again.")
     }
   })
 
@@ -173,10 +181,8 @@ export const BoardView = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
       setRenameModalOpen(false)
     },
-    onError: (err) => {
-      message.error(
-        `Failed to rename board: ${err instanceof Error ? err.message : "Unknown error"}`
-      )
+    onError: () => {
+      message.error("Failed to rename board. Please try again.")
     }
   })
 
@@ -187,8 +193,8 @@ export const BoardView = ({
       message.success("List renamed")
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to rename list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to rename list. Please try again.")
     }
   })
 
@@ -198,8 +204,8 @@ export const BoardView = ({
       message.success("List deleted")
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to delete list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete list. Please try again.")
     }
   })
 
@@ -210,8 +216,8 @@ export const BoardView = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
       showUndoToast({ type: "archive-list", entityId: listId, label: listName })
     },
-    onError: (err) => {
-      message.error(`Failed to archive list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to archive list. Please try again.")
     }
   })
 
@@ -233,8 +239,8 @@ export const BoardView = ({
         label: cardTitle
       })
     },
-    onError: (err) => {
-      message.error(`Failed to archive card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to archive card. Please try again.")
     }
   })
 
@@ -245,8 +251,8 @@ export const BoardView = ({
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
       setAddingCardListId(null)
     },
-    onError: (err) => {
-      message.error(`Failed to create card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to create card. Please try again.")
     }
   })
 
@@ -256,8 +262,8 @@ export const BoardView = ({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to update card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to update card. Please try again.")
     }
   })
 
@@ -269,8 +275,8 @@ export const BoardView = ({
       setDetailPanelOpen(false)
       setSelectedCard(null)
     },
-    onError: (err) => {
-      message.error(`Failed to delete card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete card. Please try again.")
     }
   })
 
@@ -287,8 +293,8 @@ export const BoardView = ({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     },
-    onError: (err) => {
-      message.error(`Failed to move card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to move card. Please try again.")
     }
   })
 
@@ -308,11 +314,11 @@ export const BoardView = ({
       }
       return { previous }
     },
-    onError: (err, _vars, context) => {
+    onError: (_err, _vars, context) => {
       if (context?.previous) {
         queryClient.setQueryData(["kanban-board", board.id], context.previous)
       }
-      message.error(`Failed to reorder lists: ${err instanceof Error ? err.message : "Unknown error"}`)
+      message.error("Failed to reorder lists. Please try again.")
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
@@ -340,11 +346,11 @@ export const BoardView = ({
       }
       return { previous }
     },
-    onError: (err, _vars, context) => {
+    onError: (_err, _vars, context) => {
       if (context?.previous) {
         queryClient.setQueryData(["kanban-board", board.id], context.previous)
       }
-      message.error(`Failed to reorder cards: ${err instanceof Error ? err.message : "Unknown error"}`)
+      message.error("Failed to reorder cards. Please try again.")
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
@@ -635,10 +641,10 @@ export const BoardView = ({
             </Button>
           )}
           <Popconfirm
-            title="Delete this board permanently?"
-            description="All lists and cards will be permanently deleted. This cannot be undone."
+            title="Delete this board?"
+            description="All lists and cards will be removed. This cannot be undone."
             onConfirm={onDelete}
-            okText="Delete Permanently"
+            okText="Delete"
             okType="danger"
           >
             <Button danger type="text" icon={<Trash2 className="w-4 h-4" />} size="small">
@@ -955,7 +961,7 @@ const SortableList = ({
     },
     {
       key: "delete",
-      label: "Delete Permanently",
+      label: "Delete List",
       danger: true,
       icon: <Trash2 className="w-4 h-4" />,
       onClick: () => setDeleteConfirmOpen(true)
@@ -1004,7 +1010,7 @@ const SortableList = ({
         </div>
         <Popconfirm
           title={`Delete list '${list.name}'?`}
-          description={`${list.cards.length} card${list.cards.length !== 1 ? "s" : ""} will be deleted.`}
+          description={`${list.cards.length} card${list.cards.length !== 1 ? "s" : ""} will be removed.`}
           open={deleteConfirmOpen}
           onConfirm={() => {
             setDeleteConfirmOpen(false)
@@ -1014,7 +1020,7 @@ const SortableList = ({
           okText="Delete"
           okType="danger"
         >
-          <span />
+          <span className="absolute w-0 h-0 overflow-hidden" />
         </Popconfirm>
         <Dropdown menu={{ items: menuItems }} trigger={["click"]}>
           <Button

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
@@ -57,6 +57,11 @@ interface BoardViewProps {
   onDelete: () => void
   onArchive?: () => void
   onQuickSetup?: () => void
+  /** Expose triggers so the parent can start add-card / add-list from keyboard shortcuts */
+  shortcutHandlersRef?: React.RefObject<{
+    startAddCard: () => void
+    startAddList: () => void
+  } | null>
 }
 
 type DragStartEvent = Parameters<DragDropEvents["dragstart"]>[0]
@@ -73,7 +78,8 @@ export const BoardView = ({
   onRefresh,
   onDelete,
   onArchive,
-  onQuickSetup
+  onQuickSetup,
+  shortcutHandlersRef
 }: BoardViewProps) => {
   const queryClient = useQueryClient()
 
@@ -101,6 +107,25 @@ export const BoardView = ({
 
   // Add card state - tracks which list is in "add card" mode
   const [addingCardListId, setAddingCardListId] = useState<number | null>(null)
+
+  // Expose add-card / add-list triggers to parent via ref
+  useEffect(() => {
+    if (shortcutHandlersRef) {
+      shortcutHandlersRef.current = {
+        startAddCard: () => {
+          // Open add-card on the first list
+          const firstList = board.lists[0]
+          if (firstList) setAddingCardListId(firstList.id)
+        },
+        startAddList: () => {
+          setAddingList(true)
+        }
+      }
+    }
+    return () => {
+      if (shortcutHandlersRef) shortcutHandlersRef.current = null
+    }
+  }, [shortcutHandlersRef, board.lists])
 
   // Undo state
   const undoRef = useRef<UndoAction | null>(null)

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react"
+import { useState, useCallback, useEffect, useRef, useMemo } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { Button, Input, message, Popconfirm, Dropdown, Modal, Select } from "antd"
 import type { MenuProps } from "antd"
@@ -563,7 +563,7 @@ export const BoardView = ({
   }
 
   // Collect all unique labels from cards for filter options
-  const allLabels = (() => {
+  const allLabels = useMemo(() => {
     const map = new Map<number, { id: number; name: string; color: string }>()
     for (const list of board.lists) {
       for (const card of list.cards) {
@@ -573,7 +573,13 @@ export const BoardView = ({
       }
     }
     return Array.from(map.values())
-  })()
+  }, [board.lists])
+
+  const handleClearFilters = useCallback(() => {
+    setFilterLabelIds([])
+    setFilterPriorities([])
+    setSearchQuery("")
+  }, [])
 
   // Check if card matches current filters
   const cardMatchesFilters = useCallback(
@@ -710,11 +716,7 @@ export const BoardView = ({
             <Button
               size="small"
               type="link"
-              onClick={() => {
-                setFilterLabelIds([])
-                setFilterPriorities([])
-                setSearchQuery("")
-              }}
+              onClick={handleClearFilters}
             >
               Clear filters
             </Button>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/BoardView.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback, useEffect } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Button, Input, message, Popconfirm, Dropdown, Modal } from "antd"
+import { Button, Input, message, Popconfirm, Dropdown, Modal, Select } from "antd"
 import type { MenuProps } from "antd"
 import {
   Plus,
@@ -8,7 +8,13 @@ import {
   Trash2,
   Calendar,
   GripVertical,
-  Edit2
+  Edit2,
+  CheckSquare,
+  MessageCircle,
+  FileText,
+  Archive,
+  Zap,
+  Search
 } from "lucide-react"
 import { DragDropProvider, DragOverlay, type DragDropEvents } from "@dnd-kit/react"
 import { useSortable } from "@dnd-kit/react/sortable"
@@ -19,10 +25,15 @@ import {
   createList,
   createCard,
   updateBoard,
+  updateList,
   deleteList,
   updateCard,
   deleteCard,
   moveCard,
+  archiveList,
+  unarchiveList,
+  archiveCard,
+  unarchiveCard,
   reorderLists,
   reorderCards,
   generateClientId,
@@ -34,7 +45,8 @@ import type {
   BoardWithLists,
   ListWithCards,
   Card,
-  CardUpdate
+  CardUpdate,
+  ListUpdate
 } from "@/types/kanban"
 
 import { CardDetailPanel } from "./CardDetailPanel"
@@ -43,12 +55,26 @@ interface BoardViewProps {
   board: BoardWithLists
   onRefresh: () => void
   onDelete: () => void
+  onArchive?: () => void
+  onQuickSetup?: () => void
 }
 
 type DragStartEvent = Parameters<DragDropEvents["dragstart"]>[0]
 type DragEndEvent = Parameters<DragDropEvents["dragend"]>[0]
 
-export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
+interface UndoAction {
+  type: "archive-card" | "archive-list"
+  entityId: number
+  label: string
+}
+
+export const BoardView = ({
+  board,
+  onRefresh,
+  onDelete,
+  onArchive,
+  onQuickSetup
+}: BoardViewProps) => {
   const queryClient = useQueryClient()
 
   // Drag state
@@ -63,17 +89,66 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
   const [renameModalOpen, setRenameModalOpen] = useState(false)
   const [renameValue, setRenameValue] = useState(board.name)
 
+  // Filter state
+  const [filterLabelIds, setFilterLabelIds] = useState<number[]>([])
+  const [filterPriorities, setFilterPriorities] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState("")
+  const hasFilters = filterLabelIds.length > 0 || filterPriorities.length > 0 || searchQuery.length > 0
+
   // Add list state
   const [addingList, setAddingList] = useState(false)
   const [newListName, setNewListName] = useState("")
 
   // Add card state - tracks which list is in "add card" mode
   const [addingCardListId, setAddingCardListId] = useState<number | null>(null)
-  const [newCardTitle, setNewCardTitle] = useState("")
+
+  // Undo state
+  const undoRef = useRef<UndoAction | null>(null)
 
   useEffect(() => {
     setRenameValue(board.name)
   }, [board.id, board.name])
+
+  // Show undo toast after archive
+  const showUndoToast = useCallback(
+    (action: UndoAction) => {
+      undoRef.current = action
+      message.open({
+        type: "success",
+        content: `"${action.label}" archived`,
+        duration: 10,
+        btn: (
+          <Button
+            type="link"
+            size="small"
+            onClick={() => {
+              const a = undoRef.current
+              if (!a) return
+              undoRef.current = null
+              if (a.type === "archive-card") {
+                unarchiveCard(a.entityId).then(() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ["kanban-board", board.id]
+                  })
+                  message.success("Card restored")
+                })
+              } else if (a.type === "archive-list") {
+                unarchiveList(a.entityId).then(() => {
+                  queryClient.invalidateQueries({
+                    queryKey: ["kanban-board", board.id]
+                  })
+                  message.success("List restored")
+                })
+              }
+            }}
+          >
+            Undo
+          </Button>
+        )
+      })
+    },
+    [board.id, queryClient]
+  )
 
   // Mutations
   const createListMutation = useMutation({
@@ -105,6 +180,18 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
     }
   })
 
+  const updateListMutation = useMutation({
+    mutationFn: ({ listId, data }: { listId: number; data: ListUpdate }) =>
+      updateList(listId, data),
+    onSuccess: () => {
+      message.success("List renamed")
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    },
+    onError: (err) => {
+      message.error(`Failed to rename list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
   const deleteListMutation = useMutation({
     mutationFn: (listId: number) => deleteList(listId),
     onSuccess: () => {
@@ -116,13 +203,47 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
     }
   })
 
+  const archiveListMutation = useMutation({
+    mutationFn: ({ listId, listName }: { listId: number; listName: string }) =>
+      archiveList(listId),
+    onSuccess: (_data, { listId, listName }) => {
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      showUndoToast({ type: "archive-list", entityId: listId, label: listName })
+    },
+    onError: (err) => {
+      message.error(`Failed to archive list: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const archiveCardMutation = useMutation({
+    mutationFn: ({
+      cardId,
+      cardTitle
+    }: {
+      cardId: number
+      cardTitle: string
+    }) => archiveCard(cardId),
+    onSuccess: (_data, { cardId, cardTitle }) => {
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+      setDetailPanelOpen(false)
+      setSelectedCard(null)
+      showUndoToast({
+        type: "archive-card",
+        entityId: cardId,
+        label: cardTitle
+      })
+    },
+    onError: (err) => {
+      message.error(`Failed to archive card: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
   const createCardMutation = useMutation({
     mutationFn: ({ listId, title }: { listId: number; title: string }) =>
       createCard(listId, { title, client_id: generateClientId() }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
       setAddingCardListId(null)
-      setNewCardTitle("")
     },
     onError: (err) => {
       message.error(`Failed to create card: ${err instanceof Error ? err.message : "Unknown error"}`)
@@ -173,22 +294,60 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
 
   const reorderListsMutation = useMutation({
     mutationFn: (listIds: number[]) => reorderLists(board.id, listIds),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    onMutate: async (listIds) => {
+      await queryClient.cancelQueries({ queryKey: ["kanban-board", board.id] })
+      const previous = queryClient.getQueryData<BoardWithLists>(["kanban-board", board.id])
+      if (previous) {
+        const reordered = listIds
+          .map((id) => previous.lists.find((l) => l.id === id))
+          .filter(Boolean) as ListWithCards[]
+        queryClient.setQueryData<BoardWithLists>(["kanban-board", board.id], {
+          ...previous,
+          lists: reordered
+        })
+      }
+      return { previous }
     },
-    onError: (err) => {
+    onError: (err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["kanban-board", board.id], context.previous)
+      }
       message.error(`Failed to reorder lists: ${err instanceof Error ? err.message : "Unknown error"}`)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     }
   })
 
   const reorderCardsMutation = useMutation({
     mutationFn: ({ listId, cardIds }: { listId: number; cardIds: number[] }) =>
       reorderCards(listId, cardIds),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
+    onMutate: async ({ listId, cardIds }) => {
+      await queryClient.cancelQueries({ queryKey: ["kanban-board", board.id] })
+      const previous = queryClient.getQueryData<BoardWithLists>(["kanban-board", board.id])
+      if (previous) {
+        const updated = {
+          ...previous,
+          lists: previous.lists.map((l) => {
+            if (l.id !== listId) return l
+            const reordered = cardIds
+              .map((id) => l.cards.find((c) => c.id === id))
+              .filter(Boolean) as Card[]
+            return { ...l, cards: reordered }
+          })
+        }
+        queryClient.setQueryData<BoardWithLists>(["kanban-board", board.id], updated)
+      }
+      return { previous }
     },
-    onError: (err) => {
+    onError: (err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["kanban-board", board.id], context.previous)
+      }
       message.error(`Failed to reorder cards: ${err instanceof Error ? err.message : "Unknown error"}`)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["kanban-board", board.id] })
     }
   })
 
@@ -197,15 +356,6 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
     if (!newListName.trim()) return
     createListMutation.mutate(newListName.trim())
   }, [newListName, createListMutation])
-
-  // Handle adding new card
-  const handleAddCard = useCallback(
-    (listId: number) => {
-      if (!newCardTitle.trim()) return
-      createCardMutation.mutate({ listId, title: newCardTitle.trim() })
-    },
-    [newCardTitle, createCardMutation]
-  )
 
   // Open card detail panel
   const handleCardClick = useCallback((card: Card) => {
@@ -227,6 +377,30 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
       deleteCardMutation.mutate(cardId)
     },
     [deleteCardMutation]
+  )
+
+  // Rename list
+  const handleRenameList = useCallback(
+    (listId: number, name: string) => {
+      updateListMutation.mutate({ listId, data: { name } })
+    },
+    [updateListMutation]
+  )
+
+  // Archive list
+  const handleArchiveList = useCallback(
+    (listId: number, listName: string) => {
+      archiveListMutation.mutate({ listId, listName })
+    },
+    [archiveListMutation]
+  )
+
+  // Archive card
+  const handleArchiveCard = useCallback(
+    (cardId: number, cardTitle: string) => {
+      archiveCardMutation.mutate({ cardId, cardTitle })
+    },
+    [archiveCardMutation]
   )
 
   // Drag handlers
@@ -382,6 +556,45 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
     return board.lists.find((l) => l.id === listId) || null
   }
 
+  // Collect all unique labels from cards for filter options
+  const allLabels = (() => {
+    const map = new Map<number, { id: number; name: string; color: string }>()
+    for (const list of board.lists) {
+      for (const card of list.cards) {
+        for (const label of card.labels ?? []) {
+          map.set(label.id, { id: label.id, name: label.name, color: label.color })
+        }
+      }
+    }
+    return Array.from(map.values())
+  })()
+
+  // Check if card matches current filters
+  const cardMatchesFilters = useCallback(
+    (card: Card) => {
+      if (!hasFilters) return true
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase()
+        const matchesTitle = card.title.toLowerCase().includes(q)
+        const matchesDesc = (card.description ?? "").toLowerCase().includes(q)
+        if (!matchesTitle && !matchesDesc) return false
+      }
+      if (filterPriorities.length > 0) {
+        if (!card.priority || !filterPriorities.includes(card.priority)) {
+          return false
+        }
+      }
+      if (filterLabelIds.length > 0) {
+        const cardLabelIds = (card.labels ?? []).map((l) => l.id)
+        if (!filterLabelIds.some((id) => cardLabelIds.includes(id))) {
+          return false
+        }
+      }
+      return true
+    },
+    [hasFilters, searchQuery, filterPriorities, filterLabelIds]
+  )
+
   return (
     <div className="board-view">
       {/* Board header with name and actions */}
@@ -403,19 +616,105 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
           <span className="text-sm text-text-muted">
             {board.lists.length} lists, {board.total_cards} cards
           </span>
+          {onQuickSetup && (
+            <Button
+              size="small"
+              icon={<Zap className="w-4 h-4" />}
+              onClick={onQuickSetup}
+            >
+              Quick Setup
+            </Button>
+          )}
+          {onArchive && (
+            <Button
+              size="small"
+              icon={<Archive className="w-4 h-4" />}
+              onClick={onArchive}
+            >
+              Archive Board
+            </Button>
+          )}
           <Popconfirm
-            title="Delete this board?"
-            description="All lists and cards will be deleted."
+            title="Delete this board permanently?"
+            description="All lists and cards will be permanently deleted. This cannot be undone."
             onConfirm={onDelete}
-            okText="Delete"
+            okText="Delete Permanently"
             okType="danger"
           >
-            <Button danger icon={<Trash2 className="w-4 h-4" />} size="small">
-              Delete Board
+            <Button danger type="text" icon={<Trash2 className="w-4 h-4" />} size="small">
+              Delete
             </Button>
           </Popconfirm>
         </div>
       </div>
+
+      {/* Filter bar */}
+      {(allLabels.length > 0 || board.total_cards > 0) && (
+        <div className="flex items-center gap-2 mb-3 flex-wrap">
+          <Input
+            placeholder="Search cards..."
+            prefix={<Search className="w-3.5 h-3.5 text-text-muted" />}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            allowClear
+            size="small"
+            style={{ width: 180 }}
+          />
+          {allLabels.length > 0 && (
+            <Select
+              mode="multiple"
+              placeholder="Filter by label"
+              style={{ minWidth: 160 }}
+              value={filterLabelIds}
+              onChange={setFilterLabelIds}
+              maxTagCount={2}
+              allowClear
+              size="small"
+              options={allLabels.map((l) => ({
+                value: l.id,
+                label: (
+                  <div className="flex items-center gap-1">
+                    <span
+                      className="inline-block w-3 h-3 rounded-sm"
+                      style={{ backgroundColor: l.color }}
+                    />
+                    {l.name}
+                  </div>
+                )
+              }))}
+            />
+          )}
+          <Select
+            mode="multiple"
+            placeholder="Filter by priority"
+            style={{ minWidth: 150 }}
+            value={filterPriorities}
+            onChange={setFilterPriorities}
+            maxTagCount={2}
+            allowClear
+            size="small"
+            options={[
+              { value: "urgent", label: "Urgent" },
+              { value: "high", label: "High" },
+              { value: "medium", label: "Medium" },
+              { value: "low", label: "Low" }
+            ]}
+          />
+          {hasFilters && (
+            <Button
+              size="small"
+              type="link"
+              onClick={() => {
+                setFilterLabelIds([])
+                setFilterPriorities([])
+                setSearchQuery("")
+              }}
+            >
+              Clear filters
+            </Button>
+          )}
+        </div>
+      )}
 
       {/* Kanban board with DnD */}
       <DragDropProvider onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
@@ -426,16 +725,19 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
               list={list}
               index={index}
               onDeleteList={() => deleteListMutation.mutate(list.id)}
+              onArchiveList={() =>
+                handleArchiveList(list.id, list.name)
+              }
+              onRenameList={(name) => handleRenameList(list.id, name)}
               onCardClick={handleCardClick}
               addingCard={addingCardListId === list.id}
               onStartAddCard={() => setAddingCardListId(list.id)}
-              onCancelAddCard={() => {
-                setAddingCardListId(null)
-                setNewCardTitle("")
-              }}
-              newCardTitle={newCardTitle}
-              onNewCardTitleChange={setNewCardTitle}
-              onAddCard={() => handleAddCard(list.id)}
+              onCancelAddCard={() => setAddingCardListId(null)}
+              onAddCard={(title) =>
+                createCardMutation.mutate({ listId: list.id, title })
+              }
+              createCardLoading={createCardMutation.isPending}
+              cardMatchesFilters={cardMatchesFilters}
             />
           ))}
 
@@ -502,6 +804,7 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
       {/* Card detail panel */}
       <CardDetailPanel
         card={selectedCard}
+        boardId={board.id}
         lists={board.lists}
         open={detailPanelOpen}
         onClose={() => {
@@ -510,9 +813,17 @@ export const BoardView = ({ board, onRefresh, onDelete }: BoardViewProps) => {
         }}
         onSave={handleSaveCard}
         onDelete={handleDeleteCard}
+        onArchive={(cardId, cardTitle) =>
+          handleArchiveCard(cardId, cardTitle)
+        }
         onMove={(cardId, targetListId) =>
           moveCardMutation.mutate({ cardId, targetListId })
         }
+        onCopied={() => {
+          queryClient.invalidateQueries({
+            queryKey: ["kanban-board", board.id]
+          })
+        }}
       />
 
       <Modal
@@ -547,26 +858,30 @@ interface SortableListProps {
   list: ListWithCards
   index: number
   onDeleteList: () => void
+  onArchiveList: () => void
+  onRenameList: (name: string) => void
   onCardClick: (card: Card) => void
   addingCard: boolean
   onStartAddCard: () => void
   onCancelAddCard: () => void
-  newCardTitle: string
-  onNewCardTitleChange: (value: string) => void
-  onAddCard: () => void
+  onAddCard: (title: string) => void
+  createCardLoading: boolean
+  cardMatchesFilters: (card: Card) => boolean
 }
 
 const SortableList = ({
   list,
   index,
   onDeleteList,
+  onArchiveList,
+  onRenameList,
   onCardClick,
   addingCard,
   onStartAddCard,
   onCancelAddCard,
-  newCardTitle,
-  onNewCardTitleChange,
-  onAddCard
+  onAddCard,
+  createCardLoading,
+  cardMatchesFilters
 }: SortableListProps) => {
   const {
     ref,
@@ -580,17 +895,70 @@ const SortableList = ({
     plugins: []
   })
 
+  // Local state for inline rename
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [renameValue, setRenameValue] = useState(list.name)
+
+  // Local state for card title (fixes shared newCardTitle bug)
+  const [newCardTitle, setNewCardTitle] = useState("")
+
+  // Delete confirmation state
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+
   const style = {
     opacity: isDragging ? 0.5 : 1
   }
 
+  const handleStartRename = () => {
+    setRenameValue(list.name)
+    setIsRenaming(true)
+  }
+
+  const handleConfirmRename = () => {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== list.name) {
+      onRenameList(trimmed)
+    }
+    setIsRenaming(false)
+  }
+
+  const handleCancelRename = () => {
+    setRenameValue(list.name)
+    setIsRenaming(false)
+  }
+
+  const handleAddCard = () => {
+    const trimmed = newCardTitle.trim()
+    if (!trimmed) return
+    onAddCard(trimmed)
+    setNewCardTitle("")
+  }
+
+  const handleCancelAddCard = () => {
+    setNewCardTitle("")
+    onCancelAddCard()
+  }
+
   const menuItems: MenuProps["items"] = [
     {
+      key: "rename",
+      label: "Rename List",
+      icon: <Edit2 className="w-4 h-4" />,
+      onClick: handleStartRename
+    },
+    { type: "divider" },
+    {
+      key: "archive",
+      label: "Archive List",
+      icon: <Archive className="w-4 h-4" />,
+      onClick: onArchiveList
+    },
+    {
       key: "delete",
-      label: "Delete List",
+      label: "Delete Permanently",
       danger: true,
       icon: <Trash2 className="w-4 h-4" />,
-      onClick: onDeleteList
+      onClick: () => setDeleteConfirmOpen(true)
     }
   ]
 
@@ -605,13 +973,49 @@ const SortableList = ({
         className="flex items-center justify-between p-3 cursor-grab"
         ref={handleRef}
       >
-        <div className="flex items-center gap-2">
-          <GripVertical className="w-4 h-4 text-text-subtle" />
-          <span className="font-medium">{list.name}</span>
-          <span className="text-xs text-text-muted bg-surface2 px-1.5 py-0.5 rounded">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <GripVertical className="w-4 h-4 text-text-subtle flex-shrink-0" />
+          {isRenaming ? (
+            <Input
+              size="small"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onPressEnter={handleConfirmRename}
+              onBlur={handleConfirmRename}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") handleCancelRename()
+              }}
+              autoFocus
+              className="flex-1"
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span
+              className="font-medium truncate cursor-text"
+              onDoubleClick={handleStartRename}
+              title={list.name}
+            >
+              {list.name}
+            </span>
+          )}
+          <span className="text-xs text-text-muted bg-surface2 px-1.5 py-0.5 rounded flex-shrink-0">
             {list.cards.length}
           </span>
         </div>
+        <Popconfirm
+          title={`Delete list '${list.name}'?`}
+          description={`${list.cards.length} card${list.cards.length !== 1 ? "s" : ""} will be deleted.`}
+          open={deleteConfirmOpen}
+          onConfirm={() => {
+            setDeleteConfirmOpen(false)
+            onDeleteList()
+          }}
+          onCancel={() => setDeleteConfirmOpen(false)}
+          okText="Delete"
+          okType="danger"
+        >
+          <span />
+        </Popconfirm>
         <Dropdown menu={{ items: menuItems }} trigger={["click"]}>
           <Button
             type="text"
@@ -621,8 +1025,8 @@ const SortableList = ({
         </Dropdown>
       </div>
 
-      {/* Cards container */}
-      <div className="px-2 pb-2 max-h-[500px] overflow-y-auto">
+      {/* Cards container - dynamic max height */}
+      <div className="px-2 pb-2 max-h-[calc(100vh-250px)] overflow-y-auto">
         {list.cards.map((card, cardIndex) => (
           <SortableCard
             key={card.id}
@@ -630,6 +1034,7 @@ const SortableList = ({
             index={cardIndex}
             group={`cards-${list.id}`}
             onClick={() => onCardClick(card)}
+            dimmed={!cardMatchesFilters(card)}
           />
         ))}
 
@@ -639,24 +1044,29 @@ const SortableList = ({
             <Input.TextArea
               placeholder="Enter card title"
               value={newCardTitle}
-              onChange={(e) => onNewCardTitleChange(e.target.value)}
+              onChange={(e) => setNewCardTitle(e.target.value)}
               autoSize={{ minRows: 2, maxRows: 4 }}
               autoFocus
               onKeyDown={(e) => {
                 if (e.key === "Enter" && !e.shiftKey) {
                   e.preventDefault()
-                  onAddCard()
+                  handleAddCard()
                 }
                 if (e.key === "Escape") {
-                  onCancelAddCard()
+                  handleCancelAddCard()
                 }
               }}
             />
             <div className="flex gap-2 mt-2">
-              <Button type="primary" size="small" onClick={onAddCard}>
+              <Button
+                type="primary"
+                size="small"
+                onClick={handleAddCard}
+                loading={createCardLoading}
+              >
                 Add
               </Button>
-              <Button size="small" onClick={onCancelAddCard}>
+              <Button size="small" onClick={handleCancelAddCard}>
                 Cancel
               </Button>
             </div>
@@ -685,9 +1095,10 @@ interface SortableCardProps {
   index: number
   group: string
   onClick: () => void
+  dimmed?: boolean
 }
 
-const SortableCard = ({ card, index, group, onClick }: SortableCardProps) => {
+const SortableCard = ({ card, index, group, onClick, dimmed }: SortableCardProps) => {
   const {
     ref,
     isDragging
@@ -701,7 +1112,7 @@ const SortableCard = ({ card, index, group, onClick }: SortableCardProps) => {
   })
 
   const style = {
-    opacity: isDragging ? 0.5 : 1
+    opacity: isDragging ? 0.5 : dimmed ? 0.3 : 1
   }
 
   return (
@@ -709,9 +1120,22 @@ const SortableCard = ({ card, index, group, onClick }: SortableCardProps) => {
       ref={ref}
       style={style}
       onClick={onClick}
-      className="kanban-card bg-elevated rounded-md p-3 mb-2 shadow-sm cursor-pointer hover:shadow-md transition-shadow"
+      className={`kanban-card bg-elevated rounded-md mb-2 shadow-sm cursor-pointer hover:shadow-md transition-shadow overflow-hidden${
+        dimmed ? " pointer-events-none" : ""
+      }`}
     >
-      <KanbanCardPreview card={card} />
+      {/* Priority left border */}
+      <div className="flex">
+        {card.priority && (
+          <div
+            className="w-1 flex-shrink-0 rounded-l-md"
+            style={{ backgroundColor: getPriorityColor(card.priority) }}
+          />
+        )}
+        <div className="flex-1 p-3 min-w-0">
+          <KanbanCardPreview card={card} />
+        </div>
+      </div>
     </div>
   )
 }
@@ -727,23 +1151,32 @@ interface KanbanCardPreviewProps {
 
 const KanbanCardPreview = ({ card, isDragging }: KanbanCardPreviewProps) => {
   const overdue = isCardOverdue(card)
+  const hasLabels = card.labels && card.labels.length > 0
+  const hasChecklist = (card.checklist_total ?? 0) > 0
+  const hasComments = (card.comment_count ?? 0) > 0
+  const hasDescription = !!card.description
 
   return (
     <div className={isDragging ? "bg-elevated rounded-md p-3 shadow-lg" : ""}>
+      {/* Label color bars */}
+      {hasLabels && (
+        <div className="flex items-center gap-1 flex-wrap mb-1.5">
+          {card.labels!.map((label) => (
+            <span
+              key={label.id}
+              className="inline-block w-8 h-1.5 rounded-sm"
+              style={{ backgroundColor: label.color }}
+              title={label.name}
+            />
+          ))}
+        </div>
+      )}
+
       {/* Title */}
       <div className="text-sm font-medium mb-1">{card.title}</div>
 
       {/* Badges row */}
       <div className="flex items-center gap-2 flex-wrap">
-        {/* Priority badge */}
-        {card.priority && (
-          <span
-            className="w-2 h-2 rounded-full"
-            style={{ backgroundColor: getPriorityColor(card.priority) }}
-            title={card.priority}
-          />
-        )}
-
         {/* Due date badge */}
         {card.due_date && (
           <span
@@ -757,6 +1190,39 @@ const KanbanCardPreview = ({ card, isDragging }: KanbanCardPreviewProps) => {
           >
             <Calendar className="w-3 h-3" />
             {formatDueDate(card.due_date)}
+          </span>
+        )}
+
+        {/* Description indicator */}
+        {hasDescription && (
+          <span className="text-text-muted" title="Has description">
+            <FileText className="w-3.5 h-3.5" />
+          </span>
+        )}
+
+        {/* Checklist progress */}
+        {hasChecklist && (
+          <span
+            className={`text-xs flex items-center gap-1 ${
+              card.checklist_complete === card.checklist_total
+                ? "text-success"
+                : "text-text-muted"
+            }`}
+            title="Checklist progress"
+          >
+            <CheckSquare className="w-3.5 h-3.5" />
+            {card.checklist_complete}/{card.checklist_total}
+          </span>
+        )}
+
+        {/* Comment count */}
+        {hasComments && (
+          <span
+            className="text-xs flex items-center gap-1 text-text-muted"
+            title={`${card.comment_count} comment${card.comment_count !== 1 ? "s" : ""}`}
+          >
+            <MessageCircle className="w-3.5 h-3.5" />
+            {card.comment_count}
           </span>
         )}
       </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
@@ -13,9 +13,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { Trash2, Archive, Copy, Send } from "lucide-react"
 import dayjs from "dayjs"
 
-import type { Card, CardUpdate, ListWithCards, PriorityType } from "@/types/kanban"
+import type { Card, CardUpdate, ListWithCards, PriorityType, Comment } from "@/types/kanban"
 import { copyCard, listComments, createComment, generateClientId } from "@/services/kanban"
-import type { Comment } from "@/services/kanban"
 import { LabelManager } from "./LabelManager"
 import { ChecklistSection } from "./ChecklistSection"
 
@@ -338,7 +337,13 @@ export const CardDetailPanel = ({
                     className="bg-surface rounded p-2 text-sm"
                   >
                     <div className="text-text-muted text-xs mb-1">
-                      {new Date(comment.created_at).toLocaleString()}
+                      {new Date(comment.created_at).toLocaleString(undefined, {
+                        year: "numeric",
+                        month: "short",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit"
+                      })}
                     </div>
                     <div className="whitespace-pre-wrap">{comment.content}</div>
                   </div>
@@ -381,8 +386,26 @@ export const CardDetailPanel = ({
 
           {/* Metadata (read-only info) */}
           <div className="pt-4 border-t text-xs text-text-muted space-y-1">
-            <div>Created: {new Date(card.created_at).toLocaleString()}</div>
-            <div>Updated: {new Date(card.updated_at).toLocaleString()}</div>
+            <div>
+              Created:{" "}
+              {new Date(card.created_at).toLocaleString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit"
+              })}
+            </div>
+            <div>
+              Updated:{" "}
+              {new Date(card.updated_at).toLocaleString(undefined, {
+                year: "numeric",
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit"
+              })}
+            </div>
             <div>ID: {card.id}</div>
           </div>
         </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
@@ -70,8 +70,8 @@ export const CardDetailPanel = ({
       message.success("Card copied")
       onCopied?.()
     },
-    onError: (err) => {
-      message.error(`Copy failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to copy card. Please try again.")
     }
   })
 
@@ -93,8 +93,8 @@ export const CardDetailPanel = ({
         queryKey: ["kanban-card-comments", card?.id]
       })
     },
-    onError: (err) => {
-      message.error(`Comment failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to add comment. Please try again.")
     }
   })
 
@@ -181,8 +181,8 @@ export const CardDetailPanel = ({
                 />
               )}
               <Popconfirm
-                title="Delete this card permanently?"
-                description="This cannot be undone."
+                title="Delete this card?"
+                description="This card will be removed. This cannot be undone."
                 onConfirm={() => onDelete(card.id)}
                 okText="Delete"
                 okType="danger"
@@ -191,7 +191,7 @@ export const CardDetailPanel = ({
                   danger
                   type="text"
                   icon={<Trash2 className="w-4 h-4" />}
-                  title="Delete permanently"
+                  title="Delete card"
                 />
               </Popconfirm>
             </Space>
@@ -200,7 +200,7 @@ export const CardDetailPanel = ({
       }
       open={open}
       onClose={onClose}
-      size={400}
+      width={400}
       footer={
         <div className="flex justify-end gap-2">
           <Button onClick={onClose}>Cancel</Button>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/CardDetailPanel.tsx
@@ -6,21 +6,30 @@ import {
   DatePicker,
   Button,
   Popconfirm,
-  Space
+  Space,
+  message
 } from "antd"
-import { Trash2, MoveRight } from "lucide-react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { Trash2, Archive, Copy, Send } from "lucide-react"
 import dayjs from "dayjs"
 
 import type { Card, CardUpdate, ListWithCards, PriorityType } from "@/types/kanban"
+import { copyCard, listComments, createComment, generateClientId } from "@/services/kanban"
+import type { Comment } from "@/services/kanban"
+import { LabelManager } from "./LabelManager"
+import { ChecklistSection } from "./ChecklistSection"
 
 interface CardDetailPanelProps {
   card: Card | null
+  boardId: number
   lists: ListWithCards[]
   open: boolean
   onClose: () => void
   onSave: (cardId: number, data: CardUpdate) => void
   onDelete: (cardId: number) => void
+  onArchive?: (cardId: number, cardTitle: string) => void
   onMove: (cardId: number, targetListId: number) => void
+  onCopied?: () => void
 }
 
 const PRIORITY_OPTIONS = [
@@ -32,22 +41,62 @@ const PRIORITY_OPTIONS = [
 
 export const CardDetailPanel = ({
   card,
+  boardId,
   lists,
   open,
   onClose,
   onSave,
   onDelete,
-  onMove
+  onArchive,
+  onMove,
+  onCopied
 }: CardDetailPanelProps) => {
+  const queryClient = useQueryClient()
+
   // Form state
   const [title, setTitle] = useState("")
   const [description, setDescription] = useState("")
   const [dueDate, setDueDate] = useState<dayjs.Dayjs | null>(null)
   const [priority, setPriority] = useState<PriorityType | null>(null)
-  const [moveToListId, setMoveToListId] = useState<number | null>(null)
+  const [newComment, setNewComment] = useState("")
 
   // Track if form is dirty
   const [isDirty, setIsDirty] = useState(false)
+
+  // Copy card mutation
+  const copyCardMutation = useMutation({
+    mutationFn: (cardId: number) => copyCard(cardId),
+    onSuccess: () => {
+      message.success("Card copied")
+      onCopied?.()
+    },
+    onError: (err) => {
+      message.error(`Copy failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  // Comments query
+  const { data: comments = [] } = useQuery({
+    queryKey: ["kanban-card-comments", card?.id],
+    queryFn: () => listComments(card!.id),
+    enabled: !!card?.id && open,
+    staleTime: 30 * 1000
+  })
+
+  // Add comment mutation
+  const addCommentMutation = useMutation({
+    mutationFn: ({ cardId, content }: { cardId: number; content: string }) =>
+      createComment(cardId, { content, client_id: generateClientId() }),
+    onSuccess: () => {
+      setNewComment("")
+      queryClient.invalidateQueries({
+        queryKey: ["kanban-card-comments", card?.id]
+      })
+    },
+    onError: (err) => {
+      message.error(`Comment failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
 
   // Sync form state when card changes
   useEffect(() => {
@@ -56,7 +105,6 @@ export const CardDetailPanel = ({
       setDescription(card.description || "")
       setDueDate(card.due_date ? dayjs(card.due_date) : null)
       setPriority(card.priority || null)
-      setMoveToListId(null)
       setIsDirty(false)
     }
   }, [card])
@@ -96,10 +144,10 @@ export const CardDetailPanel = ({
     setIsDirty(false)
   }
 
-  const handleMove = () => {
-    if (!card || !moveToListId || moveToListId === card.list_id) return
-    onMove(card.id, moveToListId)
-    setMoveToListId(null)
+  // Move-to-list: immediate move on select change
+  const handleMoveToList = (targetListId: number) => {
+    if (!card || targetListId === card.list_id) return
+    onMove(card.id, targetListId)
   }
 
   const currentList = lists.find((l) => l.id === card?.list_id)
@@ -116,19 +164,37 @@ export const CardDetailPanel = ({
         <div className="flex items-center justify-between">
           <span>Edit Card</span>
           {card && (
-            <Popconfirm
-              title="Delete this card?"
-              description="This action cannot be undone."
-              onConfirm={() => onDelete(card.id)}
-              okText="Delete"
-              okType="danger"
-            >
+            <Space size={4}>
               <Button
-                danger
                 type="text"
-                icon={<Trash2 className="w-4 h-4" />}
+                icon={<Copy className="w-4 h-4" />}
+                onClick={() => copyCardMutation.mutate(card.id)}
+                loading={copyCardMutation.isPending}
+                title="Copy card"
               />
-            </Popconfirm>
+              {onArchive && (
+                <Button
+                  type="text"
+                  icon={<Archive className="w-4 h-4" />}
+                  onClick={() => onArchive(card.id, card.title)}
+                  title="Archive card"
+                />
+              )}
+              <Popconfirm
+                title="Delete this card permanently?"
+                description="This cannot be undone."
+                onConfirm={() => onDelete(card.id)}
+                okText="Delete"
+                okType="danger"
+              >
+                <Button
+                  danger
+                  type="text"
+                  icon={<Trash2 className="w-4 h-4" />}
+                  title="Delete permanently"
+                />
+              </Popconfirm>
+            </Space>
           )}
         </div>
       }
@@ -159,28 +225,44 @@ export const CardDetailPanel = ({
             />
           </div>
 
-          {/* Current list indicator and move option */}
+          {/* Current list indicator — immediate move on select */}
           <div>
             <label className="block text-sm font-medium mb-1">
               In list: <span className="font-normal">{currentList?.name}</span>
             </label>
-            <div className="flex gap-2">
-              <Select
-                placeholder="Move to..."
-                style={{ flex: 1 }}
-                value={moveToListId}
-                onChange={setMoveToListId}
-                options={listOptions}
-                allowClear
-              />
-              <Button
-                icon={<MoveRight className="w-4 h-4" />}
-                onClick={handleMove}
-                disabled={!moveToListId || moveToListId === card.list_id}
-              >
-                Move
-              </Button>
-            </div>
+            <Select
+              placeholder="Move to..."
+              style={{ width: "100%" }}
+              value={card.list_id}
+              onChange={handleMoveToList}
+              options={listOptions}
+            />
+          </div>
+
+          {/* Labels */}
+          <div>
+            <label className="block text-sm font-medium mb-1">Labels</label>
+            {card.labels && card.labels.length > 0 && (
+              <div className="flex gap-1 flex-wrap mb-2">
+                {card.labels.map((label) => (
+                  <span
+                    key={label.id}
+                    className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs text-white"
+                    style={{ backgroundColor: label.color }}
+                  >
+                    {label.name}
+                  </span>
+                ))}
+              </div>
+            )}
+            <LabelManager
+              boardId={boardId}
+              cardId={card.id}
+              assignedLabelIds={(card.labels ?? []).map((l) => l.id)}
+              onChanged={() => {
+                // CardDetailPanel doesn't own the query, parent will invalidate
+              }}
+            />
           </div>
 
           {/* Description */}
@@ -240,6 +322,61 @@ export const CardDetailPanel = ({
                 )
               }))}
             />
+          </div>
+
+          {/* Checklists */}
+          <ChecklistSection cardId={card.id} />
+
+          {/* Comments */}
+          <div>
+            <label className="block text-sm font-medium mb-2">Comments</label>
+            {comments.length > 0 && (
+              <div className="space-y-2 mb-3 max-h-60 overflow-y-auto">
+                {comments.map((comment: Comment) => (
+                  <div
+                    key={comment.id}
+                    className="bg-surface rounded p-2 text-sm"
+                  >
+                    <div className="text-text-muted text-xs mb-1">
+                      {new Date(comment.created_at).toLocaleString()}
+                    </div>
+                    <div className="whitespace-pre-wrap">{comment.content}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex gap-2">
+              <Input.TextArea
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="Add a comment..."
+                autoSize={{ minRows: 1, maxRows: 4 }}
+                onPressEnter={(e) => {
+                  if (e.shiftKey) return
+                  e.preventDefault()
+                  if (newComment.trim() && card) {
+                    addCommentMutation.mutate({
+                      cardId: card.id,
+                      content: newComment.trim()
+                    })
+                  }
+                }}
+              />
+              <Button
+                type="primary"
+                icon={<Send className="w-3.5 h-3.5" />}
+                onClick={() => {
+                  if (newComment.trim() && card) {
+                    addCommentMutation.mutate({
+                      cardId: card.id,
+                      content: newComment.trim()
+                    })
+                  }
+                }}
+                loading={addCommentMutation.isPending}
+                disabled={!newComment.trim()}
+              />
+            </div>
           </div>
 
           {/* Metadata (read-only info) */}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
@@ -1,0 +1,344 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { Button, Input, Checkbox, Progress, Collapse, Popconfirm, message } from "antd"
+import { Plus, Trash2, Edit2, ChevronDown } from "lucide-react"
+
+import {
+  listChecklists,
+  createChecklist,
+  updateChecklist,
+  deleteChecklist,
+  createChecklistItem,
+  updateChecklistItem,
+  deleteChecklistItem,
+  generateClientId,
+  type ChecklistWithItems,
+  type ChecklistItem
+} from "@/services/kanban"
+
+interface ChecklistSectionProps {
+  cardId: number
+}
+
+export const ChecklistSection = ({ cardId }: ChecklistSectionProps) => {
+  const queryClient = useQueryClient()
+  const queryKey = ["kanban-card-checklists", cardId]
+
+  const { data: checklists = [], isLoading } = useQuery({
+    queryKey,
+    queryFn: () => listChecklists(cardId),
+    staleTime: 20 * 1000
+  })
+
+  const [addingChecklist, setAddingChecklist] = useState(false)
+  const [newChecklistTitle, setNewChecklistTitle] = useState("")
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey })
+
+  const createChecklistMutation = useMutation({
+    mutationFn: (title: string) =>
+      createChecklist(cardId, { title, client_id: generateClientId() }),
+    onSuccess: () => {
+      invalidate()
+      setAddingChecklist(false)
+      setNewChecklistTitle("")
+    },
+    onError: (err) => {
+      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const handleAddChecklist = () => {
+    const trimmed = newChecklistTitle.trim()
+    if (!trimmed) return
+    createChecklistMutation.mutate(trimmed)
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="block text-sm font-medium">Checklists</label>
+      </div>
+
+      {checklists.map((cl) => (
+        <SingleChecklist key={cl.id} checklist={cl} onChanged={invalidate} />
+      ))}
+
+      {addingChecklist ? (
+        <div className="space-y-2">
+          <Input
+            size="small"
+            placeholder="Checklist title"
+            value={newChecklistTitle}
+            onChange={(e) => setNewChecklistTitle(e.target.value)}
+            onPressEnter={handleAddChecklist}
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <Button
+              size="small"
+              type="primary"
+              onClick={handleAddChecklist}
+              loading={createChecklistMutation.isPending}
+            >
+              Add
+            </Button>
+            <Button size="small" onClick={() => setAddingChecklist(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          size="small"
+          type="dashed"
+          icon={<Plus className="w-3.5 h-3.5" />}
+          onClick={() => setAddingChecklist(true)}
+        >
+          Add Checklist
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// Single checklist with items
+const SingleChecklist = ({
+  checklist,
+  onChanged
+}: {
+  checklist: ChecklistWithItems
+  onChanged: () => void
+}) => {
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleValue, setTitleValue] = useState(checklist.title)
+  const [addingItem, setAddingItem] = useState(false)
+  const [newItemContent, setNewItemContent] = useState("")
+
+  const complete = checklist.items.filter((i) => i.checked).length
+  const total = checklist.items.length
+  const percent = total > 0 ? Math.round((complete / total) * 100) : 0
+
+  const updateTitleMutation = useMutation({
+    mutationFn: (title: string) => updateChecklist(checklist.id, { title }),
+    onSuccess: () => {
+      setEditingTitle(false)
+      onChanged()
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteChecklist(checklist.id),
+    onSuccess: onChanged
+  })
+
+  const addItemMutation = useMutation({
+    mutationFn: (content: string) =>
+      createChecklistItem(checklist.id, {
+        content,
+        client_id: generateClientId()
+      }),
+    onSuccess: () => {
+      setNewItemContent("")
+      onChanged()
+    }
+  })
+
+  const toggleItemMutation = useMutation({
+    mutationFn: ({ itemId, checked }: { itemId: number; checked: boolean }) =>
+      updateChecklistItem(itemId, { checked }),
+    onSuccess: onChanged
+  })
+
+  const updateItemContentMutation = useMutation({
+    mutationFn: ({ itemId, content }: { itemId: number; content: string }) =>
+      updateChecklistItem(itemId, { content }),
+    onSuccess: onChanged
+  })
+
+  const deleteItemMutation = useMutation({
+    mutationFn: (itemId: number) => deleteChecklistItem(itemId),
+    onSuccess: onChanged
+  })
+
+  const handleAddItem = () => {
+    const trimmed = newItemContent.trim()
+    if (!trimmed) return
+    addItemMutation.mutate(trimmed)
+  }
+
+  return (
+    <div className="border rounded-md p-2 bg-surface">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-1">
+        {editingTitle ? (
+          <Input
+            size="small"
+            value={titleValue}
+            onChange={(e) => setTitleValue(e.target.value)}
+            onPressEnter={() => {
+              const t = titleValue.trim()
+              if (t && t !== checklist.title) updateTitleMutation.mutate(t)
+              else setEditingTitle(false)
+            }}
+            onBlur={() => setEditingTitle(false)}
+            autoFocus
+            className="flex-1 mr-2"
+          />
+        ) : (
+          <span
+            className="text-sm font-medium cursor-pointer"
+            onDoubleClick={() => {
+              setTitleValue(checklist.title)
+              setEditingTitle(true)
+            }}
+          >
+            {checklist.title}
+          </span>
+        )}
+        <Popconfirm
+          title="Delete this checklist?"
+          onConfirm={() => deleteMutation.mutate()}
+          okText="Delete"
+          okType="danger"
+        >
+          <Button
+            type="text"
+            size="small"
+            danger
+            icon={<Trash2 className="w-3 h-3" />}
+          />
+        </Popconfirm>
+      </div>
+
+      {/* Progress */}
+      {total > 0 && (
+        <div className="mb-2">
+          <Progress
+            percent={percent}
+            size="small"
+            format={() => `${complete}/${total}`}
+            status={complete === total ? "success" : "active"}
+          />
+        </div>
+      )}
+
+      {/* Items */}
+      <div className="space-y-1">
+        {checklist.items.map((item) => (
+          <ChecklistItemRow
+            key={item.id}
+            item={item}
+            onToggle={(checked) =>
+              toggleItemMutation.mutate({ itemId: item.id, checked })
+            }
+            onUpdateContent={(content) =>
+              updateItemContentMutation.mutate({ itemId: item.id, content })
+            }
+            onDelete={() => deleteItemMutation.mutate(item.id)}
+          />
+        ))}
+      </div>
+
+      {/* Add item */}
+      {addingItem ? (
+        <div className="mt-1 space-y-1">
+          <Input
+            size="small"
+            placeholder="Add an item"
+            value={newItemContent}
+            onChange={(e) => setNewItemContent(e.target.value)}
+            onPressEnter={handleAddItem}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setAddingItem(false)
+            }}
+            autoFocus
+          />
+          <div className="flex gap-1">
+            <Button
+              size="small"
+              type="primary"
+              onClick={handleAddItem}
+              loading={addItemMutation.isPending}
+            >
+              Add
+            </Button>
+            <Button size="small" onClick={() => setAddingItem(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          type="text"
+          size="small"
+          icon={<Plus className="w-3 h-3" />}
+          onClick={() => setAddingItem(true)}
+          className="mt-1 text-text-muted"
+        >
+          Add item
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// Single checklist item row
+const ChecklistItemRow = ({
+  item,
+  onToggle,
+  onUpdateContent,
+  onDelete
+}: {
+  item: ChecklistItem
+  onToggle: (checked: boolean) => void
+  onUpdateContent: (content: string) => void
+  onDelete: () => void
+}) => {
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState(item.content)
+
+  return (
+    <div className="flex items-center gap-1 group">
+      <Checkbox
+        checked={item.checked}
+        onChange={(e) => onToggle(e.target.checked)}
+      />
+      {editing ? (
+        <Input
+          size="small"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onPressEnter={() => {
+            const t = editValue.trim()
+            if (t && t !== item.content) onUpdateContent(t)
+            setEditing(false)
+          }}
+          onBlur={() => setEditing(false)}
+          autoFocus
+          className="flex-1"
+        />
+      ) : (
+        <span
+          className={`flex-1 text-xs cursor-pointer ${
+            item.checked ? "line-through text-text-muted" : ""
+          }`}
+          onDoubleClick={() => {
+            setEditValue(item.content)
+            setEditing(true)
+          }}
+        >
+          {item.content}
+        </span>
+      )}
+      <Button
+        type="text"
+        size="small"
+        danger
+        className="!p-0 !w-5 !h-5 opacity-0 group-hover:opacity-100 transition-opacity"
+        icon={<Trash2 className="w-3 h-3" />}
+        onClick={onDelete}
+      />
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { Button, Input, Checkbox, Progress, Collapse, Popconfirm, message } from "antd"
-import { Plus, Trash2, Edit2, ChevronDown } from "lucide-react"
+import { Plus, Trash2 } from "lucide-react"
 
+import type { ChecklistWithItems, ChecklistItem } from "@/types/kanban"
 import {
   listChecklists,
   createChecklist,
@@ -11,9 +12,7 @@ import {
   createChecklistItem,
   updateChecklistItem,
   deleteChecklistItem,
-  generateClientId,
-  type ChecklistWithItems,
-  type ChecklistItem
+  generateClientId
 } from "@/services/kanban"
 
 interface ChecklistSectionProps {
@@ -199,7 +198,11 @@ const SingleChecklist = ({
               if (t && t !== checklist.title) updateTitleMutation.mutate(t)
               else setEditingTitle(false)
             }}
-            onBlur={() => setEditingTitle(false)}
+            onBlur={() => {
+              const t = titleValue.trim()
+              if (t && t !== checklist.title) updateTitleMutation.mutate(t)
+              else setEditingTitle(false)
+            }}
             autoFocus
             className="flex-1 mr-2"
           />
@@ -332,7 +335,11 @@ const ChecklistItemRow = ({
             if (t && t !== item.content) onUpdateContent(t)
             setEditing(false)
           }}
-          onBlur={() => setEditing(false)}
+          onBlur={() => {
+            const t = editValue.trim()
+            if (t && t !== item.content) onUpdateContent(t)
+            setEditing(false)
+          }}
           autoFocus
           className="flex-1"
         />

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ChecklistSection.tsx
@@ -43,8 +43,8 @@ export const ChecklistSection = ({ cardId }: ChecklistSectionProps) => {
       setAddingChecklist(false)
       setNewChecklistTitle("")
     },
-    onError: (err) => {
-      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to create checklist. Please try again.")
     }
   })
 
@@ -124,12 +124,18 @@ const SingleChecklist = ({
     onSuccess: () => {
       setEditingTitle(false)
       onChanged()
+    },
+    onError: () => {
+      message.error("Failed to rename checklist. Please try again.")
     }
   })
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteChecklist(checklist.id),
-    onSuccess: onChanged
+    onSuccess: onChanged,
+    onError: () => {
+      message.error("Failed to delete checklist. Please try again.")
+    }
   })
 
   const addItemMutation = useMutation({
@@ -141,24 +147,36 @@ const SingleChecklist = ({
     onSuccess: () => {
       setNewItemContent("")
       onChanged()
+    },
+    onError: () => {
+      message.error("Failed to add item. Please try again.")
     }
   })
 
   const toggleItemMutation = useMutation({
     mutationFn: ({ itemId, checked }: { itemId: number; checked: boolean }) =>
       updateChecklistItem(itemId, { checked }),
-    onSuccess: onChanged
+    onSuccess: onChanged,
+    onError: () => {
+      message.error("Failed to update item. Please try again.")
+    }
   })
 
   const updateItemContentMutation = useMutation({
     mutationFn: ({ itemId, content }: { itemId: number; content: string }) =>
       updateChecklistItem(itemId, { content }),
-    onSuccess: onChanged
+    onSuccess: onChanged,
+    onError: () => {
+      message.error("Failed to update item. Please try again.")
+    }
   })
 
   const deleteItemMutation = useMutation({
     mutationFn: (itemId: number) => deleteChecklistItem(itemId),
-    onSuccess: onChanged
+    onSuccess: onChanged,
+    onError: () => {
+      message.error("Failed to delete item. Please try again.")
+    }
   })
 
   const handleAddItem = () => {

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/ImportPanel.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/ImportPanel.tsx
@@ -34,10 +34,8 @@ export const ImportPanel = ({ onImported }: ImportPanelProps) => {
       setImportResult(result)
       onImported(result.board.id)
     },
-    onError: (err) => {
-      message.error(
-        `Import failed: ${err instanceof Error ? err.message : "Unknown error"}`
-      )
+    onError: () => {
+      message.error("Failed to import board. Please try again.")
     }
   })
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
@@ -61,6 +61,7 @@ export const LabelManager = ({
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["kanban-board-labels", boardId] })
+    queryClient.invalidateQueries({ queryKey: ["kanban-board", boardId] })
     onChanged?.()
   }
 
@@ -75,8 +76,8 @@ export const LabelManager = ({
       setNewLabelName("")
       invalidate()
     },
-    onError: (err) => {
-      message.error(`Failed to create label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to create label. Please try again.")
     }
   })
 
@@ -87,32 +88,32 @@ export const LabelManager = ({
       setEditingId(null)
       invalidate()
     },
-    onError: (err) => {
-      message.error(`Failed to update label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to update label. Please try again.")
     }
   })
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteLabel(id),
     onSuccess: () => invalidate(),
-    onError: (err) => {
-      message.error(`Failed to delete label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete label. Please try again.")
     }
   })
 
   const assignMutation = useMutation({
     mutationFn: (labelId: number) => assignLabelToCard(cardId, labelId),
     onSuccess: () => invalidate(),
-    onError: (err) => {
-      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to update label assignment. Please try again.")
     }
   })
 
   const removeMutation = useMutation({
     mutationFn: (labelId: number) => removeLabelFromCard(cardId, labelId),
     onSuccess: () => invalidate(),
-    onError: (err) => {
-      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to update label assignment. Please try again.")
     }
   })
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
@@ -14,15 +14,15 @@ import {
 } from "@/services/kanban"
 import type { Label } from "@/types/kanban"
 
-const PRESET_COLORS = [
-  "#ef4444", // red
-  "#f97316", // orange
-  "#eab308", // yellow
-  "#22c55e", // green
-  "#3b82f6", // blue
-  "#8b5cf6", // violet
-  "#ec4899", // pink
-  "#6b7280"  // gray
+const PRESET_COLORS: { hex: string; name: string }[] = [
+  { hex: "#ef4444", name: "Red" },
+  { hex: "#f97316", name: "Orange" },
+  { hex: "#eab308", name: "Yellow" },
+  { hex: "#22c55e", name: "Green" },
+  { hex: "#3b82f6", name: "Blue" },
+  { hex: "#8b5cf6", name: "Violet" },
+  { hex: "#ec4899", name: "Pink" },
+  { hex: "#6b7280", name: "Gray" }
 ]
 
 interface LabelManagerProps {
@@ -45,7 +45,7 @@ export const LabelManager = ({
 
   // Creating new label
   const [newLabelName, setNewLabelName] = useState("")
-  const [newLabelColor, setNewLabelColor] = useState(PRESET_COLORS[0])
+  const [newLabelColor, setNewLabelColor] = useState(PRESET_COLORS[0].hex)
 
   // Editing existing label
   const [editingId, setEditingId] = useState<number | null>(null)
@@ -163,19 +163,21 @@ export const LabelManager = ({
                   onPressEnter={confirmEdit}
                   autoFocus
                 />
-                <div className="flex gap-1">
+                <div className="flex gap-1" role="radiogroup" aria-label="Label color">
                   {PRESET_COLORS.map((c) => (
                     <button
-                      key={c}
+                      key={c.hex}
+                      role="radio"
+                      aria-checked={editColor === c.hex}
                       className={`w-5 h-5 rounded-sm border-2 ${
-                        editColor === c
+                        editColor === c.hex
                           ? "border-text"
                           : "border-transparent"
                       }`}
-                      style={{ backgroundColor: c }}
-                      onClick={() => setEditColor(c)}
-                      aria-label={`Select color ${c}`}
-                      title={c}
+                      style={{ backgroundColor: c.hex }}
+                      onClick={() => setEditColor(c.hex)}
+                      aria-label={`${c.name}${editColor === c.hex ? " (selected)" : ""}`}
+                      title={c.name}
                     />
                   ))}
                 </div>
@@ -241,19 +243,21 @@ export const LabelManager = ({
           onChange={(e) => setNewLabelName(e.target.value)}
           onPressEnter={handleCreate}
         />
-        <div className="flex gap-1">
+        <div className="flex gap-1" role="radiogroup" aria-label="Label color">
           {PRESET_COLORS.map((c) => (
             <button
-              key={c}
+              key={c.hex}
+              role="radio"
+              aria-checked={newLabelColor === c.hex}
               className={`w-5 h-5 rounded-sm border-2 ${
-                newLabelColor === c
+                newLabelColor === c.hex
                   ? "border-text"
                   : "border-transparent"
               }`}
-              style={{ backgroundColor: c }}
-              onClick={() => setNewLabelColor(c)}
-              aria-label={`Select color ${c}`}
-              title={c}
+              style={{ backgroundColor: c.hex }}
+              onClick={() => setNewLabelColor(c.hex)}
+              aria-label={`${c.name}${newLabelColor === c.hex ? " (selected)" : ""}`}
+              title={c.name}
             />
           ))}
         </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
@@ -174,6 +174,8 @@ export const LabelManager = ({
                       }`}
                       style={{ backgroundColor: c }}
                       onClick={() => setEditColor(c)}
+                      aria-label={`Select color ${c}`}
+                      title={c}
                     />
                   ))}
                 </div>
@@ -250,6 +252,8 @@ export const LabelManager = ({
               }`}
               style={{ backgroundColor: c }}
               onClick={() => setNewLabelColor(c)}
+              aria-label={`Select color ${c}`}
+              title={c}
             />
           ))}
         </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/LabelManager.tsx
@@ -1,0 +1,288 @@
+import { useState } from "react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { Popover, Button, Input, Checkbox, Popconfirm, message } from "antd"
+import { Plus, Edit2, Trash2, Tag } from "lucide-react"
+
+import {
+  listLabels,
+  createLabel,
+  updateLabel,
+  deleteLabel,
+  assignLabelToCard,
+  removeLabelFromCard,
+  generateClientId
+} from "@/services/kanban"
+import type { Label } from "@/types/kanban"
+
+const PRESET_COLORS = [
+  "#ef4444", // red
+  "#f97316", // orange
+  "#eab308", // yellow
+  "#22c55e", // green
+  "#3b82f6", // blue
+  "#8b5cf6", // violet
+  "#ec4899", // pink
+  "#6b7280"  // gray
+]
+
+interface LabelManagerProps {
+  boardId: number
+  cardId: number
+  assignedLabelIds: number[]
+  onChanged?: () => void
+  children?: React.ReactNode
+}
+
+export const LabelManager = ({
+  boardId,
+  cardId,
+  assignedLabelIds,
+  onChanged,
+  children
+}: LabelManagerProps) => {
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+
+  // Creating new label
+  const [newLabelName, setNewLabelName] = useState("")
+  const [newLabelColor, setNewLabelColor] = useState(PRESET_COLORS[0])
+
+  // Editing existing label
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [editName, setEditName] = useState("")
+  const [editColor, setEditColor] = useState("")
+
+  const { data: labels = [] } = useQuery({
+    queryKey: ["kanban-board-labels", boardId],
+    queryFn: () => listLabels(boardId),
+    enabled: open,
+    staleTime: 30 * 1000
+  })
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["kanban-board-labels", boardId] })
+    onChanged?.()
+  }
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createLabel(boardId, {
+        name: newLabelName.trim(),
+        color: newLabelColor,
+        client_id: generateClientId()
+      }),
+    onSuccess: () => {
+      setNewLabelName("")
+      invalidate()
+    },
+    onError: (err) => {
+      message.error(`Failed to create label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: { name?: string; color?: string } }) =>
+      updateLabel(id, data),
+    onSuccess: () => {
+      setEditingId(null)
+      invalidate()
+    },
+    onError: (err) => {
+      message.error(`Failed to update label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteLabel(id),
+    onSuccess: () => invalidate(),
+    onError: (err) => {
+      message.error(`Failed to delete label: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const assignMutation = useMutation({
+    mutationFn: (labelId: number) => assignLabelToCard(cardId, labelId),
+    onSuccess: () => invalidate(),
+    onError: (err) => {
+      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const removeMutation = useMutation({
+    mutationFn: (labelId: number) => removeLabelFromCard(cardId, labelId),
+    onSuccess: () => invalidate(),
+    onError: (err) => {
+      message.error(`Failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
+  const handleToggle = (labelId: number, isAssigned: boolean) => {
+    if (isAssigned) {
+      removeMutation.mutate(labelId)
+    } else {
+      assignMutation.mutate(labelId)
+    }
+  }
+
+  const handleCreate = () => {
+    if (!newLabelName.trim()) return
+    createMutation.mutate()
+  }
+
+  const startEdit = (label: Label) => {
+    setEditingId(label.id)
+    setEditName(label.name)
+    setEditColor(label.color)
+  }
+
+  const confirmEdit = () => {
+    if (!editingId) return
+    updateMutation.mutate({
+      id: editingId,
+      data: { name: editName.trim() || undefined, color: editColor || undefined }
+    })
+  }
+
+  const content = (
+    <div className="w-64 space-y-3">
+      <div className="text-sm font-medium">Labels</div>
+
+      {/* Existing labels */}
+      <div className="space-y-1 max-h-48 overflow-y-auto">
+        {labels.map((label) => {
+          const isAssigned = assignedLabelIds.includes(label.id)
+
+          if (editingId === label.id) {
+            return (
+              <div key={label.id} className="space-y-1">
+                <Input
+                  size="small"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  onPressEnter={confirmEdit}
+                  autoFocus
+                />
+                <div className="flex gap-1">
+                  {PRESET_COLORS.map((c) => (
+                    <button
+                      key={c}
+                      className={`w-5 h-5 rounded-sm border-2 ${
+                        editColor === c
+                          ? "border-text"
+                          : "border-transparent"
+                      }`}
+                      style={{ backgroundColor: c }}
+                      onClick={() => setEditColor(c)}
+                    />
+                  ))}
+                </div>
+                <div className="flex gap-1">
+                  <Button size="small" type="primary" onClick={confirmEdit}>
+                    Save
+                  </Button>
+                  <Button size="small" onClick={() => setEditingId(null)}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            )
+          }
+
+          return (
+            <div
+              key={label.id}
+              className="flex items-center gap-2 p-1 rounded hover:bg-surface"
+            >
+              <Checkbox
+                checked={isAssigned}
+                onChange={() => handleToggle(label.id, isAssigned)}
+              />
+              <span
+                className="flex-1 text-xs px-2 py-0.5 rounded text-white truncate"
+                style={{ backgroundColor: label.color }}
+              >
+                {label.name}
+              </span>
+              <Button
+                type="text"
+                size="small"
+                className="!p-0 !w-5 !h-5"
+                icon={<Edit2 className="w-3 h-3" />}
+                onClick={() => startEdit(label)}
+              />
+              <Popconfirm
+                title={`Delete label "${label.name}"?`}
+                onConfirm={() => deleteMutation.mutate(label.id)}
+                okText="Delete"
+                okType="danger"
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  danger
+                  className="!p-0 !w-5 !h-5"
+                  icon={<Trash2 className="w-3 h-3" />}
+                />
+              </Popconfirm>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Create new label */}
+      <div className="border-t pt-2 space-y-1">
+        <Input
+          size="small"
+          placeholder="New label name"
+          value={newLabelName}
+          onChange={(e) => setNewLabelName(e.target.value)}
+          onPressEnter={handleCreate}
+        />
+        <div className="flex gap-1">
+          {PRESET_COLORS.map((c) => (
+            <button
+              key={c}
+              className={`w-5 h-5 rounded-sm border-2 ${
+                newLabelColor === c
+                  ? "border-text"
+                  : "border-transparent"
+              }`}
+              style={{ backgroundColor: c }}
+              onClick={() => setNewLabelColor(c)}
+            />
+          ))}
+        </div>
+        <Button
+          size="small"
+          type="primary"
+          icon={<Plus className="w-3 h-3" />}
+          onClick={handleCreate}
+          disabled={!newLabelName.trim()}
+          loading={createMutation.isPending}
+        >
+          Create Label
+        </Button>
+      </div>
+    </div>
+  )
+
+  return (
+    <Popover
+      content={content}
+      trigger="click"
+      open={open}
+      onOpenChange={setOpen}
+      placement="bottomLeft"
+    >
+      {children ?? (
+        <Button
+          size="small"
+          type="dashed"
+          icon={<Tag className="w-3.5 h-3.5" />}
+        >
+          Add Label
+        </Button>
+      )}
+    </Popover>
+  )
+}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
@@ -38,6 +38,11 @@ import { ArchivedItemsDrawer } from "./ArchivedItemsDrawer"
 import { BoardGallery } from "./BoardGallery"
 import { useKanbanShortcuts } from "./useKanbanShortcuts"
 
+const BADGE_INDICATOR_STYLE = {
+  backgroundColor: "rgb(var(--color-primary))",
+  color: "rgb(var(--color-text))"
+}
+
 export const KanbanPlayground = () => {
   const { t } = useTranslation(["settings", "common"])
   const queryClient = useQueryClient()
@@ -195,9 +200,7 @@ export const KanbanPlayground = () => {
 
   // Keyboard shortcuts
   const { helpOpen, setHelpOpen } = useKanbanShortcuts({
-    onNewBoard: () => setCreateModalOpen(true),
-    onNewCard: undefined, // Handled by BoardView
-    onNewList: undefined  // Handled by BoardView
+    onNewBoard: () => setCreateModalOpen(true)
   })
 
   const boards = boardsData?.boards ?? []
@@ -246,12 +249,7 @@ export const KanbanPlayground = () => {
           <Badge
             count={boards.length}
             showZero
-            styles={{
-              indicator: {
-                backgroundColor: "rgb(var(--color-primary))",
-                color: "rgb(var(--color-text))"
-              }
-            }}
+            styles={{ indicator: BADGE_INDICATOR_STYLE }}
           />
         </div>
         <Select
@@ -285,14 +283,6 @@ export const KanbanPlayground = () => {
   )
 
   const renderContent = () => {
-    if (boardLoading) {
-      return (
-        <div className="flex items-center justify-center h-96">
-          <Spin size="large" />
-        </div>
-      )
-    }
-
     if (!selectedBoardId) {
       return (
         <BoardGallery
@@ -300,6 +290,14 @@ export const KanbanPlayground = () => {
           onSelectBoard={setSelectedBoardId}
           onCreateBoard={() => setCreateModalOpen(true)}
         />
+      )
+    }
+
+    if (boardLoading) {
+      return (
+        <div className="flex items-center justify-center h-96">
+          <Spin size="large" />
+        </div>
       )
     }
 
@@ -332,7 +330,7 @@ export const KanbanPlayground = () => {
       <ArchivedItemsDrawer
         open={archiveDrawerOpen}
         onClose={() => setArchiveDrawerOpen(false)}
-        board={boardData}
+        boardId={selectedBoardId}
       />
 
       {/* Import modal */}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useRef } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   Dropdown,
@@ -60,6 +60,12 @@ export const KanbanPlayground = () => {
 
   // Archive drawer state
   const [archiveDrawerOpen, setArchiveDrawerOpen] = useState(false)
+
+  // Ref for BoardView shortcut handlers (add-card / add-list)
+  const boardShortcutRef = useRef<{
+    startAddCard: () => void
+    startAddList: () => void
+  } | null>(null)
 
   // Fetch boards list
   const {
@@ -200,7 +206,9 @@ export const KanbanPlayground = () => {
 
   // Keyboard shortcuts
   const { helpOpen, setHelpOpen } = useKanbanShortcuts({
-    onNewBoard: () => setCreateModalOpen(true)
+    onNewBoard: () => setCreateModalOpen(true),
+    onNewCard: () => boardShortcutRef.current?.startAddCard(),
+    onNewList: () => boardShortcutRef.current?.startAddList()
   })
 
   const boards = boardsData?.boards ?? []
@@ -314,6 +322,7 @@ export const KanbanPlayground = () => {
             onQuickSetup={
               boardData.lists.length === 0 ? handleQuickSetup : undefined
             }
+            shortcutHandlersRef={boardShortcutRef}
           />
         </>
       )

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
@@ -91,8 +91,8 @@ export const KanbanPlayground = () => {
       setNewBoardName("")
       setNewBoardDescription("")
     },
-    onError: (err) => {
-      message.error(`Failed to create board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to create board. Please try again.")
     }
   })
 
@@ -104,8 +104,8 @@ export const KanbanPlayground = () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
       setSelectedBoardId(null)
     },
-    onError: (err) => {
-      message.error(`Failed to delete board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to delete board. Please try again.")
     }
   })
 
@@ -117,8 +117,8 @@ export const KanbanPlayground = () => {
       queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
       setSelectedBoardId(null)
     },
-    onError: (err) => {
-      message.error(`Failed to archive board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    onError: () => {
+      message.error("Failed to archive board. Please try again.")
     }
   })
 
@@ -160,7 +160,7 @@ export const KanbanPlayground = () => {
       URL.revokeObjectURL(url)
       message.success("Board exported")
     } catch (err) {
-      message.error(`Export failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+      message.error("Failed to export board. Please try again.")
     }
   }, [selectedBoardId, boardData])
 
@@ -189,9 +189,7 @@ export const KanbanPlayground = () => {
         queryKey: ["kanban-board", selectedBoardId]
       })
     } catch (err) {
-      message.error(
-        `Failed: ${err instanceof Error ? err.message : "Unknown error"}`
-      )
+      message.error("Failed to create lists. Please try again.")
     }
   }, [selectedBoardId, queryClient])
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
@@ -283,6 +283,16 @@ export const KanbanPlayground = () => {
   )
 
   const renderContent = () => {
+    const isLoading = selectedBoardId ? boardLoading : boardsLoading
+
+    if (isLoading) {
+      return (
+        <div className="flex items-center justify-center h-96">
+          <Spin size="large" />
+        </div>
+      )
+    }
+
     if (!selectedBoardId) {
       return (
         <BoardGallery
@@ -290,14 +300,6 @@ export const KanbanPlayground = () => {
           onSelectBoard={setSelectedBoardId}
           onCreateBoard={() => setCreateModalOpen(true)}
         />
-      )
-    }
-
-    if (boardLoading) {
-      return (
-        <div className="flex items-center justify-center h-96">
-          <Spin size="large" />
-        </div>
       )
     }
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/index.tsx
@@ -1,17 +1,25 @@
 import { useState, useCallback } from "react"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import {
-  Tabs,
+  Dropdown,
   message,
   Spin,
-  Empty,
   Button,
   Select,
   Modal,
   Input,
   Badge
 } from "antd"
-import { Plus, Kanban, Upload, RefreshCw } from "lucide-react"
+import type { MenuProps } from "antd"
+import {
+  Plus,
+  Kanban,
+  Upload,
+  Download,
+  RefreshCw,
+  Archive,
+  MoreVertical
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -19,18 +27,20 @@ import {
   getBoard,
   createBoard,
   deleteBoard,
+  archiveBoard,
+  exportBoard,
+  createList,
   generateClientId
 } from "@/services/kanban"
 import { BoardView } from "./BoardView"
 import { ImportPanel } from "./ImportPanel"
-
-type PlaygroundTab = "board" | "import"
+import { ArchivedItemsDrawer } from "./ArchivedItemsDrawer"
+import { BoardGallery } from "./BoardGallery"
+import { useKanbanShortcuts } from "./useKanbanShortcuts"
 
 export const KanbanPlayground = () => {
   const { t } = useTranslation(["settings", "common"])
   const queryClient = useQueryClient()
-  // Tab state
-  const [activeTab, setActiveTab] = useState<PlaygroundTab>("board")
 
   // Board selection state
   const [selectedBoardId, setSelectedBoardId] = useState<number | null>(null)
@@ -38,6 +48,13 @@ export const KanbanPlayground = () => {
   // Create board modal state
   const [createModalOpen, setCreateModalOpen] = useState(false)
   const [newBoardName, setNewBoardName] = useState("")
+  const [newBoardDescription, setNewBoardDescription] = useState("")
+
+  // Import modal state
+  const [importModalOpen, setImportModalOpen] = useState(false)
+
+  // Archive drawer state
+  const [archiveDrawerOpen, setArchiveDrawerOpen] = useState(false)
 
   // Fetch boards list
   const {
@@ -64,14 +81,15 @@ export const KanbanPlayground = () => {
 
   // Create board mutation
   const createBoardMutation = useMutation({
-    mutationFn: (name: string) =>
-      createBoard({ name, client_id: generateClientId() }),
+    mutationFn: ({ name, description }: { name: string; description?: string }) =>
+      createBoard({ name, description, client_id: generateClientId() }),
     onSuccess: (newBoard) => {
       message.success("Board created")
       queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
       setSelectedBoardId(newBoard.id)
       setCreateModalOpen(false)
       setNewBoardName("")
+      setNewBoardDescription("")
     },
     onError: (err) => {
       message.error(`Failed to create board: ${err instanceof Error ? err.message : "Unknown error"}`)
@@ -91,35 +109,132 @@ export const KanbanPlayground = () => {
     }
   })
 
+  // Archive board mutation
+  const archiveBoardMutation = useMutation({
+    mutationFn: (boardId: number) => archiveBoard(boardId),
+    onSuccess: () => {
+      message.success("Board archived")
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
+      setSelectedBoardId(null)
+    },
+    onError: (err) => {
+      message.error(`Failed to archive board: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  })
+
   const handleCreateBoard = useCallback(() => {
     if (!newBoardName.trim()) {
       message.warning("Please enter a board name")
       return
     }
-    createBoardMutation.mutate(newBoardName.trim())
-  }, [newBoardName, createBoardMutation])
+    createBoardMutation.mutate({
+      name: newBoardName.trim(),
+      description: newBoardDescription.trim() || undefined
+    })
+  }, [newBoardName, newBoardDescription, createBoardMutation])
 
   const handleDeleteBoard = useCallback(() => {
     if (!selectedBoardId) return
     deleteBoardMutation.mutate(selectedBoardId)
   }, [selectedBoardId, deleteBoardMutation])
 
-  const handleBoardImported = useCallback((boardId: number) => {
-    queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
-    setSelectedBoardId(boardId)
-    setActiveTab("board")
-  }, [queryClient])
+  const handleArchiveBoard = useCallback(() => {
+    if (!selectedBoardId) return
+    archiveBoardMutation.mutate(selectedBoardId)
+  }, [selectedBoardId, archiveBoardMutation])
+
+  const handleExportBoard = useCallback(async () => {
+    if (!selectedBoardId || !boardData) return
+    try {
+      const data = await exportBoard(selectedBoardId)
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json"
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${boardData.name.replace(/[^a-z0-9]/gi, "_")}_export.json`
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+      URL.revokeObjectURL(url)
+      message.success("Board exported")
+    } catch (err) {
+      message.error(`Export failed: ${err instanceof Error ? err.message : "Unknown error"}`)
+    }
+  }, [selectedBoardId, boardData])
+
+  const handleBoardImported = useCallback(
+    (boardId: number) => {
+      queryClient.invalidateQueries({ queryKey: ["kanban-boards"] })
+      setSelectedBoardId(boardId)
+      setImportModalOpen(false)
+    },
+    [queryClient]
+  )
+
+  // Quick setup: create To Do / In Progress / Done lists
+  const handleQuickSetup = useCallback(async () => {
+    if (!selectedBoardId) return
+    const names = ["To Do", "In Progress", "Done"]
+    try {
+      for (const name of names) {
+        await createList(selectedBoardId, {
+          name,
+          client_id: generateClientId()
+        })
+      }
+      message.success("Lists created")
+      queryClient.invalidateQueries({
+        queryKey: ["kanban-board", selectedBoardId]
+      })
+    } catch (err) {
+      message.error(
+        `Failed: ${err instanceof Error ? err.message : "Unknown error"}`
+      )
+    }
+  }, [selectedBoardId, queryClient])
+
+  // Keyboard shortcuts
+  const { helpOpen, setHelpOpen } = useKanbanShortcuts({
+    onNewBoard: () => setCreateModalOpen(true),
+    onNewCard: undefined, // Handled by BoardView
+    onNewList: undefined  // Handled by BoardView
+  })
 
   const boards = boardsData?.boards ?? []
-  const emptyDescription =
-    boards.length > 0
-      ? "Select an existing board to get started"
-      : "No boards yet. Create your first board"
 
   const boardSelectorOptions = boards.map((b) => ({
     value: b.id,
     label: b.name
   }))
+
+  // Actions dropdown menu items
+  const actionsMenuItems: MenuProps["items"] = [
+    {
+      key: "import",
+      label: "Import Board...",
+      icon: <Upload className="w-4 h-4" />,
+      onClick: () => setImportModalOpen(true)
+    },
+    ...(selectedBoardId
+      ? [
+          {
+            key: "export",
+            label: "Export Board...",
+            icon: <Download className="w-4 h-4" />,
+            onClick: handleExportBoard
+          }
+        ]
+      : []),
+    { type: "divider" as const },
+    {
+      key: "archive",
+      label: "Archived Items",
+      icon: <Archive className="w-4 h-4" />,
+      onClick: () => setArchiveDrawerOpen(true)
+    }
+  ]
 
   const renderHeader = () => (
     <div className="flex items-center justify-between mb-4">
@@ -134,7 +249,10 @@ export const KanbanPlayground = () => {
             count={boards.length}
             showZero
             styles={{
-              indicator: { backgroundColor: "rgb(var(--color-primary))", color: "rgb(var(--color-text))" }
+              indicator: {
+                backgroundColor: "rgb(var(--color-primary))",
+                color: "rgb(var(--color-text))"
+              }
             }}
           />
         </div>
@@ -154,6 +272,9 @@ export const KanbanPlayground = () => {
         >
           New Board
         </Button>
+        <Dropdown menu={{ items: actionsMenuItems }} trigger={["click"]}>
+          <Button icon={<MoreVertical className="w-4 h-4" />} />
+        </Dropdown>
         <Button
           icon={<RefreshCw className="w-4 h-4" />}
           onClick={() => {
@@ -165,65 +286,67 @@ export const KanbanPlayground = () => {
     </div>
   )
 
-  const tabItems = [
-    {
-      key: "board",
-      label: (
-        <span className="flex items-center gap-2">
-          <Kanban className="w-4 h-4" />
-          Board
-        </span>
-      ),
-      children: (
-        <div className="min-h-[500px]">
-          {boardLoading ? (
-            <div className="flex items-center justify-center h-96">
-              <Spin size="large" />
-            </div>
-          ) : !selectedBoardId ? (
-            <Empty
-              description={emptyDescription}
-              className="mt-20"
-            >
-              <Button
-                type="primary"
-                icon={<Plus className="w-4 h-4" />}
-                onClick={() => setCreateModalOpen(true)}
-              >
-                Create Board
-              </Button>
-            </Empty>
-          ) : boardData ? (
-            <BoardView
-              board={boardData}
-              onRefresh={() => refetchBoard()}
-              onDelete={handleDeleteBoard}
-            />
-          ) : null}
+  const renderContent = () => {
+    if (boardLoading) {
+      return (
+        <div className="flex items-center justify-center h-96">
+          <Spin size="large" />
         </div>
       )
-    },
-    {
-      key: "import",
-      label: (
-        <span className="flex items-center gap-2">
-          <Upload className="w-4 h-4" />
-          Import
-        </span>
-      ),
-      children: <ImportPanel onImported={handleBoardImported} />
     }
-  ]
+
+    if (!selectedBoardId) {
+      return (
+        <BoardGallery
+          boards={boards}
+          onSelectBoard={setSelectedBoardId}
+          onCreateBoard={() => setCreateModalOpen(true)}
+        />
+      )
+    }
+
+    if (boardData) {
+      return (
+        <>
+          <BoardView
+            board={boardData}
+            onRefresh={() => refetchBoard()}
+            onDelete={handleDeleteBoard}
+            onArchive={handleArchiveBoard}
+            onQuickSetup={
+              boardData.lists.length === 0 ? handleQuickSetup : undefined
+            }
+          />
+        </>
+      )
+    }
+
+    return null
+  }
 
   return (
     <div className="kanban-playground">
       {renderHeader()}
 
-      <Tabs
-        activeKey={activeTab}
-        onChange={(key) => setActiveTab(key as PlaygroundTab)}
-        items={tabItems}
+      <div className="min-h-[500px]">{renderContent()}</div>
+
+      {/* Archive drawer */}
+      <ArchivedItemsDrawer
+        open={archiveDrawerOpen}
+        onClose={() => setArchiveDrawerOpen(false)}
+        board={boardData}
       />
+
+      {/* Import modal */}
+      <Modal
+        title="Import Board"
+        open={importModalOpen}
+        onCancel={() => setImportModalOpen(false)}
+        footer={null}
+        width={600}
+      >
+        <ImportPanel onImported={handleBoardImported} />
+      </Modal>
 
       {/* Create Board Modal */}
       <Modal
@@ -232,20 +355,63 @@ export const KanbanPlayground = () => {
         onCancel={() => {
           setCreateModalOpen(false)
           setNewBoardName("")
+          setNewBoardDescription("")
         }}
         onOk={handleCreateBoard}
         okText="Create"
         confirmLoading={createBoardMutation.isPending}
       >
-        <div className="py-4">
-          <label className="block text-sm font-medium mb-2">Board Name</label>
-          <Input
-            placeholder="Enter board name"
-            value={newBoardName}
-            onChange={(e) => setNewBoardName(e.target.value)}
-            onPressEnter={handleCreateBoard}
-            autoFocus
-          />
+        <div className="py-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-2">
+              Board Name
+            </label>
+            <Input
+              placeholder="Enter board name"
+              value={newBoardName}
+              onChange={(e) => setNewBoardName(e.target.value)}
+              onPressEnter={handleCreateBoard}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-2">
+              Description{" "}
+              <span className="text-text-muted font-normal">(optional)</span>
+            </label>
+            <Input.TextArea
+              placeholder="What is this board for?"
+              value={newBoardDescription}
+              onChange={(e) => setNewBoardDescription(e.target.value)}
+              autoSize={{ minRows: 2, maxRows: 4 }}
+            />
+          </div>
+        </div>
+      </Modal>
+
+      {/* Keyboard shortcuts help */}
+      <Modal
+        title="Keyboard Shortcuts"
+        open={helpOpen}
+        onCancel={() => setHelpOpen(false)}
+        footer={null}
+        width={360}
+      >
+        <div className="space-y-2 py-2">
+          {[
+            { key: "N", desc: "New card" },
+            { key: "B", desc: "New board" },
+            { key: "L", desc: "New list" },
+            { key: "Esc", desc: "Close panel" },
+            { key: "?", desc: "Show this help" }
+          ].map(({ key, desc }) => (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm">{desc}</span>
+              <kbd className="px-2 py-0.5 rounded bg-surface text-xs font-mono border">
+                {key}
+              </kbd>
+            </div>
+          ))}
         </div>
       </Modal>
     </div>

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import {
   useKeyboardShortcuts,
   type KeyboardShortcutConfig
@@ -31,7 +31,9 @@ export const useKanbanShortcuts = (actions: KanbanShortcutActions) => {
     []
   )
 
-  const shortcuts: KeyboardShortcutConfig[] = [
+  const showHelp = useCallback(() => setHelpOpen(true), [])
+
+  const shortcuts: KeyboardShortcutConfig[] = useMemo(() => [
     ...(actions.onNewCard
       ? [{
           shortcut: { key: "n", preventDefault: true, stopPropagation: false },
@@ -62,10 +64,10 @@ export const useKanbanShortcuts = (actions: KanbanShortcutActions) => {
       : []),
     {
       shortcut: { key: "?", shiftKey: true, preventDefault: true, stopPropagation: false },
-      action: guard(() => setHelpOpen(true)),
+      action: guard(showHelp),
       description: "Show keyboard shortcuts"
     }
-  ]
+  ], [actions.onNewCard, actions.onNewBoard, actions.onNewList, actions.onClosePanel, guard, showHelp])
 
   useKeyboardShortcuts(shortcuts)
 

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
@@ -1,0 +1,65 @@
+import { useCallback, useState } from "react"
+import {
+  useKeyboardShortcuts,
+  type KeyboardShortcutConfig
+} from "@/hooks/keyboard/useKeyboardShortcuts"
+
+interface KanbanShortcutActions {
+  onNewCard?: () => void
+  onNewBoard?: () => void
+  onNewList?: () => void
+  onClosePanel?: () => void
+}
+
+function isInputFocused(): boolean {
+  const active = document.activeElement
+  if (!active) return false
+  const tag = active.tagName.toLowerCase()
+  if (tag === "input" || tag === "textarea" || tag === "select") return true
+  if ((active as HTMLElement).isContentEditable) return true
+  return false
+}
+
+export const useKanbanShortcuts = (actions: KanbanShortcutActions) => {
+  const [helpOpen, setHelpOpen] = useState(false)
+
+  const guard = useCallback(
+    (fn?: () => void) => () => {
+      if (isInputFocused()) return
+      fn?.()
+    },
+    []
+  )
+
+  const shortcuts: KeyboardShortcutConfig[] = [
+    {
+      shortcut: { key: "n", preventDefault: false, stopPropagation: false },
+      action: guard(actions.onNewCard),
+      description: "New card in active list"
+    },
+    {
+      shortcut: { key: "b", preventDefault: false, stopPropagation: false },
+      action: guard(actions.onNewBoard),
+      description: "New board"
+    },
+    {
+      shortcut: { key: "l", preventDefault: false, stopPropagation: false },
+      action: guard(actions.onNewList),
+      description: "New list"
+    },
+    {
+      shortcut: { key: "Escape", preventDefault: false, stopPropagation: false },
+      action: guard(actions.onClosePanel),
+      description: "Close panel"
+    },
+    {
+      shortcut: { key: "?", shiftKey: true, preventDefault: false, stopPropagation: false },
+      action: guard(() => setHelpOpen(true)),
+      description: "Show keyboard shortcuts"
+    }
+  ]
+
+  useKeyboardShortcuts(shortcuts)
+
+  return { helpOpen, setHelpOpen, shortcuts }
+}

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
@@ -32,26 +32,34 @@ export const useKanbanShortcuts = (actions: KanbanShortcutActions) => {
   )
 
   const shortcuts: KeyboardShortcutConfig[] = [
-    {
-      shortcut: { key: "n", preventDefault: true, stopPropagation: false },
-      action: guard(actions.onNewCard),
-      description: "New card in active list"
-    },
-    {
-      shortcut: { key: "b", preventDefault: true, stopPropagation: false },
-      action: guard(actions.onNewBoard),
-      description: "New board"
-    },
-    {
-      shortcut: { key: "l", preventDefault: true, stopPropagation: false },
-      action: guard(actions.onNewList),
-      description: "New list"
-    },
-    {
-      shortcut: { key: "Escape", preventDefault: true, stopPropagation: false },
-      action: guard(actions.onClosePanel),
-      description: "Close panel"
-    },
+    ...(actions.onNewCard
+      ? [{
+          shortcut: { key: "n", preventDefault: true, stopPropagation: false },
+          action: guard(actions.onNewCard),
+          description: "New card in active list"
+        }]
+      : []),
+    ...(actions.onNewBoard
+      ? [{
+          shortcut: { key: "b", preventDefault: true, stopPropagation: false },
+          action: guard(actions.onNewBoard),
+          description: "New board"
+        }]
+      : []),
+    ...(actions.onNewList
+      ? [{
+          shortcut: { key: "l", preventDefault: true, stopPropagation: false },
+          action: guard(actions.onNewList),
+          description: "New list"
+        }]
+      : []),
+    ...(actions.onClosePanel
+      ? [{
+          shortcut: { key: "Escape", preventDefault: true, stopPropagation: false },
+          action: guard(actions.onClosePanel),
+          description: "Close panel"
+        }]
+      : []),
     {
       shortcut: { key: "?", shiftKey: true, preventDefault: true, stopPropagation: false },
       action: guard(() => setHelpOpen(true)),

--- a/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
+++ b/apps/packages/ui/src/components/Option/KanbanPlayground/useKanbanShortcuts.ts
@@ -33,27 +33,27 @@ export const useKanbanShortcuts = (actions: KanbanShortcutActions) => {
 
   const shortcuts: KeyboardShortcutConfig[] = [
     {
-      shortcut: { key: "n", preventDefault: false, stopPropagation: false },
+      shortcut: { key: "n", preventDefault: true, stopPropagation: false },
       action: guard(actions.onNewCard),
       description: "New card in active list"
     },
     {
-      shortcut: { key: "b", preventDefault: false, stopPropagation: false },
+      shortcut: { key: "b", preventDefault: true, stopPropagation: false },
       action: guard(actions.onNewBoard),
       description: "New board"
     },
     {
-      shortcut: { key: "l", preventDefault: false, stopPropagation: false },
+      shortcut: { key: "l", preventDefault: true, stopPropagation: false },
       action: guard(actions.onNewList),
       description: "New list"
     },
     {
-      shortcut: { key: "Escape", preventDefault: false, stopPropagation: false },
+      shortcut: { key: "Escape", preventDefault: true, stopPropagation: false },
       action: guard(actions.onClosePanel),
       description: "Close panel"
     },
     {
-      shortcut: { key: "?", shiftKey: true, preventDefault: false, stopPropagation: false },
+      shortcut: { key: "?", shiftKey: true, preventDefault: true, stopPropagation: false },
       action: guard(() => setHelpOpen(true)),
       description: "Show keyboard shortcuts"
     }

--- a/apps/packages/ui/src/services/kanban.ts
+++ b/apps/packages/ui/src/services/kanban.ts
@@ -20,7 +20,10 @@ import type {
   CardMoveRequest,
   ReorderRequest,
   ReorderResponse,
-  BoardImportResponse
+  BoardImportResponse,
+  Label,
+  LabelCreate,
+  LabelUpdate
 } from "@/types/kanban"
 
 // =============================================================================
@@ -281,6 +284,279 @@ export async function reorderCards(
     path: `/api/v1/kanban/lists/${listId}/cards/reorder`,
     method: "POST",
     body: { ids: cardIds } as ReorderRequest
+  })
+}
+
+// =============================================================================
+// Archive / Restore API
+// =============================================================================
+
+export async function archiveBoard(boardId: number): Promise<Board> {
+  return await bgRequest<Board>({
+    path: `/api/v1/kanban/boards/${boardId}/archive`,
+    method: "POST"
+  })
+}
+
+export async function unarchiveBoard(boardId: number): Promise<Board> {
+  return await bgRequest<Board>({
+    path: `/api/v1/kanban/boards/${boardId}/unarchive`,
+    method: "POST"
+  })
+}
+
+export async function archiveList(listId: number): Promise<KanbanList> {
+  return await bgRequest<KanbanList>({
+    path: `/api/v1/kanban/lists/${listId}/archive`,
+    method: "POST"
+  })
+}
+
+export async function unarchiveList(listId: number): Promise<KanbanList> {
+  return await bgRequest<KanbanList>({
+    path: `/api/v1/kanban/lists/${listId}/unarchive`,
+    method: "POST"
+  })
+}
+
+export async function archiveCard(cardId: number): Promise<Card> {
+  return await bgRequest<Card>({
+    path: `/api/v1/kanban/cards/${cardId}/archive`,
+    method: "POST"
+  })
+}
+
+export async function unarchiveCard(cardId: number): Promise<Card> {
+  return await bgRequest<Card>({
+    path: `/api/v1/kanban/cards/${cardId}/unarchive`,
+    method: "POST"
+  })
+}
+
+// =============================================================================
+// Export API
+// =============================================================================
+
+export async function exportBoard(boardId: number): Promise<Record<string, any>> {
+  return await bgRequest<Record<string, any>>({
+    path: `/api/v1/kanban/boards/${boardId}/export`,
+    method: "GET"
+  })
+}
+
+// =============================================================================
+// Label API
+// =============================================================================
+
+export async function listLabels(boardId: number): Promise<Label[]> {
+  return await bgRequest<Label[]>({
+    path: `/api/v1/kanban/boards/${boardId}/labels`,
+    method: "GET"
+  })
+}
+
+export async function createLabel(
+  boardId: number,
+  data: LabelCreate
+): Promise<Label> {
+  return await bgRequest<Label>({
+    path: `/api/v1/kanban/boards/${boardId}/labels`,
+    method: "POST",
+    body: data
+  })
+}
+
+export async function updateLabel(
+  labelId: number,
+  data: LabelUpdate
+): Promise<Label> {
+  return await bgRequest<Label>({
+    path: `/api/v1/kanban/labels/${labelId}`,
+    method: "PATCH",
+    body: data
+  })
+}
+
+export async function deleteLabel(labelId: number): Promise<void> {
+  await bgRequest<void>({
+    path: `/api/v1/kanban/labels/${labelId}`,
+    method: "DELETE"
+  })
+}
+
+export async function assignLabelToCard(
+  cardId: number,
+  labelId: number
+): Promise<void> {
+  await bgRequest<void>({
+    path: `/api/v1/kanban/cards/${cardId}/labels/${labelId}`,
+    method: "POST"
+  })
+}
+
+export async function removeLabelFromCard(
+  cardId: number,
+  labelId: number
+): Promise<void> {
+  await bgRequest<void>({
+    path: `/api/v1/kanban/cards/${cardId}/labels/${labelId}`,
+    method: "DELETE"
+  })
+}
+
+// =============================================================================
+// Card Copy API
+// =============================================================================
+
+export async function copyCard(cardId: number): Promise<Card> {
+  return await bgRequest<Card>({
+    path: `/api/v1/kanban/cards/${cardId}/copy`,
+    method: "POST"
+  })
+}
+
+// =============================================================================
+// Search API
+// =============================================================================
+
+export async function searchCards(params: {
+  query: string
+  boardId?: number
+  limit?: number
+}): Promise<CardsListResponse> {
+  const qs = new URLSearchParams()
+  qs.set("q", params.query)
+  if (params.boardId != null) qs.set("board_id", String(params.boardId))
+  if (params.limit != null) qs.set("limit", String(params.limit))
+  return await bgRequest<CardsListResponse>({
+    path: `/api/v1/kanban/cards/search?${qs.toString()}`,
+    method: "GET"
+  })
+}
+
+// =============================================================================
+// Checklist API
+// =============================================================================
+
+export interface Checklist {
+  id: number
+  uuid: string
+  card_id: number
+  title: string
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ChecklistItem {
+  id: number
+  uuid: string
+  checklist_id: number
+  content: string
+  checked: boolean
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ChecklistWithItems extends Checklist {
+  items: ChecklistItem[]
+}
+
+export async function listChecklists(cardId: number): Promise<ChecklistWithItems[]> {
+  return await bgRequest<ChecklistWithItems[]>({
+    path: `/api/v1/kanban/cards/${cardId}/checklists`,
+    method: "GET"
+  })
+}
+
+export async function createChecklist(
+  cardId: number,
+  data: { title: string; client_id: string }
+): Promise<Checklist> {
+  return await bgRequest<Checklist>({
+    path: `/api/v1/kanban/cards/${cardId}/checklists`,
+    method: "POST",
+    body: data
+  })
+}
+
+export async function updateChecklist(
+  checklistId: number,
+  data: { title?: string }
+): Promise<Checklist> {
+  return await bgRequest<Checklist>({
+    path: `/api/v1/kanban/checklists/${checklistId}`,
+    method: "PATCH",
+    body: data
+  })
+}
+
+export async function deleteChecklist(checklistId: number): Promise<void> {
+  await bgRequest<void>({
+    path: `/api/v1/kanban/checklists/${checklistId}`,
+    method: "DELETE"
+  })
+}
+
+export async function createChecklistItem(
+  checklistId: number,
+  data: { content: string; client_id: string }
+): Promise<ChecklistItem> {
+  return await bgRequest<ChecklistItem>({
+    path: `/api/v1/kanban/checklists/${checklistId}/items`,
+    method: "POST",
+    body: data
+  })
+}
+
+export async function updateChecklistItem(
+  itemId: number,
+  data: { content?: string; checked?: boolean }
+): Promise<ChecklistItem> {
+  return await bgRequest<ChecklistItem>({
+    path: `/api/v1/kanban/checklist-items/${itemId}`,
+    method: "PATCH",
+    body: data
+  })
+}
+
+export async function deleteChecklistItem(itemId: number): Promise<void> {
+  await bgRequest<void>({
+    path: `/api/v1/kanban/checklist-items/${itemId}`,
+    method: "DELETE"
+  })
+}
+
+// =============================================================================
+// Comment API
+// =============================================================================
+
+export interface Comment {
+  id: number
+  uuid: string
+  card_id: number
+  user_id: string
+  content: string
+  created_at: string
+  updated_at: string
+}
+
+export async function listComments(cardId: number): Promise<Comment[]> {
+  return await bgRequest<Comment[]>({
+    path: `/api/v1/kanban/cards/${cardId}/comments`,
+    method: "GET"
+  })
+}
+
+export async function createComment(
+  cardId: number,
+  data: { content: string; client_id: string }
+): Promise<Comment> {
+  return await bgRequest<Comment>({
+    path: `/api/v1/kanban/cards/${cardId}/comments`,
+    method: "POST",
+    body: data
   })
 }
 

--- a/apps/packages/ui/src/services/kanban.ts
+++ b/apps/packages/ui/src/services/kanban.ts
@@ -23,8 +23,15 @@ import type {
   BoardImportResponse,
   Label,
   LabelCreate,
-  LabelUpdate
+  LabelUpdate,
+  Checklist,
+  ChecklistItem,
+  ChecklistWithItems,
+  Comment
 } from "@/types/kanban"
+
+// Re-export types that consumers import from this module
+export type { Checklist, ChecklistItem, ChecklistWithItems, Comment }
 
 // =============================================================================
 // Board API
@@ -54,9 +61,15 @@ export async function listBoards(params?: {
 /**
  * Get a single board with nested lists and cards
  */
-export async function getBoard(boardId: number): Promise<BoardWithLists> {
+export async function getBoard(
+  boardId: number,
+  params?: { includeArchived?: boolean }
+): Promise<BoardWithLists> {
+  const query = new URLSearchParams()
+  if (params?.includeArchived) query.set("include_archived", "true")
+  const suffix = query.toString() ? `?${query.toString()}` : ""
   return await bgRequest<BoardWithLists>({
-    path: `/api/v1/kanban/boards/${boardId}`,
+    path: `/api/v1/kanban/boards/${boardId}${suffix}`,
     method: "GET"
   })
 }
@@ -438,31 +451,6 @@ export async function searchCards(params: {
 // Checklist API
 // =============================================================================
 
-export interface Checklist {
-  id: number
-  uuid: string
-  card_id: number
-  title: string
-  position: number
-  created_at: string
-  updated_at: string
-}
-
-export interface ChecklistItem {
-  id: number
-  uuid: string
-  checklist_id: number
-  content: string
-  checked: boolean
-  position: number
-  created_at: string
-  updated_at: string
-}
-
-export interface ChecklistWithItems extends Checklist {
-  items: ChecklistItem[]
-}
-
 export async function listChecklists(cardId: number): Promise<ChecklistWithItems[]> {
   return await bgRequest<ChecklistWithItems[]>({
     path: `/api/v1/kanban/cards/${cardId}/checklists`,
@@ -531,16 +519,6 @@ export async function deleteChecklistItem(itemId: number): Promise<void> {
 // =============================================================================
 // Comment API
 // =============================================================================
-
-export interface Comment {
-  id: number
-  uuid: string
-  card_id: number
-  user_id: string
-  content: string
-  created_at: string
-  updated_at: string
-}
 
 export async function listComments(cardId: number): Promise<Comment[]> {
   return await bgRequest<Comment[]>({

--- a/apps/packages/ui/src/types/kanban.ts
+++ b/apps/packages/ui/src/types/kanban.ts
@@ -206,6 +206,49 @@ export interface ReorderResponse {
 }
 
 // =============================================================================
+// Checklist Types
+// =============================================================================
+
+export interface Checklist {
+  id: number
+  uuid: string
+  card_id: number
+  title: string
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ChecklistItem {
+  id: number
+  uuid: string
+  checklist_id: number
+  content: string
+  checked: boolean
+  position: number
+  created_at: string
+  updated_at: string
+}
+
+export interface ChecklistWithItems extends Checklist {
+  items: ChecklistItem[]
+}
+
+// =============================================================================
+// Comment Types
+// =============================================================================
+
+export interface Comment {
+  id: number
+  uuid: string
+  card_id: number
+  user_id: string
+  content: string
+  created_at: string
+  updated_at: string
+}
+
+// =============================================================================
 // Import/Export Types
 // =============================================================================
 

--- a/apps/packages/ui/src/types/kanban.ts
+++ b/apps/packages/ui/src/types/kanban.ts
@@ -15,6 +15,31 @@ export interface PaginationInfo {
 }
 
 // =============================================================================
+// Label Types
+// =============================================================================
+
+export interface Label {
+  id: number
+  uuid: string
+  board_id: number
+  name: string
+  color: string
+  created_at: string
+  updated_at: string
+}
+
+export interface LabelCreate {
+  name: string
+  color: string
+  client_id: string
+}
+
+export interface LabelUpdate {
+  name?: string
+  color?: string
+}
+
+// =============================================================================
 // Board Types
 // =============================================================================
 
@@ -116,6 +141,12 @@ export interface Card {
   deleted_at?: string | null
   version: number
   metadata?: Record<string, any> | null
+  // Fields from backend GET /boards/{id} nested response
+  labels?: Label[]
+  checklist_count?: number
+  checklist_complete?: number
+  checklist_total?: number
+  comment_count?: number
 }
 
 export interface CardCreate {


### PR DESCRIPTION
## Summary

- **Wave 1**: List rename (inline edit), delete confirmation with card count, dynamic column height, per-list card title state fix, expanded `Card` type to surface backend fields (labels, checklist counts, comment counts), enhanced card preview with priority border/label bars/metadata icons
- **Wave 2**: Archive/restore services + `ArchivedItemsDrawer`, tabs-to-dropdown menu restructure, archive-first deletion pattern with undo toast (10s restore window), board description field, quick setup (To Do/In Progress/Done)
- **Wave 3**: `LabelManager` with 8-color picker and full CRUD, label + priority multi-select filter bar, non-matching card dimming
- **Wave 4**: `ChecklistSection` with inline editing and progress bars, keyboard shortcuts (`N`/`B`/`L`/`Esc`/`?`), optimistic drag-and-drop with error rollback
- **Wave 5**: `BoardGallery` grid view for board selection, search bar with card filtering, card copy, comments section with inline compose

**Key insight**: The backend already implements every feature needed (archive/restore, labels, checklists, comments, search, export, card copy). Zero backend changes required — this PR surfaces existing capabilities in the frontend.

### Files changed
- **5 modified**: `types/kanban.ts`, `services/kanban.ts`, `BoardView.tsx`, `CardDetailPanel.tsx`, `index.tsx`
- **5 new**: `ArchivedItemsDrawer.tsx`, `BoardGallery.tsx`, `ChecklistSection.tsx`, `LabelManager.tsx`, `useKanbanShortcuts.ts`

## Test plan
- [ ] Load extension, open Kanban page — board gallery renders
- [ ] Create board, verify quick setup creates 3 default lists
- [ ] Create/rename/archive/delete lists with confirmation dialogs
- [ ] Create cards, verify per-list title input isolation
- [ ] Drag-and-drop cards between lists — optimistic update + rollback on error
- [ ] Open card detail panel — verify labels, checklists, comments, copy, archive actions
- [ ] Create/assign/filter by labels, verify card dimming
- [ ] Add checklist items, check/uncheck, verify progress bar
- [ ] Add comments, verify chronological display
- [ ] Copy card, verify duplicate appears
- [ ] Search cards via filter bar
- [ ] Test keyboard shortcuts (N, B, L, Esc, Shift+?)
- [ ] Archive board/list/card, verify in Archived Items drawer, restore
- [ ] Export board as JSON, import from JSON
- [ ] `bun run compile` passes after `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Archive and restore boards, lists, and cards with undo functionality
  * Create and manage labels with custom colors; assign labels to cards
  * Add checklists with progress tracking to cards
  * Comment on cards for team collaboration
  * Copy cards and search card functionality
  * Keyboard shortcuts for faster navigation (N: new card, B: new board, L: new list, Esc: close)
  * Import and export boards as files
  * Add descriptions when creating boards
  * Quick setup to auto-generate default board lists
  * Gallery view for organizing and selecting multiple boards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->