### PR TITLE
feat(mcp): add MCP Hub management APIs and webui routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Some kind of Versioning
 
+## [0.1.28] 2026-03-04
+
+### Added
+
+- MCP Hub management end-to-end surfaces across AuthNZ storage, API, and WebUI/extension:
+  - Added AuthNZ migrations for MCP Hub ACP profile and external server tables in SQLite and PostgreSQL bootstrap paths.
+  - Added `McpHubRepo` and `McpHubService` for ACP profile CRUD and external server lifecycle handling, including encrypted secret storage and masked secret status responses.
+  - Added MCP Hub management API contracts and routes under `/api/v1/mcp/hub` for ACP profiles, external servers, and secret set operations.
+  - Added WebUI + extension MCP Hub page wiring and tabs (`AcpProfilesTab`, `ExternalServersTab`, `ToolCatalogsTab`) with shared route-registry coverage (`/mcp-hub`, `/settings/mcp-hub`).
+  - Added frontend MCP Hub API client module/tests and route parity tests for web/extension settings exposure.
+  - Added docs for architecture and usage:
+    - `Docs/MCP/mcp_hub_management.md`
+    - `Docs/MCP/README.md`
+- Added backend and frontend regression coverage for MCP Hub migrations, repo/service behavior, API authorization boundaries, and tab interactions/error states.
+
+### Changed
+
+- Refined MCP Hub external server update flow to use a dedicated repository-level `update_external_server` path (direct `UPDATE` pattern) for consistency with ACP profile updates and clearer audit semantics.
+- Extended settings/navigation indexing so MCP Hub management is discoverable in both settings and workspace-oriented routes.
+
+### Removed
+
+- No removals in this session.
+
+### Fixed
+
+- Fixed MCP Hub list endpoint access-control gaps by constraining ACP profile and external server visibility to principal-allowed scopes (`global`, own `user`, member `org/team`) and returning `403` for forbidden explicit filters.
+- Fixed PostgreSQL timestamp persistence in MCP Hub repo by preserving timezone-aware UTC datetimes for `TIMESTAMPTZ` writes.
+- Fixed silent UI failures in MCP Hub tabs by surfacing user-visible Ant Design error alerts for load/create/save-secret failures.
+- Fixed MCP Hub security hardening follow-ups flagged during review and revalidated with targeted tests and Bandit checks for touched backend paths.
+
 ## [0.1.27] 2026-03-02
 
 ### Added

--- a/Docs/MCP/README.md
+++ b/Docs/MCP/README.md
@@ -11,6 +11,8 @@ This directory contains the Model Context Protocol (MCP) documentation for the T
   - `User_Guide.md` - HTTP/WebSocket usage patterns and examples
   - `Modules.md` - Authoring reference for pluggable MCP modules
   - `Documentation_Ingestion_Playbook.md` - How to ingest project docs and query them via MCP tools
+- `mcp_hub_management.md` - MCP Hub UI and API management surface (ACP profiles + external servers)
+- `mcp_tool_catalogs.md` - Tool catalog governance and scope-aware APIs
 
 ## Picking the Right Guide
 

--- a/Docs/MCP/mcp_hub_management.md
+++ b/Docs/MCP/mcp_hub_management.md
@@ -1,0 +1,56 @@
+# MCP Hub Management
+
+MCP Hub is the shared management surface used by the WebUI and browser extension for MCP-related configuration.
+
+## UI Routes
+
+- `/mcp-hub`
+- `/settings/mcp-hub`
+
+Both routes render the same MCP Hub page and tabs.
+
+## Scope
+
+MCP Hub currently covers:
+
+- ACP profile management
+- External MCP server registry management
+- Secret write/update for external servers (write-only reads)
+- Tool catalog management via existing catalog endpoints (see `Docs/MCP/mcp_tool_catalogs.md`)
+
+## Auth and Permissions
+
+- All MCP Hub endpoints require an authenticated principal.
+- Read/list endpoints are available to authenticated users.
+- Mutation endpoints require admin role, `system.configure`, or wildcard `*` permission.
+
+## API Endpoints
+
+### ACP Profiles
+
+- `GET /api/v1/mcp/hub/acp-profiles` - list profiles
+- `POST /api/v1/mcp/hub/acp-profiles` - create profile
+- `PUT /api/v1/mcp/hub/acp-profiles/{profile_id}` - update profile
+- `DELETE /api/v1/mcp/hub/acp-profiles/{profile_id}` - delete profile
+
+### External Servers
+
+- `GET /api/v1/mcp/hub/external-servers` - list external servers
+- `POST /api/v1/mcp/hub/external-servers` - create server
+- `PUT /api/v1/mcp/hub/external-servers/{server_id}` - update server
+- `DELETE /api/v1/mcp/hub/external-servers/{server_id}` - delete server
+- `POST /api/v1/mcp/hub/external-servers/{server_id}/secret` - set or rotate secret
+
+## Secret Handling
+
+- Secrets are encrypted before persistence.
+- Secret plaintext is not returned by read/list endpoints.
+- API responses expose only metadata (`secret_configured`, optional `key_hint`, timestamps).
+
+## Audit Events
+
+MCP Hub mutation flows emit audit events, including:
+
+- `mcp_hub.acp_profile.create|update|delete`
+- `mcp_hub.external_server.create|update|delete`
+- `mcp_hub.external_secret.update`

--- a/README.md
+++ b/README.md
@@ -742,6 +742,7 @@ curl -s -X POST http://127.0.0.1:8000/api/v1/audio/transcriptions \
 - Metrics: `GET /api/v1/metrics/text` - Prometheus metrics (text format) ([docs](Docs/Deployment/Monitoring/Metrics_Cheatsheet.md))
 - Providers: `GET /api/v1/llm/providers` - provider/models list ([docs](Docs/API-related/Providers_API_Documentation.md))
 - MCP: `GET /api/v1/mcp/status` - MCP server status ([docs](Docs/MCP/Unified/System_Admin_Guide.md))
+- MCP Hub Management: `GET /api/v1/mcp/hub/acp-profiles`, `GET /api/v1/mcp/hub/external-servers`, plus mutation endpoints for authorized principals ([docs](Docs/MCP/mcp_hub_management.md))
 
 Admin maintenance
 - Chat model aliases cache reload: `POST /api/v1/admin/chat/model-aliases/reload`

--- a/apps/packages/ui/src/assets/locale/en/settings.json
+++ b/apps/packages/ui/src/assets/locale/en/settings.json
@@ -22,6 +22,7 @@
   "researchStudioNav": "Research Studio",
   "modelPlaygroundNav": "Model Playground",
   "acpPlaygroundNav": "ACP Playground",
+  "mcpHubNav": "MCP Hub",
   "skillsNav": "Skills",
   "splashSettingsNav": "Splash screens",
   "familyGuardrailsWizardNav": "Family Guardrails Wizard",

