### PR TITLE
feat(sandbox): add strict LimaVM provider parity across REST, MCP, and ACP

### DIFF
--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -38,6 +38,9 @@ Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Li
 - Workspace mounted at `/workspace` inside VM
 - Slower startup than containers (~10-30s vs ~1s for Docker)
 - Recommended for macOS development or when maximum isolation is required
+- Runtime parity: REST, MCP `sandbox.run`, and ACP all accept `docker|firecracker|lima`
+- Strict fail-closed mode: Lima accepts only `deny_all|allowlist` network policies; unsupported requirements are rejected
+- Platform constraint: Windows/WSL strict Lima enforcement is not supported yet and fails closed
 
 ## Trust-Level Tiers
 
@@ -104,6 +107,11 @@ Response (example):
   ]
 }
 ```
+For `lima`, runtime discovery also includes:
+- `strict_deny_all_supported`
+- `strict_allowlist_supported`
+- `enforcement_ready` (object with `deny_all`/`allowlist`)
+- `host` (host capability facts for troubleshooting)
 
 ## Create a session
 POST `/api/v1/sandbox/sessions`
@@ -213,6 +221,25 @@ Content-Range: bytes */10
     "code": "idempotency_conflict",
     "message": "Idempotency-Key replay with different body",
     "details": { "prior_id": "<id>", "key": "<Idempotency-Key>", "prior_created_at": "<ISO8601>" }
+  }
+}
+```
+
+## Strict Lima failure contracts
+- `503 runtime_unavailable` when `limactl`/runtime is unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+- `422 policy_unsupported` when strict requirements cannot be proven (for example `strict_allowlist_not_supported` or unsupported `network_policy`).
+
+Example `422`:
+```
+{
+  "error": {
+    "code": "policy_unsupported",
+    "message": "Runtime 'lima' does not satisfy requirement 'allowlist'",
+    "details": {
+      "runtime": "lima",
+      "requirement": "allowlist",
+      "reasons": ["strict_allowlist_not_supported"]
+    }
   }
 }
 ```

--- a/Docs/API-related/Sandbox_API.md
+++ b/Docs/API-related/Sandbox_API.md
@@ -226,7 +226,8 @@ Content-Range: bytes */10
 ```
 
 ## Strict Lima failure contracts
-- `503 runtime_unavailable` when `limactl`/runtime is unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+- `503 runtime_unavailable` when `limactl`/runtime is unavailable or strict host enforcement permissions are unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+  - `error.details.reasons` includes provider preflight reasons (for example `limactl_missing` or `permission_denied_host_enforcement`).
 - `422 policy_unsupported` when strict requirements cannot be proven (for example `strict_allowlist_not_supported` or unsupported `network_policy`).
 
 Example `422`:

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -38,6 +38,9 @@ Lima provides full VM isolation via Virtualization.framework (macOS) or QEMU (Li
 - Workspace mounted at `/workspace` inside VM
 - Slower startup than containers (~10-30s vs ~1s for Docker)
 - Recommended for macOS development or when maximum isolation is required
+- Runtime parity: REST, MCP `sandbox.run`, and ACP all accept `docker|firecracker|lima`
+- Strict fail-closed mode: Lima accepts only `deny_all|allowlist` network policies; unsupported requirements are rejected
+- Platform constraint: Windows/WSL strict Lima enforcement is not supported yet and fails closed
 
 ## Trust-Level Tiers
 
@@ -104,6 +107,11 @@ Response (example):
   ]
 }
 ```
+For `lima`, runtime discovery also includes:
+- `strict_deny_all_supported`
+- `strict_allowlist_supported`
+- `enforcement_ready` (object with `deny_all`/`allowlist`)
+- `host` (host capability facts for troubleshooting)
 
 ## Create a session
 POST `/api/v1/sandbox/sessions`
@@ -213,6 +221,25 @@ Content-Range: bytes */10
     "code": "idempotency_conflict",
     "message": "Idempotency-Key replay with different body",
     "details": { "prior_id": "<id>", "key": "<Idempotency-Key>", "prior_created_at": "<ISO8601>" }
+  }
+}
+```
+
+## Strict Lima failure contracts
+- `503 runtime_unavailable` when `limactl`/runtime is unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+- `422 policy_unsupported` when strict requirements cannot be proven (for example `strict_allowlist_not_supported` or unsupported `network_policy`).
+
+Example `422`:
+```
+{
+  "error": {
+    "code": "policy_unsupported",
+    "message": "Runtime 'lima' does not satisfy requirement 'allowlist'",
+    "details": {
+      "runtime": "lima",
+      "requirement": "allowlist",
+      "reasons": ["strict_allowlist_not_supported"]
+    }
   }
 }
 ```

--- a/Docs/Published/API-related/Sandbox_API.md
+++ b/Docs/Published/API-related/Sandbox_API.md
@@ -226,7 +226,8 @@ Content-Range: bytes */10
 ```
 
 ## Strict Lima failure contracts
-- `503 runtime_unavailable` when `limactl`/runtime is unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+- `503 runtime_unavailable` when `limactl`/runtime is unavailable or strict host enforcement permissions are unavailable. For explicit `runtime=lima`, `error.details.suggested` is an empty list (no fallback).
+  - `error.details.reasons` includes provider preflight reasons (for example `limactl_missing` or `permission_denied_host_enforcement`).
 - `422 policy_unsupported` when strict requirements cannot be proven (for example `strict_allowlist_not_supported` or unsupported `network_policy`).
 
 Example `422`:

--- a/Helper_Scripts/ci/path_classifier.py
+++ b/Helper_Scripts/ci/path_classifier.py
@@ -18,7 +18,6 @@ COVERAGE_GLOBS = [
     "uv.lock",
 ]
 
