### PR TITLE
docs: add canonical benchmark guide for API + WebUI/extension with discoverability test

### DIFF
--- a/Docs/Plans/2026-03-02-benchmark-guide-api-webui-extension-design.md
+++ b/Docs/Plans/2026-03-02-benchmark-guide-api-webui-extension-design.md
@@ -1,0 +1,144 @@
+# Benchmark Guide (API + WebUI/Extension) Design
+
+Date: 2026-03-02  
+Status: Approved
+
+## 1) Goal
+
+Create a single canonical user guide for benchmark creation/runs focused on:
+
+- API workflows
+- WebUI/extension UI workflows
+- Current shipped behavior with explicitly labeled roadmap notes
+
+Audience is mixed: operator-first content with a contributor appendix.
+
+## 2) Problem Statement
+
+Benchmark capability exists across backend and UI surfaces, but guidance is fragmented:
+
+- Benchmark endpoints are implemented under unified evaluations routes.
+- WebUI/extension benchmark run flow exists in the Evaluations Runs tab.
+- Existing docs are evaluations-heavy and benchmark coverage is mostly API/CLI/internal, not one end-to-end operator guide for API + WebUI/extension.
+
+Result: users can run benchmarks today but must infer steps across multiple documents and code paths.
+
+## 3) Existing State (Validated)
+
+### API surface
+
+- `GET /api/v1/evaluations/benchmarks`
+- `GET /api/v1/evaluations/benchmarks/{benchmark_name}`
+- `POST /api/v1/evaluations/benchmarks/{benchmark_name}/run`
+
+Implemented in:
+
+- `tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_benchmarks.py`
+- Mounted via `tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py`
+
+### WebUI/extension surface
+
+- Evaluations route resolves to shared UI package implementation.
+- Benchmark run UI exists in Runs tab via ad-hoc evaluator mode `benchmark-run`.
+
+Implemented in:
+
+- `apps/packages/ui/src/components/Option/Evaluations/tabs/RunsTab.tsx`
+- `apps/packages/ui/src/components/Option/Evaluations/hooks/useRuns.ts`
+- `apps/packages/ui/src/services/evaluations.ts`
+
+### Documentation state
+
+- Existing server/user guides cover evaluations broadly.
+- No single canonical benchmark guide for API + WebUI/extension operator workflow.
+
+## 4) Proposed Approach (Selected)
+
+Use one canonical guide with index/cross-links.
+
+### Why this approach
+
+- Reduces drift versus split guides.
+- Improves discoverability and task completion for operators.
+- Keeps contributor depth in an appendix without overloading the main path.
+
+## 5) Deliverables
+
+1. New guide:
+   - `Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md`
+2. Discoverability update:
+   - Add guide link in `Docs/User_Guides/index.md`
+3. Cross-links (minimal):
+   - Add references from:
+     - `Docs/User_Guides/Server/Evaluations_User_Guide.md`
+     - `Docs/User_Guides/WebUI_Extension/User_Guide.md`
+
+## 6) Guide Information Architecture
+
+Planned sections:
+
+1. Audience and prerequisites
+2. Current-state capability map (what exists now)
+3. WebUI/extension quickstart for benchmark runs
+4. API quickstart for benchmark catalog/info/run
+5. “Creating custom benchmarks” (current supported path only)
+6. Troubleshooting
+7. Roadmap (not yet shipped)
+8. Contributor appendix (key files and extension points)
+
+## 7) Data Flow Coverage In Guide
+
+### WebUI/extension benchmark run flow
+
+1. User selects Evaluations -> Runs.
+2. User switches ad-hoc endpoint to `benchmark-run`.
+3. UI loads benchmark catalog from `/api/v1/evaluations/benchmarks`.
+4. User selects benchmark and submits JSON payload.
+5. UI posts to `/api/v1/evaluations/benchmarks/{name}/run`.
+6. UI displays returned run summary/output.
+
+### API benchmark run flow
+
+1. Client lists benchmarks.
+2. Client retrieves benchmark info.
+3. Client posts run payload (e.g., `limit`, `api_name`, `parallel`, `save_results`, optional filters).
+4. Server returns summary including counts and score aggregates.
+
+## 8) Accuracy and Safety Constraints
+
+- Document only verified shipped behavior.
+- Use mounted unified route paths exactly as implemented.
+- Label roadmap content explicitly as non-shipped.
+- Avoid claiming dedicated benchmark-creation UI if not present.
+
+## 9) Error Handling/Troubleshooting Content Plan
+
+Guide will include explicit resolutions for:
+
+- 401/403 auth/permissions mismatch
+- benchmark not found (404)
+- dataset load failure for benchmark
+- evaluation execution failures
+- rate limiting behavior
+
+## 10) Validation Plan
+
+Documentation validation:
+
+- Verify all referenced files/routes exist.
+- Verify examples match request/response models in code.
+- Run docs tests covering guide structure/linking when available.
+
+Success criteria:
+
+- Operator can execute benchmark run via WebUI/extension without guessing.
+- Operator can execute benchmark run via API using copy/paste examples.
+- Reader can distinguish current capability from roadmap.
+- Guide is discoverable from user guide index.
+
+## 11) Out of Scope
+
+- CLI workflow coverage in this guide
+- New benchmark backend features
+- New WebUI feature implementation beyond documentation
+

