### PR TITLE
feat(rag): add switchable profile defaults across unified RAG

### DIFF
--- a/apps/packages/ui/src/services/rag/unified-rag.test.ts
+++ b/apps/packages/ui/src/services/rag/unified-rag.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+
+import { DEFAULT_RAG_SETTINGS, buildRagSearchRequest } from "./unified-rag"
+
+
+describe("buildRagSearchRequest rag_profile", () => {
+  it("omits rag_profile when set to none", () => {
+    const req = buildRagSearchRequest({
+      ...DEFAULT_RAG_SETTINGS,
+      query: "q",
+      rag_profile: "none"
+    })
+
+    expect((req.options as Record<string, unknown>).rag_profile).toBeUndefined()
+  })
+
+  it("includes rag_profile when set to fast", () => {
+    const req = buildRagSearchRequest({
+      ...DEFAULT_RAG_SETTINGS,
+      query: "q",
+      rag_profile: "fast"
+    })
+
+    expect((req.options as Record<string, unknown>).rag_profile).toBe("fast")
+  })
+})

--- a/apps/packages/ui/src/services/rag/unified-rag.ts
+++ b/apps/packages/ui/src/services/rag/unified-rag.ts
@@ -38,11 +38,13 @@ export type RagLowConfidenceBehavior = "continue" | "ask" | "decline"
 export type RagNumericFidelityBehavior = "continue" | "ask" | "decline" | "retry"
 export type RagNumericPrecisionMode = "standard" | "strict" | "academic"
 export type RagPresetName = "fast" | "balanced" | "thorough" | "custom"
