### PR TITLE
Add Personapod tooling copy-candidates for existing tooling support

### DIFF
--- a/Helper_Scripts/common/model_container_cycle.py
+++ b/Helper_Scripts/common/model_container_cycle.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import subprocess
+import time
+
+
+def parse_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _run(cmd: list[str], *, dry_run: bool, capture_output: bool = False) -> subprocess.CompletedProcess[str] | None:
+    printable = " ".join(cmd)
+    if dry_run:
+        print(f"[dry-run] {printable}")
+        return None
+
+    try:
+        return subprocess.run(
+            cmd,
+            check=True,
+            text=True,
+            capture_output=capture_output,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Required command not found: {cmd[0]}") from exc
+
+
+def list_running_containers() -> list[str]:
+    result = _run(
+        ["docker", "ps", "--format", "{{.Names}}"],
+        dry_run=False,
+        capture_output=True,
+    )
+    assert result is not None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def stop_container(name: str, dry_run: bool = False) -> None:
+    _run(["docker", "stop", name], dry_run=dry_run)
+
+
+def start_container(name: str, boot_wait: float = 0.0, dry_run: bool = False) -> None:
+    _run(["docker", "start", name], dry_run=dry_run)
+    if boot_wait > 0:
+        if dry_run:
+            print(f"[dry-run] sleep {boot_wait}")
+            return
+        time.sleep(boot_wait)
+
+
+def stop_all_except(excluded: list[str], dry_run: bool = False) -> None:
+    excluded_set = set(excluded)
+    for name in list_running_containers():
+        if name not in excluded_set:
+            stop_container(name, dry_run=dry_run)
+
+
+def swap_containers(
+    *,
+    first_container: str,
+    second_container: str,
+    excluded: list[str] | None = None,
+    first_boot_wait: float = 0.0,
+    second_boot_wait: float = 0.0,
+    dry_run: bool = False,
+) -> None:
+    excluded_list = excluded or []
+    stop_all_except(excluded_list, dry_run=dry_run)
+    start_container(first_container, boot_wait=first_boot_wait, dry_run=dry_run)
+    stop_container(first_container, dry_run=dry_run)
+    start_container(second_container, boot_wait=second_boot_wait, dry_run=dry_run)

--- a/Helper_Scripts/common/sidecar_profiles.py
+++ b/Helper_Scripts/common/sidecar_profiles.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+PROFILE_MAP: dict[str, set[str] | None] = {
+    "full": None,
+    "llm-only": {"embeddings", "media_ingest"},
+    "tts-only": {"audio_jobs"},
+    "ingest-only": {"media_ingest"},
+}
+
+
+def _split_csv(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def resolve_workers(
+    profile: str | None,
+    explicit_workers_csv: str | None,
+    default_workers_csv: str,
+) -> list[str]:
+    explicit = _split_csv(explicit_workers_csv)
+    if explicit:
+        return explicit
+
+    defaults = _split_csv(default_workers_csv)
+    selected = PROFILE_MAP.get((profile or "full").strip().lower())
+    if selected is None:
+        return defaults
+    return [worker for worker in defaults if worker in selected]

--- a/Helper_Scripts/common/tooling_smoke_runner.py
+++ b/Helper_Scripts/common/tooling_smoke_runner.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SmokeStep:
+    name: str
+    command: list[str]
+
+
+def build_steps(base_url: str, api_key: str | None) -> list[SmokeStep]:
+    key_args = ["--api-key", api_key] if api_key else []
+    return [
+        SmokeStep(
+            name="streaming_unified",
+            command=[
+                "python",
+                "Helper_Scripts/streaming_unified_smoke.py",
+                "--base-url",
+                base_url,
+                *key_args,
+            ],
+        ),
+        SmokeStep(
+            name="watchlists_audio",
+            command=[
+                "python",
+                "Helper_Scripts/watchlists/watchlists_audio_smoke.py",
+                "--base-url",
+                base_url,
+                *key_args,
+            ],
+        ),
+    ]

--- a/Helper_Scripts/model_container_cycle.py
+++ b/Helper_Scripts/model_container_cycle.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow direct script execution from the repo root via `python Helper_Scripts/...`.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from Helper_Scripts.common.model_container_cycle import parse_csv, swap_containers
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Cycle Docker model containers for low-VRAM workflows: "
+            "stop all non-excluded containers, start first model, stop it, then start second model."
+        )
+    )
+    parser.add_argument("--first-container", required=True, help="Container to start first.")
+    parser.add_argument("--second-container", required=True, help="Container to start second.")
+    parser.add_argument(
+        "--excluded",
+        default="",
+        help="Comma-separated container names to keep running while cycling.",
+    )
+    parser.add_argument(
+        "--first-boot-wait",
+        type=float,
+        default=0.0,
+        help="Seconds to wait after starting the first container.",
+    )
+    parser.add_argument(
+        "--second-boot-wait",
+        type=float,
+        default=0.0,
+        help="Seconds to wait after starting the second container.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print Docker commands without executing them.",
+    )
+    args = parser.parse_args()
+
+    swap_containers(
+        first_container=args.first_container,
+        second_container=args.second_container,
+        excluded=parse_csv(args.excluded),
+        first_boot_wait=args.first_boot_wait,
+        second_boot_wait=args.second_boot_wait,
+        dry_run=args.dry_run,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Helper_Scripts/tooling_smoke.py
+++ b/Helper_Scripts/tooling_smoke.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+
+from Helper_Scripts.common.tooling_smoke_runner import build_steps
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run unified tooling smoke checks.")
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000", help="API base URL.")
+    parser.add_argument("--api-key", default=None, help="Single-user API key.")
+    args = parser.parse_args()
+
+    for step in build_steps(base_url=args.base_url, api_key=args.api_key):
+        subprocess.run(step.command, check=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui verify pypi-build pypi-check tooling-install tooling-smoke
+.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -12,6 +12,12 @@ DOCKER_BASE_COMPOSE ?= Dockerfiles/docker-compose.yml
 DOCKER_WEBUI_COMPOSE ?= Dockerfiles/docker-compose.webui.yml
 NEXT_PUBLIC_API_URL ?= http://localhost:8000
 PYPI_BUILD_ARGS ?= --no-isolation
+MODEL_CYCLE_FIRST ?=
+MODEL_CYCLE_SECOND ?=
+MODEL_CYCLE_EXCLUDED ?=postgres,redis
+MODEL_CYCLE_FIRST_BOOT_WAIT ?=0
+MODEL_CYCLE_SECOND_BOOT_WAIT ?=0
+MODEL_CYCLE_DRY_RUN ?=false
 
 quickstart-prereqs:
 	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "[quickstart] $(PYTHON) not found. Install Python 3.10+ and retry." && exit 1)
@@ -91,6 +97,19 @@ quickstart-docker-webui: quickstart-docker-bootstrap
 	@echo "[quickstart-docker-webui] First-use auth initialization is handled automatically by the app entrypoint."
 	@echo "[quickstart-docker-webui] API:   http://localhost:8000"
 	@echo "[quickstart-docker-webui] WebUI: http://localhost:8080"
+
+model-cycle:
+	@command -v docker >/dev/null 2>&1 || (echo "[model-cycle] docker not found. Install Docker and retry." && exit 1)
+	@test -n "$(MODEL_CYCLE_FIRST)" || (echo "[model-cycle] Set MODEL_CYCLE_FIRST=<container_name>" && exit 1)
+	@test -n "$(MODEL_CYCLE_SECOND)" || (echo "[model-cycle] Set MODEL_CYCLE_SECOND=<container_name>" && exit 1)
+	@echo "[model-cycle] Cycling $(MODEL_CYCLE_FIRST) -> $(MODEL_CYCLE_SECOND) (excluded=$(MODEL_CYCLE_EXCLUDED), dry_run=$(MODEL_CYCLE_DRY_RUN))"
+	$(PYTHON) Helper_Scripts/model_container_cycle.py \
+		--first-container "$(MODEL_CYCLE_FIRST)" \
+		--second-container "$(MODEL_CYCLE_SECOND)" \
+		--excluded "$(MODEL_CYCLE_EXCLUDED)" \
+		--first-boot-wait "$(MODEL_CYCLE_FIRST_BOOT_WAIT)" \
+		--second-boot-wait "$(MODEL_CYCLE_SECOND_BOOT_WAIT)" \
+		$(if $(filter true TRUE 1 yes YES,$(MODEL_CYCLE_DRY_RUN)),--dry-run,)
 
 verify:
 	@echo "[verify] Checking server health..."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui verify pypi-build pypi-check
+.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui verify pypi-build pypi-check tooling-install tooling-smoke
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -58,6 +58,17 @@ quickstart: quickstart-prereqs
 	@echo "[quickstart] Verify with: curl http://localhost:8000/health"
 	@echo "[quickstart] API docs at: http://127.0.0.1:8000/docs"
 	$(PYTHON) -m uvicorn tldw_Server_API.app.main:app --host 127.0.0.1 --port 8000
+
+tooling-install:
+	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "[tooling-install] $(PYTHON) not found. Install Python 3.10+ and retry." && exit 1)
+	@$(PYTHON) -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' || (echo "[tooling-install] Python 3.10+ is required." && exit 1)
+	@if [ ! -x "$(VENV_PYTHON)" ]; then \
+		echo "[tooling-install] Creating virtualenv at $(VENV_DIR)"; \
+		$(PYTHON) -m venv $(VENV_DIR); \
+	fi
+	@echo "[tooling-install] Installing tooling extras into $(VENV_DIR)..."
+	@$(VENV_PYTHON) -m pip install --upgrade pip setuptools wheel
+	@$(VENV_PYTHON) -m pip install -e ".[tooling]"
 
 quickstart-docker-bootstrap:
 	@echo "[quickstart-docker-bootstrap] Ensuring $(TLDW_ENV_FILE) has safe first-use auth defaults..."