-FRONTEND_GLOBS = [
 TLDW_FRONTEND_GLOBS = [
     "apps/tldw-frontend/**",
     "apps/packages/ui/**",
@@ -50,6 +49,7 @@ def _matches_any(path: str, patterns: Iterable[str]) -> bool:
 def classify_paths(paths: Iterable[str]) -> dict[str, bool]:
     normalized_paths = list(paths)
     backend_changed = any(_matches_any(path, BACKEND_GLOBS) for path in normalized_paths)
+    coverage_required = any(_matches_any(path, COVERAGE_GLOBS) for path in normalized_paths)
     tldw_frontend_changed = any(_matches_any(path, TLDW_FRONTEND_GLOBS) for path in normalized_paths)
     admin_ui_changed = any(_matches_any(path, ADMIN_UI_GLOBS) for path in normalized_paths)
     frontend_changed = any(_matches_any(path, FRONTEND_GLOBS) for path in normalized_paths)

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -1074,6 +1074,11 @@ const getSettingsFromPayload = (
   const rawAuthorDepthMode = String(
     settings.author_note_depth_mode ?? settings.authorNoteDepthMode ?? ""
   )
+  const supportedBasicStoppingModes: readonly BasicStoppingModeType[] = [
+    "max_tokens",
+    "new_line",
+    "fill_suffix"
+  ]
   return {
     temperature: toNumber(settings.temperature, DEFAULT_SETTINGS.temperature),
     top_p: toNumber(settings.top_p, DEFAULT_SETTINGS.top_p),
@@ -1086,21 +1091,9 @@ const getSettingsFromPayload = (
       settings.use_basic_stopping_mode ?? settings.useBasicStoppingMode,
       DEFAULT_SETTINGS.use_basic_stopping_mode
     ),
-    basic_stopping_mode_type: [
-      "max_tokens",
-      "new_line",
-      "fill_suffix"
-    ].includes(
-      String(
-        settings.basic_stopping_mode_type ??
-          settings.basicStoppingModeType ??
-          ""
-      )
+    basic_stopping_mode_type: supportedBasicStoppingModes.includes(
+      rawBasicStoppingModeType as BasicStoppingModeType
     )
-      ? (String(
-          settings.basic_stopping_mode_type ?? settings.basicStoppingModeType
-        ) as BasicStoppingModeType)
-    ].includes(rawBasicStoppingModeType)
       ? (rawBasicStoppingModeType as BasicStoppingModeType)
       : DEFAULT_SETTINGS.basic_stopping_mode_type,
     logprobs: toBoolean(settings.logprobs, DEFAULT_SETTINGS.logprobs),

--- a/tldw_Server_API/Config_Files/config.txt
+++ b/tldw_Server_API/Config_Files/config.txt
@@ -113,11 +113,12 @@ startup_timeout_ms = 10000
 [ACP-SANDBOX]
 # Enable ACP sandbox mode (runs ACP in container/VM and exposes web SSH).
 enabled = false
-# Sandbox runtime (docker|firecracker|lima). Docker only is supported initially.
+# Sandbox runtime (docker|firecracker|lima).
 runtime = docker
 # Base image for ACP sandbox (must include sshd + tldw-agent-acp).
 base_image = tldw/acp-agent:latest
-# Network policy for ACP sandbox (allow_all|allowlist|deny_all).
+# Network policy for ACP sandbox (deny_all|allowlist). In strict Lima mode,
+# allow_all is rejected and requests fail closed unless strict guarantees are provable.
 network_policy = deny_all
 # Security hardening defaults (override only for trusted debug workflows).
 run_as_root = false

--- a/tldw_Server_API/Databases/Postgres/Schema/postgresql_users.sql
+++ b/tldw_Server_API/Databases/Postgres/Schema/postgresql_users.sql
@@ -29,8 +29,37 @@ CREATE TABLE IF NOT EXISTS users (
     password_changed_at TIMESTAMP
 );
 
+-- Organizations/teams bootstrap so pg_migrations_extra can safely add
+-- org/team-referencing tables during first startup.
+CREATE TABLE IF NOT EXISTS organizations (
+    id SERIAL PRIMARY KEY,
+    uuid VARCHAR(64) UNIQUE,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    slug VARCHAR(255) UNIQUE,
+    owner_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    is_active BOOLEAN DEFAULT TRUE,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS teams (
+    id SERIAL PRIMARY KEY,
+    org_id INTEGER NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255),
+    description TEXT,
+    is_active BOOLEAN DEFAULT TRUE,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (org_id, name)
+);
+
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_uuid ON users(uuid);
 CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
 CREATE INDEX IF NOT EXISTS idx_users_is_active ON users(is_active);
+CREATE INDEX IF NOT EXISTS idx_orgs_owner ON organizations(owner_user_id);
+CREATE INDEX IF NOT EXISTS idx_teams_org ON teams(org_id);

--- a/tldw_Server_API/Databases/Postgres/Schema/postgresql_users.sql
+++ b/tldw_Server_API/Databases/Postgres/Schema/postgresql_users.sql
@@ -1,0 +1,36 @@
+-- PostgreSQL AuthNZ bootstrap schema (users core table)
+-- This file is consumed by app/core/AuthNZ/database.py during PG startup.
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    uuid TEXT UNIQUE,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    role VARCHAR(50) NOT NULL DEFAULT 'user',
+    is_active BOOLEAN DEFAULT TRUE,
+    is_verified BOOLEAN DEFAULT FALSE,
+    is_superuser BOOLEAN DEFAULT FALSE,
+    failed_login_attempts INTEGER DEFAULT 0,
+    locked_until TIMESTAMP,
+    storage_quota_mb INTEGER DEFAULT 5120,
+    storage_used_mb DOUBLE PRECISION DEFAULT 0.0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_login TIMESTAMP,
+    email_verified BOOLEAN DEFAULT FALSE,
+    email_verified_at TIMESTAMP,
+    two_factor_enabled BOOLEAN DEFAULT FALSE,
+    two_factor_secret TEXT,
+    totp_secret TEXT,
+    backup_codes TEXT,
+    created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    password_changed_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+CREATE INDEX IF NOT EXISTS idx_users_uuid ON users(uuid);
+CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+CREATE INDEX IF NOT EXISTS idx_users_is_active ON users(is_active);

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -105,6 +105,7 @@ _SANDBOX_NONCRITICAL_EXCEPTIONS = (
     IdempotencyConflict,
     QueueFull,
     SandboxPolicy.RuntimeUnavailable,
+    SandboxPolicy.PolicyUnsupported,
     SandboxService.InvalidSpecVersion,
     SandboxService.InvalidFirecrackerConfig,
 )
@@ -578,6 +579,31 @@ async def create_session(
                     "details": {"runtime": rt, "available": False, "suggested": ["docker"]}
                 }
             })
+        if isinstance(e, SandboxPolicy.PolicyUnsupported):
+            rt_attr = getattr(e, "runtime", None)
+            if rt_attr is None:
+                rt = "unknown"
+            else:
+                try:
+                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                    rt = str(rt_attr) if rt_attr is not None else "unknown"
+            requirement = str(getattr(e, "requirement", "unknown"))
+            reasons = list(getattr(e, "reasons", []) or [])
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "error": {
+                        "code": "policy_unsupported",
+                        "message": str(e),
+                        "details": {
+                            "runtime": rt,
+                            "requirement": requirement,
+                            "reasons": reasons,
+                        },
+                    }
+                },
+            )
         if isinstance(e, IdempotencyConflict):
             raise HTTPException(status_code=409, detail={
                 "error": {
@@ -1089,6 +1115,31 @@ async def start_run(
                     "details": {"runtime": rt, "available": False, "suggested": suggestions}
                 }
             })
+        if isinstance(e, SandboxPolicy.PolicyUnsupported):
+            rt_attr = getattr(e, "runtime", None)
+            if rt_attr is None:
+                rt = "unknown"
+            else:
+                try:
+                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                    rt = str(rt_attr) if rt_attr is not None else "unknown"
+            requirement = str(getattr(e, "requirement", "unknown"))
+            reasons = list(getattr(e, "reasons", []) or [])
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "error": {
+                        "code": "policy_unsupported",
+                        "message": str(e),
+                        "details": {
+                            "runtime": rt,
+                            "requirement": requirement,
+                            "reasons": reasons,
+                        },
+                    }
+                },
+            )
         if isinstance(e, IdempotencyConflict):
             return JSONResponse(status_code=409, content={
                 "error": {

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -585,12 +585,13 @@ async def create_session(
                 suggestions = sorted(set(suggestions))
             except _SANDBOX_NONCRITICAL_EXCEPTIONS:
                 suggestions = []
+            reasons = list(getattr(e, "reasons", []) or [])
             logger.exception("RuntimeUnavailable error occurred on sandbox session creation: {}", str(e))
             return JSONResponse(status_code=503, content={
                 "error": {
                     "code": "runtime_unavailable",
                     "message": "The requested runtime is currently unavailable.",
-                    "details": {"runtime": rt, "available": False, "suggested": suggestions}
+                    "details": {"runtime": rt, "available": False, "suggested": suggestions, "reasons": reasons}
                 }
             })
         if isinstance(e, SandboxPolicy.PolicyUnsupported):
@@ -1122,11 +1123,12 @@ async def start_run(
                 suggestions = sorted(set(suggestions))
             except _SANDBOX_NONCRITICAL_EXCEPTIONS:
                 suggestions = ["docker"]
+            reasons = list(getattr(e, "reasons", []) or [])
             return JSONResponse(status_code=503, content={
                 "error": {
                     "code": "runtime_unavailable",
                     "message": str(e),
-                    "details": {"runtime": rt, "available": False, "suggested": suggestions}
+                    "details": {"runtime": rt, "available": False, "suggested": suggestions, "reasons": reasons}
                 }
             })
         if isinstance(e, SandboxPolicy.PolicyUnsupported):

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -571,12 +571,26 @@ async def create_session(
                     rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
                 except _SANDBOX_NONCRITICAL_EXCEPTIONS:
                     rt = str(rt_attr) if rt_attr is not None else "unknown"
+            suggestions: list[str] = []
+            try:
+                from tldw_Server_API.app.core.Sandbox.runners.docker_runner import docker_available as _dock_avail
+                from tldw_Server_API.app.core.Sandbox.runners.firecracker_runner import (
+                    firecracker_available as _fc_avail,
+                )
+                if str(rt) == "firecracker":
+                    if _dock_avail() or True:
+                        suggestions.append("docker")
+                elif str(rt) == "docker" and _fc_avail():
+                    suggestions.append("firecracker")
+                suggestions = sorted(set(suggestions))
+            except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                suggestions = []
             logger.exception("RuntimeUnavailable error occurred on sandbox session creation: {}", str(e))
             return JSONResponse(status_code=503, content={
                 "error": {
                     "code": "runtime_unavailable",
                     "message": "The requested runtime is currently unavailable.",
-                    "details": {"runtime": rt, "available": False, "suggested": ["docker"]}
+                    "details": {"runtime": rt, "available": False, "suggested": suggestions}
                 }
             })
         if isinstance(e, SandboxPolicy.PolicyUnsupported):

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -426,6 +426,36 @@ def _normalize_reason(outcome: str, message: str | None) -> str:
         return "other"
 
 
+def _runtime_name_from_policy_exception(exc: Exception) -> str:
+    rt_attr = getattr(exc, "runtime", None)
+    if rt_attr is None:
+        return "unknown"
+    try:
+        return rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
+    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+        return str(rt_attr) if rt_attr is not None else "unknown"
+
+
+def _runtime_unavailable_suggestions(runtime_name: str) -> list[str]:
+    suggestions: list[str] = []
+    try:
+        from tldw_Server_API.app.core.Sandbox.runners.docker_runner import docker_available as _dock_avail
+        from tldw_Server_API.app.core.Sandbox.runners.firecracker_runner import (
+            firecracker_available as _fc_avail,
+        )
+
+        rt = str(runtime_name or "").strip().lower()
+        if rt == "lima":
+            return []
+        if rt == "firecracker" and _dock_avail():
+            suggestions.append("docker")
+        elif rt == "docker" and _fc_avail():
+            suggestions.append("firecracker")
+        return sorted(set(suggestions))
+    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+        return []
+
+
 @router.get("/runtimes", response_model=SandboxRuntimesResponse, summary="Discover available runtimes")
 async def get_runtimes(current_user: User = Depends(get_request_user)) -> SandboxRuntimesResponse:
     info = _service.feature_discovery()
@@ -563,28 +593,8 @@ async def create_session(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
         if isinstance(e, SandboxPolicy.RuntimeUnavailable):
             # Map to 503 with details per PRD; read runtime from exception with safe fallback
-            rt_attr = getattr(e, "runtime", None)
-            if rt_attr is None:
-                rt = "unknown"
-            else:
-                try:
-                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                    rt = str(rt_attr) if rt_attr is not None else "unknown"
-            suggestions: list[str] = []
-            try:
-                from tldw_Server_API.app.core.Sandbox.runners.docker_runner import docker_available as _dock_avail
-                from tldw_Server_API.app.core.Sandbox.runners.firecracker_runner import (
-                    firecracker_available as _fc_avail,
-                )
-                if str(rt) == "firecracker":
-                    if _dock_avail() or True:
-                        suggestions.append("docker")
-                elif str(rt) == "docker" and _fc_avail():
-                    suggestions.append("firecracker")
-                suggestions = sorted(set(suggestions))
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                suggestions = []
+            rt = _runtime_name_from_policy_exception(e)
+            suggestions = _runtime_unavailable_suggestions(rt)
             reasons = list(getattr(e, "reasons", []) or [])
             logger.exception("RuntimeUnavailable error occurred on sandbox session creation: {}", str(e))
             return JSONResponse(status_code=503, content={
@@ -595,14 +605,7 @@ async def create_session(
                 }
             })
         if isinstance(e, SandboxPolicy.PolicyUnsupported):
-            rt_attr = getattr(e, "runtime", None)
-            if rt_attr is None:
-                rt = "unknown"
-            else:
-                try:
-                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                    rt = str(rt_attr) if rt_attr is not None else "unknown"
+            rt = _runtime_name_from_policy_exception(e)
             requirement = str(getattr(e, "requirement", "unknown"))
             reasons = list(getattr(e, "reasons", []) or [])
             return JSONResponse(
@@ -1097,32 +1100,8 @@ async def start_run(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
         if isinstance(e, SandboxPolicy.RuntimeUnavailable):
             # Use runtime from exception; fallback only if missing/None
-            rt_attr = getattr(e, "runtime", None)
-            if rt_attr is None:
-                rt = "unknown"
-            else:
-                try:
-                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                    rt = str(rt_attr) if rt_attr is not None else "unknown"
-            # Build dynamic suggestions based on availability
-            suggestions = []
-            try:
-                # Prefer suggesting Docker when Firecracker unavailable
-                from tldw_Server_API.app.core.Sandbox.runners.docker_runner import docker_available as _dock_avail
-                from tldw_Server_API.app.core.Sandbox.runners.firecracker_runner import (
-                    firecracker_available as _fc_avail,
-                )
-                if str(rt) == "firecracker":
-                    # Suggest docker even if availability is unknown (tests expect this)
-                    if _dock_avail() or True:
-                        suggestions.append("docker")
-                elif str(rt) == "docker" and _fc_avail():
-                    suggestions.append("firecracker")
-                # Ensure uniqueness
-                suggestions = sorted(set(suggestions))
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                suggestions = ["docker"]
+            rt = _runtime_name_from_policy_exception(e)
+            suggestions = _runtime_unavailable_suggestions(rt)
             reasons = list(getattr(e, "reasons", []) or [])
             return JSONResponse(status_code=503, content={
                 "error": {
@@ -1132,14 +1111,7 @@ async def start_run(
                 }
             })
         if isinstance(e, SandboxPolicy.PolicyUnsupported):
-            rt_attr = getattr(e, "runtime", None)
-            if rt_attr is None:
-                rt = "unknown"
-            else:
-                try:
-                    rt = rt_attr.value if hasattr(rt_attr, "value") else str(rt_attr)
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                    rt = str(rt_attr) if rt_attr is not None else "unknown"
+            rt = _runtime_name_from_policy_exception(e)
             requirement = str(getattr(e, "requirement", "unknown"))
             reasons = list(getattr(e, "reasons", []) or [])
             return JSONResponse(

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -24,6 +24,10 @@ class SandboxRuntimeInfo(BaseModel):
     supported_spec_versions: list[str] = Field(default_factory=lambda: ["1.0"], description="Supported spec versions (e.g., ['1.0','1.1'] when 1.1 features are enabled)")
     interactive_supported: bool | None = Field(default=None, description="Whether stdin-over-WS interactive runs are supported")
     egress_allowlist_supported: bool | None = Field(default=None, description="Whether egress allowlisting is supported by the runtime")
+    strict_deny_all_supported: bool | None = Field(default=None, description="Whether strict deny-all network enforcement is supported")
+    strict_allowlist_supported: bool | None = Field(default=None, description="Whether strict allowlist network enforcement is supported")
+    enforcement_ready: dict[str, bool] | None = Field(default=None, description="Runtime enforcement readiness by network policy mode")
+    host: dict[str, str] | None = Field(default=None, description="Runtime host capability facts for troubleshooting")
     store_mode: str | None = Field(default=None, description="Current store backend mode (memory|sqlite|cluster)")
     notes: str | None = None
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -371,7 +371,11 @@ class ACPSandboxRunnerManager:
         runtime = str(self.config.runtime or "").strip().lower()
         if runtime != RuntimeType.lima.value:
             return
-        network_policy = str(self.config.network_policy or "deny_all")
+        network_policy = str(self.config.network_policy or "deny_all").strip().lower()
+        if network_policy not in {"deny_all", "allowlist"}:
+            raise ACPResponseError(
+                "ACP lima strict policy requires network_policy to be deny_all or allowlist"
+            )
         preflight = LimaRunner().preflight(network_policy=network_policy)
         if preflight.available:
             return

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -28,6 +28,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessa
 from tldw_Server_API.app.core.Agent_Client_Protocol.stream_client import ACPStreamClient
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType, SessionSpec
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.testing import is_truthy
 
@@ -366,6 +367,19 @@ class ACPSandboxRunnerManager:
         for sess in sessions:
             await self.close_session(sess.session_id)
 
+    def _validate_lima_strict_runtime_requirements(self) -> None:
+        runtime = str(self.config.runtime or "").strip().lower()
+        if runtime != RuntimeType.lima.value:
+            return
+        network_policy = str(self.config.network_policy or "deny_all")
+        preflight = LimaRunner().preflight(network_policy=network_policy)
+        if preflight.available:
+            return
+        reasons = list(preflight.reasons or [])
+        raise ACPResponseError(
+            f"ACP lima strict policy requirements not satisfied: {', '.join(reasons) if reasons else 'unknown'}"
+        )
+
     # -------------------------------------------------------------------------
     # Session lifecycle
     # -------------------------------------------------------------------------
@@ -415,6 +429,7 @@ class ACPSandboxRunnerManager:
             execute_enabled = False
         if not execute_enabled:
             raise ACPResponseError("SANDBOX_ENABLE_EXECUTION must be enabled for ACP sandbox sessions")
+        self._validate_lima_strict_runtime_requirements()
 
         sandbox_service = sandbox_ep._service  # type: ignore[attr-defined]
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -43,11 +43,11 @@ class SandboxModule(BaseModule):
         return [
             {
                 "name": "sandbox.run",
-                "description": "Execute a run in the code sandbox (Docker/Firecracker).",
+                "description": "Execute a run in the code sandbox (Docker/Firecracker/Lima).",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "runtime": {"type": "string", "enum": ["docker", "firecracker"]},
+                        "runtime": {"type": "string", "enum": ["docker", "firecracker", "lima"]},
                         "session_id": {"type": "string"},
                         "base_image": {"type": "string"},
                         "command": {"type": "array", "items": {"type": "string"}},
@@ -92,7 +92,7 @@ class SandboxModule(BaseModule):
         # Prepare RunSpec
         runtime_raw = (args.get("runtime") or "").strip().lower()
         runtime: SbxRuntimeType | None = None
-        if runtime_raw in ("docker", "firecracker"):
+        if runtime_raw in ("docker", "firecracker", "lima"):
             runtime = SbxRuntimeType(runtime_raw)
         # files (inline)
         files_inline: list[tuple[str, bytes]] = []
@@ -211,8 +211,8 @@ class SandboxModule(BaseModule):
         if (isinstance(sess, str) and sess) and (isinstance(img, str) and img):
             raise ValueError("Provide only one of session_id or base_image, not both")
         rt = arguments.get("runtime")
-        if rt is not None and str(rt).lower() not in {"docker", "firecracker"}:
-            raise ValueError("runtime must be docker|firecracker when provided")
+        if rt is not None and str(rt).lower() not in {"docker", "firecracker", "lima"}:
+            raise ValueError("runtime must be docker|firecracker|lima when provided")
         if arguments.get("timeout_sec") is not None:
             try:
                 ts = int(arguments.get("timeout_sec"))

--- a/tldw_Server_API/app/core/Sandbox/__init__.py
+++ b/tldw_Server_API/app/core/Sandbox/__init__.py
@@ -1,8 +1,12 @@
-"""Sandbox core module
+"""Sandbox core module.
 
 Provides interfaces and policy scaffolding for sandboxed code execution
-across multiple runtimes (Docker and Firecracker).
-
-This package intentionally ships minimal stubs; concrete runner logic and
-orchestration will be implemented incrementally.
+across multiple runtimes.
 """
+
+from .runtime_capabilities import RuntimeCapabilities, RuntimePreflightResult
+
+__all__ = [
+    "RuntimeCapabilities",
+    "RuntimePreflightResult",
+]

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -140,6 +140,13 @@ class SandboxPolicy:
             super().__init__(f"Requested runtime '{runtime.value}' is unavailable")
             self.runtime = runtime
 
+    class PolicyUnsupported(Exception):
+        def __init__(self, runtime: RuntimeType, requirement: str, reasons: list[str] | None = None) -> None:
+            super().__init__(f"Runtime '{runtime.value}' does not satisfy requirement '{requirement}'")
+            self.runtime = runtime
+            self.requirement = str(requirement)
+            self.reasons = list(reasons or [])
+
     def select_runtime(
         self,
         requested: RuntimeType | None,

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -136,9 +136,10 @@ class SandboxPolicy:
         self.cfg = cfg or SandboxPolicyConfig.from_settings()
 
     class RuntimeUnavailable(Exception):
-        def __init__(self, runtime: RuntimeType) -> None:
+        def __init__(self, runtime: RuntimeType, reasons: list[str] | None = None) -> None:
             super().__init__(f"Requested runtime '{runtime.value}' is unavailable")
             self.runtime = runtime
+            self.reasons = list(reasons or [])
 
     class PolicyUnsupported(Exception):
         def __init__(self, runtime: RuntimeType, requirement: str, reasons: list[str] | None = None) -> None:

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -72,7 +72,10 @@ class SandboxPolicyConfig:
             rt_raw = str(getattr(app_settings, "SANDBOX_DEFAULT_RUNTIME", "docker")).strip().lower()
         except _POLICY_NONCRITICAL_EXCEPTIONS:
             rt_raw = "docker"
-        runtime = RuntimeType.firecracker if rt_raw == "firecracker" else RuntimeType.docker
+        try:
+            runtime = RuntimeType(rt_raw)
+        except _POLICY_NONCRITICAL_EXCEPTIONS:
+            runtime = RuntimeType.docker
         try:
             network_default = str(getattr(app_settings, "SANDBOX_NETWORK_DEFAULT", "deny_all")).strip().lower()
         except _POLICY_NONCRITICAL_EXCEPTIONS:

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
@@ -38,13 +38,32 @@ class LimaSecurityEnforcer:
             return False
         return sys.platform.startswith("linux") or sys.platform == "darwin"
 
+    def _test_override_mode(self) -> bool:
+        if os.getenv("PYTEST_CURRENT_TEST"):
+            return True
+        return _truthy(os.getenv("TEST_MODE"))
+
     def preflight_capabilities(self) -> dict[str, bool]:
+        host = self.host_facts()
+        variant = str(host.get("variant", "")).strip().lower()
+        host_os = str(host.get("os", "")).strip().lower()
+        if variant == "wsl" or host_os.startswith("win"):
+            # Always fail closed on unsupported host enforcement surfaces.
+            return {"deny_all": False, "allowlist": False}
+
         default_ready = self._default_ready()
+        # Allowlist enforcement is not implemented for Lima runner yet.
+        allowlist_default = False
+        deny_default = bool(default_ready)
+
+        if not self._test_override_mode():
+            return {"deny_all": deny_default, "allowlist": allowlist_default}
+
         deny_all = os.getenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY")
         allowlist = os.getenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY")
         return {
-            "deny_all": _truthy(deny_all) if deny_all is not None else default_ready,
-            "allowlist": _truthy(allowlist) if allowlist is not None else default_ready,
+            "deny_all": _truthy(deny_all) if deny_all is not None else deny_default,
+            "allowlist": _truthy(allowlist) if allowlist is not None else allowlist_default,
         }
 
     def apply_deny_all(self, _instance_ctx: dict[str, Any]) -> bool:

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from typing import Any
+
+from tldw_Server_API.app.core.testing import is_truthy
+
+
+def _truthy(v: str | None) -> bool:
+    return is_truthy(v)
+
+
+def _detect_variant() -> str:
+    try:
+        release = platform.release().lower()
+    except Exception:
+        release = ""
+    if os.getenv("WSL_DISTRO_NAME") or "microsoft" in release:
+        return "wsl"
+    return "native"
+
+
+class LimaSecurityEnforcer:
+    """Host-aware Lima security capability probe and enforcement contract."""
+
+    def host_facts(self) -> dict[str, Any]:
+        return {
+            "os": sys.platform,
+            "arch": platform.machine(),
+            "variant": _detect_variant(),
+        }
+
+    def _default_ready(self) -> bool:
+        return sys.platform.startswith("linux") or sys.platform == "darwin"
+
+    def preflight_capabilities(self) -> dict[str, bool]:
+        default_ready = self._default_ready()
+        deny_all = os.getenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY")
+        allowlist = os.getenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY")
+        return {
+            "deny_all": _truthy(deny_all) if deny_all is not None else default_ready,
+            "allowlist": _truthy(allowlist) if allowlist is not None else default_ready,
+        }
+
+    def apply_deny_all(self, _instance_ctx: dict[str, Any]) -> bool:
+        return bool(self.preflight_capabilities().get("deny_all"))
+
+    def apply_allowlist(self, _instance_ctx: dict[str, Any], _targets: list[str]) -> bool:
+        return bool(self.preflight_capabilities().get("allowlist"))
+
+    def verify(self, _instance_ctx: dict[str, Any], mode: str) -> bool:
+        mode_norm = str(mode or "").strip().lower()
+        caps = self.preflight_capabilities()
+        if mode_norm == "allowlist":
+            return bool(caps.get("allowlist"))
+        return bool(caps.get("deny_all"))
+
+    def cleanup(self, _instance_ctx: dict[str, Any]) -> bool:
+        return True
+
+
+class LinuxLimaEnforcer(LimaSecurityEnforcer):
+    pass
+
+
+class MacOSLimaEnforcer(LimaSecurityEnforcer):
+    pass
+
+
+class WindowsLimaEnforcer(LimaSecurityEnforcer):
+    def _default_ready(self) -> bool:
+        return False
+
+
+def build_lima_enforcer() -> LimaSecurityEnforcer:
+    if sys.platform == "darwin":
+        return MacOSLimaEnforcer()
+    if sys.platform.startswith("linux"):
+        return LinuxLimaEnforcer()
+    return WindowsLimaEnforcer()
+

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py
@@ -33,6 +33,9 @@ class LimaSecurityEnforcer:
         }
 
     def _default_ready(self) -> bool:
+        host = self.host_facts()
+        if str(host.get("variant", "")).lower() == "wsl":
+            return False
         return sys.platform.startswith("linux") or sys.platform == "darwin"
 
     def preflight_capabilities(self) -> dict[str, bool]:
@@ -80,4 +83,3 @@ def build_lima_enforcer() -> LimaSecurityEnforcer:
     if sys.platform.startswith("linux"):
         return LinuxLimaEnforcer()
     return WindowsLimaEnforcer()
-

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -373,6 +373,8 @@ class LimaRunner:
         cpu = int(spec.cpu) if spec.cpu else 2
         memory_mb = int(spec.memory_mb) if spec.memory_mb else 2048
         net_policy = (spec.network_policy or "deny_all").lower()
+        if net_policy == "allowlist":
+            raise RuntimeError("strict_allowlist_not_supported")
 
         lima_config = _generate_lima_config(
             workspace_host_path=workspace,

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -17,8 +17,10 @@ from pathlib import Path
 from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy
-from ..models import RunPhase, RunSpec, RunStatus
+from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
+from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
+from .lima_enforcer import build_lima_enforcer
 
 _LIMA_RUNNER_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -156,6 +158,31 @@ class LimaRunner:
 
     def __init__(self) -> None:
         pass
+
+    def preflight(self, network_policy: str | None = None) -> RuntimePreflightResult:
+        """Probe host/runtime capabilities for Lima strict policy admission."""
+        enforcer = build_lima_enforcer()
+        host = enforcer.host_facts()
+        ready = enforcer.preflight_capabilities()
+        net_policy = str(network_policy or "deny_all").strip().lower()
+
+        reasons: list[str] = []
+        if not lima_available():
+            reasons.append("limactl_missing")
+            ready = {"deny_all": False, "allowlist": False}
+        else:
+            if net_policy == "deny_all" and not bool(ready.get("deny_all")):
+                reasons.append("strict_deny_all_not_supported")
+            if net_policy == "allowlist" and not bool(ready.get("allowlist")):
+                reasons.append("strict_allowlist_not_supported")
+
+        return RuntimePreflightResult(
+            runtime=RuntimeType.lima,
+            available=(len(reasons) == 0),
+            reasons=reasons,
+            host=host,
+            enforcement_ready=ready,
+        )
 
     @staticmethod
     def _lima_version() -> str | None:

--- a/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/lima_runner.py
@@ -165,16 +165,34 @@ class LimaRunner:
         host = enforcer.host_facts()
         ready = enforcer.preflight_capabilities()
         net_policy = str(network_policy or "deny_all").strip().lower()
+        host_variant = str(host.get("variant", "")).strip().lower()
+        host_os = str(host.get("os", "")).strip().lower()
+        permission_denied_env = _truthy(os.getenv("TLDW_SANDBOX_LIMA_ENFORCER_PERMISSION_DENIED"))
 
         reasons: list[str] = []
+
+        if permission_denied_env:
+            ready = {"deny_all": False, "allowlist": False}
+
+        def _append_reason(reason: str) -> None:
+            if reason not in reasons:
+                reasons.append(reason)
+
         if not lima_available():
-            reasons.append("limactl_missing")
+            _append_reason("limactl_missing")
             ready = {"deny_all": False, "allowlist": False}
         else:
+            permission_denied_host = permission_denied_env or host_variant == "wsl" or host_os.startswith("win")
             if net_policy == "deny_all" and not bool(ready.get("deny_all")):
-                reasons.append("strict_deny_all_not_supported")
+                if permission_denied_host:
+                    _append_reason("permission_denied_host_enforcement")
+                else:
+                    _append_reason("strict_deny_all_not_supported")
             if net_policy == "allowlist" and not bool(ready.get("allowlist")):
-                reasons.append("strict_allowlist_not_supported")
+                if permission_denied_host:
+                    _append_reason("permission_denied_host_enforcement")
+                else:
+                    _append_reason("strict_allowlist_not_supported")
 
         return RuntimePreflightResult(
             runtime=RuntimeType.lima,

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .models import RuntimeType
+
+
+@dataclass
+class RuntimeCapabilities:
+    """Capability flags advertised by a sandbox runtime provider."""
+
+    supports_strict_deny_all: bool = False
+    supports_strict_allowlist: bool = False
+    supports_interactive: bool = False
+    supports_port_mappings: bool = False
+    supports_acp_session_mode: bool = False
+
+
+@dataclass
+class RuntimePreflightResult:
+    """Host/runtime preflight status used by policy admission."""
+
+    runtime: RuntimeType
+    available: bool
+    reasons: list[str] = field(default_factory=list)
+    host: dict[str, Any] = field(default_factory=dict)
+    enforcement_ready: dict[str, bool] = field(
+        default_factory=lambda: {"deny_all": False, "allowlist": False}
+    )
+

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -559,6 +559,13 @@ class SandboxService:
                 execute_enabled = bool(getattr(app_settings, "SANDBOX_ENABLE_EXECUTION", False))
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
             execute_enabled = False
+        try:
+            lima_preflight = LimaRunner().preflight(network_policy="deny_all")
+            lima_enforcement_ready = dict(lima_preflight.enforcement_ready or {})
+            lima_host = dict(lima_preflight.host or {})
+        except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+            lima_enforcement_ready = {"deny_all": False, "allowlist": False}
+            lima_host = {}
 
         return [
             {
@@ -635,7 +642,11 @@ class SandboxService:
                 "artifact_ttl_hours": artifact_ttl_hours,
                 "supported_spec_versions": supported_spec_versions,
                 "interactive_supported": False,  # Not implemented for Lima yet
-                "egress_allowlist_supported": False,  # Lima uses VM-level network isolation
+                "egress_allowlist_supported": bool(lima_enforcement_ready.get("allowlist")),
+                "strict_deny_all_supported": bool(lima_enforcement_ready.get("deny_all")),
+                "strict_allowlist_supported": bool(lima_enforcement_ready.get("allowlist")),
+                "enforcement_ready": lima_enforcement_ready,
+                "host": lima_host,
                 "store_mode": store_mode,
                 "notes": "Full VM isolation via Lima; recommended for macOS",
             },

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -163,7 +163,13 @@ class SandboxService:
     ) -> None:
         if runtime != RuntimeType.lima:
             return
-        requested_policy = str(network_policy or self.policy.cfg.network_default or "deny_all")
+        requested_policy = str(network_policy or self.policy.cfg.network_default or "deny_all").strip().lower()
+        if requested_policy not in {"deny_all", "allowlist"}:
+            raise SandboxPolicy.PolicyUnsupported(
+                RuntimeType.lima,
+                requirement=requested_policy,
+                reasons=["unsupported_network_policy"],
+            )
         preflight = LimaRunner().preflight(network_policy=requested_policy)
         if preflight.available:
             return

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -170,6 +170,13 @@ class SandboxService:
                 requirement=requested_policy,
                 reasons=["unsupported_network_policy"],
             )
+        if requested_policy == "allowlist":
+            # Lima allowlist is not yet enforced by the runtime path; fail closed.
+            raise SandboxPolicy.PolicyUnsupported(
+                RuntimeType.lima,
+                requirement=requested_policy,
+                reasons=["strict_allowlist_not_supported"],
+            )
         preflight = LimaRunner().preflight(network_policy=requested_policy)
         if preflight.available:
             return
@@ -579,6 +586,8 @@ class SandboxService:
         try:
             lima_preflight = LimaRunner().preflight(network_policy="deny_all")
             lima_enforcement_ready = dict(lima_preflight.enforcement_ready or {})
+            # Allowlist enforcement is not implemented for Lima runtime execution.
+            lima_enforcement_ready["allowlist"] = False
             lima_host = dict(lima_preflight.host or {})
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
             lima_enforcement_ready = {"deny_all": False, "allowlist": False}
@@ -1167,10 +1176,20 @@ class SandboxService:
                     if admitted.phase != RunPhase.starting:
                         return admitted
                     self._apply_admitted_status(status, admitted)
-                    real = self._run_with_claim_lease(
-                        status.id,
-                        lambda: self._start_lima_run_with_execution_preflight(status.id, spec, ws),
-                    )
+                    try:
+                        real = self._run_with_claim_lease(
+                            status.id,
+                            lambda: self._start_lima_run_with_execution_preflight(status.id, spec, ws),
+                        )
+                    except (SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported) as e:
+                        logger.warning(f"Lima execution preflight rejected run: {e}")
+                        status.phase = RunPhase.failed
+                        status.message = "lima_policy_failed"
+                        status.finished_at = datetime.utcnow()
+                        self._orch.update_run(status.id, status)
+                        with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+                            get_hub().publish_event(status.id, "end", {"exit_code": status.exit_code, "reason": "lima_policy_failed"})
+                        return status
                     real.id = status.id
                     status.phase = real.phase
                     status.exit_code = real.exit_code

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -174,13 +174,24 @@ class SandboxService:
         if preflight.available:
             return
         reasons = list(preflight.reasons or [])
-        if "limactl_missing" in reasons:
-            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.lima)
+        if "limactl_missing" in reasons or "permission_denied_host_enforcement" in reasons:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.lima, reasons=reasons)
         raise SandboxPolicy.PolicyUnsupported(
             RuntimeType.lima,
             requirement=requested_policy,
             reasons=reasons,
         )
+
+    def _start_lima_run_with_execution_preflight(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        workspace_path: str | None,
+    ) -> RunStatus:
+        # Authoritative execution-time admission check (after claim ownership)
+        # to ensure strict Lima guarantees still hold on the executing worker.
+        self._validate_lima_policy(runtime=spec.runtime, network_policy=spec.network_policy)
+        return LimaRunner().start_run(run_id, spec, workspace_path)
 
     def _effective_claim_lease_seconds(self) -> int:
         try:
@@ -1106,11 +1117,10 @@ class SandboxService:
                             self._apply_admitted_status(status, admitted)
                             with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
                                 get_hub().publish_event(status.id, "start", {"bg": True})
-                            lr = LimaRunner()
                             ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
                             real = self._run_with_claim_lease(
                                 status.id,
-                                lambda: lr.start_run(status.id, spec, ws),
+                                lambda: self._start_lima_run_with_execution_preflight(status.id, spec, ws),
                             )
                             real.id = status.id
                             status.phase = real.phase
@@ -1130,6 +1140,17 @@ class SandboxService:
                             self._orch.update_run(status.id, status)
                             with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
                                 self._audit_run_completion(user_id=user_id, run_id=status.id, status=status, spec_version=spec_version, session_id=spec.session_id)
+                        except (SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported) as e:
+                            logger.warning(f"Lima execution preflight rejected run: {e}")
+                            try:
+                                status.phase = RunPhase.failed
+                                status.message = "lima_policy_failed"
+                                status.finished_at = datetime.utcnow()
+                                self._orch.update_run(status.id, status)
+                                with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+                                    get_hub().publish_event(status.id, "end", {"exit_code": status.exit_code, "reason": "lima_policy_failed"})
+                            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+                                pass
                         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
                             logger.warning(f"Lima background execution failed: {e}")
                     try:
@@ -1138,7 +1159,6 @@ class SandboxService:
                         logger.warning(f"Lima background submission failed: {e}")
                 else:
                     # Foreground
-                    lr = LimaRunner()
                     ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
                     admitted = self._admit_run_starting(status.id)
                     if admitted is None:
@@ -1149,7 +1169,7 @@ class SandboxService:
                     self._apply_admitted_status(status, admitted)
                     real = self._run_with_claim_lease(
                         status.id,
-                        lambda: lr.start_run(status.id, spec, ws),
+                        lambda: self._start_lima_run_with_execution_preflight(status.id, spec, ws),
                     )
                     real.id = status.id
                     status.phase = real.phase

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -155,6 +155,27 @@ class SandboxService:
         if spec_version not in self._supported_specs:
             raise SandboxService.InvalidSpecVersion(spec_version, self._supported_specs)
 
+    def _validate_lima_policy(
+        self,
+        *,
+        runtime: RuntimeType | None,
+        network_policy: str | None,
+    ) -> None:
+        if runtime != RuntimeType.lima:
+            return
+        requested_policy = str(network_policy or self.policy.cfg.network_default or "deny_all")
+        preflight = LimaRunner().preflight(network_policy=requested_policy)
+        if preflight.available:
+            return
+        reasons = list(preflight.reasons or [])
+        if "limactl_missing" in reasons:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.lima)
+        raise SandboxPolicy.PolicyUnsupported(
+            RuntimeType.lima,
+            requirement=requested_policy,
+            reasons=reasons,
+        )
+
     def _effective_claim_lease_seconds(self) -> int:
         try:
             raw = os.getenv("SANDBOX_RUN_CLAIM_LEASE_SEC")
@@ -700,6 +721,7 @@ class SandboxService:
         fc_ok = firecracker_available()
         lima_ok = lima_available()
         spec = self.policy.apply_to_session(spec, firecracker_available=fc_ok, lima_available=lima_ok)
+        self._validate_lima_policy(runtime=spec.runtime, network_policy=spec.network_policy)
         # Validate Firecracker kernel/rootfs when real execution is enabled
         self._validate_firecracker_config(spec)
         # delegate to orchestrator (with idempotency)
@@ -797,6 +819,7 @@ class SandboxService:
         fc_ok = firecracker_available()
         lima_ok = lima_available()
         spec = self.policy.apply_to_run(spec, firecracker_available=fc_ok, lima_available=lima_ok)
+        self._validate_lima_policy(runtime=spec.runtime, network_policy=spec.network_policy)
         # Validate Firecracker kernel/rootfs when real execution is enabled
         self._validate_firecracker_config(spec)
         status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_lima.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_lima.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.config import ACPSandboxConfig
+from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_runner_client import ACPSandboxRunnerManager
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acp_lima_runtime_fails_closed_when_strict_not_supported(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="lima",
+            network_policy="deny_all",
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "0")
+
+    with pytest.raises(ACPResponseError, match="strict"):
+        await manager.create_session(cwd="/workspace", user_id=7)
+

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_lima.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_lima.py
@@ -27,3 +27,21 @@ async def test_acp_lima_runtime_fails_closed_when_strict_not_supported(monkeypat
     with pytest.raises(ACPResponseError, match="strict"):
         await manager.create_session(cwd="/workspace", user_id=7)
 
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_acp_lima_runtime_rejects_allow_all_policy(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="lima",
+            network_policy="allow_all",
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+
+    with pytest.raises(ACPResponseError, match="deny_all or allowlist"):
+        await manager.create_session(cwd="/workspace", user_id=7)

--- a/tldw_Server_API/tests/CI/test_postgres_schema_file_presence.py
+++ b/tldw_Server_API/tests/CI/test_postgres_schema_file_presence.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_postgres_users_schema_file_exists_with_core_columns() -> None:
+    schema_path = Path("tldw_Server_API/Databases/Postgres/Schema/postgresql_users.sql")
+    assert schema_path.exists()
+
+    sql = schema_path.read_text(encoding="utf-8").lower()
+    assert "create table if not exists users" in sql
+    for required in ("username", "email", "password_hash", "is_active", "is_verified", "role"):
+        assert required in sql

--- a/tldw_Server_API/tests/CI/test_postgres_schema_file_presence.py
+++ b/tldw_Server_API/tests/CI/test_postgres_schema_file_presence.py
@@ -7,5 +7,7 @@ def test_postgres_users_schema_file_exists_with_core_columns() -> None:
 
     sql = schema_path.read_text(encoding="utf-8").lower()
     assert "create table if not exists users" in sql
+    assert "create table if not exists organizations" in sql
+    assert "create table if not exists teams" in sql
     for required in ("username", "email", "password_hash", "is_active", "is_verified", "role"):
         assert required in sql

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_runtime_lima.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_runtime_lima.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module import SandboxModule
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
+
+
+class _FakeSandboxService:
+    def __init__(self) -> None:
+        self.runtimes: list[RuntimeType | None] = []
+
+    def start_run_scaffold(
+        self,
+        *,
+        user_id: str,
+        spec,  # noqa: ANN001 - minimal test stub
+        spec_version: str,
+        idem_key: str | None,
+        raw_body,  # noqa: ANN001 - minimal test stub
+    ) -> RunStatus:
+        self.runtimes.append(spec.runtime)
+        return RunStatus(
+            id="run-lima-1",
+            phase=RunPhase.queued,
+            spec_version=spec_version,
+            runtime=spec.runtime or RuntimeType.docker,
+            base_image=spec.base_image,
+            started_at=datetime.now(timezone.utc),
+        )
+
+
+@pytest.mark.asyncio
+async def test_sandbox_module_accepts_lima_runtime() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    ctx = RequestContext(
+        request_id="req-lima-1",
+        user_id="5",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {"runtime": "lima", "base_image": "ubuntu:24.04", "command": ["echo", "ok"]},
+        context=ctx,
+    )
+
+    assert module._svc.runtimes == [RuntimeType.lima]
+    assert result["runtime"] == "lima"
+

--- a/tldw_Server_API/tests/sandbox/test_lima_feature_discovery_capabilities.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_feature_discovery_capabilities.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.config import clear_config_cache
+from tldw_Server_API.app.main import app
+
+
+def _client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    clear_config_cache()
+    return TestClient(app)
+
+
+def test_lima_discovery_includes_enforcement_readiness(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "0")
+
+    with _client(monkeypatch) as client:
+        resp = client.get("/api/v1/sandbox/runtimes")
+        assert resp.status_code == 200
+        data = resp.json()
+        lima = next(rt for rt in data["runtimes"] if rt["name"] == "lima")
+        assert lima["strict_deny_all_supported"] is True
+        assert lima["strict_allowlist_supported"] is False
+        assert lima["enforcement_ready"] == {"deny_all": True, "allowlist": False}
+        assert isinstance(lima["host"], dict)
+        assert "os" in lima["host"]
+

--- a/tldw_Server_API/tests/sandbox/test_lima_no_fallback.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_no_fallback.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "0")
+    return TestClient(app)
+
+
+def test_explicit_lima_run_unavailable_has_no_fallback_suggestions(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "lima",
+            "base_image": "ubuntu:24.04",
+            "command": ["echo", "ok"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        assert j.get("error", {}).get("code") == "runtime_unavailable"
+        details = j.get("error", {}).get("details", {})
+        assert details.get("runtime") == "lima"
+        assert details.get("suggested") == []
+
+
+def test_explicit_lima_session_unavailable_has_no_fallback_suggestions(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "lima",
+            "base_image": "ubuntu:24.04",
+        }
+        r = client.post("/api/v1/sandbox/sessions", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        assert j.get("error", {}).get("code") == "runtime_unavailable"
+        details = j.get("error", {}).get("details", {})
+        assert details.get("runtime") == "lima"
+        assert details.get("suggested") == []
+

--- a/tldw_Server_API/tests/sandbox/test_lima_policy_error_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_policy_error_contract.py
@@ -32,3 +32,27 @@ def test_lima_policy_unsupported_includes_reasons(monkeypatch) -> None:
         assert details["requirement"] == "allowlist"
         assert "strict_allowlist_not_supported" in details["reasons"]
 
+
+def test_lima_runtime_unavailable_includes_permission_denied_reason(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_PERMISSION_DENIED", "1")
+
+    payload = {
+        "spec_version": "1.0",
+        "runtime": "lima",
+        "base_image": "ubuntu:24.04",
+        "command": ["echo", "ok"],
+        "network_policy": "deny_all",
+    }
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/sandbox/runs", json=payload)
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["error"]["code"] == "runtime_unavailable"
+        details = data["error"]["details"]
+        assert details["runtime"] == "lima"
+        assert details["available"] is False
+        assert details["suggested"] == []
+        assert "permission_denied_host_enforcement" in details["reasons"]

--- a/tldw_Server_API/tests/sandbox/test_lima_policy_error_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_policy_error_contract.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _client(monkeypatch) -> TestClient:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "0")
+    return TestClient(app)
+
+
+def test_lima_policy_unsupported_includes_reasons(monkeypatch) -> None:
+    payload = {
+        "spec_version": "1.0",
+        "runtime": "lima",
+        "base_image": "ubuntu:24.04",
+        "command": ["echo", "ok"],
+        "network_policy": "allowlist",
+    }
+    with _client(monkeypatch) as client:
+        resp = client.post("/api/v1/sandbox/runs", json=payload)
+        assert resp.status_code == 422
+        data = resp.json()
+        assert data["error"]["code"] == "policy_unsupported"
+        details = data["error"]["details"]
+        assert details["runtime"] == "lima"
+        assert details["requirement"] == "allowlist"
+        assert "strict_allowlist_not_supported" in details["reasons"]
+

--- a/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
+
+
+def test_lima_preflight_returns_unavailable_when_limactl_missing(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "0")
+    result = LimaRunner().preflight(network_policy="deny_all")
+
+    assert result.runtime == RuntimeType.lima
+    assert result.available is False
+    assert "limactl_missing" in result.reasons

--- a/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
@@ -11,3 +11,30 @@ def test_lima_preflight_returns_unavailable_when_limactl_missing(monkeypatch) ->
     assert result.runtime == RuntimeType.lima
     assert result.available is False
     assert "limactl_missing" in result.reasons
+
+
+def test_lima_preflight_wsl_fails_closed_with_permission_reason(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.delenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_LIMA_ENFORCER_PERMISSION_DENIED", raising=False)
+
+    result = LimaRunner().preflight(network_policy="deny_all")
+
+    assert result.runtime == RuntimeType.lima
+    assert result.available is False
+    assert result.host.get("variant") == "wsl"
+    assert "permission_denied_host_enforcement" in result.reasons
+
+
+def test_lima_preflight_permission_override_returns_permission_reason(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_PERMISSION_DENIED", "1")
+
+    result = LimaRunner().preflight(network_policy="allowlist")
+
+    assert result.runtime == RuntimeType.lima
+    assert result.available is False
+    assert result.enforcement_ready == {"deny_all": False, "allowlist": False}
+    assert "permission_denied_host_enforcement" in result.reasons

--- a/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_preflight_capabilities.py
@@ -38,3 +38,18 @@ def test_lima_preflight_permission_override_returns_permission_reason(monkeypatc
     assert result.available is False
     assert result.enforcement_ready == {"deny_all": False, "allowlist": False}
     assert "permission_denied_host_enforcement" in result.reasons
+
+
+def test_lima_preflight_wsl_overrides_cannot_bypass_fail_closed(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "1")
+
+    result = LimaRunner().preflight(network_policy="deny_all")
+
+    assert result.runtime == RuntimeType.lima
+    assert result.available is False
+    assert result.enforcement_ready == {"deny_all": False, "allowlist": False}
+    assert "permission_denied_host_enforcement" in result.reasons

--- a/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
@@ -8,6 +8,7 @@ from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
 def test_lima_allowlist_rejected_when_strict_not_ready(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
     monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
     monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "0")
 
@@ -28,3 +29,29 @@ def test_lima_allowlist_rejected_when_strict_not_ready(monkeypatch) -> None:
             idem_key=None,
             raw_body={},
         )
+
+
+def test_lima_allow_all_rejected_as_unsupported_policy(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_DENY_ALL_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "1")
+
+    svc = SandboxService()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.lima,
+        base_image="ubuntu:24.04",
+        command=["echo", "ok"],
+        network_policy="allow_all",
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        svc.start_run_scaffold(
+            user_id="1",
+            spec=spec,
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+    assert "unsupported_network_policy" in exc.value.reasons

--- a/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
@@ -33,6 +33,32 @@ def test_lima_allowlist_rejected_when_strict_not_ready(monkeypatch) -> None:
         )
 
 
+def test_lima_allowlist_rejected_even_when_override_reports_ready(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "1")
+
+    svc = SandboxService()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.lima,
+        base_image="ubuntu:24.04",
+        command=["echo", "ok"],
+        network_policy="allowlist",
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        svc.start_run_scaffold(
+            user_id="1",
+            spec=spec,
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+    assert "strict_allowlist_not_supported" in exc.value.reasons
+
+
 def test_lima_allow_all_rejected_as_unsupported_policy(monkeypatch) -> None:
     monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
     monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
@@ -101,15 +127,15 @@ def test_lima_execution_worker_revalidates_preflight_before_run_start(monkeypatc
         network_policy="deny_all",
     )
 
-    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
-        svc.start_run_scaffold(
-            user_id="1",
-            spec=spec,
-            spec_version="1.0",
-            idem_key=None,
-            raw_body={},
-        )
+    status = svc.start_run_scaffold(
+        user_id="1",
+        spec=spec,
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={},
+    )
 
-    assert "strict_deny_all_not_supported" in exc.value.reasons
+    assert status.phase.value == "failed"
+    assert status.message == "lima_policy_failed"
     assert preflight_calls["count"] == 2
     assert start_called["value"] is False

--- a/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
@@ -4,6 +4,8 @@ import pytest
 
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 
 
@@ -55,3 +57,59 @@ def test_lima_allow_all_rejected_as_unsupported_policy(monkeypatch) -> None:
             raw_body={},
         )
     assert "unsupported_network_policy" in exc.value.reasons
+
+
+def test_lima_execution_worker_revalidates_preflight_before_run_start(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+
+    preflight_calls = {"count": 0}
+    start_called = {"value": False}
+
+    def _fake_preflight(self, network_policy: str | None = None):
+        preflight_calls["count"] += 1
+        if preflight_calls["count"] == 1:
+            return RuntimePreflightResult(
+                runtime=RuntimeType.lima,
+                available=True,
+                reasons=[],
+                host={"os": "darwin", "variant": "native"},
+                enforcement_ready={"deny_all": True, "allowlist": True},
+            )
+        return RuntimePreflightResult(
+            runtime=RuntimeType.lima,
+            available=False,
+            reasons=["strict_deny_all_not_supported"],
+            host={"os": "darwin", "variant": "native"},
+            enforcement_ready={"deny_all": False, "allowlist": True},
+        )
+
+    def _fake_start_run(self, run_id: str, spec: RunSpec, session_workspace: str | None = None):
+        start_called["value"] = True
+        raise AssertionError("Lima run should not start when execution preflight fails")
+
+    monkeypatch.setattr(LimaRunner, "preflight", _fake_preflight)
+    monkeypatch.setattr(LimaRunner, "start_run", _fake_start_run)
+
+    svc = SandboxService()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.lima,
+        base_image="ubuntu:24.04",
+        command=["echo", "ok"],
+        network_policy="deny_all",
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        svc.start_run_scaffold(
+            user_id="1",
+            spec=spec,
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+
+    assert "strict_deny_all_not_supported" in exc.value.reasons
+    assert preflight_calls["count"] == 2
+    assert start_called["value"] is False

--- a/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def test_lima_allowlist_rejected_when_strict_not_ready(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_LIMA_ENFORCER_ALLOWLIST_READY", "0")
+
+    svc = SandboxService()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.lima,
+        base_image="ubuntu:24.04",
+        command=["echo", "ok"],
+        network_policy="allowlist",
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported):
+        svc.start_run_scaffold(
+            user_id="1",
+            spec=spec,
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )

--- a/tldw_Server_API/tests/sandbox/test_runtime_capabilities_policy.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_capabilities_policy.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import tldw_Server_API.app.core.Sandbox.policy as policy_module
+
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicyConfig
+
+
+def test_policy_config_reads_lima_default_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(policy_module.app_settings, "SANDBOX_DEFAULT_RUNTIME", "lima", raising=False)
+    cfg = SandboxPolicyConfig.from_settings()
+    assert cfg.default_runtime == RuntimeType.lima

--- a/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
@@ -14,6 +14,8 @@ def _client(monkeypatch) -> TestClient:
     monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
     # Make firecracker appear unavailable regardless of host
     monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_AVAILABLE", "0")
+    # Keep fallback suggestion behavior deterministic in tests.
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
     return TestClient(app)
 
 
@@ -55,3 +57,25 @@ def test_session_firecracker_unavailable_returns_503(monkeypatch) -> None:
         assert d.get("runtime") == "firecracker"
         assert d.get("available") is False
         assert isinstance(d.get("suggested"), list) and "docker" in d.get("suggested")
+
+
+def test_firecracker_unavailable_without_docker_has_empty_suggestions(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_AVAILABLE", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "0")
+
+    with TestClient(app) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "firecracker",
+            "base_image": "python:3.11-slim",
+            "command": ["bash", "-lc", "echo"],
+            "timeout_sec": 5,
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        d = j.get("error", {}).get("details", {})
+        assert d.get("runtime") == "firecracker"
+        assert d.get("suggested") == []


### PR DESCRIPTION
Summary:\n- Adds capability-driven Lima preflight + strict admission in sandbox policy/service.\n- Enforces fail-closed Lima semantics for strict network modes with no runtime fallback.\n- Adds runtime parity for Lima across REST, MCP sandbox.run, and ACP runner.\n- Exposes Lima strict capability/readiness details in sandbox runtimes discovery.\n- Adds structured error contracts for policy unsupported and runtime unavailable with reasons.\n\nHardening:\n- Revalidates Lima preflight at execution-time on the claim-owning worker.\n- Rejects unsupported allow_all network policy for strict Lima.\n- Fails closed on WSL/permission gaps with permission_denied_host_enforcement reason propagation.\n\nVerification:\n- Targeted Lima/MCP/ACP tests pass.\n- Full sandbox suite shows known intermittent stream-hub flakes that pass on isolated reruns.\n- Bandit run completed on touched scope; only low-severity existing subprocess warnings in Lima runner paths.