+export type RagProfile = "fast" | "balanced" | "accuracy" | "none"
 
 export type RagSettings = {
   query: string
   sources: RagSource[]
   strategy: RagStrategy
+  rag_profile: RagProfile
   corpus: string
   index_namespace: string
   search_mode: RagSearchMode
@@ -243,6 +245,7 @@ export const DEFAULT_RAG_SETTINGS: RagSettings = {
   query: "",
   sources: ["media_db", "notes", "characters", "chats"],
   strategy: "standard",
+  rag_profile: "none",
   corpus: "",
   index_namespace: "",
   search_mode: "hybrid",
@@ -518,6 +521,7 @@ export const buildRagSearchRequest = (settings: RagSettings) => {
     generation_prompt,
     user_id,
     session_id,
+    rag_profile,
     ...rest
   } = normalizedSettings
   const options: Record<string, unknown> = {}
@@ -530,6 +534,7 @@ export const buildRagSearchRequest = (settings: RagSettings) => {
   if (generation_model) options.generation_model = generation_model
   if (generation_provider) options.generation_provider = generation_provider
   if (generation_prompt) options.generation_prompt = generation_prompt
+  if (rag_profile && rag_profile !== "none") options.rag_profile = rag_profile
   if (user_id) options.user_id = user_id
   if (session_id) options.session_id = session_id
   const timeoutMs =
@@ -544,7 +549,7 @@ export const buildRagSearchRequest = (settings: RagSettings) => {
 }
 
 export const toRagAdvancedOptions = (settings: RagSettings) => {
-  const { query, search_mode, top_k, enable_generation, enable_citations, sources, ...rest } = settings
+  const { query, search_mode, top_k, enable_generation, enable_citations, sources, rag_profile, ...rest } = settings
   const options: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(rest)) {
     if (value === undefined || value === null) continue
@@ -552,5 +557,6 @@ export const toRagAdvancedOptions = (settings: RagSettings) => {
     if (Array.isArray(value) && value.length === 0) continue
     options[key] = value
   }
+  if (rag_profile && rag_profile !== "none") options.rag_profile = rag_profile
   return options
 }

--- a/tldw_Server_API/Config_Files/Prompts/rag.prompts.md
+++ b/tldw_Server_API/Config_Files/Prompts/rag.prompts.md
@@ -12,5 +12,34 @@ Rerank the following candidates by how well they answer the query. Penalize verb
 or off-topic matches. Promote entries that contain precise, verifiable statements.
 ```
 
+## instruction_tuned
+```
+Use the provided context to answer the question. Do not use any other knowledge.
+Context:
+{context}
+Question: {question}
+Answer:
+```
+
+## multi_hop_compact
+```
+Answer using ONLY the provided documents. Connect evidence across sources.
+Context:
+{context}
+Question: {question}
+Provide concise synthesis with inline source citations.
+```
+
+## expert_synthesis
+```
+You are a meticulous research assistant. Synthesize evidence, resolve contradictions,
+and provide a precise answer grounded ONLY in context.
+Context:
+{context}
+Question: {question}
+Answer with explicit source citations.
+```
+
 Changelog:
 - v1.0: Seed prompts for retrieval and reranking.
+- v1.1: Added profile-oriented generation prompts (`instruction_tuned`, `multi_hop_compact`, `expert_synthesis`).

--- a/tldw_Server_API/Config_Files/Prompts/rag.prompts.yaml
+++ b/tldw_Server_API/Config_Files/Prompts/rag.prompts.yaml
@@ -33,3 +33,25 @@ with_citations: |
   4. Clearly indicate if information is not available in the sources
 
   Answer with citations:
+
+instruction_tuned: |
+  Use the provided context to answer the question. Do not use any other knowledge.
+  Context:
+  {context}
+  Question: {question}
+  Answer:
+
+multi_hop_compact: |
+  Answer using ONLY the provided documents. Connect evidence across sources.
+  Context:
+  {context}
+  Question: {question}
+  Provide concise synthesis with inline source citations.
+
+expert_synthesis: |
+  You are a meticulous research assistant. Synthesize evidence, resolve contradictions,
+  and provide a precise answer grounded ONLY in context.
+  Context:
+  {context}
+  Question: {question}
+  Answer with explicit source citations.

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -55,6 +55,7 @@ from tldw_Server_API.app.core.RAG.rag_service.database_retrievers import (
     RetrievalConfig,
 )
 from tldw_Server_API.app.core.RAG.rag_service.generation import generate_streaming_response
+from tldw_Server_API.app.core.RAG.rag_service.profiles import get_profile_kwargs
 from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
 from tldw_Server_API.app.core.config import get_config_value
 
@@ -209,6 +210,53 @@ def _apply_search_agent_defaults(
             payload[field_name] = parsed_value
 
 
+def _apply_rag_profile_defaults(
+    request: Any,
+    payload: dict[str, Any],
+    *,
+    allowed_fields: Optional[set[str]] = None,
+) -> None:
+    """Apply rag_profile defaults for fields omitted by the caller."""
+    profile_name = getattr(request, "rag_profile", None)
+    if not profile_name:
+        return
+
+    explicit_fields = _request_fields_set(request)
+    try:
+        profile_defaults = get_profile_kwargs(profile_name)
+    except ValueError:
+        logger.warning(f"Skipping unknown rag_profile '{profile_name}' while building payload defaults")
+        return
+
+    for field_name, value in profile_defaults.items():
+        if allowed_fields is not None and field_name not in allowed_fields:
+            continue
+        if field_name in explicit_fields:
+            continue
+        payload[field_name] = value
+
+
+def _build_effective_request_payload(
+    request: Any,
+    *,
+    allowed_search_agent_fields: Optional[set[str]] = None,
+    allowed_profile_fields: Optional[set[str]] = None,
+) -> dict[str, Any]:
+    """Resolve effective payload with explicit > profile > search-agent > schema defaults."""
+    payload = model_dump_compat(request)
+    _apply_search_agent_defaults(
+        request,
+        payload,
+        allowed_fields=allowed_search_agent_fields,
+    )
+    _apply_rag_profile_defaults(
+        request,
+        payload,
+        allowed_fields=allowed_profile_fields,
+    )
+    return payload
+
+
 def _build_unified_pipeline_kwargs(
     request: UnifiedRAGRequest,
     db_paths: dict[str, Optional[str]],
@@ -216,8 +264,7 @@ def _build_unified_pipeline_kwargs(
     chacha_db: CharactersRAGDB,
     current_user: Optional[User],
 ) -> dict[str, Any]:
-    payload = model_dump_compat(request)
-    _apply_search_agent_defaults(request, payload)
+    payload = _build_effective_request_payload(request)
     payload["media_db_path"] = db_paths.get("media_db_path")
     payload["notes_db_path"] = db_paths.get("notes_db_path")
     payload["character_db_path"] = db_paths.get("character_db_path")
@@ -1872,7 +1919,11 @@ async def unified_search_stream_endpoint(
     async def event_stream():
         try:
             # Prepare retrieval like the unified pipeline (simplified)
-            index_namespace = request.index_namespace or getattr(request, "corpus", None)
+            effective_payload = _build_effective_request_payload(request)
+            index_namespace = (
+                effective_payload.get("index_namespace")
+                or effective_payload.get("corpus")
+            )
             db_paths = {}
             if media_db:
                 db_paths["media_db"] = media_db.db_path
@@ -1920,7 +1971,7 @@ async def unified_search_stream_endpoint(
 
                         if (
                             progress_queue is not None
-                            and bool(getattr(request, "enable_research_progress", False))
+                            and bool(effective_payload.get("enable_research_progress", False))
                         ):
                             async def _stream_research_progress(event: Any) -> None:
                                 await progress_queue.put(_normalize_research_event(event))
@@ -1938,7 +1989,7 @@ async def unified_search_stream_endpoint(
                     if progress_queue is not None and done_marker is not None:
                         await progress_queue.put(done_marker)
 
-            if bool(getattr(request, "enable_research_progress", False)) and db_paths:
+            if bool(effective_payload.get("enable_research_progress", False)) and db_paths:
                 progress_queue: asyncio.Queue[Any] = asyncio.Queue()
                 done_marker = object()
                 retrieval_task = asyncio.create_task(
@@ -2032,8 +2083,14 @@ async def unified_search_stream_endpoint(
 
             # Emit initial contexts (top-k with minimal fields) + a safe rationale plan (standard path)
             try:
+                top_k_requested = effective_payload.get("top_k", request.top_k or 10)
+                try:
+                    top_k_limit = min(10, int(top_k_requested))
+                except (TypeError, ValueError):
+                    top_k_limit = min(10, (request.top_k or 10))
+
                 top_contexts = []
-                for doc in (docs or [])[: min(10, (request.top_k or 10))]:
+                for doc in (docs or [])[:top_k_limit]:
                     md = getattr(doc, 'metadata', None) or (doc.get('metadata') if isinstance(doc, dict) else {}) or {}
                     top_contexts.append({
                         "id": getattr(doc, 'id', doc.get('id') if isinstance(doc, dict) else None),
@@ -2063,7 +2120,7 @@ async def unified_search_stream_endpoint(
                 rationale = {
                     "plan": [
                         "Gather top-k contexts",
-                        f"Rerank using strategy={getattr(request, 'reranking_strategy', 'flashrank')}",
+                        f"Rerank using strategy={effective_payload.get('reranking_strategy', 'flashrank')}",
                         "Ground claims from sources",
                         "Synthesize final answer",
                     ]
@@ -2080,7 +2137,8 @@ async def unified_search_stream_endpoint(
                 cfg = {}
 
             import os as _os
-            request_provider = request.generation_provider if isinstance(request.generation_provider, str) else None
+            request_provider_raw = effective_payload.get("generation_provider")
+            request_provider = request_provider_raw if isinstance(request_provider_raw, str) else None
             env_provider = _os.getenv("RAG_DEFAULT_LLM_PROVIDER")
             provider_value = request_provider if request_provider is not None else (
                 env_provider if env_provider is not None else cfg.get("RAG_DEFAULT_LLM_PROVIDER")
@@ -2091,7 +2149,8 @@ async def unified_search_stream_endpoint(
                 else "openai"
             )
 
-            model_value = request.generation_model if isinstance(request.generation_model, str) else None
+            model_value_raw = effective_payload.get("generation_model")
+            model_value = model_value_raw if isinstance(model_value_raw, str) else None
             if not model_value:
                 env_model = _os.getenv("RAG_DEFAULT_LLM_MODEL")
                 model_value = env_model if env_model is not None else cfg.get("RAG_DEFAULT_LLM_MODEL")
@@ -2102,9 +2161,9 @@ async def unified_search_stream_endpoint(
             )
 
             max_tokens = 500
-            if request.max_generation_tokens is not None:
+            if effective_payload.get("max_generation_tokens") is not None:
                 try:
-                    max_tokens = int(request.max_generation_tokens)
+                    max_tokens = int(effective_payload.get("max_generation_tokens"))
                 except (TypeError, ValueError):
                     max_tokens = 500
 
@@ -2114,8 +2173,9 @@ async def unified_search_stream_endpoint(
                 "model": model,
                 "max_tokens": max_tokens,
             }
-            if request.generation_prompt:
-                generation_config["prompt_template"] = request.generation_prompt
+            prompt_template = effective_payload.get("generation_prompt")
+            if isinstance(prompt_template, str) and prompt_template:
+                generation_config["prompt_template"] = prompt_template
 
             context = types.SimpleNamespace()
             context.documents = docs
@@ -2126,10 +2186,10 @@ async def unified_search_stream_endpoint(
             # Initialize streaming generator with claims overlay enabled per request
             await generate_streaming_response(
                 context,
-                enable_claims=request.enable_claims,
-                claims_top_k=request.claims_top_k,
-                claims_max=request.claims_max,
-                claims_concurrency=request.claims_concurrency,
+                enable_claims=bool(effective_payload.get("enable_claims", request.enable_claims)),
+                claims_top_k=effective_payload.get("claims_top_k", request.claims_top_k),
+                claims_max=effective_payload.get("claims_max", request.claims_max),
+                claims_concurrency=effective_payload.get("claims_concurrency", request.claims_concurrency),
             )
 
             last_overlay = None

--- a/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
+++ b/tldw_Server_API/app/api/v1/endpoints/rag_unified.py
@@ -2019,56 +2019,93 @@ async def unified_search_stream_endpoint(
                 await _run_streaming_retrieval()
 
             # If strategy=agentic, assemble ephemeral chunk and emit plan + spans first
-            if getattr(request, 'strategy', 'standard') == 'agentic':
+            strategy_value = str(
+                effective_payload.get("strategy", getattr(request, "strategy", "standard"))
+            ).strip().lower()
+            if strategy_value == "agentic":
                 try:
+                    def _payload_bool(name: str, fallback: bool = False) -> bool:
+                        return bool(effective_payload.get(name, getattr(request, name, fallback)))
+
+                    def _payload_int(name: str, fallback: int) -> int:
+                        raw = effective_payload.get(name, getattr(request, name, fallback))
+                        try:
+                            return int(raw)
+                        except (TypeError, ValueError):
+                            return fallback
+
+                    def _payload_float(name: str, fallback: float) -> float:
+                        raw = effective_payload.get(name, getattr(request, name, fallback))
+                        try:
+                            return float(raw)
+                        except (TypeError, ValueError):
+                            return fallback
+
                     # Run agentic assembly without generation
                     a_cfg = AgenticConfig(
-                        top_k_docs=int(getattr(request, 'agentic_top_k_docs', 3) or 3),
-                        window_chars=int(getattr(request, 'agentic_window_chars', 1200) or 1200),
-                        max_tokens_read=int(getattr(request, 'agentic_max_tokens_read', 6000) or 6000),
-                        max_tool_calls=int(getattr(request, 'agentic_max_tool_calls', 8) or 8),
+                        top_k_docs=max(1, _payload_int("agentic_top_k_docs", 3)),
+                        window_chars=max(200, _payload_int("agentic_window_chars", 1200)),
+                        max_tokens_read=max(500, _payload_int("agentic_max_tokens_read", 6000)),
+                        max_tool_calls=max(1, _payload_int("agentic_max_tool_calls", 8)),
                         extractive_only=True,
                         quote_spans=True,
-                        enable_tools=bool(getattr(request, 'agentic_enable_tools', False)),
-                        use_llm_planner=bool(getattr(request, 'agentic_use_llm_planner', False)),
-                        time_budget_sec=(getattr(request, 'agentic_time_budget_sec', None)),
-                        cache_ttl_sec=int(getattr(request, 'agentic_cache_ttl_sec', 600) or 600),
-                        debug_trace=bool(getattr(request, 'agentic_debug_trace', False) or request.debug_mode),
-                        enable_query_decomposition=bool(getattr(request, 'agentic_enable_query_decomposition', False)),
-                        subgoal_max=int(getattr(request, 'agentic_subgoal_max', 3) or 3),
-                        enable_semantic_within=bool(getattr(request, 'agentic_enable_semantic_within', True)),
-                        enable_section_index=bool(getattr(request, 'agentic_enable_section_index', True)),
-                        prefer_structural_anchors=bool(getattr(request, 'agentic_prefer_structural_anchors', True)),
-                        enable_table_support=bool(getattr(request, 'agentic_enable_table_support', True)),
-                        agentic_enable_vlm_late_chunking=bool(getattr(request, 'agentic_enable_vlm_late_chunking', False)),
-                        agentic_vlm_backend=getattr(request, 'agentic_vlm_backend', None),
-                        agentic_vlm_detect_tables_only=bool(getattr(request, 'agentic_vlm_detect_tables_only', True)),
-                        agentic_vlm_max_pages=getattr(request, 'agentic_vlm_max_pages', None),
-                        agentic_vlm_late_chunk_top_k_docs=int(getattr(request, 'agentic_vlm_late_chunk_top_k_docs', 2) or 2),
-                        agentic_use_provider_embeddings_within=bool(getattr(request, 'agentic_use_provider_embeddings_within', False)),
-                        agentic_provider_embedding_model_id=getattr(request, 'agentic_provider_embedding_model_id', None),
+                        enable_tools=_payload_bool("agentic_enable_tools", False),
+                        use_llm_planner=_payload_bool("agentic_use_llm_planner", False),
+                        time_budget_sec=effective_payload.get(
+                            "agentic_time_budget_sec",
+                            getattr(request, "agentic_time_budget_sec", None),
+                        ),
+                        cache_ttl_sec=max(1, _payload_int("agentic_cache_ttl_sec", 600)),
+                        debug_trace=_payload_bool("agentic_debug_trace", False)
+                        or _payload_bool("debug_mode", getattr(request, "debug_mode", False)),
+                        enable_query_decomposition=_payload_bool("agentic_enable_query_decomposition", False),
+                        subgoal_max=max(1, _payload_int("agentic_subgoal_max", 3)),
+                        enable_semantic_within=_payload_bool("agentic_enable_semantic_within", True),
+                        enable_section_index=_payload_bool("agentic_enable_section_index", True),
+                        prefer_structural_anchors=_payload_bool("agentic_prefer_structural_anchors", True),
+                        enable_table_support=_payload_bool("agentic_enable_table_support", True),
+                        agentic_enable_vlm_late_chunking=_payload_bool("agentic_enable_vlm_late_chunking", False),
+                        agentic_vlm_backend=effective_payload.get(
+                            "agentic_vlm_backend",
+                            getattr(request, "agentic_vlm_backend", None),
+                        ),
+                        agentic_vlm_detect_tables_only=_payload_bool("agentic_vlm_detect_tables_only", True),
+                        agentic_vlm_max_pages=effective_payload.get(
+                            "agentic_vlm_max_pages",
+                            getattr(request, "agentic_vlm_max_pages", None),
+                        ),
+                        agentic_vlm_late_chunk_top_k_docs=max(
+                            1, _payload_int("agentic_vlm_late_chunk_top_k_docs", 2)
+                        ),
+                        agentic_use_provider_embeddings_within=_payload_bool(
+                            "agentic_use_provider_embeddings_within", False
+                        ),
+                        agentic_provider_embedding_model_id=effective_payload.get(
+                            "agentic_provider_embedding_model_id",
+                            getattr(request, "agentic_provider_embedding_model_id", None),
+                        ),
                     )
                     ares = await agentic_rag_pipeline(
                         query=request.query,
-                        sources=request.sources,
+                        sources=effective_payload.get("sources", request.sources),
                         media_db=media_db,
                         chacha_db=chacha_db,
                         media_db_path=(media_db.db_path if media_db else None),
                         notes_db_path=(chacha_db.db_path if chacha_db else None),
                         character_db_path=(chacha_db.db_path if chacha_db else None),
                         kanban_db_path=kanban_db_path,
-                        search_mode=request.search_mode,
-                        fts_level=request.fts_level,
-                        hybrid_alpha=request.hybrid_alpha,
-                        top_k=request.top_k,
-                        min_score=request.min_score,
+                        search_mode=effective_payload.get("search_mode", request.search_mode),
+                        fts_level=effective_payload.get("fts_level", request.fts_level),
+                        hybrid_alpha=_payload_float("hybrid_alpha", request.hybrid_alpha),
+                        top_k=max(1, _payload_int("top_k", request.top_k or 10)),
+                        min_score=_payload_float("min_score", request.min_score or 0.0),
                         index_namespace=index_namespace,
                         agentic=a_cfg,
                         enable_generation=False,
                         enable_citations=False,
                         include_chunk_citations=False,
-                        debug_mode=request.debug_mode,
-                        explain_only=bool(getattr(request, 'explain_only', False)),
+                        debug_mode=_payload_bool("debug_mode", request.debug_mode),
+                        explain_only=_payload_bool("explain_only", getattr(request, "explain_only", False)),
                     )
                     # Emit plan + spans
                     plan = ares.metadata.get('agentic_metrics', {}) if isinstance(ares.metadata, dict) else {}

--- a/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
+++ b/tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py
@@ -69,6 +69,11 @@ class UnifiedRAGRequest(BaseModel):
         description="Pipeline strategy: standard (pre-chunked) or agentic (query-time synthetic chunk)",
         example="agentic",
     )
+    rag_profile: Optional[Literal["fast", "balanced", "accuracy"]] = Field(
+        default=None,
+        description="Switchable profile defaults applied at request handling time",
+        example="balanced",
+    )
 
     if model_validator is not None:
         @model_validator(mode="before")
@@ -960,7 +965,7 @@ class UnifiedRAGRequest(BaseModel):
     max_generation_tokens: int = Field(
         default=500,
         ge=50,
-        le=2000,
+        le=4000,
         description="Maximum tokens for generated answer",
         example=500
     )
@@ -1843,7 +1848,7 @@ class UnifiedBatchRequest(BaseModel):
     generation_model: Optional[str] = Field(default=None)
     generation_provider: Optional[str] = Field(default=None)
     generation_prompt: Optional[str] = Field(default=None)
-    max_generation_tokens: int = Field(default=500, ge=50, le=2000)
+    max_generation_tokens: int = Field(default=500, ge=50, le=4000)
     # Search Agent / Round 2 enhancements
     enable_suggestions: bool = Field(default=False)
     num_suggestions: int = Field(default=5, ge=1, le=10)

--- a/tldw_Server_API/app/core/RAG/API_DOCUMENTATION.md
+++ b/tldw_Server_API/app/core/RAG/API_DOCUMENTATION.md
@@ -28,6 +28,7 @@ The main RAG endpoint with complete feature access.
 
   // ========== DATA SOURCES ==========
   "sources": ["media_db", "notes", "characters", "chats"],  // Default: ["media_db"]
+  "rag_profile": "balanced",  // Optional: "fast" | "balanced" | "accuracy"
 
   // ========== SEARCH CONFIGURATION ==========
   "search_mode": "hybrid",  // "fts" | "vector" | "hybrid"
@@ -95,7 +96,7 @@ The main RAG endpoint with complete feature access.
   "strict_extractive": false,              // Assemble answer only from retrieved spans (no free-form generation)
   "generation_model": "gpt-4o",     // Model name
   "generation_prompt": "string (optional)",
-  "max_generation_tokens": 500,
+  "max_generation_tokens": 500,     // Range: 50-4000
   // Abstention & multi-turn synthesis (optional)
   "enable_abstention": false,
   "abstention_behavior": "continue",  // "continue" | "ask" | "decline"
@@ -170,6 +171,13 @@ The main RAG endpoint with complete feature access.
   "track_cost": false
 }
 ```
+
+Profile precedence is strict and deterministic:
+
+1. Explicit request fields
+2. `rag_profile` defaults
+3. Search-Agent env/config defaults
+4. Schema defaults
 
 #### Response Schema
 

--- a/tldw_Server_API/app/core/RAG/CAPABILITIES.md
+++ b/tldw_Server_API/app/core/RAG/CAPABILITIES.md
@@ -116,3 +116,20 @@ curl -s "http://127.0.0.1:8000/api/v1/rag/capabilities" | jq
 Notes:
 - Capability labels “fulltext” and “semantic” correspond to request values `"fts"` and `"vector"` for `search_mode`.
 - Source values `"characters"` and `"chats"` both map to the `character_db` datastore internally.
+
+## Switchable Profiles
+
+The unified RAG request supports optional switchable profile defaults via `rag_profile`:
+
+- `fast`
+- `balanced`
+- `accuracy`
+
+When provided, profile defaults are resolved with strict precedence:
+
+1. Explicit request field
+2. Profile default
+3. Search-Agent env/config defaults
+4. Schema default
+
+Generation token limits now support up to `4000` (`max_generation_tokens <= 4000`).

--- a/tldw_Server_API/app/core/RAG/rag_service/generation.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/generation.py
@@ -13,9 +13,12 @@ import time
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, cast
 
 from loguru import logger
+
+from tldw_Server_API.app.core.Utils.prompt_loader import load_prompt
 
 from .types import Document
 
@@ -136,9 +139,26 @@ Your question: {question}
 
 Let me explain:"""
 
+    @staticmethod
+    @lru_cache(maxsize=64)
+    def _load_rag_prompt_cached(name: str) -> Optional[str]:
+        """Load prompt snippets from rag.prompts.* with a small process cache."""
+        try:
+            prompt_text = load_prompt("rag", name)
+        except Exception as exc:  # noqa: BLE001 - prompt loading must remain best-effort
+            logger.debug(f"Prompt loader failed for rag prompt '{name}': {exc}")
+            return None
+        if isinstance(prompt_text, str) and prompt_text.strip():
+            return prompt_text.strip()
+        return None
+
     @classmethod
     def get_template(cls, name: str) -> str:
         """Get a template by name."""
+        external = cls._load_rag_prompt_cached(name)
+        if external is not None:
+            return external
+
         templates = {
             "default": cls.DEFAULT,
             "detailed": cls.DETAILED,

--- a/tldw_Server_API/app/core/RAG/rag_service/generation.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/generation.py
@@ -153,6 +153,23 @@ Let me explain:"""
         return None
 
     @classmethod
+    async def warm_template_async(cls, name: str) -> None:
+        """Preload a template off the event loop for async request paths."""
+        if not isinstance(name, str):
+            return
+        normalized_name = name.strip()
+        if not normalized_name:
+            return
+        try:
+            await asyncio.to_thread(cls._load_rag_prompt_cached, normalized_name)
+        except Exception as exc:  # noqa: BLE001 - warmup remains best-effort
+            logger.debug(
+                "Prompt warmup failed for rag prompt '{}': {}",
+                normalized_name,
+                exc,
+            )
+
+    @classmethod
     def get_template(cls, name: str) -> str:
         """Get a template by name."""
         external = cls._load_rag_prompt_cached(name)
@@ -522,6 +539,10 @@ async def generate_response(context: Any, **kwargs) -> Any:
     # Override with kwargs
     config_dict.update(kwargs)
 
+    prompt_name = config_dict.get("prompt_template", "default")
+    if isinstance(prompt_name, str):
+        await PromptTemplates.warm_template_async(prompt_name)
+
     # Create generator
     generator = create_generator(config_dict)
 
@@ -577,6 +598,7 @@ class AnswerGenerator:
             prompt_template=(prompt_template or "default"),
             system_prompt=self.system_prompt,
         )
+        await PromptTemplates.warm_template_async(gcfg.prompt_template)
         gen = LLMGenerator(gcfg)
 
         # Create a tiny context holder compatible with BaseGenerator expectations
@@ -600,6 +622,10 @@ async def generate_streaming_response(context: Any, **kwargs) -> Any:
 
     # Override with kwargs
     config_dict.update(kwargs)
+
+    prompt_name = config_dict.get("prompt_template", "default")
+    if isinstance(prompt_name, str):
+        await PromptTemplates.warm_template_async(prompt_name)
 
     # Create generator
     generator = create_generator(config_dict)

--- a/tldw_Server_API/app/core/RAG/rag_service/profiles.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/profiles.py
@@ -12,6 +12,9 @@ Current built-in profiles:
                       and model/retrieval experiments.
     - "cheap"       : Cost- and latency-optimized configuration with most
                       expensive extras disabled.
+    - "fast"        : Latency-first profile for short, direct answers.
+    - "balanced"    : Practical quality/latency tradeoff for most usage.
+    - "accuracy"    : Quality-first profile with stronger retrieval/synthesis.
 
 Profiles are intentionally conservative: they override only a subset of
 pipeline parameters and rely on function-level defaults for everything else.
@@ -22,7 +25,14 @@ from collections.abc import Mapping, MutableMapping
 from dataclasses import dataclass
 from typing import Any, Literal, Optional
 
-ProfileName = Literal["production", "research", "cheap"]
+ProfileName = Literal[
+    "production",
+    "research",
+    "cheap",
+    "fast",
+    "balanced",
+    "accuracy",
+]
 
 
 @dataclass(frozen=True)
@@ -181,6 +191,67 @@ _PROFILES: dict[ProfileName, RAGProfile] = {
             "enable_observability": False,
             "enable_performance_analysis": False,
             "track_cost": False,
+        },
+    ),
+    "fast": RAGProfile(
+        name="fast",
+        description=(
+            "Latency-first profile using compact instruction-style prompting "
+            "with lightweight retrieval and no decomposition."
+        ),
+        defaults={
+            "generation_prompt": "instruction_tuned",
+            "enable_query_decomposition": False,
+            "enable_reranking": True,
+            "reranking_strategy": "flashrank",
+            "top_k": 6,
+            "max_generation_tokens": 440,
+            "enable_structured_response": False,
+            "enable_multi_turn_synthesis": False,
+            "require_hard_citations": False,
+            "enable_claims": False,
+        },
+    ),
+    "balanced": RAGProfile(
+        name="balanced",
+        description=(
+            "Balanced quality/latency profile with compact multi-hop guidance "
+            "and hybrid reranking."
+        ),
+        defaults={
+            "generation_prompt": "multi_hop_compact",
+            "enable_query_decomposition": True,
+            "max_subqueries": 3,
+            "subquery_time_budget_sec": 2.5,
+            "enable_reranking": True,
+            "reranking_strategy": "hybrid",
+            "top_k": 10,
+            "max_generation_tokens": 1000,
+            "enable_structured_response": True,
+            "require_hard_citations": False,
+            "enable_claims": False,
+        },
+    ),
+    "accuracy": RAGProfile(
+        name="accuracy",
+        description=(
+            "Quality-first profile emphasizing decomposition depth, stronger "
+            "reranking, and expert synthesis prompting."
+        ),
+        defaults={
+            "generation_prompt": "expert_synthesis",
+            "enable_query_decomposition": True,
+            "max_subqueries": 5,
+            "subquery_time_budget_sec": 6.0,
+            "enable_reranking": True,
+            "reranking_strategy": "two_tier",
+            "top_k": 16,
+            "rerank_top_k": 16,
+            "max_generation_tokens": 2200,
+            "enable_structured_response": True,
+            "require_hard_citations": True,
+            "enable_numeric_fidelity": True,
+            "enable_claims": True,
         },
     ),
 }