--- a/Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md
+++ b/Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md
@@ -1,0 +1,185 @@
+# Benchmark Creation and Runs (API + WebUI/Extension)
+
+This guide covers how to run benchmarks using:
+
+- The API (`/api/v1/evaluations/benchmarks...`)
+- The WebUI/extension Evaluations workflow (`benchmark-run`)
+
+It reflects current shipped behavior in this repository as of March 2, 2026.
+
+## Who This Guide Is For
+
+- Operators who want copy/paste benchmark runs
+- Team members validating model quality with existing benchmark definitions
+- Contributors who need a map of the benchmark run surface
+
+## Prerequisites
+
+- Server running (for example `http://127.0.0.1:8000`)
+- Auth configured:
+  - Single-user: API key (`X-API-KEY` or Bearer token)
+  - Multi-user: JWT bearer token
+- Permission scope that can run evaluations/benchmarks
+
+## Current State (Shipped)
+
+### API Routes
+
+- `GET /api/v1/evaluations/benchmarks`
+- `GET /api/v1/evaluations/benchmarks/{benchmark_name}`
+- `POST /api/v1/evaluations/benchmarks/{benchmark_name}/run`
+
+### WebUI/Extension Flow
+
+- Open Evaluations
+- Go to Runs
+- Use Ad-hoc evaluator mode
+- Select endpoint `benchmark-run`
+- Pick a benchmark from the selector
+- Submit JSON config
+
+## WebUI/Extension Quickstart
+
+1. Open `/evaluations`.
+2. Open the `Runs` tab.
+3. In `Ad-hoc evaluator`, set endpoint to `benchmark-run`.
+4. Choose a benchmark.
+5. Use a payload like:
+
+```json
+{
+  "limit": 25,
+  "api_name": "openai",
+  "parallel": 4,
+  "save_results": true
+}
+```
+
+6. Click `Start run`.
+7. Review returned summary in the result panel (totals, average score, min/max, category breakdown when available).
+
+### Optional Filters
+
+If a benchmark dataset includes taxonomy labels, you can filter categories:
+
+```json
+{
+  "limit": 100,
+  "api_name": "openai",
+  "parallel": 4,
+  "save_results": true,
+  "filter_categories": ["science", "history"]
+}
+```
+
+## API Quickstart
+
+Examples below use single-user API key mode. Replace auth header for JWT mode as needed.
+
+### 1) List Benchmarks
+
+```bash
+curl -X GET "http://127.0.0.1:8000/api/v1/evaluations/benchmarks" \
+  -H "X-API-KEY: YOUR_API_KEY"
+```
+
+### 2) Get One Benchmark Definition
+
+```bash
+curl -X GET "http://127.0.0.1:8000/api/v1/evaluations/benchmarks/bullshit_benchmark" \
+  -H "X-API-KEY: YOUR_API_KEY"
+```
+
+### 3) Run Benchmark
+
+```bash
+curl -X POST "http://127.0.0.1:8000/api/v1/evaluations/benchmarks/bullshit_benchmark/run" \
+  -H "X-API-KEY: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "limit": 25,
+    "api_name": "openai",
+    "parallel": 4,
+    "save_results": true
+  }'
+```
+
+Typical response shape:
+
+```json
+{
+  "benchmark": "bullshit_benchmark",
+  "total_samples": 25,
+  "results_summary": {
+    "total_evaluated": 25,
+    "successful": 25,
+    "failed": 0,
+    "average_score": 0.84,
+    "min_score": 0.5,
+    "max_score": 1.0
+  },
+  "evaluation_id": "eval_..."
+}
+```
+
+## Creating Custom Benchmarks (Current Supported Path)
+
+Current behavior distinguishes between:
+
+- Running registered benchmark definitions (`/benchmarks/...`)
+- Creating custom evaluation definitions/datasets (`/api/v1/evaluations` and `/api/v1/evaluations/datasets`)
+
+Important: there is no dedicated end-user API in this route group for creating brand-new benchmark types dynamically. In current shipped behavior, benchmark names are loaded from server-side benchmark registry/configuration.
+
+If your goal is a custom quality test today without backend benchmark registration:
+
+1. Create a dataset in `/api/v1/evaluations/datasets`
+2. Create an evaluation definition in `/api/v1/evaluations`
+3. Run it through `/api/v1/evaluations/{eval_id}/runs`
+
+## Troubleshooting
+
+### 401/403
+
+- Verify auth header type for your mode.
+- Confirm user has permission to read/run evaluations benchmarks.
+
+### 404 benchmark not found
+
+- Run benchmark list first and use returned `name` exactly.
+
+### 404 dataset load failure during run
+
+- Benchmark exists but backing dataset failed to load. Check server logs and benchmark data configuration.
+
+### Run failures in summary
+
+- `failed > 0` means per-item evaluator errors occurred.
+- Reduce `parallel` and retry.
+- Confirm provider credentials (`api_name`) are valid server-side.
+
+### Rate limiting
+
+- If requests are throttled, retry after the server rate-limit window resets.
+
+## Roadmap (Not Yet Shipped)
+
+Potential future improvements (not currently guaranteed in this build):
+
+- Dedicated benchmark creation UI flow in Evaluations.
+- First-class benchmark create/register API for operator workflows.
+- Richer run telemetry and per-item drill-down in UI benchmark mode.
+
+Treat this section as directional only. Use the current-state sections above for operational steps.
+
+## Contributor Appendix (Code Map)
+
+- Benchmark API routes:
+  - `tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_benchmarks.py`
+- Unified router mounting:
+  - `tldw_Server_API/app/api/v1/endpoints/evaluations/evaluations_unified.py`
+- WebUI runs tab benchmark mode:
+  - `apps/packages/ui/src/components/Option/Evaluations/tabs/RunsTab.tsx`
+- WebUI hooks/service calls:
+  - `apps/packages/ui/src/components/Option/Evaluations/hooks/useRuns.ts`
+  - `apps/packages/ui/src/services/evaluations.ts`