@@ -174,6 +185,19 @@ watchlists-audio-smoke:
 		--base-url "$(WATCHLISTS_BASE_URL)" \
 		--api-key "$(WATCHLISTS_API_KEY)" \
 		$(WATCHLISTS_AUDIO_SMOKE_ARGS)
+
+# -----------------------------------------------------------------------------
+# Unified tooling smoke (streaming + watchlists audio)
+# -----------------------------------------------------------------------------
+
+TOOLING_SMOKE_BASE_URL ?= http://127.0.0.1:8000
+TOOLING_SMOKE_API_KEY ?= $(SINGLE_USER_API_KEY)
+
+tooling-smoke:
+	@echo "[tooling-smoke] Running unified tooling smoke checks against $(TOOLING_SMOKE_BASE_URL)"
+	$(PYTHON) Helper_Scripts/tooling_smoke.py \
+		--base-url "$(TOOLING_SMOKE_BASE_URL)" \
+		--api-key "$(TOOLING_SMOKE_API_KEY)"
 
 # -----------------------------------------------------------------------------
 # Prompt Studio tests

--- a/README.md
+++ b/README.md
@@ -422,6 +422,27 @@ Notes:
 In-process workers are fine for light dev use, but SQLite + multiple Uvicorn workers can increase lock contention; use sidecars or Postgres for heavier workloads.
 </details>
 