--- a/apps/packages/ui/src/components/Option/MCPHub/AcpProfilesTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/AcpProfilesTab.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useMemo, useState } from "react"
+import { Button, Card, Empty, List, Space, Tag, Typography } from "antd"
+
+import { createAcpProfile, listAcpProfiles, type McpHubProfile } from "@/services/tldw/mcp-hub"
+
+export const AcpProfilesTab = () => {
+  const [profiles, setProfiles] = useState<McpHubProfile[]>([])
+  const [loading, setLoading] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [name, setName] = useState("")
+  const [saving, setSaving] = useState(false)
+  const canSave = useMemo(() => name.trim().length > 0 && !saving, [name, saving])
+
+  const loadProfiles = async () => {
+    setLoading(true)
+    try {
+      const rows = await listAcpProfiles()
+      setProfiles(Array.isArray(rows) ? rows : [])
+    } catch {
+      setProfiles([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadProfiles()
+  }, [])
+
+  const handleCreate = async () => {
+    if (!canSave) return
+    setSaving(true)
+    try {
+      await createAcpProfile({
+        name: name.trim(),
+        owner_scope_type: "global",
+        profile: {}
+      })
+      setCreateOpen(false)
+      setName("")
+      await loadProfiles()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Typography.Text type="secondary">
+        ACP profiles define reusable MCP execution defaults.
+      </Typography.Text>
+
+      <Space>
+        <Button type="primary" onClick={() => setCreateOpen(true)}>
+          Create Profile
+        </Button>
+      </Space>
+
+      {createOpen ? (
+        <Card title="Create ACP Profile">
+          <Space direction="vertical" style={{ width: "100%" }}>
+            <label htmlFor="mcp-profile-name">Profile Name</label>
+            <input
+              id="mcp-profile-name"
+              aria-label="Profile Name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="default-dev"
+            />
+            <Space>
+              <Button type="primary" onClick={handleCreate} disabled={!canSave} loading={saving}>
+                Save Profile
+              </Button>
+              <Button
+                onClick={() => {
+                  setCreateOpen(false)
+                  setName("")
+                }}
+              >
+                Cancel
+              </Button>
+            </Space>
+          </Space>
+        </Card>
+      ) : null}
+
+      <List
+        bordered
+        loading={loading}
+        dataSource={profiles}
+        locale={{ emptyText: <Empty description="No ACP profiles yet" /> }}
+        renderItem={(profile) => (
+          <List.Item>
+            <Space direction="vertical" size={2}>
+              <Typography.Text strong>{profile.name}</Typography.Text>
+              <Space size={6}>
+                <Tag>{profile.owner_scope_type}</Tag>
+                {profile.is_active ? <Tag color="green">active</Tag> : <Tag>inactive</Tag>}
+              </Space>
+            </Space>
+          </List.Item>
+        )}
+      />
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/AcpProfilesTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/AcpProfilesTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { Button, Card, Empty, List, Space, Tag, Typography } from "antd"
+import { Alert, Button, Card, Empty, List, Space, Tag, Typography } from "antd"
 
 import { createAcpProfile, listAcpProfiles, type McpHubProfile } from "@/services/tldw/mcp-hub"
 
@@ -9,15 +9,18 @@ export const AcpProfilesTab = () => {
   const [createOpen, setCreateOpen] = useState(false)
   const [name, setName] = useState("")
   const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const canSave = useMemo(() => name.trim().length > 0 && !saving, [name, saving])
 
   const loadProfiles = async () => {
     setLoading(true)
+    setErrorMessage(null)
     try {
       const rows = await listAcpProfiles()
       setProfiles(Array.isArray(rows) ? rows : [])
     } catch {
       setProfiles([])
+      setErrorMessage("Failed to load ACP profiles.")
     } finally {
       setLoading(false)
     }
@@ -30,6 +33,7 @@ export const AcpProfilesTab = () => {
   const handleCreate = async () => {
     if (!canSave) return
     setSaving(true)
+    setErrorMessage(null)
     try {
       await createAcpProfile({
         name: name.trim(),
@@ -39,6 +43,8 @@ export const AcpProfilesTab = () => {
       setCreateOpen(false)
       setName("")
       await loadProfiles()
+    } catch {
+      setErrorMessage("Failed to create ACP profile.")
     } finally {
       setSaving(false)
     }
@@ -49,6 +55,7 @@ export const AcpProfilesTab = () => {
       <Typography.Text type="secondary">
         ACP profiles define reusable MCP execution defaults.
       </Typography.Text>
+      {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
       <Space>
         <Button type="primary" onClick={() => setCreateOpen(true)}>

--- a/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx
@@ -14,6 +14,7 @@ export const ExternalServersTab = () => {
   const [secretValue, setSecretValue] = useState("")
   const [saving, setSaving] = useState(false)
   const [configured, setConfigured] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const canSave = useMemo(
     () => activeServerId.trim().length > 0 && secretValue.trim().length > 0 && !saving,
@@ -24,6 +25,7 @@ export const ExternalServersTab = () => {
     let cancelled = false
     const load = async () => {
       setLoading(true)
+      setErrorMessage(null)
       try {
         const rows = await listExternalServers()
         if (!cancelled) {
@@ -33,7 +35,10 @@ export const ExternalServersTab = () => {
           }
         }
       } catch {
-        if (!cancelled) setServers([])
+        if (!cancelled) {
+          setServers([])
+          setErrorMessage("Failed to load external servers.")
+        }
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -47,10 +52,13 @@ export const ExternalServersTab = () => {
   const handleSaveSecret = async () => {
     if (!canSave) return
     setSaving(true)
+    setErrorMessage(null)
     try {
       await setExternalServerSecret(activeServerId, secretValue)
       setSecretValue("")
       setConfigured(true)
+    } catch {
+      setErrorMessage("Failed to save external server secret.")
     } finally {
       setSaving(false)
     }
@@ -61,6 +69,7 @@ export const ExternalServersTab = () => {
       <Typography.Text type="secondary">
         External MCP servers are configured here. Secrets are write-only after save.
       </Typography.Text>
+      {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
       {servers.length > 0 ? (
         <Space>
@@ -95,7 +104,7 @@ export const ExternalServersTab = () => {
         </Button>
       </Space>
 
-      {configured ? <Alert type="success" message="Secret configured" showIcon /> : null}
+      {configured ? <Alert type="success" title="Secret configured" showIcon /> : null}
 
       <List
         bordered

--- a/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ExternalServersTab.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from "react"
+import { Alert, Button, Empty, List, Space, Tag, Typography } from "antd"
+
+import {
+  listExternalServers,
+  setExternalServerSecret,
+  type McpHubExternalServer
+} from "@/services/tldw/mcp-hub"
+
+export const ExternalServersTab = () => {
+  const [servers, setServers] = useState<McpHubExternalServer[]>([])
+  const [loading, setLoading] = useState(false)
+  const [activeServerId, setActiveServerId] = useState<string>("")
+  const [secretValue, setSecretValue] = useState("")
+  const [saving, setSaving] = useState(false)
+  const [configured, setConfigured] = useState(false)
+
+  const canSave = useMemo(
+    () => activeServerId.trim().length > 0 && secretValue.trim().length > 0 && !saving,
+    [activeServerId, secretValue, saving]
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      try {
+        const rows = await listExternalServers()
+        if (!cancelled) {
+          setServers(rows)
+          if (!activeServerId && rows.length > 0) {
+            setActiveServerId(rows[0].id)
+          }
+        }
+      } catch {
+        if (!cancelled) setServers([])
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleSaveSecret = async () => {
+    if (!canSave) return
+    setSaving(true)
+    try {
+      await setExternalServerSecret(activeServerId, secretValue)
+      setSecretValue("")
+      setConfigured(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Typography.Text type="secondary">
+        External MCP servers are configured here. Secrets are write-only after save.
+      </Typography.Text>
+
+      {servers.length > 0 ? (
+        <Space>
+          <label htmlFor="mcp-external-server">Server</label>
+          <select
+            id="mcp-external-server"
+            aria-label="Server"
+            value={activeServerId}
+            onChange={(event) => setActiveServerId(event.target.value)}
+          >
+            {servers.map((server) => (
+              <option key={server.id} value={server.id}>
+                {server.name}
+              </option>
+            ))}
+          </select>
+        </Space>
+      ) : null}
+
+      <Space direction="vertical" style={{ width: "100%" }}>
+        <label htmlFor="mcp-external-secret">Secret</label>
+        <input
+          id="mcp-external-secret"
+          aria-label="Secret"
+          type="password"
+          value={secretValue}
+          onChange={(event) => setSecretValue(event.target.value)}
+          placeholder="Paste secret token"
+        />
+        <Button type="primary" onClick={handleSaveSecret} disabled={!canSave} loading={saving}>
+          Save Secret
+        </Button>
+      </Space>
+
+      {configured ? <Alert type="success" message="Secret configured" showIcon /> : null}
+
+      <List
+        bordered
+        loading={loading}
+        dataSource={servers}
+        locale={{ emptyText: <Empty description="No external servers configured" /> }}
+        renderItem={(server) => (
+          <List.Item>
+            <Space>
+              <Typography.Text strong>{server.name}</Typography.Text>
+              {server.secret_configured ? <Tag color="green">secret configured</Tag> : <Tag>no secret</Tag>}
+            </Space>
+          </List.Item>
+        )}
+      />
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react"
+import { Tabs, Typography } from "antd"
+
+import { AcpProfilesTab } from "./AcpProfilesTab"
+import { ToolCatalogsTab } from "./ToolCatalogsTab"
+import { ExternalServersTab } from "./ExternalServersTab"
+
+export const McpHubPage = () => {
+  const [activeTab, setActiveTab] = useState("acp-profiles")
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 p-4">
+      <Typography.Title level={3} style={{ margin: 0 }}>
+        MCP Hub
+      </Typography.Title>
+      <Tabs
+        activeKey={activeTab}
+        onChange={setActiveTab}
+        items={[
+          {
+            key: "acp-profiles",
+            label: "ACP Profiles",
+            children: <AcpProfilesTab />
+          },
+          {
+            key: "tool-catalogs",
+            label: "Tool Catalogs",
+            children: <ToolCatalogsTab />
+          },
+          {
+            key: "external-servers",
+            label: "External Servers",
+            children: <ExternalServersTab />
+          }
+        ]}
+      />
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Card, Empty, List, Space, Typography } from "antd"
+import { Alert, Card, Empty, List, Space, Typography } from "antd"
 
 import {
   fetchMcpToolCatalogs,
@@ -19,11 +19,13 @@ export const ToolCatalogsTab = () => {
   const [scope, setScope] = useState<CatalogScope>("global")
   const [catalogs, setCatalogs] = useState<McpToolCatalog[]>([])
   const [loading, setLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
     const load = async () => {
       setLoading(true)
+      setErrorMessage(null)
       try {
         const discovered = await fetchMcpToolCatalogsViaDiscovery(scope)
         if (!cancelled && discovered.length > 0) {
@@ -37,6 +39,7 @@ export const ToolCatalogsTab = () => {
       } catch {
         if (!cancelled) {
           setCatalogs([])
+          setErrorMessage("Failed to load tool catalogs.")
         }
       } finally {
         if (!cancelled) {
@@ -55,6 +58,7 @@ export const ToolCatalogsTab = () => {
       <Typography.Text type="secondary">
         Tool catalogs control which MCP tools are exposed by scope.
       </Typography.Text>
+      {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
       <Space>
         <label htmlFor="mcp-catalog-scope">Scope</label>

--- a/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react"
+import { Card, Empty, List, Space, Typography } from "antd"
+
+import {
+  fetchMcpToolCatalogs,
+  fetchMcpToolCatalogsViaDiscovery,
+  type McpToolCatalog
+} from "@/services/tldw/mcp"
+
+type CatalogScope = "global" | "org" | "team"
+
+const SCOPE_LABELS: Record<CatalogScope, string> = {
+  global: "Global",
+  org: "Org",
+  team: "Team"
+}
+
+export const ToolCatalogsTab = () => {
+  const [scope, setScope] = useState<CatalogScope>("global")
+  const [catalogs, setCatalogs] = useState<McpToolCatalog[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      setLoading(true)
+      try {
+        const discovered = await fetchMcpToolCatalogsViaDiscovery(scope)
+        if (!cancelled && discovered.length > 0) {
+          setCatalogs(discovered)
+          return
+        }
+        const fallback = await fetchMcpToolCatalogs()
+        if (!cancelled) {
+          setCatalogs(fallback)
+        }
+      } catch {
+        if (!cancelled) {
+          setCatalogs([])
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [scope])
+
+  return (
+    <Space direction="vertical" size="middle" style={{ width: "100%" }}>
+      <Typography.Text type="secondary">
+        Tool catalogs control which MCP tools are exposed by scope.
+      </Typography.Text>
+
+      <Space>
+        <label htmlFor="mcp-catalog-scope">Scope</label>
+        <select
+          id="mcp-catalog-scope"
+          aria-label="Scope"
+          value={scope}
+          onChange={(event) => setScope(event.target.value as CatalogScope)}
+        >
+          <option value="global">Global</option>
+          <option value="org">Org</option>
+          <option value="team">Team</option>
+        </select>
+      </Space>
+
+      <Card title={`${SCOPE_LABELS[scope]} Catalogs`}>
+        <List
+          loading={loading}
+          dataSource={catalogs}
+          locale={{ emptyText: <Empty description="No catalogs available" /> }}
+          renderItem={(catalog) => (
+            <List.Item>
+              <Space direction="vertical" size={2}>
+                <Typography.Text strong>{catalog.name}</Typography.Text>
+                <Typography.Text type="secondary">
+                  {catalog.description || "No description"}
+                </Typography.Text>
+              </Space>
+            </List.Item>
+          )}
+        />
+      </Card>
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/AcpProfilesTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/AcpProfilesTab.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  listAcpProfiles: vi.fn(),
+  createAcpProfile: vi.fn()
+}))
+
+vi.mock("@/services/tldw/mcp-hub", () => ({
+  listAcpProfiles: (...args: unknown[]) => mocks.listAcpProfiles(...args),
+  createAcpProfile: (...args: unknown[]) => mocks.createAcpProfile(...args)
+}))
+
+import { AcpProfilesTab } from "../AcpProfilesTab"
+
+describe("AcpProfilesTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listAcpProfiles.mockResolvedValue([])
+    mocks.createAcpProfile.mockResolvedValue({
+      id: 1,
+      name: "default-dev",
+      owner_scope_type: "global",
+      profile: {},
+      is_active: true
+    })
+  })
+
+  it("renders ACP profile list and can open create form", async () => {
+    const user = userEvent.setup()
+    render(<AcpProfilesTab />)
+
+    expect(await screen.findByRole("button", { name: /create profile/i })).toBeTruthy()
+    await user.click(screen.getByRole("button", { name: /create profile/i }))
+    expect(screen.getByLabelText(/profile name/i)).toBeTruthy()
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  listExternalServers: vi.fn(),
+  setExternalServerSecret: vi.fn()
+}))
+
+vi.mock("@/services/tldw/mcp-hub", () => ({
+  listExternalServers: (...args: unknown[]) => mocks.listExternalServers(...args),
+  setExternalServerSecret: (...args: unknown[]) => mocks.setExternalServerSecret(...args)
+}))
+
+import { ExternalServersTab } from "../ExternalServersTab"
+
+describe("ExternalServersTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listExternalServers.mockResolvedValue([
+      {
+        id: "docs",
+        name: "Docs",
+        enabled: true,
+        owner_scope_type: "global",
+        transport: "stdio",
+        config: {},
+        secret_configured: false
+      }
+    ])
+    mocks.setExternalServerSecret.mockResolvedValue({
+      server_id: "docs",
+      secret_configured: true
+    })
+  })
+
+  it("submits secret and only displays configured state", async () => {
+    const user = userEvent.setup()
+    render(<ExternalServersTab />)
+
+    const secretInput = (await screen.findByLabelText(/secret/i)) as HTMLInputElement
+    await user.type(secretInput, "super-secret")
+    await user.click(screen.getByRole("button", { name: /save secret/i }))
+
+    expect(await screen.findByText(/secret configured/i)).toBeTruthy()
+    expect(secretInput.value).toBe("")
+    expect(screen.queryByDisplayValue("super-secret")).toBeNull()
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  fetchMcpToolCatalogsViaDiscovery: vi.fn(),
+  fetchMcpToolCatalogs: vi.fn()
+}))
+
+vi.mock("@/services/tldw/mcp", () => ({
+  fetchMcpToolCatalogsViaDiscovery: (...args: unknown[]) =>
+    mocks.fetchMcpToolCatalogsViaDiscovery(...args),
+  fetchMcpToolCatalogs: (...args: unknown[]) => mocks.fetchMcpToolCatalogs(...args)
+}))
+
+import { ToolCatalogsTab } from "../ToolCatalogsTab"
+
+describe("ToolCatalogsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.fetchMcpToolCatalogsViaDiscovery.mockImplementation(async (scope: string) => [
+      { id: 1, name: `${scope}-catalog`, description: `${scope} catalog` }
+    ])
+    mocks.fetchMcpToolCatalogs.mockResolvedValue([])
+  })
+
+  it("switches scope and calls proper catalog loader", async () => {
+    const user = userEvent.setup()
+    render(<ToolCatalogsTab />)
+
+    await user.selectOptions(screen.getByLabelText(/scope/i), "org")
+    expect(await screen.findByText(/org catalogs/i)).toBeTruthy()
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/index.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/index.tsx
@@ -1,0 +1,4 @@
+export { McpHubPage } from "./McpHubPage"
+export { AcpProfilesTab } from "./AcpProfilesTab"
+export { ToolCatalogsTab } from "./ToolCatalogsTab"
+export { ExternalServersTab } from "./ExternalServersTab"

--- a/apps/packages/ui/src/data/settings-index.ts
+++ b/apps/packages/ui/src/data/settings-index.ts
@@ -161,6 +161,16 @@ export const SETTINGS_INDEX: SettingDefinition[] = [
     keywords: ["key", "auth", "authentication", "token", "password"],
     controlType: "input",
   },
+  {
+    id: "setting-mcp-hub",
+    labelKey: "settings:mcpHubNav",
+    defaultLabel: "MCP Hub",
+    defaultDescription: "Manage ACP profiles, tool catalogs, and external MCP servers",
+    route: "/settings/mcp-hub",
+    section: "Server",
+    keywords: ["mcp", "tooling", "agent", "catalog", "external server", "acp"],
+    controlType: "button",
+  },
 
   // ========================================
   // RAG Settings

--- a/apps/packages/ui/src/public/_locales/en/settings.json
+++ b/apps/packages/ui/src/public/_locales/en/settings.json
@@ -35,6 +35,9 @@
   "chatSettingsNav": {
     "message": "Chat"
   },
+  "mcpHubNav": {
+    "message": "MCP Hub"
+  },
   "admin_adminGuardForbiddenTitle": {
     "message": "Admin access required for these controls"
   },

--- a/apps/packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/mcp-hub-route.test.tsx
@@ -1,0 +1,25 @@
+import { existsSync, readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const routeRegistryPathCandidates = [
+  "src/routes/route-registry.tsx",
+  "../packages/ui/src/routes/route-registry.tsx",
+  "apps/packages/ui/src/routes/route-registry.tsx"
+]
+
+const routeRegistryPath = routeRegistryPathCandidates.find((candidate) =>
+  existsSync(candidate)
+)
+
+if (!routeRegistryPath) {
+  throw new Error("Unable to locate route-registry.tsx for MCP Hub route test")
+}
+
+const routeRegistrySource = readFileSync(routeRegistryPath, "utf8")
+
+describe("mcp hub route wiring", () => {
+  it("registers mcp hub in route registry for both workspace and settings entry", () => {
+    expect(routeRegistrySource).toMatch(/path:\s*"\/mcp-hub"/)
+    expect(routeRegistrySource).toMatch(/path:\s*"\/settings\/mcp-hub"/)
+  })
+})

--- a/apps/packages/ui/src/routes/option-mcp-hub.tsx
+++ b/apps/packages/ui/src/routes/option-mcp-hub.tsx
@@ -1,0 +1,15 @@
+import OptionLayout from "~/components/Layouts/Layout"
+import { PageShell } from "@/components/Common/PageShell"
+import { McpHubPage } from "@/components/Option/MCPHub"
+
+const OptionMcpHub = () => {
+  return (
+    <OptionLayout>
+      <PageShell className="flex-1 min-h-0" maxWidthClassName="max-w-full">
+        <McpHubPage />
+      </PageShell>
+    </OptionLayout>
+  )
+}
+
+export default OptionMcpHub

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -195,6 +195,7 @@ const OptionCollections = lazy(() => import("./option-collections"))
 const OptionAudiobookStudio = lazy(() => import("./option-audiobook-studio"))
 const OptionWorkflowEditor = lazy(() => import("./option-workflow-editor"))
 const OptionACPPlayground = lazy(() => import("./option-acp-playground"))
+const OptionMcpHub = lazy(() => import("./option-mcp-hub"))
 const OptionSkills = lazy(() => import("./option-skills"))
 const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
 const OptionSetup = lazy(() => import("./option-setup"))
@@ -243,6 +244,17 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       labelToken: "settings:manageModels.title",
       icon: BrainCircuitIcon,
       order: 6
+    }
+  },
+  {
+    kind: "options",
+    path: "/settings/mcp-hub",
+    element: <OptionMcpHub />,
+    nav: {
+      group: "server",
+      labelToken: "settings:mcpHubNav",
+      icon: ServerIcon,
+      order: 7
     }
   },
   {
@@ -645,6 +657,18 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       labelToken: "settings:acpPlaygroundNav",
       icon: Bot,
       order: 12,
+      beta: true
+    }
+  },
+  {
+    kind: "options",
+    path: "/mcp-hub",
+    element: <OptionMcpHub />,
+    nav: {
+      group: "workspace",
+      labelToken: "settings:mcpHubNav",
+      icon: Bot,
+      order: 12.5,
       beta: true
     }
   },

--- a/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequestClient: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequestClient: (...args: unknown[]) => mocks.bgRequestClient(...args)
+}))
+
+import { setExternalServerSecret } from "../mcp-hub"
+
+describe("mcp hub service client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("maps external secret set response without exposing plaintext", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      server_id: "docs",
+      secret_configured: true,
+      key_hint: "cdef"
+    })
+
+    const out = await setExternalServerSecret("docs", "my-secret")
+
+    expect(out.secret_configured).toBe(true)
+    expect(JSON.stringify(out)).not.toContain("my-secret")
+    expect(mocks.bgRequestClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/mcp/hub/external-servers/docs/secret",
+        method: "POST",
+        body: { secret: "my-secret" }
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/tldw/index.ts
+++ b/apps/packages/ui/src/services/tldw/index.ts
@@ -4,6 +4,7 @@ export { tldwAuth, type LoginCredentials, type TokenResponse, type UserInfo } fr
 export { tldwModels, type ModelInfo } from './TldwModels'
 export { tldwChat, type TldwChatOptions, type ChatStreamChunk } from './TldwChat'
 export { getWorkflowStepTypes } from './workflows'
+export * from './mcp-hub'
 
 // Re-export for convenience
 export * from './TldwApiClient'

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -1,0 +1,188 @@
+import { bgRequestClient } from "@/services/background-proxy"
+import type { ClientPathOrUrlWithQuery } from "@/services/tldw/openapi-guard"
+
+export type McpHubScopeType = "global" | "org" | "team" | "user"
+
+export type McpHubProfile = {
+  id: number
+  name: string
+  description?: string | null
+  owner_scope_type: McpHubScopeType
+  owner_scope_id?: number | null
+  profile: Record<string, unknown>
+  is_active: boolean
+  created_by?: number | null
+  updated_by?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type McpHubProfileCreateInput = {
+  name: string
+  description?: string | null
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  profile?: Record<string, unknown>
+  is_active?: boolean
+}
+
+export type McpHubProfileUpdateInput = {
+  name?: string
+  description?: string | null
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  profile?: Record<string, unknown>
+  is_active?: boolean
+}
+
+export type McpHubExternalServer = {
+  id: string
+  name: string
+  enabled: boolean
+  owner_scope_type: McpHubScopeType
+  owner_scope_id?: number | null
+  transport: string
+  config: Record<string, unknown>
+  secret_configured: boolean
+  key_hint?: string | null
+  created_by?: number | null
+  updated_by?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type McpHubExternalServerCreateInput = {
+  server_id: string
+  name: string
+  transport: string
+  config?: Record<string, unknown>
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  enabled?: boolean
+}
+
+export type McpHubExternalServerUpdateInput = {
+  name?: string
+  transport?: string
+  config?: Record<string, unknown>
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  enabled?: boolean
+}
+
+export type McpHubSecretSetResponse = {
+  server_id: string
+  secret_configured: boolean
+  key_hint?: string | null
+  updated_at?: string | null
+}
+
+const withQuery = (
+  path: string,
+  params: Record<string, string | number | boolean | null | undefined>
+): ClientPathOrUrlWithQuery => {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) continue
+    query.set(key, String(value))
+  }
+  const qs = query.toString()
+  return (qs ? `${path}?${qs}` : path) as ClientPathOrUrlWithQuery
+}
+
+export const listAcpProfiles = async (params: {
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+} = {}): Promise<McpHubProfile[]> => {
+  return await bgRequestClient<McpHubProfile[]>({
+    path: withQuery("/api/v1/mcp/hub/acp-profiles", {
+      owner_scope_type: params.owner_scope_type,
+      owner_scope_id: params.owner_scope_id
+    }),
+    method: "GET"
+  })
+}
+
+export const createAcpProfile = async (
+  payload: McpHubProfileCreateInput
+): Promise<McpHubProfile> => {
+  return await bgRequestClient<McpHubProfile>({
+    path: "/api/v1/mcp/hub/acp-profiles",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const updateAcpProfile = async (
+  profileId: number,
+  payload: McpHubProfileUpdateInput
+): Promise<McpHubProfile> => {
+  return await bgRequestClient<McpHubProfile>({
+    path: `/api/v1/mcp/hub/acp-profiles/${profileId}`,
+    method: "PUT",
+    body: payload
+  })
+}
+
+export const deleteAcpProfile = async (
+  profileId: number
+): Promise<{ ok: boolean }> => {
+  return await bgRequestClient<{ ok: boolean }>({
+    path: `/api/v1/mcp/hub/acp-profiles/${profileId}`,
+    method: "DELETE"
+  })
+}
+
+export const listExternalServers = async (params: {
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+} = {}): Promise<McpHubExternalServer[]> => {
+  return await bgRequestClient<McpHubExternalServer[]>({
+    path: withQuery("/api/v1/mcp/hub/external-servers", {
+      owner_scope_type: params.owner_scope_type,
+      owner_scope_id: params.owner_scope_id
+    }),
+    method: "GET"
+  })
+}
+
+export const createExternalServer = async (
+  payload: McpHubExternalServerCreateInput
+): Promise<McpHubExternalServer> => {
+  return await bgRequestClient<McpHubExternalServer>({
+    path: "/api/v1/mcp/hub/external-servers",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const updateExternalServer = async (
+  serverId: string,
+  payload: McpHubExternalServerUpdateInput
+): Promise<McpHubExternalServer> => {
+  return await bgRequestClient<McpHubExternalServer>({
+    path: `/api/v1/mcp/hub/external-servers/${encodeURIComponent(serverId)}`,
+    method: "PUT",
+    body: payload
+  })
+}
+
+export const deleteExternalServer = async (
+  serverId: string
+): Promise<{ ok: boolean }> => {
+  return await bgRequestClient<{ ok: boolean }>({
+    path: `/api/v1/mcp/hub/external-servers/${encodeURIComponent(serverId)}`,
+    method: "DELETE"
+  })
+}
+
+export const setExternalServerSecret = async (
+  serverId: string,
+  secret: string
+): Promise<McpHubSecretSetResponse> => {
+  return await bgRequestClient<McpHubSecretSetResponse>({
+    path: `/api/v1/mcp/hub/external-servers/${encodeURIComponent(serverId)}/secret`,
+    method: "POST",
+    body: { secret }
+  })
+}

--- a/apps/tldw-frontend/pages/mcp-hub.tsx
+++ b/apps/tldw-frontend/pages/mcp-hub.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-mcp-hub"), { ssr: false })

--- a/apps/tldw-frontend/pages/settings/mcp-hub.tsx
+++ b/apps/tldw-frontend/pages/settings/mcp-hub.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-mcp-hub"), { ssr: false })

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
+    ACPProfileCreateRequest,
+    ACPProfileResponse,
+    ACPProfileUpdateRequest,
+    ExternalSecretSetRequest,
+    ExternalSecretSetResponse,
+    ExternalServerCreateRequest,
+    ExternalServerResponse,
+    ExternalServerUpdateRequest,
+    MCPHubDeleteResponse,
+)
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.services.mcp_hub_service import McpHubService
+
+router = APIRouter(prefix="/mcp/hub", tags=["mcp-hub"])
+
+_MCP_HUB_ADMIN_PERMISSIONS = frozenset({SYSTEM_CONFIGURE, "*"})
+
+
+async def get_mcp_hub_service() -> McpHubService:
+    pool = await get_db_pool()
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return McpHubService(repo)
+
+
+def _load_json_object(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return parsed
+        except (TypeError, ValueError):
+            logger.debug("MCP hub payload JSON decode failed")
+            return {}
+    return {}
+
+
+def _is_mutation_allowed(principal: AuthPrincipal) -> bool:
+    roles = {
+        str(role).strip().lower()
+        for role in (principal.roles or [])
+        if str(role).strip()
+    }
+    if "admin" in roles:
+        return True
+    permissions = {
+        str(permission).strip().lower()
+        for permission in (principal.permissions or [])
+        if str(permission).strip()
+    }
+    required = {perm.lower() for perm in _MCP_HUB_ADMIN_PERMISSIONS}
+    return bool(permissions & required)
+
+
+def _require_mutation_permission(principal: AuthPrincipal) -> None:
+    if _is_mutation_allowed(principal):
+        return
+    raise HTTPException(status_code=403, detail=f"{SYSTEM_CONFIGURE} permission required")
+
+
+def _profile_row_to_response(row: dict[str, Any]) -> ACPProfileResponse:
+    return ACPProfileResponse(
+        id=int(row.get("id")),
+        name=str(row.get("name") or ""),
+        description=row.get("description"),
+        owner_scope_type=str(row.get("owner_scope_type") or "global"),
+        owner_scope_id=row.get("owner_scope_id"),
+        profile=_load_json_object(row.get("profile_json")),
+        is_active=bool(row.get("is_active")),
+        created_by=row.get("created_by"),
+        updated_by=row.get("updated_by"),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+def _external_row_to_response(row: dict[str, Any]) -> ExternalServerResponse:
+    return ExternalServerResponse(
+        id=str(row.get("id") or ""),
+        name=str(row.get("name") or ""),
+        enabled=bool(row.get("enabled")),
+        owner_scope_type=str(row.get("owner_scope_type") or "global"),
+        owner_scope_id=row.get("owner_scope_id"),
+        transport=str(row.get("transport") or ""),
+        config=_load_json_object(row.get("config_json")),
+        secret_configured=bool(row.get("secret_configured")),
+        key_hint=row.get("key_hint"),
+        created_by=row.get("created_by"),
+        updated_by=row.get("updated_by"),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+@router.get("/acp-profiles", response_model=list[ACPProfileResponse])
+async def list_acp_profiles(
+    owner_scope_type: str | None = None,
+    owner_scope_id: int | None = None,
+    _principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> list[ACPProfileResponse]:
+    rows = await svc.list_acp_profiles(
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
+    return [_profile_row_to_response(row) for row in rows]
+
+
+@router.post("/acp-profiles", response_model=ACPProfileResponse, status_code=201)
+async def create_acp_profile(
+    payload: ACPProfileCreateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> ACPProfileResponse:
+    _require_mutation_permission(principal)
+    row = await svc.create_acp_profile(
+        name=payload.name,
+        description=payload.description,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+        profile=payload.profile,
+        is_active=payload.is_active,
+        actor_id=principal.user_id,
+    )
+    return _profile_row_to_response(row)
+
+
+@router.put("/acp-profiles/{profile_id}", response_model=ACPProfileResponse)
+async def update_acp_profile(
+    profile_id: int,
+    payload: ACPProfileUpdateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> ACPProfileResponse:
+    _require_mutation_permission(principal)
+    row = await svc.update_acp_profile(
+        profile_id,
+        name=payload.name,
+        description=payload.description,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+        profile=payload.profile,
+        is_active=payload.is_active,
+        actor_id=principal.user_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="ACP profile not found")
+    return _profile_row_to_response(row)
+
+
+@router.delete("/acp-profiles/{profile_id}", response_model=MCPHubDeleteResponse)
+async def delete_acp_profile(
+    profile_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> MCPHubDeleteResponse:
+    _require_mutation_permission(principal)
+    deleted = await svc.delete_acp_profile(profile_id, actor_id=principal.user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="ACP profile not found")
+    return MCPHubDeleteResponse(ok=True)
+
+
+@router.get("/external-servers", response_model=list[ExternalServerResponse])
+async def list_external_servers(
+    owner_scope_type: str | None = None,
+    owner_scope_id: int | None = None,
+    _principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> list[ExternalServerResponse]:
+    rows = await svc.list_external_servers(
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
+    return [_external_row_to_response(row) for row in rows]
+
+
+@router.post("/external-servers", response_model=ExternalServerResponse, status_code=201)
+async def create_external_server(
+    payload: ExternalServerCreateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> ExternalServerResponse:
+    _require_mutation_permission(principal)
+    row = await svc.create_external_server(
+        server_id=payload.server_id,
+        name=payload.name,
+        transport=payload.transport,
+        config=payload.config,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+        enabled=payload.enabled,
+        actor_id=principal.user_id,
+    )
+    return _external_row_to_response(row)
+
+
+@router.put("/external-servers/{server_id}", response_model=ExternalServerResponse)
+async def update_external_server(
+    server_id: str,
+    payload: ExternalServerUpdateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> ExternalServerResponse:
+    _require_mutation_permission(principal)
+    existing = await svc.repo.get_external_server(server_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="External server not found")
+    row = await svc.create_external_server(
+        server_id=server_id,
+        name=payload.name if payload.name is not None else str(existing.get("name") or ""),
+        transport=payload.transport if payload.transport is not None else str(existing.get("transport") or ""),
+        config=payload.config if payload.config is not None else _load_json_object(existing.get("config_json")),
+        owner_scope_type=payload.owner_scope_type if payload.owner_scope_type is not None else str(existing.get("owner_scope_type") or "global"),
+        owner_scope_id=payload.owner_scope_id if payload.owner_scope_id is not None else existing.get("owner_scope_id"),
+        enabled=payload.enabled if payload.enabled is not None else bool(existing.get("enabled")),
+        actor_id=principal.user_id,
+    )
+    return _external_row_to_response(row)
+
+
+@router.delete("/external-servers/{server_id}", response_model=MCPHubDeleteResponse)
+async def delete_external_server(
+    server_id: str,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> MCPHubDeleteResponse:
+    _require_mutation_permission(principal)
+    deleted = await svc.delete_external_server(server_id, actor_id=principal.user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="External server not found")
+    return MCPHubDeleteResponse(ok=True)
+
+
+@router.post("/external-servers/{server_id}/secret", response_model=ExternalSecretSetResponse)
+async def set_external_secret(
+    server_id: str,
+    payload: ExternalSecretSetRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> ExternalSecretSetResponse:
+    _require_mutation_permission(principal)
+    try:
+        out = await svc.set_external_server_secret(
+            server_id=server_id,
+            secret_value=payload.secret,
+            actor_id=principal.user_id,
+        )
+    except ValueError as exc:
+        detail = str(exc) or "Invalid secret payload"
+        if "not found" in detail.lower():
+            raise HTTPException(status_code=404, detail=detail) from exc
+        raise HTTPException(status_code=400, detail=detail) from exc
+    return ExternalSecretSetResponse(**out)

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -22,14 +22,17 @@ from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
-from tldw_Server_API.app.services.mcp_hub_service import McpHubService
+from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
+from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError, McpHubService
 
 router = APIRouter(prefix="/mcp/hub", tags=["mcp-hub"])
 
 _MCP_HUB_ADMIN_PERMISSIONS = frozenset({SYSTEM_CONFIGURE, "*"})
+_VALID_SCOPE_TYPES = frozenset({"global", "org", "team", "user"})
 
 
 async def get_mcp_hub_service() -> McpHubService:
+    """Resolve MCP Hub service with storage bootstrap checks."""
     pool = await get_db_pool()
     repo = McpHubRepo(pool)
     await repo.ensure_tables()
@@ -37,6 +40,7 @@ async def get_mcp_hub_service() -> McpHubService:
 
 
 def _load_json_object(raw: Any) -> dict[str, Any]:
+    """Parse JSON-like values into a dict, returning empty dict on decode failures."""
     if isinstance(raw, dict):
         return raw
     if not raw:
@@ -53,6 +57,7 @@ def _load_json_object(raw: Any) -> dict[str, Any]:
 
 
 def _is_mutation_allowed(principal: AuthPrincipal) -> bool:
+    """Return True when the principal is allowed to mutate MCP Hub configuration."""
     roles = {
         str(role).strip().lower()
         for role in (principal.roles or [])
@@ -70,9 +75,107 @@ def _is_mutation_allowed(principal: AuthPrincipal) -> bool:
 
 
 def _require_mutation_permission(principal: AuthPrincipal) -> None:
+    """Require mutation permission for MCP Hub write operations."""
     if _is_mutation_allowed(principal):
         return
     raise HTTPException(status_code=403, detail=f"{SYSTEM_CONFIGURE} permission required")
+
+
+def _collect_scope_ids(values: list[int] | None, active_id: int | None) -> list[int]:
+    out: set[int] = set()
+    for raw in values or []:
+        try:
+            out.add(int(raw))
+        except (TypeError, ValueError):
+            continue
+    if active_id is not None:
+        try:
+            out.add(int(active_id))
+        except (TypeError, ValueError):
+            pass
+    return sorted(out)
+
+
+def _resolve_visible_scope_filters(
+    *,
+    principal: AuthPrincipal,
+    owner_scope_type: str | None,
+    owner_scope_id: int | None,
+) -> list[tuple[str | None, int | None]]:
+    """
+    Resolve list query filters constrained to scopes visible to the authenticated principal.
+
+    Returns one or more `(scope_type, scope_id)` filters. A `scope_type` of `None` means
+    unrestricted query (admin-like contexts only).
+    """
+    scope_type = owner_scope_type.strip().lower() if owner_scope_type else None
+    if scope_type is not None and scope_type not in _VALID_SCOPE_TYPES:
+        raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+
+    if _is_mutation_allowed(principal):
+        if scope_type is None:
+            if owner_scope_id is not None:
+                raise HTTPException(status_code=422, detail="owner_scope_id requires owner_scope_type")
+            return [(None, None)]
+        if scope_type == "global":
+            if owner_scope_id is not None:
+                raise HTTPException(status_code=422, detail="global scope cannot include owner_scope_id")
+            return [("global", None)]
+        if owner_scope_id is None:
+            raise HTTPException(status_code=422, detail=f"{scope_type} scope requires owner_scope_id")
+        return [(scope_type, int(owner_scope_id))]
+
+    user_id = int(principal.user_id) if principal.user_id is not None else None
+    org_ids = _collect_scope_ids(principal.org_ids, principal.active_org_id)
+    team_ids = _collect_scope_ids(principal.team_ids, principal.active_team_id)
+
+    if scope_type is None:
+        if owner_scope_id is not None:
+            raise HTTPException(status_code=422, detail="owner_scope_id requires owner_scope_type")
+        filters: list[tuple[str | None, int | None]] = [("global", None)]
+        if user_id is not None:
+            filters.append(("user", user_id))
+        filters.extend(("org", org_id) for org_id in org_ids)
+        filters.extend(("team", team_id) for team_id in team_ids)
+        return filters
+
+    if scope_type == "global":
+        if owner_scope_id is not None:
+            raise HTTPException(status_code=422, detail="global scope cannot include owner_scope_id")
+        return [("global", None)]
+
+    if scope_type == "user":
+        target_user_id = int(owner_scope_id) if owner_scope_id is not None else user_id
+        if target_user_id is None or user_id is None or target_user_id != user_id:
+            raise HTTPException(status_code=403, detail="Forbidden scope filter")
+        return [("user", user_id)]
+
+    if scope_type == "org":
+        if owner_scope_id is None:
+            return [("org", org_id) for org_id in org_ids]
+        if int(owner_scope_id) not in set(org_ids):
+            raise HTTPException(status_code=403, detail="Forbidden scope filter")
+        return [("org", int(owner_scope_id))]
+
+    if scope_type == "team":
+        if owner_scope_id is None:
+            return [("team", team_id) for team_id in team_ids]
+        if int(owner_scope_id) not in set(team_ids):
+            raise HTTPException(status_code=403, detail="Forbidden scope filter")
+        return [("team", int(owner_scope_id))]
+
+    raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+
+
+def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deduplicate row dictionaries by `id` while preserving final-write wins semantics."""
+    deduped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        row_id = str(row.get("id") or "")
+        if not row_id:
+            continue
+        deduped[row_id] = row
+    return list(deduped.values())
 
 
 def _profile_row_to_response(row: dict[str, Any]) -> ACPProfileResponse:
@@ -113,13 +216,24 @@ def _external_row_to_response(row: dict[str, Any]) -> ExternalServerResponse:
 async def list_acp_profiles(
     owner_scope_type: str | None = None,
     owner_scope_id: int | None = None,
-    _principal: AuthPrincipal = Depends(get_auth_principal),
+    principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> list[ACPProfileResponse]:
-    rows = await svc.list_acp_profiles(
+    """List ACP profiles visible to the current principal with scope-constrained filtering."""
+    filters = _resolve_visible_scope_filters(
+        principal=principal,
         owner_scope_type=owner_scope_type,
         owner_scope_id=owner_scope_id,
     )
+    rows: list[dict[str, Any]] = []
+    for scope_type, scope_id in filters:
+        rows.extend(
+            await svc.list_acp_profiles(
+                owner_scope_type=scope_type,
+                owner_scope_id=scope_id,
+            )
+        )
+    rows = _dedupe_rows(rows)
     return [_profile_row_to_response(row) for row in rows]
 
 
@@ -129,6 +243,7 @@ async def create_acp_profile(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> ACPProfileResponse:
+    """Create a new ACP profile within the provided owner scope."""
     _require_mutation_permission(principal)
     row = await svc.create_acp_profile(
         name=payload.name,
@@ -149,6 +264,7 @@ async def update_acp_profile(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> ACPProfileResponse:
+    """Update an existing ACP profile by id."""
     _require_mutation_permission(principal)
     row = await svc.update_acp_profile(
         profile_id,
@@ -171,6 +287,7 @@ async def delete_acp_profile(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> MCPHubDeleteResponse:
+    """Delete an ACP profile by id."""
     _require_mutation_permission(principal)
     deleted = await svc.delete_acp_profile(profile_id, actor_id=principal.user_id)
     if not deleted:
@@ -182,13 +299,24 @@ async def delete_acp_profile(
 async def list_external_servers(
     owner_scope_type: str | None = None,
     owner_scope_id: int | None = None,
-    _principal: AuthPrincipal = Depends(get_auth_principal),
+    principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> list[ExternalServerResponse]:
-    rows = await svc.list_external_servers(
+    """List external MCP servers visible to the current principal with scope-constrained filtering."""
+    filters = _resolve_visible_scope_filters(
+        principal=principal,
         owner_scope_type=owner_scope_type,
         owner_scope_id=owner_scope_id,
     )
+    rows: list[dict[str, Any]] = []
+    for scope_type, scope_id in filters:
+        rows.extend(
+            await svc.list_external_servers(
+                owner_scope_type=scope_type,
+                owner_scope_id=scope_id,
+            )
+        )
+    rows = _dedupe_rows(rows)
     return [_external_row_to_response(row) for row in rows]
 
 
@@ -198,17 +326,22 @@ async def create_external_server(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> ExternalServerResponse:
+    """Create a new external MCP server definition."""
     _require_mutation_permission(principal)
-    row = await svc.create_external_server(
-        server_id=payload.server_id,
-        name=payload.name,
-        transport=payload.transport,
-        config=payload.config,
-        owner_scope_type=payload.owner_scope_type,
-        owner_scope_id=payload.owner_scope_id,
-        enabled=payload.enabled,
-        actor_id=principal.user_id,
-    )
+    try:
+        row = await svc.create_external_server(
+            server_id=payload.server_id,
+            name=payload.name,
+            transport=payload.transport,
+            config=payload.config,
+            owner_scope_type=payload.owner_scope_type,
+            owner_scope_id=payload.owner_scope_id,
+            enabled=payload.enabled,
+            actor_id=principal.user_id,
+            allow_existing=False,
+        )
+    except McpHubConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return _external_row_to_response(row)
 
 
@@ -219,20 +352,21 @@ async def update_external_server(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> ExternalServerResponse:
+    """Update an existing external MCP server definition."""
     _require_mutation_permission(principal)
-    existing = await svc.repo.get_external_server(server_id)
-    if not existing:
-        raise HTTPException(status_code=404, detail="External server not found")
-    row = await svc.create_external_server(
-        server_id=server_id,
-        name=payload.name if payload.name is not None else str(existing.get("name") or ""),
-        transport=payload.transport if payload.transport is not None else str(existing.get("transport") or ""),
-        config=payload.config if payload.config is not None else _load_json_object(existing.get("config_json")),
-        owner_scope_type=payload.owner_scope_type if payload.owner_scope_type is not None else str(existing.get("owner_scope_type") or "global"),
-        owner_scope_id=payload.owner_scope_id if payload.owner_scope_id is not None else existing.get("owner_scope_id"),
-        enabled=payload.enabled if payload.enabled is not None else bool(existing.get("enabled")),
-        actor_id=principal.user_id,
-    )
+    try:
+        row = await svc.update_external_server(
+            server_id,
+            name=payload.name,
+            transport=payload.transport,
+            config=payload.config,
+            owner_scope_type=payload.owner_scope_type,
+            owner_scope_id=payload.owner_scope_id,
+            enabled=payload.enabled,
+            actor_id=principal.user_id,
+        )
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return _external_row_to_response(row)
 
 
@@ -242,6 +376,7 @@ async def delete_external_server(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> MCPHubDeleteResponse:
+    """Delete an external MCP server definition by id."""
     _require_mutation_permission(principal)
     deleted = await svc.delete_external_server(server_id, actor_id=principal.user_id)
     if not deleted:
@@ -256,6 +391,7 @@ async def set_external_secret(
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> ExternalSecretSetResponse:
+    """Set or rotate an external MCP server secret using encrypted-at-rest storage."""
     _require_mutation_permission(principal)
     try:
         out = await svc.set_external_server_secret(
@@ -263,9 +399,8 @@ async def set_external_secret(
             secret_value=payload.secret,
             actor_id=principal.user_id,
         )
-    except ValueError as exc:
-        detail = str(exc) or "Invalid secret payload"
-        if "not found" in detail.lower():
-            raise HTTPException(status_code=404, detail=detail) from exc
-        raise HTTPException(status_code=400, detail=detail) from exc
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except BadRequestError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return ExternalSecretSetResponse(**out)

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+ScopeType = Literal["global", "org", "team", "user"]
+
+
+class ACPProfileCreateRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=512)
+    owner_scope_type: ScopeType = Field(default="global")
+    owner_scope_id: int | None = None
+    profile: dict[str, Any] = Field(default_factory=dict)
+    is_active: bool = True
+
+
+class ACPProfileUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=512)
+    owner_scope_type: ScopeType | None = None
+    owner_scope_id: int | None = None
+    profile: dict[str, Any] | None = None
+    is_active: bool | None = None
+
+
+class ACPProfileResponse(BaseModel):
+    id: int
+    name: str
+    description: str | None = None
+    owner_scope_type: ScopeType
+    owner_scope_id: int | None = None
+    profile: dict[str, Any] = Field(default_factory=dict)
+    is_active: bool
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class ExternalServerCreateRequest(BaseModel):
+    server_id: str = Field(..., min_length=1, max_length=128)
+    name: str = Field(..., min_length=1, max_length=200)
+    transport: str = Field(..., min_length=1, max_length=64)
+    config: dict[str, Any] = Field(default_factory=dict)
+    owner_scope_type: ScopeType = Field(default="global")
+    owner_scope_id: int | None = None
+    enabled: bool = True
+
+
+class ExternalServerUpdateRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    transport: str | None = Field(default=None, min_length=1, max_length=64)
+    config: dict[str, Any] | None = None
+    owner_scope_type: ScopeType | None = None
+    owner_scope_id: int | None = None
+    enabled: bool | None = None
+
+
+class ExternalServerResponse(BaseModel):
+    id: str
+    name: str
+    enabled: bool
+    owner_scope_type: ScopeType
+    owner_scope_id: int | None = None
+    transport: str
+    config: dict[str, Any] = Field(default_factory=dict)
+    secret_configured: bool
+    key_hint: str | None = None
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class ExternalSecretSetRequest(BaseModel):
+    secret: str = Field(..., min_length=1, max_length=8192)
+
+
+class ExternalSecretSetResponse(BaseModel):
+    server_id: str
+    secret_configured: bool
+    key_hint: str | None = None
+    updated_at: datetime | str | None = None
+
+
+class MCPHubDeleteResponse(BaseModel):
+    ok: bool

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -1355,6 +1355,74 @@ def migration_054_add_llm_usage_log_router_analytics_columns(conn: sqlite3.Conne
     logger.info("Migration 054: Added llm_usage_log router analytics columns/indexes")
 
 
+def migration_055_create_mcp_hub_tables(conn: sqlite3.Connection) -> None:
+    """Create MCP Hub management tables (SQLite)."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_acp_profiles (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            description TEXT,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER,
+            profile_json TEXT NOT NULL DEFAULT '{}',
+            is_active INTEGER DEFAULT 1,
+            created_by INTEGER,
+            updated_by INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(name, owner_scope_type, owner_scope_id)
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_acp_profiles_scope "
+        "ON mcp_acp_profiles(owner_scope_type, owner_scope_id)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_external_servers (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            enabled INTEGER DEFAULT 1,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER,
+            transport TEXT NOT NULL,
+            config_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER,
+            updated_by INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_external_servers_scope "
+        "ON mcp_external_servers(owner_scope_type, owner_scope_id)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_external_server_secrets (
+            server_id TEXT PRIMARY KEY,
+            encrypted_blob TEXT NOT NULL,
+            key_hint TEXT,
+            updated_by INTEGER,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (server_id) REFERENCES mcp_external_servers(id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_external_server_secrets_updated_at "
+        "ON mcp_external_server_secrets(updated_at)"
+    )
+
+    conn.commit()
+    logger.info("Migration 055: Created MCP Hub tables")
+
+
 def rollback_053_drop_byok_oauth_state(conn: sqlite3.Connection) -> None:
     """Rollback migration 053 by dropping the byok_oauth_state table."""
     conn.execute("DROP TABLE IF EXISTS byok_oauth_state")
@@ -2782,6 +2850,11 @@ def get_authnz_migrations() -> list[Migration]:
             54,
             "Add llm_usage_log router analytics columns and indexes",
             migration_054_add_llm_usage_log_router_analytics_columns,
+        ),
+        Migration(
+            55,
+            "Create MCP Hub tables",
+            migration_055_create_mcp_hub_tables,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -74,6 +74,74 @@ _CREATE_TOOL_CATALOGS = [
 ]
 
 
+_CREATE_MCP_HUB_TABLES = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_acp_profiles (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT NULL,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER NULL,
+            profile_json TEXT NOT NULL DEFAULT '{}',
+            is_active BOOLEAN DEFAULT TRUE,
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            CONSTRAINT uq_mcp_acp_profiles_scope UNIQUE (name, owner_scope_type, owner_scope_id)
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_acp_profiles_scope "
+        "ON mcp_acp_profiles(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_external_servers (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            enabled BOOLEAN DEFAULT TRUE,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER NULL,
+            transport TEXT NOT NULL,
+            config_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_external_servers_scope "
+        "ON mcp_external_servers(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_external_server_secrets (
+            server_id TEXT PRIMARY KEY REFERENCES mcp_external_servers(id) ON DELETE CASCADE,
+            encrypted_blob TEXT NOT NULL,
+            key_hint TEXT NULL,
+            updated_by INTEGER NULL,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_external_server_secrets_updated_at "
+        "ON mcp_external_server_secrets(updated_at)",
+        (),
+    ),
+]
+
+
 _CREATE_PRIVILEGE_SNAPSHOTS = [
     (
         """
@@ -1144,6 +1212,28 @@ async def ensure_tool_catalogs_tables_pg(pool: DatabasePool | None = None) -> bo
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL tool catalogs tables: {exc}")
+        return False
+
+
+async def ensure_mcp_hub_tables_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure MCP Hub management tables exist on PostgreSQL backends."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False  # not postgres
+        try:
+            await ensure_authnz_core_tables_pg(db_pool)
+        except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"PG ensure authnz core tables before mcp hub tables failed: {exc}")
+        for sql, params in _CREATE_MCP_HUB_TABLES:
+            try:
+                await db_pool.execute(sql, *params)
+            except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(f"PG ensure mcp hub tables DDL failed: {exc}")
+        logger.info("Ensured PostgreSQL MCP Hub tables (idempotent)")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL MCP Hub tables: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/core/AuthNZ/repos/__init__.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/__init__.py
@@ -5,3 +5,7 @@ This package provides thin, dialect-aware repositories that encapsulate
 SQL for core AuthNZ tables (users, api_keys, RBAC) so that higher-level
 services like APIKeyManager can remain backend-agnostic.
 """
+
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+
+__all__ = ["McpHubRepo"]

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -323,6 +323,53 @@ class McpHubRepo:
         row = await self.get_external_server(server_id)
         return row or {}
 
+    async def update_external_server(
+        self,
+        server_id: str,
+        *,
+        name: str,
+        transport: str,
+        config_json: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        enabled: bool,
+        actor_id: int | None,
+    ) -> dict[str, Any] | None:
+        """Update an existing external server row and return the normalized record."""
+        scope_type = _normalize_scope_type(owner_scope_type)
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        enabled_value: bool | int = enabled if getattr(self.db_pool, "pool", None) is not None else int(enabled)
+        cursor = await self.db_pool.execute(
+            """
+            UPDATE mcp_external_servers
+            SET name = ?,
+                enabled = ?,
+                owner_scope_type = ?,
+                owner_scope_id = ?,
+                transport = ?,
+                config_json = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                name.strip(),
+                enabled_value,
+                scope_type,
+                owner_scope_id,
+                transport.strip(),
+                config_json,
+                actor_id,
+                ts,
+                server_id.strip(),
+            ),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        if not (rowcount and rowcount > 0):
+            return None
+        return await self.get_external_server(server_id)
+
     async def get_external_server(self, server_id: str) -> dict[str, Any] | None:
         row = await self.db_pool.fetchone(
             """

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -91,10 +91,6 @@ class McpHubRepo:
             return {}
 
     @staticmethod
-    def _normalize_datetime_for_postgres(dt: datetime) -> datetime:
-        return dt.replace(tzinfo=None) if getattr(dt, "tzinfo", None) else dt
-
-    @staticmethod
     def _normalize_acp_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
         if row is None:
             return None
@@ -124,11 +120,7 @@ class McpHubRepo:
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         now = datetime.now(timezone.utc)
-        ts = (
-            self._normalize_datetime_for_postgres(now)
-            if getattr(self.db_pool, "pool", None) is not None
-            else now.isoformat()
-        )
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
         await self.db_pool.execute(
             """
@@ -244,11 +236,7 @@ class McpHubRepo:
         next_profile_json = profile_json if profile_json is not None else str(existing["profile_json"])
         next_active = _to_bool(is_active) if is_active is not None else _to_bool(existing.get("is_active"))
         now = datetime.now(timezone.utc)
-        ts = (
-            self._normalize_datetime_for_postgres(now)
-            if getattr(self.db_pool, "pool", None) is not None
-            else now.isoformat()
-        )
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = next_active if getattr(self.db_pool, "pool", None) is not None else int(next_active)
 
         await self.db_pool.execute(
@@ -300,11 +288,7 @@ class McpHubRepo:
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         now = datetime.now(timezone.utc)
-        ts = (
-            self._normalize_datetime_for_postgres(now)
-            if getattr(self.db_pool, "pool", None) is not None
-            else now.isoformat()
-        )
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         enabled_value: bool | int = enabled if getattr(self.db_pool, "pool", None) is not None else int(enabled)
         await self.db_pool.execute(
             """
@@ -427,11 +411,7 @@ class McpHubRepo:
         actor_id: int | None,
     ) -> dict[str, Any]:
         now = datetime.now(timezone.utc)
-        ts = (
-            self._normalize_datetime_for_postgres(now)
-            if getattr(self.db_pool, "pool", None) is not None
-            else now.isoformat()
-        )
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         await self.db_pool.execute(
             """
             INSERT INTO mcp_external_server_secrets (

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -81,12 +81,13 @@ class McpHubRepo:
             return dict(row)
         try:
             return dict(row)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug(f"McpHubRepo._row_to_dict direct cast failed: {exc}")
         try:
             keys = row.keys()
             return {key: row[key] for key in keys}
-        except Exception:
+        except Exception as exc:
+            logger.debug(f"McpHubRepo._row_to_dict key extraction failed: {exc}")
             return {}
 
     @staticmethod
@@ -187,26 +188,29 @@ class McpHubRepo:
         owner_scope_type: str | None = None,
         owner_scope_id: int | None = None,
     ) -> list[dict[str, Any]]:
-        clauses: list[str] = []
-        params: list[Any] = []
-
-        if owner_scope_type is not None:
-            clauses.append("owner_scope_type = ?")
-            params.append(_normalize_scope_type(owner_scope_type))
-        if owner_scope_id is not None:
-            clauses.append("owner_scope_id = ?")
-            params.append(int(owner_scope_id))
-
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        normalized_scope_type = (
+            _normalize_scope_type(owner_scope_type)
+            if owner_scope_type is not None
+            else None
+        )
+        normalized_scope_id = (
+            int(owner_scope_id) if owner_scope_id is not None else None
+        )
         rows = await self.db_pool.fetchall(
-            f"""
+            """
             SELECT id, name, description, owner_scope_type, owner_scope_id, profile_json, is_active,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_acp_profiles
-            {where}
+            WHERE (? IS NULL OR owner_scope_type = ?)
+              AND (? IS NULL OR owner_scope_id = ?)
             ORDER BY name, id
             """,
-            tuple(params),
+            (
+                normalized_scope_type,
+                normalized_scope_type,
+                normalized_scope_id,
+                normalized_scope_id,
+            ),
         )
         return [
             self._normalize_acp_row(self._row_to_dict(row)) or {}
@@ -365,19 +369,16 @@ class McpHubRepo:
         owner_scope_type: str | None = None,
         owner_scope_id: int | None = None,
     ) -> list[dict[str, Any]]:
-        clauses: list[str] = []
-        params: list[Any] = []
-
-        if owner_scope_type is not None:
-            clauses.append("s.owner_scope_type = ?")
-            params.append(_normalize_scope_type(owner_scope_type))
-        if owner_scope_id is not None:
-            clauses.append("s.owner_scope_id = ?")
-            params.append(int(owner_scope_id))
-
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        normalized_scope_type = (
+            _normalize_scope_type(owner_scope_type)
+            if owner_scope_type is not None
+            else None
+        )
+        normalized_scope_id = (
+            int(owner_scope_id) if owner_scope_id is not None else None
+        )
         rows = await self.db_pool.fetchall(
-            f"""
+            """
             SELECT s.id,
                    s.name,
                    s.enabled,
@@ -393,10 +394,16 @@ class McpHubRepo:
                    sec.key_hint
             FROM mcp_external_servers s
             LEFT JOIN mcp_external_server_secrets sec ON sec.server_id = s.id
-            {where}
+            WHERE (? IS NULL OR s.owner_scope_type = ?)
+              AND (? IS NULL OR s.owner_scope_id = ?)
             ORDER BY s.name, s.id
             """,
-            tuple(params),
+            (
+                normalized_scope_type,
+                normalized_scope_type,
+                normalized_scope_id,
+                normalized_scope_id,
+            ),
         )
         return [
             self._normalize_external_row(self._row_to_dict(row)) or {}

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -1,0 +1,467 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+_VALID_SCOPE_TYPES = {"global", "org", "team", "user"}
+
+
+def _normalize_scope_type(scope_type: str | None) -> str:
+    value = (scope_type or "").strip().lower()
+    if value in {"organization", "orgs"}:
+        return "org"
+    if value in {"teams"}:
+        return "team"
+    if value in _VALID_SCOPE_TYPES:
+        return value
+    raise ValueError(f"Invalid owner_scope_type: {scope_type}")
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    text = str(value).strip().lower()
+    return text in {"1", "true", "t", "yes", "y"}
+
+
+@dataclass
+class McpHubRepo:
+    """Data access for MCP Hub ACP profiles and external server configuration."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        """Ensure MCP Hub tables are available on the current backend."""
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_mcp_hub_tables_pg,
+                )
+
+                ok = await ensure_mcp_hub_tables_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL MCP Hub schema ensure failed")
+                return
+
+            required = {
+                "mcp_acp_profiles",
+                "mcp_external_servers",
+                "mcp_external_server_secrets",
+            }
+            rows = await self.db_pool.fetchall(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name IN (?, ?, ?)",
+                tuple(required),
+            )
+            existing = {str(row["name"]) for row in rows}
+            missing = required - existing
+            if missing:
+                raise RuntimeError(
+                    "SQLite MCP Hub tables are missing. "
+                    "Run AuthNZ migrations/bootstrap. "
+                    f"Missing: {sorted(missing)}"
+                )
+        except Exception as exc:
+            logger.error(f"McpHubRepo.ensure_tables failed: {exc}")
+            raise
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if row is None:
+            return {}
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return dict(row)
+        except Exception:
+            pass
+        try:
+            keys = row.keys()
+            return {key: row[key] for key in keys}
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(dt: datetime) -> datetime:
+        return dt.replace(tzinfo=None) if getattr(dt, "tzinfo", None) else dt
+
+    @staticmethod
+    def _normalize_acp_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["is_active"] = _to_bool(out.get("is_active"))
+        return out
+
+    @staticmethod
+    def _normalize_external_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["enabled"] = _to_bool(out.get("enabled"))
+        out["secret_configured"] = _to_bool(out.get("secret_configured"))
+        return out
+
+    async def create_acp_profile(
+        self,
+        *,
+        name: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        profile_json: str,
+        actor_id: int | None,
+        description: str | None = None,
+        is_active: bool = True,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        now = datetime.now(timezone.utc)
+        ts = (
+            self._normalize_datetime_for_postgres(now)
+            if getattr(self.db_pool, "pool", None) is not None
+            else now.isoformat()
+        )
+        active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_acp_profiles (
+                name, description, owner_scope_type, owner_scope_id, profile_json, is_active,
+                created_by, updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name.strip(),
+                description,
+                scope_type,
+                owner_scope_id,
+                profile_json,
+                active_value,
+                actor_id,
+                actor_id,
+                ts,
+                ts,
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM mcp_acp_profiles
+            WHERE name = ?
+              AND owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (name.strip(), scope_type, owner_scope_id, owner_scope_id),
+        )
+        if not row:
+            return {}
+        created = await self.get_acp_profile(int(row["id"]))
+        return created or {}
+
+    async def get_acp_profile(self, profile_id: int) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, name, description, owner_scope_type, owner_scope_id, profile_json, is_active,
+                   created_by, updated_by, created_at, updated_at
+            FROM mcp_acp_profiles
+            WHERE id = ?
+            """,
+            (int(profile_id),),
+        )
+        return self._normalize_acp_row(self._row_to_dict(row) if row else None)
+
+    async def list_acp_profiles(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if owner_scope_type is not None:
+            clauses.append("owner_scope_type = ?")
+            params.append(_normalize_scope_type(owner_scope_type))
+        if owner_scope_id is not None:
+            clauses.append("owner_scope_id = ?")
+            params.append(int(owner_scope_id))
+
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = await self.db_pool.fetchall(
+            f"""
+            SELECT id, name, description, owner_scope_type, owner_scope_id, profile_json, is_active,
+                   created_by, updated_by, created_at, updated_at
+            FROM mcp_acp_profiles
+            {where}
+            ORDER BY name, id
+            """,
+            tuple(params),
+        )
+        return [
+            self._normalize_acp_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
+
+    async def update_acp_profile(
+        self,
+        profile_id: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        profile_json: str | None = None,
+        is_active: bool | None = None,
+        actor_id: int | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_acp_profile(profile_id)
+        if not existing:
+            return None
+
+        next_name = name.strip() if name is not None else str(existing["name"])
+        next_description = description if description is not None else existing.get("description")
+        next_scope = (
+            _normalize_scope_type(owner_scope_type)
+            if owner_scope_type is not None
+            else str(existing["owner_scope_type"])
+        )
+        next_scope_id = owner_scope_id if owner_scope_id is not None else existing.get("owner_scope_id")
+        next_profile_json = profile_json if profile_json is not None else str(existing["profile_json"])
+        next_active = _to_bool(is_active) if is_active is not None else _to_bool(existing.get("is_active"))
+        now = datetime.now(timezone.utc)
+        ts = (
+            self._normalize_datetime_for_postgres(now)
+            if getattr(self.db_pool, "pool", None) is not None
+            else now.isoformat()
+        )
+        active_value: bool | int = next_active if getattr(self.db_pool, "pool", None) is not None else int(next_active)
+
+        await self.db_pool.execute(
+            """
+            UPDATE mcp_acp_profiles
+            SET name = ?,
+                description = ?,
+                owner_scope_type = ?,
+                owner_scope_id = ?,
+                profile_json = ?,
+                is_active = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                next_name,
+                next_description,
+                next_scope,
+                next_scope_id,
+                next_profile_json,
+                active_value,
+                actor_id,
+                ts,
+                int(profile_id),
+            ),
+        )
+        return await self.get_acp_profile(profile_id)
+
+    async def delete_acp_profile(self, profile_id: int) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_acp_profiles WHERE id = ?",
+            (int(profile_id),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)
+
+    async def upsert_external_server(
+        self,
+        *,
+        server_id: str,
+        name: str,
+        transport: str,
+        config_json: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        enabled: bool,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        now = datetime.now(timezone.utc)
+        ts = (
+            self._normalize_datetime_for_postgres(now)
+            if getattr(self.db_pool, "pool", None) is not None
+            else now.isoformat()
+        )
+        enabled_value: bool | int = enabled if getattr(self.db_pool, "pool", None) is not None else int(enabled)
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_external_servers (
+                id, name, enabled, owner_scope_type, owner_scope_id, transport, config_json,
+                created_by, updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                enabled = excluded.enabled,
+                owner_scope_type = excluded.owner_scope_type,
+                owner_scope_id = excluded.owner_scope_id,
+                transport = excluded.transport,
+                config_json = excluded.config_json,
+                updated_by = excluded.updated_by,
+                updated_at = excluded.updated_at
+            """,
+            (
+                server_id.strip(),
+                name.strip(),
+                enabled_value,
+                scope_type,
+                owner_scope_id,
+                transport.strip(),
+                config_json,
+                actor_id,
+                actor_id,
+                ts,
+                ts,
+            ),
+        )
+        row = await self.get_external_server(server_id)
+        return row or {}
+
+    async def get_external_server(self, server_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT s.id,
+                   s.name,
+                   s.enabled,
+                   s.owner_scope_type,
+                   s.owner_scope_id,
+                   s.transport,
+                   s.config_json,
+                   s.created_by,
+                   s.updated_by,
+                   s.created_at,
+                   s.updated_at,
+                   CASE WHEN sec.server_id IS NULL THEN 0 ELSE 1 END AS secret_configured,
+                   sec.key_hint
+            FROM mcp_external_servers s
+            LEFT JOIN mcp_external_server_secrets sec ON sec.server_id = s.id
+            WHERE s.id = ?
+            """,
+            (server_id.strip(),),
+        )
+        return self._normalize_external_row(self._row_to_dict(row) if row else None)
+
+    async def list_external_servers(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
+
+        if owner_scope_type is not None:
+            clauses.append("s.owner_scope_type = ?")
+            params.append(_normalize_scope_type(owner_scope_type))
+        if owner_scope_id is not None:
+            clauses.append("s.owner_scope_id = ?")
+            params.append(int(owner_scope_id))
+
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = await self.db_pool.fetchall(
+            f"""
+            SELECT s.id,
+                   s.name,
+                   s.enabled,
+                   s.owner_scope_type,
+                   s.owner_scope_id,
+                   s.transport,
+                   s.config_json,
+                   s.created_by,
+                   s.updated_by,
+                   s.created_at,
+                   s.updated_at,
+                   CASE WHEN sec.server_id IS NULL THEN 0 ELSE 1 END AS secret_configured,
+                   sec.key_hint
+            FROM mcp_external_servers s
+            LEFT JOIN mcp_external_server_secrets sec ON sec.server_id = s.id
+            {where}
+            ORDER BY s.name, s.id
+            """,
+            tuple(params),
+        )
+        return [
+            self._normalize_external_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
+
+    async def delete_external_server(self, server_id: str) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_external_servers WHERE id = ?",
+            (server_id.strip(),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)
+
+    async def upsert_external_secret(
+        self,
+        server_id: str,
+        *,
+        encrypted_blob: str,
+        key_hint: str | None,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        ts = (
+            self._normalize_datetime_for_postgres(now)
+            if getattr(self.db_pool, "pool", None) is not None
+            else now.isoformat()
+        )
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_external_server_secrets (
+                server_id, encrypted_blob, key_hint, updated_by, updated_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(server_id) DO UPDATE SET
+                encrypted_blob = excluded.encrypted_blob,
+                key_hint = excluded.key_hint,
+                updated_by = excluded.updated_by,
+                updated_at = excluded.updated_at
+            """,
+            (
+                server_id.strip(),
+                encrypted_blob,
+                key_hint,
+                actor_id,
+                ts,
+            ),
+        )
+        row = await self.get_external_secret(server_id)
+        return row or {}
+
+    async def get_external_secret(self, server_id: str) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT server_id, encrypted_blob, key_hint, updated_by, updated_at
+            FROM mcp_external_server_secrets
+            WHERE server_id = ?
+            """,
+            (server_id.strip(),),
+        )
+        return self._row_to_dict(row) if row else None
+
+    async def clear_external_secret(self, server_id: str) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_external_server_secrets WHERE server_id = ?",
+            (server_id.strip(),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -5634,6 +5634,12 @@ elif _MINIMAL_TEST_APP:
             app.include_router(mcp_catalogs_manage_router, prefix=f"{API_V1_PREFIX}", tags=["mcp-catalogs"])
         except _IMPORT_EXCEPTIONS as _mcp_cat_err:
             logger.debug(f"Skipping MCP catalogs router in minimal test app: {_mcp_cat_err}")
+        try:
+            from tldw_Server_API.app.api.v1.endpoints.mcp_hub_management import router as mcp_hub_management_router
+
+            app.include_router(mcp_hub_management_router, prefix=f"{API_V1_PREFIX}", tags=["mcp-hub"])
+        except _IMPORT_EXCEPTIONS as _mcp_hub_err:
+            logger.debug(f"Skipping MCP hub router in minimal test app: {_mcp_hub_err}")
         # Privileges endpoints used by tests that introspect RBAC snapshots
         try:
             from tldw_Server_API.app.api.v1.endpoints.privileges import router as privileges_router
@@ -5807,10 +5813,12 @@ else:
         logger.warning(f"Admin endpoints unavailable at import time; deferring: {_admin_import_err}")
         admin_router = None  # type: ignore[assignment]
     from tldw_Server_API.app.api.v1.endpoints.mcp_catalogs_manage import router as mcp_catalogs_manage_router
+    from tldw_Server_API.app.api.v1.endpoints.mcp_hub_management import router as mcp_hub_management_router
 
     if admin_router is not None:
         _include_if_enabled("admin", admin_router, prefix=f"{API_V1_PREFIX}", tags=["admin"])
     _include_if_enabled("mcp-catalogs", mcp_catalogs_manage_router, prefix=f"{API_V1_PREFIX}")
+    _include_if_enabled("mcp-hub", mcp_hub_management_router, prefix=f"{API_V1_PREFIX}", tags=["mcp-hub"])
     # Self-service organization management endpoints
     try:
         from tldw_Server_API.app.api.v1.endpoints.orgs import router as orgs_router

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -261,9 +261,10 @@ class McpHubService:
                 metadata={"key_hint": stored.get("key_hint")},
             )
         )
+        secret_configured = bool(stored)
         return {
             "server_id": server_id,
-            "secret_configured": True,
+            "secret_configured": secret_configured,
             "key_hint": stored.get("key_hint"),
             "updated_at": stored.get("updated_at"),
         }

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -14,6 +14,10 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
     AuditEventType,
 )
+from tldw_Server_API.app.core.exceptions import (
+    BadRequestError,
+    ResourceNotFoundError,
+)
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     build_secret_payload,
@@ -63,6 +67,10 @@ async def emit_mcp_hub_audit(
         await svc.flush(raise_on_failure=False)
     except Exception as exc:
         logger.warning("MCP hub audit emission failed for action={}: {}", action, exc)
+
+
+class McpHubConflictError(BadRequestError):
+    """Raised when creating an MCP Hub resource would overwrite an existing one."""
 
 
 class McpHubService:
@@ -172,8 +180,12 @@ class McpHubService:
         owner_scope_id: int | None,
         enabled: bool,
         actor_id: int | None,
+        allow_existing: bool = False,
     ) -> dict[str, Any]:
+        """Create an external server definition, optionally allowing idempotent update behavior."""
         previous = await self.repo.get_external_server(server_id)
+        if previous is not None and not allow_existing:
+            raise McpHubConflictError(f"External server already exists: {server_id}")
         row = await self.repo.upsert_external_server(
             server_id=server_id,
             name=name,
@@ -203,6 +215,49 @@ class McpHubService:
             )
         )
         return row
+
+    async def update_external_server(
+        self,
+        server_id: str,
+        *,
+        name: str | None = None,
+        transport: str | None = None,
+        config: dict[str, Any] | None = None,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        enabled: bool | None = None,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        """Update an existing external server definition."""
+        existing = await self.repo.get_external_server(server_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_external_server", identifier=server_id)
+        existing_config: dict[str, Any] = {}
+        raw_config = existing.get("config_json")
+        if isinstance(raw_config, dict):
+            existing_config = dict(raw_config)
+        elif isinstance(raw_config, str) and raw_config.strip():
+            try:
+                parsed = json.loads(raw_config)
+                if isinstance(parsed, dict):
+                    existing_config = parsed
+            except (TypeError, ValueError):
+                existing_config = {}
+        return await self.create_external_server(
+            server_id=server_id,
+            name=name if name is not None else str(existing.get("name") or ""),
+            transport=transport if transport is not None else str(existing.get("transport") or ""),
+            config=config if config is not None else existing_config,
+            owner_scope_type=(
+                owner_scope_type
+                if owner_scope_type is not None
+                else str(existing.get("owner_scope_type") or "global")
+            ),
+            owner_scope_id=owner_scope_id if owner_scope_id is not None else existing.get("owner_scope_id"),
+            enabled=enabled if enabled is not None else bool(existing.get("enabled")),
+            actor_id=actor_id,
+            allow_existing=True,
+        )
 
     async def list_external_servers(
         self,
@@ -238,11 +293,11 @@ class McpHubService:
     ) -> dict[str, Any]:
         server = await self.repo.get_external_server(server_id)
         if not server:
-            raise ValueError("External server not found")
+            raise ResourceNotFoundError("mcp_external_server", identifier=server_id)
 
         secret = (secret_value or "").strip()
         if not secret:
-            raise ValueError("Secret value is required")
+            raise BadRequestError("Secret value is required")
 
         secret_payload = build_secret_payload(secret)
         envelope = encrypt_byok_payload(secret_payload)

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -243,11 +243,11 @@ class McpHubService:
                     existing_config = parsed
             except (TypeError, ValueError):
                 existing_config = {}
-        return await self.create_external_server(
-            server_id=server_id,
+        row = await self.repo.update_external_server(
+            server_id,
             name=name if name is not None else str(existing.get("name") or ""),
             transport=transport if transport is not None else str(existing.get("transport") or ""),
-            config=config if config is not None else existing_config,
+            config_json=json.dumps(config if config is not None else existing_config),
             owner_scope_type=(
                 owner_scope_type
                 if owner_scope_type is not None
@@ -256,8 +256,23 @@ class McpHubService:
             owner_scope_id=owner_scope_id if owner_scope_id is not None else existing.get("owner_scope_id"),
             enabled=enabled if enabled is not None else bool(existing.get("enabled")),
             actor_id=actor_id,
-            allow_existing=True,
         )
+        if not row:
+            raise ResourceNotFoundError("mcp_external_server", identifier=server_id)
+        await _await_if_needed(
+            emit_mcp_hub_audit(
+                action="mcp_hub.external_server.update",
+                actor_id=actor_id,
+                resource_type="mcp_external_server",
+                resource_id=server_id,
+                metadata={
+                    "name": row.get("name"),
+                    "transport": row.get("transport"),
+                    "enabled": row.get("enabled"),
+                },
+            )
+        )
+        return row
 
     async def list_external_servers(
         self,

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
+    get_or_create_audit_service_for_user_id_optional,
+)
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditContext,
+    AuditEventCategory,
+    AuditEventType,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    build_secret_payload,
+    dumps_envelope,
+    encrypt_byok_payload,
+    key_hint_for_api_key,
+)
+
+
+async def _await_if_needed(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def emit_mcp_hub_audit(
+    *,
+    action: str,
+    actor_id: int | None,
+    resource_type: str,
+    resource_id: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Best-effort audit emitter for MCP Hub mutations."""
+    try:
+        svc = await get_or_create_audit_service_for_user_id_optional(actor_id)
+        ctx = AuditContext(
+            user_id=str(actor_id) if actor_id is not None else None,
+            endpoint="/api/v1/mcp/hub",
+            method="INTERNAL",
+        )
+        await svc.log_event(
+            event_type=AuditEventType.CONFIG_CHANGED,
+            category=AuditEventCategory.SYSTEM,
+            context=ctx,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            metadata={
+                "actor_id": actor_id,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "action": action,
+                **(metadata or {}),
+            },
+        )
+        await svc.flush(raise_on_failure=False)
+    except Exception as exc:
+        logger.warning("MCP hub audit emission failed for action={}: {}", action, exc)
+
+
+class McpHubService:
+    """Business logic for MCP Hub profile and external server management."""
+
+    def __init__(self, repo: McpHubRepo):
+        self.repo = repo
+
+    async def create_acp_profile(
+        self,
+        *,
+        name: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        profile: dict[str, Any],
+        actor_id: int | None,
+        description: str | None = None,
+        is_active: bool = True,
+    ) -> dict[str, Any]:
+        row = await self.repo.create_acp_profile(
+            name=name,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            profile_json=json.dumps(profile or {}),
+            actor_id=actor_id,
+            description=description,
+            is_active=is_active,
+        )
+        await _await_if_needed(
+            emit_mcp_hub_audit(
+                action="mcp_hub.acp_profile.create",
+                actor_id=actor_id,
+                resource_type="mcp_acp_profile",
+                resource_id=str(row.get("id") or ""),
+                metadata={"name": row.get("name"), "owner_scope_type": row.get("owner_scope_type")},
+            )
+        )
+        return row
+
+    async def list_acp_profiles(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return await self.repo.list_acp_profiles(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def update_acp_profile(
+        self,
+        profile_id: int,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        profile: dict[str, Any] | None = None,
+        is_active: bool | None = None,
+        actor_id: int | None = None,
+    ) -> dict[str, Any] | None:
+        row = await self.repo.update_acp_profile(
+            profile_id,
+            name=name,
+            description=description,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            profile_json=json.dumps(profile) if profile is not None else None,
+            is_active=is_active,
+            actor_id=actor_id,
+        )
+        if row:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.acp_profile.update",
+                    actor_id=actor_id,
+                    resource_type="mcp_acp_profile",
+                    resource_id=str(row.get("id") or profile_id),
+                    metadata={"name": row.get("name"), "owner_scope_type": row.get("owner_scope_type")},
+                )
+            )
+        return row
+
+    async def delete_acp_profile(self, profile_id: int, *, actor_id: int | None) -> bool:
+        deleted = await self.repo.delete_acp_profile(profile_id)
+        if deleted:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.acp_profile.delete",
+                    actor_id=actor_id,
+                    resource_type="mcp_acp_profile",
+                    resource_id=str(profile_id),
+                    metadata=None,
+                )
+            )
+        return deleted
+
+    async def create_external_server(
+        self,
+        *,
+        server_id: str,
+        name: str,
+        transport: str,
+        config: dict[str, Any],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        enabled: bool,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        previous = await self.repo.get_external_server(server_id)
+        row = await self.repo.upsert_external_server(
+            server_id=server_id,
+            name=name,
+            transport=transport,
+            config_json=json.dumps(config or {}),
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            enabled=enabled,
+            actor_id=actor_id,
+        )
+        action = (
+            "mcp_hub.external_server.create"
+            if previous is None
+            else "mcp_hub.external_server.update"
+        )
+        await _await_if_needed(
+            emit_mcp_hub_audit(
+                action=action,
+                actor_id=actor_id,
+                resource_type="mcp_external_server",
+                resource_id=server_id,
+                metadata={
+                    "name": row.get("name"),
+                    "transport": row.get("transport"),
+                    "enabled": row.get("enabled"),
+                },
+            )
+        )
+        return row
+
+    async def list_external_servers(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return await self.repo.list_external_servers(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def delete_external_server(self, server_id: str, *, actor_id: int | None) -> bool:
+        deleted = await self.repo.delete_external_server(server_id)
+        if deleted:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.external_server.delete",
+                    actor_id=actor_id,
+                    resource_type="mcp_external_server",
+                    resource_id=server_id,
+                    metadata=None,
+                )
+            )
+        return deleted
+
+    async def set_external_server_secret(
+        self,
+        *,
+        server_id: str,
+        secret_value: str,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        server = await self.repo.get_external_server(server_id)
+        if not server:
+            raise ValueError("External server not found")
+
+        secret = (secret_value or "").strip()
+        if not secret:
+            raise ValueError("Secret value is required")
+
+        secret_payload = build_secret_payload(secret)
+        envelope = encrypt_byok_payload(secret_payload)
+        stored = await self.repo.upsert_external_secret(
+            server_id=server_id,
+            encrypted_blob=dumps_envelope(envelope),
+            key_hint=key_hint_for_api_key(secret),
+            actor_id=actor_id,
+        )
+        await _await_if_needed(
+            emit_mcp_hub_audit(
+                action="mcp_hub.external_secret.update",
+                actor_id=actor_id,
+                resource_type="mcp_external_server",
+                resource_id=server_id,
+                metadata={"key_hint": stored.get("key_hint")},
+            )
+        )
+        return {
+            "server_id": server_id,
+            "secret_configured": True,
+            "key_hint": stored.get("key_hint"),
+            "updated_at": stored.get("updated_at"),
+        }
+
+    async def clear_external_server_secret(
+        self,
+        *,
+        server_id: str,
+        actor_id: int | None,
+    ) -> bool:
+        cleared = await self.repo.clear_external_secret(server_id)
+        if cleared:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.external_secret.clear",
+                    actor_id=actor_id,
+                    resource_type="mcp_external_server",
+                    resource_id=server_id,
+                    metadata=None,
+                )
+            )
+        return cleared

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) -> None:
+    from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+        ensure_mcp_hub_tables_pg,
+    )
+
+    assert await ensure_mcp_hub_tables_pg(test_db_pool)
+
+    rows = await test_db_pool.fetch(
+        """
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name IN (
+            'mcp_acp_profiles',
+            'mcp_external_servers',
+            'mcp_external_server_secrets'
+          )
+        """
+    )
+    names = {str(row["table_name"]) for row in rows}
+
+    assert "mcp_acp_profiles" in names
+    assert "mcp_external_servers" in names
+    assert "mcp_external_server_secrets" in names
+

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mcp_hub_tables_exist_after_authnz_migrations_sqlite(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(pool.db_path))
+
+    rows = await pool.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    names = {str(row["name"]) for row in rows}
+
+    assert "mcp_acp_profiles" in names
+    assert "mcp_external_servers" in names
+    assert "mcp_external_server_secrets" in names
+

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_permissions_claims.py
@@ -11,10 +11,20 @@ from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management as mcp_hub_mod
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError
 
 
 class _FakeService:
+    def __init__(self) -> None:
+        self.acp_calls: list[dict[str, Any]] = []
+        self.external_calls: list[dict[str, Any]] = []
+
+    async def list_acp_profiles(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.acp_calls.append(kwargs)
+        return []
+
     async def list_external_servers(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        self.external_calls.append(dict(_kwargs))
         return []
 
     async def create_external_server(self, **_kwargs: Any) -> dict[str, Any]:
@@ -51,21 +61,22 @@ def _principal(*, roles: list[str] | None = None, permissions: list[str] | None 
     )
 
 
-def _build_app(principal: AuthPrincipal) -> FastAPI:
+def _build_app(principal: AuthPrincipal) -> tuple[FastAPI, _FakeService]:
     app = FastAPI()
     app.include_router(mcp_hub_mod.router, prefix="/api/v1")
+    fake_service = _FakeService()
 
     async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
         return principal
 
     app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
-    app.dependency_overrides[mcp_hub_mod.get_mcp_hub_service] = lambda: _FakeService()
-    return app
+    app.dependency_overrides[mcp_hub_mod.get_mcp_hub_service] = lambda: fake_service
+    return app, fake_service
 
 
 @pytest.mark.asyncio
 async def test_authenticated_user_can_view_hub_lists_but_cannot_mutate_without_claims() -> None:
-    app = _build_app(_principal(roles=["user"], permissions=[]))
+    app, _ = _build_app(_principal(roles=["user"], permissions=[]))
     with TestClient(app) as client:
         get_resp = client.get("/api/v1/mcp/hub/external-servers")
         post_resp = client.post(
@@ -86,7 +97,7 @@ async def test_authenticated_user_can_view_hub_lists_but_cannot_mutate_without_c
 
 @pytest.mark.asyncio
 async def test_authenticated_user_with_system_configure_can_mutate() -> None:
-    app = _build_app(_principal(roles=["user"], permissions=[SYSTEM_CONFIGURE]))
+    app, _ = _build_app(_principal(roles=["user"], permissions=[SYSTEM_CONFIGURE]))
     with TestClient(app) as client:
         post_resp = client.post(
             "/api/v1/mcp/hub/external-servers",
@@ -100,3 +111,73 @@ async def test_authenticated_user_with_system_configure_can_mutate() -> None:
             },
         )
     assert post_resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_non_admin_default_list_queries_are_scope_bounded() -> None:
+    principal = _principal(roles=["user"], permissions=[])
+    principal.org_ids = [7]
+    principal.team_ids = [9]
+    app, svc = _build_app(principal)
+
+    with TestClient(app) as client:
+        acp_resp = client.get("/api/v1/mcp/hub/acp-profiles")
+        ext_resp = client.get("/api/v1/mcp/hub/external-servers")
+
+    assert acp_resp.status_code == 200
+    assert ext_resp.status_code == 200
+
+    assert {"owner_scope_type": "global", "owner_scope_id": None} in svc.acp_calls
+    assert {"owner_scope_type": "user", "owner_scope_id": 1} in svc.acp_calls
+    assert {"owner_scope_type": "org", "owner_scope_id": 7} in svc.acp_calls
+    assert {"owner_scope_type": "team", "owner_scope_id": 9} in svc.acp_calls
+
+    assert {"owner_scope_type": "global", "owner_scope_id": None} in svc.external_calls
+    assert {"owner_scope_type": "user", "owner_scope_id": 1} in svc.external_calls
+    assert {"owner_scope_type": "org", "owner_scope_id": 7} in svc.external_calls
+    assert {"owner_scope_type": "team", "owner_scope_id": 9} in svc.external_calls
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_query_other_scope_ids() -> None:
+    principal = _principal(roles=["user"], permissions=[])
+    principal.org_ids = [7]
+    app, _ = _build_app(principal)
+
+    with TestClient(app) as client:
+        forbidden = client.get("/api/v1/mcp/hub/external-servers?owner_scope_type=org&owner_scope_id=999")
+        denied_user = client.get("/api/v1/mcp/hub/acp-profiles?owner_scope_type=user&owner_scope_id=2")
+
+    assert forbidden.status_code == 403
+    assert denied_user.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_external_server_conflict_maps_to_409() -> None:
+    class _ConflictService(_FakeService):
+        async def create_external_server(self, **_kwargs: Any) -> dict[str, Any]:
+            raise McpHubConflictError("External server already exists: docs")
+
+    app = FastAPI()
+    app.include_router(mcp_hub_mod.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        return _principal(roles=["user"], permissions=[SYSTEM_CONFIGURE])
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[mcp_hub_mod.get_mcp_hub_service] = lambda: _ConflictService()
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/external-servers",
+            json={
+                "server_id": "docs",
+                "name": "Docs",
+                "transport": "stdio",
+                "config": {"cmd": "npx"},
+                "owner_scope_type": "global",
+                "enabled": True,
+            },
+        )
+
+    assert resp.status_code == 409

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_permissions_claims.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management as mcp_hub_mod
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+class _FakeService:
+    async def list_external_servers(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    async def create_external_server(self, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "id": "docs",
+            "name": "Docs",
+            "enabled": True,
+            "owner_scope_type": "global",
+            "owner_scope_id": None,
+            "transport": "stdio",
+            "config_json": "{}",
+            "secret_configured": False,
+            "key_hint": None,
+            "created_by": 1,
+            "updated_by": 1,
+            "created_at": None,
+            "updated_at": None,
+        }
+
+
+def _principal(*, roles: list[str] | None = None, permissions: list[str] | None = None) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject="1",
+        token_type="access",
+        jti=None,
+        roles=roles or ["user"],
+        permissions=permissions or [],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+def _build_app(principal: AuthPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.include_router(mcp_hub_mod.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[mcp_hub_mod.get_mcp_hub_service] = lambda: _FakeService()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_authenticated_user_can_view_hub_lists_but_cannot_mutate_without_claims() -> None:
+    app = _build_app(_principal(roles=["user"], permissions=[]))
+    with TestClient(app) as client:
+        get_resp = client.get("/api/v1/mcp/hub/external-servers")
+        post_resp = client.post(
+            "/api/v1/mcp/hub/external-servers",
+            json={
+                "server_id": "docs",
+                "name": "Docs",
+                "transport": "stdio",
+                "config": {"cmd": "npx"},
+                "owner_scope_type": "global",
+                "enabled": True,
+            },
+        )
+    assert get_resp.status_code == 200
+    assert post_resp.status_code == 403
+    assert SYSTEM_CONFIGURE in post_resp.json().get("detail", "")
+
+
+@pytest.mark.asyncio
+async def test_authenticated_user_with_system_configure_can_mutate() -> None:
+    app = _build_app(_principal(roles=["user"], permissions=[SYSTEM_CONFIGURE]))
+    with TestClient(app) as client:
+        post_resp = client.post(
+            "/api/v1/mcp/hub/external-servers",
+            json={
+                "server_id": "docs",
+                "name": "Docs",
+                "transport": "stdio",
+                "config": {"cmd": "npx"},
+                "owner_scope_type": "global",
+                "enabled": True,
+            },
+        )
+    assert post_resp.status_code == 201

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+@pytest.mark.asyncio
+async def test_repo_can_crud_acp_profile(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    created = await repo.create_acp_profile(
+        name="default-dev",
+        owner_scope_type="org",
+        owner_scope_id=42,
+        profile_json='{"sandbox":"strict"}',
+        actor_id=1,
+    )
+    assert created["name"] == "default-dev"
+
+    fetched = await repo.get_acp_profile(int(created["id"]))
+    assert fetched is not None
+    assert fetched["name"] == "default-dev"
+    assert fetched["owner_scope_type"] == "org"
+    assert int(fetched["owner_scope_id"]) == 42
+
+    listed = await repo.list_acp_profiles(owner_scope_type="org", owner_scope_id=42)
+    assert len(listed) == 1
+    assert listed[0]["name"] == "default-dev"
+
+    updated = await repo.update_acp_profile(
+        int(created["id"]),
+        name="default-prod",
+        profile_json='{"sandbox":"relaxed"}',
+        is_active=False,
+        actor_id=2,
+    )
+    assert updated is not None
+    assert updated["name"] == "default-prod"
+    assert updated["is_active"] is False
+
+    deleted = await repo.delete_acp_profile(int(created["id"]))
+    assert deleted is True
+    missing = await repo.get_acp_profile(int(created["id"]))
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_repo_external_server_secret_is_stored_separately(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="stdio",
+        config_json='{"cmd":"npx"}',
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.upsert_external_secret(
+        server_id="docs",
+        encrypted_blob='{"ciphertext":"abc"}',
+        key_hint="cdef",
+        actor_id=1,
+    )
+
+    row = await repo.get_external_server("docs")
+    assert row is not None
+    assert row["id"] == "docs"
+    assert row["secret_configured"] is True
+    assert "encrypted_blob" not in row
+
+    secret = await repo.get_external_secret("docs")
+    assert secret is not None
+    assert secret["server_id"] == "docs"
+    assert secret["encrypted_blob"] == '{"ciphertext":"abc"}'

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+import pytest
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+def _make_principal(
+    *,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject="1",
+        token_type="access",
+        jti=None,
+        roles=roles or [],
+        permissions=permissions or [],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+class _FakeService:
+    async def list_acp_profiles(self, **_kwargs: Any) -> list[dict[str, Any]]:
+        return []
+
+    async def set_external_server_secret(self, *, server_id: str, secret_value: str, actor_id: int | None):
+        assert actor_id == 1
+        assert server_id == "docs"
+        assert secret_value == "abc123secret"
+        return {
+            "server_id": server_id,
+            "secret_configured": True,
+            "key_hint": "cdef",
+            "updated_at": None,
+        }
+
+
+def _build_app(
+    *,
+    principal: AuthPrincipal | None,
+    fail_with_401: bool,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(mcp_hub_management.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        if fail_with_401:
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        assert principal is not None
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_service] = lambda: _FakeService()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_hub_profiles_requires_auth() -> None:
+    app = _build_app(principal=None, fail_with_401=True)
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/acp-profiles")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_set_external_secret_returns_masked_only() -> None:
+    app = _build_app(
+        principal=_make_principal(roles=["admin"], permissions=[]),
+        fail_with_401=False,
+    )
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/external-servers/docs/secret",
+            json={"secret": "abc123secret"},
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["secret_configured"] is True
+    assert "abc123secret" not in json.dumps(payload)

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
 
 
 def _make_principal(
@@ -96,3 +97,41 @@ async def test_set_external_secret_returns_masked_only() -> None:
     payload = resp.json()
     assert payload["secret_configured"] is True
     assert "abc123secret" not in json.dumps(payload)
+
+
+@pytest.mark.asyncio
+async def test_set_external_secret_not_found_maps_to_404() -> None:
+    class _MissingService(_FakeService):
+        async def set_external_server_secret(self, *, server_id: str, secret_value: str, actor_id: int | None):
+            raise ResourceNotFoundError("mcp_external_server", identifier=server_id)
+
+    app = _build_app(
+        principal=_make_principal(roles=["admin"], permissions=[]),
+        fail_with_401=False,
+    )
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_service] = lambda: _MissingService()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/external-servers/docs/secret",
+            json={"secret": "abc123secret"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_set_external_secret_bad_request_maps_to_400() -> None:
+    class _BadPayloadService(_FakeService):
+        async def set_external_server_secret(self, *, server_id: str, secret_value: str, actor_id: int | None):
+            raise BadRequestError("Secret value is required")
+
+    app = _build_app(
+        principal=_make_principal(roles=["admin"], permissions=[]),
+        fail_with_401=False,
+    )
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_service] = lambda: _BadPayloadService()
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/external-servers/docs/secret",
+            json={"secret": "abc123secret"},
+        )
+    assert resp.status_code == 400

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+@pytest.mark.asyncio
+async def test_set_external_secret_encrypts_and_never_returns_plaintext(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_hub_service import McpHubService
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    svc = McpHubService(repo=repo)
+
+    await svc.create_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="stdio",
+        config={"cmd": "npx"},
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    out = await svc.set_external_server_secret(
+        server_id="docs",
+        secret_value="super-secret-token",
+        actor_id=1,
+    )
+
+    assert out["secret_configured"] is True
+    assert "super-secret-token" not in json.dumps(out)
+
+    secret = await repo.get_external_secret("docs")
+    assert secret is not None
+    assert "super-secret-token" not in json.dumps(secret)
+
+
+@pytest.mark.asyncio
+async def test_service_emits_audit_event_on_external_server_update(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_hub_service import McpHubService
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    calls: list[dict[str, object]] = []
+
+    def _capture(**kwargs):
+        calls.append(kwargs)
+        return None
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.mcp_hub_service.emit_mcp_hub_audit",
+        _capture,
+    )
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    svc = McpHubService(repo=repo)
+
+    await svc.create_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="stdio",
+        config={"cmd": "npx"},
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+
+    assert calls
+    assert calls[0]["action"] == "mcp_hub.external_server.create"

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
@@ -107,3 +107,49 @@ async def test_service_emits_audit_event_on_external_server_update(tmp_path, mon
 
     assert calls
     assert calls[0]["action"] == "mcp_hub.external_server.create"
+
+
+@pytest.mark.asyncio
+async def test_create_external_server_raises_conflict_without_allow_existing(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError, McpHubService
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    svc = McpHubService(repo=repo)
+
+    await svc.create_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="stdio",
+        config={"cmd": "npx"},
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+
+    with pytest.raises(McpHubConflictError):
+        await svc.create_external_server(
+            server_id="docs",
+            name="Docs Updated",
+            transport="stdio",
+            config={"cmd": "npx"},
+            owner_scope_type="global",
+            owner_scope_id=None,
+            enabled=True,
+            actor_id=1,
+        )


### PR DESCRIPTION
## Summary
- add MCP Hub backend control-plane support for ACP profiles and external server registry (SQLite + Postgres migration coverage)
- add MCP Hub service layer with encrypted secret storage, masked secret responses, and audit event emission for mutations
- add MCP Hub REST endpoints under `/api/v1/mcp/hub/*` with authenticated read access and claim-gated mutations (`system.configure`, `*`, or admin role)
- add shared WebUI/extension MCP Hub page with tabs for ACP Profiles, Tool Catalogs, and External Servers
- wire MCP Hub routes at both `/mcp-hub` and `/settings/mcp-hub`, plus settings index and locale/navigation entries
- document MCP Hub routes, API surface, and permission model in MCP docs and README key endpoints

## Implementation Details
- backend additions:
  - `tldw_Server_API/app/core/AuthNZ/migrations.py`
  - `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
  - `tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py`
  - `tldw_Server_API/app/services/mcp_hub_service.py`
  - `tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py`
  - `tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py`
  - `tldw_Server_API/app/main.py` route wiring
- frontend additions:
  - `apps/packages/ui/src/components/Option/MCPHub/*`
  - `apps/packages/ui/src/routes/option-mcp-hub.tsx`
  - `apps/tldw-frontend/pages/mcp-hub.tsx`
  - `apps/tldw-frontend/pages/settings/mcp-hub.tsx`

## Security
- remediated Bandit findings in touched MCP Hub backend paths:
  - removed `try/except/pass` flow
  - replaced dynamic SQL interpolation patterns in list queries with parameterized nullable filters
  - adjusted secret response boolean construction to avoid false-positive hardcoded-password signature

## Verification
- backend MCP Hub suite:
  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -v tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_permissions_claims.py`
  - result: `9 passed, 1 skipped`
- frontend MCP Hub targeted tests:
  - `bun run vitest run src/services/tldw/__tests__/mcp-hub.test.ts src/components/Option/MCPHub/__tests__/AcpProfilesTab.test.tsx src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx src/routes/__tests__/mcp-hub-route.test.tsx`
  - result: `5 passed`
- bandit:
  - `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/mcp_hub_service.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py tldw_Server_API/app/core/AuthNZ/migrations.py tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py -f json -o /tmp/bandit_mcp_hub_20260303.json`
  - result: `0 findings`
