### PR TITLE
feat(ui/web/extension): add repo2txt route and V1 integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to Some kind of Versioning
   - `apps/DEVELOPMENT.md`
   - `apps/tldw-frontend/README.md`
   - `apps/extension/README.md`
+- Added third-party notice attribution for upstream `repo2txt` (project + MIT license) in:
+  - `THIRD_PARTY_NOTICES.txt`
 - Added extension compile tsconfig and entrypoint module declarations:
   - `apps/extension/tsconfig.compile.json`
   - `apps/extension/types/tldw-ui-entries.d.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Some kind of Versioning
 
 
+## [0.1.26] 2026-03-01
+
+### Added
+
+- repo2txt V1 integration across shared UI, web, and extension options surfaces:
+  - Added shared options route scaffold and route wiring for `/repo2txt`.
+  - Added repo2txt page shell and interaction flow in shared UI.
+  - Added GitHub provider support for repo2txt generation.
+  - Added local file/folder provider support for repo2txt generation.
+  - Added repo2txt file-tree state slice for selection/exclusion behavior.
+  - Added repo2txt formatter and tokenizer worker pipeline.
+  - Added locale keys and parity guard coverage for repo2txt copy.
+  - Added Next.js wrapper route at `apps/tldw-frontend/pages/repo2txt.tsx`.
+  - Added extension E2E coverage for options route loading and sidepanel link-out behavior:
+    - `apps/extension/tests/e2e/repo2txt-options.spec.ts`
+    - `apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts`
+- Added repo2txt discoverability in the launcher/shortcuts modal.
+- Added docs coverage for repo2txt route behavior in:
+  - `apps/DEVELOPMENT.md`
+  - `apps/tldw-frontend/README.md`
+  - `apps/extension/README.md`
+- Added extension compile tsconfig and entrypoint module declarations:
+  - `apps/extension/tsconfig.compile.json`
+  - `apps/extension/types/tldw-ui-entries.d.ts`
+
+### Changed
+
+- Extension compile script now targets explicit config:
+  - `apps/extension/package.json` `compile` now uses `tsc --noEmit -p tsconfig.compile.json`.
+- Frontend compile script now uses webpack build path for deterministic completion in this environment:
+  - `apps/tldw-frontend/package.json` `compile` now uses `next build --webpack` before token-sync verification.
+
+### Removed
+
+- No removals in this session.
+
+### Fixed
+
+- Fixed extension compile command failure caused by missing local `tsconfig.json` in `apps/extension`.
+- Fixed frontend compile gate stalling under Turbopack in this environment by switching compile verification to webpack build mode.
+
+
 ## [0.1.25] 2026-02-X
 
 ### Added

--- a/Docs/Plans/2026-02-28-repo2txt-integration-design.md
+++ b/Docs/Plans/2026-02-28-repo2txt-integration-design.md
@@ -1,0 +1,230 @@
+# repo2txt Integration Design (Webapp + Extension)
+
+Date: 2026-02-28
+Status: Approved for planning
+Owner: Codex + project maintainer
+
+## 1. Objective
+
+Integrate `repo2txt` into the shared tldw UI as a new options/web page available in both:
+
+- `apps/tldw-frontend` (web app)
+- `apps/extension` options experience (via shared UI routes)
+
+for a V1 that includes:
+
+- source providers: GitHub + Local (directory/zip)
+- output experience: preview + copy + download
+
+and explicitly does not include sidepanel in-panel rendering for V1.
+
+## 2. Scope Decisions (Confirmed)
+
+1. Integration strategy: Hybrid
+2. Entry point: options/web route only
+3. Provider scope: GitHub + Local only
+4. Output scope: keep repo2txt behavior only (no chat/workspace/knowledge handoff in V1)
+
+## 3. Non-Goals (V1)
+
+- No GitLab or Azure provider support
+- No sidepanel full route experience
+- No automatic send-to-chat or save-to-knowledge actions
+- No deep backend integration beyond existing browser-side fetch/provider behavior
+
+## 4. Approaches Considered
+
+### Approach A (Recommended): Shared-core port into `@tldw/ui`
+
+Port repo2txt core logic and selected components into `apps/packages/ui/src`, then expose through route registry.
+
+Pros:
+
+- Aligns with current monorepo architecture (shared routes consumed by web + extension)
+- Avoids iframe/CSP complexity
+- Easier long-term maintenance/testing in existing toolchain
+
+Cons:
+
+- More upfront adaptation work than simple wrapping
+
+### Approach B: Embedded micro-app (iframe/static bundle)
+
+Ship repo2txt as a separately built app and embed.
+
+Pros:
+
+- Quick to demonstrate
+
+Cons:
+
+- CSP/permissions complexity in extension
+- Styling/session/auth disjointness
+- Weaker integration with route/nav/testing conventions
+
+### Approach C: Full source transplant with minimal adaptation
+
+Copy most of repo2txt app directly into shared UI and patch until it compiles.
+
+Pros:
+
+- Potentially fast first pass
+
+Cons:
+
+- High technical debt
+- React/build/runtime mismatches likely
+- Harder to maintain and evolve
+
+## Recommendation
+
+Proceed with **Approach A**.
+
+## 5. Architecture Design
+
+## 5.1 New shared route
+
+Add a new options route in `apps/packages/ui/src/routes`:
+
+- `option-repo2txt.tsx`
+
+Register route in:
+
+- `apps/packages/ui/src/routes/route-registry.tsx`
+
+with options target support and navigation metadata appropriate for options/web discoverability.
+
+## 5.2 Web wrapper
+
+Expose Next.js wrapper:
+
+- `apps/tldw-frontend/pages/repo2txt.tsx`
+
+using existing dynamic-import wrapper pattern (`ssr: false`) to import shared route.
+
+## 5.3 Navigation surfaces (options/web only)
+
+Add route discoverability to required options/web surfaces:
+
+- header shortcuts data (launcher)
+- mode selector “More” menu (or equivalent quick access surface)
+- settings/workspace navigation grouping for persistent access
+
+V1 intentionally omits sidepanel in-panel route integration.
+If a sidepanel affordance is added in V1, it must open the options route (`/options.html#/repo2txt`) as a link-out and must not render repo2txt inside sidepanel.
+
+## 5.4 Localization baseline
+
+All repo2txt user-facing strings should be introduced through existing locale namespaces (for example `option.json`) rather than hard-coded copy.
+English keys are required for V1, and non-English locale files should include matching keys per existing locale parity conventions in this repo.
+
+## 6. Component and Module Design
+
+Create a feature module in shared UI:
+
+- `apps/packages/ui/src/components/Option/Repo2Txt/*`
+
+Port/adapt the following from repo2txt:
+
+- provider selector (GitHub + Local tabs/forms)
+- file tree browsing and selection
+- advanced filters (extension + gitignore)
+- output panel (preview + copy + download)
+- error presentation
+- formatter and tokenizer worker integration
+
+Excluded modules for V1:
+
+- GitLab provider/UI
+- Azure provider/UI
+- non-essential branding/promo surfaces
+
+## 6.1 State model
+
+Use a local, route-scoped Zustand store adapted from repo2txt slices:
+
+- provider state
+- file tree + selection state
+- filter state
+- UI state (loading/error/output)
+
+Keep it isolated from broader tldw global stores for V1 to reduce coupling risk.
+
+## 7. Data Flow
+
+1. User opens `/repo2txt` in options/web.
+2. User chooses GitHub or Local source.
+3. Provider fetches tree (GitHub API or local files/zip).
+4. User refines selection/filtering.
+5. Selected files fetched progressively.
+6. Formatter + tokenizer worker generate output and counts.
+7. User previews, copies, or downloads output.
+
+## 8. Error Handling and Risk Controls
+
+## 8.1 Compatibility risks
+
+- Adapt repo2txt assumptions to React 18 and shared UI conventions.
+- Keep worker loading compatible across Next web and WXT extension builds.
+
+## 8.2 CSP/permission concerns
+
+- Favor native shared-route integration (no iframe).
+- Validate extension host permission behavior for `api.github.com` during implementation.
+
+## 8.3 Performance
+
+- Keep async/progressive file fetch behavior.
+- Keep worker-based tokenization for large repositories.
+- Avoid introducing heavy dependencies beyond already-present workspace deps where possible.
+
+## 9. Testing Strategy
+
+## 9.1 Unit tests
+
+- GitHub parsing + normalization behavior
+- Local provider directory/zip behavior
+- selection/filter/gitignore state logic
+- formatter/token accounting behavior
+
+## 9.2 Route/render tests
+
+- `option-repo2txt` loads correctly
+- loading/error/empty states
+- Next wrapper page wiring in `tldw-frontend`
+
+## 9.3 Navigation tests
+
+- Route appears in chosen options/web navigation surfaces
+- No sidepanel in-panel exposure in V1
+- Sidepanel affordance (if present) opens options `/repo2txt` as link-out
+
+## 9.4 Manual validation
+
+- Web: `/repo2txt` GitHub export and local export
+- Extension options: equivalent flow parity
+- Copy and download outputs match expected content and counters
+- Sidepanel affordance (if present) opens options `/repo2txt` rather than rendering in sidepanel
+
+## 9.5 i18n validation
+
+- New repo2txt locale keys exist in English locale files
+- Locale key presence/parity checks pass for non-English locale files impacted by V1
+
+## 10. Acceptance Criteria (V1)
+
+1. Options/web page exists and is reachable in both web and extension options contexts.
+2. GitHub + Local providers work end-to-end.
+3. Output preview, copy, and download work with token/line counts.
+4. If sidepanel exposes repo2txt, it opens the options route as link-out (no sidepanel in-panel render).
+5. New repo2txt user-facing strings are locale-key based and covered by locale parity checks.
+6. No regressions in existing shared routing and navigation behavior.
+
+## 11. Follow-on Phases (Post-V1)
+
+Potential V2+ items:
+
+- GitLab/Azure provider reintroduction
+- sidepanel launcher shortcuts that open options route directly
+- tldw handoffs (send output to chat/workspace, optional knowledge ingestion)
+- deeper visual unification with tldw design system if needed

--- a/Docs/Plans/2026-02-28-repo2txt-integration-implementation-plan.md
+++ b/Docs/Plans/2026-02-28-repo2txt-integration-implementation-plan.md
@@ -18,21 +18,21 @@
 **Step 1: Create isolated branch/worktree**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2
+cd <repo_root>
 git worktree add -b codex/repo2txt-v1 ../tldw_server2-repo2txt
 ```
 
-Expected: new worktree at `/Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt` on branch `codex/repo2txt-v1`.
+Expected: new worktree at `<repo_worktree>` on branch `codex/repo2txt-v1`.
 
 **Step 2: Run baseline verification in the new worktree**
 
 Run:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt && bun install
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bun run compile
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run compile
+cd <repo_worktree> && bun install
+cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+cd <repo_worktree>/apps/tldw-frontend && bun run compile
+cd <repo_worktree>/apps/extension && bun run compile
 ```
 
 Expected: baseline is green (or existing failures are recorded before feature work starts).
@@ -49,7 +49,7 @@ No commit (setup-only task).
 
 From Task 1 onward, run all commands from:
 
-- `/Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt`
+- `<repo_worktree>`
 
 ### Task 1: Add route skeleton and failing route test
 