+<details>
+<summary>Model container cycling (optional, Docker)</summary>
+
+For low-VRAM dev rigs, you can cycle model containers instead of running all model stacks at once:
+
+```bash
+make model-cycle \
+  MODEL_CYCLE_FIRST=your-llm-container \
+  MODEL_CYCLE_SECOND=your-tts-container \
+  MODEL_CYCLE_EXCLUDED=postgres,redis \
+  MODEL_CYCLE_FIRST_BOOT_WAIT=30 \
+  MODEL_CYCLE_SECOND_BOOT_WAIT=10
+```
+
+Notes:
+- Runs `Helper_Scripts/model_container_cycle.py`.
+- Workflow is: stop all running containers except exclusions, start first model container, stop it, then start second model container.
+- Use `MODEL_CYCLE_DRY_RUN=true` to print Docker commands without executing them.
+- Container names are whatever Docker reports via `docker ps --format '{{.Names}}'`.
+</details>
+
 ### Run the Web UI (WIP)
 
 The current Next.js UI is a work in progress and may be unstable, buggy, or rough around the edges.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,8 @@ curl http://localhost:8000/health
 ```bash
 # Optional pip extras
 pip install -e ".[multiplayer]"   # multi-user/PostgreSQL features
-pip install -e ".[dev]"           # tests, linters, tooling
+pip install -e ".[tooling]"       # unified tooling smoke helpers/scripts
+pip install -e ".[dev]"           # tests and linters
 pip install -e ".[otel]"          # OpenTelemetry metrics/tracing
 
 # pyaudio (needed for audio capture and some processing paths)
@@ -939,6 +940,7 @@ All limits are designed to be conservative by default and can be tuned using the
 - `python -m pytest --cov=tldw_Server_API --cov-report=term-missing` - coverage report.
 - Use markers (`unit`, `integration`, `e2e`, `external_api`, `performance`) to focus specific areas.
 - Enable optional suites with environment flags such as `RUN_MCP_TESTS=1`, `TLDW_TEST_POSTGRES_REQUIRED=1`, or `RUN_MOCK_OPENAI=1`.
+- `make tooling-smoke` - runs unified tooling smoke checks (`streaming_unified_smoke.py` + `watchlists_audio_smoke.py`) against a running local API (`http://127.0.0.1:8000` by default).
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,12 @@ dev = [
   "locust>=2.20.0"
 ]
 
