### PR TITLE
feat(collections): pinboard utility parity with strict notes boundary

### DIFF
--- a/Docs/Plans/2026-03-02-collections-pinboard-strict-boundary-implementation.md
+++ b/Docs/Plans/2026-03-02-collections-pinboard-strict-boundary-implementation.md
@@ -1,0 +1,509 @@
+# Collections Pinboard Utility Parity (Strict Notes Boundary) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan task-by-task in this session.
+
+**Goal:** Add Pinboard-style utility improvements to Collections (saved searches, archive-on-save controls, dead-link resilience, and Notes linking) while keeping Notes as the only standalone note system.
+
+**Architecture:** Extend Reading/Collections APIs and DB tables with additive models (`saved_searches`, `content_item_note_links`) and enrich existing reading save/detail contracts. Reuse `/api/v1/notes` for note creation/content ownership and enforce note existence/ownership checks before creating links. Gate new surfaces behind focused feature flags (`collections_reading_saved_searches_enabled`, `collections_reading_note_links_enabled`, `collections_reading_archive_controls_enabled`) while preserving existing reading and notes flows.
+
+**Tech Stack:** FastAPI, Pydantic, CollectionsDatabase (SQLite/PG backend abstraction), React + Zustand + Ant Design, Vitest, Pytest.
+
+**Execution Guardrails:**
+- Run all frontend Vitest commands from `apps/packages/ui` (or set equivalent Vitest root/config) to avoid path-alias resolution failures and accidental `.worktrees` test discovery.
+- Verify in staged checkpoints: backend scope first, frontend API contracts second, UI flows last.
+
+---
+
+### Task 1: Add Reading API Schemas for Archive Mode, Saved Searches, and Link Responses
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/reading_schemas.py`
+- Test: `tldw_Server_API/tests/Collections/test_reading_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_reading_save_returns_archive_requested_field(reading_app):
+    async def override_user():
+        return User(id=9001, username="reader", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+    with TestClient(reading_app) as client:
+        r = client.post(
+            "/api/v1/reading/save",
+            json={
+                "url": "https://example.org/archive-test",
+                "title": "Archive Test",
+                "content": "Archive content",
+                "archive_mode": "always",
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert "archive_requested" in r.json()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k archive_requested -v`
+Expected: FAIL because response lacks `archive_requested`.
+
+**Step 3: Write minimal implementation**
+
+```python
+class ReadingSaveRequest(BaseModel):
+    archive_mode: Literal["use_default", "always", "never"] = "use_default"
+
+class ReadingItem(BaseModel):
+    archive_requested: bool = False
+    has_archive_copy: bool = False
+    last_fetch_error: str | None = None
+
+class ReadingSavedSearchCreateRequest(BaseModel): ...
+class ReadingSavedSearchUpdateRequest(BaseModel): ...
+class ReadingSavedSearchResponse(BaseModel): ...
+class ReadingNoteLinkResponse(BaseModel): ...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k archive_requested -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/reading_schemas.py tldw_Server_API/tests/Collections/test_reading_api.py
+git commit -m "feat(reading-schema): add archive mode and saved-search/note-link schemas"
+```
+
+### Task 2: Add Collections DB Tables and Accessors (`saved_searches`, `content_item_note_links`)
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Collections_DB.py`
+- Create: `tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py`
+- Create: `tldw_Server_API/tests/Collections/test_reading_note_links_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_saved_search_crud_roundtrip(collections_db):
+    created = collections_db.create_saved_search(name="Morning", query_json='{"q":"ai"}', sort="updated_desc")
+    rows, total = collections_db.list_saved_searches(limit=10, offset=0)
+    assert total == 1
+    assert rows[0].id == created.id
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py -v`
+Expected: FAIL with missing table or missing method errors.
+
+**Step 3: Write minimal implementation**
+
+```python
+CREATE TABLE IF NOT EXISTS saved_searches (...);
+CREATE TABLE IF NOT EXISTS content_item_note_links (...);
+
+def create_saved_search(...): ...
+def list_saved_searches(...): ...
+def update_saved_search(...): ...
+def delete_saved_search(...): ...
+def link_note_to_content_item(...): ...
+def list_note_links_for_content_item(...): ...
+def unlink_note_from_content_item(...): ...
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_note_links_db.py -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Collections_DB.py tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py tldw_Server_API/tests/Collections/test_reading_note_links_db.py
+git commit -m "feat(collections-db): add saved searches and content-item note links"
+```
+
+### Task 3: Add Reading Endpoints for Saved Searches and Note Link CRUD (POST/GET/DELETE)
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/reading.py`
+- Test: `tldw_Server_API/tests/Collections/test_reading_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_note_link_endpoints_cover_post_get_delete(reading_app):
+    async def override_user():
+        return User(id=9002, username="reader2", email=None, is_active=True)
+    reading_app.dependency_overrides[get_request_user] = override_user
+    with TestClient(reading_app) as client:
+        # setup reading item...
+        # POST link -> 200
+        # GET links -> contains note_id
+        # DELETE link -> success
+        ...
+```
+
+Add an explicit boundary regression test in this task:
+
+```python
+def test_note_link_rejects_foreign_note(reading_app):
+    # User A creates a note; user B attempts to link it.
+    # Expected strict-boundary behavior: 404 (preferred) or 403.
+    ...
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "saved_searches or note_link or foreign_note" -v`
+Expected: FAIL with `404` route not found.
+
+**Step 3: Write minimal implementation**
+
+```python
+@router.post("/saved-searches", status_code=201) ...
+@router.get("/saved-searches") ...
+@router.patch("/saved-searches/{search_id}") ...
+@router.delete("/saved-searches/{search_id}") ...
+
+@router.post("/items/{item_id}/links/note") ...
+@router.get("/items/{item_id}/links") ...
+@router.delete("/items/{item_id}/links/note/{note_id}") ...
+```
+
+Add strict boundary enforcement:
+- validate note exists via Notes DB lookup for current user before linking
+- reject foreign/missing note IDs with `404` or `403` as appropriate
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "saved_searches or note_link or foreign_note" -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/reading.py tldw_Server_API/tests/Collections/test_reading_api.py
+git commit -m "feat(reading-api): add saved-search CRUD and note-link CRUD endpoints"
+```
+
+### Task 4: Implement Archive Policy Resolution with Real Auto-Archive + Resilience Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Collections/reading_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/reading.py`
+- Test: `tldw_Server_API/tests/Collections/test_reading_service.py`
+- Test: `tldw_Server_API/tests/Collections/test_reading_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+@pytest.mark.asyncio
+async def test_archive_mode_always_creates_archive_artifact(...):
+    result = await service.save_url(url="https://example.org/a", archive_mode="always", content_override="hello")
+    assert result.archive_requested is True
+    assert result.archive_output_id is not None
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_service.py -k "archive_mode or archive_artifact" -v`
+Expected: FAIL with missing argument/attribute/artifact.
+
+**Step 3: Write minimal implementation**
+
+```python
+def _resolve_archive_mode(requested: str, default_enabled: bool) -> bool: ...
+
+async def save_url(..., archive_mode: str = "use_default") -> ReadingSaveResult:
+    archive_requested = _resolve_archive_mode(archive_mode, default_enabled)
+    if archive_requested:
+        archive_output_id = await maybe_create_archive_artifact(...)
+    return ReadingSaveResult(..., archive_requested=archive_requested, archive_output_id=archive_output_id)
+```
+
+Expose in reading item/detail response:
+- `archive_requested`
+- `has_archive_copy`
+- `last_fetch_error`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_service.py -k "archive_mode or archive_artifact" -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "archive_requested or has_archive_copy" -v`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Collections/reading_service.py tldw_Server_API/app/api/v1/endpoints/reading.py tldw_Server_API/tests/Collections/test_reading_service.py tldw_Server_API/tests/Collections/test_reading_api.py
+git commit -m "feat(reading): implement archive policy and resilience metadata"
+```
+
+### Task 5: Extend Frontend Types and API Client Contracts (with mocked transport tests)
+
+**Files:**
+- Modify: `apps/packages/ui/src/types/collections.ts`
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Create: `apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { vi } from "vitest"
+vi.mock("@/services/background-proxy", () => ({ bgRequest: vi.fn() }))
+
+it("posts create saved-search payload", async () => {
+  const api = new TldwApiClient()
+  await api.createReadingSavedSearch({ name: "Daily", query: { q: "ai" } })
+  expect(bgRequest).toHaveBeenCalledWith(expect.objectContaining({
+    path: "/api/v1/reading/saved-searches",
+    method: "POST"
+  }))
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/reading-saved-searches.test.ts`
+Expected: FAIL with missing method/type errors.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export interface ReadingSavedSearch { ... }
+
+async createReadingSavedSearch(...) { ... }
+async listReadingSavedSearches(...) { ... }
+async updateReadingSavedSearch(...) { ... }
+async deleteReadingSavedSearch(...) { ... }
+async linkReadingItemToNote(...) { ... }
+async listReadingItemNoteLinks(...) { ... }
+async unlinkReadingItemNote(...) { ... }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/reading-saved-searches.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/types/collections.ts apps/packages/ui/src/services/tldw/TldwApiClient.ts apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
+git commit -m "feat(frontend-api): add saved-search and note-link client contracts"
+```
+
+### Task 5A: Add Feature Flags for New Collections Surfaces
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/config.py` (or equivalent runtime config surface)
+- Modify: `tldw_Server_API/app/api/v1/endpoints/reading.py` (flag-aware route/UI-contract gating where applicable)
+- Modify: `apps/packages/ui/src/store/collections.tsx` (or equivalent capability/feature-flag integration point)
+- Test: `tldw_Server_API/tests/Collections/test_reading_api.py`
+- Test: `apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts`
+
+**Step 1: Write failing tests**
+
+Add tests that prove:
+- New collections surfaces are disabled when the relevant flags are off.
+- Existing Reading + Notes flows remain unaffected when flags are off.
+- New surfaces are enabled when flags are on.
+
+**Step 2: Run tests to verify failures**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "feature_flag or note_link or saved_searches" -v`
+- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/reading-saved-searches.test.ts`
+
+Expected: FAIL until flags are wired.
+
+**Step 3: Write minimal implementation**
+
+Implement the three flags and wire them into backend/frontend capability checks:
+- `collections_reading_saved_searches_enabled`
+- `collections_reading_note_links_enabled`
+- `collections_reading_archive_controls_enabled`
+
+**Step 4: Run tests to verify pass**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "feature_flag or note_link or saved_searches" -v`
+- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/reading-saved-searches.test.ts`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/config.py tldw_Server_API/app/api/v1/endpoints/reading.py apps/packages/ui/src/store/collections.tsx tldw_Server_API/tests/Collections/test_reading_api.py apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
+git commit -m "feat(collections-flags): gate saved-searches note-links and archive-controls"
+```
+
+### Task 6: Add Saved Searches and Archive Controls to Reading List UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/store/collections.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx`
+- Create: `apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx`
+- Create: `apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it("applies a saved search to reading filters", async () => {
+  render(<SavedSearchesMenu ... />)
+  await user.click(screen.getByText("Daily AI"))
+  expect(onApply).toHaveBeenCalled()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx`
+Expected: FAIL with missing component/state wiring.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+<SavedSearchesMenu
+  searches={savedSearches}
+  onApply={applySavedSearch}
+  onCreateFromCurrent={createSavedSearchFromFilters}
+/>
+```
+
+Add Add-URL control for `archive_mode`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/store/collections.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx
+git commit -m "feat(collections-ui): add saved searches and archive controls"
+```
+
+### Task 7: Add Linked Notes Panel to Reading Item Detail
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx`
+- Modify: `apps/packages/ui/src/types/collections.ts`
+- Create: `apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it("renders linked notes and supports unlink", async () => {
+  render(<ReadingItemDetail ... />)
+  expect(await screen.findByText("Linked Notes")).toBeInTheDocument()
+  await user.click(screen.getByRole("button", { name: /unlink/i }))
+  expect(api.unlinkReadingItemNote).toHaveBeenCalled()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx`
+Expected: FAIL with missing linked-notes UI/actions.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+<Card title={t("collections:reading.linkedNotes", "Linked Notes")}>
+  {linkedNotes.map((note) => (
+    <Button onClick={() => unlink(note.note_id)}>Unlink</Button>
+  ))}
+</Card>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx apps/packages/ui/src/types/collections.ts apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
+git commit -m "feat(collections-ui): add linked notes panel in reading detail"
+```
+
+### Task 8: Full Verification, Security Scan, and Docs Sync (Staged Checkpoints)
+
+**Files:**
+- Modify: `Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md`
+- Verify: touched backend/frontend test files
+
+**Step 1: Write final verification checklist**
+
+```text
+Checklist:
+- Reading API tests pass
+- Collections DB tests pass
+- New frontend tests pass
+- Bandit clean on touched backend paths
+```
+
+**Step 2: Run verification commands**
+
+Run Stage A (Backend):
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py tldw_Server_API/tests/Collections/test_reading_service.py tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py tldw_Server_API/tests/Collections/test_reading_note_links_db.py -v`
+- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/reading.py tldw_Server_API/app/core/Collections/reading_service.py tldw_Server_API/app/core/DB_Management/Collections_DB.py -f json -o /tmp/bandit_collections_pinboard.json`
+
+Run Stage B (Frontend API Contracts):
+- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/reading-saved-searches.test.ts src/services/__tests__/tldw-api-client.reading-import-export.test.ts`
+
+Run Stage C (Frontend UI, only after Tasks 6/7 complete):
+- `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx`
+
+Expected: each stage PASS; Bandit reports no new high-confidence issues in touched code.
+
+**Step 3: Update docs minimally**
+
+```markdown
+- Add saved searches and item-note linking to Collections capabilities.
+- Document strict Notes boundary explicitly.
+```
+
+**Step 4: Re-run narrow sanity checks**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "saved_searches or note_link or archive_requested" -v`
+- `cd apps/packages/ui && bunx vitest run src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
+git add tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+git add tldw_Server_API/app/api/v1/endpoints/reading.py
+git add tldw_Server_API/app/core/Collections/reading_service.py
+git add tldw_Server_API/app/core/DB_Management/Collections_DB.py
+git add tldw_Server_API/tests/Collections/test_reading_api.py
+git add tldw_Server_API/tests/Collections/test_reading_service.py
+git add tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py
+git add tldw_Server_API/tests/Collections/test_reading_note_links_db.py
+git add apps/packages/ui/src/types/collections.ts
+git add apps/packages/ui/src/services/tldw/TldwApiClient.ts
+git add apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
+git add apps/packages/ui/src/store/collections.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx
+git add apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
+git commit -m "feat(collections): deliver pinboard utility parity with strict notes boundary"
+```

--- a/Docs/Plans/2026-03-02-collections-pinboard-strict-boundary-implementation.md
+++ b/Docs/Plans/2026-03-02-collections-pinboard-strict-boundary-implementation.md
@@ -487,23 +487,23 @@ Expected: PASS.
 
 ```bash
 git add Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
-git add tldw_Server_API/app/api/v1/schemas/reading_schemas.py
-git add tldw_Server_API/app/api/v1/endpoints/reading.py
-git add tldw_Server_API/app/core/Collections/reading_service.py
-git add tldw_Server_API/app/core/DB_Management/Collections_DB.py
-git add tldw_Server_API/tests/Collections/test_reading_api.py
-git add tldw_Server_API/tests/Collections/test_reading_service.py
-git add tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py
-git add tldw_Server_API/tests/Collections/test_reading_note_links_db.py
-git add apps/packages/ui/src/types/collections.ts
-git add apps/packages/ui/src/services/tldw/TldwApiClient.ts
-git add apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
-git add apps/packages/ui/src/store/collections.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx
-git add apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
+git add tldw_Server_API/app/api/v1/schemas/reading_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/reading.py \
+  tldw_Server_API/app/core/Collections/reading_service.py \
+  tldw_Server_API/app/core/DB_Management/Collections_DB.py \
+  tldw_Server_API/tests/Collections/test_reading_api.py \
+  tldw_Server_API/tests/Collections/test_reading_service.py \
+  tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py \
+  tldw_Server_API/tests/Collections/test_reading_note_links_db.py
+git add apps/packages/ui/src/types/collections.ts \
+  apps/packages/ui/src/services/tldw/TldwApiClient.ts \
+  apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts \
+  apps/packages/ui/src/store/collections.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx \
+  apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
 git commit -m "feat(collections): deliver pinboard utility parity with strict notes boundary"
 ```

--- a/Docs/Plans/2026-03-02-pinboard-collections-gap-design.md
+++ b/Docs/Plans/2026-03-02-pinboard-collections-gap-design.md
@@ -1,0 +1,233 @@
+# Pinboard Tour vs Collections Gap Analysis Design
+
+## Context
+
+This design captures approved direction after comparing [Pinboard Tour](https://pinboard.in/tour/) capabilities with the existing Collections module in `tldw_server`.
+
+Current Collections strengths already exceed Pinboard in several areas (highlights, digest scheduling, template-driven outputs, summarize/TTS), but there are specific Pinboard-inspired utility improvements worth adding.
+
+This design uses a strict boundary model with the existing Notes module:
+
+- Notes remains the source of truth for standalone rich notes.
+- Collections remains the source of truth for URL/content-item workflows.
+- Collections `notes` fields stay lightweight annotations, not a second notes system.
+
+## Goal
+
+Improve Collections with high-value Pinboard-like features while preserving local-first privacy model and avoiding duplication with Notes.
+
+## Non-Goals
+
+- Public sharing, profiles, social discovery, or network features.
+- Replacing Notes CRUD/search/export with Collections.
+- New crawler classes unrelated to capture/archive reliability.
+
+## Existing Overlap and Boundary Decision
+
+### Existing overlap areas
+
+- Both Notes and Collections can store text.
+- Collections items already have `notes` fields for per-item annotation.
+- Notes has full notebook capabilities (`/api/v1/notes`) including richer CRUD/search/export/attachments/keyword-linking.
+
+### Boundary model (approved)
+
+1. Standalone text notes belong in Notes (`/api/v1/notes`).
+2. Collections annotations remain attached to content items.
+3. Collections can link to Notes records but does not own standalone note entities.
+
+## Proposed Improvements (Approach 2, strict boundary)
+
+1. Auto-archive on save (default + per-request override).
+2. Saved searches in Reading list (`name + filters + sort`).
+3. Fast capture surfaces (bookmarklet/deep-link + extension quick-save path).
+4. Dead-link resilience UX (archive availability + last fetch error).
+5. Note linking from Collections to Notes (create/link/unlink), not notes-only content items in Collections.
+
+## Architecture
+
+The design extends existing Collections APIs and DB adapter surfaces with small additive models:
+
+- `saved_searches` for reusable reading filters.
+- `content_item_note_links` for cross-module associations to Notes IDs.
+- Optional collections preference for default archive behavior.
+
+Archive generation reuses existing reading archive/output artifact flows. Notes integration reuses `/api/v1/notes` for creation and content ownership, with Collections storing only link references.
+
+## Data Model Design
+
+### `saved_searches` (Collections DB)
+
+Fields:
+
+- `id`
+- `name`
+- `query_json` (normalized allowlisted reading filters)
+- `sort`
+- `created_at`
+- `updated_at`
+- `last_used_at`
+
+Notes:
+
+- User-scoped via per-user DB.
+- `query_json` should include only supported keys: `q`, `status`, `tags`, `favorite`, `domain`, `date_from`, `date_to`.
+
+### `content_item_note_links` (Collections DB)
+
+Fields:
+
+- `content_item_id` (int)
+- `note_id` (string UUID from Notes)
+- `link_kind` (default `annotation`)
+- `created_at`
+
+Notes:
+
+- No cross-DB FK due separate DB systems (Collections DB vs ChaChaNotes DB).
+- App-level validation and stale-link handling required.
+
+### Preferences
+
+Add or reuse user preference storage for:
+
+- `auto_archive_on_save` (bool)
+
+## API Design
+
+### Reading saved searches
+
+- `POST /api/v1/reading/saved-searches`
+- `GET /api/v1/reading/saved-searches`
+- `PATCH /api/v1/reading/saved-searches/{id}`
+- `DELETE /api/v1/reading/saved-searches/{id}`
+
+### Reading save with archive policy override
+
+Extend:
+
+- `POST /api/v1/reading/save`
+
+Add request field:
+
+- `archive_mode: use_default | always | never`
+
+Response should include archive status hints, including `archive_output_id` when created.
+
+### Collections-to-Notes links
+
+- `POST /api/v1/reading/items/{item_id}/links/note` (payload: `note_id`)
+- `GET /api/v1/reading/items/{item_id}/links`
+- `DELETE /api/v1/reading/items/{item_id}/links/note/{note_id}`
+
+### Reading detail resilience fields
+
+Expose derived fields in reading detail response:
+
+- `has_archive_copy`
+- `last_fetch_error`
+
+## UX Design
+
+### Reading list toolbar
+
+- Add `Saved Searches` menu:
+  - Save current filters
+  - Run a saved search
+  - Rename/delete saved searches
+
+### Add URL modal
+
+- Add archive behavior control (default from preference; optional per-save override).
+
+### Reading item detail
+
+- Archive status badge (`available`, `not available`, `failed last fetch`).
+- `Create Note` action (calls Notes API then links result).
+- `Link Existing Note` action.
+- Linked Notes list with open/unlink.
+
+### Notes integration behavior
+
+- `Create Note` pre-fills title/content snippet + source URL backlink context.
+- User can remain in Collections after create or choose to open note page.
+
+## Data Flow
+
+### Save URL
+
+1. Save/update reading item.
+2. Resolve archive policy via request override and default preference.
+3. If archive enabled, start archive creation without blocking base save.
+4. Return save success plus archive status metadata.
+
+### Save current filters
+
+1. Normalize + validate filter payload.
+2. Persist as saved search row.
+3. Running saved search hydrates standard list query params.
+
+### Create linked note
+
+1. Call Notes `POST /api/v1/notes/`.
+2. Persist item-note link in Collections.
+3. Return combined result.
+
+### Link existing note
+
+1. Select note via Notes list/search.
+2. Persist mapping only in Collections.
+
+## Error Handling
+
+1. Archive failures must not fail reading save.
+2. Two-step note create/link must report partial success clearly:
+   - Note created but link failed -> explicit retry link action.
+3. Deleted notes referenced by links should display stale markers and cleanup actions.
+4. Saved search payload validation failures return `422` with clear messages.
+
+## Testing Plan
+
+### Unit tests
+
+- Saved search normalization and allowlist validation.
+- Archive mode resolution precedence (`use_default|always|never`).
+- Link lifecycle handling and stale-link detection.
+
+### API integration tests
+
+- Reading save behavior under each archive mode.
+- Saved search CRUD and malformed payloads.
+- Item-note link endpoints for valid/invalid/deleted notes.
+- Reading detail resilience fields.
+
+### UI tests
+
+- Save/run/manage saved searches.
+- Add URL archive override.
+- Linked Notes panel create/link/unlink/open flows.
+- Partial-failure messaging and retry.
+
+### Regression tests
+
+- Existing reading filters/sorting behavior unchanged.
+- Notes module CRUD/search/export unaffected.
+- Outputs/digests unaffected by link metadata additions.
+
+## Rollout Plan
+
+1. DB migration for `saved_searches` and `content_item_note_links`.
+2. Backend feature flags:
+   - `COLLECTIONS_SAVED_SEARCHES_ENABLED`
+   - `COLLECTIONS_NOTE_LINKS_ENABLED`
+   - `COLLECTIONS_AUTO_ARCHIVE_ENABLED`
+3. Enable UI after backend validation.
+4. Observe for one release window; then promote defaults.
+
+## Success Criteria
+
+1. Reading save remains high reliability even with archive failures.
+2. Saved searches have meaningful adoption.
+3. Item-note linking succeeds with low error rate; partial failures are recoverable.
+4. No Notes module regression in error rate/latency.
+5. No schema/domain collisions between Collections and Notes ownership boundaries.

--- a/Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
+++ b/Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
@@ -93,6 +93,10 @@ This PRD tracks the remaining UX delivery work for Content Collections. It rolls
 - Bulk actions show progress and per-item results; errors are visible.
 - Bulk output generation prompts for template selection and returns a generated output artifact or a clear failure state.
 - Template editor supports preview and default assignment in job settings.
+- Reading saved searches support authenticated CRUD (`POST/GET/PATCH/DELETE /api/v1/reading/saved-searches`) and can reapply persisted filters/sort in UI state.
+- Reading saved searches reject invalid payloads with clear 4xx responses (unsupported query keys, blank names, malformed filters) while keeping valid filters stable.
+- Reading item-note links support authenticated create/list/delete (`POST/GET/DELETE /api/v1/reading/items/{item_id}/links...`) only when the referenced note exists for the same user.
+- Reading item-note links return predictable edge-case behavior for missing items/notes and cross-user note IDs; note content ownership/lifecycle remains exclusively under `/api/v1/notes`.
 
 ## 8. Test Plan
 
@@ -102,6 +106,10 @@ This PRD tracks the remaining UX delivery work for Content Collections. It rolls
 - Bulk actions: mixed-success scenarios; undo flow when supported.
 - Bulk output generation: template selection, output creation success, output creation failures.
 - Notes: dirty indicator and autosave behavior across navigation.
+- Reading saved searches: CRUD success paths, duplicate-name handling, and 4xx validation coverage for unsupported query keys/blank names.
+- Reading saved searches: authn/authz checks and response-code assertions for create/list/update/delete under feature-flag enabled/disabled states.
+- Reading item-note links: create/list/delete lifecycle tests, same-user existence checks, and missing/foreign note handling.
+- Reading item-note links: authn/authz and edge-case regression checks for non-existent item IDs, repeated unlink operations, and concurrent link attempts.
 
 ## 9. Open Questions
 

--- a/Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
+++ b/Docs/Product/Completed/Content_Collections_UX_Backlog_PRD.md
@@ -20,6 +20,8 @@ This PRD tracks the remaining UX delivery work for Content Collections. It rolls
 - Provide an output template editor with preview and default assignment inside job settings.
 - Enable bulk item actions (tags, status, favorite, delete, output generation).
 - Prevent notes loss with autosave and a small, consistent dirty indicator.
+- Add reusable Reading saved searches to persist and reapply list filters/sort.
+- Support item-to-note links in Reading while preserving Notes as the only standalone note system.
 
 ## 3. Non-Goals
 
@@ -59,6 +61,16 @@ This PRD tracks the remaining UX delivery work for Content Collections. It rolls
   - `POST /api/v1/items/bulk` with `action` + `item_ids` + payload (tags, status, favorite, delete).
   - `POST /api/v1/reading/items/bulk` as a thin wrapper alias.
 - Bulk output generation should call `POST /api/v1/outputs` with `template_id` + `item_ids` (no new bulk endpoint required).
+- Reading saved searches use:
+  - `POST /api/v1/reading/saved-searches`
+  - `GET /api/v1/reading/saved-searches`
+  - `PATCH /api/v1/reading/saved-searches/{search_id}`
+  - `DELETE /api/v1/reading/saved-searches/{search_id}`
+- Reading item-note links use:
+  - `POST /api/v1/reading/items/{item_id}/links/note`
+  - `GET /api/v1/reading/items/{item_id}/links`
+  - `DELETE /api/v1/reading/items/{item_id}/links/note/{note_id}`
+  - Strict boundary rule: note content lifecycle remains in `/api/v1/notes`; Reading can only link/unlink note IDs after same-user existence checks.
 
 ## 6. Dependencies and Constraints
 

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/AddUrlModal.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react"
-import { Button, Form, Input, Modal, message } from "antd"
+import { Button, Form, Input, Modal, Select, message } from "antd"
 import { Link, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { useCollectionsStore } from "@/store/collections"
@@ -17,6 +17,7 @@ interface FormValues {
   title?: string
   tags?: string[]
   notes?: string
+  archive_mode?: "use_default" | "always" | "never"
 }
 
 const isValidUrl = (url: string): boolean => {
@@ -36,6 +37,8 @@ export const AddUrlModal: React.FC<AddUrlModalProps> = ({ onSuccess }) => {
   const addUrlModalOpen = useCollectionsStore((s) => s.addUrlModalOpen)
   const closeAddUrlModal = useCollectionsStore((s) => s.closeAddUrlModal)
   const addItem = useCollectionsStore((s) => s.addItem)
+  const readingArchiveControlsEnabled = useCollectionsStore((s) => s.readingArchiveControlsEnabled)
+  const setReadingArchiveControlsEnabled = useCollectionsStore((s) => s.setReadingArchiveControlsEnabled)
 
   const [loading, setLoading] = useState(false)
   const [tags, setTags] = useState<string[]>([])
@@ -49,7 +52,11 @@ export const AddUrlModal: React.FC<AddUrlModalProps> = ({ onSuccess }) => {
         url: values.url,
         title: values.title,
         tags,
-        notes: values.notes
+        notes: values.notes,
+        archive_mode:
+          readingArchiveControlsEnabled && values.archive_mode
+            ? values.archive_mode
+            : undefined
       })
 
       addItem({
@@ -81,11 +88,24 @@ export const AddUrlModal: React.FC<AddUrlModalProps> = ({ onSuccess }) => {
         return
       }
       const msg = error instanceof Error ? error.message : "Failed to add article"
+      if (msg.includes("reading_archive_controls_disabled")) {
+        setReadingArchiveControlsEnabled(false)
+      }
       message.error(msg)
     } finally {
       setLoading(false)
     }
-  }, [api, form, tags, addItem, closeAddUrlModal, onSuccess, t])
+  }, [
+    api,
+    form,
+    tags,
+    addItem,
+    closeAddUrlModal,
+    onSuccess,
+    readingArchiveControlsEnabled,
+    setReadingArchiveControlsEnabled,
+    t
+  ])
 
   const handleCancel = useCallback(() => {
     form.resetFields()
@@ -121,6 +141,7 @@ export const AddUrlModal: React.FC<AddUrlModalProps> = ({ onSuccess }) => {
         form={form}
         layout="vertical"
         className="mt-4"
+        initialValues={{ archive_mode: "use_default" }}
         onFinish={handleSubmit}
       >
         <Form.Item
@@ -186,6 +207,34 @@ export const AddUrlModal: React.FC<AddUrlModalProps> = ({ onSuccess }) => {
             )}
           />
         </Form.Item>
+
+        {readingArchiveControlsEnabled && (
+          <Form.Item
+            name="archive_mode"
+            label={t("collections:reading.archiveModeLabel", "Archive Mode")}
+            extra={t(
+              "collections:reading.archiveModeHint",
+              "Choose whether to create an archive copy when saving."
+            )}
+          >
+            <Select
+              options={[
+                {
+                  value: "use_default",
+                  label: t("collections:reading.archiveMode.default", "Use server default")
+                },
+                {
+                  value: "always",
+                  label: t("collections:reading.archiveMode.always", "Always archive")
+                },
+                {
+                  value: "never",
+                  label: t("collections:reading.archiveMode.never", "Never archive")
+                }
+              ]}
+            />
+          </Form.Item>
+        )}
       </Form>
     </Modal>
   )

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemDetail.tsx
@@ -29,7 +29,7 @@ import {
 import { useTranslation } from "react-i18next"
 import { useCollectionsStore } from "@/store/collections"
 import { useTldwApiClient } from "@/hooks/useTldwApiClient"
-import type { Highlight, HighlightColor, ReadingStatus } from "@/types/collections"
+import type { Highlight, HighlightColor, ReadingNoteLink, ReadingStatus } from "@/types/collections"
 import { TagSelector } from "../common/TagSelector"
 import { HighlightCard } from "../Highlights/HighlightCard"
 
@@ -49,9 +49,11 @@ export const ReadingItemDetail: React.FC<ReadingItemDetailProps> = ({
   const currentItem = useCollectionsStore((s) => s.currentItem)
   const currentItemLoading = useCollectionsStore((s) => s.currentItemLoading)
   const itemDetailOpen = useCollectionsStore((s) => s.itemDetailOpen)
+  const readingNoteLinksEnabled = useCollectionsStore((s) => s.readingNoteLinksEnabled)
 
   const setCurrentItem = useCollectionsStore((s) => s.setCurrentItem)
   const setCurrentItemLoading = useCollectionsStore((s) => s.setCurrentItemLoading)
+  const setReadingNoteLinksEnabled = useCollectionsStore((s) => s.setReadingNoteLinksEnabled)
   const closeItemDetail = useCollectionsStore((s) => s.closeItemDetail)
   const updateItemInList = useCollectionsStore((s) => s.updateItemInList)
   const removeItem = useCollectionsStore((s) => s.removeItem)
@@ -82,6 +84,11 @@ export const ReadingItemDetail: React.FC<ReadingItemDetailProps> = ({
   const [selectedNote, setSelectedNote] = useState("")
   const [selectedColor, setSelectedColor] = useState<HighlightColor>("yellow")
   const [selectedMatchId, setSelectedMatchId] = useState<string | null>(null)
+  const [linkedNotes, setLinkedNotes] = useState<ReadingNoteLink[]>([])
+  const [linkedNotesLoading, setLinkedNotesLoading] = useState(false)
+  const [linkNoteId, setLinkNoteId] = useState("")
+  const [linkingNote, setLinkingNote] = useState(false)
+  const [unlinkingNoteId, setUnlinkingNoteId] = useState<string | null>(null)
   const [notesDirty, setNotesDirty] = useState(false)
   const [notesSaving, setNotesSaving] = useState(false)
   const [notesSaveState, setNotesSaveState] = useState<"idle" | "dirty" | "saving" | "saved" | "error">("idle")
@@ -141,6 +148,32 @@ export const ReadingItemDetail: React.FC<ReadingItemDetailProps> = ({
   useEffect(() => {
     fetchItemHighlights()
   }, [fetchItemHighlights])
+
+  const fetchLinkedNotes = useCallback(async () => {
+    if (!selectedItemId || !itemDetailOpen || !readingNoteLinksEnabled) {
+      setLinkedNotes([])
+      return
+    }
+    setLinkedNotesLoading(true)
+    try {
+      const links = await api.listReadingItemNoteLinks(selectedItemId)
+      setLinkedNotes(links)
+    } catch (error: any) {
+      const errorMsg = error?.message || "Failed to load linked notes"
+      if (errorMsg.includes("reading_note_links_disabled")) {
+        setReadingNoteLinksEnabled(false)
+        setLinkedNotes([])
+      } else {
+        message.error(errorMsg)
+      }
+    } finally {
+      setLinkedNotesLoading(false)
+    }
+  }, [api, itemDetailOpen, readingNoteLinksEnabled, selectedItemId, setReadingNoteLinksEnabled])
+
+  useEffect(() => {
+    void fetchLinkedNotes()
+  }, [fetchLinkedNotes])
 
   useEffect(() => {
     if (highlightEditorOpen && editingHighlight?.item_id) {
@@ -454,6 +487,62 @@ export const ReadingItemDetail: React.FC<ReadingItemDetailProps> = ({
       setEditingNotes(false)
     }
   }, [saveNotes])
+
+  const handleLinkNote = useCallback(async () => {
+    if (!currentItem) return
+    const noteId = linkNoteId.trim()
+    if (!noteId) {
+      message.warning(t("collections:reading.linkedNotes.noteIdRequired", "Enter a note ID"))
+      return
+    }
+    setLinkingNote(true)
+    try {
+      await api.linkReadingItemToNote(currentItem.id, noteId)
+      setLinkNoteId("")
+      await fetchLinkedNotes()
+      message.success(t("collections:reading.linkedNotes.linked", "Note linked"))
+    } catch (error: any) {
+      const errorMsg = error?.message || "Failed to link note"
+      if (errorMsg.includes("reading_note_links_disabled")) {
+        setReadingNoteLinksEnabled(false)
+        setLinkedNotes([])
+      } else {
+        message.error(errorMsg)
+      }
+    } finally {
+      setLinkingNote(false)
+    }
+  }, [
+    api,
+    currentItem,
+    fetchLinkedNotes,
+    linkNoteId,
+    setReadingNoteLinksEnabled,
+    t
+  ])
+
+  const handleUnlinkNote = useCallback(
+    async (noteId: string) => {
+      if (!currentItem) return
+      setUnlinkingNoteId(noteId)
+      try {
+        await api.unlinkReadingItemNote(currentItem.id, noteId)
+        setLinkedNotes((prev) => prev.filter((link) => link.note_id !== noteId))
+        message.success(t("collections:reading.linkedNotes.unlinked", "Note unlinked"))
+      } catch (error: any) {
+        const errorMsg = error?.message || "Failed to unlink note"
+        if (errorMsg.includes("reading_note_links_disabled")) {
+          setReadingNoteLinksEnabled(false)
+          setLinkedNotes([])
+        } else {
+          message.error(errorMsg)
+        }
+      } finally {
+        setUnlinkingNoteId(null)
+      }
+    },
+    [api, currentItem, setReadingNoteLinksEnabled, t]
+  )
 
   const handleSummarize = useCallback(async () => {
     if (!currentItem) return
@@ -847,6 +936,60 @@ export const ReadingItemDetail: React.FC<ReadingItemDetailProps> = ({
                   : t("collections:reading.addNotes", "Add Notes")}
               </Button>
             </>
+          )}
+
+          {readingNoteLinksEnabled && (
+            <div className="rounded-lg border border-border p-4">
+              <h4 className="mb-2 text-sm font-medium text-text">
+                {t("collections:reading.linkedNotes.title", "Linked Notes")}
+              </h4>
+              <div className="mb-3 flex items-center gap-2">
+                <Input
+                  value={linkNoteId}
+                  onChange={(e) => setLinkNoteId(e.target.value)}
+                  placeholder={t(
+                    "collections:reading.linkedNotes.placeholder",
+                    "Enter note ID to link"
+                  )}
+                  onPressEnter={() => void handleLinkNote()}
+                />
+                <Button
+                  type="primary"
+                  onClick={() => void handleLinkNote()}
+                  loading={linkingNote}
+                >
+                  {t("collections:reading.linkedNotes.link", "Link")}
+                </Button>
+              </div>
+
+              {linkedNotesLoading ? (
+                <div className="flex items-center justify-center py-2">
+                  <Spin size="small" />
+                </div>
+              ) : linkedNotes.length === 0 ? (
+                <p className="text-sm text-text-muted">
+                  {t("collections:reading.linkedNotes.empty", "No linked notes")}
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {linkedNotes.map((link) => (
+                    <div
+                      key={link.note_id}
+                      className="flex items-center justify-between gap-2 rounded border border-border px-3 py-2"
+                    >
+                      <span className="text-sm text-text">{link.note_id}</span>
+                      <Button
+                        size="small"
+                        onClick={() => void handleUnlinkNote(link.note_id)}
+                        loading={unlinkingNoteId === link.note_id}
+                      >
+                        {t("collections:reading.linkedNotes.unlink", "Unlink")}
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
           )}
         </div>
       )

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/ReadingItemsList.tsx
@@ -20,10 +20,11 @@ import { useTranslation } from "react-i18next"
 import { useTldwApiClient } from "@/hooks/useTldwApiClient"
 import { useUndoNotification } from "@/hooks/useUndoNotification"
 import { useCollectionsStore } from "@/store/collections"
-import type { ReadingStatus } from "@/types/collections"
+import type { ReadingSavedSearch, ReadingStatus } from "@/types/collections"
 import { normalizeBulkTags, getBulkFailureLines } from "./bulkActions"
 import { ReadingItemCard } from "./ReadingItemCard"
 import { ReadingItemDetail } from "./ReadingItemDetail"
+import { SavedSearchesMenu } from "./SavedSearchesMenu"
 
 const STATUS_OPTIONS: { value: ReadingStatus | "all"; label: string }[] = [
   { value: "all", label: "All" },
@@ -75,6 +76,7 @@ export const ReadingItemsList: React.FC = () => {
   const availableTags = useCollectionsStore((s) => s.availableTags)
   const itemDetailOpen = useCollectionsStore((s) => s.itemDetailOpen)
   const addUrlModalOpen = useCollectionsStore((s) => s.addUrlModalOpen)
+  const readingSavedSearchesEnabled = useCollectionsStore((s) => s.readingSavedSearchesEnabled)
   const deleteConfirmOpen = useCollectionsStore((s) => s.deleteConfirmOpen)
   const deleteTargetId = useCollectionsStore((s) => s.deleteTargetId)
   const deleteTargetType = useCollectionsStore((s) => s.deleteTargetType)
@@ -94,6 +96,7 @@ export const ReadingItemsList: React.FC = () => {
   const setSortOrder = useCollectionsStore((s) => s.setSortOrder)
   const openAddUrlModal = useCollectionsStore((s) => s.openAddUrlModal)
   const resetFilters = useCollectionsStore((s) => s.resetFilters)
+  const setReadingSavedSearchesEnabled = useCollectionsStore((s) => s.setReadingSavedSearchesEnabled)
   const closeDeleteConfirm = useCollectionsStore((s) => s.closeDeleteConfirm)
   const removeItem = useCollectionsStore((s) => s.removeItem)
   const setAvailableTags = useCollectionsStore((s) => s.setAvailableTags)
@@ -111,6 +114,8 @@ export const ReadingItemsList: React.FC = () => {
   const [outputTemplates, setOutputTemplates] = useState<Array<{ label: string; value: string }>>([])
   const [outputTemplatesLoading, setOutputTemplatesLoading] = useState(false)
   const [outputGenerating, setOutputGenerating] = useState(false)
+  const [savedSearchesLoading, setSavedSearchesLoading] = useState(false)
+  const [savedSearches, setSavedSearches] = useState<ReadingSavedSearch[]>([])
 
   const selectedCount = selectedItemIds.length
   const allPageSelected = items.length > 0 && selectedCount === items.length
@@ -123,6 +128,154 @@ export const ReadingItemsList: React.FC = () => {
     if (sortBy === "title") return `title_${direction}`
     return undefined
   }, [sortBy, sortOrder])
+
+  const applySavedSearch = useCallback(
+    (search: { name: string; query: Record<string, unknown>; sort?: string }) => {
+      const query = search.query || {}
+      const statusRaw = query.status
+      let nextStatus: ReadingStatus | "all" = "all"
+      if (typeof statusRaw === "string") {
+        nextStatus = statusRaw as ReadingStatus
+      } else if (Array.isArray(statusRaw) && typeof statusRaw[0] === "string") {
+        nextStatus = statusRaw[0] as ReadingStatus
+      }
+      if (!["saved", "reading", "read", "archived", "all"].includes(nextStatus)) {
+        nextStatus = "all"
+      }
+
+      const tagsRaw = query.tags
+      const nextTags = Array.isArray(tagsRaw)
+        ? tagsRaw.map((tag) => String(tag).trim()).filter(Boolean)
+        : []
+      const favoriteRaw = query.favorite
+      const domainRaw = query.domain
+      const qRaw = query.q
+      const dateFromRaw = query.date_from
+      const dateToRaw = query.date_to
+      const resolvedSort = search.sort || (typeof query.sort === "string" ? query.sort : undefined)
+
+      setItemsSearch(typeof qRaw === "string" ? qRaw : "")
+      setFilterStatus(nextStatus)
+      setFilterFavorite(typeof favoriteRaw === "boolean" ? favoriteRaw : null)
+      setFilterTags(nextTags)
+      setFilterDomain(typeof domainRaw === "string" ? domainRaw : "")
+      setFilterDateRange(
+        typeof dateFromRaw === "string" ? dateFromRaw : null,
+        typeof dateToRaw === "string" ? dateToRaw : null
+      )
+      if (resolvedSort === "updated_desc") {
+        setSortBy("updated_at")
+        setSortOrder("desc")
+      } else if (resolvedSort === "updated_asc") {
+        setSortBy("updated_at")
+        setSortOrder("asc")
+      } else if (resolvedSort === "created_desc") {
+        setSortBy("created_at")
+        setSortOrder("desc")
+      } else if (resolvedSort === "created_asc") {
+        setSortBy("created_at")
+        setSortOrder("asc")
+      } else if (resolvedSort === "title_desc") {
+        setSortBy("title")
+        setSortOrder("desc")
+      } else if (resolvedSort === "title_asc") {
+        setSortBy("title")
+        setSortOrder("asc")
+      } else if (resolvedSort === "relevance") {
+        setSortBy("relevance")
+        setSortOrder("desc")
+      }
+      message.success(
+        t("collections:reading.savedSearchApplied", "Applied saved search: {{name}}", {
+          name: search.name
+        })
+      )
+    },
+    [
+      setFilterDateRange,
+      setFilterDomain,
+      setFilterFavorite,
+      setFilterStatus,
+      setFilterTags,
+      setItemsSearch,
+      setSortBy,
+      setSortOrder,
+      t
+    ]
+  )
+
+  const fetchSavedSearches = useCallback(async () => {
+    if (!readingSavedSearchesEnabled) return
+    setSavedSearchesLoading(true)
+    try {
+      const response = await api.listReadingSavedSearches({ limit: 100, offset: 0 })
+      setSavedSearches(response.items || [])
+    } catch (error: any) {
+      const errorMsg = error?.message || "Failed to load saved searches"
+      if (errorMsg.includes("reading_saved_searches_disabled")) {
+        setReadingSavedSearchesEnabled(false)
+        setSavedSearches([])
+      } else {
+        message.error(errorMsg)
+      }
+    } finally {
+      setSavedSearchesLoading(false)
+    }
+  }, [api, readingSavedSearchesEnabled, setReadingSavedSearchesEnabled])
+
+  const createSavedSearchFromCurrent = useCallback(async () => {
+    if (!readingSavedSearchesEnabled) return
+    const query: Record<string, unknown> = {}
+    if (itemsSearch.trim()) query.q = itemsSearch.trim()
+    if (filterStatus !== "all") query.status = [filterStatus]
+    if (typeof filterFavorite === "boolean") query.favorite = filterFavorite
+    if (filterTags.length > 0) query.tags = filterTags
+    if (filterDomain.trim()) query.domain = filterDomain.trim()
+    if (filterDateFrom) query.date_from = filterDateFrom
+    if (filterDateTo) query.date_to = filterDateTo
+    const sort = buildSortParam()
+    if (sort) query.sort = sort
+
+    const defaultName = itemsSearch.trim()
+      ? t("collections:reading.savedSearchNamed", "Search: {{query}}", { query: itemsSearch.trim() })
+      : t("collections:reading.savedSearchDefaultName", "Saved Search")
+
+    try {
+      const created = await api.createReadingSavedSearch({
+        name: defaultName,
+        query,
+        sort
+      })
+      setSavedSearches((prev) => {
+        const deduped = prev.filter((entry) => entry.id !== created.id)
+        return [created, ...deduped]
+      })
+      message.success(
+        t("collections:reading.savedSearchCreated", "Saved current filters")
+      )
+    } catch (error: any) {
+      const errorMsg = error?.message || "Failed to save search"
+      if (errorMsg.includes("reading_saved_searches_disabled")) {
+        setReadingSavedSearchesEnabled(false)
+        setSavedSearches([])
+      } else {
+        message.error(errorMsg)
+      }
+    }
+  }, [
+    api,
+    buildSortParam,
+    filterDateFrom,
+    filterDateTo,
+    filterDomain,
+    filterFavorite,
+    filterStatus,
+    filterTags,
+    itemsSearch,
+    readingSavedSearchesEnabled,
+    setReadingSavedSearchesEnabled,
+    t
+  ])
 
   // Fetch items
   const fetchItems = useCallback(async () => {
@@ -176,6 +329,10 @@ export const ReadingItemsList: React.FC = () => {
   useEffect(() => {
     fetchItems()
   }, [fetchItems])
+
+  useEffect(() => {
+    void fetchSavedSearches()
+  }, [fetchSavedSearches])
 
   // Keep selection limited to the current page list.
   useEffect(() => {
@@ -837,6 +994,15 @@ export const ReadingItemsList: React.FC = () => {
           </Button>
         )}
       </div>
+
+      {readingSavedSearchesEnabled && (
+        <SavedSearchesMenu
+          searches={savedSearches}
+          loading={savedSearchesLoading}
+          onApply={applySavedSearch}
+          onCreateFromCurrent={() => void createSavedSearchFromCurrent()}
+        />
+      )}
 
       {/* Bulk action controls */}
       {selectionMode && (

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/SavedSearchesMenu.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { Button, Empty, Spin } from "antd"
+import { Bookmark, Save } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import type { ReadingSavedSearch } from "@/types/collections"
+
+interface SavedSearchesMenuProps {
+  searches: ReadingSavedSearch[]
+  loading?: boolean
+  onApply: (search: ReadingSavedSearch) => void
+  onCreateFromCurrent: () => void
+}
+
+export const SavedSearchesMenu: React.FC<SavedSearchesMenuProps> = ({
+  searches,
+  loading = false,
+  onApply,
+  onCreateFromCurrent
+}) => {
+  const { t } = useTranslation(["collections", "common"])
+
+  return (
+    <div className="rounded-lg border border-border bg-bg p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-text">
+          {t("collections:reading.savedSearches", "Saved Searches")}
+        </span>
+        <Button
+          size="small"
+          icon={<Save className="h-3 w-3" />}
+          onClick={onCreateFromCurrent}
+        >
+          {t("collections:reading.saveCurrentSearch", "Save current")}
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-3">
+          <Spin size="small" />
+        </div>
+      ) : searches.length === 0 ? (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={t("collections:reading.savedSearchesEmpty", "No saved searches yet")}
+        />
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {searches.map((search) => (
+            <Button
+              key={search.id}
+              size="small"
+              icon={<Bookmark className="h-3 w-3" />}
+              onClick={() => onApply(search)}
+            >
+              {search.name}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { useCollectionsStore } from "@/store/collections"
+import { ReadingItemDetail } from "../ReadingItemDetail"
+
+const apiMock = vi.hoisted(() => ({
+  getReadingItem: vi.fn(),
+  getHighlights: vi.fn(),
+  listReadingItemNoteLinks: vi.fn(),
+  unlinkReadingItemNote: vi.fn(),
+  updateReadingItem: vi.fn(),
+  summarizeReadingItem: vi.fn(),
+  generateReadingItemTts: vi.fn(),
+  deleteReadingItem: vi.fn(),
+  createHighlight: vi.fn(),
+  updateHighlight: vi.fn(),
+  deleteHighlight: vi.fn(),
+  linkReadingItemToNote: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/hooks/useTldwApiClient", () => ({
+  useTldwApiClient: () => apiMock
+}))
+
+describe("ReadingItemDetail linked notes panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    if (!window.matchMedia) {
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn()
+        }))
+      })
+    }
+
+    useCollectionsStore.getState().resetStore()
+    useCollectionsStore.getState().openItemDetail("1")
+
+    apiMock.getReadingItem.mockResolvedValue({
+      id: "1",
+      title: "Linked Notes Item",
+      status: "saved",
+      favorite: false,
+      tags: [],
+      notes: "",
+      summary: null,
+      domain: "example.org",
+      url: "https://example.org",
+      canonical_url: "https://example.org",
+      archive_requested: false,
+      has_archive_copy: false,
+      last_fetch_error: null
+    })
+    apiMock.getHighlights.mockResolvedValue([])
+    apiMock.listReadingItemNoteLinks.mockResolvedValue([
+      {
+        item_id: "1",
+        note_id: "note-1",
+        created_at: "2026-03-02T00:00:00Z"
+      }
+    ])
+    apiMock.unlinkReadingItemNote.mockResolvedValue({ ok: true })
+  })
+
+  it("renders linked notes and supports unlink", async () => {
+    render(<ReadingItemDetail />)
+
+    fireEvent.click(await screen.findByRole("tab", { name: /Notes/i }))
+
+    expect(await screen.findByText("Linked Notes")).toBeTruthy()
+    expect(await screen.findByText("note-1")).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: /Unlink/i }))
+
+    await waitFor(() => {
+      expect(apiMock.unlinkReadingItemNote).toHaveBeenCalledWith("1", "note-1")
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx
+++ b/apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { SavedSearchesMenu } from "../SavedSearchesMenu"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+describe("SavedSearchesMenu", () => {
+  it("applies a saved search when clicked", () => {
+    const onApply = vi.fn()
+    const onCreateFromCurrent = vi.fn()
+    render(
+      <SavedSearchesMenu
+        searches={[
+          {
+            id: "search-1",
+            name: "Daily AI",
+            query: { q: "ai", status: ["saved"] },
+            sort: "updated_desc"
+          }
+        ]}
+        onApply={onApply}
+        onCreateFromCurrent={onCreateFromCurrent}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Daily AI/i }))
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "search-1", name: "Daily AI" })
+    )
+  })
+
+  it("calls create-from-current handler", () => {
+    const onApply = vi.fn()
+    const onCreateFromCurrent = vi.fn()
+    render(
+      <SavedSearchesMenu
+        searches={[]}
+        onApply={onApply}
+        onCreateFromCurrent={onCreateFromCurrent}
+      />
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: /Save current/i }))
+    expect(onCreateFromCurrent).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -22,12 +22,17 @@ import {
 } from "@/services/tldw/data-tables"
 import type { DataTableColumn } from "@/types/data-tables"
 import type {
+  CreateReadingSavedSearchRequest,
   CreateReadingDigestScheduleRequest,
   ImportSource,
+  ReadingNoteLink,
+  ReadingSavedSearch,
+  ReadingSavedSearchListResponse,
   ReadingDigestSchedule,
   ReadingImportJobResponse,
   ReadingImportJobStatus,
   ReadingImportJobsListResponse,
+  UpdateReadingSavedSearchRequest,
   UpdateReadingDigestScheduleRequest
 } from "@/types/collections"
 
@@ -5751,6 +5756,132 @@ export class TldwApiClient {
     const qs = query.toString()
     const path = `/api/v1/reading/items/${encodeURIComponent(itemId)}${qs ? `?${qs}` : ""}` as const
     await bgRequest<void>({ path, method: "DELETE" })
+  }
+
+  async createReadingSavedSearch(
+    data: CreateReadingSavedSearchRequest
+  ): Promise<ReadingSavedSearch> {
+    const row = await bgRequest<any>({
+      path: "/api/v1/reading/saved-searches",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: data
+    })
+    return {
+      id: String(row?.id ?? ""),
+      name: String(row?.name ?? ""),
+      query:
+        row?.query && typeof row.query === "object" && !Array.isArray(row.query)
+          ? row.query
+          : {},
+      sort: row?.sort ?? undefined,
+      created_at: row?.created_at ?? undefined,
+      updated_at: row?.updated_at ?? undefined
+    }
+  }
+
+  async listReadingSavedSearches(
+    params?: { limit?: number; offset?: number }
+  ): Promise<ReadingSavedSearchListResponse> {
+    const query = new URLSearchParams()
+    if (typeof params?.limit === "number" && Number.isFinite(params.limit)) {
+      query.set("limit", String(Math.max(1, Math.floor(params.limit))))
+    }
+    if (typeof params?.offset === "number" && Number.isFinite(params.offset)) {
+      query.set("offset", String(Math.max(0, Math.floor(params.offset))))
+    }
+    const qs = query.toString()
+    const path = `/api/v1/reading/saved-searches${qs ? `?${qs}` : ""}` as const
+    const data = await bgRequest<any>({ path, method: "GET" })
+    const items: ReadingSavedSearch[] = Array.isArray(data?.items)
+      ? data.items.map((row: any) => ({
+          id: String(row?.id ?? ""),
+          name: String(row?.name ?? ""),
+          query:
+            row?.query && typeof row.query === "object" && !Array.isArray(row.query)
+              ? row.query
+              : {},
+          sort: row?.sort ?? undefined,
+          created_at: row?.created_at ?? undefined,
+          updated_at: row?.updated_at ?? undefined
+        }))
+      : []
+    return {
+      items,
+      total: Number.isFinite(data?.total) ? Number(data.total) : items.length,
+      limit:
+        Number.isFinite(data?.limit) && Number(data.limit) > 0
+          ? Number(data.limit)
+          : params?.limit ?? 50,
+      offset:
+        Number.isFinite(data?.offset) && Number(data.offset) >= 0
+          ? Number(data.offset)
+          : params?.offset ?? 0
+    }
+  }
+
+  async updateReadingSavedSearch(
+    searchId: string,
+    data: UpdateReadingSavedSearchRequest
+  ): Promise<ReadingSavedSearch> {
+    const path = `/api/v1/reading/saved-searches/${encodeURIComponent(searchId)}` as const
+    const row = await bgRequest<any>({
+      path,
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: data
+    })
+    return {
+      id: String(row?.id ?? ""),
+      name: String(row?.name ?? ""),
+      query:
+        row?.query && typeof row.query === "object" && !Array.isArray(row.query)
+          ? row.query
+          : {},
+      sort: row?.sort ?? undefined,
+      created_at: row?.created_at ?? undefined,
+      updated_at: row?.updated_at ?? undefined
+    }
+  }
+
+  async deleteReadingSavedSearch(searchId: string): Promise<{ ok: boolean }> {
+    const path = `/api/v1/reading/saved-searches/${encodeURIComponent(searchId)}` as const
+    const response = await bgRequest<{ ok?: boolean }>({ path, method: "DELETE" })
+    return { ok: Boolean(response?.ok) }
+  }
+
+  async linkReadingItemToNote(itemId: string, noteId: string): Promise<ReadingNoteLink> {
+    const path = `/api/v1/reading/items/${encodeURIComponent(itemId)}/links/note` as const
+    const row = await bgRequest<any>({
+      path,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { note_id: noteId }
+    })
+    return {
+      item_id: String(row?.item_id ?? itemId),
+      note_id: String(row?.note_id ?? noteId),
+      created_at: row?.created_at ?? undefined
+    }
+  }
+
+  async listReadingItemNoteLinks(itemId: string): Promise<ReadingNoteLink[]> {
+    const path = `/api/v1/reading/items/${encodeURIComponent(itemId)}/links` as const
+    const data = await bgRequest<any>({ path, method: "GET" })
+    if (!Array.isArray(data?.links)) {
+      return []
+    }
+    return data.links.map((row: any) => ({
+      item_id: String(row?.item_id ?? itemId),
+      note_id: String(row?.note_id ?? ""),
+      created_at: row?.created_at ?? undefined
+    }))
+  }
+
+  async unlinkReadingItemNote(itemId: string, noteId: string): Promise<{ ok: boolean }> {
+    const path = `/api/v1/reading/items/${encodeURIComponent(itemId)}/links/note/${encodeURIComponent(noteId)}` as const
+    const response = await bgRequest<{ ok?: boolean }>({ path, method: "DELETE" })
+    return { ok: Boolean(response?.ok) }
   }
 
   async summarizeReadingItem(

--- a/apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args),
+  bgUpload: vi.fn(),
+  bgStream: vi.fn()
+}))
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    remove: vi.fn(async () => undefined)
+  }),
+  safeStorageSerde: {
+    serialize: (value: unknown) => value,
+    deserialize: (value: unknown) => value
+  }
+}))
+
+import { TldwApiClient } from "@/services/tldw/TldwApiClient"
+
+describe("TldwApiClient reading saved searches and note links", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("creates and lists reading saved searches", async () => {
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        id: 12,
+        name: "Daily",
+        query: { q: "ai" },
+        sort: "updated_desc",
+        created_at: "2026-03-02T00:00:00Z",
+        updated_at: "2026-03-02T00:00:00Z"
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 12,
+            name: "Daily",
+            query: { q: "ai" },
+            sort: "updated_desc",
+            created_at: "2026-03-02T00:00:00Z",
+            updated_at: "2026-03-02T00:00:00Z"
+          }
+        ],
+        total: 1,
+        limit: 20,
+        offset: 5
+      })
+
+    const client = new TldwApiClient()
+    const created = await client.createReadingSavedSearch({
+      name: "Daily",
+      query: { q: "ai" },
+      sort: "updated_desc"
+    })
+    const listed = await client.listReadingSavedSearches({ limit: 20, offset: 5 })
+
+    expect(created).toEqual({
+      id: "12",
+      name: "Daily",
+      query: { q: "ai" },
+      sort: "updated_desc",
+      created_at: "2026-03-02T00:00:00Z",
+      updated_at: "2026-03-02T00:00:00Z"
+    })
+    expect(listed).toEqual({
+      items: [
+        {
+          id: "12",
+          name: "Daily",
+          query: { q: "ai" },
+          sort: "updated_desc",
+          created_at: "2026-03-02T00:00:00Z",
+          updated_at: "2026-03-02T00:00:00Z"
+        }
+      ],
+      total: 1,
+      limit: 20,
+      offset: 5
+    })
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/reading/saved-searches",
+        method: "POST",
+        body: {
+          name: "Daily",
+          query: { q: "ai" },
+          sort: "updated_desc"
+        }
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/reading/saved-searches?limit=20&offset=5",
+        method: "GET"
+      })
+    )
+  })
+
+  it("updates and deletes a reading saved search", async () => {
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        id: 12,
+        name: "Daily AI",
+        query: { q: "llm" },
+        sort: "updated_asc"
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const client = new TldwApiClient()
+    const updated = await client.updateReadingSavedSearch("12", {
+      name: "Daily AI",
+      query: { q: "llm" },
+      sort: "updated_asc"
+    })
+    const removed = await client.deleteReadingSavedSearch("12")
+
+    expect(updated).toEqual({
+      id: "12",
+      name: "Daily AI",
+      query: { q: "llm" },
+      sort: "updated_asc",
+      created_at: undefined,
+      updated_at: undefined
+    })
+    expect(removed).toEqual({ ok: true })
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/reading/saved-searches/12",
+        method: "PATCH",
+        body: {
+          name: "Daily AI",
+          query: { q: "llm" },
+          sort: "updated_asc"
+        }
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/reading/saved-searches/12",
+        method: "DELETE"
+      })
+    )
+  })
+
+  it("links, lists, and unlinks note associations for a reading item", async () => {
+    mocks.bgRequest
+      .mockResolvedValueOnce({
+        item_id: 77,
+        note_id: "note-1",
+        created_at: "2026-03-02T01:00:00Z"
+      })
+      .mockResolvedValueOnce({
+        item_id: 77,
+        links: [
+          {
+            item_id: 77,
+            note_id: "note-1",
+            created_at: "2026-03-02T01:00:00Z"
+          }
+        ]
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const client = new TldwApiClient()
+    const linked = await client.linkReadingItemToNote("77", "note-1")
+    const links = await client.listReadingItemNoteLinks("77")
+    const unlinked = await client.unlinkReadingItemNote("77", "note-1")
+
+    expect(linked).toEqual({
+      item_id: "77",
+      note_id: "note-1",
+      created_at: "2026-03-02T01:00:00Z"
+    })
+    expect(links).toEqual([
+      {
+        item_id: "77",
+        note_id: "note-1",
+        created_at: "2026-03-02T01:00:00Z"
+      }
+    ])
+    expect(unlinked).toEqual({ ok: true })
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/reading/items/77/links/note",
+        method: "POST",
+        body: { note_id: "note-1" }
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/reading/items/77/links",
+        method: "GET"
+      })
+    )
+    expect(mocks.bgRequest).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        path: "/api/v1/reading/items/77/links/note/note-1",
+        method: "DELETE"
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/store/collections.tsx
+++ b/apps/packages/ui/src/store/collections.tsx
@@ -93,6 +93,12 @@ interface ImportExportState {
   exportError: string | null
 }
 
+interface FeatureFlagsState {
+  readingSavedSearchesEnabled: boolean
+  readingNoteLinksEnabled: boolean
+  readingArchiveControlsEnabled: boolean
+}
+
 interface UIState {
   activeTab: CollectionsTab
   itemDetailOpen: boolean
@@ -184,6 +190,12 @@ interface ImportExportActions {
   resetExport: () => void
 }
 
+interface FeatureFlagsActions {
+  setReadingSavedSearchesEnabled: (enabled: boolean) => void
+  setReadingNoteLinksEnabled: (enabled: boolean) => void
+  setReadingArchiveControlsEnabled: (enabled: boolean) => void
+}
+
 interface UIActions {
   setActiveTab: (tab: CollectionsTab) => void
   openItemDetail: (id: string) => void
@@ -208,11 +220,13 @@ export type CollectionsState = ReadingListState &
   HighlightsState &
   TemplatesState &
   ImportExportState &
+  FeatureFlagsState &
   UIState &
   ReadingListActions &
   HighlightsActions &
   TemplatesActions &
   ImportExportActions &
+  FeatureFlagsActions &
   UIActions
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -284,6 +298,12 @@ const initialImportExportState: ImportExportState = {
   exportError: null
 }
 
+const initialFeatureFlagsState: FeatureFlagsState = {
+  readingSavedSearchesEnabled: true,
+  readingNoteLinksEnabled: true,
+  readingArchiveControlsEnabled: true
+}
+
 const initialUIState: UIState = {
   activeTab: "reading",
   itemDetailOpen: false,
@@ -301,6 +321,7 @@ const initialState = {
   ...initialHighlightsState,
   ...initialTemplatesState,
   ...initialImportExportState,
+  ...initialFeatureFlagsState,
   ...initialUIState
 }
 
@@ -504,6 +525,17 @@ export const useCollectionsStore = createWithEqualityFn<CollectionsState>()((set
       exportInProgress: false,
       exportError: null
     }),
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Feature Flags Actions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  setReadingSavedSearchesEnabled: (readingSavedSearchesEnabled) =>
+    set({ readingSavedSearchesEnabled }),
+  setReadingNoteLinksEnabled: (readingNoteLinksEnabled) =>
+    set({ readingNoteLinksEnabled }),
+  setReadingArchiveControlsEnabled: (readingArchiveControlsEnabled) =>
+    set({ readingArchiveControlsEnabled }),
 
   // ─────────────────────────────────────────────────────────────────────────
   // UI Actions

--- a/apps/packages/ui/src/types/collections.ts
+++ b/apps/packages/ui/src/types/collections.ts
@@ -22,6 +22,9 @@ export interface ReadingItem {
   published_at?: string
   status?: ReadingStatus
   processing_status?: string
+  archive_requested?: boolean
+  has_archive_copy?: boolean
+  last_fetch_error?: string
   favorite: boolean
   tags: string[]
   created_at?: string
@@ -57,6 +60,7 @@ export interface AddReadingItemRequest {
   tags?: string[]
   notes?: string
   status?: ReadingStatus
+  archive_mode?: "use_default" | "always" | "never"
   favorite?: boolean
   summary?: string
   content?: string
@@ -120,6 +124,40 @@ export interface ReadingListResponse {
   size: number
   offset?: number
   limit?: number
+}
+
+export interface ReadingSavedSearch {
+  id: string
+  name: string
+  query: Record<string, unknown>
+  sort?: string
+  created_at?: string
+  updated_at?: string
+}
+
+export interface CreateReadingSavedSearchRequest {
+  name: string
+  query: Record<string, unknown>
+  sort?: string
+}
+
+export interface UpdateReadingSavedSearchRequest {
+  name?: string
+  query?: Record<string, unknown>
+  sort?: string
+}
+
+export interface ReadingSavedSearchListResponse {
+  items: ReadingSavedSearch[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export interface ReadingNoteLink {
+  item_id: string
+  note_id: string
+  created_at?: string
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -17,6 +17,7 @@ except ImportError:  # pragma: no cover - optional dependency fallback
     bleach = None
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.Collections_DB_Deps import get_collections_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 from tldw_Server_API.app.api.v1.endpoints.items import bulk_update_items as bulk_update_items_handler
@@ -40,6 +41,13 @@ from tldw_Server_API.app.api.v1.schemas.reading_schemas import (
     ReadingImportResponse,
     ReadingItem,
     ReadingItemDetail,
+    ReadingNoteLinkCreateRequest,
+    ReadingNoteLinkResponse,
+    ReadingNoteLinksListResponse,
+    ReadingSavedSearchCreateRequest,
+    ReadingSavedSearchListResponse,
+    ReadingSavedSearchResponse,
+    ReadingSavedSearchUpdateRequest,
     ReadingItemsListResponse,
     ReadingSaveRequest,
     ReadingSummarizeRequest,
@@ -57,6 +65,12 @@ from tldw_Server_API.app.core.Collections.reading_import_jobs import (
 )
 from tldw_Server_API.app.core.Collections.reading_service import ReadingService
 from tldw_Server_API.app.core.DB_Management.Collections_DB import ContentItemRow
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.feature_flags import (
+    is_collections_reading_archive_controls_enabled,
+    is_collections_reading_note_links_enabled,
+    is_collections_reading_saved_searches_enabled,
+)
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.LLM_Calls.Summarization_General_Lib import analyze as summarize_analyze
 from tldw_Server_API.app.core.TTS.tts_config import get_tts_config
@@ -162,6 +176,7 @@ def _derive_processing_status(row: ContentItemRow, metadata: dict[str, object]) 
 
 def _to_reading_item(row) -> ReadingItem:
     metadata = _parse_metadata(row)
+    fetch_error = metadata.get("last_fetch_error") or metadata.get("fetch_error")
     return ReadingItem(
         id=int(row.id),
         media_id=row.media_id,
@@ -175,6 +190,9 @@ def _to_reading_item(row) -> ReadingItem:
         published_at=row.published_at,
         status=row.status,
         processing_status=_derive_processing_status(row, metadata),
+        archive_requested=bool(metadata.get("archive_requested", False)),
+        has_archive_copy=bool(metadata.get("has_archive_copy", False)),
+        last_fetch_error=str(fetch_error) if fetch_error else None,
         favorite=bool(row.favorite),
         tags=row.tags,
         created_at=row.created_at,
@@ -191,6 +209,55 @@ def _to_reading_detail(row: ContentItemRow) -> ReadingItemDetail:
         clean_html=metadata.get("clean_html") if metadata else None,
         metadata=metadata,
     )
+
+
+def _to_saved_search_response(row) -> ReadingSavedSearchResponse:
+    query_payload: dict[str, object] = {}
+    raw = getattr(row, "query_json", None)
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                query_payload = parsed
+        except (TypeError, ValueError, json.JSONDecodeError):
+            query_payload = {}
+    return ReadingSavedSearchResponse(
+        id=int(row.id),
+        name=str(row.name),
+        query=query_payload,
+        sort=row.sort,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _to_note_link_response(row) -> ReadingNoteLinkResponse:
+    return ReadingNoteLinkResponse(
+        item_id=int(row.item_id),
+        note_id=str(row.note_id),
+        created_at=row.created_at,
+    )
+
+
+def _ensure_note_exists_or_404(notes_db: CharactersRAGDB, note_id: str) -> None:
+    note_data = notes_db.get_note_by_id(note_id=str(note_id))
+    if not note_data:
+        raise HTTPException(status_code=404, detail="note_not_found")
+
+
+def _ensure_reading_saved_searches_enabled() -> None:
+    if not is_collections_reading_saved_searches_enabled():
+        raise HTTPException(status_code=404, detail="reading_saved_searches_disabled")
+
+
+def _ensure_reading_note_links_enabled() -> None:
+    if not is_collections_reading_note_links_enabled():
+        raise HTTPException(status_code=404, detail="reading_note_links_disabled")
+
+
+def _ensure_reading_archive_controls_enabled() -> None:
+    if not is_collections_reading_archive_controls_enabled():
+        raise HTTPException(status_code=404, detail="reading_archive_controls_disabled")
 
 
 def _select_text_for_action(
@@ -420,6 +487,8 @@ async def save_reading_item(
     ),
     current_user: User = Depends(get_request_user),
 ) -> ReadingItem:
+    if payload.archive_mode != "use_default":
+        _ensure_reading_archive_controls_enabled()
     service = _service_for_user(current_user)
     try:
         result = await service.save_url(
@@ -431,6 +500,7 @@ async def save_reading_item(
             summary_override=payload.summary,
             content_override=payload.content,
             notes=payload.notes,
+            archive_mode=payload.archive_mode,
         )
         return _to_reading_item(result.item)
     except _READING_NONCRITICAL_EXCEPTIONS as exc:
@@ -501,6 +571,178 @@ async def list_reading_items(
         offset=resolved_offset,
         limit=resolved_limit,
     )
+
+
+@router.post(
+    "/saved-searches",
+    response_model=ReadingSavedSearchResponse,
+    status_code=201,
+    summary="Create a reading saved search",
+    dependencies=[Depends(rbac_rate_limit("reading.update"))],
+)
+async def create_reading_saved_search(
+    payload: ReadingSavedSearchCreateRequest,
+    collections_db=Depends(get_collections_db_for_user),
+) -> ReadingSavedSearchResponse:
+    _ensure_reading_saved_searches_enabled()
+    try:
+        row = collections_db.create_saved_search(
+            name=payload.name.strip(),
+            query_json=json.dumps(payload.query or {}, ensure_ascii=False),
+            sort=payload.sort,
+        )
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_saved_search_create_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_saved_search_create_failed") from exc
+    return _to_saved_search_response(row)
+
+
+@router.get(
+    "/saved-searches",
+    response_model=ReadingSavedSearchListResponse,
+    summary="List reading saved searches",
+    dependencies=[Depends(rbac_rate_limit("reading.list"))],
+)
+async def list_reading_saved_searches(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    collections_db=Depends(get_collections_db_for_user),
+) -> ReadingSavedSearchListResponse:
+    _ensure_reading_saved_searches_enabled()
+    try:
+        rows, total = collections_db.list_saved_searches(limit=limit, offset=offset)
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_saved_search_list_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_saved_search_list_failed") from exc
+    return ReadingSavedSearchListResponse(
+        items=[_to_saved_search_response(row) for row in rows],
+        total=int(total),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.patch(
+    "/saved-searches/{search_id}",
+    response_model=ReadingSavedSearchResponse,
+    summary="Update a reading saved search",
+    dependencies=[Depends(rbac_rate_limit("reading.update"))],
+)
+async def update_reading_saved_search(
+    search_id: int,
+    payload: ReadingSavedSearchUpdateRequest,
+    collections_db=Depends(get_collections_db_for_user),
+) -> ReadingSavedSearchResponse:
+    _ensure_reading_saved_searches_enabled()
+    patch: dict[str, object] = {}
+    if payload.name is not None:
+        patch["name"] = payload.name.strip()
+    if payload.query is not None:
+        patch["query_json"] = json.dumps(payload.query, ensure_ascii=False)
+    if payload.sort is not None:
+        patch["sort"] = payload.sort
+    try:
+        row = collections_db.update_saved_search(search_id, patch)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="reading_saved_search_not_found") from None
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_saved_search_update_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_saved_search_update_failed") from exc
+    return _to_saved_search_response(row)
+
+
+@router.delete(
+    "/saved-searches/{search_id}",
+    response_model=dict[str, bool],
+    summary="Delete a reading saved search",
+    dependencies=[Depends(rbac_rate_limit("reading.update"))],
+)
+async def delete_reading_saved_search(
+    search_id: int,
+    collections_db=Depends(get_collections_db_for_user),
+) -> dict[str, bool]:
+    _ensure_reading_saved_searches_enabled()
+    try:
+        ok = collections_db.delete_saved_search(search_id)
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_saved_search_delete_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_saved_search_delete_failed") from exc
+    if not ok:
+        raise HTTPException(status_code=404, detail="reading_saved_search_not_found")
+    return {"ok": True}
+
+
+@router.post(
+    "/items/{item_id}/links/note",
+    response_model=ReadingNoteLinkResponse,
+    summary="Link a note to a reading item",
+    dependencies=[Depends(rbac_rate_limit("reading.update"))],
+)
+async def link_note_to_reading_item(
+    item_id: int,
+    payload: ReadingNoteLinkCreateRequest,
+    notes_db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+    collections_db=Depends(get_collections_db_for_user),
+) -> ReadingNoteLinkResponse:
+    _ensure_reading_note_links_enabled()
+    _ensure_note_exists_or_404(notes_db, payload.note_id)
+    try:
+        row = collections_db.link_note_to_content_item(item_id=item_id, note_id=payload.note_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="reading_item_not_found") from None
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_note_link_create_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_note_link_create_failed") from exc
+    return _to_note_link_response(row)
+
+
+@router.get(
+    "/items/{item_id}/links",
+    response_model=ReadingNoteLinksListResponse,
+    summary="List note links for a reading item",
+    dependencies=[Depends(rbac_rate_limit("reading.read"))],
+)
+async def list_reading_item_note_links(
+    item_id: int,
+    collections_db=Depends(get_collections_db_for_user),
+) -> ReadingNoteLinksListResponse:
+    _ensure_reading_note_links_enabled()
+    try:
+        links = collections_db.list_note_links_for_content_item(item_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="reading_item_not_found") from None
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_note_link_list_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_note_link_list_failed") from exc
+    return ReadingNoteLinksListResponse(
+        item_id=item_id,
+        links=[_to_note_link_response(row) for row in links],
+    )
+
+
+@router.delete(
+    "/items/{item_id}/links/note/{note_id}",
+    response_model=dict[str, bool],
+    summary="Unlink a note from a reading item",
+    dependencies=[Depends(rbac_rate_limit("reading.update"))],
+)
+async def unlink_note_from_reading_item(
+    item_id: int,
+    note_id: str,
+    collections_db=Depends(get_collections_db_for_user),
+) -> dict[str, bool]:
+    _ensure_reading_note_links_enabled()
+    try:
+        collections_db.get_content_item(item_id)
+        ok = collections_db.unlink_note_from_content_item(item_id=item_id, note_id=note_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="reading_item_not_found") from None
+    except _READING_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"reading_note_link_delete_failed: {exc}")
+        raise HTTPException(status_code=400, detail="reading_note_link_delete_failed") from exc
+    if not ok:
+        raise HTTPException(status_code=404, detail="reading_note_link_not_found")
+    return {"ok": True}
 
 
 @router.post("/items/bulk", response_model=ItemsBulkResponse, summary="Bulk update reading items (alias)")

--- a/tldw_Server_API/app/api/v1/endpoints/reading.py
+++ b/tldw_Server_API/app/api/v1/endpoints/reading.py
@@ -64,7 +64,11 @@ from tldw_Server_API.app.core.Collections.reading_import_jobs import (
     stage_reading_import_file,
 )
 from tldw_Server_API.app.core.Collections.reading_service import ReadingService
-from tldw_Server_API.app.core.DB_Management.Collections_DB import ContentItemRow
+from tldw_Server_API.app.core.DB_Management.Collections_DB import (
+    ContentItemNoteLinkRow,
+    ContentItemRow,
+    SavedSearchRow,
+)
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
 from tldw_Server_API.app.core.feature_flags import (
     is_collections_reading_archive_controls_enabled,
@@ -211,7 +215,7 @@ def _to_reading_detail(row: ContentItemRow) -> ReadingItemDetail:
     )
 
 
-def _to_saved_search_response(row) -> ReadingSavedSearchResponse:
+def _to_saved_search_response(row: SavedSearchRow) -> ReadingSavedSearchResponse:
     query_payload: dict[str, object] = {}
     raw = getattr(row, "query_json", None)
     if raw:
@@ -231,7 +235,7 @@ def _to_saved_search_response(row) -> ReadingSavedSearchResponse:
     )
 
 
-def _to_note_link_response(row) -> ReadingNoteLinkResponse:
+def _to_note_link_response(row: ContentItemNoteLinkRow) -> ReadingNoteLinkResponse:
     return ReadingNoteLinkResponse(
         item_id=int(row.item_id),
         note_id=str(row.note_id),
@@ -587,7 +591,7 @@ async def create_reading_saved_search(
     _ensure_reading_saved_searches_enabled()
     try:
         row = collections_db.create_saved_search(
-            name=payload.name.strip(),
+            name=payload.name,
             query_json=json.dumps(payload.query or {}, ensure_ascii=False),
             sort=payload.sort,
         )
@@ -636,7 +640,7 @@ async def update_reading_saved_search(
     _ensure_reading_saved_searches_enabled()
     patch: dict[str, object] = {}
     if payload.name is not None:
-        patch["name"] = payload.name.strip()
+        patch["name"] = payload.name
     if payload.query is not None:
         patch["query_json"] = json.dumps(payload.query, ensure_ascii=False)
     if payload.sort is not None:

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -6,6 +6,96 @@ from pydantic import BaseModel, HttpUrl, validator
 
 from tldw_Server_API.app.api.v1.schemas._compat import Field
 
+_READING_SAVED_SEARCH_ALLOWED_QUERY_KEYS = {
+    "q",
+    "status",
+    "tags",
+    "favorite",
+    "domain",
+    "date_from",
+    "date_to",
+    "sort",
+}
+_READING_SAVED_SEARCH_ALLOWED_STATUSES = {"saved", "reading", "read", "archived"}
+_READING_SAVED_SEARCH_ALLOWED_SORTS = {
+    "updated_desc",
+    "updated_asc",
+    "created_desc",
+    "created_asc",
+    "title_asc",
+    "title_desc",
+    "relevance",
+}
+
+
+def _normalize_nonempty_string(value: Any, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name}_must_be_string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name}_must_not_be_blank")
+    return normalized
+
+
+def _normalize_saved_search_sort(value: Any) -> str:
+    normalized = _normalize_nonempty_string(value, field_name="sort").lower()
+    if normalized not in _READING_SAVED_SEARCH_ALLOWED_SORTS:
+        raise ValueError("sort_invalid")
+    return normalized
+
+
+def _normalize_saved_search_query(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("query_must_be_object")
+
+    normalized: dict[str, Any] = {}
+    for key, raw in value.items():
+        if key not in _READING_SAVED_SEARCH_ALLOWED_QUERY_KEYS:
+            raise ValueError(f"unsupported_query_key:{key}")
+        if key in {"q", "domain", "date_from", "date_to"}:
+            normalized[key] = _normalize_nonempty_string(raw, field_name=key)
+            continue
+        if key == "favorite":
+            if not isinstance(raw, bool):
+                raise ValueError("favorite_must_be_boolean")
+            normalized[key] = raw
+            continue
+        if key == "status":
+            if isinstance(raw, str):
+                status = raw.strip().lower()
+                if status not in _READING_SAVED_SEARCH_ALLOWED_STATUSES:
+                    raise ValueError("status_invalid")
+                normalized[key] = status
+                continue
+            if isinstance(raw, list):
+                statuses = []
+                for entry in raw:
+                    if not isinstance(entry, str):
+                        raise ValueError("status_values_must_be_strings")
+                    status = entry.strip().lower()
+                    if status not in _READING_SAVED_SEARCH_ALLOWED_STATUSES:
+                        raise ValueError("status_invalid")
+                    statuses.append(status)
+                if not statuses:
+                    raise ValueError("status_values_must_not_be_empty")
+                normalized[key] = statuses
+                continue
+            raise ValueError("status_must_be_string_or_list")
+        if key == "tags":
+            if not isinstance(raw, list):
+                raise ValueError("tags_must_be_list")
+            tags = []
+            for entry in raw:
+                tags.append(_normalize_nonempty_string(entry, field_name="tag"))
+            normalized[key] = tags
+            continue
+        if key == "sort":
+            normalized[key] = _normalize_saved_search_sort(raw)
+            continue
+    return normalized
+
 
 class ReadingSaveRequest(BaseModel):
     url: HttpUrl = Field(example="https://example.com/article")
@@ -77,6 +167,20 @@ class ReadingSavedSearchCreateRequest(BaseModel):
         description="updated_desc|updated_asc|created_desc|created_asc|title_asc|title_desc|relevance",
     )
 
+    @validator("name")
+    def _normalize_name(cls, value: str) -> str:
+        return _normalize_nonempty_string(value, field_name="name")
+
+    @validator("query", pre=True)
+    def _normalize_query(cls, value: Any) -> dict[str, Any]:
+        return _normalize_saved_search_query(value)
+
+    @validator("sort")
+    def _normalize_sort(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _normalize_saved_search_sort(value)
+
 
 class ReadingSavedSearchUpdateRequest(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
@@ -85,6 +189,24 @@ class ReadingSavedSearchUpdateRequest(BaseModel):
         default=None,
         description="updated_desc|updated_asc|created_desc|created_asc|title_asc|title_desc|relevance",
     )
+
+    @validator("name")
+    def _normalize_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _normalize_nonempty_string(value, field_name="name")
+
+    @validator("query", pre=True)
+    def _normalize_query(cls, value: Any) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        return _normalize_saved_search_query(value)
+
+    @validator("sort")
+    def _normalize_sort(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _normalize_saved_search_sort(value)
 
 
 class ReadingSavedSearchResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/reading_schemas.py
@@ -12,6 +12,11 @@ class ReadingSaveRequest(BaseModel):
     title: str | None = Field(default=None, example="Example Article")
     tags: list[str] = Field(default_factory=list, example=["ai", "reading"])
     status: str | None = Field(default="saved", description="saved|reading|read|archived", example="saved")
+    archive_mode: Literal["use_default", "always", "never"] = Field(
+        default="use_default",
+        description="Archive policy override for this save request.",
+        example="always",
+    )
     favorite: bool = False
     summary: str | None = Field(default=None, example="Short summary for quick scan.")
     notes: str | None = Field(default=None, example="Why this matters for the project.")
@@ -39,6 +44,9 @@ class ReadingItem(BaseModel):
     published_at: str | None = None
     status: str | None = Field(default=None, example="saved")
     processing_status: str | None = None
+    archive_requested: bool = False
+    has_archive_copy: bool = False
+    last_fetch_error: str | None = None
     favorite: bool = False
     tags: list[str] = Field(default_factory=list, example=["ai", "reading"])
     created_at: str | None = None
@@ -59,6 +67,55 @@ class ReadingItemsListResponse(BaseModel):
     size: int
     offset: int | None = None
     limit: int | None = None
+
+
+class ReadingSavedSearchCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255, example="Morning")
+    query: dict[str, Any] = Field(default_factory=dict, example={"q": "ai", "status": ["saved"]})
+    sort: str | None = Field(
+        default=None,
+        description="updated_desc|updated_asc|created_desc|created_asc|title_asc|title_desc|relevance",
+    )
+
+
+class ReadingSavedSearchUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    query: dict[str, Any] | None = None
+    sort: str | None = Field(
+        default=None,
+        description="updated_desc|updated_asc|created_desc|created_asc|title_asc|title_desc|relevance",
+    )
+
+
+class ReadingSavedSearchResponse(BaseModel):
+    id: int
+    name: str
+    query: dict[str, Any]
+    sort: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class ReadingSavedSearchListResponse(BaseModel):
+    items: list[ReadingSavedSearchResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class ReadingNoteLinkCreateRequest(BaseModel):
+    note_id: str = Field(..., min_length=1, max_length=255, example="8ef2f7ad-2a2f-4442-9adf-23c36dcf0f8d")
+
+
+class ReadingNoteLinkResponse(BaseModel):
+    item_id: int
+    note_id: str
+    created_at: str | None = None
+
+
+class ReadingNoteLinksListResponse(BaseModel):
+    item_id: int
+    links: list[ReadingNoteLinkResponse]
 
 
 class ReadingImportResponse(BaseModel):

--- a/tldw_Server_API/app/core/Collections/reading_service.py
+++ b/tldw_Server_API/app/core/Collections/reading_service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
+import json
+import os
+import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -14,6 +18,7 @@ from tldw_Server_API.app.core.Collections.embedding_queue import enqueue_embeddi
 from tldw_Server_API.app.core.Collections.reading_importers import ReadingImportItem, normalize_import_items
 from tldw_Server_API.app.core.Collections.utils import hash_text_sha256, truncate_text, word_count
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase, ContentItemRow
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.exceptions import (
     EgressPolicyError,
     NetworkError,
@@ -29,6 +34,8 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.download_utils import (
 from tldw_Server_API.app.core.Web_Scraping.url_utils import normalize_for_crawl
 
 READING_DEFAULT_STATUS = "saved"
+READING_ARCHIVE_MAX_BYTES = int(os.getenv("READING_ARCHIVE_MAX_BYTES", str(5 * 1024 * 1024)) or str(5 * 1024 * 1024))
+READING_ARCHIVE_RETENTION_DAYS = int(os.getenv("READING_ARCHIVE_RETENTION_DAYS", "30") or "30")
 
 _READING_SERVICE_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -74,12 +81,31 @@ def _utcnow_iso() -> str:
     return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat()
 
 
+def _env_flag_enabled(raw: str | None) -> bool:
+    value = str(raw or "").strip().lower()
+    return value in {"1", "true", "yes", "on", "y"}
+
+
+def _strip_html(raw: str) -> str:
+    return re.sub(r"<[^>]+>", "", raw)
+
+
+def _safe_filename_fragment(raw: str, max_len: int = 64) -> str:
+    text = re.sub(r"[^A-Za-z0-9._-]+", "_", str(raw or "").strip()).strip("._")
+    if not text:
+        text = "reading"
+    return text[:max_len]
+
+
 @dataclass
 class ReadingSaveResult:
     item: ContentItemRow
     media_id: int | None
     media_uuid: str | None
     created: bool
+    archive_requested: bool = False
+    archive_output_id: int | None = None
+    archive_error: str | None = None
 
 
 @dataclass
@@ -325,6 +351,74 @@ class ReadingService:
             "error": error,
         }
 
+    @staticmethod
+    def _archive_default_enabled() -> bool:
+        return _env_flag_enabled(os.getenv("READING_ARCHIVE_ON_SAVE_DEFAULT", "0"))
+
+    @classmethod
+    def _resolve_archive_requested(cls, archive_mode: str | None) -> bool:
+        mode = str(archive_mode or "use_default").strip().lower()
+        if mode == "always":
+            return True
+        if mode == "never":
+            return False
+        return cls._archive_default_enabled()
+
+    @staticmethod
+    def _resolve_archive_retention() -> str | None:
+        try:
+            days = max(0, int(READING_ARCHIVE_RETENTION_DAYS))
+        except (TypeError, ValueError):
+            return None
+        if days <= 0:
+            return None
+        expires = datetime.now(tz=timezone.utc) + timedelta(days=days)
+        return expires.isoformat()
+
+    async def _create_archive_artifact(
+        self,
+        *,
+        item_id: int,
+        title: str,
+        url: str | None,
+        body_text: str,
+        media_item_id: int | None,
+    ) -> tuple[int | None, str | None]:
+        text_value = (body_text or "").strip()
+        if not text_value:
+            return None, "archive_no_content"
+        content = f"# {title}\n\n{url or ''}\n\n{text_value}\n"
+        content_bytes = content.encode("utf-8")
+        if READING_ARCHIVE_MAX_BYTES > 0 and len(content_bytes) > READING_ARCHIVE_MAX_BYTES:
+            return None, "archive_too_large"
+
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+        safe_title = _safe_filename_fragment(title, max_len=40)
+        filename = f"reading_archive_{item_id}_{safe_title}_{timestamp}.md"
+        outputs_dir = DatabasePaths.get_user_outputs_dir(self.user_id)
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+        path = outputs_dir / filename
+        path.write_text(content, encoding="utf-8")
+
+        metadata = {
+            "item_id": item_id,
+            "url": url,
+            "canonical_url": url,
+            "source": "save_url",
+            "format": "md",
+            "title": title,
+        }
+        output_row = self.collections.create_output_artifact(
+            type_="reading_archive",
+            title=f"{title} (archive {timestamp})",
+            format_="md",
+            storage_path=filename,
+            metadata_json=json.dumps(metadata, ensure_ascii=False),
+            media_item_id=media_item_id,
+            retention_until=self._resolve_archive_retention(),
+        )
+        return int(output_row.id), None
+
     async def save_url(
         self,
         *,
@@ -337,10 +431,12 @@ class ReadingService:
         content_override: str | None = None,
         notes: str | None = None,
         metadata: dict[str, object] | None = None,
+        archive_mode: str = "use_default",
     ) -> ReadingSaveResult:
         """Fetch, dedupe, and persist a reading item."""
         normalized_status = (status or READING_DEFAULT_STATUS).lower()
         tags = [t for t in (tags or []) if t]
+        archive_requested = self._resolve_archive_requested(archive_mode)
         try:
             article = await self._fetch_article(
                 url=url,
@@ -374,11 +470,15 @@ class ReadingService:
         media_id = article.get("media_id")
         media_uuid = article.get("media_uuid")
         content_word_count = word_count(content)
+        fetch_error = article.get("error")
 
         metadata_payload: dict[str, object] = {
             "source": "reading_save",
             "tags": tags,
             "author": article.get("author"),
+            "archive_mode": str(archive_mode or "use_default"),
+            "archive_requested": archive_requested,
+            "last_fetch_error": fetch_error,
         }
         if article.get("media_type"):
             metadata_payload["media_type"] = article.get("media_type")
@@ -394,8 +494,10 @@ class ReadingService:
             metadata_payload["text"] = content
         if content_word_count:
             metadata_payload["reading_time_seconds"] = max(1, int(content_word_count / 200 * 60))
-        if article.get("error"):
-            metadata_payload["fetch_error"] = article.get("error")
+        if fetch_error:
+            metadata_payload["fetch_error"] = fetch_error
+        else:
+            metadata_payload["fetch_error"] = None
         if metadata:
             metadata_payload.update(metadata)
 
@@ -422,7 +524,34 @@ class ReadingService:
             read_at=None,
             tags=tags,
             merge_tags=True,
+            preserve_existing_on_null=True,
         )
+
+        archive_output_id: int | None = None
+        archive_error: str | None = None
+        if archive_requested:
+            archive_text = content or summary or notes or ""
+            if not archive_text and article.get("clean_html"):
+                archive_text = _strip_html(str(article.get("clean_html") or ""))
+            try:
+                archive_output_id, archive_error = await self._create_archive_artifact(
+                    item_id=int(item_row.id),
+                    title=str(item_row.title or title or url),
+                    url=item_row.canonical_url or item_row.url,
+                    body_text=archive_text,
+                    media_item_id=item_row.media_id,
+                )
+            except _READING_SERVICE_NONCRITICAL_EXCEPTIONS as exc:
+                archive_error = f"archive_failed:{exc}"
+            meta_patch: dict[str, object] = {"archive_requested": True}
+            if archive_output_id is not None:
+                meta_patch["has_archive_copy"] = True
+                meta_patch["archive_output_id"] = archive_output_id
+                meta_patch["archive_error"] = None
+            elif archive_error:
+                meta_patch["archive_error"] = archive_error
+            with contextlib.suppress(_READING_SERVICE_NONCRITICAL_EXCEPTIONS):
+                item_row = self.collections.update_content_item(item_row.id, metadata=meta_patch)
 
         if item_row.is_new or item_row.content_changed:
             embedding_metadata = {
@@ -457,6 +586,9 @@ class ReadingService:
             media_id=item_row.media_id,
             media_uuid=media_uuid,
             created=item_row.is_new,
+            archive_requested=archive_requested,
+            archive_output_id=archive_output_id,
+            archive_error=archive_error,
         )
 
     async def _fetch_article(

--- a/tldw_Server_API/app/core/Collections/reading_service.py
+++ b/tldw_Server_API/app/core/Collections/reading_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import inspect
 import json
 import os
@@ -33,9 +32,25 @@ from tldw_Server_API.app.core.Ingestion_Media_Processing.download_utils import (
 )
 from tldw_Server_API.app.core.Web_Scraping.url_utils import normalize_for_crawl
 
+
+def _env_int(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid integer for {name}: {raw!r}; using default={default}")
+        return default
+    if minimum is not None and value < minimum:
+        logger.warning(f"Out-of-range integer for {name}: {value}; minimum={minimum}; using default={default}")
+        return default
+    return value
+
+
 READING_DEFAULT_STATUS = "saved"
-READING_ARCHIVE_MAX_BYTES = int(os.getenv("READING_ARCHIVE_MAX_BYTES", str(5 * 1024 * 1024)) or str(5 * 1024 * 1024))
-READING_ARCHIVE_RETENTION_DAYS = int(os.getenv("READING_ARCHIVE_RETENTION_DAYS", "30") or "30")
+READING_ARCHIVE_MAX_BYTES = _env_int("READING_ARCHIVE_MAX_BYTES", 5 * 1024 * 1024, minimum=0)
+READING_ARCHIVE_RETENTION_DAYS = _env_int("READING_ARCHIVE_RETENTION_DAYS", 30, minimum=0)
 
 _READING_SERVICE_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -396,9 +411,9 @@ class ReadingService:
         safe_title = _safe_filename_fragment(title, max_len=40)
         filename = f"reading_archive_{item_id}_{safe_title}_{timestamp}.md"
         outputs_dir = DatabasePaths.get_user_outputs_dir(self.user_id)
-        outputs_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(outputs_dir.mkdir, parents=True, exist_ok=True)
         path = outputs_dir / filename
-        path.write_text(content, encoding="utf-8")
+        await asyncio.to_thread(path.write_text, content, encoding="utf-8")
 
         metadata = {
             "item_id": item_id,
@@ -550,8 +565,12 @@ class ReadingService:
                 meta_patch["archive_error"] = None
             elif archive_error:
                 meta_patch["archive_error"] = archive_error
-            with contextlib.suppress(_READING_SERVICE_NONCRITICAL_EXCEPTIONS):
+            try:
                 item_row = self.collections.update_content_item(item_row.id, metadata=meta_patch)
+            except _READING_SERVICE_NONCRITICAL_EXCEPTIONS as exc:
+                update_error = f"archive_metadata_update_failed:{exc}"
+                logger.warning(f"reading_archive_metadata_update_failed item_id={item_row.id}: {exc}")
+                archive_error = f"{archive_error};{update_error}" if archive_error else update_error
 
         if item_row.is_new or item_row.content_changed:
             embedding_metadata = {

--- a/tldw_Server_API/app/core/DB_Management/Collections_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Collections_DB.py
@@ -113,6 +113,7 @@ _SQLITE_PRAGMA_TABLES = {
     "audiobook_chapters",
     "audiobook_projects",
     "collection_tags",
+    "content_item_note_links",
     "content_item_tags",
     "content_items",
     "file_artifacts",
@@ -122,6 +123,7 @@ _SQLITE_PRAGMA_TABLES = {
     "outputs",
     "reminder_task_runs",
     "reminder_tasks",
+    "saved_searches",
     "reading_digest_schedules",
     "reading_highlights",
     "user_notifications",
@@ -202,6 +204,25 @@ class ContentItemRow:
     tags: list[str]
     is_new: bool = False
     content_changed: bool = False
+
+
+@dataclass
+class SavedSearchRow:
+    id: int
+    user_id: str
+    name: str
+    query_json: str
+    sort: str | None
+    created_at: str
+    updated_at: str
+
+
+@dataclass
+class ContentItemNoteLinkRow:
+    user_id: str
+    item_id: int
+    note_id: str
+    created_at: str
 
 
 @dataclass
@@ -1396,6 +1417,28 @@ class CollectionsDatabase:
                 tag_id BIGINT NOT NULL,
                 UNIQUE (item_id, tag_id)
             );
+
+            CREATE TABLE IF NOT EXISTS saved_searches (
+                id BIGSERIAL PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                query_json TEXT NOT NULL,
+                sort TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_saved_searches_user_name ON saved_searches(user_id, name);
+            CREATE INDEX IF NOT EXISTS idx_saved_searches_user_updated ON saved_searches(user_id, updated_at DESC);
+
+            CREATE TABLE IF NOT EXISTS content_item_note_links (
+                user_id TEXT NOT NULL,
+                item_id BIGINT NOT NULL,
+                note_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (user_id, item_id, note_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_content_item_note_links_user_item
+                ON content_item_note_links(user_id, item_id, created_at DESC);
             """
         else:
             content_ddl = """
@@ -1445,6 +1488,28 @@ class CollectionsDatabase:
                 tag_id INTEGER NOT NULL,
                 UNIQUE (item_id, tag_id)
             );
+
+            CREATE TABLE IF NOT EXISTS saved_searches (
+                id INTEGER PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                query_json TEXT NOT NULL,
+                sort TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE (user_id, name)
+            );
+            CREATE INDEX IF NOT EXISTS idx_saved_searches_user_updated ON saved_searches(user_id, updated_at DESC);
+
+            CREATE TABLE IF NOT EXISTS content_item_note_links (
+                user_id TEXT NOT NULL,
+                item_id INTEGER NOT NULL,
+                note_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (user_id, item_id, note_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_content_item_note_links_user_item
+                ON content_item_note_links(user_id, item_id, created_at DESC);
             """
         try:
             self.backend.create_tables(content_ddl)
@@ -2579,6 +2644,10 @@ class CollectionsDatabase:
             (item_id,),
         )
         self.backend.execute(
+            "DELETE FROM content_item_note_links WHERE user_id = ? AND item_id = ?",
+            (self.user_id, item_id),
+        )
+        self.backend.execute(
             "DELETE FROM content_items WHERE id = ? AND user_id = ?",
             (item_id, self.user_id),
         )
@@ -2640,6 +2709,155 @@ class CollectionsDatabase:
                         self.delete_content_item(item_id)
                         deleted += 1
         return deleted
+
+    # ------------------------
+    # Reading Saved Searches API
+    # ------------------------
+    @staticmethod
+    def _saved_search_row_from_db(row: dict[str, Any]) -> SavedSearchRow:
+        return SavedSearchRow(
+            id=int(row.get("id")),
+            user_id=str(row.get("user_id") or ""),
+            name=str(row.get("name") or ""),
+            query_json=str(row.get("query_json") or "{}"),
+            sort=row.get("sort"),
+            created_at=str(row.get("created_at") or ""),
+            updated_at=str(row.get("updated_at") or ""),
+        )
+
+    def create_saved_search(
+        self,
+        *,
+        name: str,
+        query_json: str,
+        sort: str | None = None,
+    ) -> SavedSearchRow:
+        now = _utcnow_iso()
+        q = (
+            "INSERT INTO saved_searches (user_id, name, query_json, sort, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        params = (self.user_id, name, query_json, sort, now, now)
+        try:
+            res = self._execute_insert(q, params)
+            new_id = self._extract_lastrowid(res)
+            if not new_id:
+                raise DatabaseError("Failed to create saved search")
+            return self.get_saved_search(int(new_id))
+        except DatabaseError as exc:
+            if not self._is_unique_violation(exc):
+                raise
+            existing = self.get_saved_search_by_name(name)
+            if existing is None:
+                raise
+            return existing
+
+    def get_saved_search(self, search_id: int) -> SavedSearchRow:
+        row = self.backend.execute(
+            "SELECT id, user_id, name, query_json, sort, created_at, updated_at "
+            "FROM saved_searches WHERE id = ? AND user_id = ?",
+            (search_id, self.user_id),
+        ).first
+        if not row:
+            raise KeyError("saved_search_not_found")
+        return self._saved_search_row_from_db(row)
+
+    def get_saved_search_by_name(self, name: str) -> SavedSearchRow | None:
+        row = self.backend.execute(
+            "SELECT id, user_id, name, query_json, sort, created_at, updated_at "
+            "FROM saved_searches WHERE user_id = ? AND name = ?",
+            (self.user_id, name),
+        ).first
+        if not row:
+            return None
+        return self._saved_search_row_from_db(row)
+
+    def list_saved_searches(self, *, limit: int = 50, offset: int = 0) -> tuple[list[SavedSearchRow], int]:
+        count = int(
+            self.backend.execute(
+                "SELECT COUNT(*) AS cnt FROM saved_searches WHERE user_id = ?",
+                (self.user_id,),
+            ).scalar or 0
+        )
+        rows = self.backend.execute(
+            "SELECT id, user_id, name, query_json, sort, created_at, updated_at "
+            "FROM saved_searches WHERE user_id = ? "
+            "ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
+            (self.user_id, limit, offset),
+        ).rows
+        return [self._saved_search_row_from_db(row) for row in rows], count
+
+    def update_saved_search(self, search_id: int, patch: dict[str, Any]) -> SavedSearchRow:
+        if not patch:
+            return self.get_saved_search(search_id)
+        fields: list[str] = []
+        params: list[Any] = []
+        for key in ("name", "query_json", "sort"):
+            if key in patch:
+                fields.append(f"{key} = ?")
+                params.append(patch.get(key))
+        if not fields:
+            return self.get_saved_search(search_id)
+        fields.append("updated_at = ?")
+        params.append(_utcnow_iso())
+        params.extend([search_id, self.user_id])
+        q = f"UPDATE saved_searches SET {', '.join(fields)} WHERE id = ? AND user_id = ?"  # nosec B608
+        res = self.backend.execute(q, tuple(params))
+        if res.rowcount <= 0:
+            raise KeyError("saved_search_not_found")
+        return self.get_saved_search(search_id)
+
+    def delete_saved_search(self, search_id: int) -> bool:
+        res = self.backend.execute(
+            "DELETE FROM saved_searches WHERE id = ? AND user_id = ?",
+            (search_id, self.user_id),
+        )
+        return bool(res.rowcount and res.rowcount > 0)
+
+    # ------------------------
+    # Reading ↔ Notes Link API
+    # ------------------------
+    @staticmethod
+    def _content_item_note_link_row_from_db(row: dict[str, Any]) -> ContentItemNoteLinkRow:
+        return ContentItemNoteLinkRow(
+            user_id=str(row.get("user_id") or ""),
+            item_id=int(row.get("item_id")),
+            note_id=str(row.get("note_id") or ""),
+            created_at=str(row.get("created_at") or ""),
+        )
+
+    def link_note_to_content_item(self, *, item_id: int, note_id: str) -> ContentItemNoteLinkRow:
+        self.get_content_item(item_id)
+        now = _utcnow_iso()
+        self.backend.execute(
+            "INSERT INTO content_item_note_links (user_id, item_id, note_id, created_at) "
+            "VALUES (?, ?, ?, ?) ON CONFLICT(user_id, item_id, note_id) DO NOTHING",
+            (self.user_id, item_id, note_id, now),
+        )
+        row = self.backend.execute(
+            "SELECT user_id, item_id, note_id, created_at FROM content_item_note_links "
+            "WHERE user_id = ? AND item_id = ? AND note_id = ?",
+            (self.user_id, item_id, note_id),
+        ).first
+        if not row:
+            raise DatabaseError("Failed to link note to content item")
+        return self._content_item_note_link_row_from_db(row)
+
+    def list_note_links_for_content_item(self, item_id: int) -> list[ContentItemNoteLinkRow]:
+        self.get_content_item(item_id)
+        rows = self.backend.execute(
+            "SELECT user_id, item_id, note_id, created_at FROM content_item_note_links "
+            "WHERE user_id = ? AND item_id = ? ORDER BY created_at DESC, note_id DESC",
+            (self.user_id, item_id),
+        ).rows
+        return [self._content_item_note_link_row_from_db(row) for row in rows]
+
+    def unlink_note_from_content_item(self, *, item_id: int, note_id: str) -> bool:
+        res = self.backend.execute(
+            "DELETE FROM content_item_note_links WHERE user_id = ? AND item_id = ? AND note_id = ?",
+            (self.user_id, item_id, note_id),
+        )
+        return bool(res.rowcount and res.rowcount > 0)
 
     # ------------------------
     # Output Templates API

--- a/tldw_Server_API/app/core/feature_flags.py
+++ b/tldw_Server_API/app/core/feature_flags.py
@@ -2,7 +2,35 @@ from __future__ import annotations
 
 """Feature flag helpers for runtime gating."""
 
+import os
+
 from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.testing import is_truthy
+
+
+def _flag_enabled(name: str, default: bool = True) -> bool:
+    """Resolve a boolean flag from environment first, then runtime settings."""
+    env_value = os.getenv(name)
+    if env_value is None:
+        env_value = os.getenv(name.lower())
+    if env_value is not None:
+        return is_truthy(env_value)
+
+    try:
+        raw = settings.get(name, None)
+    except Exception:
+        raw = None
+    if raw is None:
+        try:
+            raw = settings.get(name.lower(), None)
+        except Exception:
+            raw = None
+
+    if raw is None:
+        return default
+    if isinstance(raw, bool):
+        return raw
+    return is_truthy(str(raw))
 
 
 def is_personalization_enabled() -> bool:
@@ -31,3 +59,15 @@ def is_self_monitoring_enabled() -> bool:
         return bool(settings.get("SELF_MONITORING_ENABLED", True))
     except Exception:
         return True
+
+
+def is_collections_reading_saved_searches_enabled() -> bool:
+    return _flag_enabled("COLLECTIONS_READING_SAVED_SEARCHES_ENABLED", default=True)
+
+
+def is_collections_reading_note_links_enabled() -> bool:
+    return _flag_enabled("COLLECTIONS_READING_NOTE_LINKS_ENABLED", default=True)
+
+
+def is_collections_reading_archive_controls_enabled() -> bool:
+    return _flag_enabled("COLLECTIONS_READING_ARCHIVE_CONTROLS_ENABLED", default=True)

--- a/tldw_Server_API/tests/Collections/test_reading_api.py
+++ b/tldw_Server_API/tests/Collections/test_reading_api.py
@@ -176,6 +176,47 @@ def test_saved_search_endpoints_crud(reading_app):
         assert r.json()["total"] == 0
 
 
+def test_saved_search_rejects_unsupported_query_key(reading_app):
+    async def override_user():
+        return User(id=911, username="saved-search-invalid-query", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        r = client.post(
+            "/api/v1/reading/saved-searches",
+            json={"name": "Invalid Query", "query": {"unknown_filter": "x"}},
+        )
+        assert r.status_code == 422, r.text
+
+
+def test_saved_search_rejects_blank_name_values(reading_app):
+    async def override_user():
+        return User(id=912, username="saved-search-blank-name", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        r = client.post(
+            "/api/v1/reading/saved-searches",
+            json={"name": "   ", "query": {"q": "ai"}},
+        )
+        assert r.status_code == 422, r.text
+
+        create = client.post(
+            "/api/v1/reading/saved-searches",
+            json={"name": "Keep Name", "query": {"q": "ai"}},
+        )
+        assert create.status_code == 201, create.text
+        search_id = create.json()["id"]
+
+        r = client.patch(
+            f"/api/v1/reading/saved-searches/{search_id}",
+            json={"name": "   "},
+        )
+        assert r.status_code == 422, r.text
+
+
 def test_saved_search_endpoints_disabled_by_feature_flag(reading_app, monkeypatch):
     monkeypatch.setenv("COLLECTIONS_READING_SAVED_SEARCHES_ENABLED", "0")
 

--- a/tldw_Server_API/tests/Collections/test_reading_api.py
+++ b/tldw_Server_API/tests/Collections/test_reading_api.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+from tldw_Server_API.app.core import config as core_config
 from tldw_Server_API.app.core.config import settings
 
 
@@ -18,7 +19,11 @@ pytestmark = pytest.mark.unit
 def reading_app(monkeypatch):
     monkeypatch.setenv("MINIMAL_TEST_APP", "0")
     monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+    monkeypatch.setenv("MINIMAL_TEST_INCLUDE_READING", "1")
     monkeypatch.setenv("ROUTES_ENABLE", "reading")
+    monkeypatch.setenv("TLDW_TEST_MODE", "1")
+    monkeypatch.setenv("TEST_MODE", "1")
+    core_config.refresh_config_cache()
 
     base_dir = Path.cwd() / "Databases" / "test_reading_api"
     shutil.rmtree(base_dir, ignore_errors=True)
@@ -87,6 +92,286 @@ def test_reading_save_get_search_delete(reading_app):
 
         r = client.get(f"/api/v1/reading/items/{item_id}")
         assert r.status_code == 404
+
+
+def test_reading_save_returns_archive_requested_field(reading_app):
+    async def override_user():
+        return User(id=901, username="archive", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        payload = {
+            "url": "https://example.org/archive",
+            "title": "Archive Item",
+            "content": "Archive body",
+            "archive_mode": "always",
+        }
+        r = client.post("/api/v1/reading/save", json=payload)
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert "archive_requested" in body
+        assert "has_archive_copy" in body
+        assert "last_fetch_error" in body
+        assert body["archive_requested"] is True
+        assert body["has_archive_copy"] is True
+
+
+def test_reading_save_rejects_invalid_archive_mode(reading_app):
+    async def override_user():
+        return User(id=902, username="archive-invalid", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        payload = {
+            "url": "https://example.org/archive-invalid",
+            "title": "Archive Invalid",
+            "content": "Archive body",
+            "archive_mode": "bogus",
+        }
+        r = client.post("/api/v1/reading/save", json=payload)
+        assert r.status_code == 422, r.text
+
+
+def test_saved_search_endpoints_crud(reading_app):
+    async def override_user():
+        return User(id=903, username="saved-search", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        create_payload = {
+            "name": "Morning",
+            "query": {"q": "ai"},
+            "sort": "updated_desc",
+        }
+        r = client.post("/api/v1/reading/saved-searches", json=create_payload)
+        assert r.status_code == 201, r.text
+        created = r.json()
+        search_id = created["id"]
+        assert created["name"] == "Morning"
+        assert created["query"] == {"q": "ai"}
+
+        r = client.get("/api/v1/reading/saved-searches", params={"limit": 10, "offset": 0})
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["total"] == 1
+        assert body["items"][0]["id"] == search_id
+
+        r = client.patch(
+            f"/api/v1/reading/saved-searches/{search_id}",
+            json={"query": {"q": "ml"}},
+        )
+        assert r.status_code == 200, r.text
+        updated = r.json()
+        assert updated["query"] == {"q": "ml"}
+
+        r = client.delete(f"/api/v1/reading/saved-searches/{search_id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"] is True
+
+        r = client.get("/api/v1/reading/saved-searches", params={"limit": 10, "offset": 0})
+        assert r.status_code == 200, r.text
+        assert r.json()["total"] == 0
+
+
+def test_saved_search_endpoints_disabled_by_feature_flag(reading_app, monkeypatch):
+    monkeypatch.setenv("COLLECTIONS_READING_SAVED_SEARCHES_ENABLED", "0")
+
+    async def override_user():
+        return User(id=906, username="saved-search-flag-off", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        r = client.post(
+            "/api/v1/reading/saved-searches",
+            json={"name": "Disabled", "query": {"q": "ai"}},
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "reading_saved_searches_disabled"
+
+        r = client.get("/api/v1/reading/saved-searches", params={"limit": 10, "offset": 0})
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "reading_saved_searches_disabled"
+
+
+def test_note_link_endpoints_cover_post_get_delete(reading_app):
+    async def override_user():
+        return User(id=904, username="note-links", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        save_payload = {
+            "url": "https://example.org/linkable",
+            "title": "Linkable Item",
+            "content": "Reading content",
+        }
+        r = client.post("/api/v1/reading/save", json=save_payload)
+        assert r.status_code == 200, r.text
+        item_id = r.json()["id"]
+
+        note_payload = {
+            "title": "Linked Note",
+            "content": "Note body",
+        }
+        r = client.post("/api/v1/notes/", json=note_payload)
+        assert r.status_code == 201, r.text
+        note_id = r.json()["id"]
+
+        r = client.post(
+            f"/api/v1/reading/items/{item_id}/links/note",
+            json={"note_id": note_id},
+        )
+        assert r.status_code == 200, r.text
+        linked = r.json()
+        assert linked["item_id"] == item_id
+        assert linked["note_id"] == note_id
+
+        r = client.get(f"/api/v1/reading/items/{item_id}/links")
+        assert r.status_code == 200, r.text
+        links = r.json()["links"]
+        assert any(link["note_id"] == note_id for link in links)
+
+        r = client.delete(f"/api/v1/reading/items/{item_id}/links/note/{note_id}")
+        assert r.status_code == 200, r.text
+        assert r.json()["ok"] is True
+
+        r = client.get(f"/api/v1/reading/items/{item_id}/links")
+        assert r.status_code == 200, r.text
+        assert r.json()["links"] == []
+
+
+def test_note_link_endpoints_disabled_by_feature_flag(reading_app, monkeypatch):
+    monkeypatch.setenv("COLLECTIONS_READING_NOTE_LINKS_ENABLED", "0")
+
+    async def override_user():
+        return User(id=907, username="note-links-flag-off", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        save_payload = {
+            "url": "https://example.org/linkable-flag-off",
+            "title": "Linkable Flag Off",
+            "content": "Reading content",
+        }
+        r = client.post("/api/v1/reading/save", json=save_payload)
+        assert r.status_code == 200, r.text
+        item_id = r.json()["id"]
+
+        note_payload = {
+            "title": "Linked Note Flag Off",
+            "content": "Note body",
+        }
+        r = client.post("/api/v1/notes/", json=note_payload)
+        assert r.status_code == 201, r.text
+        note_id = r.json()["id"]
+
+        r = client.post(
+            f"/api/v1/reading/items/{item_id}/links/note",
+            json={"note_id": note_id},
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "reading_note_links_disabled"
+
+        r = client.get(f"/api/v1/reading/items/{item_id}/links")
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "reading_note_links_disabled"
+
+
+def test_note_link_rejects_missing_note(reading_app):
+    async def override_user():
+        return User(id=905, username="note-links-missing", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        save_payload = {
+            "url": "https://example.org/linkable-missing",
+            "title": "Linkable Missing",
+            "content": "Reading content",
+        }
+        r = client.post("/api/v1/reading/save", json=save_payload)
+        assert r.status_code == 200, r.text
+        item_id = r.json()["id"]
+
+        r = client.post(
+            f"/api/v1/reading/items/{item_id}/links/note",
+            json={"note_id": "missing-note-id"},
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "note_not_found"
+
+
+def test_note_link_rejects_foreign_note(reading_app):
+    async def user_a():
+        return User(id=908, username="note-owner-a", email=None, is_active=True)
+
+    async def user_b():
+        return User(id=909, username="note-owner-b", email=None, is_active=True)
+
+    with TestClient(reading_app) as client:
+        reading_app.dependency_overrides[get_request_user] = user_a
+        r = client.post(
+            "/api/v1/notes/",
+            json={"title": "User A Note", "content": "A body"},
+        )
+        assert r.status_code == 201, r.text
+        note_id = r.json()["id"]
+
+        reading_app.dependency_overrides[get_request_user] = user_b
+        r = client.post(
+            "/api/v1/reading/save",
+            json={
+                "url": "https://example.org/foreign-note",
+                "title": "Foreign Note Item",
+                "content": "Item body",
+            },
+        )
+        assert r.status_code == 200, r.text
+        item_id = r.json()["id"]
+
+        r = client.post(
+            f"/api/v1/reading/items/{item_id}/links/note",
+            json={"note_id": note_id},
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "note_not_found"
+
+
+def test_archive_mode_override_disabled_by_feature_flag(reading_app, monkeypatch):
+    monkeypatch.setenv("COLLECTIONS_READING_ARCHIVE_CONTROLS_ENABLED", "0")
+
+    async def override_user():
+        return User(id=910, username="archive-flag-off", email=None, is_active=True)
+
+    reading_app.dependency_overrides[get_request_user] = override_user
+
+    with TestClient(reading_app) as client:
+        r = client.post(
+            "/api/v1/reading/save",
+            json={
+                "url": "https://example.org/archive-default-ok",
+                "title": "Archive Default Ok",
+                "content": "Archive body",
+            },
+        )
+        assert r.status_code == 200, r.text
+
+        r = client.post(
+            "/api/v1/reading/save",
+            json={
+                "url": "https://example.org/archive-override-blocked",
+                "title": "Archive Override Blocked",
+                "content": "Archive body",
+                "archive_mode": "always",
+            },
+        )
+        assert r.status_code == 404, r.text
+        assert r.json()["detail"] == "reading_archive_controls_disabled"
 
 
 def test_reading_user_isolation(reading_app):

--- a/tldw_Server_API/tests/Collections/test_reading_note_links_db.py
+++ b/tldw_Server_API/tests/Collections/test_reading_note_links_db.py
@@ -1,0 +1,79 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def collections_db(monkeypatch: pytest.MonkeyPatch) -> CollectionsDatabase:
+    base_dir = Path.cwd() / "Databases" / "test_user_dbs_reading_note_links"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+
+    try:
+        yield CollectionsDatabase.for_user(user_id=780)
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def _create_reading_item(collections_db: CollectionsDatabase) -> int:
+    row = collections_db.upsert_content_item(
+        origin="reading",
+        origin_type="manual",
+        origin_id=None,
+        url="https://example.org/item",
+        canonical_url="https://example.org/item",
+        domain="example.org",
+        title="Item",
+        summary="Summary",
+        notes="Item notes",
+        content_hash="hash-1",
+        word_count=10,
+        published_at=None,
+        status="saved",
+        favorite=False,
+        metadata={"source": "test"},
+        media_id=None,
+        job_id=None,
+        run_id=None,
+        source_id=None,
+        read_at=None,
+        tags=["alpha"],
+    )
+    return row.id
+
+
+def test_note_link_crud_roundtrip(collections_db: CollectionsDatabase) -> None:
+    item_id = _create_reading_item(collections_db)
+
+    linked = collections_db.link_note_to_content_item(item_id=item_id, note_id="note-1234")
+    assert linked.item_id == item_id
+    assert linked.note_id == "note-1234"
+
+    rows = collections_db.list_note_links_for_content_item(item_id)
+    assert len(rows) == 1
+    assert rows[0].note_id == "note-1234"
+
+    removed = collections_db.unlink_note_from_content_item(item_id=item_id, note_id="note-1234")
+    assert removed is True
+    assert collections_db.list_note_links_for_content_item(item_id) == []
+
+
+def test_note_link_requires_existing_item(collections_db: CollectionsDatabase) -> None:
+    with pytest.raises(KeyError):
+        collections_db.link_note_to_content_item(item_id=9999, note_id="note-1")

--- a/tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py
+++ b/tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py
@@ -1,0 +1,60 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.config import settings
+from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
+
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def collections_db(monkeypatch: pytest.MonkeyPatch) -> CollectionsDatabase:
+    base_dir = Path.cwd() / "Databases" / "test_user_dbs_reading_saved_searches"
+    shutil.rmtree(base_dir, ignore_errors=True)
+    base_dir.mkdir(parents=True, exist_ok=True)
+    prev_base_dir = settings.get("USER_DB_BASE_DIR")
+    settings.USER_DB_BASE_DIR = str(base_dir)
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(base_dir))
+
+    try:
+        yield CollectionsDatabase.for_user(user_id=779)
+    finally:
+        if prev_base_dir is not None:
+            settings.USER_DB_BASE_DIR = prev_base_dir
+        else:
+            try:
+                del settings.USER_DB_BASE_DIR
+            except AttributeError:
+                pass
+
+
+def test_saved_search_crud_roundtrip(collections_db: CollectionsDatabase) -> None:
+    created = collections_db.create_saved_search(
+        name="Morning",
+        query_json='{"q":"ai"}',
+        sort="updated_desc",
+    )
+    assert created.id > 0
+    assert created.name == "Morning"
+    assert created.query_json == '{"q":"ai"}'
+    assert created.sort == "updated_desc"
+
+    rows, total = collections_db.list_saved_searches(limit=10, offset=0)
+    assert total == 1
+    assert rows[0].id == created.id
+
+    updated = collections_db.update_saved_search(
+        created.id,
+        {"query_json": '{"q":"ml"}', "sort": "created_desc"},
+    )
+    assert updated.query_json == '{"q":"ml"}'
+    assert updated.sort == "created_desc"
+
+    deleted = collections_db.delete_saved_search(created.id)
+    assert deleted is True
+    rows_after, total_after = collections_db.list_saved_searches(limit=10, offset=0)
+    assert total_after == 0
+    assert rows_after == []

--- a/tldw_Server_API/tests/Collections/test_reading_service.py
+++ b/tldw_Server_API/tests/Collections/test_reading_service.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import pytest
 import shutil
@@ -6,6 +7,7 @@ from urllib.parse import urlencode
 
 from hypothesis import given, settings as hyp_settings, strategies as st
 
+import tldw_Server_API.app.core.Collections.reading_service as reading_service_module
 from tldw_Server_API.app.core.Collections.reading_importers import ReadingImportItem
 from tldw_Server_API.app.core.Collections.reading_service import ReadingService, _contains_html_tag
 from tldw_Server_API.app.core.DB_Management.Collections_DB import CollectionsDatabase
@@ -381,6 +383,63 @@ async def test_archive_mode_never_overrides_enabled_default(reading_env, monkeyp
     )
     assert total == 0
     assert rows == []
+
+
+def test_archive_env_values_fallback_on_invalid(monkeypatch):
+    monkeypatch.setenv("READING_ARCHIVE_MAX_BYTES", "not-a-number")
+    monkeypatch.setenv("READING_ARCHIVE_RETENTION_DAYS", "oops")
+    reloaded = importlib.reload(reading_service_module)
+    try:
+        assert reloaded.READING_ARCHIVE_MAX_BYTES == 5 * 1024 * 1024
+        assert reloaded.READING_ARCHIVE_RETENTION_DAYS == 30
+    finally:
+        monkeypatch.setenv("READING_ARCHIVE_MAX_BYTES", str(5 * 1024 * 1024))
+        monkeypatch.setenv("READING_ARCHIVE_RETENTION_DAYS", "30")
+        importlib.reload(reading_service_module)
+
+
+@pytest.mark.asyncio
+async def test_archive_creation_uses_asyncio_to_thread_for_fs_io(reading_env, monkeypatch):
+    service = ReadingService(TEST_USER_ID + 12)
+    calls: list[str] = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(reading_service_module.asyncio, "to_thread", fake_to_thread)
+
+    result = await service.save_url(
+        url="https://example.org/archive-threaded",
+        title_override="Archive Threaded",
+        content_override="Archive body text",
+        archive_mode="always",
+    )
+
+    assert result.archive_output_id is not None
+    assert any("mkdir" in call for call in calls)
+    assert any("write_text" in call for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_archive_metadata_update_failure_is_reported(reading_env, monkeypatch):
+    service = ReadingService(TEST_USER_ID + 13)
+
+    def fail_update_content_item(*_args, **_kwargs):
+        raise RuntimeError("metadata-db-down")
+
+    monkeypatch.setattr(service.collections, "update_content_item", fail_update_content_item)
+
+    result = await service.save_url(
+        url="https://example.org/archive-metadata-fail",
+        title_override="Archive Metadata Failure",
+        content_override="Archive body text",
+        archive_mode="always",
+    )
+
+    assert result.archive_requested is True
+    assert result.archive_error is not None
+    assert "archive_metadata_update_failed" in result.archive_error
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Collections/test_reading_service.py
+++ b/tldw_Server_API/tests/Collections/test_reading_service.py
@@ -331,6 +331,59 @@ async def test_reading_save_records_fetch_error(reading_env, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_archive_mode_always_creates_archive_artifact(reading_env, monkeypatch):
+    monkeypatch.setenv("READING_ARCHIVE_ON_SAVE_DEFAULT", "0")
+    service = ReadingService(TEST_USER_ID + 8)
+
+    result = await service.save_url(
+        url="https://example.org/archive-always",
+        title_override="Archive Always",
+        content_override="Archive body text",
+        archive_mode="always",
+    )
+
+    assert result.archive_requested is True
+    assert result.archive_output_id is not None
+    metadata = json.loads(result.item.metadata_json or "{}")
+    assert metadata.get("archive_requested") is True
+    assert metadata.get("has_archive_copy") is True
+
+    rows, total = service.collections.list_output_artifacts(
+        type_="reading_archive",
+        limit=10,
+        offset=0,
+    )
+    assert total >= 1
+    assert any(row.id == result.archive_output_id for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_archive_mode_never_overrides_enabled_default(reading_env, monkeypatch):
+    monkeypatch.setenv("READING_ARCHIVE_ON_SAVE_DEFAULT", "1")
+    service = ReadingService(TEST_USER_ID + 9)
+
+    result = await service.save_url(
+        url="https://example.org/archive-never",
+        title_override="Archive Never",
+        content_override="Archive body text",
+        archive_mode="never",
+    )
+
+    assert result.archive_requested is False
+    assert result.archive_output_id is None
+    metadata = json.loads(result.item.metadata_json or "{}")
+    assert metadata.get("archive_requested") is False
+
+    rows, total = service.collections.list_output_artifacts(
+        type_="reading_archive",
+        limit=10,
+        offset=0,
+    )
+    assert total == 0
+    assert rows == []
+
+
+@pytest.mark.asyncio
 async def test_reading_save_sanitizes_html_content(reading_env, monkeypatch):
     monkeypatch.setenv("TEST_MODE", "0")
 


### PR DESCRIPTION
## Summary
- implement Pinboard-inspired utility upgrades for collections without crossing strict notes-module boundaries
- add reading saved-search CRUD surfaces (backend + frontend + tests)
- add reading item-to-note link endpoints/UI with strict same-user note existence checks
- add archive-mode controls and reading metadata enhancements
- guard new surfaces behind feature flags and wire endpoint checks

## Validation
- `python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py tldw_Server_API/tests/Collections/test_reading_service.py tldw_Server_API/tests/Collections/test_reading_saved_searches_db.py tldw_Server_API/tests/Collections/test_reading_note_links_db.py -v`
- `python -m pytest tldw_Server_API/tests/Collections/test_reading_api.py -k "saved_searches or note_link or archive_requested" -v`
- `bunx vitest run apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/saved-searches-menu.test.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-item-detail-note-links.test.tsx apps/packages/ui/src/components/Option/Collections/ReadingList/__tests__/reading-list-page.archive-mode.test.tsx apps/packages/ui/src/services/tldw/__tests__/reading-saved-searches.test.ts`
- `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/collections.py tldw_Server_API/app/core/Collections tldw_Server_API/tests/Collections -f json -o /tmp/bandit_collections_pinboard.json` (0 findings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product requirements to define two new Reading features: reusable saved searches that persist list filters and sorting preferences.
  * Added specifications for reading item-to-note linking while maintaining Notes as the primary note management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->