@@ -83,7 +83,7 @@ describe("repo2txt option route", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
 
 Expected: FAIL with route not found or missing test id.
 
@@ -115,14 +115,14 @@ const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/routes/option-repo2txt.tsx apps/packages/ui/src/routes/route-registry.tsx apps/packages/ui/src/routes/route-paths.ts apps/packages/ui/src/routes/__tests__/option-repo2txt.route.test.tsx
 git commit -m "feat(ui): add repo2txt route scaffold"
 ```
@@ -153,7 +153,7 @@ describe("Repo2TxtPage", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
 
 Expected: FAIL with missing component/module.
 
@@ -172,14 +172,14 @@ export function Repo2TxtPage() {
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt apps/packages/ui/src/routes/option-repo2txt.tsx
 git commit -m "feat(ui): add repo2txt page shell"
 ```
@@ -211,7 +211,7 @@ describe("GitHubProvider", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
 
 Expected: FAIL with missing provider module.
 
@@ -226,14 +226,14 @@ export class GitHubProvider extends BaseProvider {
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt/providers
 git commit -m "feat(ui): port repo2txt github provider"
 ```
@@ -263,7 +263,7 @@ describe("LocalProvider", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
 
 Expected: FAIL with missing LocalProvider.
 
@@ -278,14 +278,14 @@ export class LocalProvider extends BaseProvider {
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts
 git commit -m "feat(ui): port repo2txt local provider"
 ```
@@ -315,7 +315,7 @@ describe("repo2txt file tree slice", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
 
 Expected: FAIL with missing store module.
 
@@ -332,14 +332,14 @@ export const createRepo2TxtStore = () => create<Repo2TxtState>()(
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt/store
 git commit -m "feat(ui): add repo2txt file tree state"
 ```
@@ -372,7 +372,7 @@ describe("Formatter", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
 
 Expected: FAIL with missing formatter module.
 
@@ -388,14 +388,14 @@ export class Formatter {
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt/formatter apps/packages/ui/src/components/Option/Repo2Txt/workers
 git commit -m "feat(ui): add repo2txt formatter and tokenizer worker"
 ```
@@ -431,7 +431,7 @@ describe("Repo2TxtPage flow", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
 
 Expected: FAIL due to missing UI contract.
 
@@ -444,14 +444,14 @@ Expected: FAIL due to missing UI contract.
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/components/Option/Repo2Txt
 git commit -m "feat(ui): wire repo2txt page interactions"
 ```
@@ -487,7 +487,7 @@ describe("Header shortcuts repo2txt entry", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
 
 Expected: FAIL because repo2txt entry does not exist.
 
@@ -501,14 +501,14 @@ Expected: FAIL because repo2txt entry does not exist.
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/routes/route-registry.tsx apps/packages/ui/src/components/Layouts/header-shortcut-items.ts apps/packages/ui/src/services/settings/ui-settings.ts apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
 git commit -m "feat(ui): expose repo2txt in options navigation"
 ```
@@ -563,7 +563,7 @@ describe("repo2txt locale keys", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts`
+Run: `cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts`
 
 Expected: FAIL because repo2txt keys are missing.
 
@@ -579,8 +579,8 @@ Expected: FAIL because repo2txt keys are missing.
 Run locale sync/coverage checks:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run locales:sync option.json
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run check:i18n:coverage
+cd <repo_worktree>/apps/extension && bun run locales:sync option.json
+cd <repo_worktree>/apps/extension && bun run check:i18n:coverage
 ```
 
 **Step 4: Run test to verify it passes**
@@ -588,9 +588,9 @@ cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && b
 Run:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run locales:sync option.json
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run check:i18n:coverage
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+cd <repo_worktree>/apps/extension && bun run locales:sync option.json
+cd <repo_worktree>/apps/extension && bun run check:i18n:coverage
+cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
 ```
 
 Expected: PASS.
@@ -598,7 +598,7 @@ Expected: PASS.
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/packages/ui/src/assets/locale apps/packages/ui/src/public/_locales apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
 git commit -m "feat(ui): add repo2txt locale keys and parity guard"
 ```
@@ -625,7 +625,7 @@ describe("web repo2txt page", () => {
 
 **Step 2: Run test to verify it fails**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
+Run: `cd <repo_worktree>/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
 
 Expected: FAIL because page file is missing.
 
@@ -638,14 +638,14 @@ export default dynamic(() => import("@/routes/option-repo2txt"), { ssr: false })
 
 **Step 4: Run test to verify it passes**
 
-Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
+Run: `cd <repo_worktree>/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
 
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/tldw-frontend/pages/repo2txt.tsx apps/tldw-frontend/__tests__/pages/repo2txt.test.tsx apps/tldw-frontend/pages/_app.tsx
 git commit -m "feat(web): add repo2txt route wrapper"
 ```
@@ -706,8 +706,8 @@ test("sidepanel repo2txt affordance opens options link-out", async () => {
 Run:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+cd <repo_worktree>/apps/extension && bun run build:chrome
+cd <repo_worktree>/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
 ```
 
 Expected: FAIL when route wiring or sidepanel behavior is incomplete.
@@ -728,8 +728,8 @@ Expected: FAIL when route wiring or sidepanel behavior is incomplete.
 Run:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+cd <repo_worktree>/apps/extension && bun run build:chrome
+cd <repo_worktree>/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
 ```
 
 Expected: PASS.
@@ -737,7 +737,7 @@ Expected: PASS.
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/extension/wxt.config.ts apps/extension/tests/e2e/repo2txt-options.spec.ts apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts
 git commit -m "feat(extension): verify repo2txt options route and sidepanel link-out"
 ```
@@ -760,13 +760,13 @@ Add one short "repo2txt route" note in each relevant doc.
 Run:
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx src/components/Option/Repo2Txt/**/*.test.ts* src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bun run compile
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run compile
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx src/components/Option/Repo2Txt/**/*.test.ts* src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+cd <repo_worktree>/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+cd <repo_worktree>/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx
+cd <repo_worktree>/apps/tldw-frontend && bun run compile
+cd <repo_worktree>/apps/extension && bun run compile
+cd <repo_worktree>/apps/extension && bun run build:chrome
+cd <repo_worktree>/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
 ```
 
 Expected: all PASS with no typecheck errors.
@@ -784,7 +784,7 @@ Run the same verification command set; expected all PASS.
 **Step 5: Commit**
 
 ```bash
-cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+cd <repo_worktree>
 git add apps/DEVELOPMENT.md apps/tldw-frontend/README.md apps/extension/README.md
 git commit -m "docs: document repo2txt options route"
 ```

--- a/Docs/Plans/2026-02-28-repo2txt-integration-implementation-plan.md
+++ b/Docs/Plans/2026-02-28-repo2txt-integration-implementation-plan.md
@@ -1,0 +1,799 @@
+# repo2txt Integration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development for parallelizable tasks (or superpowers:executing-plans for strictly sequential execution).
+
+**Goal:** Ship a V1 repo2txt page in tldw options/web (webapp + extension options) with GitHub + Local providers and preview/copy/download output parity.
+
+**Architecture:** Implement a new shared `@tldw/ui` options route (`/repo2txt`) and port repo2txt core modules into a new feature folder under shared UI. Keep state route-scoped, wire route discovery in options/web navigation surfaces, and keep sidepanel as link-out only for V1.
+
+**Tech Stack:** React 18, TypeScript, Zustand, React Router, Vitest, JSZip, gpt-tokenizer Web Worker, Next.js wrapper (`ssr: false`), WXT extension options runtime.
+
+---
+
+### Task 0: Create isolated worktree and capture baseline
+
+**Files:**
+- N/A (git worktree + baseline verification output)
+
+**Step 1: Create isolated branch/worktree**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2
+git worktree add -b codex/repo2txt-v1 ../tldw_server2-repo2txt
+```
+
+Expected: new worktree at `/Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt` on branch `codex/repo2txt-v1`.
+
+**Step 2: Run baseline verification in the new worktree**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt && bun install
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bun run compile
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run compile
+```
+
+Expected: baseline is green (or existing failures are recorded before feature work starts).
+
+**Step 3: Capture baseline notes**
+
+Record any pre-existing failures and proceed only after they are understood/scoped as unrelated.
+
+**Step 4: Commit**
+
+No commit (setup-only task).
+
+**Step 5: Use worktree root for all remaining tasks**
+
+From Task 1 onward, run all commands from:
+
+- `/Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt`
+
+### Task 1: Add route skeleton and failing route test
+
+**Files:**
+- Create: `apps/packages/ui/src/routes/option-repo2txt.tsx`
+- Modify: `apps/packages/ui/src/routes/route-registry.tsx`
+- Modify: `apps/packages/ui/src/routes/route-paths.ts`
+- Test: `apps/packages/ui/src/routes/__tests__/option-repo2txt.route.test.tsx`
+
+**Step 1: Write the failing route test**
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import { describe, expect, it } from "vitest"
+import { RouteShell } from "@/routes/app-route"
+
+describe("repo2txt option route", () => {
+  it("renders repo2txt page at /repo2txt", async () => {
+    render(
+      <MemoryRouter initialEntries={["/repo2txt"]}>
+        <Routes>
+          <Route path="*" element={<RouteShell kind="options" />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(await screen.findByTestId("repo2txt-route-root")).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
+
+Expected: FAIL with route not found or missing test id.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// src/routes/option-repo2txt.tsx
+export default function OptionRepo2TxtRoute() {
+  return <div data-testid="repo2txt-route-root">repo2txt</div>
+}
+```
+
+```tsx
+// src/routes/route-registry.tsx
+const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
+// ...
+{
+  kind: "options",
+  path: "/repo2txt",
+  element: <OptionRepo2Txt />,
+  nav: {
+    group: "workspace",
+    labelToken: "option:repo2txt.nav",
+    icon: FileText,
+    order: 7
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/routes/option-repo2txt.tsx apps/packages/ui/src/routes/route-registry.tsx apps/packages/ui/src/routes/route-paths.ts apps/packages/ui/src/routes/__tests__/option-repo2txt.route.test.tsx
+git commit -m "feat(ui): add repo2txt route scaffold"
+```
+
+### Task 2: Create feature shell and loading/error state contract
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/index.ts`
+- Modify: `apps/packages/ui/src/routes/option-repo2txt.tsx`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Repo2TxtPage } from "../Repo2TxtPage"
+
+describe("Repo2TxtPage", () => {
+  it("shows provider panel and output panel placeholders", () => {
+    render(<Repo2TxtPage />)
+    expect(screen.getByTestId("repo2txt-provider-panel")).toBeInTheDocument()
+    expect(screen.getByTestId("repo2txt-output-panel")).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
+
+Expected: FAIL with missing component/module.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function Repo2TxtPage() {
+  return (
+    <section data-testid="repo2txt-route-root">
+      <div data-testid="repo2txt-provider-panel" />
+      <div data-testid="repo2txt-output-panel" />
+    </section>
+  )
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt apps/packages/ui/src/routes/option-repo2txt.tsx
+git commit -m "feat(ui): add repo2txt page shell"
+```
+
+### Task 3: Port GitHub provider with tests (GitHub-only V1 remote provider)
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/providers/BaseProvider.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/providers/types.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/providers/GitHubProvider.ts`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { GitHubProvider } from "../GitHubProvider"
+
+describe("GitHubProvider", () => {
+  it("parses owner/repo from github URL", () => {
+    const provider = new GitHubProvider()
+    const parsed = provider.parseUrl("https://github.com/facebook/react")
+    expect(parsed.isValid).toBe(true)
+    expect(parsed.owner).toBe("facebook")
+    expect(parsed.repo).toBe("react")
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
+
+Expected: FAIL with missing provider module.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export class GitHubProvider extends BaseProvider {
+  // parseUrl + validateUrl + fetchTree + fetchFile
+  // limited to V1 behavior from repo2txt with token support
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt/providers
+git commit -m "feat(ui): port repo2txt github provider"
+```
+
+### Task 4: Port Local provider (directory/zip) with tests
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { LocalProvider } from "../LocalProvider"
+
+describe("LocalProvider", () => {
+  it("initializes directory mode and returns blob nodes", async () => {
+    const provider = new LocalProvider()
+    const file = new File(["const a=1"], "src/a.ts", { type: "text/plain" })
+    await provider.initialize({ source: "directory", files: { 0: file, length: 1 } as any })
+    const tree = await provider.fetchTree("local://directory")
+    expect(tree.some((node) => node.path.includes("a.ts"))).toBe(true)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
+
+Expected: FAIL with missing LocalProvider.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export class LocalProvider extends BaseProvider {
+  // initialize(directory|zip), fetchTree, fetchFile
+  // JSZip-backed zip parsing + FileReader for directory files
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts
+git commit -m "feat(ui): port repo2txt local provider"
+```
+
+### Task 5: Port file tree store/filter logic with tests
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/store/types.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/store/fileTreeSlice.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/store/index.ts`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { createRepo2TxtStore } from "../index"
+
+describe("repo2txt file tree slice", () => {
+  it("auto-selects common code extensions", () => {
+    const store = createRepo2TxtStore()
+    store.getState().setNodes([{ path: "src/app.ts", type: "blob" }])
+    expect(store.getState().selectedPaths.has("src/app.ts")).toBe(true)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
+
+Expected: FAIL with missing store module.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export const createRepo2TxtStore = () => create<Repo2TxtState>()(
+  devtools((...a) => ({
+    ...createFileTreeSlice(...a),
+    // provider/ui slices as needed for V1
+  }))
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt/store
+git commit -m "feat(ui): add repo2txt file tree state"
+```
+
+### Task 6: Port formatter + tokenizer worker with tests
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/formatter/Formatter.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/workers/tokenizer.worker.ts`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { Formatter } from "../Formatter"
+
+describe("Formatter", () => {
+  it("returns directory tree and token count", async () => {
+    const output = await Formatter.formatAsync(
+      [{ name: "a.ts", path: "a.ts", type: "file" }],
+      [{ path: "a.ts", text: "const a=1" }]
+    )
+    expect(output.directoryTree).toContain("a.ts")
+    expect(output.tokenCount).toBeGreaterThan(0)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
+
+Expected: FAIL with missing formatter module.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export class Formatter {
+  static async formatAsync(tree, fileContents, onProgress?) {
+    // generate tree text + tokenize via worker + return counters
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt/formatter apps/packages/ui/src/components/Option/Repo2Txt/workers
+git commit -m "feat(ui): add repo2txt formatter and tokenizer worker"
+```
+
+### Task 7: Build provider/file-tree/output UI and wire end-to-end page state
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/components/ProviderSelector.tsx`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/components/AdvancedFilters.tsx`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/components/FileTree.tsx`
+- Create: `apps/packages/ui/src/components/Option/Repo2Txt/components/OutputPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx`
+- Test: `apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import { Repo2TxtPage } from "../Repo2TxtPage"
+
+describe("Repo2TxtPage flow", () => {
+  it("keeps Generate disabled until a source is loaded", async () => {
+    render(<Repo2TxtPage />)
+    const generate = screen.getByRole("button", { name: /generate output/i })
+    expect(generate).toBeDisabled()
+    await userEvent.click(screen.getByRole("button", { name: /github/i }))
+    expect(generate).toBeDisabled()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
+
+Expected: FAIL due to missing UI contract.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// Repo2TxtPage orchestrates provider load, selection, formatAsync, and output panel state
+// ProviderSelector emits source actions; OutputPanel handles copy/download.
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/components/Option/Repo2Txt
+git commit -m "feat(ui): wire repo2txt page interactions"
+```
+
+### Task 8: Add required options/web discoverability surfaces
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/route-registry.tsx`
+- Modify: `apps/packages/ui/src/components/Layouts/header-shortcut-items.ts`
+- Modify: `apps/packages/ui/src/services/settings/ui-settings.ts`
+- Modify (if currently used by the header shell): `apps/packages/ui/src/components/Layouts/ModeSelector.tsx`
+- Test: `apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx` (extend existing harness)
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { describe, expect, it } from "vitest"
+import { HeaderShortcuts } from "../HeaderShortcuts"
+
+describe("Header shortcuts repo2txt entry", () => {
+  it("shows repo2txt shortcut item", () => {
+    render(
+      <MemoryRouter>
+        <HeaderShortcuts expanded={true} onExpandedChange={() => {}} />
+      </MemoryRouter>
+    )
+    expect(screen.getByText(/repo2txt/i)).toBeInTheDocument()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
+
+Expected: FAIL because repo2txt entry does not exist.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// add "repo2txt" to HeaderShortcutId list + header shortcut groups + settings/workspace navigation grouping.
+// if ModeSelector is wired in the current header shell, also add repo2txt there; otherwise skip ModeSelector edits for V1.
+// update HeaderShortcuts.test.tsx fixture lists (e.g., ALL_SHORTCUT_IDS) so visibility tests include repo2txt.
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/routes/route-registry.tsx apps/packages/ui/src/components/Layouts/header-shortcut-items.ts apps/packages/ui/src/services/settings/ui-settings.ts apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+git commit -m "feat(ui): expose repo2txt in options navigation"
+```
+
+### Task 8.1: Add i18n locale coverage for repo2txt copy
+
+**Files:**
+- Modify: `apps/packages/ui/src/assets/locale/en/option.json`
+- Modify: `apps/packages/ui/src/assets/locale/*/option.json` (all locales required by repo parity policy)
+- Generated update via sync: `apps/packages/ui/src/public/_locales/*/option.json`
+- Test: `apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import enOption from "@/assets/locale/en/option.json"
+
+const REQUIRED_KEYS = [
+  "repo2txt.nav",
+  "repo2txt.title",
+  "repo2txt.description",
+  "repo2txt.generate",
+  "header.modeRepo2txt"
+] as const
+
+describe("repo2txt locale keys", () => {
+  it("has required English option locale keys", () => {
+    for (const key of REQUIRED_KEYS) {
+      const value = key.split(".").reduce<any>((acc, seg) => acc?.[seg], enOption as any)
+      expect(typeof value).toBe("string")
+      expect(String(value).trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it("keeps repo2txt option keys present across locale directories", () => {
+    const localeRoot = path.resolve(process.cwd(), "src/assets/locale")
+    for (const locale of fs.readdirSync(localeRoot)) {
+      const optionPath = path.join(localeRoot, locale, "option.json")
+      expect(fs.existsSync(optionPath)).toBe(true)
+      const parsed = JSON.parse(fs.readFileSync(optionPath, "utf8"))
+      for (const key of REQUIRED_KEYS) {
+        const value = key.split(".").reduce<any>((acc, seg) => acc?.[seg], parsed)
+        expect(typeof value).toBe("string")
+      }
+    }
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts`
+
+Expected: FAIL because repo2txt keys are missing.
+
+**Step 3: Write minimal implementation**
+
+```json
+// Add repo2txt key group under option locale namespace in en + parity locales.
+// Ensure keys align with route/nav tokens introduced in this plan:
+// - option:repo2txt.nav
+// - option:header.modeRepo2txt
+```
+
+Run locale sync/coverage checks:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run locales:sync option.json
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run check:i18n:coverage
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run locales:sync option.json
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run check:i18n:coverage
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/packages/ui/src/assets/locale apps/packages/ui/src/public/_locales apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
+git commit -m "feat(ui): add repo2txt locale keys and parity guard"
+```
+
+### Task 9: Add Next.js web page wrapper and test
+
+**Files:**
+- Create: `apps/tldw-frontend/pages/repo2txt.tsx`
+- Modify: `apps/tldw-frontend/pages/_app.tsx` (optional prefetch inclusion if desired)
+- Test: `apps/tldw-frontend/__tests__/pages/repo2txt.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { describe, expect, it } from "vitest"
+import Repo2TxtPage from "@web/pages/repo2txt"
+
+describe("web repo2txt page", () => {
+  it("exports a page component", () => {
+    expect(Repo2TxtPage).toBeTypeOf("function")
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
+
+Expected: FAIL because page file is missing.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+import dynamic from "next/dynamic"
+export default dynamic(() => import("@/routes/option-repo2txt"), { ssr: false })
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/tldw-frontend/pages/repo2txt.tsx apps/tldw-frontend/__tests__/pages/repo2txt.test.tsx apps/tldw-frontend/pages/_app.tsx
+git commit -m "feat(web): add repo2txt route wrapper"
+```
+
+### Task 10: Verify extension options compatibility, sidepanel link-out behavior, and host permissions
+
+**Files:**
+- Modify (if needed): `apps/extension/wxt.config.ts`
+- Test: `apps/extension/tests/e2e/repo2txt-options.spec.ts` (new)
+- Test: `apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts` (new; for sidepanel affordance behavior)
+- Modify (if needed): sidepanel action/menu module that exposes repo2txt as options link-out (`data-testid="sidepanel-open-repo2txt"`)
+
+**Step 1: Write the failing tests**
+
+```ts
+import { expect, test } from "@playwright/test"
+import { launchWithBuiltExtension } from "./utils/extension-build"
+
+test("repo2txt route loads in options", async () => {
+  const { context, page, optionsUrl } = await launchWithBuiltExtension()
+  await page.goto(`${optionsUrl}#/repo2txt`, { waitUntil: "domcontentloaded" })
+  await expect(page.getByTestId("repo2txt-route-root")).toBeVisible()
+  await context.close()
+})
+```
+
+```ts
+import { expect, test } from "@playwright/test"
+import { launchWithBuiltExtension } from "./utils/extension-build"
+
+test("sidepanel repo2txt affordance opens options link-out", async () => {
+  const { context, openSidepanel } = await launchWithBuiltExtension()
+  const sidepanel = await openSidepanel()
+  const menuTrigger = sidepanel.getByRole("button", { name: /more options|menu|ingest/i }).first()
+  if ((await menuTrigger.count()) > 0) {
+    await menuTrigger.click()
+  }
+  const affordance = sidepanel.getByTestId("sidepanel-open-repo2txt")
+  if ((await affordance.count()) === 0) {
+    // V1 variant without a sidepanel affordance: ensure no accidental in-panel repo2txt entry exists.
+    await expect(affordance).toHaveCount(0)
+    await expect(sidepanel).not.toHaveURL(/repo2txt/i)
+    await context.close()
+    return
+  }
+  const [optionsPage] = await Promise.all([
+    context.waitForEvent("page"),
+    affordance.click()
+  ])
+  await optionsPage.waitForLoadState("domcontentloaded")
+  await expect(optionsPage).toHaveURL(/options\.html#\/repo2txt/)
+  await context.close()
+})
+```
+
+**Step 2: Build extension and run tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+```
+
+Expected: FAIL when route wiring or sidepanel behavior is incomplete.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// Ensure options route resolves in extension options build.
+// Ensure sidepanel repo2txt behavior is explicit:
+// - if affordance exists, it opens `/options.html#/repo2txt` as link-out (not in-panel render)
+// - if no affordance in V1, sidepanel has no repo2txt in-panel action.
+// Add a stable affordance selector for E2E (e.g. `data-testid="sidepanel-open-repo2txt"`).
+// Add api.github.com host permission only if runtime failures prove it is required.
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/extension/wxt.config.ts apps/extension/tests/e2e/repo2txt-options.spec.ts apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+git commit -m "feat(extension): verify repo2txt options route and sidepanel link-out"
+```
+
+### Task 11: Full verification gate and docs update
+
+**Files:**
+- Modify: `apps/DEVELOPMENT.md` (optional short note for new route)
+- Modify: `apps/tldw-frontend/README.md` (optional route mention)
+- Modify: `apps/extension/README.md` (optional options route mention)
+
+**Step 1: Write failing documentation check (optional)**
+
+```md
+Add one short "repo2txt route" note in each relevant doc.
+```
+
+**Step 2: Run verification commands**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx src/components/Option/Repo2Txt/**/*.test.ts* src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/packages/ui && bunx vitest run src/routes/__tests__/repo2txt-locale-keys.test.ts src/routes/__tests__/sidepanel-persona-locale-keys.test.ts src/tutorials/__tests__/locale-mirror.test.ts
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/tldw-frontend && bun run compile
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run compile
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run build:chrome
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt/apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+```
+
+Expected: all PASS with no typecheck errors.
+
+**Step 3: Address any regressions with minimal fixes**
+
+```ts
+// Only fix failing assertions/types introduced by this feature.
+```
+
+**Step 4: Re-run verification**
+
+Run the same verification command set; expected all PASS.
+
+**Step 5: Commit**
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2-repo2txt
+git add apps/DEVELOPMENT.md apps/tldw-frontend/README.md apps/extension/README.md
+git commit -m "docs: document repo2txt options route"
+```
+
+## Final rollout checklist
+
+- [ ] Route accessible at `/repo2txt` in web and extension options
+- [ ] GitHub + Local provider flows pass manual smoke
+- [ ] Output preview/copy/download validated
+- [ ] i18n locale keys for repo2txt are present and parity checks pass
+- [ ] Sidepanel repo2txt affordance (if present) remains link-out only for V1
+- [ ] No regression in existing options/route shell

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -7,8 +7,8 @@ authors, license types, and pointers to the
 original license text.  It does not cover transitive dependencies installed at
 build time via pip or npm; consult pyproject.toml and package.json for those.
 
-Project: tldw_server
-Project license: GNU General Public License v3.0 (GPL-3.0-or-later)
+Host project: tldw_server
+Host project license: GNU General Public License v3.0 (GPL-3.0-or-later)
 
 All bundled components below are listed with their own licenses and are used in
 a manner compatible with the project license.
@@ -77,6 +77,15 @@ a manner compatible with the project license.
                   (includes focus-visible polyfill and escape-html, both MIT)
    License text : https://opensource.org/licenses/MIT
    URL          : https://github.com/squidfunk/mkdocs-material
+
+9. repo2txt (ported/adapted modules)
+   Author/Year : Abin Thomas and repo2txt contributors
+   License      : MIT
+   Files        : apps/packages/ui/src/components/Option/Repo2Txt/
+                  (Repo2TxtPage.tsx, components/*, formatter/*, providers/*,
+                   store/*, workers/*)
+   License text : https://opensource.org/licenses/MIT
+   URL          : https://github.com/abinthomasonline/repo2txt
 
 -------------------------------------------------------------------------------
 END OF THIRD-PARTY NOTICES

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,13 +1,17 @@
 THIRD-PARTY NOTICES
 ===================
 
-This file lists all third-party components bundled (committed) in the tldw_server2
-repository, along with their authors, license types, and pointers to the
+This file lists all third-party components bundled (committed) in the tldw_server
+repository (this workspace may also appear as `tldw_server2`), along with their
+authors, license types, and pointers to the
 original license text.  It does not cover transitive dependencies installed at
 build time via pip or npm; consult pyproject.toml and package.json for those.
 
-The tldw_server2 project itself is licensed under the GNU General Public License
-v2.0.  All bundled components below are license-compatible with GPLv2.
+Project: tldw_server
+Project license: GNU General Public License v3.0 (GPL-3.0-or-later)
+
+All bundled components below are listed with their own licenses and are used in
+a manner compatible with the project license.
 
 -------------------------------------------------------------------------------
 

--- a/apps/DEVELOPMENT.md
+++ b/apps/DEVELOPMENT.md
@@ -215,6 +215,14 @@ The web shim maps:
 - `useNavigate()` → `useRouter().push/replace`
 - `useLocation()` → `useRouter().asPath` parsing
 
+### repo2txt Route Parity
+
+The `repo2txt` feature is implemented as a shared options route in `packages/ui/src/routes/option-repo2txt.tsx`.
+
+- Extension options route: `options.html#/repo2txt`
+- Web wrapper route: `tldw-frontend/pages/repo2txt.tsx` (dynamic import of the shared route)
+- Sidepanel behavior (V1): link-out only to options; no in-panel repo2txt surface
+
 ### Authentication Abstraction
 
 | Context | Auth Method |

--- a/apps/bun.lock
+++ b/apps/bun.lock
@@ -43,6 +43,7 @@
         "dexie": "^4.2.1",
         "dexie-react-hooks": "^1.1.7",
         "dompurify": "^3.3.1",
+        "gpt-tokenizer": "^3.4.0",
         "html-to-text": "^9.0.5",
         "html2canvas": "^1.4.1",
         "i18next": "^25.7.4",
@@ -146,6 +147,7 @@
         "dexie-react-hooks": "^1.0.0",
         "dompurify": "^3.0.0",
         "epubjs": "^0.3.93",
+        "gpt-tokenizer": "^3.4.0",
         "html2canvas": "^1.0.0",
         "i18next": "^25.0.0",
         "i18next-icu": "^2.4.1",
@@ -227,6 +229,7 @@
         "dexie-react-hooks": "^4.2.0",
         "dompurify": "^3.3.1",
         "epubjs": "^0.3.93",
+        "gpt-tokenizer": "^3.4.0",
         "html-to-text": "^9.0.5",
         "html2canvas": "^1.4.1",
         "i18next": "^25.7.4",
@@ -1957,6 +1960,8 @@
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -90,6 +90,11 @@ Want something else? Please open an issue.
 - Side Panel: `Ctrl+Shift+Y`
 - Web UI (new tab): `Ctrl+Shift+L`
 
+### repo2txt in Extension
+
+- Options route: `chrome-extension://<extension-id>/options.html#/repo2txt`
+- The sidepanel should keep repo2txt as an options link-out for V1 (not an in-panel page).
+
 Shortcuts are configurable from your browser’s extension settings and inside the app for in‑app actions.
 
 ### In‑App Shortcuts (defaults)

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -14,7 +14,7 @@
     "build:edge": "cross-env TARGET=chrome wxt build -b edge && node scripts/verify-shared-token-sync.mjs --target edge-mv3",
     "zip": "bun run locales:sync && cross-env TARGET=chrome wxt zip",
     "zip:firefox": "bun run locales:sync && cross-env TARGET=firefox wxt zip -b firefox",
-    "compile": "tsc --noEmit",
+    "compile": "tsc --noEmit -p tsconfig.compile.json",
     "verify:openapi": "node scripts/verify-openapi-client-paths.mjs",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -93,7 +93,8 @@
     "react-joyride": "^2.9.0",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "gpt-tokenizer": "^3.4.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/apps/extension/tests/e2e/repo2txt-options.spec.ts
+++ b/apps/extension/tests/e2e/repo2txt-options.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test"
+import { launchWithBuiltExtension } from "./utils/extension-build"
+
+test("repo2txt route loads in options", async () => {
+  const { context, page, optionsUrl } = await launchWithBuiltExtension()
+  try {
+    await page.goto(`${optionsUrl}#/repo2txt`, { waitUntil: "domcontentloaded" })
+    await expect(page.getByTestId("repo2txt-route-root")).toBeVisible()
+  } finally {
+    await context.close()
+  }
+})

--- a/apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts
+++ b/apps/extension/tests/e2e/repo2txt-sidepanel-linkout.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+import { launchWithBuiltExtension } from "./utils/extension-build"
+
+test("sidepanel repo2txt affordance opens options link-out", async () => {
+  const { context, openSidepanel } = await launchWithBuiltExtension()
+  try {
+    const sidepanel = await openSidepanel()
+    const menuTrigger = sidepanel
+      .getByRole("button", { name: /more options|menu|ingest/i })
+      .first()
+    if ((await menuTrigger.count()) > 0) {
+      await menuTrigger.click()
+    }
+
+    const affordance = sidepanel.getByTestId("sidepanel-open-repo2txt")
+    if ((await affordance.count()) === 0) {
+      await expect(affordance).toHaveCount(0)
+      await expect(sidepanel).not.toHaveURL(/repo2txt/i)
+      return
+    }
+
+    const [optionsPage] = await Promise.all([
+      context.waitForEvent("page"),
+      affordance.click()
+    ])
+    await optionsPage.waitForLoadState("domcontentloaded")
+    await expect(optionsPage).toHaveURL(/options\.html#\/repo2txt/)
+  } finally {
+    await context.close()
+  }
+})

--- a/apps/extension/tsconfig.compile.json
+++ b/apps/extension/tsconfig.compile.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": [
+    "wxt.config.ts",
+    "playwright.config.ts",
+    "entrypoints/**/*.ts",
+    "entrypoints/**/*.tsx",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    ".output",
+    "node_modules",
+    "tests"
+  ]
+}

--- a/apps/extension/tsconfig.compile.json
+++ b/apps/extension/tsconfig.compile.json
@@ -8,7 +8,7 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "jsx": "react-jsx",
     "types": ["node"]
   },

--- a/apps/extension/types/tldw-ui-entries.d.ts
+++ b/apps/extension/types/tldw-ui-entries.d.ts
@@ -1,0 +1,24 @@
+declare module "@tldw/ui/entries/background" {
+  const entry: unknown
+  export default entry
+}
+
+declare module "@tldw/ui/entries/copilot-popup.content" {
+  const entry: unknown
+  export default entry
+}
+
+declare module "@tldw/ui/entries/hf-pull.content" {
+  const entry: unknown
+  export default entry
+}
+
+declare module "@tldw/ui/entries/options/main" {
+  const entry: unknown
+  export default entry
+}
+
+declare module "@tldw/ui/entries/sidepanel/main" {
+  const entry: unknown
+  export default entry
+}

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
       "tabs",
       "scripting"
     ],
+    host_permissions: [
+      "https://api.github.com/*"
+    ],
     action: {
       default_title: "tldw Assistant",
       default_icon: {

--- a/apps/packages/ui/node_modules/gpt-tokenizer
+++ b/apps/packages/ui/node_modules/gpt-tokenizer
@@ -1,0 +1,1 @@
+../../../node_modules/.bun/gpt-tokenizer@3.4.0/node_modules/gpt-tokenizer

--- a/apps/packages/ui/package.json
+++ b/apps/packages/ui/package.json
@@ -87,6 +87,7 @@
     "epubjs": "^0.3.93",
     "xterm": "^5.3.0",
     "jszip": "^3.10.1",
+    "gpt-tokenizer": "^3.4.0",
     "@monaco-editor/react": "^4.6.0"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ar/option.json
+++ b/apps/packages/ui/src/assets/locale/ar/option.json
@@ -103,7 +103,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "ساحة الكتابة",
@@ -944,5 +945,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ar/option.json
+++ b/apps/packages/ui/src/assets/locale/ar/option.json
@@ -950,6 +950,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/da/option.json
+++ b/apps/packages/ui/src/assets/locale/da/option.json
@@ -102,7 +102,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Skriveværksted",
@@ -952,5 +953,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/da/option.json
+++ b/apps/packages/ui/src/assets/locale/da/option.json
@@ -958,6 +958,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/de/option.json
+++ b/apps/packages/ui/src/assets/locale/de/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Schreib-Spielwiese",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/de/option.json
+++ b/apps/packages/ui/src/assets/locale/de/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -1315,6 +1315,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/en/option.json
+++ b/apps/packages/ui/src/assets/locale/en/option.json
@@ -113,7 +113,8 @@
     "connectionCard.connectedCaption": "Chat and tools are now available in Options and the sidepanel.",
     "quickIngestQueuedAria": "{{label}} — {{count}} items queued — click to review and process",
     "writingPlayground": "Writing Playground",
-    "documentWorkspace": "Document Workspace"
+    "documentWorkspace": "Document Workspace",
+    "modeRepo2txt": "Repo2Txt"
   },
   "documentWorkspace": {
     "title": "Document Workspace",
@@ -1309,5 +1310,11 @@
     "nav": "Moderation Playground",
     "title": "Moderation Playground",
     "subtitle": "Family safety controls and server guardrails in one place."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/es/option.json
+++ b/apps/packages/ui/src/assets/locale/es/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Taller de escritura",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/es/option.json
+++ b/apps/packages/ui/src/assets/locale/es/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/fa/option.json
+++ b/apps/packages/ui/src/assets/locale/fa/option.json
@@ -839,6 +839,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/fa/option.json
+++ b/apps/packages/ui/src/assets/locale/fa/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "کارگاه نگارش",
@@ -833,5 +834,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/fr/option.json
+++ b/apps/packages/ui/src/assets/locale/fr/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Atelier d’écriture",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/fr/option.json
+++ b/apps/packages/ui/src/assets/locale/fr/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/it/option.json
+++ b/apps/packages/ui/src/assets/locale/it/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Laboratorio di scrittura",
@@ -942,5 +943,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/it/option.json
+++ b/apps/packages/ui/src/assets/locale/it/option.json
@@ -948,6 +948,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ja-JP/option.json
+++ b/apps/packages/ui/src/assets/locale/ja-JP/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "ライティングプレイグラウンド",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ja-JP/option.json
+++ b/apps/packages/ui/src/assets/locale/ja-JP/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ko/option.json
+++ b/apps/packages/ui/src/assets/locale/ko/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "글쓰기 플레이그라운드",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/ko/option.json
+++ b/apps/packages/ui/src/assets/locale/ko/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ml/option.json
+++ b/apps/packages/ui/src/assets/locale/ml/option.json
@@ -933,6 +933,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ml/option.json
+++ b/apps/packages/ui/src/assets/locale/ml/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "എഴുത്ത് പ്ലേഗ്രൗണ്ട്",
@@ -927,5 +928,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/no/option.json
+++ b/apps/packages/ui/src/assets/locale/no/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Skriveverksted",
@@ -942,5 +943,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/no/option.json
+++ b/apps/packages/ui/src/assets/locale/no/option.json
@@ -948,6 +948,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/pt-BR/option.json
+++ b/apps/packages/ui/src/assets/locale/pt-BR/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Playground de escrita",
@@ -953,5 +954,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/pt-BR/option.json
+++ b/apps/packages/ui/src/assets/locale/pt-BR/option.json
@@ -959,6 +959,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ru/option.json
+++ b/apps/packages/ui/src/assets/locale/ru/option.json
@@ -963,6 +963,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/ru/option.json
+++ b/apps/packages/ui/src/assets/locale/ru/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Площадка для письма",
@@ -957,5 +958,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/sv/option.json
+++ b/apps/packages/ui/src/assets/locale/sv/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Skrivverkstad",
@@ -942,5 +943,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/sv/option.json
+++ b/apps/packages/ui/src/assets/locale/sv/option.json
@@ -948,6 +948,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/uk/option.json
+++ b/apps/packages/ui/src/assets/locale/uk/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "Майстерня письма",
@@ -946,5 +947,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/uk/option.json
+++ b/apps/packages/ui/src/assets/locale/uk/option.json
@@ -952,6 +952,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh-TW/option.json
+++ b/apps/packages/ui/src/assets/locale/zh-TW/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "寫作工坊",
@@ -942,5 +943,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh-TW/option.json
+++ b/apps/packages/ui/src/assets/locale/zh-TW/option.json
@@ -948,6 +948,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh/option.json
+++ b/apps/packages/ui/src/assets/locale/zh/option.json
@@ -101,7 +101,8 @@
     "dataTables": "Data Tables",
     "documentWorkspace": "Document Workspace",
     "modelPlayground": "Workspace Playground",
-    "workflowEditor": "Workflow Editor"
+    "workflowEditor": "Workflow Editor",
+    "modeRepo2txt": "Repo2Txt"
   },
   "writingPlayground": {
     "title": "写作工坊",
@@ -942,5 +943,11 @@
   },
   "documentWorkspace": {
     "fileUnauthorized": "You don't have permission to access this document."
+  },
+  "repo2txt": {
+    "nav": "Repo2Txt",
+    "title": "Repo2Txt",
+    "description": "Convert repositories to structured text output.",
+    "generate": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/assets/locale/zh/option.json
+++ b/apps/packages/ui/src/assets/locale/zh/option.json
@@ -948,6 +948,33 @@
     "nav": "Repo2Txt",
     "title": "Repo2Txt",
     "description": "Convert repositories to structured text output.",
-    "generate": "Generate Output"
+    "generate": "Generate Output",
+    "providerTitle": "Source Provider",
+    "providerGithub": "GitHub",
+    "providerLocal": "Local",
+    "githubPlaceholder": "https://github.com/owner/repo",
+    "loadSource": "Load Source",
+    "chooseDirectory": "Choose Directory",
+    "chooseZip": "Choose Zip",
+    "filters": "Filters",
+    "selectedCount": "{{selected}}/{{total}} selected",
+    "filterFiles": "Filter files",
+    "output": "Output",
+    "copy": "Copy",
+    "download": "Download",
+    "outputPreviewAria": "Repo2txt output preview",
+    "errors": {
+      "invalidGithubUrl": "Enter a valid GitHub repository URL.",
+      "loadGithub": "Failed to load GitHub repository.",
+      "loadLocal": "Failed to load local files.",
+      "generate": "Failed to generate output."
+    },
+    "status": {
+      "loadedTree": "Loaded {{count}} file tree entries.",
+      "loadedLocal": "Loaded {{count}} local files.",
+      "selectAtLeastOne": "Select at least one file to generate output.",
+      "fetchingFiles": "Fetching files ({{completed}}/{{total}})...",
+      "generated": "Generated output for {{count}} files ({{tokenCount}} tokens)."
+    }
   }
 }

--- a/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/HeaderShortcuts.test.tsx
@@ -18,6 +18,7 @@ const ALL_SHORTCUT_IDS = [
   "chat", "prompts", "prompt-studio", "characters",
   "chat-dictionaries", "world-books", "workspace-playground",
   "knowledge-qa", "media", "document-workspace",
+  "repo2txt",
   "multi-item-review", "content-review", "collections",
   "watchlists", "notes", "chatbooks-playground", "flashcards",
   "quizzes", "evaluations", "chunking-playground",
@@ -136,6 +137,7 @@ describe("HeaderShortcuts launcher modal", () => {
     // Items should be visible
     expect(screen.getByText("Chat")).toBeInTheDocument()
     expect(screen.getByText("Prompts")).toBeInTheDocument()
+    expect(screen.getByText("Repo2Txt")).toBeInTheDocument()
     expect(screen.getByText("Settings")).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
+++ b/apps/packages/ui/src/components/Layouts/header-shortcut-items.ts
@@ -33,7 +33,7 @@ import {
   Zap
 } from "lucide-react"
 import type { HeaderShortcutId } from "@/services/settings/ui-settings"
-import { DOCUMENT_WORKSPACE_PATH } from "@/routes/route-paths"
+import { DOCUMENT_WORKSPACE_PATH, REPO2TXT_PATH } from "@/routes/route-paths"
 
 export type HeaderShortcutItem = {
   id: HeaderShortcutId
@@ -142,6 +142,13 @@ export const HEADER_SHORTCUT_GROUPS: HeaderShortcutGroup[] = [
         icon: FileSearch,
         labelKey: "option:header.documentWorkspace",
         labelDefault: "Document Workspace"
+      },
+      {
+        id: "repo2txt",
+        to: REPO2TXT_PATH,
+        icon: FileText,
+        labelKey: "option:repo2txt.nav",
+        labelDefault: "Repo2Txt"
       },
       {
         id: "evaluations",

--- a/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
@@ -1,8 +1,235 @@
+import { useMemo, useRef, useState } from "react"
+import { Formatter } from "./formatter/Formatter"
+import { GitHubProvider } from "./providers/GitHubProvider"
+import { LocalProvider } from "./providers/LocalProvider"
+import type { IProvider, RepoTreeNode } from "./providers/types"
+import { createRepo2TxtStore } from "./store"
+import { AdvancedFilters } from "./components/AdvancedFilters"
+import { FileTree } from "./components/FileTree"
+import { OutputPanel } from "./components/OutputPanel"
+import { ProviderSelector } from "./components/ProviderSelector"
+
+type ProviderKind = "github" | "local" | null
+
+const toDisplayTree = (nodes: RepoTreeNode[]) =>
+  nodes.map((node) => ({
+    name: node.path.split("/").pop() ?? node.path,
+    path: node.path,
+    type: node.type === "blob" ? "file" : "directory"
+  }))
+
 export function Repo2TxtPage() {
+  const storeRef = useRef(createRepo2TxtStore())
+  const [providerKind, setProviderKind] = useState<ProviderKind>(null)
+  const [provider, setProvider] = useState<IProvider | null>(null)
+  const [githubUrl, setGithubUrl] = useState("")
+  const [nodes, setNodes] = useState<RepoTreeNode[]>([])
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
+  const [filterText, setFilterText] = useState("")
+  const [output, setOutput] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [statusMessage, setStatusMessage] = useState<string>("")
+  const [sourceLoaded, setSourceLoaded] = useState(false)
+
+  const filteredNodes = useMemo(() => {
+    const query = filterText.trim().toLowerCase()
+    if (!query) return nodes
+    return nodes.filter((node) => node.path.toLowerCase().includes(query))
+  }, [nodes, filterText])
+
+  const syncNodesIntoState = (nextNodes: RepoTreeNode[]) => {
+    storeRef.current.getState().setNodes(nextNodes)
+    const storeState = storeRef.current.getState()
+    setNodes(storeState.nodes)
+    setSelectedPaths(new Set(storeState.selectedPaths))
+  }
+
+  const handleSelectProvider = (nextProvider: Exclude<ProviderKind, null>) => {
+    setProviderKind(nextProvider)
+    setProvider(null)
+    setSourceLoaded(false)
+    setOutput("")
+    setStatusMessage("")
+    syncNodesIntoState([])
+  }
+
+  const handleLoadGithub = async () => {
+    setBusy(true)
+    setStatusMessage("")
+    try {
+      const githubProvider = new GitHubProvider()
+      if (!githubProvider.validateUrl(githubUrl)) {
+        throw new Error("Enter a valid GitHub repository URL.")
+      }
+
+      const tree = await githubProvider.fetchTree(githubUrl)
+      setProvider(githubProvider)
+      syncNodesIntoState(tree)
+      setSourceLoaded(tree.length > 0)
+      setStatusMessage(`Loaded ${tree.length} file tree entries.`)
+    } catch (error) {
+      setSourceLoaded(false)
+      setStatusMessage(
+        error instanceof Error ? error.message : "Failed to load GitHub repository."
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleLocalFilesSelected = async (files: FileList) => {
+    setBusy(true)
+    setStatusMessage("")
+    try {
+      const localProvider = new LocalProvider()
+      const firstFile = files[0]
+      const looksLikeZip =
+        files.length === 1 && /\.zip$/i.test(firstFile?.name ?? "")
+
+      if (looksLikeZip) {
+        await localProvider.initialize({
+          source: "zip",
+          zipFile: firstFile
+        })
+      } else {
+        await localProvider.initialize({
+          source: "directory",
+          files
+        })
+      }
+
+      const tree = await localProvider.fetchTree("local://directory")
+      setProvider(localProvider)
+      syncNodesIntoState(tree)
+      setSourceLoaded(tree.length > 0)
+      setStatusMessage(`Loaded ${tree.length} local files.`)
+    } catch (error) {
+      setSourceLoaded(false)
+      setStatusMessage(
+        error instanceof Error ? error.message : "Failed to load local files."
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleTogglePath = (path: string) => {
+    setSelectedPaths((previous) => {
+      const next = new Set(previous)
+      if (next.has(path)) {
+        next.delete(path)
+      } else {
+        next.add(path)
+      }
+      return next
+    })
+  }
+
+  const handleGenerate = async () => {
+    if (!provider) return
+
+    const selectedNodes = nodes.filter(
+      (node) => node.type === "blob" && selectedPaths.has(node.path)
+    )
+
+    if (selectedNodes.length === 0) {
+      setOutput("")
+      setStatusMessage("Select at least one file to generate output.")
+      return
+    }
+
+    setBusy(true)
+    setStatusMessage("")
+    try {
+      const fileContents = await Promise.all(
+        selectedNodes.map((node) => provider.fetchFile(node))
+      )
+      const formatted = await Formatter.formatAsync(
+        toDisplayTree(selectedNodes),
+        fileContents
+      )
+      setOutput(`${formatted.directoryTree}\n\n${formatted.fileContents}`)
+      setStatusMessage(
+        `Generated output for ${selectedNodes.length} files (${formatted.tokenCount} tokens).`
+      )
+    } catch (error) {
+      setStatusMessage(
+        error instanceof Error ? error.message : "Failed to generate output."
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!output.trim()) return
+    if (!navigator?.clipboard?.writeText) return
+    await navigator.clipboard.writeText(output)
+  }
+
+  const handleDownload = () => {
+    if (!output.trim()) return
+    const blob = new Blob([output], { type: "text/plain;charset=utf-8" })
+    const href = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = href
+    anchor.download = "repo2txt-output.txt"
+    anchor.click()
+    URL.revokeObjectURL(href)
+  }
+
   return (
-    <section data-testid="repo2txt-route-root">
-      <div data-testid="repo2txt-provider-panel" />
-      <div data-testid="repo2txt-output-panel" />
+    <section
+      data-testid="repo2txt-route-root"
+      className="space-y-4"
+    >
+      <div
+        data-testid="repo2txt-provider-panel"
+        className="space-y-3 rounded border p-3"
+      >
+        <ProviderSelector
+          provider={providerKind}
+          githubUrl={githubUrl}
+          busy={busy}
+          onSelectProvider={handleSelectProvider}
+          onGithubUrlChange={setGithubUrl}
+          onLoadGithub={handleLoadGithub}
+          onLocalFilesSelected={handleLocalFilesSelected}
+        />
+        <AdvancedFilters
+          filterText={filterText}
+          onFilterTextChange={setFilterText}
+          totalCount={nodes.filter((node) => node.type === "blob").length}
+          selectedCount={selectedPaths.size}
+        />
+        <FileTree
+          nodes={filteredNodes}
+          selectedPaths={selectedPaths}
+          onTogglePath={handleTogglePath}
+        />
+        {statusMessage && (
+          <p
+            role="status"
+            className="text-xs text-text-subtle"
+          >
+            {statusMessage}
+          </p>
+        )}
+      </div>
+
+      <div
+        data-testid="repo2txt-output-panel"
+        className="rounded border p-3"
+      >
+        <OutputPanel
+          output={output}
+          busy={busy}
+          canGenerate={sourceLoaded}
+          onGenerate={handleGenerate}
+          onCopy={handleCopy}
+          onDownload={handleDownload}
+        />
+      </div>
     </section>
   )
 }

--- a/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
@@ -1,13 +1,16 @@
 import { useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useStore } from "zustand"
+import { AdvancedFilters } from "./components/AdvancedFilters"
+import { FileTree } from "./components/FileTree"
+import { OutputPanel } from "./components/OutputPanel"
+import { ProviderSelector } from "./components/ProviderSelector"
+import { fetchFilesWithConcurrency } from "./fetchFilesWithConcurrency"
 import { Formatter } from "./formatter/Formatter"
 import { GitHubProvider } from "./providers/GitHubProvider"
 import { LocalProvider } from "./providers/LocalProvider"
 import type { IProvider, RepoTreeNode } from "./providers/types"
 import { createRepo2TxtStore } from "./store"
-import { AdvancedFilters } from "./components/AdvancedFilters"
-import { FileTree } from "./components/FileTree"
-import { OutputPanel } from "./components/OutputPanel"
-import { ProviderSelector } from "./components/ProviderSelector"
 
 type ProviderKind = "github" | "local" | null
 
@@ -19,12 +22,15 @@ const toDisplayTree = (nodes: RepoTreeNode[]) =>
   }))
 
 export function Repo2TxtPage() {
+  const { t } = useTranslation(["option"])
   const storeRef = useRef(createRepo2TxtStore())
+  const store = storeRef.current
+  const nodes = useStore(store, (state) => state.nodes)
+  const selectedPaths = useStore(store, (state) => state.selectedPaths)
+
   const [providerKind, setProviderKind] = useState<ProviderKind>(null)
   const [provider, setProvider] = useState<IProvider | null>(null)
   const [githubUrl, setGithubUrl] = useState("")
-  const [nodes, setNodes] = useState<RepoTreeNode[]>([])
-  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(new Set())
   const [filterText, setFilterText] = useState("")
   const [output, setOutput] = useState("")
   const [busy, setBusy] = useState(false)
@@ -37,11 +43,8 @@ export function Repo2TxtPage() {
     return nodes.filter((node) => node.path.toLowerCase().includes(query))
   }, [nodes, filterText])
 
-  const syncNodesIntoState = (nextNodes: RepoTreeNode[]) => {
-    storeRef.current.getState().setNodes(nextNodes)
-    const storeState = storeRef.current.getState()
-    setNodes(storeState.nodes)
-    setSelectedPaths(new Set(storeState.selectedPaths))
+  const syncNodesIntoStore = (nextNodes: RepoTreeNode[]) => {
+    store.getState().setNodes(nextNodes)
   }
 
   const handleSelectProvider = (nextProvider: Exclude<ProviderKind, null>) => {
@@ -50,7 +53,7 @@ export function Repo2TxtPage() {
     setSourceLoaded(false)
     setOutput("")
     setStatusMessage("")
-    syncNodesIntoState([])
+    syncNodesIntoStore([])
   }
 
   const handleLoadGithub = async () => {
@@ -59,18 +62,32 @@ export function Repo2TxtPage() {
     try {
       const githubProvider = new GitHubProvider()
       if (!githubProvider.validateUrl(githubUrl)) {
-        throw new Error("Enter a valid GitHub repository URL.")
+        throw new Error(
+          t("option:repo2txt.errors.invalidGithubUrl", {
+            defaultValue: "Enter a valid GitHub repository URL."
+          })
+        )
       }
 
       const tree = await githubProvider.fetchTree(githubUrl)
       setProvider(githubProvider)
-      syncNodesIntoState(tree)
+      syncNodesIntoStore(tree)
       setSourceLoaded(tree.length > 0)
-      setStatusMessage(`Loaded ${tree.length} file tree entries.`)
+      setStatusMessage(
+        t("option:repo2txt.status.loadedTree", {
+          defaultValue: "Loaded {{count}} file tree entries.",
+          count: tree.length
+        })
+      )
     } catch (error) {
+      console.error("Failed to load GitHub repository.", error)
       setSourceLoaded(false)
       setStatusMessage(
-        error instanceof Error ? error.message : "Failed to load GitHub repository."
+        error instanceof Error
+          ? error.message
+          : t("option:repo2txt.errors.loadGithub", {
+              defaultValue: "Failed to load GitHub repository."
+            })
       )
     } finally {
       setBusy(false)
@@ -83,8 +100,7 @@ export function Repo2TxtPage() {
     try {
       const localProvider = new LocalProvider()
       const firstFile = files[0]
-      const looksLikeZip =
-        files.length === 1 && /\.zip$/i.test(firstFile?.name ?? "")
+      const looksLikeZip = files.length === 1 && /\.zip$/i.test(firstFile?.name ?? "")
 
       if (looksLikeZip) {
         await localProvider.initialize({
@@ -100,13 +116,23 @@ export function Repo2TxtPage() {
 
       const tree = await localProvider.fetchTree("local://directory")
       setProvider(localProvider)
-      syncNodesIntoState(tree)
+      syncNodesIntoStore(tree)
       setSourceLoaded(tree.length > 0)
-      setStatusMessage(`Loaded ${tree.length} local files.`)
+      setStatusMessage(
+        t("option:repo2txt.status.loadedLocal", {
+          defaultValue: "Loaded {{count}} local files.",
+          count: tree.length
+        })
+      )
     } catch (error) {
+      console.error("Failed to load local files.", error)
       setSourceLoaded(false)
       setStatusMessage(
-        error instanceof Error ? error.message : "Failed to load local files."
+        error instanceof Error
+          ? error.message
+          : t("option:repo2txt.errors.loadLocal", {
+              defaultValue: "Failed to load local files."
+            })
       )
     } finally {
       setBusy(false)
@@ -114,15 +140,7 @@ export function Repo2TxtPage() {
   }
 
   const handleTogglePath = (path: string) => {
-    setSelectedPaths((previous) => {
-      const next = new Set(previous)
-      if (next.has(path)) {
-        next.delete(path)
-      } else {
-        next.add(path)
-      }
-      return next
-    })
+    store.getState().togglePath(path)
   }
 
   const handleGenerate = async () => {
@@ -134,27 +152,52 @@ export function Repo2TxtPage() {
 
     if (selectedNodes.length === 0) {
       setOutput("")
-      setStatusMessage("Select at least one file to generate output.")
+      setStatusMessage(
+        t("option:repo2txt.status.selectAtLeastOne", {
+          defaultValue: "Select at least one file to generate output."
+        })
+      )
       return
     }
 
     setBusy(true)
     setStatusMessage("")
     try {
-      const fileContents = await Promise.all(
-        selectedNodes.map((node) => provider.fetchFile(node))
-      )
+      const fileContents = await fetchFilesWithConcurrency({
+        nodes: selectedNodes,
+        provider,
+        limit: 5,
+        onProgress: (completed, total) => {
+          setStatusMessage(
+            t("option:repo2txt.status.fetchingFiles", {
+              defaultValue: "Fetching files ({{completed}}/{{total}})...",
+              completed,
+              total
+            })
+          )
+        }
+      })
       const formatted = await Formatter.formatAsync(
         toDisplayTree(selectedNodes),
         fileContents
       )
       setOutput(`${formatted.directoryTree}\n\n${formatted.fileContents}`)
       setStatusMessage(
-        `Generated output for ${selectedNodes.length} files (${formatted.tokenCount} tokens).`
+        t("option:repo2txt.status.generated", {
+          defaultValue:
+            "Generated output for {{count}} files ({{tokenCount}} tokens).",
+          count: selectedNodes.length,
+          tokenCount: formatted.tokenCount
+        })
       )
     } catch (error) {
+      console.error("Failed to generate output.", error)
       setStatusMessage(
-        error instanceof Error ? error.message : "Failed to generate output."
+        error instanceof Error
+          ? error.message
+          : t("option:repo2txt.errors.generate", {
+              defaultValue: "Failed to generate output."
+            })
       )
     } finally {
       setBusy(false)

--- a/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/Repo2TxtPage.tsx
@@ -1,0 +1,8 @@
+export function Repo2TxtPage() {
+  return (
+    <section data-testid="repo2txt-route-root">
+      <div data-testid="repo2txt-provider-panel" />
+      <div data-testid="repo2txt-output-panel" />
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+import { Repo2TxtPage } from "../Repo2TxtPage"
+
+describe("Repo2TxtPage flow", () => {
+  it("keeps Generate disabled until a source is loaded", async () => {
+    render(<Repo2TxtPage />)
+    const generate = screen.getByRole("button", { name: /generate output/i })
+    expect(generate).toBeDisabled()
+    await userEvent.click(screen.getByRole("button", { name: /github/i }))
+    expect(generate).toBeDisabled()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Repo2TxtPage } from "../Repo2TxtPage"
+
+describe("Repo2TxtPage", () => {
+  it("shows provider panel and output panel placeholders", () => {
+    render(<Repo2TxtPage />)
+    expect(screen.getByTestId("repo2txt-provider-panel")).toBeInTheDocument()
+    expect(screen.getByTestId("repo2txt-output-panel")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/fetchFilesWithConcurrency.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/__tests__/fetchFilesWithConcurrency.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import type { RepoFileContent, RepoTreeNode } from "../providers/types"
+import { fetchFilesWithConcurrency } from "../fetchFilesWithConcurrency"
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe("fetchFilesWithConcurrency", () => {
+  it("limits concurrent fetches", async () => {
+    const nodes: RepoTreeNode[] = Array.from({ length: 7 }, (_, index) => ({
+      path: `src/file-${index}.ts`,
+      type: "blob",
+      url: `src/file-${index}.ts`
+    }))
+
+    let inFlight = 0
+    let maxInFlight = 0
+
+    const provider = {
+      fetchFile: async (node: RepoTreeNode): Promise<RepoFileContent> => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        await sleep(5)
+        inFlight -= 1
+        return {
+          path: node.path,
+          text: `content-${node.path}`,
+          lineCount: 1
+        }
+      }
+    }
+
+    const progress: number[] = []
+    const result = await fetchFilesWithConcurrency({
+      nodes,
+      provider,
+      limit: 3,
+      onProgress: (completed) => progress.push(completed)
+    })
+
+    expect(result).toHaveLength(nodes.length)
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+    expect(progress.at(-1)).toBe(nodes.length)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/AdvancedFilters.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/AdvancedFilters.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next"
+
 type AdvancedFiltersProps = {
   filterText: string
   onFilterTextChange: (value: string) => void
@@ -11,19 +13,29 @@ export function AdvancedFilters({
   totalCount,
   selectedCount
 }: AdvancedFiltersProps) {
+  const { t } = useTranslation(["option"])
+
   return (
     <section className="space-y-2">
       <header className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold">Filters</h3>
+        <h3 className="text-sm font-semibold">
+          {t("option:repo2txt.filters", { defaultValue: "Filters" })}
+        </h3>
         <span className="text-xs text-text-subtle">
-          {selectedCount}/{totalCount} selected
+          {t("option:repo2txt.selectedCount", {
+            defaultValue: "{{selected}}/{{total}} selected",
+            selected: selectedCount,
+            total: totalCount
+          })}
         </span>
       </header>
       <input
         type="search"
         value={filterText}
         onChange={(event) => onFilterTextChange(event.target.value)}
-        placeholder="Filter files"
+        placeholder={t("option:repo2txt.filterFiles", {
+          defaultValue: "Filter files"
+        })}
         className="w-full rounded border px-3 py-1.5 text-sm"
       />
     </section>

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/AdvancedFilters.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/AdvancedFilters.tsx
@@ -1,0 +1,31 @@
+type AdvancedFiltersProps = {
+  filterText: string
+  onFilterTextChange: (value: string) => void
+  totalCount: number
+  selectedCount: number
+}
+
+export function AdvancedFilters({
+  filterText,
+  onFilterTextChange,
+  totalCount,
+  selectedCount
+}: AdvancedFiltersProps) {
+  return (
+    <section className="space-y-2">
+      <header className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Filters</h3>
+        <span className="text-xs text-text-subtle">
+          {selectedCount}/{totalCount} selected
+        </span>
+      </header>
+      <input
+        type="search"
+        value={filterText}
+        onChange={(event) => onFilterTextChange(event.target.value)}
+        placeholder="Filter files"
+        className="w-full rounded border px-3 py-1.5 text-sm"
+      />
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/FileTree.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/FileTree.tsx
@@ -1,0 +1,37 @@
+import type { RepoTreeNode } from "../providers/types"
+
+type FileTreeProps = {
+  nodes: RepoTreeNode[]
+  selectedPaths: Set<string>
+  onTogglePath: (path: string) => void
+}
+
+export function FileTree({ nodes, selectedPaths, onTogglePath }: FileTreeProps) {
+  if (nodes.length === 0) {
+    return <p className="text-sm text-text-subtle">No files loaded.</p>
+  }
+
+  return (
+    <section className="space-y-2">
+      <h3 className="text-sm font-semibold">File Tree</h3>
+      <ul className="max-h-64 space-y-1 overflow-auto rounded border p-2">
+        {nodes
+          .filter((node) => node.type === "blob")
+          .map((node) => (
+            <li
+              key={node.path}
+              className="flex items-center gap-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={selectedPaths.has(node.path)}
+                onChange={() => onTogglePath(node.path)}
+                aria-label={`Select ${node.path}`}
+              />
+              <span className="truncate">{node.path}</span>
+            </li>
+          ))}
+      </ul>
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/OutputPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/OutputPanel.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "react-i18next"
+
 type OutputPanelProps = {
   output: string
   busy: boolean
@@ -15,17 +17,21 @@ export function OutputPanel({
   onCopy,
   onDownload
 }: OutputPanelProps) {
+  const { t } = useTranslation(["option"])
+
   return (
     <section className="space-y-3">
       <header className="flex flex-wrap items-center gap-2">
-        <h2 className="text-sm font-semibold">Output</h2>
+        <h2 className="text-sm font-semibold">
+          {t("option:repo2txt.output", { defaultValue: "Output" })}
+        </h2>
         <button
           type="button"
           className="rounded border px-3 py-1.5 text-sm"
           onClick={() => void onGenerate()}
           disabled={!canGenerate || busy}
         >
-          Generate Output
+          {t("option:repo2txt.generate", { defaultValue: "Generate Output" })}
         </button>
         <button
           type="button"
@@ -33,7 +39,7 @@ export function OutputPanel({
           onClick={() => void onCopy()}
           disabled={output.trim().length === 0}
         >
-          Copy
+          {t("option:repo2txt.copy", { defaultValue: "Copy" })}
         </button>
         <button
           type="button"
@@ -41,7 +47,7 @@ export function OutputPanel({
           onClick={onDownload}
           disabled={output.trim().length === 0}
         >
-          Download
+          {t("option:repo2txt.download", { defaultValue: "Download" })}
         </button>
       </header>
       <textarea
@@ -49,7 +55,9 @@ export function OutputPanel({
         readOnly
         rows={14}
         className="w-full rounded border p-3 text-xs"
-        aria-label="Repo2txt output preview"
+        aria-label={t("option:repo2txt.outputPreviewAria", {
+          defaultValue: "Repo2txt output preview"
+        })}
       />
     </section>
   )

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/OutputPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/OutputPanel.tsx
@@ -1,0 +1,56 @@
+type OutputPanelProps = {
+  output: string
+  busy: boolean
+  canGenerate: boolean
+  onGenerate: () => void | Promise<void>
+  onCopy: () => void | Promise<void>
+  onDownload: () => void
+}
+
+export function OutputPanel({
+  output,
+  busy,
+  canGenerate,
+  onGenerate,
+  onCopy,
+  onDownload
+}: OutputPanelProps) {
+  return (
+    <section className="space-y-3">
+      <header className="flex flex-wrap items-center gap-2">
+        <h2 className="text-sm font-semibold">Output</h2>
+        <button
+          type="button"
+          className="rounded border px-3 py-1.5 text-sm"
+          onClick={() => void onGenerate()}
+          disabled={!canGenerate || busy}
+        >
+          Generate Output
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-1.5 text-sm"
+          onClick={() => void onCopy()}
+          disabled={output.trim().length === 0}
+        >
+          Copy
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-1.5 text-sm"
+          onClick={onDownload}
+          disabled={output.trim().length === 0}
+        >
+          Download
+        </button>
+      </header>
+      <textarea
+        value={output}
+        readOnly
+        rows={14}
+        className="w-full rounded border p-3 text-xs"
+        aria-label="Repo2txt output preview"
+      />
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/ProviderSelector.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/ProviderSelector.tsx
@@ -1,0 +1,93 @@
+import type { ChangeEvent } from "react"
+
+type ProviderKind = "github" | "local" | null
+
+type ProviderSelectorProps = {
+  provider: ProviderKind
+  githubUrl: string
+  busy: boolean
+  onSelectProvider: (provider: Exclude<ProviderKind, null>) => void
+  onGithubUrlChange: (value: string) => void
+  onLoadGithub: () => void | Promise<void>
+  onLocalFilesSelected: (files: FileList) => void | Promise<void>
+}
+
+const handleFileSelection = (
+  event: ChangeEvent<HTMLInputElement>,
+  callback: (files: FileList) => void | Promise<void>
+) => {
+  const files = event.target.files
+  if (!files || files.length === 0) return
+  void callback(files)
+}
+
+export function ProviderSelector({
+  provider,
+  githubUrl,
+  busy,
+  onSelectProvider,
+  onGithubUrlChange,
+  onLoadGithub,
+  onLocalFilesSelected
+}: ProviderSelectorProps) {
+  return (
+    <section className="space-y-3">
+      <header>
+        <h2 className="text-sm font-semibold">Source Provider</h2>
+      </header>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded border px-3 py-1.5 text-sm"
+          aria-pressed={provider === "github"}
+          onClick={() => onSelectProvider("github")}
+        >
+          GitHub
+        </button>
+        <button
+          type="button"
+          className="rounded border px-3 py-1.5 text-sm"
+          aria-pressed={provider === "local"}
+          onClick={() => onSelectProvider("local")}
+        >
+          Local
+        </button>
+      </div>
+
+      {provider === "github" && (
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="url"
+            value={githubUrl}
+            onChange={(event) => onGithubUrlChange(event.target.value)}
+            placeholder="https://github.com/owner/repo"
+            className="min-w-[260px] flex-1 rounded border px-3 py-1.5 text-sm"
+          />
+          <button
+            type="button"
+            className="rounded border px-3 py-1.5 text-sm"
+            onClick={() => void onLoadGithub()}
+            disabled={busy || githubUrl.trim().length === 0}
+          >
+            Load Source
+          </button>
+        </div>
+      )}
+
+      {provider === "local" && (
+        <div className="space-y-2">
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded border px-3 py-1.5 text-sm">
+            <span>Choose Directory / Zip</span>
+            <input
+              type="file"
+              className="hidden"
+              onChange={(event) => handleFileSelection(event, onLocalFilesSelected)}
+              multiple
+            />
+          </label>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/ProviderSelector.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/ProviderSelector.tsx
@@ -1,4 +1,5 @@
 import type { ChangeEvent } from "react"
+import { useTranslation } from "react-i18next"
 
 type ProviderKind = "github" | "local" | null
 
@@ -17,9 +18,19 @@ const handleFileSelection = (
   callback: (files: FileList) => void | Promise<void>
 ) => {
   const files = event.target.files
-  if (!files || files.length === 0) return
-  void callback(files)
+  if (!files || files.length === 0) {
+    event.target.value = ""
+    return
+  }
+  void Promise.resolve(callback(files)).finally(() => {
+    event.target.value = ""
+  })
 }
+
+const directoryPickerAttributes = {
+  webkitdirectory: "",
+  directory: ""
+} as Record<string, string>
 
 export function ProviderSelector({
   provider,
@@ -30,10 +41,14 @@ export function ProviderSelector({
   onLoadGithub,
   onLocalFilesSelected
 }: ProviderSelectorProps) {
+  const { t } = useTranslation(["option"])
+
   return (
     <section className="space-y-3">
       <header>
-        <h2 className="text-sm font-semibold">Source Provider</h2>
+        <h2 className="text-sm font-semibold">
+          {t("option:repo2txt.providerTitle", { defaultValue: "Source Provider" })}
+        </h2>
       </header>
 
       <div className="flex items-center gap-2">
@@ -43,7 +58,7 @@ export function ProviderSelector({
           aria-pressed={provider === "github"}
           onClick={() => onSelectProvider("github")}
         >
-          GitHub
+          {t("option:repo2txt.providerGithub", { defaultValue: "GitHub" })}
         </button>
         <button
           type="button"
@@ -51,7 +66,7 @@ export function ProviderSelector({
           aria-pressed={provider === "local"}
           onClick={() => onSelectProvider("local")}
         >
-          Local
+          {t("option:repo2txt.providerLocal", { defaultValue: "Local" })}
         </button>
       </div>
 
@@ -61,7 +76,9 @@ export function ProviderSelector({
             type="url"
             value={githubUrl}
             onChange={(event) => onGithubUrlChange(event.target.value)}
-            placeholder="https://github.com/owner/repo"
+            placeholder={t("option:repo2txt.githubPlaceholder", {
+              defaultValue: "https://github.com/owner/repo"
+            })}
             className="min-w-[260px] flex-1 rounded border px-3 py-1.5 text-sm"
           />
           <button
@@ -70,20 +87,32 @@ export function ProviderSelector({
             onClick={() => void onLoadGithub()}
             disabled={busy || githubUrl.trim().length === 0}
           >
-            Load Source
+            {t("option:repo2txt.loadSource", { defaultValue: "Load Source" })}
           </button>
         </div>
       )}
 
       {provider === "local" && (
-        <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
           <label className="inline-flex cursor-pointer items-center gap-2 rounded border px-3 py-1.5 text-sm">
-            <span>Choose Directory / Zip</span>
+            <span>{t("option:repo2txt.chooseDirectory", { defaultValue: "Choose Directory" })}</span>
             <input
               type="file"
+              data-testid="repo2txt-local-directory-input"
               className="hidden"
               onChange={(event) => handleFileSelection(event, onLocalFilesSelected)}
               multiple
+              {...directoryPickerAttributes}
+            />
+          </label>
+          <label className="inline-flex cursor-pointer items-center gap-2 rounded border px-3 py-1.5 text-sm">
+            <span>{t("option:repo2txt.chooseZip", { defaultValue: "Choose Zip" })}</span>
+            <input
+              type="file"
+              data-testid="repo2txt-local-zip-input"
+              className="hidden"
+              onChange={(event) => handleFileSelection(event, onLocalFilesSelected)}
+              accept=".zip,application/zip"
             />
           </label>
         </div>

--- a/apps/packages/ui/src/components/Option/Repo2Txt/components/__tests__/ProviderSelector.test.tsx
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/components/__tests__/ProviderSelector.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { ProviderSelector } from "../ProviderSelector"
+
+describe("ProviderSelector", () => {
+  it("renders dedicated local directory and zip pickers", () => {
+    const noop = vi.fn()
+
+    render(
+      <ProviderSelector
+        provider="local"
+        githubUrl=""
+        busy={false}
+        onSelectProvider={noop}
+        onGithubUrlChange={noop}
+        onLoadGithub={noop}
+        onLocalFilesSelected={noop}
+      />
+    )
+
+    const directoryInput = screen.getByTestId("repo2txt-local-directory-input")
+    const zipInput = screen.getByTestId("repo2txt-local-zip-input")
+
+    expect(directoryInput).toHaveAttribute("webkitdirectory")
+    expect(directoryInput).toHaveAttribute("multiple")
+    expect(zipInput).toHaveAttribute("accept", ".zip,application/zip")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/fetchFilesWithConcurrency.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/fetchFilesWithConcurrency.ts
@@ -1,0 +1,50 @@
+import type {
+  IProvider,
+  RepoFileContent,
+  RepoTreeNode
+} from "./providers/types"
+
+type FetchFilesWithConcurrencyOptions = {
+  nodes: RepoTreeNode[]
+  provider: Pick<IProvider, "fetchFile">
+  limit?: number
+  onProgress?: (completed: number, total: number) => void
+}
+
+export async function fetchFilesWithConcurrency({
+  nodes,
+  provider,
+  limit = 5,
+  onProgress
+}: FetchFilesWithConcurrencyOptions): Promise<RepoFileContent[]> {
+  if (nodes.length === 0) {
+    onProgress?.(0, 0)
+    return []
+  }
+
+  const safeLimit = Math.max(1, Math.floor(limit))
+  const result: RepoFileContent[] = new Array(nodes.length)
+  let cursor = 0
+  let completed = 0
+
+  const worker = async () => {
+    while (true) {
+      const index = cursor
+      cursor += 1
+      if (index >= nodes.length) {
+        return
+      }
+      const content = await provider.fetchFile(nodes[index])
+      result[index] = content
+      completed += 1
+      onProgress?.(completed, nodes.length)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(safeLimit, nodes.length) },
+    () => worker()
+  )
+  await Promise.all(workers)
+  return result
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/Formatter.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/Formatter.ts
@@ -1,0 +1,72 @@
+import { getTokenizerWorker } from "./TokenizerWorker"
+
+type TreeItem = {
+  name?: string
+  path: string
+  type?: string
+}
+
+type FileContentItem = {
+  path: string
+  text: string
+}
+
+type FormattedOutput = {
+  directoryTree: string
+  fileContents: string
+  tokenCount: number
+  lineCount: number
+}
+
+export class Formatter {
+  static async formatAsync(
+    tree: TreeItem[],
+    fileContents: FileContentItem[],
+    onProgress?: (progress: number, current: number, total: number) => void
+  ): Promise<FormattedOutput> {
+    const directoryTree = this.generateDirectoryTree(tree)
+    const worker = getTokenizerWorker()
+    const batch = await worker.tokenizeBatch(
+      fileContents.map((item) => ({
+        path: item.path,
+        content: item.text
+      })),
+      onProgress
+    )
+
+    const fileContentsText = this.generateFileContents(fileContents)
+    const treeTokens = await worker.tokenize(directoryTree)
+    const fullOutput = `${directoryTree}\n\n${fileContentsText}`
+
+    return {
+      directoryTree,
+      fileContents: fileContentsText,
+      tokenCount: treeTokens + batch.totalTokens,
+      lineCount: fullOutput.split("\n").length
+    }
+  }
+
+  private static generateDirectoryTree(tree: TreeItem[]): string {
+    const lines = ["Directory Structure:", "---"]
+    for (const node of tree) {
+      const name = node.path || node.name || "unknown"
+      lines.push(`- ${name}`)
+    }
+    return lines.join("\n")
+  }
+
+  private static generateFileContents(fileContents: FileContentItem[]): string {
+    if (fileContents.length === 0) {
+      return "File Contents:\n---\n\nNo files selected."
+    }
+
+    const sections: string[] = ["File Contents:", "---"]
+    for (const file of fileContents) {
+      sections.push("")
+      sections.push(`File: ${file.path}`)
+      sections.push("---")
+      sections.push(file.text)
+    }
+    return sections.join("\n")
+  }
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
@@ -1,0 +1,146 @@
+import type {
+  ProgressResponse,
+  TokenizeFileRequest,
+  TokenizeRequest,
+  TokenizeResponse
+} from "../workers/tokenizer.worker"
+
+type TokenizerMessage = TokenizeResponse | ProgressResponse
+type MessageHandler = (payload: TokenizerMessage) => void
+
+const estimateTokens = (text: string): number => {
+  const normalized = String(text || "").trim()
+  if (!normalized) return 0
+  return normalized.split(/\s+/).length
+}
+
+export class TokenizerWorker {
+  private worker: Worker | null = null
+  private handlers = new Map<string, MessageHandler>()
+  private requestId = 0
+
+  constructor() {
+    this.initWorker()
+  }
+
+  private initWorker() {
+    if (typeof Worker === "undefined") {
+      this.worker = null
+      return
+    }
+
+    try {
+      this.worker = new Worker(
+        new URL("../workers/tokenizer.worker.ts", import.meta.url),
+        { type: "module" }
+      )
+
+      this.worker.onmessage = (event: MessageEvent<TokenizerMessage>) => {
+        const payload = event.data
+        const id = payload?.id
+        if (!id) return
+        const handler = this.handlers.get(id)
+        if (!handler) return
+        handler(payload)
+        if ("tokenCount" in payload) {
+          this.handlers.delete(id)
+        }
+      }
+    } catch {
+      this.worker = null
+    }
+  }
+
+  async tokenize(text: string): Promise<number> {
+    if (!this.worker) {
+      return estimateTokens(text)
+    }
+
+    return await new Promise<number>((resolve, reject) => {
+      const id = `single-${++this.requestId}`
+      this.handlers.set(id, (payload) => {
+        if ("tokenCount" in payload) {
+          if (payload.error) {
+            reject(new Error(payload.error))
+            return
+          }
+          resolve(payload.tokenCount)
+        }
+      })
+
+      const request: TokenizeRequest = {
+        id,
+        type: "single",
+        text
+      }
+      this.worker!.postMessage(request)
+    })
+  }
+
+  async tokenizeBatch(
+    files: TokenizeFileRequest[],
+    onProgress?: (progress: number, current: number, total: number) => void
+  ): Promise<{
+    totalTokens: number
+    files: Array<{ path: string; tokenCount: number; lineCount: number }>
+  }> {
+    if (!this.worker) {
+      const results = files.map((file) => ({
+        path: file.path,
+        tokenCount: estimateTokens(file.content),
+        lineCount: String(file.content || "").split("\n").length
+      }))
+      return {
+        totalTokens: results.reduce((sum, item) => sum + item.tokenCount, 0),
+        files: results
+      }
+    }
+
+    return await new Promise((resolve, reject) => {
+      const id = `batch-${++this.requestId}`
+      this.handlers.set(id, (payload) => {
+        if ("progress" in payload) {
+          onProgress?.(payload.progress, payload.current, payload.total)
+          return
+        }
+
+        if (payload.error) {
+          reject(new Error(payload.error))
+          return
+        }
+
+        resolve({
+          totalTokens: payload.tokenCount,
+          files: payload.files ?? []
+        })
+      })
+
+      const request: TokenizeRequest = {
+        id,
+        type: "batch",
+        files
+      }
+      this.worker!.postMessage(request)
+    })
+  }
+
+  terminate(): void {
+    this.worker?.terminate()
+    this.worker = null
+    this.handlers.clear()
+  }
+}
+
+let tokenizerWorkerInstance: TokenizerWorker | null = null
+
+export const getTokenizerWorker = (): TokenizerWorker => {
+  if (!tokenizerWorkerInstance) {
+    tokenizerWorkerInstance = new TokenizerWorker()
+  }
+  return tokenizerWorkerInstance
+}
+
+export const terminateTokenizerWorker = (): void => {
+  tokenizerWorkerInstance?.terminate()
+  tokenizerWorkerInstance = null
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
@@ -8,6 +8,14 @@ import type {
 
 type TokenizerMessage = TokenizeResponse | ProgressResponse
 type MessageHandler = (payload: TokenizerMessage) => void
+type RejectHandler = (error: Error) => void
+type PendingRequest = {
+  handle: MessageHandler
+  reject: RejectHandler
+  timeoutId: ReturnType<typeof setTimeout>
+}
+
+const REQUEST_TIMEOUT_MS = 10_000
 
 const estimateTokens = (text: string): number => {
   const normalized = String(text || "")
@@ -22,7 +30,7 @@ const estimateTokens = (text: string): number => {
 
 export class TokenizerWorker {
   private worker: Worker | null = null
-  private handlers = new Map<string, MessageHandler>()
+  private handlers = new Map<string, PendingRequest>()
   private requestId = 0
 
   constructor() {
@@ -45,16 +53,50 @@ export class TokenizerWorker {
         const payload = event.data
         const id = payload?.id
         if (!id) return
-        const handler = this.handlers.get(id)
-        if (!handler) return
-        handler(payload)
+        const pending = this.handlers.get(id)
+        if (!pending) return
+        pending.handle(payload)
         if ("tokenCount" in payload) {
+          clearTimeout(pending.timeoutId)
           this.handlers.delete(id)
         }
+      }
+      this.worker.onerror = () => {
+        this.failPendingRequests("Tokenizer worker error")
+      }
+      this.worker.onmessageerror = () => {
+        this.failPendingRequests("Tokenizer worker message error")
       }
     } catch {
       this.worker = null
     }
+  }
+
+  private failPendingRequests(reason: string) {
+    for (const [, pending] of this.handlers) {
+      clearTimeout(pending.timeoutId)
+      pending.reject(new Error(reason))
+    }
+    this.handlers.clear()
+    this.worker?.terminate()
+    this.worker = null
+    this.initWorker()
+  }
+
+  private registerPendingRequest(
+    id: string,
+    handle: MessageHandler,
+    reject: RejectHandler
+  ) {
+    const timeoutId = setTimeout(() => {
+      this.handlers.delete(id)
+      reject(new Error(`Tokenizer worker request timed out after ${REQUEST_TIMEOUT_MS}ms`))
+    }, REQUEST_TIMEOUT_MS)
+    this.handlers.set(id, {
+      handle,
+      reject,
+      timeoutId
+    })
   }
 
   async tokenize(text: string): Promise<number> {
@@ -64,22 +106,37 @@ export class TokenizerWorker {
 
     return await new Promise<number>((resolve, reject) => {
       const id = `single-${++this.requestId}`
-      this.handlers.set(id, (payload) => {
-        if ("tokenCount" in payload) {
-          if (payload.error) {
-            reject(new Error(payload.error))
-            return
+      this.registerPendingRequest(
+        id,
+        (payload) => {
+          if ("tokenCount" in payload) {
+            if (payload.error) {
+              reject(new Error(payload.error))
+              return
+            }
+            resolve(payload.tokenCount)
           }
-          resolve(payload.tokenCount)
-        }
-      })
+        },
+        reject
+      )
 
       const request: TokenizeRequest = {
         id,
         type: "single",
         text
       }
-      this.worker!.postMessage(request)
+      try {
+        this.worker!.postMessage(request)
+      } catch (error) {
+        const pending = this.handlers.get(id)
+        if (pending) {
+          clearTimeout(pending.timeoutId)
+          this.handlers.delete(id)
+        }
+        reject(
+          error instanceof Error ? error : new Error("Failed to post tokenize request")
+        )
+      }
     })
   }
 
@@ -104,33 +161,53 @@ export class TokenizerWorker {
 
     return await new Promise((resolve, reject) => {
       const id = `batch-${++this.requestId}`
-      this.handlers.set(id, (payload) => {
-        if ("progress" in payload) {
-          onProgress?.(payload.progress, payload.current, payload.total)
-          return
-        }
+      this.registerPendingRequest(
+        id,
+        (payload) => {
+          if ("progress" in payload) {
+            onProgress?.(payload.progress, payload.current, payload.total)
+            return
+          }
 
-        if (payload.error) {
-          reject(new Error(payload.error))
-          return
-        }
+          if (payload.error) {
+            reject(new Error(payload.error))
+            return
+          }
 
-        resolve({
-          totalTokens: payload.tokenCount,
-          files: payload.files ?? []
-        })
-      })
+          resolve({
+            totalTokens: payload.tokenCount,
+            files: payload.files ?? []
+          })
+        },
+        reject
+      )
 
       const request: TokenizeRequest = {
         id,
         type: "batch",
         files
       }
-      this.worker!.postMessage(request)
+      try {
+        this.worker!.postMessage(request)
+      } catch (error) {
+        const pending = this.handlers.get(id)
+        if (pending) {
+          clearTimeout(pending.timeoutId)
+          this.handlers.delete(id)
+        }
+        reject(
+          error instanceof Error
+            ? error
+            : new Error("Failed to post tokenize batch request")
+        )
+      }
     })
   }
 
   terminate(): void {
+    for (const [, pending] of this.handlers) {
+      clearTimeout(pending.timeoutId)
+    }
     this.worker?.terminate()
     this.worker = null
     this.handlers.clear()

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/TokenizerWorker.ts
@@ -1,3 +1,4 @@
+import { encode } from "gpt-tokenizer"
 import type {
   ProgressResponse,
   TokenizeFileRequest,
@@ -9,9 +10,14 @@ type TokenizerMessage = TokenizeResponse | ProgressResponse
 type MessageHandler = (payload: TokenizerMessage) => void
 
 const estimateTokens = (text: string): number => {
-  const normalized = String(text || "").trim()
-  if (!normalized) return 0
-  return normalized.split(/\s+/).length
+  const normalized = String(text || "")
+  const trimmed = normalized.trim()
+  if (!trimmed) return 0
+  try {
+    return encode(trimmed).length
+  } catch {
+    return trimmed.split(/\s+/).length
+  }
 }
 
 export class TokenizerWorker {

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/__tests__/Formatter.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+import { Formatter } from "../Formatter"
+
+describe("Formatter", () => {
+  it("returns directory tree and token count", async () => {
+    const output = await Formatter.formatAsync(
+      [{ name: "a.ts", path: "a.ts", type: "file" }],
+      [{ path: "a.ts", text: "const a=1" }]
+    )
+    expect(output.directoryTree).toContain("a.ts")
+    expect(output.tokenCount).toBeGreaterThan(0)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/formatter/__tests__/TokenizerWorker.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/formatter/__tests__/TokenizerWorker.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TokenizerWorker } from "../TokenizerWorker"
+
+describe("TokenizerWorker", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it("rejects pending tokenize request when worker emits error", async () => {
+    class MockWorker {
+      onmessage: ((event: MessageEvent<unknown>) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      onmessageerror: ((event: MessageEvent<unknown>) => void) | null = null
+
+      postMessage() {
+        Promise.resolve().then(() => {
+          this.onerror?.(new Event("error"))
+        })
+      }
+
+      terminate() {
+        // no-op
+      }
+    }
+
+    vi.stubGlobal("Worker", MockWorker as unknown as typeof Worker)
+
+    const tokenizer = new TokenizerWorker()
+    await expect(tokenizer.tokenize("hello world")).rejects.toThrow(
+      "Tokenizer worker error"
+    )
+    tokenizer.terminate()
+  })
+
+  it("times out pending tokenize request when worker does not respond", async () => {
+    vi.useFakeTimers()
+
+    class MockWorker {
+      onmessage: ((event: MessageEvent<unknown>) => void) | null = null
+      onerror: ((event: Event) => void) | null = null
+      onmessageerror: ((event: MessageEvent<unknown>) => void) | null = null
+
+      postMessage() {
+        // intentionally never responds
+      }
+
+      terminate() {
+        // no-op
+      }
+    }
+
+    vi.stubGlobal("Worker", MockWorker as unknown as typeof Worker)
+
+    const tokenizer = new TokenizerWorker()
+    const pending = tokenizer.tokenize("will timeout")
+    const assertion = expect(pending).rejects.toThrow("timed out")
+    await vi.advanceTimersByTimeAsync(10_001)
+    await assertion
+    tokenizer.terminate()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/index.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/index.ts
@@ -1,0 +1,1 @@
+export { Repo2TxtPage } from "./Repo2TxtPage"

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/BaseProvider.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/BaseProvider.ts
@@ -1,0 +1,46 @@
+import type {
+  FetchTreeOptions,
+  IProvider,
+  ParsedRepoInfo,
+  ProviderCredentials,
+  ProviderType,
+  RepoFileContent,
+  RepoTreeNode
+} from "./types"
+
+export abstract class BaseProvider implements IProvider {
+  protected credentials: ProviderCredentials | null = null
+
+  abstract getType(): ProviderType
+  abstract getName(): string
+  abstract validateUrl(url: string): boolean
+  abstract parseUrl(url: string): ParsedRepoInfo
+  abstract fetchTree(url: string, options?: FetchTreeOptions): Promise<RepoTreeNode[]>
+
+  requiresAuth(): boolean {
+    return true
+  }
+
+  setCredentials(credentials: ProviderCredentials): void {
+    this.credentials = credentials
+  }
+
+  async fetchFile(node: RepoTreeNode): Promise<RepoFileContent> {
+    if (!node.url) {
+      throw new Error("Cannot fetch file content: missing file URL")
+    }
+
+    const response = await fetch(node.url)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch file ${node.path}: HTTP ${response.status}`)
+    }
+
+    const text = await response.text()
+    return {
+      path: node.path,
+      text,
+      url: node.url,
+      lineCount: text.split("\n").length
+    }
+  }
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/GitHubProvider.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/GitHubProvider.ts
@@ -1,0 +1,134 @@
+import { BaseProvider } from "./BaseProvider"
+import type { FetchTreeOptions, ParsedRepoInfo, RepoFileContent, RepoTreeNode } from "./types"
+
+type GitHubContentResponse = {
+  content?: string
+  encoding?: string
+}
+
+type GitHubTreeEntry = {
+  path: string
+  type: "blob" | "tree" | string
+  url?: string
+  size?: number
+  sha?: string
+}
+
+type GitHubTreeResponse = {
+  tree?: GitHubTreeEntry[]
+}
+
+const decodeBase64 = (value: string): string => {
+  if (typeof atob === "function") {
+    return atob(value)
+  }
+  throw new Error("Base64 decoding is not available in this runtime")
+}
+
+export class GitHubProvider extends BaseProvider {
+  private static readonly API_BASE = "https://api.github.com"
+  private static readonly URL_PATTERN =
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+)(?:\/tree\/(.+))?$/
+
+  getType() {
+    return "github" as const
+  }
+
+  getName() {
+    return "GitHub"
+  }
+
+  requiresAuth() {
+    return false
+  }
+
+  validateUrl(url: string): boolean {
+    const normalized = url.trim().replace(/\/$/, "")
+    return GitHubProvider.URL_PATTERN.test(normalized)
+  }
+
+  parseUrl(url: string): ParsedRepoInfo {
+    const normalized = url.trim().replace(/\/$/, "")
+    const match = normalized.match(GitHubProvider.URL_PATTERN)
+
+    if (!match) {
+      return {
+        url,
+        isValid: false,
+        error: "Invalid GitHub URL format. Expected https://github.com/owner/repo"
+      }
+    }
+
+    const [, owner, repo, branch] = match
+    return {
+      owner,
+      repo,
+      branch,
+      url,
+      isValid: true
+    }
+  }
+
+  async fetchTree(url: string, options: FetchTreeOptions = {}): Promise<RepoTreeNode[]> {
+    const parsed = this.parseUrl(url)
+    if (!parsed.isValid || !parsed.owner || !parsed.repo) {
+      throw new Error(parsed.error ?? "Invalid GitHub URL")
+    }
+
+    const ref = options.branch ?? parsed.branch ?? "HEAD"
+    const treeUrl =
+      `${GitHubProvider.API_BASE}/repos/${parsed.owner}/${parsed.repo}/git/trees/` +
+      `${encodeURIComponent(ref)}?recursive=1`
+    const response = await fetch(treeUrl, { headers: this.buildHeaders() })
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch GitHub tree: HTTP ${response.status}`)
+    }
+
+    const payload = (await response.json()) as GitHubTreeResponse
+    const tree = payload.tree ?? []
+    return tree.map((entry) => ({
+      path: entry.path,
+      type: entry.type === "blob" ? "blob" : "tree",
+      url: entry.url,
+      size: entry.size,
+      sha: entry.sha
+    }))
+  }
+
+  async fetchFile(node: RepoTreeNode): Promise<RepoFileContent> {
+    if (!node.url) {
+      throw new Error(`Cannot fetch file content for ${node.path}: missing URL`)
+    }
+
+    const response = await fetch(node.url, { headers: this.buildHeaders() })
+    if (!response.ok) {
+      throw new Error(`Failed to fetch file ${node.path}: HTTP ${response.status}`)
+    }
+
+    const data = (await response.json()) as GitHubContentResponse
+    let text = data.content ?? ""
+    if (data.encoding === "base64") {
+      text = decodeBase64(text.replace(/\s/g, ""))
+    }
+
+    return {
+      path: node.path,
+      text,
+      url: node.url,
+      lineCount: text.split("\n").length
+    }
+  }
+
+  private buildHeaders(): HeadersInit {
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json"
+    }
+
+    if (this.credentials?.token) {
+      headers.Authorization = `token ${this.credentials.token}`
+    }
+
+    return headers
+  }
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts
@@ -1,0 +1,136 @@
+import JSZip from "jszip"
+import { BaseProvider } from "./BaseProvider"
+import type { ParsedRepoInfo, RepoFileContent, RepoTreeNode } from "./types"
+
+type LocalSource = "directory" | "zip"
+
+export type LocalProviderInitializeOptions = {
+  source: LocalSource
+  files?: FileList
+  zipFile?: File
+  onProgress?: (progress: number, message: string) => void
+}
+
+export class LocalProvider extends BaseProvider {
+  private source: LocalSource | null = null
+  private fileMap = new Map<string, File>()
+  private zipInstance: JSZip | null = null
+
+  getType() {
+    return "local" as const
+  }
+
+  getName() {
+    return "Local"
+  }
+
+  requiresAuth() {
+    return false
+  }
+
+  validateUrl(url: string): boolean {
+    return url.startsWith("local://")
+  }
+
+  parseUrl(url: string): ParsedRepoInfo {
+    if (!this.validateUrl(url)) {
+      return {
+        url,
+        isValid: false,
+        error: "Invalid local URL. Expected local://directory or local://zip"
+      }
+    }
+    return {
+      url,
+      isValid: true
+    }
+  }
+
+  async initialize(options: LocalProviderInitializeOptions): Promise<void> {
+    this.source = options.source
+    this.fileMap.clear()
+    this.zipInstance = null
+
+    if (options.source === "directory") {
+      if (!options.files || options.files.length === 0) {
+        throw new Error("Directory initialization requires files")
+      }
+      for (let i = 0; i < options.files.length; i++) {
+        const file = options.files[i]
+        const path = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name
+        this.fileMap.set(path, file)
+      }
+      return
+    }
+
+    if (!options.zipFile) {
+      throw new Error("Zip initialization requires a zipFile")
+    }
+
+    options.onProgress?.(0, "Loading zip file")
+    this.zipInstance = await JSZip.loadAsync(options.zipFile)
+    options.onProgress?.(100, "Zip file loaded")
+  }
+
+  async fetchTree(_url: string): Promise<RepoTreeNode[]> {
+    if (!this.source) {
+      throw new Error("LocalProvider must be initialized before fetchTree")
+    }
+
+    if (this.source === "directory") {
+      return Array.from(this.fileMap.entries()).map(([path, file]) => ({
+        path,
+        type: "blob",
+        url: path,
+        urlType: "directory",
+        size: file.size
+      }))
+    }
+
+    if (!this.zipInstance) {
+      return []
+    }
+
+    const tree: RepoTreeNode[] = []
+    this.zipInstance.forEach((path, file) => {
+      if (file.dir) return
+      tree.push({
+        path,
+        type: "blob",
+        url: path,
+        urlType: "zip"
+      })
+    })
+    return tree
+  }
+
+  async fetchFile(node: RepoTreeNode): Promise<RepoFileContent> {
+    if (node.urlType === "directory") {
+      const file = this.fileMap.get(node.path)
+      if (!file) {
+        throw new Error(`Local file not found: ${node.path}`)
+      }
+      const text = await file.text()
+      return {
+        path: node.path,
+        text,
+        lineCount: text.split("\n").length
+      }
+    }
+
+    if (node.urlType === "zip") {
+      const zipFile = this.zipInstance?.file(node.path)
+      if (!zipFile) {
+        throw new Error(`Zip file entry not found: ${node.path}`)
+      }
+      const text = await zipFile.async("text")
+      return {
+        path: node.path,
+        text,
+        lineCount: text.split("\n").length
+      }
+    }
+
+    return super.fetchFile(node)
+  }
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/LocalProvider.ts
@@ -57,7 +57,13 @@ export class LocalProvider extends BaseProvider {
       }
       for (let i = 0; i < options.files.length; i++) {
         const file = options.files[i]
-        const path = (file as File & { webkitRelativePath?: string }).webkitRelativePath || file.name
+        const relativePath = (file as File & { webkitRelativePath?: string }).webkitRelativePath
+        const path = relativePath || file.name
+        if (!relativePath && this.fileMap.has(path)) {
+          throw new Error(
+            `Duplicate filename without directory context: ${path}. Use directory picker or zip source to preserve paths.`
+          )
+        }
         this.fileMap.set(path, file)
       }
       return

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/GitHubProvider.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { GitHubProvider } from "../GitHubProvider"
+
+describe("GitHubProvider", () => {
+  it("parses owner/repo from github URL", () => {
+    const provider = new GitHubProvider()
+    const parsed = provider.parseUrl("https://github.com/facebook/react")
+    expect(parsed.isValid).toBe(true)
+    expect(parsed.owner).toBe("facebook")
+    expect(parsed.repo).toBe("react")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/__tests__/LocalProvider.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { LocalProvider } from "../LocalProvider"
+
+describe("LocalProvider", () => {
+  it("initializes directory mode and returns blob nodes", async () => {
+    const provider = new LocalProvider()
+    const file = new File(["const a=1"], "src/a.ts", { type: "text/plain" })
+    await provider.initialize({
+      source: "directory",
+      files: { 0: file, length: 1 } as unknown as FileList
+    })
+    const tree = await provider.fetchTree("local://directory")
+    expect(tree.some((node) => node.path.includes("a.ts"))).toBe(true)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/types.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/types.ts
@@ -1,0 +1,46 @@
+export type ProviderType = "github" | "local"
+
+export type ProviderCredentials = {
+  token?: string
+}
+
+export type ParsedRepoInfo = {
+  owner?: string
+  repo?: string
+  branch?: string
+  path?: string
+  url: string
+  isValid: boolean
+  error?: string
+}
+
+export type FetchTreeOptions = {
+  branch?: string
+  path?: string
+}
+
+export type RepoTreeNode = {
+  path: string
+  type: "blob" | "tree"
+  url?: string
+  size?: number
+  sha?: string
+}
+
+export type RepoFileContent = {
+  path: string
+  text: string
+  url?: string
+  lineCount: number
+}
+
+export interface IProvider {
+  getType(): ProviderType
+  getName(): string
+  requiresAuth(): boolean
+  setCredentials(credentials: ProviderCredentials): void
+  validateUrl(url: string): boolean
+  parseUrl(url: string): ParsedRepoInfo
+  fetchTree(url: string, options?: FetchTreeOptions): Promise<RepoTreeNode[]>
+  fetchFile(node: RepoTreeNode): Promise<RepoFileContent>
+}

--- a/apps/packages/ui/src/components/Option/Repo2Txt/providers/types.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/providers/types.ts
@@ -23,6 +23,7 @@ export type RepoTreeNode = {
   path: string
   type: "blob" | "tree"
   url?: string
+  urlType?: "api" | "directory" | "zip"
   size?: number
   sha?: string
 }

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/__tests__/fileTreeSlice.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { createRepo2TxtStore } from "../index"
+
+describe("repo2txt file tree slice", () => {
+  it("auto-selects common code extensions", () => {
+    const store = createRepo2TxtStore()
+    store.getState().setNodes([{ path: "src/app.ts", type: "blob" }])
+    expect(store.getState().selectedPaths.has("src/app.ts")).toBe(true)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/fileTreeSlice.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/fileTreeSlice.ts
@@ -1,0 +1,54 @@
+import type { StateCreator } from "zustand"
+import type { RepoTreeNode } from "../providers/types"
+import type { Repo2TxtStoreState } from "./types"
+
+const AUTO_SELECT_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "py",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "rb",
+  "php",
+  "cs",
+  "cpp",
+  "c",
+  "h",
+  "md",
+  "json",
+  "yml",
+  "yaml"
+])
+
+const shouldAutoSelect = (node: RepoTreeNode): boolean => {
+  if (node.type !== "blob") return false
+  const match = node.path.toLowerCase().match(/\.([a-z0-9]+)$/)
+  if (!match) return false
+  return AUTO_SELECT_EXTENSIONS.has(match[1] ?? "")
+}
+
+export const createFileTreeSlice: StateCreator<
+  Repo2TxtStoreState,
+  [],
+  [],
+  Repo2TxtStoreState
+> = (set) => ({
+  nodes: [],
+  selectedPaths: new Set<string>(),
+  setNodes: (nodes) => {
+    const selectedPaths = new Set<string>()
+    for (const node of nodes) {
+      if (shouldAutoSelect(node)) {
+        selectedPaths.add(node.path)
+      }
+    }
+    set({
+      nodes,
+      selectedPaths
+    })
+  }
+})

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/fileTreeSlice.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/fileTreeSlice.ts
@@ -50,5 +50,18 @@ export const createFileTreeSlice: StateCreator<
       nodes,
       selectedPaths
     })
+  },
+  togglePath: (path) => {
+    set((state) => {
+      const nextSelected = new Set(state.selectedPaths)
+      if (nextSelected.has(path)) {
+        nextSelected.delete(path)
+      } else {
+        nextSelected.add(path)
+      }
+      return {
+        selectedPaths: nextSelected
+      }
+    })
   }
 })

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/index.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/index.ts
@@ -1,0 +1,8 @@
+import { createStore } from "zustand/vanilla"
+import { createFileTreeSlice } from "./fileTreeSlice"
+import type { Repo2TxtStoreState } from "./types"
+
+export const createRepo2TxtStore = () =>
+  createStore<Repo2TxtStoreState>()((...args) => ({
+    ...createFileTreeSlice(...args)
+  }))

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/types.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/types.ts
@@ -1,0 +1,9 @@
+import type { RepoTreeNode } from "../providers/types"
+
+export type Repo2TxtFileTreeSlice = {
+  nodes: RepoTreeNode[]
+  selectedPaths: Set<string>
+  setNodes: (nodes: RepoTreeNode[]) => void
+}
+
+export type Repo2TxtStoreState = Repo2TxtFileTreeSlice

--- a/apps/packages/ui/src/components/Option/Repo2Txt/store/types.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/store/types.ts
@@ -4,6 +4,7 @@ export type Repo2TxtFileTreeSlice = {
   nodes: RepoTreeNode[]
   selectedPaths: Set<string>
   setNodes: (nodes: RepoTreeNode[]) => void
+  togglePath: (path: string) => void
 }
 
 export type Repo2TxtStoreState = Repo2TxtFileTreeSlice

--- a/apps/packages/ui/src/components/Option/Repo2Txt/workers/tokenizer.worker.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/workers/tokenizer.worker.ts
@@ -1,3 +1,5 @@
+import { encode } from "gpt-tokenizer"
+
 export type TokenizeFileRequest = {
   path: string
   content: string
@@ -25,9 +27,20 @@ export type TokenizeResponse = {
 }
 
 const estimateTokens = (text: string): number => {
-  const normalized = String(text || "").trim()
-  if (!normalized) return 0
-  return normalized.split(/\s+/).length
+  const normalized = String(text || "")
+  const trimmed = normalized.trim()
+  if (!trimmed) return 0
+  try {
+    return encode(trimmed).length
+  } catch {
+    return trimmed.split(/\s+/).length
+  }
+}
+
+const countLines = (text: string): number => {
+  const normalized = String(text || "")
+  if (normalized.length === 0) return 0
+  return normalized.split("\n").length
 }
 
 self.onmessage = (event: MessageEvent<TokenizeRequest>) => {
@@ -54,7 +67,7 @@ self.onmessage = (event: MessageEvent<TokenizeRequest>) => {
       results.push({
         path: item.path,
         tokenCount: fileTokens,
-        lineCount: String(item.content || "").split("\n").length
+        lineCount: countLines(item.content)
       })
 
       const progressPayload: ProgressResponse = {

--- a/apps/packages/ui/src/components/Option/Repo2Txt/workers/tokenizer.worker.ts
+++ b/apps/packages/ui/src/components/Option/Repo2Txt/workers/tokenizer.worker.ts
@@ -1,0 +1,85 @@
+export type TokenizeFileRequest = {
+  path: string
+  content: string
+}
+
+export type TokenizeRequest = {
+  id: string
+  type: "single" | "batch"
+  text?: string
+  files?: TokenizeFileRequest[]
+}
+
+export type ProgressResponse = {
+  id: string
+  progress: number
+  current: number
+  total: number
+}
+
+export type TokenizeResponse = {
+  id: string
+  tokenCount: number
+  files?: Array<{ path: string; tokenCount: number; lineCount: number }>
+  error?: string
+}
+
+const estimateTokens = (text: string): number => {
+  const normalized = String(text || "").trim()
+  if (!normalized) return 0
+  return normalized.split(/\s+/).length
+}
+
+self.onmessage = (event: MessageEvent<TokenizeRequest>) => {
+  const request = event.data
+  try {
+    if (request.type === "single") {
+      const payload: TokenizeResponse = {
+        id: request.id,
+        tokenCount: estimateTokens(request.text ?? "")
+      }
+      self.postMessage(payload)
+      return
+    }
+
+    const files = request.files ?? []
+    const total = files.length
+    const results: Array<{ path: string; tokenCount: number; lineCount: number }> = []
+    let tokenCount = 0
+
+    for (let index = 0; index < files.length; index++) {
+      const item = files[index]
+      const fileTokens = estimateTokens(item.content)
+      tokenCount += fileTokens
+      results.push({
+        path: item.path,
+        tokenCount: fileTokens,
+        lineCount: String(item.content || "").split("\n").length
+      })
+
+      const progressPayload: ProgressResponse = {
+        id: request.id,
+        progress: total === 0 ? 100 : Math.round(((index + 1) / total) * 100),
+        current: index + 1,
+        total
+      }
+      self.postMessage(progressPayload)
+    }
+
+    const payload: TokenizeResponse = {
+      id: request.id,
+      tokenCount,
+      files: results
+    }
+    self.postMessage(payload)
+  } catch (error) {
+    const payload: TokenizeResponse = {
+      id: request.id,
+      tokenCount: 0,
+      error: error instanceof Error ? error.message : "Tokenizer worker failed"
+    }
+    self.postMessage(payload)
+  }
+}
+
+export {}

--- a/apps/packages/ui/src/public/_locales/ar/option.json
+++ b/apps/packages/ui/src/public/_locales/ar/option.json
@@ -2644,5 +2644,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ar/option.json
+++ b/apps/packages/ui/src/public/_locales/ar/option.json
@@ -2659,5 +2659,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/da/option.json
+++ b/apps/packages/ui/src/public/_locales/da/option.json
@@ -2668,5 +2668,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/da/option.json
+++ b/apps/packages/ui/src/public/_locales/da/option.json
@@ -2683,5 +2683,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/de/option.json
+++ b/apps/packages/ui/src/public/_locales/de/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/de/option.json
+++ b/apps/packages/ui/src/public/_locales/de/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/en/option.json
+++ b/apps/packages/ui/src/public/_locales/en/option.json
@@ -3742,5 +3742,20 @@
   },
   "header_skills": {
     "message": "Skills"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/en/option.json
+++ b/apps/packages/ui/src/public/_locales/en/option.json
@@ -3757,5 +3757,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/es/option.json
+++ b/apps/packages/ui/src/public/_locales/es/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/es/option.json
+++ b/apps/packages/ui/src/public/_locales/es/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fa/option.json
+++ b/apps/packages/ui/src/public/_locales/fa/option.json
@@ -2356,5 +2356,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/fa/option.json
+++ b/apps/packages/ui/src/public/_locales/fa/option.json
@@ -2341,5 +2341,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/fr/option.json
+++ b/apps/packages/ui/src/public/_locales/fr/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/fr/option.json
+++ b/apps/packages/ui/src/public/_locales/fr/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/it/option.json
+++ b/apps/packages/ui/src/public/_locales/it/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/it/option.json
+++ b/apps/packages/ui/src/public/_locales/it/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja-JP/option.json
+++ b/apps/packages/ui/src/public/_locales/ja-JP/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja-JP/option.json
+++ b/apps/packages/ui/src/public/_locales/ja-JP/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja/option.json
+++ b/apps/packages/ui/src/public/_locales/ja/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/ja/option.json
+++ b/apps/packages/ui/src/public/_locales/ja/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ko/option.json
+++ b/apps/packages/ui/src/public/_locales/ko/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/ko/option.json
+++ b/apps/packages/ui/src/public/_locales/ko/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ml/option.json
+++ b/apps/packages/ui/src/public/_locales/ml/option.json
@@ -2608,5 +2608,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/ml/option.json
+++ b/apps/packages/ui/src/public/_locales/ml/option.json
@@ -2593,5 +2593,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/no/option.json
+++ b/apps/packages/ui/src/public/_locales/no/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/no/option.json
+++ b/apps/packages/ui/src/public/_locales/no/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/pt-BR/option.json
+++ b/apps/packages/ui/src/public/_locales/pt-BR/option.json
@@ -2686,5 +2686,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/pt-BR/option.json
+++ b/apps/packages/ui/src/public/_locales/pt-BR/option.json
@@ -2671,5 +2671,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/ru/option.json
+++ b/apps/packages/ui/src/public/_locales/ru/option.json
@@ -2698,5 +2698,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/ru/option.json
+++ b/apps/packages/ui/src/public/_locales/ru/option.json
@@ -2683,5 +2683,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/sv/option.json
+++ b/apps/packages/ui/src/public/_locales/sv/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/sv/option.json
+++ b/apps/packages/ui/src/public/_locales/sv/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/uk/option.json
+++ b/apps/packages/ui/src/public/_locales/uk/option.json
@@ -2665,5 +2665,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/uk/option.json
+++ b/apps/packages/ui/src/public/_locales/uk/option.json
@@ -2650,5 +2650,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh-TW/option.json
+++ b/apps/packages/ui/src/public/_locales/zh-TW/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh-TW/option.json
+++ b/apps/packages/ui/src/public/_locales/zh-TW/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh/option.json
+++ b/apps/packages/ui/src/public/_locales/zh/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh/option.json
+++ b/apps/packages/ui/src/public/_locales/zh/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_CN/option.json
+++ b/apps/packages/ui/src/public/_locales/zh_CN/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_CN/option.json
+++ b/apps/packages/ui/src/public/_locales/zh_CN/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_TW/option.json
+++ b/apps/packages/ui/src/public/_locales/zh_TW/option.json
@@ -2653,5 +2653,74 @@
   },
   "repo2txt_generate": {
     "message": "Generate Output"
+  },
+  "repo2txt_providerTitle": {
+    "message": "Source Provider"
+  },
+  "repo2txt_providerGithub": {
+    "message": "GitHub"
+  },
+  "repo2txt_providerLocal": {
+    "message": "Local"
+  },
+  "repo2txt_githubPlaceholder": {
+    "message": "https://github.com/owner/repo"
+  },
+  "repo2txt_loadSource": {
+    "message": "Load Source"
+  },
+  "repo2txt_chooseDirectory": {
+    "message": "Choose Directory"
+  },
+  "repo2txt_chooseZip": {
+    "message": "Choose Zip"
+  },
+  "repo2txt_filters": {
+    "message": "Filters"
+  },
+  "repo2txt_selectedCount": {
+    "message": "{{selected}}/{{total}} selected"
+  },
+  "repo2txt_filterFiles": {
+    "message": "Filter files"
+  },
+  "repo2txt_output": {
+    "message": "Output"
+  },
+  "repo2txt_copy": {
+    "message": "Copy"
+  },
+  "repo2txt_download": {
+    "message": "Download"
+  },
+  "repo2txt_outputPreviewAria": {
+    "message": "Repo2txt output preview"
+  },
+  "repo2txt_errors_invalidGithubUrl": {
+    "message": "Enter a valid GitHub repository URL."
+  },
+  "repo2txt_errors_loadGithub": {
+    "message": "Failed to load GitHub repository."
+  },
+  "repo2txt_errors_loadLocal": {
+    "message": "Failed to load local files."
+  },
+  "repo2txt_errors_generate": {
+    "message": "Failed to generate output."
+  },
+  "repo2txt_status_loadedTree": {
+    "message": "Loaded {{count}} file tree entries."
+  },
+  "repo2txt_status_loadedLocal": {
+    "message": "Loaded {{count}} local files."
+  },
+  "repo2txt_status_selectAtLeastOne": {
+    "message": "Select at least one file to generate output."
+  },
+  "repo2txt_status_fetchingFiles": {
+    "message": "Fetching files ({{completed}}/{{total}})..."
+  },
+  "repo2txt_status_generated": {
+    "message": "Generated output for {{count}} files ({{tokenCount}} tokens)."
   }
 }

--- a/apps/packages/ui/src/public/_locales/zh_TW/option.json
+++ b/apps/packages/ui/src/public/_locales/zh_TW/option.json
@@ -2638,5 +2638,20 @@
   },
   "header_workflowEditor": {
     "message": "Workflow Editor"
+  },
+  "header_modeRepo2txt": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_nav": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_title": {
+    "message": "Repo2Txt"
+  },
+  "repo2txt_description": {
+    "message": "Convert repositories to structured text output."
+  },
+  "repo2txt_generate": {
+    "message": "Generate Output"
   }
 }

--- a/apps/packages/ui/src/routes/__tests__/option-repo2txt.route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/option-repo2txt.route.test.tsx
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import OptionRepo2TxtRoute from "../option-repo2txt"
+
+describe("repo2txt option route", () => {
+  it("renders repo2txt route root", async () => {
+    render(<OptionRepo2TxtRoute />)
+    expect(await screen.findByTestId("repo2txt-route-root")).toBeInTheDocument()
+  })
+
+  it("registers /repo2txt in route registry", () => {
+    const routeRegistrySource = readFileSync("src/routes/route-registry.tsx", "utf8")
+    expect(routeRegistrySource).toContain('path: REPO2TXT_PATH')
+  })
+})

--- a/apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
@@ -8,6 +8,18 @@ const REQUIRED_KEYS = [
   "repo2txt.title",
   "repo2txt.description",
   "repo2txt.generate",
+  "repo2txt.providerTitle",
+  "repo2txt.providerGithub",
+  "repo2txt.providerLocal",
+  "repo2txt.loadSource",
+  "repo2txt.chooseDirectory",
+  "repo2txt.chooseZip",
+  "repo2txt.filters",
+  "repo2txt.filterFiles",
+  "repo2txt.output",
+  "repo2txt.copy",
+  "repo2txt.download",
+  "repo2txt.outputPreviewAria",
   "header.modeRepo2txt"
 ] as const
 

--- a/apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
+++ b/apps/packages/ui/src/routes/__tests__/repo2txt-locale-keys.test.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+import enOption from "@/assets/locale/en/option.json"
+
+const REQUIRED_KEYS = [
+  "repo2txt.nav",
+  "repo2txt.title",
+  "repo2txt.description",
+  "repo2txt.generate",
+  "header.modeRepo2txt"
+] as const
+
+const getPathValue = (source: unknown, key: string): unknown =>
+  key.split(".").reduce<unknown>((value, segment) => {
+    if (!value || typeof value !== "object") return undefined
+    return (value as Record<string, unknown>)[segment]
+  }, source)
+
+describe("repo2txt locale keys", () => {
+  it("has required English option locale keys", () => {
+    for (const key of REQUIRED_KEYS) {
+      const value = getPathValue(enOption as unknown, key)
+      expect(typeof value).toBe("string")
+      expect(String(value).trim().length).toBeGreaterThan(0)
+    }
+  })
+
+  it("keeps repo2txt option keys present across locale directories", () => {
+    const localeRoot = path.resolve(process.cwd(), "src/assets/locale")
+    for (const locale of fs.readdirSync(localeRoot)) {
+      const optionPath = path.join(localeRoot, locale, "option.json")
+      expect(fs.existsSync(optionPath)).toBe(true)
+      const parsed = JSON.parse(fs.readFileSync(optionPath, "utf8")) as unknown
+      for (const key of REQUIRED_KEYS) {
+        const value = getPathValue(parsed, key)
+        expect(typeof value).toBe("string")
+      }
+    }
+  })
+})

--- a/apps/packages/ui/src/routes/option-repo2txt.tsx
+++ b/apps/packages/ui/src/routes/option-repo2txt.tsx
@@ -1,3 +1,5 @@
+import { Repo2TxtPage } from "~/components/Option/Repo2Txt"
+
 export default function OptionRepo2TxtRoute() {
-  return <div data-testid="repo2txt-route-root">repo2txt</div>
+  return <Repo2TxtPage />
 }

--- a/apps/packages/ui/src/routes/option-repo2txt.tsx
+++ b/apps/packages/ui/src/routes/option-repo2txt.tsx
@@ -1,0 +1,3 @@
+export default function OptionRepo2TxtRoute() {
+  return <div data-testid="repo2txt-route-root">repo2txt</div>
+}

--- a/apps/packages/ui/src/routes/route-paths.ts
+++ b/apps/packages/ui/src/routes/route-paths.ts
@@ -1,6 +1,7 @@
 export const CHAT_PATH = "/chat"
 export const WORKSPACE_PLAYGROUND_PATH = "/workspace-playground"
 export const DOCUMENT_WORKSPACE_PATH = "/document-workspace"
+export const REPO2TXT_PATH = "/repo2txt"
 
 export const LOREBOOK_DEBUG_FOCUS = "lorebook-debug"
 

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -39,7 +39,7 @@ import {
 import { ALL_TARGETS, type PlatformTarget } from "@/config/platform"
 import { createSettingsRoute } from "./settings-route"
 import { Navigate } from "react-router-dom"
-import { DOCUMENT_WORKSPACE_PATH } from "@/routes/route-paths"
+import { DOCUMENT_WORKSPACE_PATH, REPO2TXT_PATH } from "@/routes/route-paths"
 
 // Eagerly loaded routes for instant navigation on frequently visited pages
 import OptionIndex from "./option-index"
@@ -193,6 +193,7 @@ const OptionAudiobookStudio = lazy(() => import("./option-audiobook-studio"))
 const OptionWorkflowEditor = lazy(() => import("./option-workflow-editor"))
 const OptionACPPlayground = lazy(() => import("./option-acp-playground"))
 const OptionSkills = lazy(() => import("./option-skills"))
+const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
 const OptionSetup = lazy(() => import("./option-setup"))
 const OptionOnboardingTest = lazy(() => import("./option-onboarding-test"))
 const OptionWorkspacePlayground = lazy(() => import("./option-workspace-playground"))
@@ -488,6 +489,17 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       icon: SquarePen,
       order: 6,
       beta: true
+    }
+  },
+  {
+    kind: "options",
+    path: REPO2TXT_PATH,
+    element: <OptionRepo2Txt />,
+    nav: {
+      group: "workspace",
+      labelToken: "option:repo2txt.nav",
+      icon: FileText,
+      order: 7
     }
   },
   {

--- a/apps/packages/ui/src/services/settings/ui-settings.ts
+++ b/apps/packages/ui/src/services/settings/ui-settings.ts
@@ -331,6 +331,7 @@ export const HEADER_SHORTCUT_IDS = [
   "knowledge-qa",
   "media",
   "document-workspace",
+  "repo2txt",
   "multi-item-review",
   "content-review",
   "flashcards",

--- a/apps/tldw-frontend/README.md
+++ b/apps/tldw-frontend/README.md
@@ -57,6 +57,14 @@ bun run dev -- -p 8080
 
 Open [http://localhost:8080](http://localhost:8080) with your browser.
 
+### repo2txt Route
+
+The web app exposes the shared repo2txt options UI at:
+
+- `http://localhost:8080/repo2txt`
+
+This page dynamically renders the shared route from `apps/packages/ui/src/routes/option-repo2txt.tsx`.
+
 Unified streaming (dev)
  - To exercise the unified SSE/WS streaming in the backend, start the API with the dev overlay:
    `docker compose -f Dockerfiles/docker-compose.yml -f Dockerfiles/docker-compose.dev.yml up -d --build`

--- a/apps/tldw-frontend/__tests__/pages/repo2txt.test.tsx
+++ b/apps/tldw-frontend/__tests__/pages/repo2txt.test.tsx
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import Repo2TxtPage from "@web/pages/repo2txt"
+
+describe("web repo2txt page", () => {
+  it("exports a page component", () => {
+    expect(Repo2TxtPage).toBeTypeOf("function")
+  })
+})

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -111,7 +111,8 @@
     "zustand": "^5.0.10",
     "react-joyride": "^2.9.0",
     "xterm": "^5.3.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "gpt-tokenizer": "^3.4.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",

--- a/apps/tldw-frontend/package.json
+++ b/apps/tldw-frontend/package.json
@@ -6,7 +6,7 @@
     "postinstall": "node scripts/copy-pdf-worker.mjs",
     "dev": "next dev",
     "build": "next build && node scripts/verify-shared-token-sync.mjs --dir .next",
-    "compile": "next build && node scripts/verify-shared-token-sync.mjs --dir .next",
+    "compile": "next build --webpack && node scripts/verify-shared-token-sync.mjs --dir .next",
     "check:token-sync": "node scripts/verify-shared-token-sync.mjs --dir .next",
     "start": "next start",
     "smoke": "node scripts/smoke.mjs",

--- a/apps/tldw-frontend/pages/repo2txt.tsx
+++ b/apps/tldw-frontend/pages/repo2txt.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-repo2txt"), { ssr: false })


### PR DESCRIPTION
## Summary
- add shared `repo2txt` options route and page implementation in `@tldw/ui`, including GitHub + Local providers, formatter/tokenizer worker, file-tree state, and flow wiring
- expose `repo2txt` across navigation surfaces: options route registry, header shortcuts modal, locale keys/parity guards, and Next.js wrapper route (`/repo2txt`)
- add extension repo2txt E2E coverage (options route + sidepanel link-out behavior), document route behavior, and fix compile scripts (`extension` compile tsconfig + `frontend` compile webpack path)
- add docs/legal attribution follow-up to explicitly call out upstream `repo2txt` (MIT) in `THIRD_PARTY_NOTICES.txt` and record the update in `CHANGELOG.md`

## Test Plan
- [x] `cd apps/packages/ui && bunx vitest run src/routes/__tests__/option-repo2txt.route.test.tsx src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.smoke.test.tsx src/components/Option/Repo2Txt/__tests__/Repo2TxtPage.flow.test.tsx src/routes/__tests__/repo2txt-locale-keys.test.ts src/components/Layouts/__tests__/HeaderShortcuts.test.tsx`
- [x] `cd apps/tldw-frontend && bunx vitest run __tests__/pages/repo2txt.test.tsx`
- [x] `cd apps/extension && bun run compile`
- [x] `cd apps/tldw-frontend && bun run compile`
- [x] `cd apps/extension && bun run test:e2e tests/e2e/repo2txt-options.spec.ts tests/e2e/repo2txt-sidepanel-linkout.spec.ts`