+# Tooling smoke helpers and local scripts
+tooling = [
+  "requests>=2.31.0",
+  "websockets>=12.0",
+]
+
 # OpenTelemetry (optional, for metrics/tracing export)
 otel = [
   "opentelemetry-distro>=0.48b0",

--- a/start-sidecars.sh
+++ b/start-sidecars.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${ROOT_DIR}"
 
 if [[ -n "${TLDW_ENV_FILE:-}" && -f "${TLDW_ENV_FILE}" ]]; then
   set -a
@@ -16,6 +17,12 @@ UVICORN_PORT="${UVICORN_PORT:-8000}"
 UVICORN_WORKERS="${UVICORN_WORKERS:-1}"
 UVICORN_RELOAD="${UVICORN_RELOAD:-false}"
 UVICORN_EXTRA_ARGS="${UVICORN_EXTRA_ARGS:-}"
+SIDECAR_PROFILE="${TLDW_SIDECAR_PROFILE:-full}"
+SIDECAR_DRY_RUN="${TLDW_SIDECAR_DRY_RUN:-false}"
+WAIT_FOR_SERVER_HEALTH="${TLDW_WAIT_FOR_SERVER_HEALTH:-true}"
+SERVER_HEALTH_URL="${TLDW_SERVER_HEALTH_URL:-http://${UVICORN_HOST}:${UVICORN_PORT}/healthz}"
+SERVER_HEALTH_RETRIES="${TLDW_SERVER_HEALTH_RETRIES:-60}"
+SERVER_HEALTH_INTERVAL="${TLDW_SERVER_HEALTH_INTERVAL:-1}"
 
 LOG_DIR="${TLDW_LOG_DIR:-${ROOT_DIR}/.logs/sidecars}"
 mkdir -p "${LOG_DIR}"
@@ -64,7 +71,20 @@ while IFS= read -r line; do
   fi
 done <<< "${MANIFEST_OUTPUT}"
 
-WORKERS_CSV="${TLDW_SIDECAR_WORKERS:-${DEFAULT_WORKERS}}"
+WORKERS_CSV="$("${PYTHON_BIN}" - "${SIDECAR_PROFILE}" "${TLDW_SIDECAR_WORKERS:-}" "${DEFAULT_WORKERS}" <<'PY'
+import sys
+
+from Helper_Scripts.common.sidecar_profiles import resolve_workers
+
+profile, explicit_workers_csv, default_workers_csv = sys.argv[1], sys.argv[2], sys.argv[3]
+workers = resolve_workers(
+    profile=profile,
+    explicit_workers_csv=explicit_workers_csv or None,
+    default_workers_csv=default_workers_csv,
+)
+print(",".join(workers))
+PY
+)"
 
 declare -a PIDS=()
 declare -a NAMES=()