--- a/Docs/User_Guides/Server/Evaluations_User_Guide.md
+++ b/Docs/User_Guides/Server/Evaluations_User_Guide.md
@@ -1,5 +1,7 @@
 # Evaluations Module User Guide
 
+See also: [Benchmark Creation and Runs (API + WebUI/Extension)](Benchmark_Creation_API_WebUI_Extension_Guide.md)
+
 ## Table of Contents
 - [Overview](#overview)
 - [Getting Started](#getting-started)

--- a/Docs/User_Guides/WebUI_Extension/User_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/User_Guide.md
@@ -72,6 +72,8 @@ Top navigation groups features into tabs. Notable areas include:
 
 - Evaluations
   - Evaluations tab: run unified evaluations (RAG, batch, metrics) and inspect results.
+  - Benchmark runs via API + WebUI/extension:
+    [Benchmark Creation and Runs (API + WebUI/Extension)](../Server/Benchmark_Creation_API_WebUI_Extension_Guide.md).
 
 - Vector stores and embeddings
   - Embeddings and Vector Stores tabs: manage providers/models, warmups, caches, collections, upserts, and queries.

--- a/Docs/User_Guides/index.md
+++ b/Docs/User_Guides/index.md
@@ -35,6 +35,7 @@ This section is organized by product surface so you can quickly find the right d
 - [RAG Production Configuration](Server/RAG_Production_Configuration_Guide.md)
 - [RAG Evals Playbook](Server/RAG_Evals_Playbook.md)
 - [Evaluations User Guide](Server/Evaluations_User_Guide.md)
+- [Benchmark Creation and Runs (API + WebUI/Extension)](Server/Benchmark_Creation_API_WebUI_Extension_Guide.md)
 - [Evaluations Deployment Guide](Server/Evaluations_Deployment_Guide.md)
 - [Evaluations End User Guide](Server/Evaluations_End_User_Guide.md)
 - [Evaluations Production Deployment](Server/Evaluations_Production_Deployment_Guide.md)

--- a/tldw_Server_API/tests/Docs/test_benchmark_guide_discoverability.py
+++ b/tldw_Server_API/tests/Docs/test_benchmark_guide_discoverability.py
@@ -3,16 +3,16 @@ from pathlib import Path
 
 def test_benchmark_guide_exists_and_is_indexed() -> None:
     guide = Path("Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md")
-    assert guide.exists()
+    assert guide.exists()  # nosec B101 - pytest assertion in test code
 
     index_text = Path("Docs/User_Guides/index.md").read_text()
-    assert "Benchmark_Creation_API_WebUI_Extension_Guide.md" in index_text
+    assert "Benchmark_Creation_API_WebUI_Extension_Guide.md" in index_text  # nosec B101
 
 
 def test_benchmark_guide_mentions_api_and_webui_paths() -> None:
     text = Path(
         "Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md"
     ).read_text()
-    assert "/api/v1/evaluations/benchmarks" in text
-    assert "/api/v1/evaluations/benchmarks/{benchmark_name}/run" in text
-    assert "benchmark-run" in text
+    assert "/api/v1/evaluations/benchmarks" in text  # nosec B101
+    assert "/api/v1/evaluations/benchmarks/{benchmark_name}/run" in text  # nosec B101
+    assert "benchmark-run" in text  # nosec B101

--- a/tldw_Server_API/tests/Docs/test_benchmark_guide_discoverability.py
+++ b/tldw_Server_API/tests/Docs/test_benchmark_guide_discoverability.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_benchmark_guide_exists_and_is_indexed() -> None:
+    guide = Path("Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md")
+    assert guide.exists()
+
+    index_text = Path("Docs/User_Guides/index.md").read_text()
+    assert "Benchmark_Creation_API_WebUI_Extension_Guide.md" in index_text
+
+
+def test_benchmark_guide_mentions_api_and_webui_paths() -> None:
+    text = Path(
+        "Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md"
+    ).read_text()
+    assert "/api/v1/evaluations/benchmarks" in text
+    assert "/api/v1/evaluations/benchmarks/{benchmark_name}/run" in text
+    assert "benchmark-run" in text


### PR DESCRIPTION
## Summary
Adds a canonical user guide for benchmark runs across API and WebUI/extension, wires discoverability links, and adds a docs regression test.

## Changes
- Add Docs/User_Guides/Server/Benchmark_Creation_API_WebUI_Extension_Guide.md
- Update Docs/User_Guides/index.md
- Update Docs/User_Guides/Server/Evaluations_User_Guide.md
- Update Docs/User_Guides/WebUI_Extension/User_Guide.md
- Add tldw_Server_API/tests/Docs/test_benchmark_guide_discoverability.py

## Verification
- Ran targeted benchmark guide docs pytest successfully.
- Ran Bandit on the touched docs test file with zero findings.

## Notes
Broader speech/published docs tests in this worktree fail due missing Docs/Published paths in the local environment; unrelated to touched files.