--- a/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
@@ -1209,6 +1209,7 @@ async def unified_rag_pipeline(
     # ========== MEDIA SEARCH ==========
     enable_image_search: bool = False,
     enable_video_search: bool = False,
+    rag_profile: Optional[Literal["fast", "balanced", "accuracy"]] = None,
 
     # ========== ADDITIONAL PARAMETERS ==========
     **kwargs: Any
@@ -1357,6 +1358,41 @@ async def unified_rag_pipeline(
             result.metadata.update(inbound_meta)
     except TypeError:
         pass
+
+    def _ensure_profile_resolution_metadata() -> dict[str, Any]:
+        profile_resolution = result.metadata.get("profile_resolution")
+        if not isinstance(profile_resolution, dict):
+            profile_resolution = {}
+        profile_resolution.setdefault("requested_profile", rag_profile)
+        profile_resolution.setdefault("applied_profile", rag_profile)
+        profile_resolution.setdefault("effective_overrides_count", 0)
+        if not isinstance(profile_resolution.get("degraded_features"), list):
+            profile_resolution["degraded_features"] = []
+        result.metadata["profile_resolution"] = profile_resolution
+        return profile_resolution
+
+    def _record_profile_degradation(
+        *,
+        component: str,
+        from_value: str,
+        to_value: str,
+        reason: str,
+    ) -> None:
+        profile_resolution = _ensure_profile_resolution_metadata()
+        degraded_features = profile_resolution.get("degraded_features")
+        if not isinstance(degraded_features, list):
+            degraded_features = []
+            profile_resolution["degraded_features"] = degraded_features
+        degraded_features.append(
+            {
+                "component": component,
+                "from": from_value,
+                "to": to_value,
+                "reason": reason,
+            }
+        )
+
+    _ensure_profile_resolution_metadata()
 
     cache_instance = None
     cache_max_size = 1000
@@ -3930,6 +3966,17 @@ async def unified_rag_pipeline(
         # ========== RERANKING ==========
         if enable_reranking and result.documents and reranking_strategy != "none":
             rerank_start = time.time()
+            if (
+                reranking_strategy == "two_tier"
+                and not (create_reranker and RerankingStrategy and RerankingConfig)
+            ):
+                _record_profile_degradation(
+                    component="reranking_strategy",
+                    from_value="two_tier",
+                    to_value="hybrid",
+                    reason="unavailable_dependency",
+                )
+                reranking_strategy = "hybrid"
             try:
                 # --- OTEL: reranking span ---
                 _otel_cm_rk = None
@@ -4027,8 +4074,29 @@ async def unified_rag_pipeline(
                         min_relevance_prob=rerank_min_relevance_prob,
                         sentinel_margin=rerank_sentinel_margin,
                     )
-                    reranker = create_reranker(selected_strategy, rerank_config, llm_client=llm_client)
-                    reranked = await _resilient_call("reranking", reranker.rerank, query, result.documents)
+                    try:
+                        reranker = create_reranker(selected_strategy, rerank_config, llm_client=llm_client)
+                        reranked = await _resilient_call("reranking", reranker.rerank, query, result.documents)
+                    except Exception:
+                        if reranking_strategy != "two_tier":
+                            raise
+                        _record_profile_degradation(
+                            component="reranking_strategy",
+                            from_value="two_tier",
+                            to_value="hybrid",
+                            reason="runtime_failure",
+                        )
+                        reranking_strategy = "hybrid"
+                        selected_strategy = RerankingStrategy.HYBRID
+                        rerank_config = RerankingConfig(
+                            strategy=selected_strategy,
+                            top_k=rerank_top_k or top_k,
+                            model_name=None,
+                            min_relevance_prob=rerank_min_relevance_prob,
+                            sentinel_margin=rerank_sentinel_margin,
+                        )
+                        reranker = create_reranker(selected_strategy, rerank_config, llm_client=llm_client)
+                        reranked = await _resilient_call("reranking", reranker.rerank, query, result.documents)
                     if reranked and hasattr(reranked[0], 'document'):
                         result.documents = [sd.document for sd in reranked[:(rerank_top_k or top_k)]]
                     else:

--- a/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
+++ b/tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py
@@ -4077,9 +4077,13 @@ async def unified_rag_pipeline(
                     try:
                         reranker = create_reranker(selected_strategy, rerank_config, llm_client=llm_client)
                         reranked = await _resilient_call("reranking", reranker.rerank, query, result.documents)
-                    except Exception:
+                    except Exception as rerank_exc:
                         if reranking_strategy != "two_tier":
                             raise
+                        logger.warning(
+                            "Two-tier reranker failed at runtime; degrading to hybrid strategy: {}",
+                            rerank_exc,
+                        )
                         _record_profile_degradation(
                             component="reranking_strategy",
                             from_value="two_tier",

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
@@ -1,3 +1,8 @@
+"""Integration coverage for `/rag/search/stream` profile and event parity."""
+
+from collections.abc import Iterator
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -10,14 +15,17 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)
-def _set_test_mode_env(monkeypatch):
+def _set_test_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("RAG_DEFAULT_LLM_PROVIDER", "test-provider")
     monkeypatch.setenv("RAG_DEFAULT_LLM_MODEL", "default-model")
 
 
 @pytest.fixture()
-def client_with_stream_overrides(monkeypatch, auth_headers):
+def client_with_stream_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    auth_headers: dict[str, str],
+) -> Iterator[TestClient]:
     async def override_user():
         return User(id=1, username="tester", email=None, is_active=True)
 
@@ -52,7 +60,10 @@ def client_with_stream_overrides(monkeypatch, auth_headers):
     fastapi_app.dependency_overrides.clear()
 
 
-def test_rag_streaming_parity_generation_and_hybrid_sources(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_parity_generation_and_hybrid_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
 
 
     from tldw_Server_API.app.core.RAG.rag_service.types import Document, DataSource
@@ -76,7 +87,7 @@ def test_rag_streaming_parity_generation_and_hybrid_sources(monkeypatch, client_
                 )
             ]
 
-    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         captured["generation_config"] = context.config.get("generation")
 
         async def _gen():
@@ -124,7 +135,10 @@ def test_rag_streaming_parity_generation_and_hybrid_sources(monkeypatch, client_
     assert generation_config["streaming"] is True
 
 
-def test_rag_streaming_generation_provider_override(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_generation_provider_override(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
     captured = {"generation_config": None}
@@ -146,7 +160,7 @@ def test_rag_streaming_generation_provider_override(monkeypatch, client_with_str
                 )
             ]
 
-    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         captured["generation_config"] = context.config.get("generation")
 
         async def _gen():
@@ -178,14 +192,17 @@ def test_rag_streaming_generation_provider_override(monkeypatch, client_with_str
     assert generation_config["model"] == "llama-3.3-70b-versatile"
 
 
-def test_rag_streaming_emits_research_progress_before_generation(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_emits_research_progress_before_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
     import asyncio
     from types import SimpleNamespace
 
     from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
-    async def _fake_unified_pipeline(**kwargs):  # noqa: ANN001
+    async def _fake_unified_pipeline(**kwargs: Any) -> Any:
         callback = kwargs.get("research_progress_callback")
         if callback:
             await callback(SimpleNamespace(event_type="research_reasoning", data={"step": 1, "text": "plan"}))
@@ -218,7 +235,7 @@ def test_rag_streaming_emits_research_progress_before_generation(monkeypatch, cl
             total_time=0.0,
         )
 
-    async def _fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def _fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         async def _gen():
             yield "stream token"
 
@@ -267,11 +284,14 @@ def test_rag_streaming_emits_research_progress_before_generation(monkeypatch, cl
     assert types.index("research_complete") < types.index("delta")
 
 
-def test_rag_streaming_preserves_delta_and_claim_events(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_preserves_delta_and_claim_events(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
     from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
-    async def _fake_unified_pipeline(**kwargs):  # noqa: ANN001
+    async def _fake_unified_pipeline(**kwargs: Any) -> Any:
         return rag_ep.UnifiedSearchResult(
             documents=[
                 Document(
@@ -295,7 +315,7 @@ def test_rag_streaming_preserves_delta_and_claim_events(monkeypatch, client_with
             total_time=0.0,
         )
 
-    async def _fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def _fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         context.metadata = {}
 
         async def _gen():
@@ -336,7 +356,10 @@ def test_rag_streaming_preserves_delta_and_claim_events(monkeypatch, client_with
     assert final_events[0].get("claim_count") == 2
 
 
-def test_rag_streaming_profile_defaults_affect_generation_config(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_profile_defaults_affect_generation_config(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
     captured = {"generation_config": None}
@@ -358,7 +381,7 @@ def test_rag_streaming_profile_defaults_affect_generation_config(monkeypatch, cl
                 )
             ]
 
-    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         captured["generation_config"] = context.config.get("generation")
 
         async def _gen():
@@ -390,7 +413,10 @@ def test_rag_streaming_profile_defaults_affect_generation_config(monkeypatch, cl
     assert generation_config["prompt_template"] == "multi_hop_compact"
 
 
-def test_rag_streaming_profile_fast_applies_instruction_prompt(monkeypatch, client_with_stream_overrides):
+def test_rag_streaming_profile_fast_applies_instruction_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
     import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
 
     captured = {"generation_config": None}
@@ -412,7 +438,7 @@ def test_rag_streaming_profile_fast_applies_instruction_prompt(monkeypatch, clie
                 )
             ]
 
-    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+    async def fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
         captured["generation_config"] = context.config.get("generation")
 
         async def _gen():
@@ -441,3 +467,72 @@ def test_rag_streaming_profile_fast_applies_instruction_prompt(monkeypatch, clie
     assert generation_config is not None
     assert generation_config["max_tokens"] == 440
     assert generation_config["prompt_template"] == "instruction_tuned"
+
+
+def test_rag_streaming_agentic_path_uses_profile_resolved_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    client_with_stream_overrides: TestClient,
+) -> None:
+    from types import SimpleNamespace
+
+    from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    captured: dict[str, Any] = {"agentic_kwargs": None}
+
+    class StubRetriever:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.retrievers = {}
+
+        async def retrieve(self, query: str, **kwargs: Any) -> list[Document]:
+            return [
+                Document(
+                    id="doc-1",
+                    content="Context content",
+                    metadata={"title": "Doc"},
+                    source=DataSource.MEDIA_DB,
+                    score=0.9,
+                )
+            ]
+
+    async def fake_agentic_rag_pipeline(**kwargs: Any) -> Any:
+        captured["agentic_kwargs"] = kwargs
+        return SimpleNamespace(
+            documents=[
+                Document(
+                    id="agentic-doc-1",
+                    content="Agentic context",
+                    metadata={"title": "Agentic"},
+                    source=DataSource.MEDIA_DB,
+                    score=0.95,
+                )
+            ],
+            metadata={"agentic_metrics": {"steps": 1}, "provenance": []},
+        )
+
+    async def fake_generate_streaming_response(context: Any, **kwargs: Any) -> Any:
+        async def _gen():
+            yield "chunk"
+
+        context.stream_generator = _gen()
+        context.metadata = {"streaming": True}
+        return context
+
+    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", StubRetriever)
+    monkeypatch.setattr(rag_ep, "agentic_rag_pipeline", fake_agentic_rag_pipeline)
+    monkeypatch.setattr(rag_ep, "generate_streaming_response", fake_generate_streaming_response)
+
+    payload = {
+        "query": "Agentic profile defaults parity",
+        "strategy": "agentic",
+        "rag_profile": "fast",
+        "enable_generation": True,
+    }
+
+    with client_with_stream_overrides.stream("POST", "/api/v1/rag/search/stream", json=payload) as resp:
+        assert resp.status_code == 200
+        next(resp.iter_lines(), None)
+
+    agentic_kwargs = captured["agentic_kwargs"]
+    assert agentic_kwargs is not None
+    assert agentic_kwargs["top_k"] == 6

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
@@ -388,3 +388,56 @@ def test_rag_streaming_profile_defaults_affect_generation_config(monkeypatch, cl
     assert generation_config is not None
     assert generation_config["max_tokens"] == 1000
     assert generation_config["prompt_template"] == "multi_hop_compact"
+
+
+def test_rag_streaming_profile_fast_applies_instruction_prompt(monkeypatch, client_with_stream_overrides):
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    captured = {"generation_config": None}
+
+    class StubRetriever:
+        def __init__(self, *args, **kwargs):
+            self.retrievers = {}
+
+        async def retrieve(self, query, **kwargs):
+            from tldw_Server_API.app.core.RAG.rag_service.types import Document, DataSource
+
+            return [
+                Document(
+                    id="doc-1",
+                    content="Context content",
+                    metadata={"title": "Doc"},
+                    source=DataSource.MEDIA_DB,
+                    score=0.9,
+                )
+            ]
+
+    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+        captured["generation_config"] = context.config.get("generation")
+
+        async def _gen():
+            yield "chunk"
+
+        context.stream_generator = _gen()
+        context.metadata = {"streaming": True}
+        return context
+
+    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", StubRetriever)
+    monkeypatch.setattr(rag_ep, "generate_streaming_response", fake_generate_streaming_response)
+
+    payload = {
+        "query": "Fast profile streaming parity",
+        "search_mode": "hybrid",
+        "sources": ["media_db"],
+        "enable_generation": True,
+        "rag_profile": "fast",
+    }
+
+    with client_with_stream_overrides.stream("POST", "/api/v1/rag/search/stream", json=payload) as resp:
+        assert resp.status_code == 200
+        next(resp.iter_lines(), None)
+
+    generation_config = captured["generation_config"]
+    assert generation_config is not None
+    assert generation_config["max_tokens"] == 440
+    assert generation_config["prompt_template"] == "instruction_tuned"

--- a/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
+++ b/tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py
@@ -334,3 +334,57 @@ def test_rag_streaming_preserves_delta_and_claim_events(monkeypatch, client_with
     assert len(overlay_events) >= 2
     assert len(final_events) == 1
     assert final_events[0].get("claim_count") == 2
+
+
+def test_rag_streaming_profile_defaults_affect_generation_config(monkeypatch, client_with_stream_overrides):
+    import tldw_Server_API.app.api.v1.endpoints.rag_unified as rag_ep
+
+    captured = {"generation_config": None}
+
+    class StubRetriever:
+        def __init__(self, *args, **kwargs):
+            self.retrievers = {}
+
+        async def retrieve(self, query, **kwargs):
+            from tldw_Server_API.app.core.RAG.rag_service.types import Document, DataSource
+
+            return [
+                Document(
+                    id="doc-1",
+                    content="Context content",
+                    metadata={"title": "Doc"},
+                    source=DataSource.MEDIA_DB,
+                    score=0.9,
+                )
+            ]
+
+    async def fake_generate_streaming_response(context, **kwargs):  # noqa: ANN001
+        captured["generation_config"] = context.config.get("generation")
+
+        async def _gen():
+            yield "chunk"
+
+        context.stream_generator = _gen()
+        context.metadata = {"streaming": True}
+        return context
+
+    monkeypatch.setattr(rag_ep, "MultiDatabaseRetriever", StubRetriever)
+    monkeypatch.setattr(rag_ep, "generate_streaming_response", fake_generate_streaming_response)
+
+    payload = {
+        "query": "Profile streaming parity",
+        "search_mode": "hybrid",
+        "sources": ["media_db"],
+        "enable_generation": True,
+        "generation_model": "explicit-model",
+        "rag_profile": "balanced",
+    }
+
+    with client_with_stream_overrides.stream("POST", "/api/v1/rag/search/stream", json=payload) as resp:
+        assert resp.status_code == 200
+        next(resp.iter_lines(), None)
+
+    generation_config = captured["generation_config"]
+    assert generation_config is not None
+    assert generation_config["max_tokens"] == 1000
+    assert generation_config["prompt_template"] == "multi_hop_compact"

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_generation_prompt_loader.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_generation_prompt_loader.py
@@ -1,0 +1,21 @@
+import pytest
+
+from tldw_Server_API.app.core.RAG.rag_service.generation import PromptTemplates
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_prompt_templates_load_switchable_profile_prompt_keys():
+    text = PromptTemplates.get_template("instruction_tuned")
+
+    assert "Use the provided context" in text
+    assert "{context}" in text
+    assert "{question}" in text
+
+
+def test_prompt_templates_falls_back_to_default_for_unknown_key():
+    unknown = PromptTemplates.get_template("does_not_exist")
+
+    assert "Context:" in unknown
+    assert "Question:" in unknown

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_generation_prompt_loader.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_generation_prompt_loader.py
@@ -1,12 +1,19 @@
+"""Unit tests for RAG generation prompt-template loading behavior."""
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
 import pytest
 
+from tldw_Server_API.app.core.RAG.rag_service import generation as generation_mod
 from tldw_Server_API.app.core.RAG.rag_service.generation import PromptTemplates
 
 
 pytestmark = pytest.mark.unit
 
 
-def test_prompt_templates_load_switchable_profile_prompt_keys():
+def test_prompt_templates_load_switchable_profile_prompt_keys() -> None:
     text = PromptTemplates.get_template("instruction_tuned")
 
     assert "Use the provided context" in text
@@ -14,8 +21,36 @@ def test_prompt_templates_load_switchable_profile_prompt_keys():
     assert "{question}" in text
 
 
-def test_prompt_templates_falls_back_to_default_for_unknown_key():
+def test_prompt_templates_falls_back_to_default_for_unknown_key() -> None:
     unknown = PromptTemplates.get_template("does_not_exist")
 
     assert "Context:" in unknown
     assert "Question:" in unknown
+
+
+@pytest.mark.asyncio
+async def test_generate_streaming_response_warms_prompt_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warmed: list[str] = []
+
+    async def _fake_warm(name: str) -> None:
+        warmed.append(name)
+
+    class _StubGenerator:
+        async def generate_stream(self, context: Any, query: str) -> AsyncIterator[str]:
+            if False:
+                yield ""  # pragma: no cover
+
+    monkeypatch.setattr(PromptTemplates, "warm_template_async", _fake_warm)
+    monkeypatch.setattr(generation_mod, "create_generator", lambda _config: _StubGenerator())
+
+    ctx = SimpleNamespace(
+        config={"generation": {"prompt_template": "instruction_tuned"}},
+        query="warm prompt",
+        metadata={},
+    )
+
+    await generation_mod.generate_streaming_response(ctx)
+
+    assert warmed == ["instruction_tuned"]

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_profiles.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_profiles.py
@@ -21,6 +21,28 @@ class TestRAGProfiles:
         assert "production" in profiles
         assert "research" in profiles
         assert "cheap" in profiles
+        assert "fast" in profiles
+        assert "balanced" in profiles
+        assert "accuracy" in profiles
+
+    def test_switchable_profile_defaults_match_design_targets(self):
+        fast = get_profile_kwargs("fast")
+        balanced = get_profile_kwargs("balanced")
+        accuracy = get_profile_kwargs("accuracy")
+
+        assert fast["max_generation_tokens"] == 440
+        assert fast["generation_prompt"] == "instruction_tuned"
+        assert fast["enable_query_decomposition"] is False
+
+        assert balanced["max_generation_tokens"] == 1000
+        assert balanced["generation_prompt"] == "multi_hop_compact"
+        assert balanced["enable_query_decomposition"] is True
+        assert balanced["reranking_strategy"] == "hybrid"
+
+        assert accuracy["max_generation_tokens"] == 2200
+        assert accuracy["generation_prompt"] == "expert_synthesis"
+        assert accuracy["enable_query_decomposition"] is True
+        assert accuracy["reranking_strategy"] == "two_tier"
 
     def test_get_profile_kwargs_merges_overrides(self):
 

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_request_schema_profiles.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_request_schema_profiles.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.rag_schemas_unified import UnifiedRAGRequest
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("profile", ["fast", "balanced", "accuracy"])
+def test_rag_profile_accepts_switchable_values(profile: str) -> None:
+    req = UnifiedRAGRequest(query="q", rag_profile=profile)
+    assert req.rag_profile == profile
+
+
+def test_rag_profile_rejects_unknown_value() -> None:
+    with pytest.raises(ValidationError):
+        UnifiedRAGRequest(query="q", rag_profile="production")
+
+
+def test_max_generation_tokens_allows_2200_but_rejects_4001() -> None:
+    ok_req = UnifiedRAGRequest(query="q", max_generation_tokens=2200)
+    assert ok_req.max_generation_tokens == 2200
+
+    with pytest.raises(ValidationError):
+        UnifiedRAGRequest(query="q", max_generation_tokens=4001)

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_rag_unified_search_agent_defaults.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_rag_unified_search_agent_defaults.py
@@ -24,7 +24,6 @@ def _config_value_factory(mapping: dict[str, str]):
 
     return _fake_get_config_value
 
-
 def test_search_agent_defaults_apply_when_request_fields_omitted(monkeypatch):
     for env_key in (
         "SEARCH_QUERY_CLASSIFICATION",
@@ -100,7 +99,6 @@ def test_search_agent_defaults_apply_when_request_fields_omitted(monkeypatch):
     assert kwargs["research_max_iterations_balanced"] == 7
     assert kwargs["research_max_iterations_quality"] == 15
 
-
 def test_search_agent_defaults_do_not_override_explicit_request_values(monkeypatch):
     monkeypatch.setattr(
         rag_ep,
@@ -171,7 +169,6 @@ def test_search_agent_defaults_do_not_override_explicit_request_values(monkeypat
     assert kwargs["research_max_iterations_balanced"] == 2
     assert kwargs["research_max_iterations_quality"] == 3
 
-
 def test_search_agent_env_overrides_config_defaults(monkeypatch):
     monkeypatch.setattr(
         rag_ep,
@@ -205,7 +202,6 @@ def test_search_agent_env_overrides_config_defaults(monkeypatch):
     assert kwargs["discussion_platforms"] == ["stackoverflow", "hackernews"]
     assert kwargs["enable_suggestions"] is True
 
-
 def test_build_kwargs_uses_authenticated_numeric_user_id_for_storage_paths():
     request = UnifiedRAGRequest(query="normalize authenticated user id")
     current_user = SimpleNamespace(id=1, id_int=1, username="single_user")
@@ -221,7 +217,6 @@ def test_build_kwargs_uses_authenticated_numeric_user_id_for_storage_paths():
     assert kwargs["user_id"] == "1"
     assert kwargs["feedback_user_id"] == "1"
 
-
 def test_resolve_implicit_feedback_user_id_maps_single_user_alias_without_user(monkeypatch):
     monkeypatch.setattr(
         rag_ep.DatabasePaths,
@@ -232,7 +227,6 @@ def test_resolve_implicit_feedback_user_id_maps_single_user_alias_without_user(m
     resolved = rag_ep._resolve_implicit_feedback_user_id("single_user", None)
 
     assert resolved == "7"
-
 
 def test_batch_round2_defaults_apply_when_fields_omitted(monkeypatch):
     for env_key in (
@@ -268,3 +262,51 @@ def test_batch_round2_defaults_apply_when_fields_omitted(monkeypatch):
     assert payload["enable_structured_response"] is True
     assert payload["enable_image_search"] is False
     assert payload["enable_video_search"] is True
+
+def test_rag_profile_applies_defaults_when_fields_omitted():
+    request = UnifiedRAGRequest(query="profile apply", rag_profile="fast")
+    kwargs = rag_ep._build_unified_pipeline_kwargs(
+        request=request,
+        db_paths=_EMPTY_DB_PATHS,
+        media_db=None,  # type: ignore[arg-type]
+        chacha_db=None,  # type: ignore[arg-type]
+        current_user=None,
+    )
+
+    assert kwargs["generation_prompt"] == "instruction_tuned"
+    assert kwargs["max_generation_tokens"] == 440
+
+
+def test_explicit_request_fields_override_profile_defaults():
+    request = UnifiedRAGRequest(
+        query="profile override",
+        rag_profile="accuracy",
+        max_generation_tokens=700,
+        generation_prompt="concise",
+    )
+    kwargs = rag_ep._build_unified_pipeline_kwargs(
+        request=request,
+        db_paths=_EMPTY_DB_PATHS,
+        media_db=None,  # type: ignore[arg-type]
+        chacha_db=None,  # type: ignore[arg-type]
+        current_user=None,
+    )
+
+    assert kwargs["max_generation_tokens"] == 700
+    assert kwargs["generation_prompt"] == "concise"
+    assert kwargs["reranking_strategy"] == "two_tier"
+
+
+def test_profile_defaults_override_search_agent_defaults_when_request_omits_field(monkeypatch):
+    monkeypatch.setenv("SEARCH_STRUCTURED_RESPONSE", "false")
+
+    request = UnifiedRAGRequest(query="precedence", rag_profile="balanced")
+    kwargs = rag_ep._build_unified_pipeline_kwargs(
+        request=request,
+        db_paths=_EMPTY_DB_PATHS,
+        media_db=None,  # type: ignore[arg-type]
+        chacha_db=None,  # type: ignore[arg-type]
+        current_user=None,
+    )
+
+    assert kwargs["enable_structured_response"] is True

--- a/tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_profile_metadata.py
+++ b/tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_profile_metadata.py
@@ -1,0 +1,94 @@
+import types
+
+import pytest
+
+from tldw_Server_API.app.core.RAG.rag_service.types import DataSource, Document
+import tldw_Server_API.app.core.RAG.rag_service.unified_pipeline as up
+
+
+pytestmark = pytest.mark.unit
+
+
+class FakeRetriever:
+    def __init__(self, *args, **kwargs):
+        self.retrievers = {}
+
+    async def retrieve(self, query: str, sources=None, config=None, index_namespace=None, **kwargs):
+        return [
+            Document(
+                id="m1",
+                content="first doc",
+                source=DataSource.MEDIA_DB,
+                metadata={"title": "Doc 1"},
+                score=0.8,
+            ),
+            Document(
+                id="m2",
+                content="second doc",
+                source=DataSource.MEDIA_DB,
+                metadata={"title": "Doc 2"},
+                score=0.6,
+            ),
+        ]
+
+
+class FakeHybridReranker:
+    async def rerank(self, query, documents, original_scores=None):
+        return [types.SimpleNamespace(document=d, rerank_score=getattr(d, "score", 0.0)) for d in documents]
+
+
+
+def _metadata(result):
+    if isinstance(result, dict):
+        return result.get("metadata", {})
+    return getattr(result, "metadata", {}) or {}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_records_profile_resolution_metadata(monkeypatch):
+    monkeypatch.setattr(up, "MultiDatabaseRetriever", FakeRetriever)
+
+    result = await up.unified_rag_pipeline(
+        query="q",
+        sources=["media_db"],
+        enable_cache=False,
+        enable_generation=False,
+        enable_reranking=False,
+        rag_profile="balanced",
+    )
+
+    md = _metadata(result)
+    profile = md.get("profile_resolution", {})
+    assert profile.get("requested_profile") == "balanced"
+    assert profile.get("applied_profile") == "balanced"
+
+
+@pytest.mark.asyncio
+async def test_two_tier_unavailable_degrades_to_hybrid(monkeypatch):
+    monkeypatch.setattr(up, "MultiDatabaseRetriever", FakeRetriever)
+
+    def _fake_create_reranker(strategy, *args, **kwargs):
+        strategy_name = str(getattr(strategy, "name", strategy)).lower()
+        if "two_tier" in strategy_name:
+            raise RuntimeError("reranker unavailable")
+        return FakeHybridReranker()
+
+    monkeypatch.setattr(up, "create_reranker", _fake_create_reranker)
+
+    result = await up.unified_rag_pipeline(
+        query="q",
+        sources=["media_db"],
+        enable_cache=False,
+        enable_generation=False,
+        enable_reranking=True,
+        reranking_strategy="two_tier",
+        rag_profile="accuracy",
+        top_k=2,
+    )
+
+    md = _metadata(result)
+    degraded = md.get("profile_resolution", {}).get("degraded_features", [])
+    assert any(
+        item.get("from") == "two_tier" and item.get("to") == "hybrid"
+        for item in degraded
+    )


### PR DESCRIPTION
## Summary
- add switchable `rag_profile` support (`fast`, `balanced`, `accuracy`) across schema, backend profiles, endpoint payload resolution, and frontend request wiring
- apply strict precedence in API payload resolution (`explicit request > profile defaults > Search-Agent defaults > schema defaults`) and ensure streaming parity for profile-driven generation settings
- add profile-oriented prompt templates with cached prompt loading, pipeline profile-resolution metadata, and safe `two_tier -> hybrid` degradation metadata on unavailable/runtime failure paths
- update RAG docs and add targeted unit/integration/frontend tests for schema, profiles, resolver precedence, prompt loading, pipeline metadata, and streaming profile behavior

## Test Plan
- `python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_request_schema_profiles.py -v`
- `python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_profiles.py -v`
- `python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_rag_unified_search_agent_defaults.py -k rag_profile -v`
- `python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_generation_prompt_loader.py -v`
- `python -m pytest tldw_Server_API/tests/RAG_NEW/unit/test_unified_pipeline_profile_metadata.py -v`
- `python -m pytest tldw_Server_API/tests/RAG_NEW/integration/test_rag_stream_parity.py -k profile_fast -v`
- `bunx vitest run apps/packages/ui/src/services/rag/unified-rag.test.ts`
- `python -m bandit -r tldw_Server_API/app/api/v1/schemas/rag_schemas_unified.py tldw_Server_API/app/core/RAG/rag_service/profiles.py tldw_Server_API/app/api/v1/endpoints/rag_unified.py tldw_Server_API/app/core/RAG/rag_service/generation.py tldw_Server_API/app/core/RAG/rag_service/unified_pipeline.py -f json -o /tmp/bandit_rag_profiles.json`