@@ -82,10 +102,31 @@ start_proc() {
 
 stop_all() {
   printf '\nStopping sidecar stack...\n'
-  for pid in "${PIDS[@]}"; do
+  for pid in "${PIDS[@]-}"; do
     kill "${pid}" 2>/dev/null || true
   done
   wait || true
+}
+
+wait_for_server_health() {
+  if [[ "${WAIT_FOR_SERVER_HEALTH}" != "true" ]]; then
+    return 0
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    printf 'curl not available; skipping server health wait.\n'
+    return 0
+  fi
+
+  local attempt=1
+  while [[ "${attempt}" -le "${SERVER_HEALTH_RETRIES}" ]]; do
+    if curl -fsS "${SERVER_HEALTH_URL}" >/dev/null 2>&1; then
+      printf 'Server healthy at %s\n' "${SERVER_HEALTH_URL}"
+      return 0
+    fi
+    sleep "${SERVER_HEALTH_INTERVAL}"
+    attempt=$((attempt + 1))
+  done
+  return 1
 }
 
 trap stop_all INT TERM EXIT
@@ -104,10 +145,25 @@ if [[ -n "${UVICORN_EXTRA_ARGS}" ]]; then
   server_cmd+=( "${extra_args[@]}" )
 fi
 
+IFS=',' read -r -a WORKER_LIST <<< "${WORKERS_CSV}"
+
+if [[ "${SIDECAR_DRY_RUN}" == "true" ]]; then
+  printf 'Dry run enabled. Profile=%s selected_workers=%s\n' "${SIDECAR_PROFILE}" "${WORKERS_CSV}"
+  printf 'Server command: %s\n' "${server_cmd[*]}"
+  for worker in "${WORKER_LIST[@]}"; do
+    [[ -z "${worker}" ]] && continue
+    printf 'Worker key: %s\n' "${worker}"
+  done
+  exit 0
+fi
+
 start_proc "server" "${server_cmd[@]}"
 SERVER_PID="${PIDS[$(( ${#PIDS[@]} - 1 ))]}"
 
-IFS=',' read -r -a WORKER_LIST <<< "${WORKERS_CSV}"
+if ! wait_for_server_health; then
+  printf 'Server failed health check at %s\n' "${SERVER_HEALTH_URL}" >&2
+  exit 1
+fi
 
 for worker in "${WORKER_LIST[@]}"; do
   if [[ -z "${worker}" ]]; then

--- a/tldw_Server_API/app/core/Utils/prompt_loader.py
+++ b/tldw_Server_API/app/core/Utils/prompt_loader.py
@@ -29,6 +29,26 @@ def _norm_key(key: str) -> str:
     return re.sub(r"[^a-z0-9_]+", "_", key.strip().lower())
 
 
+def _prompt_env_file_key(module: str, key: str) -> str:
+    module_token = re.sub(r"[^A-Za-z0-9]+", "_", module.strip().upper()).strip("_")
+    key_token = re.sub(r"[^A-Za-z0-9]+", "_", key.strip().upper()).strip("_")
+    return f"TLDW_PROMPT_FILE_{module_token}__{key_token}"
+
+
+def _load_env_prompt_file(module: str, key: str) -> Optional[str]:
+    env_name = _prompt_env_file_key(module, key)
+    raw_path = os.getenv(env_name)
+    if not raw_path or not str(raw_path).strip():
+        return None
+
+    path = os.path.expanduser(str(raw_path).strip())
+    try:
+        with open(path, encoding="utf-8") as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
 def _load_yaml(path: str) -> Optional[dict[str, Any]]:
     try:
         import yaml  # type: ignore
@@ -61,6 +81,10 @@ def load_prompt(module: str, key: str) -> Optional[str]:
     Searches for a markdown heading containing the key, then returns the
     first fenced code block following that heading. If not found, returns None.
     """
+    env_override = _load_env_prompt_file(module, key)
+    if env_override is not None:
+        return env_override
+
     base = _module_file_base(module)
     norm = _norm_key(key)
 

--- a/tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py
+++ b/tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+def test_pyproject_has_tooling_optional_dependency_group():
+    data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    optional = data["project"]["optional-dependencies"]
+    assert "tooling" in optional
+    assert any(dep.startswith("requests") for dep in optional["tooling"])

--- a/tldw_Server_API/tests/Utils/test_makefile_tooling_smoke_target.py
+++ b/tldw_Server_API/tests/Utils/test_makefile_tooling_smoke_target.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+
+
+def test_makefile_contains_tooling_smoke_target():
+    text = Path("Makefile").read_text(encoding="utf-8")
+    assert "tooling-smoke:" in text

--- a/tldw_Server_API/tests/Utils/test_model_container_cycle.py
+++ b/tldw_Server_API/tests/Utils/test_model_container_cycle.py
@@ -1,0 +1,54 @@
+from Helper_Scripts.common.model_container_cycle import parse_csv, stop_all_except, swap_containers
+
+
+def test_parse_csv_splits_and_trims():
+    assert parse_csv(" llm , tts ,, redis ") == ["llm", "tts", "redis"]
+
+
+def test_stop_all_except_uses_exclusion_list(monkeypatch):
+    stopped: list[str] = []
+
+    monkeypatch.setattr(
+        "Helper_Scripts.common.model_container_cycle.list_running_containers",
+        lambda: ["llm", "tts", "redis"],
+    )
+    monkeypatch.setattr(
+        "Helper_Scripts.common.model_container_cycle.stop_container",
+        lambda name, dry_run=False: stopped.append(name),
+    )
+
+    stop_all_except(["redis"])
+    assert stopped == ["llm", "tts"]
+
+
+def test_swap_containers_orders_operations(monkeypatch):
+    calls: list[tuple] = []
+
+    monkeypatch.setattr(
+        "Helper_Scripts.common.model_container_cycle.stop_all_except",
+        lambda excluded, dry_run=False: calls.append(("stop_all_except", tuple(excluded), dry_run)),
+    )
+    monkeypatch.setattr(
+        "Helper_Scripts.common.model_container_cycle.start_container",
+        lambda name, boot_wait=0.0, dry_run=False: calls.append(("start", name, boot_wait, dry_run)),
+    )
+    monkeypatch.setattr(
+        "Helper_Scripts.common.model_container_cycle.stop_container",
+        lambda name, dry_run=False: calls.append(("stop", name, dry_run)),
+    )
+
+    swap_containers(
+        first_container="llm",
+        second_container="tts",
+        excluded=["postgres", "redis"],
+        first_boot_wait=3.0,
+        second_boot_wait=5.0,
+        dry_run=False,
+    )
+
+    assert calls == [
+        ("stop_all_except", ("postgres", "redis"), False),
+        ("start", "llm", 3.0, False),
+        ("stop", "llm", False),
+        ("start", "tts", 5.0, False),
+    ]

--- a/tldw_Server_API/tests/Utils/test_model_container_cycle_wiring.py
+++ b/tldw_Server_API/tests/Utils/test_model_container_cycle_wiring.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_makefile_contains_model_cycle_target():
+    text = Path("Makefile").read_text(encoding="utf-8")
+    assert "model-cycle:" in text
+    assert "Helper_Scripts/model_container_cycle.py" in text
+
+
+def test_readme_mentions_model_cycle_usage():
+    text = Path("README.md").read_text(encoding="utf-8")
+    assert "make model-cycle" in text
+
+
+def test_model_container_cycle_script_help_runs():
+    result = subprocess.run(
+        [sys.executable, "Helper_Scripts/model_container_cycle.py", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "--first-container" in result.stdout

--- a/tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
+++ b/tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py
@@ -1,0 +1,18 @@
+def test_load_prompt_prefers_env_prompt_file(tmp_path, monkeypatch):
+    cfg_dir = tmp_path / "cfg"
+    prompts = cfg_dir / "Prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "demo.prompts.md").write_text(
+        "# Existing Key\n```\nfrom-md\n```\n",
+        encoding="utf-8",
+    )
+
+    override_file = tmp_path / "override.txt"
+    override_file.write_text("from-env-file", encoding="utf-8")
+
+    monkeypatch.setenv("TLDW_CONFIG_DIR", str(cfg_dir))
+    monkeypatch.setenv("TLDW_PROMPT_FILE_DEMO__EXISTING_KEY", str(override_file))
+
+    from tldw_Server_API.app.core.Utils import prompt_loader as pl
+
+    assert pl.load_prompt("demo", "Existing Key") == "from-env-file"

--- a/tldw_Server_API/tests/Utils/test_sidecar_profiles.py
+++ b/tldw_Server_API/tests/Utils/test_sidecar_profiles.py
@@ -1,0 +1,10 @@
+from Helper_Scripts.common.sidecar_profiles import resolve_workers
+
+
+def test_resolve_workers_tts_only_profile():
+    workers = resolve_workers(
+        profile="tts-only",
+        explicit_workers_csv=None,
+        default_workers_csv="media_ingest,audio_jobs,embeddings",
+    )
+    assert workers == ["audio_jobs"]

--- a/tldw_Server_API/tests/Utils/test_start_sidecars_dry_run.py
+++ b/tldw_Server_API/tests/Utils/test_start_sidecars_dry_run.py
@@ -1,0 +1,38 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_start_sidecars_dry_run_profile(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "default_workers": ["media_ingest", "audio_jobs"],
+                "workers": [
+                    {"key": "media_ingest", "slug": "media", "module": "x.y.z"},
+                    {"key": "audio_jobs", "slug": "audio", "module": "x.y.z"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["TLDW_WORKERS_MANIFEST"] = str(manifest)
+    env["TLDW_SIDECAR_PROFILE"] = "tts-only"
+    env["TLDW_SIDECAR_DRY_RUN"] = "true"
+    env["PYTHON_BIN"] = "python3"
+
+    result = subprocess.run(
+        ["bash", "start-sidecars.sh"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert "audio_jobs" in result.stdout
+    assert "media_ingest" not in result.stdout

--- a/tldw_Server_API/tests/Utils/test_tooling_install_wiring.py
+++ b/tldw_Server_API/tests/Utils/test_tooling_install_wiring.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_makefile_contains_tooling_install_target():
+    text = Path("Makefile").read_text(encoding="utf-8")
+    assert "tooling-install:" in text
+    assert ".[tooling]" in text
+
+
+def test_readme_mentions_tooling_extra_install():
+    text = Path("README.md").read_text(encoding="utf-8")
+    assert 'pip install -e ".[tooling]"' in text

--- a/tldw_Server_API/tests/Utils/test_tooling_smoke_runner.py
+++ b/tldw_Server_API/tests/Utils/test_tooling_smoke_runner.py
@@ -1,0 +1,7 @@
+from Helper_Scripts.common.tooling_smoke_runner import build_steps
+
+
+def test_build_steps_default_includes_streaming_and_watchlists():
+    steps = build_steps(base_url="http://127.0.0.1:8000", api_key="test-key")
+    names = [step.name for step in steps]
+    assert names == ["streaming_unified", "watchlists_audio"]


### PR DESCRIPTION
## Summary
- add unified tooling smoke runner and CLI wrapper
- add sidecar profile resolver and start-sidecars profile/dry-run/health-gate wiring
- add prompt loader env-file overrides and tooling optional dependency profile
- wire Makefile/README for tooling install + tooling smoke
- add targeted tests for all new wiring

## Verification
- python3 -m pytest tldw_Server_API/tests/Utils/test_tooling_smoke_runner.py tldw_Server_API/tests/Utils/test_makefile_tooling_smoke_target.py tldw_Server_API/tests/Utils/test_sidecar_profiles.py tldw_Server_API/tests/Utils/test_start_sidecars_dry_run.py tldw_Server_API/tests/Utils/test_prompt_loader_env_overrides.py tldw_Server_API/tests/Utils/test_prompt_loader_paths.py tldw_Server_API/tests/Config/test_pyproject_tooling_extra.py tldw_Server_API/tests/Utils/test_tooling_install_wiring.py -q
- 12 passed