### PR TITLE
docs(kanban): document safe workflow-control primitives and MCP skill

### DIFF
--- a/Docs/MCP/Unified/User_Guide.md
+++ b/Docs/MCP/Unified/User_Guide.md
@@ -383,7 +383,83 @@ Catalog membership affects discovery, not execution rights.
 
 Reference: `Docs/MCP/mcp_tool_catalogs.md`
 
-## 11. Troubleshooting
+## 11. Kanban Workflow Control (Safe Orchestrators)
+
+The Kanban MCP module now exposes a workflow control plane intended for safe orchestrator loops.
+
+### Canonical state model
+
+- `card.workflow_status` is the canonical orchestrator state (`kanban_card_workflow_state.workflow_status_key`).
+- Card list placement is a projection side effect (`auto_move_list_id`) and can be strict (`strict_projection=true`) or best-effort (`false`).
+- Do not infer workflow status from list placement.
+
+### Workflow tools
+
+- `kanban.workflow.policy.get`
+- `kanban.workflow.policy.upsert`
+- `kanban.workflow.statuses.list`
+- `kanban.workflow.transitions.list`
+- `kanban.workflow.task.state.get`
+- `kanban.workflow.task.state.patch`
+- `kanban.workflow.task.claim`
+- `kanban.workflow.task.release`
+- `kanban.workflow.task.transition`
+- `kanban.workflow.task.approval.decide`
+- `kanban.workflow.task.events.list`
+- `kanban.workflow.control.pause` (admin)
+- `kanban.workflow.control.resume` (admin)
+- `kanban.workflow.control.drain` (admin)
+- `kanban.workflow.recovery.list_stale_claims`
+- `kanban.workflow.recovery.force_reassign` (admin)
+
+### Write safety contract
+
+For orchestrator writes, use optimistic concurrency and idempotency consistently:
+
+- Always pass `expected_version` on status mutation calls.
+- Always pass a unique `idempotency_key` per intent.
+- Pass `correlation_id` for traceability across multi-step runs (required on transition, approval, and force-reassign).
+- Re-read state (`kanban.workflow.task.state.get`) before retries.
+
+### Stable conflict codes
+
+Workflow conflict responses surface machine-readable codes in `detail.code`:
+
+- `version_conflict`
+- `lease_required`
+- `lease_mismatch`
+- `policy_paused`
+- `transition_not_allowed`
+- `approval_required`
+- `projection_failed`
+- `idempotency_conflict`
+
+Recommended handling:
+
+- `version_conflict`: refresh state and retry once with new `expected_version`.
+- `lease_required`: claim lease, then retry transition.
+- `policy_paused`: stop writes; wait for admin resume.
+- `transition_not_allowed`/`approval_required`: treat as logic/state errors, not transient retries.
+- `projection_failed`: repair target list mapping or disable strict projection if appropriate.
+
+### Recommended loop (explicit, not implicit)
+
+There is no built-in autonomous multi-stage agent loop. The safe pattern is explicit orchestration:
+
+1. Get state (`kanban.workflow.task.state.get`).
+2. Claim lease (`kanban.workflow.task.claim`) when required by policy edge.
+3. Transition (`kanban.workflow.task.transition`) with `expected_version`, `idempotency_key`, and `correlation_id`.
+4. If `approval_state=awaiting_approval`, decide (`kanban.workflow.task.approval.decide`) explicitly.
+5. Inspect audit trail (`kanban.workflow.task.events.list`) for deterministic recovery.
+6. Release lease (`kanban.workflow.task.release`) when work completes.
+
+### Control and recovery
+
+- Use `pause`/`resume`/`drain` to gate orchestrator writes during incidents, migrations, or maintenance.
+- Use stale-claim listing plus force-reassign to recover orphaned leases.
+- Keep privileged operations behind admin-only identities.
+
+## 12. Troubleshooting
 
 ### `503 Server not initialized` on `/health`
 
@@ -411,7 +487,7 @@ Reference: `Docs/MCP/mcp_tool_catalogs.md`
 - If close reason is auth related, verify token/key and `MCP_WS_AUTH_REQUIRED`
 - If close reason is origin/IP related, review `MCP_WS_ALLOWED_ORIGINS`, `MCP_ALLOWED_IPS`, and proxy setup
 
-## 12. Next Docs
+## 13. Next Docs
 
 - Architecture and internals: `Docs/MCP/Unified/Developer_Guide.md`
 - Deployment and hardening: `Docs/MCP/Unified/System_Admin_Guide.md`

--- a/Docs/MCP/mcp_tool_catalogs.md
+++ b/Docs/MCP/mcp_tool_catalogs.md
@@ -84,6 +84,25 @@ JSON-RPC Usage
 }
 ```
 
+Recommended Catalog: `kanban-safe-orchestrator`
+- Use this catalog to expose only workflow-control primitives to autonomous agents.
+- Suggested entries:
+  - `kanban.workflow.policy.get`
+  - `kanban.workflow.statuses.list`
+  - `kanban.workflow.transitions.list`
+  - `kanban.workflow.task.state.get`
+  - `kanban.workflow.task.claim`
+  - `kanban.workflow.task.transition`
+  - `kanban.workflow.task.approval.decide`
+  - `kanban.workflow.task.release`
+  - `kanban.workflow.task.events.list`
+- Add admin-only controls/recovery tools only for operator identities:
+  - `kanban.workflow.control.pause`
+  - `kanban.workflow.control.resume`
+  - `kanban.workflow.control.drain`
+  - `kanban.workflow.recovery.list_stale_claims`
+  - `kanban.workflow.recovery.force_reassign`
+
 Migration
 - Add migration 022 to AuthNZ migrations (SQLite) to create the two tables (with indexes/constraints above).
 - Future: add Postgres DDL to `Databases/Postgres/Schema` and include in PG init path.

--- a/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-design.md
+++ b/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-design.md
@@ -1,0 +1,349 @@
+# Kanban Safe Orchestrator Workflow Primitives Design
+
+Date: 2026-03-04  
+Status: Approved (brainstorming)
+
+## Goal
+
+Expose a complete, policy-enforced workflow-control surface for Kanban tasks so autonomous orchestrators can safely run multi-stage pipelines with deterministic transitions, strict concurrency control, and full auditability.
+
+This design explicitly separates workflow state from board lane placement:
+
+- Source of truth: `card.workflow_status` (runtime state table)
+- Projection: optional status-to-list mapping applied during transitions
+
+## Scope
+
+In scope:
+
+- Explicit workflow policy model per board
+- Explicit task workflow runtime-state model
+- Explicit transition and approval primitives with server-side enforcement
+- Lease/claim controls for exclusive task ownership
+- Immutable workflow event stream
+- Pause/resume/drain operational controls
+- Recovery primitives for stale claims
+- MCP tooling surface for the above
+
+Out of scope:
+
+- Full implementation details for UI workflows
+- Automatic migration of existing boards into policy-backed workflows
+- Cross-board/global orchestration policy inheritance
+
+## Current-State Summary
+
+Current Kanban API/DB support includes optimistic locking on selected updates, archive/delete/restore mechanics, metadata blobs, and activity logs. However, there is no first-class workflow engine with centralized transition-policy enforcement, nor a complete MCP surface for orchestrator-safe control.
+
+## Design Decisions (Locked)
+
+1. Workflow state model
+- Store workflow state explicitly and independently of `list_id`.
+- `workflow_status` is canonical.
+
+2. Lane behavior
+- Use status-driven projection.
+- Status transitions may auto-move cards to mapped lists.
+- Manual list moves do not mutate status.
+
+3. Policy storage
+- Use dedicated relational policy tables (not free-form metadata).
+
+4. Transition representation
+- Use normalized transition edges table.
+
+5. Runtime task state
+- Use dedicated `kanban_card_workflow_state` table.
+
+6. Audit history
+- Use dedicated append-only `kanban_card_workflow_events` table.
+
+7. Projection failures
+- Transition fails if configured projection target list is invalid (missing/archived).
+
+8. Lease enforcement
+- Strict lease requirement for workflow-mutating operations (except explicit admin override path).
+
+9. Idempotency
+- DB-enforced idempotency key storage and uniqueness for workflow-mutating ops.
+
+10. Review gates
+- First-class approval records and approval actions.
+
+11. Rejection routing
+- Policy-defined reject target per gated transition.
+
+12. Status vocabulary
+- Per-board status catalog (not fixed global enum).
+
+## Data Model
+
+### 1) `board_workflow_policies`
+
+One active workflow policy per board.
+
+Representative fields:
+
+- `id` PK
+- `board_id` UNIQUE FK
+- `version` (policy version)
+- `is_paused` bool
+- `is_draining` bool
+- `default_lease_ttl_sec` int
+- `strict_projection` bool (default true)
+- `created_at`, `updated_at`
+
+### 2) `board_workflow_statuses`
+
+Per-board status catalog.
+
+Representative fields:
+
+- `id` PK
+- `policy_id` FK
+- `status_key` (machine key)
+- `display_name`
+- `is_terminal` bool
+- `sort_order` int
+- `is_active` bool
+
+Constraints:
+
+- UNIQUE(`policy_id`, `status_key`)
+
+### 3) `board_workflow_transitions`
+
+Normalized allowed edges and gate behavior.
+
+Representative fields:
+
+- `id` PK
+- `policy_id` FK
+- `from_status_key`
+- `to_status_key`
+- `requires_claim` bool
+- `requires_approval` bool
+- `approve_to_status_key` nullable
+- `reject_to_status_key` nullable
+- `auto_move_list_id` nullable FK to list
+- `max_retries` int
+- `is_active` bool
+
+Constraints:
+
+- UNIQUE(`policy_id`, `from_status_key`, `to_status_key`)
+
+### 4) `kanban_card_workflow_state`
+
+Canonical runtime state for each card.
+
+Representative fields:
+
+- `card_id` PK FK
+- `policy_id` FK
+- `workflow_status_key`
+- `lease_owner` nullable
+- `lease_expires_at` nullable
+- `approval_state` enum-like (`none|awaiting_approval|approved|rejected`)
+- `pending_transition_id` nullable
+- `retry_counters` JSON
+- `last_transition_at` nullable
+- `last_actor` nullable
+- `version` int
+
+### 5) `kanban_card_workflow_events` (append-only)
+
+Immutable workflow audit trail.
+
+Representative fields:
+
+- `id` PK
+- `card_id` FK
+- `event_type`
+- `from_status_key` nullable
+- `to_status_key` nullable
+- `actor`
+- `reason` nullable
+- `idempotency_key`
+- `correlation_id` nullable
+- `before_snapshot` JSON
+- `after_snapshot` JSON
+- `created_at`
+
+Constraints:
+
+- UNIQUE(`card_id`, `event_type`, `idempotency_key`)
+
+### 6) `kanban_card_workflow_approvals`
+
+First-class approval records.
+
+Representative fields:
+
+- `id` PK
+- `card_id` FK
+- `transition_id` FK
+- `state` (`pending|approved|rejected`)
+- `reviewer`
+- `decision_reason` nullable
+- `created_at`, `updated_at`
+
+## Server-Side Safety Contract
+
+## Transition command (`workflow.task.transition`)
+
+Must be atomic and enforce all of the following in one transaction:
+
+- policy not paused/draining-blocked
+- lease ownership valid (unless explicit admin override primitive is used)
+- edge allowed by policy
+- expected version matches
+- approval gate requirements
+- projection target list validity when `auto_move_list_id` is configured
+
+On success:
+
+- update `kanban_card_workflow_state`
+- apply optional list projection
+- append workflow event
+- increment state version
+
+### Approval flow
+
+If transition requires approval:
+
+- create pending approval record
+- set `approval_state=awaiting_approval`
+- do not finalize status advance until decision
+
+Approval decision primitive (`workflow.task.approval.decide`):
+
+- `approved` routes to `approve_to_status_key`
+- `rejected` routes to `reject_to_status_key`
+- both append immutable events and increment version
+
+### Lease model
+
+- `claim` acquires or renews lease (`lease_owner`, `lease_expires_at`)
+- `release` clears lease
+- stale-lease recovery through dedicated recovery/admin primitives
+- strict lease requirement for workflow-mutating calls
+
+### Idempotency and CAS
+
+All workflow-mutating operations require:
+
+- `expected_version`
+- `idempotency_key`
+
+Idempotency is persisted in DB constraints (not cache-only).
+
+### Stable machine error reasons
+
+- `version_conflict`
+- `lease_required`
+- `lease_mismatch`
+- `policy_paused`
+- `transition_not_allowed`
+- `approval_required`
+- `projection_failed`
+- `idempotency_conflict`
+
+## MCP Primitive Surface
+
+Policy/config:
+
+- `kanban.workflow.policy.get`
+- `kanban.workflow.policy.upsert`
+- `kanban.workflow.statuses.list`
+- `kanban.workflow.transitions.list`
+
+Task runtime state:
+
+- `kanban.workflow.task.state.get`
+- `kanban.workflow.task.state.patch` (allowlisted mutable fields only)
+
+Execution control:
+
+- `kanban.workflow.task.claim`
+- `kanban.workflow.task.release`
+- `kanban.workflow.task.transition`
+- `kanban.workflow.task.approval.decide`
+
+Observability/recovery:
+
+- `kanban.workflow.task.events.list`
+- `kanban.workflow.control.pause`
+- `kanban.workflow.control.resume`
+- `kanban.workflow.control.drain`
+- `kanban.workflow.recovery.list_stale_claims`
+- `kanban.workflow.recovery.force_reassign` (admin-only)
+
+Write-tool argument requirements:
+
+- `expected_version`
+- `idempotency_key`
+- `correlation_id` (required for orchestrator paths)
+
+## Architecture and Data Flow
+
+1. Orchestrator acquires card lease.
+2. Orchestrator requests transition with CAS + idempotency key.
+3. Server validates policy, lease, version, approval constraints, projection validity.
+4. Server commits state/projection/event atomically.
+5. Orchestrator reads updated runtime state and events for next decision.
+
+## Testing Strategy
+
+Unit:
+
+- transition policy matrix enforcement
+- version conflict behavior
+- idempotency replay behavior
+- lease ownership and expiry handling
+- approval routing (approve/reject targets)
+- projection failure behavior
+
+Integration:
+
+- end-to-end transition lifecycle via MCP tools
+- pause/resume/drain effects
+- stale-claim recovery flows
+- event stream completeness and ordering
+
+Property-based:
+
+- transition invariants over random edge graphs and state sequences
+- monotonic version increments under concurrent attempts
+
+## Risks and Mitigations
+
+1. Drift between status and lane
+- Mitigation: strict projection failures and atomic status+projection commit.
+
+2. Duplicate side effects under retries
+- Mitigation: DB-level idempotency uniqueness + structured replay semantics.
+
+3. Concurrent orchestrator contention
+- Mitigation: strict leases + CAS + clear error reasons for retry logic.
+
+4. Policy misconfiguration
+- Mitigation: normalized schema + validation (terminal-state rules, approval route completeness, edge integrity).
+
+## Acceptance Criteria
+
+- All workflow transitions are centrally policy-enforced server-side.
+- Workflow runtime state is stored and controlled in one place.
+- Every workflow mutation is lease-protected, CAS-protected, and idempotent.
+- Every successful mutation emits immutable workflow events.
+- MCP exposes the full safe orchestrator primitive set.
+
+## Next Step
+
+Create implementation plan covering staged rollout:
+
+- schema/migrations
+- DB service methods
+- API endpoints
+- MCP module extensions
+- tests and docs updates

--- a/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-implementation-plan.md
+++ b/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-implementation-plan.md
@@ -1,0 +1,358 @@
+# Kanban Safe Orchestrator Workflow Primitives Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a policy-enforced Kanban workflow control plane (status model, transitions, approvals, leases, idempotency, events, and MCP primitives) suitable for safe autonomous orchestration.
+
+**Architecture:** Introduce dedicated workflow tables in Kanban DB, add transactional DB methods for state transitions and approvals, expose REST endpoints for workflow control, then expose MCP primitives that call those DB methods with strict CAS + lease + idempotency checks. Preserve existing board/list/card behavior while making workflow status the canonical orchestrator state.
+
+**Tech Stack:** FastAPI, SQLite (Kanban DB), Pydantic schemas, MCP Unified module system, pytest.
+
+---
+
+### Task 1: Add Workflow Schema and DB Migration Hooks
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Kanban_DB.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_kanban_module.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_workflow_tables_exist_after_db_init(tmp_path):
+    db = KanbanDB(db_path=str(tmp_path / "kanban.db"), user_id="u1")
+    # query sqlite_master and assert workflow tables exist
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py::test_workflow_tables_exist_after_db_init`
+Expected: FAIL due missing workflow tables.
+
+**Step 3: Write minimal implementation**
+
+- Extend `_get_schema_sql()` with:
+  - `board_workflow_policies`
+  - `board_workflow_statuses`
+  - `board_workflow_transitions`
+  - `kanban_card_workflow_state`
+  - `kanban_card_workflow_events`
+  - `kanban_card_workflow_approvals`
+  - workflow idempotency uniqueness constraints/indexes.
+
+**Step 4: Run test to verify it passes**
+
+Run same pytest command.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Kanban_DB.py tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py
+git commit -m "feat(kanban): add workflow control tables to schema"
+```
+
+### Task 2: Implement Policy and Runtime State DB Methods
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Kanban_DB.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_upsert_and_get_workflow_policy_roundtrip(db):
+    # upsert policy + statuses + transitions
+    # fetch and assert normalized structure
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py::test_upsert_and_get_workflow_policy_roundtrip`
+Expected: FAIL due missing DB methods.
+
+**Step 3: Write minimal implementation**
+
+Add DB methods:
+- `upsert_workflow_policy(...)`
+- `get_workflow_policy(board_id)`
+- `list_workflow_statuses(board_id)`
+- `list_workflow_transitions(board_id)`
+- `get_card_workflow_state(card_id)`
+- `patch_card_workflow_state(card_id, ..., expected_version, lease_owner, idempotency_key)`
+
+**Step 4: Run test to verify it passes**
+
+Run same pytest command.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Kanban_DB.py tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py
+git commit -m "feat(kanban): add workflow policy and runtime state DB methods"
+```
+
+### Task 3: Implement Lease, Transition, Approval, and Event DB Operations
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Kanban_DB.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_transition_contract.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_transition_requires_lease_and_expected_version(db):
+    # attempt transition without lease -> lease_required
+    # with lease but wrong version -> version_conflict
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/kanban/test_workflow_transition_contract.py::test_transition_requires_lease_and_expected_version`
+Expected: FAIL due missing transition engine.
+
+**Step 3: Write minimal implementation**
+
+Add DB methods:
+- `claim_card_workflow(...)`
+- `release_card_workflow(...)`
+- `transition_card_workflow(...)` (atomic policy enforcement)
+- `decide_card_workflow_approval(...)`
+- `list_card_workflow_events(...)`
+- `list_stale_workflow_claims(...)`
+- `force_reassign_workflow_claim(...)`
+
+Implement strict projection behavior (`projection_failed`) for invalid mapped list targets.
+
+**Step 4: Run test to verify it passes**
+
+Run same pytest command and then full new workflow DB tests.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Kanban_DB.py tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
+git commit -m "feat(kanban): add transactional workflow transition and approval engine"
+```
+
+### Task 4: Add REST Schemas and Workflow Endpoints
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/kanban_schemas.py`
+- Create: `tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/kanban/__init__.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_endpoints.py`
+
+**Step 1: Write the failing endpoint test**
+
+```python
+def test_transition_endpoint_enforces_policy_and_returns_structured_error(client):
+    # POST transition and assert error code payload for lease/version failures
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/kanban/test_workflow_endpoints.py::test_transition_endpoint_enforces_policy_and_returns_structured_error`
+Expected: FAIL (route missing).
+
+**Step 3: Write minimal implementation**
+
+Add endpoints:
+- policy get/upsert
+- statuses list
+- transitions list
+- task state get/patch
+- claim/release
+- transition
+- approval decide
+- events list
+- pause/resume/drain
+- stale claims list
+- force reassign
+
+Ensure required fields on writes: `expected_version`, `idempotency_key`, `correlation_id` (for orchestrator write paths).
+
+**Step 4: Run test to verify it passes**
+
+Run same endpoint test, then full `test_workflow_endpoints.py`.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/kanban_schemas.py tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py tldw_Server_API/app/api/v1/endpoints/kanban/__init__.py tldw_Server_API/tests/kanban/test_workflow_endpoints.py
+git commit -m "feat(kanban-api): expose workflow control endpoints"
+```
+
+### Task 5: Extend MCP Kanban Module with Workflow Primitives
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py`
+
+**Step 1: Write the failing MCP test**
+
+```python
+async def test_kanban_workflow_transition_tool_requires_expected_version_and_idempotency(...):
+    # call tool with missing args and assert validation error
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py -k workflow`
+Expected: FAIL (tool names missing).
+
+**Step 3: Write minimal implementation**
+
+Add MCP tools:
+- `kanban.workflow.policy.get`
+- `kanban.workflow.policy.upsert`
+- `kanban.workflow.statuses.list`
+- `kanban.workflow.transitions.list`
+- `kanban.workflow.task.state.get`
+- `kanban.workflow.task.state.patch`
+- `kanban.workflow.task.claim`
+- `kanban.workflow.task.release`
+- `kanban.workflow.task.transition`
+- `kanban.workflow.task.approval.decide`
+- `kanban.workflow.task.events.list`
+- `kanban.workflow.control.pause`
+- `kanban.workflow.control.resume`
+- `kanban.workflow.control.drain`
+- `kanban.workflow.recovery.list_stale_claims`
+- `kanban.workflow.recovery.force_reassign`
+
+Wire validation and execution handlers to DB methods.
+
+**Step 4: Run test to verify it passes**
+
+Run same pytest command and full MCP kanban test file.
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
+git commit -m "feat(mcp-kanban): add safe workflow-control primitives"
+```
+
+### Task 6: Add Concurrency, Idempotency, and Projection Regression Tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/kanban/test_workflow_idempotency_and_concurrency.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_projection_failures.py`
+
+**Step 1: Write failing tests**
+
+```python
+def test_reused_idempotency_key_replays_without_duplicate_event(...): ...
+def test_projection_fails_when_target_list_archived(...): ...
+```
+
+**Step 2: Run tests to verify fail**
+
+Run: `source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/kanban/test_workflow_idempotency_and_concurrency.py tldw_Server_API/tests/kanban/test_workflow_projection_failures.py`
+Expected: FAIL until behavior finalized.
+
+**Step 3: Implement minimal fixes**
+
+Adjust DB/API/MCP flow as needed for deterministic behavior.
+
+**Step 4: Re-run tests**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/kanban/test_workflow_idempotency_and_concurrency.py tldw_Server_API/tests/kanban/test_workflow_projection_failures.py tldw_Server_API/app/core/DB_Management/Kanban_DB.py tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py
+git commit -m "test(kanban-workflow): lock idempotency, concurrency, and projection contracts"
+```
+
+### Task 7: Documentation Updates
+
+**Files:**
+- Modify: `Docs/MCP/Unified/User_Guide.md`
+- Modify: `Docs/Published/User_Guides/WebUI_Extension/Kanban_Board_Guide.md`
+- Create: `Docs/Prompts/Skills/kanban/SKILL.md`
+- Modify: `Docs/MCP/mcp_tool_catalogs.md` (if tool-catalog examples need workflow grouping references)
+
+**Step 1: Write docs-focused failing checks**
+
+- Add/extend docs test or lint checks if available.
+- At minimum, run markdown lint/spell/link checks used by project.
+
+**Step 2: Run docs checks and capture failures**
+
+Run project docs validation command(s).
+Expected: FAIL before updates.
+
+**Step 3: Update docs**
+
+- Document workflow primitives, safety contract, and orchestrator usage.
+- Add skill file using tldw MCP primitives for safe Kanban orchestration.
+
+**Step 4: Re-run docs checks**
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/MCP/Unified/User_Guide.md Docs/Published/User_Guides/WebUI_Extension/Kanban_Board_Guide.md Docs/Prompts/Skills/kanban/SKILL.md Docs/MCP/mcp_tool_catalogs.md
+git commit -m "docs(kanban): add safe orchestrator workflow and skill guidance"
+```
+
+### Task 8: Final Verification and Security Gate
+
+**Files:**
+- No new files required; run verification on touched scope.
+
+**Step 1: Run targeted test suites**
+
+```bash
+source .venv/bin/activate && \
+python -m pytest -v \
+  tldw_Server_API/tests/kanban \
+  tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
+```
+
+**Step 2: Run Bandit on touched code**
+
+```bash
+source .venv/bin/activate && \
+python -m bandit -r \
+  tldw_Server_API/app/core/DB_Management/Kanban_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py \
+  -f json -o /tmp/bandit_kanban_workflow.json
+```
+
+**Step 3: Fix any new findings**
+
+Address only new issues introduced by this work.
+
+**Step 4: Final status check**
+
+```bash
+git status
+```
+
+Expected: clean working tree.
+
+**Step 5: Commit any final adjustments**
+
+```bash
+git add -A
+git commit -m "chore(kanban-workflow): final verification and hardening"
+```
+
+## Notes for Implementation
+
+- Keep workflow status independent from list movement; list updates are projection side-effects only.
+- Never bypass transition policy checks in API or MCP layers.
+- Keep stable machine-readable error codes for orchestrator retry logic.
+- Maintain backward compatibility for existing Kanban CRUD APIs.

--- a/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-implementation-plan.md
+++ b/Docs/Plans/2026-03-04-kanban-safe-orchestrator-workflow-primitives-implementation-plan.md
@@ -14,7 +14,7 @@
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/DB_Management/Kanban_DB.py`
-- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_kanban_module.py`
+- Test: `tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py`
 - Create: `tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py`
 
 **Step 1: Write the failing test**
@@ -82,6 +82,11 @@ Add DB methods:
 - `get_card_workflow_state(card_id)`
 - `patch_card_workflow_state(card_id, ..., expected_version, lease_owner, idempotency_key)`
 
+Include compatibility bootstrap behavior:
+- Seed default workflow policy/statuses/transitions for existing boards that have no policy yet.
+- Add lazy initialization for `kanban_card_workflow_state` on first workflow access for legacy cards.
+- Ensure bootstrap is idempotent and safe under concurrency.
+
 **Step 4: Run test to verify it passes**
 
 Run same pytest command.
@@ -143,8 +148,9 @@ git commit -m "feat(kanban): add transactional workflow transition and approval 
 **Files:**
 - Modify: `tldw_Server_API/app/api/v1/schemas/kanban_schemas.py`
 - Create: `tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py`
-- Modify: `tldw_Server_API/app/api/v1/endpoints/kanban/__init__.py`
+- Modify: `tldw_Server_API/app/main.py`
 - Create: `tldw_Server_API/tests/kanban/test_workflow_endpoints.py`
+- Create: `tldw_Server_API/tests/kanban/test_workflow_authz.py`
 
 **Step 1: Write the failing endpoint test**
 
@@ -174,16 +180,18 @@ Add endpoints:
 - force reassign
 
 Ensure required fields on writes: `expected_version`, `idempotency_key`, `correlation_id` (for orchestrator write paths).
+Wire router in `main.py` alongside existing kanban routers in both registration paths.
+Enforce authz for privileged operations (pause/resume/drain/force-reassign) and return forbidden responses for non-admin callers.
 
 **Step 4: Run test to verify it passes**
 
-Run same endpoint test, then full `test_workflow_endpoints.py`.
+Run same endpoint test, then full `test_workflow_endpoints.py` and `test_workflow_authz.py`.
 Expected: PASS.
 
 **Step 5: Commit**
 
 ```bash
-git add tldw_Server_API/app/api/v1/schemas/kanban_schemas.py tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py tldw_Server_API/app/api/v1/endpoints/kanban/__init__.py tldw_Server_API/tests/kanban/test_workflow_endpoints.py
+git add tldw_Server_API/app/api/v1/schemas/kanban_schemas.py tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py tldw_Server_API/app/main.py tldw_Server_API/tests/kanban/test_workflow_endpoints.py tldw_Server_API/tests/kanban/test_workflow_authz.py
 git commit -m "feat(kanban-api): expose workflow control endpoints"
 ```
 
@@ -226,6 +234,7 @@ Add MCP tools:
 - `kanban.workflow.recovery.force_reassign`
 
 Wire validation and execution handlers to DB methods.
+Add explicit tool-level auth checks for privileged recovery/control operations and test forbidden paths.
 
 **Step 4: Run test to verify it passes**
 
@@ -346,7 +355,16 @@ Expected: clean working tree.
 **Step 5: Commit any final adjustments**
 
 ```bash
-git add -A
+git add tldw_Server_API/app/core/DB_Management/Kanban_DB.py \
+  tldw_Server_API/app/api/v1/schemas/kanban_schemas.py \
+  tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py \
+  tldw_Server_API/tests/kanban \
+  tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py \
+  Docs/MCP/Unified/User_Guide.md \
+  Docs/Published/User_Guides/WebUI_Extension/Kanban_Board_Guide.md \
+  Docs/Prompts/Skills/kanban/SKILL.md
 git commit -m "chore(kanban-workflow): final verification and hardening"
 ```
 
@@ -356,3 +374,4 @@ git commit -m "chore(kanban-workflow): final verification and hardening"
 - Never bypass transition policy checks in API or MCP layers.
 - Keep stable machine-readable error codes for orchestrator retry logic.
 - Maintain backward compatibility for existing Kanban CRUD APIs.
+- Do not require manual one-off migration scripts for existing boards/cards; policy and state bootstrap must be automatic and idempotent.

--- a/Docs/Prompts/Skills/kanban/SKILL.md
+++ b/Docs/Prompts/Skills/kanban/SKILL.md
@@ -149,5 +149,5 @@ Approval decision:
 ## Notes
 
 - Prefer explicit transitions over direct state patching for normal lifecycle flow.
-- Use `task.state.patch` only for controlled repair/administrative corrections.
+- Use `task.state.patch` only for controlled admin repair operations.
 - Keep admin-only tools out of general-purpose agent catalogs.

--- a/Docs/Prompts/Skills/kanban/SKILL.md
+++ b/Docs/Prompts/Skills/kanban/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: kanban
+description: Manage tldw_server Kanban boards via MCP with explicit workflow-status control, safe transitions, lease/approval gates, and recovery primitives for orchestrators.
+license: MIT
+---
+
+Manages Kanban boards in **tldw_server** using MCP tools from the `kanban` module.
+
+## Core Rule: Workflow State Is Canonical
+
+For orchestration, treat `card.workflow_status` as source of truth.
+
+- Canonical state: `kanban_card_workflow_state.workflow_status_key`
+- List placement is projection side effect only (`auto_move_list_id`)
+- Never infer workflow state from list column placement
+
+## MCP Tooling
+
+### Board/List/Card primitives
+
+- `kanban.boards.list`
+- `kanban.boards.get`
+- `kanban.boards.create`
+- `kanban.lists.list`
+- `kanban.lists.create`
+- `kanban.cards.list`
+- `kanban.cards.create`
+- `kanban.cards.move`
+- `kanban.cards.search`
+- `kanban.comments.list`
+- `kanban.comments.create`
+
+### Workflow control primitives
+
+- `kanban.workflow.policy.get`
+- `kanban.workflow.policy.upsert`
+- `kanban.workflow.statuses.list`
+- `kanban.workflow.transitions.list`
+- `kanban.workflow.task.state.get`
+- `kanban.workflow.task.state.patch`
+- `kanban.workflow.task.claim`
+- `kanban.workflow.task.release`
+- `kanban.workflow.task.transition`
+- `kanban.workflow.task.approval.decide`
+- `kanban.workflow.task.events.list`
+- `kanban.workflow.control.pause` (admin)
+- `kanban.workflow.control.resume` (admin)
+- `kanban.workflow.control.drain` (admin)
+- `kanban.workflow.recovery.list_stale_claims`
+- `kanban.workflow.recovery.force_reassign` (admin)
+
+## Safety Contract (Always Enforce)
+
+For workflow write operations:
+
+- Always pass `expected_version` (CAS)
+- Always pass unique `idempotency_key`
+- Always pass `correlation_id` on transitions/approval/recovery writes
+- Re-read state before retries (`kanban.workflow.task.state.get`)
+
+Stable conflict codes to handle:
+
+- `version_conflict`
+- `lease_required`
+- `lease_mismatch`
+- `policy_paused`
+- `transition_not_allowed`
+- `approval_required`
+- `projection_failed`
+- `idempotency_conflict`
+
+## Suggested Status Pipeline (Optional Policy)
+
+Use if the project wants a 7-stage flow:
+
+`req -> plan -> review_plan -> impl -> review_impl -> test -> done`
+
+Suggested transitions:
+
+- `req -> plan`
+- `plan -> review_plan`
+- `review_plan -> impl`
+- `review_plan -> plan` (reject)
+- `impl -> review_impl`
+- `review_impl -> test`
+- `review_impl -> impl` (reject)
+- `test -> done`
+- `test -> impl` (fail)
+
+Implement this using `kanban.workflow.policy.upsert` with explicit statuses/transitions.
+
+## Default Execution Pattern
+
+No autonomous 7-stage loop is assumed by default.
+Use explicit step-wise orchestration:
+
+1. Load policy and task state (`policy.get`, `task.state.get`)
+2. Claim lease (`task.claim`) when required by transition policy
+3. Transition (`task.transition`) with CAS + idempotency + correlation
+4. If approval is pending, resolve with `task.approval.decide`
+5. Append card comments/checklists as execution notes
+6. Release lease (`task.release`) when complete
+7. Audit/replay via `task.events.list`
+
+## Pause/Drain/Recovery Runbook
+
+- Pause writes during incidents: `kanban.workflow.control.pause`
+- Resume when safe: `kanban.workflow.control.resume`
+- Drain board for controlled shutdown: `kanban.workflow.control.drain`
+- Find orphaned claims: `kanban.workflow.recovery.list_stale_claims`
+- Reassign ownership when needed: `kanban.workflow.recovery.force_reassign`
+
+## Minimal MCP Call Shapes
+
+Transition:
+
+```json
+{
+  "name": "kanban.workflow.task.transition",
+  "arguments": {
+    "card_id": 123,
+    "to_status_key": "impl",
+    "actor": "builder",
+    "expected_version": 4,
+    "idempotency_key": "wf-123-transition-0001",
+    "correlation_id": "run-2026-03-05-001",
+    "reason": "begin implementation"
+  }
+}
+```
+
+Approval decision:
+
+```json
+{
+  "name": "kanban.workflow.task.approval.decide",
+  "arguments": {
+    "card_id": 123,
+    "reviewer": "inspector",
+    "decision": "approved",
+    "expected_version": 5,
+    "idempotency_key": "wf-123-approval-0001",
+    "correlation_id": "run-2026-03-05-001",
+    "reason": "checks passed"
+  }
+}
+```
+
+## Notes
+
+- Prefer explicit transitions over direct state patching for normal lifecycle flow.
+- Use `task.state.patch` only for controlled repair/administrative corrections.
+- Keep admin-only tools out of general-purpose agent catalogs.

--- a/Docs/User_Guides/WebUI_Extension/Kanban_Board_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Kanban_Board_Guide.md
@@ -12,6 +12,7 @@ This guide covers the Kanban Board module for organizing tasks, research workflo
    - [Boards](#boards)
    - [Lists](#lists)
    - [Cards](#cards)
+   - [Workflow Control Plane](#workflow-control-plane)
    - [Labels](#labels)
    - [Checklists](#checklists)
    - [Comments](#comments)
@@ -35,6 +36,7 @@ This guide covers the Kanban Board module for organizing tasks, research workflo
 The Kanban Board module provides Trello-like task management integrated with tldw_server's RAG infrastructure. Key features include:
 
 - **Boards, Lists, and Cards**: Organize work visually across columns
+- **Workflow Control Plane**: Policy-enforced status transitions with lease/CAS/idempotency safeguards
 - **Rich Card Features**: Due dates, labels, checklists, comments, and markdown descriptions
 - **Full-Text Search**: FTS5-powered search across card titles and descriptions
 - **Vector Search** (optional): Semantic search via ChromaDB embeddings
@@ -128,6 +130,81 @@ curl -X POST "http://localhost:8000/api/v1/kanban/cards/{card_id}/copy" \
   -H "Content-Type: application/json" \
   -d '{"target_list_id": 5, "include_checklists": true, "include_labels": true}'
 ```
+
+### Workflow Control Plane
+
+Workflow state is explicitly tracked independent of list placement:
+
+- Canonical orchestrator state is `card.workflow_status` (`kanban_card_workflow_state.workflow_status_key`).
+- List movement is projection side effect from transition policy (`auto_move_list_id`).
+- For automation safety, read/write workflow status directly; do not infer state from list column.
+
+#### Get board workflow policy
+```bash
+curl "http://localhost:8000/api/v1/kanban/workflow/boards/{board_id}/policy" \
+  -H "Authorization: Bearer <token>"
+```
+
+#### Transition workflow status safely
+```bash
+curl -X POST "http://localhost:8000/api/v1/kanban/workflow/cards/{card_id}/transition" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to_status_key": "impl",
+    "actor": "builder",
+    "expected_version": 3,
+    "idempotency_key": "wf-transition-123",
+    "correlation_id": "run-2026-03-05-001",
+    "reason": "start implementation"
+  }'
+```
+
+#### Decide pending approval
+```bash
+curl -X POST "http://localhost:8000/api/v1/kanban/workflow/cards/{card_id}/approval" \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "reviewer": "inspector",
+    "decision": "approved",
+    "expected_version": 4,
+    "idempotency_key": "wf-approval-123",
+    "correlation_id": "run-2026-03-05-001",
+    "reason": "criteria met"
+  }'
+```
+
+#### Control and recovery endpoints (admin)
+- Pause board workflow: `POST /workflow/control/boards/{board_id}/pause`
+- Resume board workflow: `POST /workflow/control/boards/{board_id}/resume`
+- Enable draining mode: `POST /workflow/control/boards/{board_id}/drain`
+- List stale claims: `GET /workflow/recovery/stale-claims`
+- Force-reassign claim: `POST /workflow/recovery/cards/{card_id}/force-reassign`
+
+#### Stable workflow conflict codes
+
+Workflow conflicts are machine-readable:
+
+```json
+{
+  "detail": {
+    "code": "lease_required",
+    "message": "lease_required"
+  }
+}
+```
+
+Common codes:
+
+- `version_conflict`
+- `lease_required`
+- `lease_mismatch`
+- `policy_paused`
+- `transition_not_allowed`
+- `approval_required`
+- `projection_failed`
+- `idempotency_conflict`
 
 ### Labels
 
@@ -342,6 +419,27 @@ All endpoints are prefixed with `/api/v1/kanban`.
 | POST | `/cards/{id}/copy` | Copy card |
 | POST | `/lists/{list_id}/cards/reorder` | Reorder cards |
 
+#### Workflow Control
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/workflow/boards/{board_id}/policy` | Get board workflow policy |
+| PUT | `/workflow/boards/{board_id}/policy` | Upsert workflow policy |
+| GET | `/workflow/boards/{board_id}/statuses` | List workflow statuses |
+| GET | `/workflow/boards/{board_id}/transitions` | List workflow transitions |
+| GET | `/workflow/cards/{card_id}/state` | Get workflow runtime state |
+| PATCH | `/workflow/cards/{card_id}/state` | Patch workflow runtime state (CAS) |
+| POST | `/workflow/cards/{card_id}/claim` | Claim workflow lease |
+| POST | `/workflow/cards/{card_id}/release` | Release workflow lease |
+| POST | `/workflow/cards/{card_id}/transition` | Transition workflow status |
+| POST | `/workflow/cards/{card_id}/approval` | Decide pending approval |
+| GET | `/workflow/cards/{card_id}/events` | List workflow events |
+| GET | `/workflow/recovery/stale-claims` | List stale workflow claims |
+| POST | `/workflow/recovery/cards/{card_id}/force-reassign` | Force-reassign claim (admin) |
+| POST | `/workflow/control/boards/{board_id}/pause` | Pause transitions (admin) |
+| POST | `/workflow/control/boards/{board_id}/resume` | Resume transitions (admin) |
+| POST | `/workflow/control/boards/{board_id}/drain` | Enable drain mode (admin) |
+
 #### Labels
 
 | Method | Endpoint | Description |
@@ -466,6 +564,28 @@ Error response format:
 }
 ```
 
+Workflow endpoints may return structured `detail` objects with stable machine-readable conflict codes:
+
+```json
+{
+  "detail": {
+    "code": "policy_paused",
+    "message": "policy_paused"
+  }
+}
+```
+
+Workflow conflict codes:
+
+- `version_conflict`
+- `lease_required`
+- `lease_mismatch`
+- `policy_paused`
+- `transition_not_allowed`
+- `approval_required`
+- `projection_failed`
+- `idempotency_conflict`
+
 ### Code Architecture
 
 #### Key Files
@@ -475,6 +595,7 @@ Error response format:
 | `app/core/DB_Management/Kanban_DB.py` | Database layer with all CRUD operations |
 | `app/core/DB_Management/kanban_vector_search.py` | ChromaDB vector search integration |
 | `app/api/v1/endpoints/kanban_*.py` | API endpoint handlers |
+| `app/api/v1/endpoints/kanban/kanban_workflow.py` | Workflow policy/state/lease/transition/recovery endpoints |
 | `app/api/v1/schemas/kanban_schemas.py` | Pydantic models |
 | `app/api/v1/API_Deps/kanban_deps.py` | FastAPI dependencies |
 
@@ -491,6 +612,12 @@ The Kanban module uses SQLite with the following tables:
 - `kanban_comments` - Comments on cards
 - `kanban_activities` - Activity log
 - `kanban_card_links` - Card-to-card relationships (currently undocumented)
+- `board_workflow_policies` - Board-level workflow policy settings
+- `board_workflow_statuses` - Allowed workflow statuses
+- `board_workflow_transitions` - Allowed workflow edges and requirements
+- `kanban_card_workflow_state` - Canonical runtime workflow state per card
+- `kanban_card_workflow_events` - Append-only workflow audit events
+- `kanban_card_workflow_approvals` - Approval state/history for gated transitions
 
 #### Key Design Patterns
 
@@ -696,4 +823,5 @@ Expected healthy response:
 
 ## Version History
 
+- **v0.2** (2026-03): Added workflow control plane (policy/state/lease/transition/approval/recovery)
 - **v0.1** (2025-12): Initial release with full CRUD, search, and vector integration

--- a/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
+++ b/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import Any, Callable, TypeVar
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.kanban_deps import (
     get_kanban_db_for_user,
@@ -17,11 +19,14 @@ from tldw_Server_API.app.api.v1.schemas.kanban_schemas import (
     WorkflowControlResponse,
     WorkflowEventsListResponse,
     WorkflowForceReassignRequest,
+    WorkflowPolicyResponse,
     WorkflowPolicyUpsertRequest,
     WorkflowReleaseRequest,
     WorkflowStaleClaimsListResponse,
     WorkflowStatePatchRequest,
     WorkflowStateResponse,
+    WorkflowStatusesListResponse,
+    WorkflowTransitionsListResponse,
     WorkflowTransitionRequest,
 )
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
@@ -46,45 +51,83 @@ _KNOWN_WORKFLOW_ERROR_CODES = {
     "idempotency_conflict",
 }
 
+T = TypeVar("T")
+
 
 def _extract_workflow_error_code(exc: Exception) -> str:
+    """Extract a stable workflow conflict code from an exception."""
+    explicit_code = getattr(exc, "code", None)
+    if isinstance(explicit_code, str) and explicit_code in _KNOWN_WORKFLOW_ERROR_CODES:
+        return explicit_code
+
     message = str(exc).strip()
     if not message:
         return "workflow_error"
+
     code = message.split("(", 1)[0].strip().split(" ", 1)[0].strip()
     if code in _KNOWN_WORKFLOW_ERROR_CODES:
         return code
     return "workflow_error"
 
 
-def _workflow_http_error(exc: Exception) -> HTTPException:
+def _workflow_http_error(
+    exc: Exception,
+    *,
+    operation: str,
+    context: dict[str, Any] | None = None,
+) -> HTTPException:
+    """Map domain errors to HTTP errors and log contextual diagnostics."""
+    log = logger.bind(operation=operation, **(context or {}))
+
     if isinstance(exc, NotFoundError):
+        log.warning("Workflow request failed with not_found: {}", exc)
         return HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"code": "not_found", "message": str(exc)},
         )
     if isinstance(exc, InputError):
+        log.warning("Workflow request failed with invalid_request: {}", exc)
         return HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "invalid_request", "message": str(exc)},
         )
     if isinstance(exc, ConflictError):
+        error_code = _extract_workflow_error_code(exc)
+        log.warning("Workflow request failed with conflict code {}: {}", error_code, exc)
         return HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail={"code": _extract_workflow_error_code(exc), "message": str(exc)},
+            detail={"code": error_code, "message": str(exc)},
         )
     if isinstance(exc, KanbanDBError):
+        log.exception("Workflow request failed with Kanban DB error")
         return HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={"code": "kanban_db_error", "message": str(exc)},
         )
+
+    log.exception("Workflow request failed with unexpected error")
     return HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         detail={"code": "internal_error", "message": "An unexpected error occurred"},
     )
 
 
+async def _run_db_call(
+    *,
+    operation: str,
+    func: Callable[..., T],
+    context: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> T:
+    """Execute synchronous KanbanDB calls in a worker thread with mapped errors."""
+    try:
+        return await asyncio.to_thread(func, **kwargs)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc, operation=operation, context=context) from exc
+
+
 def _require_admin(current_user: User) -> None:
+    """Reject non-admin callers for privileged workflow operations."""
     if not getattr(current_user, "is_admin", False):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -94,71 +137,99 @@ def _require_admin(current_user: User) -> None:
 
 @router.get(
     "/workflow/boards/{board_id}/policy",
+    response_model=WorkflowPolicyResponse,
     dependencies=[Depends(kanban_rate_limit("kanban.workflow.policy.get"))],
 )
 async def get_workflow_policy(
     board_id: int,
     db: KanbanDB = Depends(get_kanban_db_for_user),
-) -> dict[str, Any]:
-    try:
-        policy = db.get_workflow_policy(board_id)
-        if policy is None:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
-        return policy
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+) -> WorkflowPolicyResponse:
+    """Return workflow policy for a board."""
+    policy = await _run_db_call(
+        operation="workflow.policy.get",
+        func=db.get_workflow_policy,
+        context={"board_id": board_id},
+        board_id=board_id,
+    )
+    if policy is None:
+        raise _workflow_http_error(
+            NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id),
+            operation="workflow.policy.get",
+            context={"board_id": board_id},
+        )
+    return WorkflowPolicyResponse(**policy)
 
 
 @router.put(
     "/workflow/boards/{board_id}/policy",
+    response_model=WorkflowPolicyResponse,
     dependencies=[Depends(kanban_rate_limit("kanban.workflow.policy.upsert"))],
 )
 async def upsert_workflow_policy(
     board_id: int,
     policy_in: WorkflowPolicyUpsertRequest,
     db: KanbanDB = Depends(get_kanban_db_for_user),
-) -> dict[str, Any]:
-    try:
-        return db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=[status.model_dump() for status in policy_in.statuses] if policy_in.statuses is not None else None,
-            transitions=[transition.model_dump() for transition in policy_in.transitions] if policy_in.transitions is not None else None,
-            is_paused=policy_in.is_paused,
-            is_draining=policy_in.is_draining,
-            default_lease_ttl_sec=policy_in.default_lease_ttl_sec,
-            strict_projection=policy_in.strict_projection,
-            metadata=policy_in.metadata,
-        )
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+) -> WorkflowPolicyResponse:
+    """Create or replace workflow policy configuration for a board."""
+    upsert_kwargs: dict[str, Any] = {
+        "board_id": board_id,
+        "statuses": [status.model_dump() for status in policy_in.statuses] if policy_in.statuses is not None else None,
+        "transitions": [transition.model_dump() for transition in policy_in.transitions]
+        if policy_in.transitions is not None
+        else None,
+        "is_paused": policy_in.is_paused,
+        "is_draining": policy_in.is_draining,
+        "default_lease_ttl_sec": policy_in.default_lease_ttl_sec,
+        "strict_projection": policy_in.strict_projection,
+    }
+    if "metadata" in policy_in.model_fields_set:
+        upsert_kwargs["metadata"] = policy_in.metadata
+
+    policy = await _run_db_call(
+        operation="workflow.policy.upsert",
+        func=db.upsert_workflow_policy,
+        context={"board_id": board_id},
+        **upsert_kwargs,
+    )
+    return WorkflowPolicyResponse(**policy)
 
 
 @router.get(
     "/workflow/boards/{board_id}/statuses",
+    response_model=WorkflowStatusesListResponse,
     dependencies=[Depends(kanban_rate_limit("kanban.workflow.statuses.list"))],
 )
 async def list_workflow_statuses(
     board_id: int,
     db: KanbanDB = Depends(get_kanban_db_for_user),
-) -> dict[str, Any]:
-    try:
-        return {"statuses": db.list_workflow_statuses(board_id)}
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+) -> WorkflowStatusesListResponse:
+    """List active workflow statuses for a board."""
+    statuses = await _run_db_call(
+        operation="workflow.statuses.list",
+        func=db.list_workflow_statuses,
+        context={"board_id": board_id},
+        board_id=board_id,
+    )
+    return WorkflowStatusesListResponse(statuses=statuses)
 
 
 @router.get(
     "/workflow/boards/{board_id}/transitions",
+    response_model=WorkflowTransitionsListResponse,
     dependencies=[Depends(kanban_rate_limit("kanban.workflow.transitions.list"))],
 )
 async def list_workflow_transitions(
     board_id: int,
     db: KanbanDB = Depends(get_kanban_db_for_user),
-) -> dict[str, Any]:
-    try:
-        return {"transitions": db.list_workflow_transitions(board_id)}
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+) -> WorkflowTransitionsListResponse:
+    """List active workflow transitions for a board."""
+    transitions = await _run_db_call(
+        operation="workflow.transitions.list",
+        func=db.list_workflow_transitions,
+        context={"board_id": board_id},
+        board_id=board_id,
+    )
+    return WorkflowTransitionsListResponse(transitions=transitions)
 
 
 @router.get(
@@ -170,10 +241,14 @@ async def get_card_workflow_state(
     card_id: int,
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        return WorkflowStateResponse(**db.get_card_workflow_state(card_id))
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Return workflow runtime state for a card."""
+    state = await _run_db_call(
+        operation="workflow.task.state.get",
+        func=db.get_card_workflow_state,
+        context={"card_id": card_id},
+        card_id=card_id,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.patch(
@@ -184,21 +259,24 @@ async def get_card_workflow_state(
 async def patch_card_workflow_state(
     card_id: int,
     state_in: WorkflowStatePatchRequest,
+    current_user: User = Depends(get_request_user),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        state = db.patch_card_workflow_state(
-            card_id=card_id,
-            workflow_status_key=state_in.workflow_status_key,
-            expected_version=state_in.expected_version,
-            lease_owner=state_in.lease_owner,
-            idempotency_key=state_in.idempotency_key,
-            correlation_id=state_in.correlation_id,
-            last_actor=state_in.actor,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Apply a privileged direct patch to workflow runtime state."""
+    _require_admin(current_user)
+    state = await _run_db_call(
+        operation="workflow.task.state.patch",
+        func=db.patch_card_workflow_state,
+        context={"card_id": card_id},
+        card_id=card_id,
+        workflow_status_key=state_in.workflow_status_key,
+        expected_version=state_in.expected_version,
+        lease_owner=state_in.lease_owner,
+        idempotency_key=state_in.idempotency_key,
+        correlation_id=state_in.correlation_id,
+        last_actor=state_in.actor,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.post(
@@ -211,17 +289,18 @@ async def claim_card_workflow(
     claim_in: WorkflowClaimRequest,
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        state = db.claim_card_workflow(
-            card_id=card_id,
-            owner=claim_in.owner,
-            lease_ttl_sec=claim_in.lease_ttl_sec,
-            idempotency_key=claim_in.idempotency_key,
-            correlation_id=claim_in.correlation_id,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Claim workflow lease ownership for a card."""
+    state = await _run_db_call(
+        operation="workflow.task.claim",
+        func=db.claim_card_workflow,
+        context={"card_id": card_id, "owner": claim_in.owner},
+        card_id=card_id,
+        owner=claim_in.owner,
+        lease_ttl_sec=claim_in.lease_ttl_sec,
+        idempotency_key=claim_in.idempotency_key,
+        correlation_id=claim_in.correlation_id,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.post(
@@ -234,16 +313,17 @@ async def release_card_workflow(
     release_in: WorkflowReleaseRequest,
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        state = db.release_card_workflow(
-            card_id=card_id,
-            owner=release_in.owner,
-            idempotency_key=release_in.idempotency_key,
-            correlation_id=release_in.correlation_id,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Release workflow lease ownership for a card."""
+    state = await _run_db_call(
+        operation="workflow.task.release",
+        func=db.release_card_workflow,
+        context={"card_id": card_id, "owner": release_in.owner},
+        card_id=card_id,
+        owner=release_in.owner,
+        idempotency_key=release_in.idempotency_key,
+        correlation_id=release_in.correlation_id,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.post(
@@ -256,19 +336,20 @@ async def transition_card_workflow(
     transition_in: WorkflowTransitionRequest,
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        state = db.transition_card_workflow(
-            card_id=card_id,
-            to_status_key=transition_in.to_status_key,
-            actor=transition_in.actor,
-            expected_version=transition_in.expected_version,
-            idempotency_key=transition_in.idempotency_key,
-            correlation_id=transition_in.correlation_id,
-            reason=transition_in.reason,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Execute a policy-enforced workflow transition for a card."""
+    state = await _run_db_call(
+        operation="workflow.task.transition",
+        func=db.transition_card_workflow,
+        context={"card_id": card_id, "to_status_key": transition_in.to_status_key},
+        card_id=card_id,
+        to_status_key=transition_in.to_status_key,
+        actor=transition_in.actor,
+        expected_version=transition_in.expected_version,
+        idempotency_key=transition_in.idempotency_key,
+        correlation_id=transition_in.correlation_id,
+        reason=transition_in.reason,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.post(
@@ -281,19 +362,20 @@ async def decide_card_workflow_approval(
     approval_in: WorkflowApprovalDecisionRequest,
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
-    try:
-        state = db.decide_card_workflow_approval(
-            card_id=card_id,
-            reviewer=approval_in.reviewer,
-            decision=approval_in.decision,
-            expected_version=approval_in.expected_version,
-            idempotency_key=approval_in.idempotency_key,
-            correlation_id=approval_in.correlation_id,
-            reason=approval_in.reason,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """Record approval decision for a pending transition."""
+    state = await _run_db_call(
+        operation="workflow.task.approval.decide",
+        func=db.decide_card_workflow_approval,
+        context={"card_id": card_id, "decision": approval_in.decision},
+        card_id=card_id,
+        reviewer=approval_in.reviewer,
+        decision=approval_in.decision,
+        expected_version=approval_in.expected_version,
+        idempotency_key=approval_in.idempotency_key,
+        correlation_id=approval_in.correlation_id,
+        reason=approval_in.reason,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.get(
@@ -307,10 +389,16 @@ async def list_card_workflow_events(
     offset: int = Query(0, ge=0),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowEventsListResponse:
-    try:
-        return WorkflowEventsListResponse(events=db.list_card_workflow_events(card_id=card_id, limit=limit, offset=offset))
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """List append-only workflow events for a card."""
+    events = await _run_db_call(
+        operation="workflow.task.events.list",
+        func=db.list_card_workflow_events,
+        context={"card_id": card_id, "limit": limit, "offset": offset},
+        card_id=card_id,
+        limit=limit,
+        offset=offset,
+    )
+    return WorkflowEventsListResponse(events=events)
 
 
 @router.get(
@@ -323,11 +411,15 @@ async def list_stale_workflow_claims(
     limit: int = Query(100, ge=1, le=500),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStaleClaimsListResponse:
-    try:
-        claims = db.list_stale_workflow_claims(board_id=board_id, limit=limit)
-        return WorkflowStaleClaimsListResponse(stale_claims=claims)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    """List cards with expired active lease claims."""
+    claims = await _run_db_call(
+        operation="workflow.recovery.list_stale_claims",
+        func=db.list_stale_workflow_claims,
+        context={"board_id": board_id, "limit": limit},
+        board_id=board_id,
+        limit=limit,
+    )
+    return WorkflowStaleClaimsListResponse(stale_claims=claims)
 
 
 @router.post(
@@ -341,18 +433,19 @@ async def force_reassign_workflow_claim(
     current_user: User = Depends(get_request_user),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowStateResponse:
+    """Force-reassign workflow lease ownership for a card (admin only)."""
     _require_admin(current_user)
-    try:
-        state = db.force_reassign_workflow_claim(
-            card_id=card_id,
-            new_owner=request_in.new_owner,
-            idempotency_key=request_in.idempotency_key,
-            correlation_id=request_in.correlation_id,
-            reason=request_in.reason,
-        )
-        return WorkflowStateResponse(**state)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    state = await _run_db_call(
+        operation="workflow.recovery.force_reassign",
+        func=db.force_reassign_workflow_claim,
+        context={"card_id": card_id, "new_owner": request_in.new_owner},
+        card_id=card_id,
+        new_owner=request_in.new_owner,
+        idempotency_key=request_in.idempotency_key,
+        correlation_id=request_in.correlation_id,
+        reason=request_in.reason,
+    )
+    return WorkflowStateResponse(**state)
 
 
 @router.post(
@@ -365,24 +458,16 @@ async def pause_workflow_policy(
     current_user: User = Depends(get_request_user),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowControlResponse:
+    """Pause workflow transitions for a board (admin only)."""
     _require_admin(current_user)
-    try:
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=True,
-            is_draining=bool(policy.get("is_draining", False)),
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
-        return WorkflowControlResponse(success=True, policy=updated)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    policy = await _run_db_call(
+        operation="workflow.control.pause",
+        func=db.update_workflow_policy_flags,
+        context={"board_id": board_id},
+        board_id=board_id,
+        is_paused=True,
+    )
+    return WorkflowControlResponse(success=True, policy=WorkflowPolicyResponse(**policy))
 
 
 @router.post(
@@ -395,24 +480,16 @@ async def resume_workflow_policy(
     current_user: User = Depends(get_request_user),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowControlResponse:
+    """Resume workflow transitions for a board (admin only)."""
     _require_admin(current_user)
-    try:
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=False,
-            is_draining=bool(policy.get("is_draining", False)),
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
-        return WorkflowControlResponse(success=True, policy=updated)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    policy = await _run_db_call(
+        operation="workflow.control.resume",
+        func=db.update_workflow_policy_flags,
+        context={"board_id": board_id},
+        board_id=board_id,
+        is_paused=False,
+    )
+    return WorkflowControlResponse(success=True, policy=WorkflowPolicyResponse(**policy))
 
 
 @router.post(
@@ -425,21 +502,13 @@ async def drain_workflow_policy(
     current_user: User = Depends(get_request_user),
     db: KanbanDB = Depends(get_kanban_db_for_user),
 ) -> WorkflowControlResponse:
+    """Enable workflow draining mode for a board (admin only)."""
     _require_admin(current_user)
-    try:
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=bool(policy.get("is_paused", False)),
-            is_draining=True,
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
-        return WorkflowControlResponse(success=True, policy=updated)
-    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
-        raise _workflow_http_error(exc) from exc
+    policy = await _run_db_call(
+        operation="workflow.control.drain",
+        func=db.update_workflow_policy_flags,
+        context={"board_id": board_id},
+        board_id=board_id,
+        is_draining=True,
+    )
+    return WorkflowControlResponse(success=True, policy=WorkflowPolicyResponse(**policy))

--- a/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
+++ b/tldw_Server_API/app/api/v1/endpoints/kanban/kanban_workflow.py
@@ -1,0 +1,445 @@
+# app/api/v1/endpoints/kanban/kanban_workflow.py
+"""Kanban workflow-control API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from tldw_Server_API.app.api.v1.API_Deps.kanban_deps import (
+    get_kanban_db_for_user,
+    kanban_rate_limit,
+)
+from tldw_Server_API.app.api.v1.schemas.kanban_schemas import (
+    WorkflowApprovalDecisionRequest,
+    WorkflowClaimRequest,
+    WorkflowControlResponse,
+    WorkflowEventsListResponse,
+    WorkflowForceReassignRequest,
+    WorkflowPolicyUpsertRequest,
+    WorkflowReleaseRequest,
+    WorkflowStaleClaimsListResponse,
+    WorkflowStatePatchRequest,
+    WorkflowStateResponse,
+    WorkflowTransitionRequest,
+)
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import (
+    ConflictError,
+    InputError,
+    KanbanDB,
+    KanbanDBError,
+    NotFoundError,
+)
+
+router = APIRouter(tags=["Kanban Workflow"])
+
+_KNOWN_WORKFLOW_ERROR_CODES = {
+    "version_conflict",
+    "lease_required",
+    "lease_mismatch",
+    "policy_paused",
+    "transition_not_allowed",
+    "approval_required",
+    "projection_failed",
+    "idempotency_conflict",
+}
+
+
+def _extract_workflow_error_code(exc: Exception) -> str:
+    message = str(exc).strip()
+    if not message:
+        return "workflow_error"
+    code = message.split("(", 1)[0].strip().split(" ", 1)[0].strip()
+    if code in _KNOWN_WORKFLOW_ERROR_CODES:
+        return code
+    return "workflow_error"
+
+
+def _workflow_http_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, NotFoundError):
+        return HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "not_found", "message": str(exc)},
+        )
+    if isinstance(exc, InputError):
+        return HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "invalid_request", "message": str(exc)},
+        )
+    if isinstance(exc, ConflictError):
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"code": _extract_workflow_error_code(exc), "message": str(exc)},
+        )
+    if isinstance(exc, KanbanDBError):
+        return HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": "kanban_db_error", "message": str(exc)},
+        )
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail={"code": "internal_error", "message": "An unexpected error occurred"},
+    )
+
+
+def _require_admin(current_user: User) -> None:
+    if not getattr(current_user, "is_admin", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "forbidden", "message": "Admin privileges required"},
+        )
+
+
+@router.get(
+    "/workflow/boards/{board_id}/policy",
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.policy.get"))],
+)
+async def get_workflow_policy(
+    board_id: int,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> dict[str, Any]:
+    try:
+        policy = db.get_workflow_policy(board_id)
+        if policy is None:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
+        return policy
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.put(
+    "/workflow/boards/{board_id}/policy",
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.policy.upsert"))],
+)
+async def upsert_workflow_policy(
+    board_id: int,
+    policy_in: WorkflowPolicyUpsertRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> dict[str, Any]:
+    try:
+        return db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=[status.model_dump() for status in policy_in.statuses] if policy_in.statuses is not None else None,
+            transitions=[transition.model_dump() for transition in policy_in.transitions] if policy_in.transitions is not None else None,
+            is_paused=policy_in.is_paused,
+            is_draining=policy_in.is_draining,
+            default_lease_ttl_sec=policy_in.default_lease_ttl_sec,
+            strict_projection=policy_in.strict_projection,
+            metadata=policy_in.metadata,
+        )
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.get(
+    "/workflow/boards/{board_id}/statuses",
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.statuses.list"))],
+)
+async def list_workflow_statuses(
+    board_id: int,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> dict[str, Any]:
+    try:
+        return {"statuses": db.list_workflow_statuses(board_id)}
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.get(
+    "/workflow/boards/{board_id}/transitions",
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.transitions.list"))],
+)
+async def list_workflow_transitions(
+    board_id: int,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> dict[str, Any]:
+    try:
+        return {"transitions": db.list_workflow_transitions(board_id)}
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.get(
+    "/workflow/cards/{card_id}/state",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.state.get"))],
+)
+async def get_card_workflow_state(
+    card_id: int,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        return WorkflowStateResponse(**db.get_card_workflow_state(card_id))
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.patch(
+    "/workflow/cards/{card_id}/state",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.state.patch"))],
+)
+async def patch_card_workflow_state(
+    card_id: int,
+    state_in: WorkflowStatePatchRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        state = db.patch_card_workflow_state(
+            card_id=card_id,
+            workflow_status_key=state_in.workflow_status_key,
+            expected_version=state_in.expected_version,
+            lease_owner=state_in.lease_owner,
+            idempotency_key=state_in.idempotency_key,
+            correlation_id=state_in.correlation_id,
+            last_actor=state_in.actor,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/cards/{card_id}/claim",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.claim"))],
+)
+async def claim_card_workflow(
+    card_id: int,
+    claim_in: WorkflowClaimRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        state = db.claim_card_workflow(
+            card_id=card_id,
+            owner=claim_in.owner,
+            lease_ttl_sec=claim_in.lease_ttl_sec,
+            idempotency_key=claim_in.idempotency_key,
+            correlation_id=claim_in.correlation_id,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/cards/{card_id}/release",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.release"))],
+)
+async def release_card_workflow(
+    card_id: int,
+    release_in: WorkflowReleaseRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        state = db.release_card_workflow(
+            card_id=card_id,
+            owner=release_in.owner,
+            idempotency_key=release_in.idempotency_key,
+            correlation_id=release_in.correlation_id,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/cards/{card_id}/transition",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.transition"))],
+)
+async def transition_card_workflow(
+    card_id: int,
+    transition_in: WorkflowTransitionRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        state = db.transition_card_workflow(
+            card_id=card_id,
+            to_status_key=transition_in.to_status_key,
+            actor=transition_in.actor,
+            expected_version=transition_in.expected_version,
+            idempotency_key=transition_in.idempotency_key,
+            correlation_id=transition_in.correlation_id,
+            reason=transition_in.reason,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/cards/{card_id}/approval",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.approval.decide"))],
+)
+async def decide_card_workflow_approval(
+    card_id: int,
+    approval_in: WorkflowApprovalDecisionRequest,
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    try:
+        state = db.decide_card_workflow_approval(
+            card_id=card_id,
+            reviewer=approval_in.reviewer,
+            decision=approval_in.decision,
+            expected_version=approval_in.expected_version,
+            idempotency_key=approval_in.idempotency_key,
+            correlation_id=approval_in.correlation_id,
+            reason=approval_in.reason,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.get(
+    "/workflow/cards/{card_id}/events",
+    response_model=WorkflowEventsListResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.task.events.list"))],
+)
+async def list_card_workflow_events(
+    card_id: int,
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowEventsListResponse:
+    try:
+        return WorkflowEventsListResponse(events=db.list_card_workflow_events(card_id=card_id, limit=limit, offset=offset))
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.get(
+    "/workflow/recovery/stale-claims",
+    response_model=WorkflowStaleClaimsListResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.recovery.list_stale_claims"))],
+)
+async def list_stale_workflow_claims(
+    board_id: int | None = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStaleClaimsListResponse:
+    try:
+        claims = db.list_stale_workflow_claims(board_id=board_id, limit=limit)
+        return WorkflowStaleClaimsListResponse(stale_claims=claims)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/recovery/cards/{card_id}/force-reassign",
+    response_model=WorkflowStateResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.recovery.force_reassign"))],
+)
+async def force_reassign_workflow_claim(
+    card_id: int,
+    request_in: WorkflowForceReassignRequest,
+    current_user: User = Depends(get_request_user),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowStateResponse:
+    _require_admin(current_user)
+    try:
+        state = db.force_reassign_workflow_claim(
+            card_id=card_id,
+            new_owner=request_in.new_owner,
+            idempotency_key=request_in.idempotency_key,
+            correlation_id=request_in.correlation_id,
+            reason=request_in.reason,
+        )
+        return WorkflowStateResponse(**state)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/control/boards/{board_id}/pause",
+    response_model=WorkflowControlResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.control.pause"))],
+)
+async def pause_workflow_policy(
+    board_id: int,
+    current_user: User = Depends(get_request_user),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowControlResponse:
+    _require_admin(current_user)
+    try:
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=True,
+            is_draining=bool(policy.get("is_draining", False)),
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return WorkflowControlResponse(success=True, policy=updated)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/control/boards/{board_id}/resume",
+    response_model=WorkflowControlResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.control.resume"))],
+)
+async def resume_workflow_policy(
+    board_id: int,
+    current_user: User = Depends(get_request_user),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowControlResponse:
+    _require_admin(current_user)
+    try:
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=False,
+            is_draining=bool(policy.get("is_draining", False)),
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return WorkflowControlResponse(success=True, policy=updated)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc
+
+
+@router.post(
+    "/workflow/control/boards/{board_id}/drain",
+    response_model=WorkflowControlResponse,
+    dependencies=[Depends(kanban_rate_limit("kanban.workflow.control.drain"))],
+)
+async def drain_workflow_policy(
+    board_id: int,
+    current_user: User = Depends(get_request_user),
+    db: KanbanDB = Depends(get_kanban_db_for_user),
+) -> WorkflowControlResponse:
+    _require_admin(current_user)
+    try:
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=bool(policy.get("is_paused", False)),
+            is_draining=True,
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return WorkflowControlResponse(success=True, policy=updated)
+    except (NotFoundError, InputError, ConflictError, KanbanDBError) as exc:
+        raise _workflow_http_error(exc) from exc

--- a/tldw_Server_API/app/api/v1/schemas/kanban_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/kanban_schemas.py
@@ -956,6 +956,67 @@ class WorkflowPolicyUpsertRequest(BaseModel):
     metadata: Optional[dict[str, Any]] = None
 
 
+class WorkflowPolicyStatusResponse(BaseModel):
+    """Workflow status response item."""
+
+    id: int
+    policy_id: int
+    status_key: str
+    display_name: str
+    is_terminal: bool
+    sort_order: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkflowPolicyTransitionResponse(BaseModel):
+    """Workflow transition response item."""
+
+    id: int
+    policy_id: int
+    from_status_key: str
+    to_status_key: str
+    requires_claim: bool
+    requires_approval: bool
+    approve_to_status_key: Optional[str] = None
+    reject_to_status_key: Optional[str] = None
+    auto_move_list_id: Optional[int] = None
+    max_retries: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkflowPolicyResponse(BaseModel):
+    """Workflow policy response payload."""
+
+    id: int
+    board_id: int
+    version: int
+    is_paused: bool
+    is_draining: bool
+    default_lease_ttl_sec: int
+    strict_projection: bool
+    metadata: Optional[dict[str, Any]] = None
+    created_at: datetime
+    updated_at: datetime
+    statuses: list[WorkflowPolicyStatusResponse]
+    transitions: list[WorkflowPolicyTransitionResponse]
+
+
+class WorkflowStatusesListResponse(BaseModel):
+    """Workflow statuses list response."""
+
+    statuses: list[WorkflowPolicyStatusResponse]
+
+
+class WorkflowTransitionsListResponse(BaseModel):
+    """Workflow transitions list response."""
+
+    transitions: list[WorkflowPolicyTransitionResponse]
+
+
 class WorkflowStateResponse(BaseModel):
     """Workflow runtime state response."""
 
@@ -1037,7 +1098,7 @@ class WorkflowControlResponse(BaseModel):
     """Simple success response for workflow controls."""
 
     success: bool = Field(True)
-    policy: dict[str, Any]
+    policy: WorkflowPolicyResponse
 
 
 class WorkflowEventResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/kanban_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/kanban_schemas.py
@@ -913,3 +913,171 @@ class LinkedCardsListResponse(BaseModel):
     linked_type: str = Field(..., description="Type queried")
     linked_id: str = Field(..., description="Content ID queried")
     cards: list[LinkedCardResponse] = Field(..., description="Cards linked to this content")
+
+
+# =============================================================================
+# Workflow Control Schemas (Safe Orchestrator)
+# =============================================================================
+
+
+class WorkflowPolicyStatusConfig(BaseModel):
+    """Status configuration for workflow policy upsert."""
+
+    status_key: str = Field(..., min_length=1, max_length=128)
+    display_name: str = Field(..., min_length=1, max_length=255)
+    is_terminal: bool = Field(False)
+    sort_order: int = Field(0)
+    is_active: bool = Field(True)
+
+
+class WorkflowPolicyTransitionConfig(BaseModel):
+    """Transition edge configuration for workflow policy upsert."""
+
+    from_status_key: str = Field(..., min_length=1, max_length=128)
+    to_status_key: str = Field(..., min_length=1, max_length=128)
+    requires_claim: bool = Field(True)
+    requires_approval: bool = Field(False)
+    approve_to_status_key: Optional[str] = Field(None, min_length=1, max_length=128)
+    reject_to_status_key: Optional[str] = Field(None, min_length=1, max_length=128)
+    auto_move_list_id: Optional[int] = Field(None)
+    max_retries: int = Field(0, ge=0)
+    is_active: bool = Field(True)
+
+
+class WorkflowPolicyUpsertRequest(BaseModel):
+    """Workflow policy upsert payload."""
+
+    statuses: Optional[list[WorkflowPolicyStatusConfig]] = None
+    transitions: Optional[list[WorkflowPolicyTransitionConfig]] = None
+    is_paused: bool = Field(False)
+    is_draining: bool = Field(False)
+    default_lease_ttl_sec: int = Field(900, gt=0)
+    strict_projection: bool = Field(True)
+    metadata: Optional[dict[str, Any]] = None
+
+
+class WorkflowStateResponse(BaseModel):
+    """Workflow runtime state response."""
+
+    card_id: int
+    policy_id: int
+    workflow_status_key: str
+    lease_owner: Optional[str] = None
+    lease_expires_at: Optional[datetime] = None
+    approval_state: str
+    pending_transition_id: Optional[int] = None
+    retry_counters: Optional[dict[str, Any]] = None
+    last_transition_at: Optional[datetime] = None
+    last_actor: Optional[str] = None
+    version: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkflowStatePatchRequest(BaseModel):
+    """Patch workflow runtime state payload."""
+
+    workflow_status_key: Optional[str] = Field(None, min_length=1, max_length=128)
+    expected_version: int = Field(..., ge=1)
+    lease_owner: Optional[str] = None
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    correlation_id: Optional[str] = Field(None, min_length=1, max_length=255)
+    actor: Optional[str] = Field(None, min_length=1, max_length=255)
+
+
+class WorkflowClaimRequest(BaseModel):
+    """Claim/lease request payload."""
+
+    owner: str = Field(..., min_length=1, max_length=255)
+    lease_ttl_sec: Optional[int] = Field(None, gt=0)
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    correlation_id: Optional[str] = Field(None, min_length=1, max_length=255)
+
+
+class WorkflowReleaseRequest(BaseModel):
+    """Release claim payload."""
+
+    owner: str = Field(..., min_length=1, max_length=255)
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    correlation_id: Optional[str] = Field(None, min_length=1, max_length=255)
+
+
+class WorkflowTransitionRequest(BaseModel):
+    """Workflow transition payload."""
+
+    to_status_key: str = Field(..., min_length=1, max_length=128)
+    actor: str = Field(..., min_length=1, max_length=255)
+    expected_version: int = Field(..., ge=1)
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    reason: Optional[str] = Field(None, max_length=2000)
+    correlation_id: str = Field(..., min_length=1, max_length=255)
+
+
+class WorkflowApprovalDecisionRequest(BaseModel):
+    """Approval decision payload."""
+
+    reviewer: str = Field(..., min_length=1, max_length=255)
+    decision: Literal["approved", "rejected"]
+    expected_version: int = Field(..., ge=1)
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    reason: Optional[str] = Field(None, max_length=2000)
+    correlation_id: str = Field(..., min_length=1, max_length=255)
+
+
+class WorkflowForceReassignRequest(BaseModel):
+    """Force-reassign payload."""
+
+    new_owner: str = Field(..., min_length=1, max_length=255)
+    idempotency_key: str = Field(..., min_length=1, max_length=255)
+    reason: Optional[str] = Field(None, max_length=2000)
+    correlation_id: str = Field(..., min_length=1, max_length=255)
+
+
+class WorkflowControlResponse(BaseModel):
+    """Simple success response for workflow controls."""
+
+    success: bool = Field(True)
+    policy: dict[str, Any]
+
+
+class WorkflowEventResponse(BaseModel):
+    """Workflow event response item."""
+
+    id: int
+    card_id: int
+    event_type: str
+    from_status_key: Optional[str] = None
+    to_status_key: Optional[str] = None
+    actor: str
+    reason: Optional[str] = None
+    idempotency_key: str
+    correlation_id: Optional[str] = None
+    before_snapshot: Optional[dict[str, Any]] = None
+    after_snapshot: Optional[dict[str, Any]] = None
+    created_at: datetime
+
+
+class WorkflowEventsListResponse(BaseModel):
+    """Workflow events list response."""
+
+    events: list[WorkflowEventResponse]
+
+
+class WorkflowStaleClaimResponse(BaseModel):
+    """Stale claim item response."""
+
+    card_id: int
+    board_id: int
+    list_id: int
+    title: str
+    workflow_status_key: str
+    lease_owner: str
+    lease_expires_at: datetime
+    version: int
+    updated_at: datetime
+
+
+class WorkflowStaleClaimsListResponse(BaseModel):
+    """Stale claims list response."""
+
+    stale_claims: list[WorkflowStaleClaimResponse]

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -1652,9 +1652,19 @@ END;
             try:
                 state_row = self._ensure_card_workflow_state(conn, card_id)
                 current_state = self._row_to_card_workflow_state_dict(state_row)
+                card_row = conn.execute(
+                    """
+                    SELECT id, board_id, list_id
+                    FROM kanban_cards
+                    WHERE id = ? AND deleted = 0
+                    """,
+                    (card_id,),
+                ).fetchone()
+                if not card_row:
+                    raise NotFoundError("Card not found", entity="card", entity_id=card_id)  # noqa: TRY003
 
                 policy_row = conn.execute(
-                    "SELECT is_paused FROM board_workflow_policies WHERE id = ?",
+                    "SELECT is_paused, strict_projection FROM board_workflow_policies WHERE id = ?",
                     (current_state["policy_id"],),
                 ).fetchone()
                 if policy_row and bool(policy_row["is_paused"]):
@@ -1664,7 +1674,9 @@ END;
                     """
                     SELECT id
                     FROM kanban_card_workflow_events
-                    WHERE card_id = ? AND event_type = 'workflow_transitioned' AND idempotency_key = ?
+                    WHERE card_id = ?
+                      AND event_type IN ('workflow_transitioned', 'workflow_approval_requested')
+                      AND idempotency_key = ?
                     """,
                     (card_id, idempotency_key.strip()),
                 ).fetchone()
@@ -1677,7 +1689,7 @@ END;
 
                 transition_row = conn.execute(
                     """
-                    SELECT id, requires_claim, requires_approval, is_active
+                    SELECT id, requires_claim, requires_approval, is_active, auto_move_list_id
                     FROM board_workflow_transitions
                     WHERE policy_id = ? AND from_status_key = ? AND to_status_key = ? AND is_active = 1
                     """,
@@ -1694,6 +1706,21 @@ END;
                         raise ConflictError("lease_required", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
                     if not lease_expires_at or str(lease_expires_at) <= now:
                         raise ConflictError("lease_required", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                projected_list_id: int | None = None
+                if transition_row["auto_move_list_id"] is not None:
+                    projected_row = conn.execute(
+                        """
+                        SELECT id
+                        FROM kanban_lists
+                        WHERE id = ? AND board_id = ? AND deleted = 0 AND archived = 0
+                        """,
+                        (transition_row["auto_move_list_id"], card_row["board_id"]),
+                    ).fetchone()
+                    if not projected_row and bool(policy_row["strict_projection"]):
+                        raise ConflictError("projection_failed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                    if projected_row:
+                        projected_list_id = int(projected_row["id"])
 
                 if bool(transition_row["requires_approval"]):
                     update_cur = conn.execute(
@@ -1774,6 +1801,18 @@ END;
                 if update_cur.rowcount != 1:
                     raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
 
+                if projected_list_id is not None and int(card_row["list_id"]) != projected_list_id:
+                    projected_update = conn.execute(
+                        """
+                        UPDATE kanban_cards
+                        SET list_id = ?, version = version + 1, updated_at = ?
+                        WHERE id = ? AND board_id = ? AND deleted = 0 AND archived = 0
+                        """,
+                        (projected_list_id, now, card_id, card_row["board_id"]),
+                    )
+                    if projected_update.rowcount != 1 and bool(policy_row["strict_projection"]):
+                        raise ConflictError("projection_failed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
                 updated_row = self._get_card_workflow_state_row(conn, card_id)
                 if not updated_row:
                     raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
@@ -1853,7 +1892,7 @@ END;
 
                 transition_row = conn.execute(
                     """
-                    SELECT id, to_status_key, approve_to_status_key, reject_to_status_key
+                    SELECT id, to_status_key, approve_to_status_key, reject_to_status_key, auto_move_list_id
                     FROM board_workflow_transitions
                     WHERE id = ?
                     """,
@@ -1870,6 +1909,35 @@ END;
                     approval_state = "rejected"
 
                 now = _utcnow_iso()
+                card_row = conn.execute(
+                    """
+                    SELECT id, board_id, list_id
+                    FROM kanban_cards
+                    WHERE id = ? AND deleted = 0
+                    """,
+                    (card_id,),
+                ).fetchone()
+                if not card_row:
+                    raise NotFoundError("Card not found", entity="card", entity_id=card_id)  # noqa: TRY003
+                policy_row = conn.execute(
+                    "SELECT strict_projection FROM board_workflow_policies WHERE id = ?",
+                    (current_state["policy_id"],),
+                ).fetchone()
+                projected_list_id: int | None = None
+                if decision == "approved" and transition_row["auto_move_list_id"] is not None:
+                    projected_row = conn.execute(
+                        """
+                        SELECT id
+                        FROM kanban_lists
+                        WHERE id = ? AND board_id = ? AND deleted = 0 AND archived = 0
+                        """,
+                        (transition_row["auto_move_list_id"], card_row["board_id"]),
+                    ).fetchone()
+                    if not projected_row and bool(policy_row and policy_row["strict_projection"]):
+                        raise ConflictError("projection_failed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                    if projected_row:
+                        projected_list_id = int(projected_row["id"])
+
                 conn.execute(
                     """
                     UPDATE kanban_card_workflow_approvals
@@ -1895,6 +1963,18 @@ END;
                 )
                 if update_cur.rowcount != 1:
                     raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                if projected_list_id is not None and int(card_row["list_id"]) != projected_list_id:
+                    projected_update = conn.execute(
+                        """
+                        UPDATE kanban_cards
+                        SET list_id = ?, version = version + 1, updated_at = ?
+                        WHERE id = ? AND board_id = ? AND deleted = 0 AND archived = 0
+                        """,
+                        (projected_list_id, now, card_id, card_row["board_id"]),
+                    )
+                    if projected_update.rowcount != 1 and bool(policy_row and policy_row["strict_projection"]):
+                        raise ConflictError("projection_failed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
 
                 updated_row = self._get_card_workflow_state_row(conn, card_id)
                 if not updated_row:

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -591,6 +591,120 @@ CREATE INDEX IF NOT EXISTS idx_activities_list ON kanban_activities(list_id);
 CREATE INDEX IF NOT EXISTS idx_activities_card ON kanban_activities(card_id);
 CREATE INDEX IF NOT EXISTS idx_activities_created ON kanban_activities(created_at);
 
+-- Workflow Policies
+CREATE TABLE IF NOT EXISTS board_workflow_policies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    board_id INTEGER NOT NULL UNIQUE REFERENCES kanban_boards(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL DEFAULT 1,
+    is_paused INTEGER NOT NULL DEFAULT 0 CHECK (is_paused IN (0, 1)),
+    is_draining INTEGER NOT NULL DEFAULT 0 CHECK (is_draining IN (0, 1)),
+    default_lease_ttl_sec INTEGER NOT NULL DEFAULT 900 CHECK (default_lease_ttl_sec > 0),
+    strict_projection INTEGER NOT NULL DEFAULT 1 CHECK (strict_projection IN (0, 1)),
+    metadata JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_policies_board ON board_workflow_policies(board_id);
+
+-- Workflow Status Catalog
+CREATE TABLE IF NOT EXISTS board_workflow_statuses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER NOT NULL REFERENCES board_workflow_policies(id) ON DELETE CASCADE,
+    status_key TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    is_terminal INTEGER NOT NULL DEFAULT 0 CHECK (is_terminal IN (0, 1)),
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(policy_id, status_key)
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_statuses_policy ON board_workflow_statuses(policy_id);
+
+-- Workflow Transition Edges
+CREATE TABLE IF NOT EXISTS board_workflow_transitions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    policy_id INTEGER NOT NULL REFERENCES board_workflow_policies(id) ON DELETE CASCADE,
+    from_status_key TEXT NOT NULL,
+    to_status_key TEXT NOT NULL,
+    requires_claim INTEGER NOT NULL DEFAULT 1 CHECK (requires_claim IN (0, 1)),
+    requires_approval INTEGER NOT NULL DEFAULT 0 CHECK (requires_approval IN (0, 1)),
+    approve_to_status_key TEXT,
+    reject_to_status_key TEXT,
+    auto_move_list_id INTEGER REFERENCES kanban_lists(id) ON DELETE SET NULL,
+    max_retries INTEGER NOT NULL DEFAULT 0 CHECK(max_retries >= 0),
+    is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(policy_id, from_status_key, to_status_key),
+    FOREIGN KEY(policy_id, from_status_key)
+        REFERENCES board_workflow_statuses(policy_id, status_key) ON DELETE CASCADE,
+    FOREIGN KEY(policy_id, to_status_key)
+        REFERENCES board_workflow_statuses(policy_id, status_key) ON DELETE CASCADE,
+    FOREIGN KEY(policy_id, approve_to_status_key)
+        REFERENCES board_workflow_statuses(policy_id, status_key) ON DELETE SET NULL,
+    FOREIGN KEY(policy_id, reject_to_status_key)
+        REFERENCES board_workflow_statuses(policy_id, status_key) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_workflow_transitions_policy ON board_workflow_transitions(policy_id);
+
+-- Card Workflow Runtime State
+CREATE TABLE IF NOT EXISTS kanban_card_workflow_state (
+    card_id INTEGER PRIMARY KEY REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    policy_id INTEGER NOT NULL REFERENCES board_workflow_policies(id) ON DELETE CASCADE,
+    workflow_status_key TEXT NOT NULL,
+    lease_owner TEXT,
+    lease_expires_at TIMESTAMP,
+    approval_state TEXT NOT NULL DEFAULT 'none'
+        CHECK (approval_state IN ('none', 'awaiting_approval', 'approved', 'rejected')),
+    pending_transition_id INTEGER REFERENCES board_workflow_transitions(id) ON DELETE SET NULL,
+    retry_counters JSON,
+    last_transition_at TIMESTAMP,
+    last_actor TEXT,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(policy_id, workflow_status_key)
+        REFERENCES board_workflow_statuses(policy_id, status_key) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_card_workflow_state_policy ON kanban_card_workflow_state(policy_id);
+CREATE INDEX IF NOT EXISTS idx_card_workflow_state_status ON kanban_card_workflow_state(workflow_status_key);
+CREATE INDEX IF NOT EXISTS idx_card_workflow_state_lease ON kanban_card_workflow_state(lease_expires_at);
+
+-- Card Workflow Events (append-only)
+CREATE TABLE IF NOT EXISTS kanban_card_workflow_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_id INTEGER NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    event_type TEXT NOT NULL,
+    from_status_key TEXT,
+    to_status_key TEXT,
+    actor TEXT NOT NULL,
+    reason TEXT,
+    idempotency_key TEXT NOT NULL,
+    correlation_id TEXT,
+    before_snapshot JSON,
+    after_snapshot JSON,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(card_id, event_type, idempotency_key)
+);
+CREATE INDEX IF NOT EXISTS idx_card_workflow_events_card_created ON kanban_card_workflow_events(card_id, created_at DESC);
+
+-- Card Workflow Approvals
+CREATE TABLE IF NOT EXISTS kanban_card_workflow_approvals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    card_id INTEGER NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    transition_id INTEGER NOT NULL REFERENCES board_workflow_transitions(id) ON DELETE CASCADE,
+    state TEXT NOT NULL CHECK (state IN ('pending', 'approved', 'rejected')),
+    reviewer TEXT,
+    decision_reason TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_card_workflow_approvals_card ON kanban_card_workflow_approvals(card_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_card_workflow_approvals_pending_unique
+    ON kanban_card_workflow_approvals(card_id, transition_id)
+    WHERE state = 'pending';
+
 -- Card Links
 CREATE TABLE IF NOT EXISTS kanban_card_links (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -1347,6 +1347,7 @@ END;
         expected_version: int,
         lease_owner: str | None,
         idempotency_key: str,
+        correlation_id: str | None = None,
         last_actor: str | None = None,
     ) -> dict[str, Any]:
         if expected_version < 1:
@@ -1355,6 +1356,7 @@ END;
             raise InputError("idempotency_key is required")  # noqa: TRY003
 
         actor = (last_actor or self.user_id).strip()
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
 
         with self._lock:
             conn = self._connect()
@@ -1427,8 +1429,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'state_patched', ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'state_patched', ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -1436,6 +1438,7 @@ END;
                         updated_state["workflow_status_key"],
                         actor,
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,
@@ -1454,11 +1457,13 @@ END;
         owner: str,
         lease_ttl_sec: int | None = None,
         idempotency_key: str,
+        correlation_id: str | None = None,
     ) -> dict[str, Any]:
         if not owner or not owner.strip():
             raise InputError("owner is required")  # noqa: TRY003
         if not idempotency_key or not idempotency_key.strip():
             raise InputError("idempotency_key is required")  # noqa: TRY003
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
 
         with self._lock:
             conn = self._connect()
@@ -1514,8 +1519,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'workflow_claimed', ?, ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_claimed', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -1524,6 +1529,7 @@ END;
                         owner.strip(),
                         "claim_acquired",
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,
@@ -1541,11 +1547,13 @@ END;
         card_id: int,
         owner: str,
         idempotency_key: str,
+        correlation_id: str | None = None,
     ) -> dict[str, Any]:
         if not owner or not owner.strip():
             raise InputError("owner is required")  # noqa: TRY003
         if not idempotency_key or not idempotency_key.strip():
             raise InputError("idempotency_key is required")  # noqa: TRY003
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
 
         with self._lock:
             conn = self._connect()
@@ -1593,8 +1601,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'workflow_released', ?, ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_released', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -1603,6 +1611,7 @@ END;
                         owner.strip(),
                         "claim_released",
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,
@@ -1622,6 +1631,7 @@ END;
         actor: str,
         expected_version: int,
         idempotency_key: str,
+        correlation_id: str | None = None,
         reason: str | None = None,
     ) -> dict[str, Any]:
         if not to_status_key or not to_status_key.strip():
@@ -1635,12 +1645,20 @@ END;
 
         target_status_key = to_status_key.strip()
         actor_name = actor.strip()
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
 
         with self._lock:
             conn = self._connect()
             try:
                 state_row = self._ensure_card_workflow_state(conn, card_id)
                 current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                policy_row = conn.execute(
+                    "SELECT is_paused FROM board_workflow_policies WHERE id = ?",
+                    (current_state["policy_id"],),
+                ).fetchone()
+                if policy_row and bool(policy_row["is_paused"]):
+                    raise ConflictError("policy_paused", entity="workflow_policy", entity_id=current_state["policy_id"])  # noqa: TRY003
 
                 replay = conn.execute(
                     """
@@ -1719,8 +1737,8 @@ END;
                         """
                         INSERT INTO kanban_card_workflow_events
                         (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                         before_snapshot, after_snapshot, created_at)
-                        VALUES (?, 'workflow_approval_requested', ?, ?, ?, ?, ?, ?, ?, ?)
+                         correlation_id, before_snapshot, after_snapshot, created_at)
+                        VALUES (?, 'workflow_approval_requested', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             card_id,
@@ -1729,6 +1747,7 @@ END;
                             actor_name,
                             reason,
                             idempotency_key.strip(),
+                            corr_id,
                             json.dumps(current_state),
                             json.dumps(updated_state),
                             now,
@@ -1764,8 +1783,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'workflow_transitioned', ?, ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_transitioned', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -1774,6 +1793,7 @@ END;
                         actor_name,
                         reason,
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,
@@ -1793,6 +1813,7 @@ END;
         decision: str,
         expected_version: int,
         idempotency_key: str,
+        correlation_id: str | None = None,
         reason: str | None = None,
     ) -> dict[str, Any]:
         if not reviewer or not reviewer.strip():
@@ -1805,6 +1826,7 @@ END;
             raise InputError("idempotency_key is required")  # noqa: TRY003
 
         reviewer_name = reviewer.strip()
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
 
         with self._lock:
             conn = self._connect()
@@ -1883,8 +1905,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'workflow_approval_decided', ?, ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_approval_decided', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -1893,6 +1915,7 @@ END;
                         reviewer_name,
                         reason or decision,
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,
@@ -2010,6 +2033,7 @@ END;
         card_id: int,
         new_owner: str,
         idempotency_key: str,
+        correlation_id: str | None = None,
         reason: str | None = None,
     ) -> dict[str, Any]:
         if not new_owner or not new_owner.strip():
@@ -2018,6 +2042,7 @@ END;
             raise InputError("idempotency_key is required")  # noqa: TRY003
 
         owner = new_owner.strip()
+        corr_id = correlation_id.strip() if correlation_id and correlation_id.strip() else None
         with self._lock:
             conn = self._connect()
             try:
@@ -2068,8 +2093,8 @@ END;
                     """
                     INSERT INTO kanban_card_workflow_events
                     (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
-                     before_snapshot, after_snapshot, created_at)
-                    VALUES (?, 'workflow_claim_reassigned', ?, ?, ?, ?, ?, ?, ?, ?)
+                     correlation_id, before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_claim_reassigned', ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -2078,6 +2103,7 @@ END;
                         owner,
                         reason,
                         idempotency_key.strip(),
+                        corr_id,
                         json.dumps(current_state),
                         json.dumps(updated_state),
                         now,

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -197,10 +197,18 @@ class ConflictError(KanbanDBError):
     an update/delete operation (optimistic locking), or if an insert/update
     violates a unique constraint (e.g., duplicate client_id).
     """
-    def __init__(self, message: str = "Conflict detected.", entity: str | None = None, entity_id: Any = None):
+    def __init__(
+        self,
+        message: str = "Conflict detected.",
+        entity: str | None = None,
+        entity_id: Any = None,
+        *,
+        code: str | None = None,
+    ):
         super().__init__(message)
         self.entity = entity
         self.entity_id = entity_id
+        self.code = code
 
     def __str__(self):
         base = super().__str__()
@@ -1236,6 +1244,49 @@ END;
             finally:
                 conn.close()
 
+    def update_workflow_policy_flags(
+        self,
+        *,
+        board_id: int,
+        is_paused: bool | None = None,
+        is_draining: bool | None = None,
+    ) -> dict[str, Any]:
+        """Update policy control flags without rewriting statuses/transitions."""
+        with self._lock:
+            conn = self._connect()
+            try:
+                policy = self._ensure_workflow_policy_for_board(conn, board_id)
+                policy_row = self._get_workflow_policy_row(conn, board_id)
+                if not policy_row:
+                    raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)  # noqa: TRY003
+
+                next_paused = bool(policy["is_paused"]) if is_paused is None else bool(is_paused)
+                next_draining = bool(policy["is_draining"]) if is_draining is None else bool(is_draining)
+                now = _utcnow_iso()
+                conn.execute(
+                    """
+                    UPDATE board_workflow_policies
+                    SET version = version + 1,
+                        is_paused = ?,
+                        is_draining = ?,
+                        updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        self._coerce_bool_int(next_paused),
+                        self._coerce_bool_int(next_draining),
+                        now,
+                        int(policy_row["id"]),
+                    ),
+                )
+                updated = self._get_workflow_policy_internal(conn, board_id)
+                if not updated:
+                    raise KanbanDBError("workflow_policy_update_failed")  # noqa: TRY003
+                conn.commit()
+                return updated
+            finally:
+                conn.close()
+
     def get_workflow_policy(self, board_id: int) -> dict[str, Any] | None:
         with self._lock:
             conn = self._connect()
@@ -1378,9 +1429,10 @@ END;
 
                 if int(current_state["version"]) != int(expected_version):
                     raise ConflictError(  # noqa: TRY003
-                        f"Version mismatch: expected {expected_version}, got {current_state['version']}",
+                        f"version_conflict: expected {expected_version}, got {current_state['version']}",
                         entity="card_workflow_state",
                         entity_id=card_id,
+                        code="version_conflict",
                     )
 
                 next_status_key = workflow_status_key.strip() if workflow_status_key else current_state["workflow_status_key"]
@@ -1418,7 +1470,12 @@ END;
                     ),
                 )
                 if update_cur.rowcount != 1:
-                    raise ConflictError("Workflow state update conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                    raise ConflictError(  # noqa: TRY003
+                        "version_conflict: workflow state update conflict",
+                        entity="card_workflow_state",
+                        entity_id=card_id,
+                        code="version_conflict",
+                    )
 
                 updated_row = self._get_card_workflow_state_row(conn, card_id)
                 if not updated_row:
@@ -1494,6 +1551,17 @@ END;
 
                 now = _utcnow_iso()
                 lease_expires_at = (datetime.now(timezone.utc) + timedelta(seconds=lease_ttl_sec)).strftime("%Y-%m-%d %H:%M:%S")
+                lease_owner = current_state["lease_owner"]
+                lease_expiry = current_state["lease_expires_at"]
+                owner_name = owner.strip()
+
+                if lease_owner and lease_owner != owner_name and lease_expiry and str(lease_expiry) > now:
+                    raise ConflictError(  # noqa: TRY003
+                        "lease_mismatch",
+                        entity="card_workflow_state",
+                        entity_id=card_id,
+                        code="lease_mismatch",
+                    )
 
                 update_cur = conn.execute(
                     """
@@ -1504,11 +1572,29 @@ END;
                         version = version + 1,
                         updated_at = ?
                     WHERE card_id = ? AND version = ?
+                      AND (
+                        lease_owner IS NULL
+                        OR lease_expires_at IS NULL
+                        OR lease_expires_at <= ?
+                        OR lease_owner = ?
+                      )
                     """,
-                    (owner.strip(), lease_expires_at, owner.strip(), now, card_id, current_state["version"]),
+                    (owner_name, lease_expires_at, owner_name, now, card_id, current_state["version"], now, owner_name),
                 )
                 if update_cur.rowcount != 1:
-                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                    latest_row = self._get_card_workflow_state_row(conn, card_id)
+                    latest_state = self._row_to_card_workflow_state_dict(latest_row) if latest_row else None
+                    if latest_state:
+                        latest_owner = latest_state["lease_owner"]
+                        latest_expiry = latest_state["lease_expires_at"]
+                        if latest_owner and latest_owner != owner_name and latest_expiry and str(latest_expiry) > now:
+                            raise ConflictError(  # noqa: TRY003
+                                "lease_mismatch",
+                                entity="card_workflow_state",
+                                entity_id=card_id,
+                                code="lease_mismatch",
+                            )
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id, code="version_conflict")  # noqa: TRY003
 
                 updated_row = self._get_card_workflow_state_row(conn, card_id)
                 if not updated_row:
@@ -1717,7 +1803,7 @@ END;
                         """,
                         (transition_row["auto_move_list_id"], card_row["board_id"]),
                     ).fetchone()
-                    if not projected_row and bool(policy_row["strict_projection"]):
+                    if not projected_row and bool(policy_row and policy_row["strict_projection"]):
                         raise ConflictError("projection_failed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
                     if projected_row:
                         projected_list_id = int(projected_row["id"])

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -1447,6 +1447,648 @@ END;
             finally:
                 conn.close()
 
+    def claim_card_workflow(
+        self,
+        *,
+        card_id: int,
+        owner: str,
+        lease_ttl_sec: int | None = None,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        if not owner or not owner.strip():
+            raise InputError("owner is required")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'workflow_claimed' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                if lease_ttl_sec is None:
+                    ttl_row = conn.execute(
+                        "SELECT default_lease_ttl_sec FROM board_workflow_policies WHERE id = ?",
+                        (current_state["policy_id"],),
+                    ).fetchone()
+                    lease_ttl_sec = int(ttl_row["default_lease_ttl_sec"]) if ttl_row else 900
+                if lease_ttl_sec <= 0:
+                    raise InputError("lease_ttl_sec must be greater than zero")  # noqa: TRY003
+
+                now = _utcnow_iso()
+                lease_expires_at = (datetime.now(timezone.utc) + timedelta(seconds=lease_ttl_sec)).strftime("%Y-%m-%d %H:%M:%S")
+
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET lease_owner = ?,
+                        lease_expires_at = ?,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (owner.strip(), lease_expires_at, owner.strip(), now, card_id, current_state["version"]),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_claimed', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        owner.strip(),
+                        "claim_acquired",
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
+
+    def release_card_workflow(
+        self,
+        *,
+        card_id: int,
+        owner: str,
+        idempotency_key: str,
+    ) -> dict[str, Any]:
+        if not owner or not owner.strip():
+            raise InputError("owner is required")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'workflow_released' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                if current_state["lease_owner"] and current_state["lease_owner"] != owner.strip():
+                    raise ConflictError("lease_mismatch", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                now = _utcnow_iso()
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET lease_owner = NULL,
+                        lease_expires_at = NULL,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (owner.strip(), now, card_id, current_state["version"]),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_released', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        owner.strip(),
+                        "claim_released",
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
+
+    def transition_card_workflow(
+        self,
+        *,
+        card_id: int,
+        to_status_key: str,
+        actor: str,
+        expected_version: int,
+        idempotency_key: str,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        if not to_status_key or not to_status_key.strip():
+            raise InputError("to_status_key is required")  # noqa: TRY003
+        if not actor or not actor.strip():
+            raise InputError("actor is required")  # noqa: TRY003
+        if expected_version < 1:
+            raise InputError("expected_version must be >= 1")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        target_status_key = to_status_key.strip()
+        actor_name = actor.strip()
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'workflow_transitioned' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                if int(current_state["version"]) != int(expected_version):
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                transition_row = conn.execute(
+                    """
+                    SELECT id, requires_claim, requires_approval, is_active
+                    FROM board_workflow_transitions
+                    WHERE policy_id = ? AND from_status_key = ? AND to_status_key = ? AND is_active = 1
+                    """,
+                    (current_state["policy_id"], current_state["workflow_status_key"], target_status_key),
+                ).fetchone()
+                if not transition_row:
+                    raise ConflictError("transition_not_allowed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                now = _utcnow_iso()
+                if bool(transition_row["requires_claim"]):
+                    lease_owner = current_state["lease_owner"]
+                    lease_expires_at = current_state["lease_expires_at"]
+                    if not lease_owner or lease_owner != actor_name:
+                        raise ConflictError("lease_required", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                    if not lease_expires_at or str(lease_expires_at) <= now:
+                        raise ConflictError("lease_required", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                if bool(transition_row["requires_approval"]):
+                    update_cur = conn.execute(
+                        """
+                        UPDATE kanban_card_workflow_state
+                        SET approval_state = 'awaiting_approval',
+                            pending_transition_id = ?,
+                            last_actor = ?,
+                            version = version + 1,
+                            updated_at = ?
+                        WHERE card_id = ? AND version = ?
+                        """,
+                        (transition_row["id"], actor_name, now, card_id, expected_version),
+                    )
+                    if update_cur.rowcount != 1:
+                        raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                    conn.execute(
+                        """
+                        UPDATE kanban_card_workflow_approvals
+                        SET state = 'rejected', updated_at = ?, decision_reason = COALESCE(decision_reason, 'superseded')
+                        WHERE card_id = ? AND state = 'pending'
+                        """,
+                        (now, card_id),
+                    )
+                    conn.execute(
+                        """
+                        INSERT INTO kanban_card_workflow_approvals
+                        (card_id, transition_id, state, reviewer, decision_reason, created_at, updated_at)
+                        VALUES (?, ?, 'pending', NULL, ?, ?, ?)
+                        """,
+                        (card_id, transition_row["id"], reason, now, now),
+                    )
+
+                    updated_row = self._get_card_workflow_state_row(conn, card_id)
+                    if not updated_row:
+                        raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                    updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                    conn.execute(
+                        """
+                        INSERT INTO kanban_card_workflow_events
+                        (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                         before_snapshot, after_snapshot, created_at)
+                        VALUES (?, 'workflow_approval_requested', ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            card_id,
+                            current_state["workflow_status_key"],
+                            target_status_key,
+                            actor_name,
+                            reason,
+                            idempotency_key.strip(),
+                            json.dumps(current_state),
+                            json.dumps(updated_state),
+                            now,
+                        ),
+                    )
+
+                    conn.commit()
+                    return updated_state
+
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET workflow_status_key = ?,
+                        approval_state = 'none',
+                        pending_transition_id = NULL,
+                        last_transition_at = ?,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (target_status_key, now, actor_name, now, card_id, expected_version),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_transitioned', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        actor_name,
+                        reason,
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
+
+    def decide_card_workflow_approval(
+        self,
+        *,
+        card_id: int,
+        reviewer: str,
+        decision: str,
+        expected_version: int,
+        idempotency_key: str,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        if not reviewer or not reviewer.strip():
+            raise InputError("reviewer is required")  # noqa: TRY003
+        if decision not in {"approved", "rejected"}:
+            raise InputError("decision must be 'approved' or 'rejected'")  # noqa: TRY003
+        if expected_version < 1:
+            raise InputError("expected_version must be >= 1")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        reviewer_name = reviewer.strip()
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'workflow_approval_decided' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                if int(current_state["version"]) != int(expected_version):
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+                if current_state["approval_state"] != "awaiting_approval" or not current_state["pending_transition_id"]:
+                    raise ConflictError("approval_required", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                transition_row = conn.execute(
+                    """
+                    SELECT id, to_status_key, approve_to_status_key, reject_to_status_key
+                    FROM board_workflow_transitions
+                    WHERE id = ?
+                    """,
+                    (current_state["pending_transition_id"],),
+                ).fetchone()
+                if not transition_row:
+                    raise ConflictError("transition_not_allowed", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                if decision == "approved":
+                    target_status_key = transition_row["approve_to_status_key"] or transition_row["to_status_key"]
+                    approval_state = "approved"
+                else:
+                    target_status_key = transition_row["reject_to_status_key"] or current_state["workflow_status_key"]
+                    approval_state = "rejected"
+
+                now = _utcnow_iso()
+                conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_approvals
+                    SET state = ?, reviewer = ?, decision_reason = ?, updated_at = ?
+                    WHERE card_id = ? AND transition_id = ? AND state = 'pending'
+                    """,
+                    (decision, reviewer_name, reason, now, card_id, transition_row["id"]),
+                )
+
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET workflow_status_key = ?,
+                        approval_state = ?,
+                        pending_transition_id = NULL,
+                        last_transition_at = ?,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (target_status_key, approval_state, now, reviewer_name, now, card_id, expected_version),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_approval_decided', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        reviewer_name,
+                        reason or decision,
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
+
+    def list_card_workflow_events(
+        self,
+        *,
+        card_id: int,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        if limit < 1:
+            raise InputError("limit must be positive")  # noqa: TRY003
+        if offset < 0:
+            raise InputError("offset must be non-negative")  # noqa: TRY003
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT e.id, e.card_id, e.event_type, e.from_status_key, e.to_status_key, e.actor,
+                           e.reason, e.idempotency_key, e.correlation_id, e.before_snapshot, e.after_snapshot,
+                           e.created_at
+                    FROM kanban_card_workflow_events e
+                    JOIN kanban_cards c ON c.id = e.card_id
+                    JOIN kanban_boards b ON b.id = c.board_id
+                    WHERE e.card_id = ? AND b.user_id = ?
+                    ORDER BY e.id DESC
+                    LIMIT ? OFFSET ?
+                    """,
+                    (card_id, self.user_id, limit, offset),
+                ).fetchall()
+                events: list[dict[str, Any]] = []
+                for row in rows:
+                    events.append(
+                        {
+                            "id": row["id"],
+                            "card_id": row["card_id"],
+                            "event_type": row["event_type"],
+                            "from_status_key": row["from_status_key"],
+                            "to_status_key": row["to_status_key"],
+                            "actor": row["actor"],
+                            "reason": row["reason"],
+                            "idempotency_key": row["idempotency_key"],
+                            "correlation_id": row["correlation_id"],
+                            "before_snapshot": json.loads(row["before_snapshot"]) if row["before_snapshot"] else None,
+                            "after_snapshot": json.loads(row["after_snapshot"]) if row["after_snapshot"] else None,
+                            "created_at": row["created_at"],
+                        }
+                    )
+                return events
+            finally:
+                conn.close()
+
+    def list_stale_workflow_claims(
+        self,
+        *,
+        board_id: int | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        if limit < 1:
+            raise InputError("limit must be positive")  # noqa: TRY003
+
+        now = _utcnow_iso()
+        with self._lock:
+            conn = self._connect()
+            try:
+                sql = """
+                    SELECT s.card_id, c.board_id, c.list_id, c.title, s.workflow_status_key,
+                           s.lease_owner, s.lease_expires_at, s.version, s.updated_at
+                    FROM kanban_card_workflow_state s
+                    JOIN kanban_cards c ON c.id = s.card_id
+                    JOIN kanban_boards b ON b.id = c.board_id
+                    WHERE b.user_id = ?
+                      AND s.lease_owner IS NOT NULL
+                      AND s.lease_expires_at IS NOT NULL
+                      AND s.lease_expires_at <= ?
+                """
+                params: list[Any] = [self.user_id, now]
+                if board_id is not None:
+                    sql += " AND c.board_id = ?"
+                    params.append(board_id)
+                sql += " ORDER BY s.lease_expires_at ASC LIMIT ?"
+                params.append(limit)
+                rows = conn.execute(sql, params).fetchall()
+
+                return [
+                    {
+                        "card_id": row["card_id"],
+                        "board_id": row["board_id"],
+                        "list_id": row["list_id"],
+                        "title": row["title"],
+                        "workflow_status_key": row["workflow_status_key"],
+                        "lease_owner": row["lease_owner"],
+                        "lease_expires_at": row["lease_expires_at"],
+                        "version": row["version"],
+                        "updated_at": row["updated_at"],
+                    }
+                    for row in rows
+                ]
+            finally:
+                conn.close()
+
+    def force_reassign_workflow_claim(
+        self,
+        *,
+        card_id: int,
+        new_owner: str,
+        idempotency_key: str,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        if not new_owner or not new_owner.strip():
+            raise InputError("new_owner is required")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        owner = new_owner.strip()
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'workflow_claim_reassigned' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                ttl_row = conn.execute(
+                    "SELECT default_lease_ttl_sec FROM board_workflow_policies WHERE id = ?",
+                    (current_state["policy_id"],),
+                ).fetchone()
+                lease_ttl_sec = int(ttl_row["default_lease_ttl_sec"]) if ttl_row else 900
+
+                now = _utcnow_iso()
+                lease_expires_at = (datetime.now(timezone.utc) + timedelta(seconds=lease_ttl_sec)).strftime("%Y-%m-%d %H:%M:%S")
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET lease_owner = ?,
+                        lease_expires_at = ?,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (owner, lease_expires_at, owner, now, card_id, current_state["version"]),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, reason, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'workflow_claim_reassigned', ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        owner,
+                        reason,
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
+
     # =========================================================================
     # BOARD OPERATIONS
     # =========================================================================

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -59,6 +59,8 @@ _KANBAN_NONCRITICAL_EXCEPTIONS = (
     ValueError,
 )
 
+_WORKFLOW_METADATA_UNSET = object()
+
 
 # --- Helper Functions ---
 def _utcnow_iso() -> str:
@@ -1028,7 +1030,7 @@ END;
         is_draining: bool = False,
         default_lease_ttl_sec: int = 900,
         strict_projection: bool = True,
-        metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None | object = _WORKFLOW_METADATA_UNSET,
     ) -> dict[str, Any]:
         board = self._get_board_by_id(conn, board_id)
         if not board:
@@ -1045,8 +1047,11 @@ END;
         )
 
         now = _utcnow_iso()
-        metadata_json = json.dumps(metadata) if metadata is not None else None
         policy_row = self._get_workflow_policy_row(conn, board_id)
+        if metadata is _WORKFLOW_METADATA_UNSET:
+            metadata_json = policy_row["metadata"] if policy_row else None
+        else:
+            metadata_json = json.dumps(metadata) if metadata is not None else None
 
         if policy_row:
             policy_id = policy_row["id"]
@@ -1210,7 +1215,7 @@ END;
         is_draining: bool = False,
         default_lease_ttl_sec: int = 900,
         strict_projection: bool = True,
-        metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None | object = _WORKFLOW_METADATA_UNSET,
     ) -> dict[str, Any]:
         with self._lock:
             conn = self._connect()

--- a/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Kanban_DB.py
@@ -248,6 +248,15 @@ class KanbanDB:
     MAX_COMMENT_SIZE = 16384  # characters
     VECTOR_INDEX_RETRY_DELAY_SECONDS = 5
     VECTOR_INDEX_MAX_RETRY_ATTEMPTS = 1
+    DEFAULT_WORKFLOW_STATUSES = (
+        ("todo", "To Do", 0, 0, 1),
+        ("impl", "In Progress", 1, 0, 1),
+        ("done", "Done", 2, 1, 1),
+    )
+    DEFAULT_WORKFLOW_TRANSITIONS = (
+        ("todo", "impl", 1, 0, None, None, None, 0, 1),
+        ("impl", "done", 1, 0, None, None, None, 0, 1),
+    )
 
     def __init__(self, db_path: str, user_id: str) -> None:
         """
@@ -754,6 +763,684 @@ CREATE TRIGGER kanban_cards_au AFTER UPDATE ON kanban_cards BEGIN
     WHERE NEW.deleted = 0 AND NEW.archived = 0;
 END;
 """
+
+    # =========================================================================
+    # WORKFLOW OPERATIONS
+    # =========================================================================
+
+    @staticmethod
+    def _coerce_bool_int(value: Any, *, default: bool = False) -> int:
+        """Coerce a boolean-like value to SQLite integer form."""
+        if value is None:
+            return 1 if default else 0
+        if isinstance(value, bool):
+            return 1 if value else 0
+        if isinstance(value, int):
+            return 1 if value != 0 else 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"1", "true", "yes", "on"}:
+                return 1
+            if normalized in {"0", "false", "no", "off", ""}:
+                return 0
+        raise InputError("Boolean-like value required")  # noqa: TRY003
+
+    def _default_workflow_statuses(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "status_key": status_key,
+                "display_name": display_name,
+                "sort_order": sort_order,
+                "is_terminal": is_terminal,
+                "is_active": is_active,
+            }
+            for status_key, display_name, sort_order, is_terminal, is_active in self.DEFAULT_WORKFLOW_STATUSES
+        ]
+
+    def _default_workflow_transitions(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "from_status_key": from_status_key,
+                "to_status_key": to_status_key,
+                "requires_claim": requires_claim,
+                "requires_approval": requires_approval,
+                "approve_to_status_key": approve_to_status_key,
+                "reject_to_status_key": reject_to_status_key,
+                "auto_move_list_id": auto_move_list_id,
+                "max_retries": max_retries,
+                "is_active": is_active,
+            }
+            for (
+                from_status_key,
+                to_status_key,
+                requires_claim,
+                requires_approval,
+                approve_to_status_key,
+                reject_to_status_key,
+                auto_move_list_id,
+                max_retries,
+                is_active,
+            ) in self.DEFAULT_WORKFLOW_TRANSITIONS
+        ]
+
+    def _normalize_workflow_statuses(
+        self,
+        statuses: list[dict[str, Any]] | None,
+    ) -> list[dict[str, Any]]:
+        raw_statuses = statuses if statuses is not None else self._default_workflow_statuses()
+        if not raw_statuses:
+            raise InputError("At least one workflow status is required")  # noqa: TRY003
+
+        normalized: list[dict[str, Any]] = []
+        seen_keys: set[str] = set()
+        for index, raw in enumerate(raw_statuses):
+            status_key = str(raw.get("status_key") or "").strip()
+            if not status_key:
+                raise InputError("status_key is required for all statuses")  # noqa: TRY003
+            if status_key in seen_keys:
+                raise InputError(f"Duplicate workflow status_key: {status_key}")  # noqa: TRY003
+            seen_keys.add(status_key)
+
+            display_name = str(raw.get("display_name") or "").strip() or status_key
+            sort_order = int(raw.get("sort_order", index))
+            normalized.append(
+                {
+                    "status_key": status_key,
+                    "display_name": display_name,
+                    "sort_order": sort_order,
+                    "is_terminal": self._coerce_bool_int(raw.get("is_terminal"), default=False),
+                    "is_active": self._coerce_bool_int(raw.get("is_active"), default=True),
+                }
+            )
+        return normalized
+
+    def _normalize_workflow_transitions(
+        self,
+        transitions: list[dict[str, Any]] | None,
+        *,
+        valid_status_keys: set[str],
+    ) -> list[dict[str, Any]]:
+        raw_transitions = transitions if transitions is not None else self._default_workflow_transitions()
+        normalized: list[dict[str, Any]] = []
+        seen_edges: set[tuple[str, str]] = set()
+
+        for raw in raw_transitions:
+            from_status_key = str(raw.get("from_status_key") or "").strip()
+            to_status_key = str(raw.get("to_status_key") or "").strip()
+            if not from_status_key or not to_status_key:
+                raise InputError("from_status_key and to_status_key are required for transitions")  # noqa: TRY003
+            if from_status_key not in valid_status_keys:
+                raise InputError(f"Unknown transition from_status_key: {from_status_key}")  # noqa: TRY003
+            if to_status_key not in valid_status_keys:
+                raise InputError(f"Unknown transition to_status_key: {to_status_key}")  # noqa: TRY003
+
+            edge_key = (from_status_key, to_status_key)
+            if edge_key in seen_edges:
+                raise InputError(f"Duplicate transition edge: {from_status_key} -> {to_status_key}")  # noqa: TRY003
+            seen_edges.add(edge_key)
+
+            approve_to_status_key = raw.get("approve_to_status_key")
+            reject_to_status_key = raw.get("reject_to_status_key")
+            if approve_to_status_key is not None and str(approve_to_status_key).strip() not in valid_status_keys:
+                raise InputError("approve_to_status_key must reference a known status_key")  # noqa: TRY003
+            if reject_to_status_key is not None and str(reject_to_status_key).strip() not in valid_status_keys:
+                raise InputError("reject_to_status_key must reference a known status_key")  # noqa: TRY003
+
+            normalized.append(
+                {
+                    "from_status_key": from_status_key,
+                    "to_status_key": to_status_key,
+                    "requires_claim": self._coerce_bool_int(raw.get("requires_claim"), default=True),
+                    "requires_approval": self._coerce_bool_int(raw.get("requires_approval"), default=False),
+                    "approve_to_status_key": str(approve_to_status_key).strip() if approve_to_status_key else None,
+                    "reject_to_status_key": str(reject_to_status_key).strip() if reject_to_status_key else None,
+                    "auto_move_list_id": raw.get("auto_move_list_id"),
+                    "max_retries": max(0, int(raw.get("max_retries", 0))),
+                    "is_active": self._coerce_bool_int(raw.get("is_active"), default=True),
+                }
+            )
+
+        return normalized
+
+    def _row_to_workflow_policy_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "board_id": row["board_id"],
+            "version": row["version"],
+            "is_paused": bool(row["is_paused"]),
+            "is_draining": bool(row["is_draining"]),
+            "default_lease_ttl_sec": row["default_lease_ttl_sec"],
+            "strict_projection": bool(row["strict_projection"]),
+            "metadata": json.loads(row["metadata"]) if row["metadata"] else None,
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def _row_to_workflow_status_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "policy_id": row["policy_id"],
+            "status_key": row["status_key"],
+            "display_name": row["display_name"],
+            "is_terminal": bool(row["is_terminal"]),
+            "sort_order": row["sort_order"],
+            "is_active": bool(row["is_active"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def _row_to_workflow_transition_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": row["id"],
+            "policy_id": row["policy_id"],
+            "from_status_key": row["from_status_key"],
+            "to_status_key": row["to_status_key"],
+            "requires_claim": bool(row["requires_claim"]),
+            "requires_approval": bool(row["requires_approval"]),
+            "approve_to_status_key": row["approve_to_status_key"],
+            "reject_to_status_key": row["reject_to_status_key"],
+            "auto_move_list_id": row["auto_move_list_id"],
+            "max_retries": row["max_retries"],
+            "is_active": bool(row["is_active"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def _row_to_card_workflow_state_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        retry_counters = row["retry_counters"]
+        return {
+            "card_id": row["card_id"],
+            "policy_id": row["policy_id"],
+            "workflow_status_key": row["workflow_status_key"],
+            "lease_owner": row["lease_owner"],
+            "lease_expires_at": row["lease_expires_at"],
+            "approval_state": row["approval_state"],
+            "pending_transition_id": row["pending_transition_id"],
+            "retry_counters": json.loads(retry_counters) if retry_counters else None,
+            "last_transition_at": row["last_transition_at"],
+            "last_actor": row["last_actor"],
+            "version": row["version"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    def _get_workflow_policy_row(self, conn: sqlite3.Connection, board_id: int) -> sqlite3.Row | None:
+        return conn.execute(
+            """
+            SELECT p.id, p.board_id, p.version, p.is_paused, p.is_draining,
+                   p.default_lease_ttl_sec, p.strict_projection, p.metadata,
+                   p.created_at, p.updated_at
+            FROM board_workflow_policies p
+            JOIN kanban_boards b ON b.id = p.board_id
+            WHERE p.board_id = ? AND b.user_id = ? AND b.deleted = 0
+            """,
+            (board_id, self.user_id),
+        ).fetchone()
+
+    def _list_workflow_statuses_for_policy(
+        self,
+        conn: sqlite3.Connection,
+        policy_id: int,
+        *,
+        include_inactive: bool = False,
+    ) -> list[dict[str, Any]]:
+        sql = """
+            SELECT id, policy_id, status_key, display_name, is_terminal, sort_order, is_active, created_at, updated_at
+            FROM board_workflow_statuses
+            WHERE policy_id = ?
+        """
+        params: list[Any] = [policy_id]
+        if not include_inactive:
+            sql += " AND is_active = 1"
+        sql += " ORDER BY sort_order ASC, status_key ASC"
+        rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_workflow_status_dict(row) for row in rows]
+
+    def _list_workflow_transitions_for_policy(
+        self,
+        conn: sqlite3.Connection,
+        policy_id: int,
+        *,
+        include_inactive: bool = False,
+    ) -> list[dict[str, Any]]:
+        sql = """
+            SELECT id, policy_id, from_status_key, to_status_key, requires_claim, requires_approval,
+                   approve_to_status_key, reject_to_status_key, auto_move_list_id, max_retries,
+                   is_active, created_at, updated_at
+            FROM board_workflow_transitions
+            WHERE policy_id = ?
+        """
+        params: list[Any] = [policy_id]
+        if not include_inactive:
+            sql += " AND is_active = 1"
+        sql += " ORDER BY from_status_key ASC, to_status_key ASC"
+        rows = conn.execute(sql, params).fetchall()
+        return [self._row_to_workflow_transition_dict(row) for row in rows]
+
+    def _upsert_workflow_policy_internal(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        board_id: int,
+        statuses: list[dict[str, Any]] | None = None,
+        transitions: list[dict[str, Any]] | None = None,
+        is_paused: bool = False,
+        is_draining: bool = False,
+        default_lease_ttl_sec: int = 900,
+        strict_projection: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        board = self._get_board_by_id(conn, board_id)
+        if not board:
+            raise NotFoundError("Board not found", entity="board", entity_id=board_id)  # noqa: TRY003
+
+        if default_lease_ttl_sec <= 0:
+            raise InputError("default_lease_ttl_sec must be greater than zero")  # noqa: TRY003
+
+        normalized_statuses = self._normalize_workflow_statuses(statuses)
+        status_keys = {status["status_key"] for status in normalized_statuses}
+        normalized_transitions = self._normalize_workflow_transitions(
+            transitions,
+            valid_status_keys=status_keys,
+        )
+
+        now = _utcnow_iso()
+        metadata_json = json.dumps(metadata) if metadata is not None else None
+        policy_row = self._get_workflow_policy_row(conn, board_id)
+
+        if policy_row:
+            policy_id = policy_row["id"]
+            conn.execute(
+                """
+                UPDATE board_workflow_policies
+                SET version = version + 1,
+                    is_paused = ?,
+                    is_draining = ?,
+                    default_lease_ttl_sec = ?,
+                    strict_projection = ?,
+                    metadata = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    self._coerce_bool_int(is_paused),
+                    self._coerce_bool_int(is_draining),
+                    int(default_lease_ttl_sec),
+                    self._coerce_bool_int(strict_projection, default=True),
+                    metadata_json,
+                    now,
+                    policy_id,
+                ),
+            )
+        else:
+            cur = conn.execute(
+                """
+                INSERT INTO board_workflow_policies
+                (board_id, version, is_paused, is_draining, default_lease_ttl_sec,
+                 strict_projection, metadata, created_at, updated_at)
+                VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    board_id,
+                    self._coerce_bool_int(is_paused),
+                    self._coerce_bool_int(is_draining),
+                    int(default_lease_ttl_sec),
+                    self._coerce_bool_int(strict_projection, default=True),
+                    metadata_json,
+                    now,
+                    now,
+                ),
+            )
+            policy_id = int(cur.lastrowid)
+
+        for status in normalized_statuses:
+            conn.execute(
+                """
+                INSERT INTO board_workflow_statuses
+                (policy_id, status_key, display_name, is_terminal, sort_order, is_active, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(policy_id, status_key) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    is_terminal = excluded.is_terminal,
+                    sort_order = excluded.sort_order,
+                    is_active = excluded.is_active,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    policy_id,
+                    status["status_key"],
+                    status["display_name"],
+                    status["is_terminal"],
+                    status["sort_order"],
+                    status["is_active"],
+                    now,
+                    now,
+                ),
+            )
+
+        status_placeholders = ",".join("?" * len(status_keys))
+        conn.execute(
+            f"""
+            UPDATE board_workflow_statuses
+            SET is_active = 0, updated_at = ?
+            WHERE policy_id = ? AND status_key NOT IN ({status_placeholders})
+            """,  # nosec B608
+            [now, policy_id, *status_keys],
+        )
+
+        for transition in normalized_transitions:
+            conn.execute(
+                """
+                INSERT INTO board_workflow_transitions
+                (policy_id, from_status_key, to_status_key, requires_claim, requires_approval,
+                 approve_to_status_key, reject_to_status_key, auto_move_list_id, max_retries,
+                 is_active, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(policy_id, from_status_key, to_status_key) DO UPDATE SET
+                    requires_claim = excluded.requires_claim,
+                    requires_approval = excluded.requires_approval,
+                    approve_to_status_key = excluded.approve_to_status_key,
+                    reject_to_status_key = excluded.reject_to_status_key,
+                    auto_move_list_id = excluded.auto_move_list_id,
+                    max_retries = excluded.max_retries,
+                    is_active = excluded.is_active,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    policy_id,
+                    transition["from_status_key"],
+                    transition["to_status_key"],
+                    transition["requires_claim"],
+                    transition["requires_approval"],
+                    transition["approve_to_status_key"],
+                    transition["reject_to_status_key"],
+                    transition["auto_move_list_id"],
+                    transition["max_retries"],
+                    transition["is_active"],
+                    now,
+                    now,
+                ),
+            )
+
+        if normalized_transitions:
+            transition_clauses = " OR ".join(["(from_status_key = ? AND to_status_key = ?)"] * len(normalized_transitions))
+            transition_params: list[Any] = [now, policy_id]
+            for transition in normalized_transitions:
+                transition_params.extend([transition["from_status_key"], transition["to_status_key"]])
+            conn.execute(
+                f"""
+                UPDATE board_workflow_transitions
+                SET is_active = 0, updated_at = ?
+                WHERE policy_id = ? AND NOT ({transition_clauses})
+                """,  # nosec B608
+                transition_params,
+            )
+        else:
+            conn.execute(
+                "UPDATE board_workflow_transitions SET is_active = 0, updated_at = ? WHERE policy_id = ?",
+                (now, policy_id),
+            )
+
+        return self._get_workflow_policy_internal(conn, board_id)
+
+    def _ensure_workflow_policy_for_board(self, conn: sqlite3.Connection, board_id: int) -> dict[str, Any]:
+        policy = self._get_workflow_policy_internal(conn, board_id)
+        if policy:
+            return policy
+        return self._upsert_workflow_policy_internal(conn, board_id=board_id)
+
+    def _get_workflow_policy_internal(self, conn: sqlite3.Connection, board_id: int) -> dict[str, Any] | None:
+        row = self._get_workflow_policy_row(conn, board_id)
+        if not row:
+            return None
+
+        policy = self._row_to_workflow_policy_dict(row)
+        policy_id = int(row["id"])
+        policy["statuses"] = self._list_workflow_statuses_for_policy(conn, policy_id)
+        policy["transitions"] = self._list_workflow_transitions_for_policy(conn, policy_id)
+        return policy
+
+    def upsert_workflow_policy(
+        self,
+        *,
+        board_id: int,
+        statuses: list[dict[str, Any]] | None = None,
+        transitions: list[dict[str, Any]] | None = None,
+        is_paused: bool = False,
+        is_draining: bool = False,
+        default_lease_ttl_sec: int = 900,
+        strict_projection: bool = True,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                policy = self._upsert_workflow_policy_internal(
+                    conn,
+                    board_id=board_id,
+                    statuses=statuses,
+                    transitions=transitions,
+                    is_paused=is_paused,
+                    is_draining=is_draining,
+                    default_lease_ttl_sec=default_lease_ttl_sec,
+                    strict_projection=strict_projection,
+                    metadata=metadata,
+                )
+                conn.commit()
+                return policy
+            finally:
+                conn.close()
+
+    def get_workflow_policy(self, board_id: int) -> dict[str, Any] | None:
+        with self._lock:
+            conn = self._connect()
+            try:
+                policy = self._ensure_workflow_policy_for_board(conn, board_id)
+                conn.commit()
+                return policy
+            finally:
+                conn.close()
+
+    def list_workflow_statuses(self, board_id: int) -> list[dict[str, Any]]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                policy = self._ensure_workflow_policy_for_board(conn, board_id)
+                statuses = self._list_workflow_statuses_for_policy(conn, int(policy["id"]))
+                conn.commit()
+                return statuses
+            finally:
+                conn.close()
+
+    def list_workflow_transitions(self, board_id: int) -> list[dict[str, Any]]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                policy = self._ensure_workflow_policy_for_board(conn, board_id)
+                transitions = self._list_workflow_transitions_for_policy(conn, int(policy["id"]))
+                conn.commit()
+                return transitions
+            finally:
+                conn.close()
+
+    def _get_card_workflow_state_row(self, conn: sqlite3.Connection, card_id: int) -> sqlite3.Row | None:
+        return conn.execute(
+            """
+            SELECT s.card_id, s.policy_id, s.workflow_status_key, s.lease_owner, s.lease_expires_at,
+                   s.approval_state, s.pending_transition_id, s.retry_counters, s.last_transition_at,
+                   s.last_actor, s.version, s.created_at, s.updated_at
+            FROM kanban_card_workflow_state s
+            JOIN kanban_cards c ON c.id = s.card_id
+            JOIN kanban_boards b ON b.id = c.board_id
+            WHERE s.card_id = ? AND b.user_id = ? AND b.deleted = 0 AND c.deleted = 0
+            """,
+            (card_id, self.user_id),
+        ).fetchone()
+
+    def _get_default_policy_status_key(self, conn: sqlite3.Connection, policy_id: int) -> str:
+        row = conn.execute(
+            """
+            SELECT status_key
+            FROM board_workflow_statuses
+            WHERE policy_id = ? AND is_active = 1
+            ORDER BY sort_order ASC, status_key ASC
+            LIMIT 1
+            """,
+            (policy_id,),
+        ).fetchone()
+        if not row:
+            raise NotFoundError("No active workflow statuses found for policy", entity="workflow_policy", entity_id=policy_id)  # noqa: TRY003
+        return str(row["status_key"])
+
+    def _ensure_card_workflow_state(self, conn: sqlite3.Connection, card_id: int) -> sqlite3.Row:
+        existing_state = self._get_card_workflow_state_row(conn, card_id)
+        if existing_state:
+            return existing_state
+
+        card = self._get_card_by_id(conn, card_id)
+        if not card:
+            raise NotFoundError("Card not found", entity="card", entity_id=card_id)  # noqa: TRY003
+
+        policy = self._ensure_workflow_policy_for_board(conn, int(card["board_id"]))
+        policy_id = int(policy["id"])
+        default_status_key = self._get_default_policy_status_key(conn, policy_id)
+        now = _utcnow_iso()
+
+        try:
+            conn.execute(
+                """
+                INSERT INTO kanban_card_workflow_state
+                (card_id, policy_id, workflow_status_key, approval_state, version, created_at, updated_at)
+                VALUES (?, ?, ?, 'none', 1, ?, ?)
+                """,
+                (card_id, policy_id, default_status_key, now, now),
+            )
+        except sqlite3.IntegrityError:
+            # Lost a race to another initializer; fetch the row created by the winner.
+            pass
+
+        state_row = self._get_card_workflow_state_row(conn, card_id)
+        if not state_row:
+            raise KanbanDBError("Failed to initialize card workflow state")  # noqa: TRY003
+        return state_row
+
+    def get_card_workflow_state(self, card_id: int) -> dict[str, Any]:
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                conn.commit()
+                return self._row_to_card_workflow_state_dict(state_row)
+            finally:
+                conn.close()
+
+    def patch_card_workflow_state(
+        self,
+        *,
+        card_id: int,
+        workflow_status_key: str | None,
+        expected_version: int,
+        lease_owner: str | None,
+        idempotency_key: str,
+        last_actor: str | None = None,
+    ) -> dict[str, Any]:
+        if expected_version < 1:
+            raise InputError("expected_version must be >= 1")  # noqa: TRY003
+        if not idempotency_key or not idempotency_key.strip():
+            raise InputError("idempotency_key is required")  # noqa: TRY003
+
+        actor = (last_actor or self.user_id).strip()
+
+        with self._lock:
+            conn = self._connect()
+            try:
+                state_row = self._ensure_card_workflow_state(conn, card_id)
+                current_state = self._row_to_card_workflow_state_dict(state_row)
+
+                replay = conn.execute(
+                    """
+                    SELECT id
+                    FROM kanban_card_workflow_events
+                    WHERE card_id = ? AND event_type = 'state_patched' AND idempotency_key = ?
+                    """,
+                    (card_id, idempotency_key.strip()),
+                ).fetchone()
+                if replay:
+                    conn.commit()
+                    return current_state
+
+                if int(current_state["version"]) != int(expected_version):
+                    raise ConflictError(  # noqa: TRY003
+                        f"Version mismatch: expected {expected_version}, got {current_state['version']}",
+                        entity="card_workflow_state",
+                        entity_id=card_id,
+                    )
+
+                next_status_key = workflow_status_key.strip() if workflow_status_key else current_state["workflow_status_key"]
+                status_row = conn.execute(
+                    """
+                    SELECT status_key
+                    FROM board_workflow_statuses
+                    WHERE policy_id = ? AND status_key = ? AND is_active = 1
+                    """,
+                    (current_state["policy_id"], next_status_key),
+                ).fetchone()
+                if not status_row:
+                    raise InputError("workflow_status_key is not valid for this policy")  # noqa: TRY003
+
+                now = _utcnow_iso()
+                update_cur = conn.execute(
+                    """
+                    UPDATE kanban_card_workflow_state
+                    SET workflow_status_key = ?,
+                        lease_owner = ?,
+                        last_transition_at = ?,
+                        last_actor = ?,
+                        version = version + 1,
+                        updated_at = ?
+                    WHERE card_id = ? AND version = ?
+                    """,
+                    (
+                        next_status_key,
+                        lease_owner,
+                        now,
+                        actor,
+                        now,
+                        card_id,
+                        expected_version,
+                    ),
+                )
+                if update_cur.rowcount != 1:
+                    raise ConflictError("Workflow state update conflict", entity="card_workflow_state", entity_id=card_id)  # noqa: TRY003
+
+                updated_row = self._get_card_workflow_state_row(conn, card_id)
+                if not updated_row:
+                    raise KanbanDBError("Updated workflow state could not be loaded")  # noqa: TRY003
+                updated_state = self._row_to_card_workflow_state_dict(updated_row)
+
+                conn.execute(
+                    """
+                    INSERT INTO kanban_card_workflow_events
+                    (card_id, event_type, from_status_key, to_status_key, actor, idempotency_key,
+                     before_snapshot, after_snapshot, created_at)
+                    VALUES (?, 'state_patched', ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        card_id,
+                        current_state["workflow_status_key"],
+                        updated_state["workflow_status_key"],
+                        actor,
+                        idempotency_key.strip(),
+                        json.dumps(current_state),
+                        json.dumps(updated_state),
+                        now,
+                    ),
+                )
+
+                conn.commit()
+                return updated_state
+            finally:
+                conn.close()
 
     # =========================================================================
     # BOARD OPERATIONS

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py
@@ -1564,15 +1564,20 @@ class KanbanModule(BaseModule):
 
     def _workflow_policy_upsert_sync(self, context: Any | None, board_id: int, args: dict[str, Any]) -> dict[str, Any]:
         db = self._open_db(context)
+        upsert_kwargs: dict[str, Any] = {
+            "board_id": board_id,
+            "statuses": args.get("statuses"),
+            "transitions": args.get("transitions"),
+            "is_paused": bool(args.get("is_paused", False)),
+            "is_draining": bool(args.get("is_draining", False)),
+            "default_lease_ttl_sec": int(args.get("default_lease_ttl_sec", 900)),
+            "strict_projection": bool(args.get("strict_projection", True)),
+        }
+        if "metadata" in args:
+            upsert_kwargs["metadata"] = args.get("metadata")
+
         policy = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=args.get("statuses"),
-            transitions=args.get("transitions"),
-            is_paused=bool(args.get("is_paused", False)),
-            is_draining=bool(args.get("is_draining", False)),
-            default_lease_ttl_sec=int(args.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(args.get("strict_projection", True)),
-            metadata=args.get("metadata"),
+            **upsert_kwargs,
         )
         return {"policy": policy}
 
@@ -1699,19 +1704,7 @@ class KanbanModule(BaseModule):
     def _workflow_control_pause_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
         self._require_admin(context)
         db = self._open_db(context)
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=True,
-            is_draining=bool(policy.get("is_draining", False)),
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
+        updated = db.update_workflow_policy_flags(board_id=board_id, is_paused=True)
         return {"success": True, "policy": updated}
 
     async def _workflow_control_resume(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
@@ -1721,19 +1714,7 @@ class KanbanModule(BaseModule):
     def _workflow_control_resume_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
         self._require_admin(context)
         db = self._open_db(context)
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=False,
-            is_draining=bool(policy.get("is_draining", False)),
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
+        updated = db.update_workflow_policy_flags(board_id=board_id, is_paused=False)
         return {"success": True, "policy": updated}
 
     async def _workflow_control_drain(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
@@ -1743,19 +1724,7 @@ class KanbanModule(BaseModule):
     def _workflow_control_drain_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
         self._require_admin(context)
         db = self._open_db(context)
-        policy = db.get_workflow_policy(board_id)
-        if not policy:
-            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
-        updated = db.upsert_workflow_policy(
-            board_id=board_id,
-            statuses=policy.get("statuses"),
-            transitions=policy.get("transitions"),
-            is_paused=bool(policy.get("is_paused", False)),
-            is_draining=True,
-            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
-            strict_projection=bool(policy.get("strict_projection", True)),
-            metadata=policy.get("metadata"),
-        )
+        updated = db.update_workflow_policy_flags(board_id=board_id, is_draining=True)
         return {"success": True, "policy": updated}
 
     async def _workflow_recovery_list_stale_claims(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/kanban_module.py
@@ -420,6 +420,234 @@ class KanbanModule(BaseModule):
                 },
                 metadata={"category": "management", "auth_required": True},
             ),
+            create_tool_definition(
+                name="kanban.workflow.policy.get",
+                description="Get workflow policy for a board.",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.policy.upsert",
+                description="Upsert workflow policy, statuses, and transitions for a board.",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                        "statuses": {"type": "array", "items": {"type": "object"}},
+                        "transitions": {"type": "array", "items": {"type": "object"}},
+                        "is_paused": {"type": "boolean"},
+                        "is_draining": {"type": "boolean"},
+                        "default_lease_ttl_sec": {"type": "integer", "minimum": 1},
+                        "strict_projection": {"type": "boolean"},
+                        "metadata": {"type": "object"},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.statuses.list",
+                description="List workflow statuses for a board.",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.transitions.list",
+                description="List workflow transitions for a board.",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.state.get",
+                description="Get workflow runtime state for a card.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["card_id"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.state.patch",
+                description="Patch workflow runtime state for a card using optimistic concurrency.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "workflow_status_key": {"type": "string", "minLength": 1},
+                        "expected_version": {"type": "integer", "minimum": 1},
+                        "lease_owner": {"type": "string"},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                        "last_actor": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["card_id", "expected_version", "idempotency_key"],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.claim",
+                description="Claim a workflow lease for a card.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "owner": {"type": "string", "minLength": 1},
+                        "lease_ttl_sec": {"type": "integer", "minimum": 1},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["card_id", "owner", "idempotency_key"],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.release",
+                description="Release a workflow lease for a card.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "owner": {"type": "string", "minLength": 1},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                    },
+                    "required": ["card_id", "owner", "idempotency_key"],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.transition",
+                description="Transition a card workflow status with policy/CAS enforcement.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "to_status_key": {"type": "string", "minLength": 1},
+                        "actor": {"type": "string", "minLength": 1},
+                        "expected_version": {"type": "integer", "minimum": 1},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "card_id",
+                        "to_status_key",
+                        "actor",
+                        "expected_version",
+                        "idempotency_key",
+                        "correlation_id",
+                    ],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.approval.decide",
+                description="Record approval decision for pending workflow transition.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "reviewer": {"type": "string", "minLength": 1},
+                        "decision": {"type": "string", "enum": ["approved", "rejected"]},
+                        "expected_version": {"type": "integer", "minimum": 1},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                        "reason": {"type": "string"},
+                    },
+                    "required": [
+                        "card_id",
+                        "reviewer",
+                        "decision",
+                        "expected_version",
+                        "idempotency_key",
+                        "correlation_id",
+                    ],
+                },
+                metadata={"category": "management", "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.task.events.list",
+                description="List workflow events for a card.",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 100},
+                        "offset": {"type": "integer", "minimum": 0, "default": 0},
+                    },
+                    "required": ["card_id"],
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.control.pause",
+                description="Pause workflow transitions for a board (admin only).",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "management", "auth_required": True, "admin_only": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.control.resume",
+                description="Resume workflow transitions for a board (admin only).",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "management", "auth_required": True, "admin_only": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.control.drain",
+                description="Enable workflow drain mode for a board (admin only).",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                    },
+                    "required": ["board_id"],
+                },
+                metadata={"category": "management", "auth_required": True, "admin_only": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.recovery.list_stale_claims",
+                description="List stale workflow claims optionally scoped to a board.",
+                parameters={
+                    "properties": {
+                        "board_id": {"type": "integer", "minimum": 1},
+                        "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 100},
+                    },
+                },
+                metadata={"category": "retrieval", "readOnlyHint": True, "auth_required": True},
+            ),
+            create_tool_definition(
+                name="kanban.workflow.recovery.force_reassign",
+                description="Force-reassign workflow claim to another owner (admin only).",
+                parameters={
+                    "properties": {
+                        "card_id": {"type": "integer", "minimum": 1},
+                        "new_owner": {"type": "string", "minLength": 1},
+                        "idempotency_key": {"type": "string", "minLength": 1},
+                        "correlation_id": {"type": "string", "minLength": 1},
+                        "reason": {"type": "string"},
+                    },
+                    "required": ["card_id", "new_owner", "idempotency_key", "correlation_id"],
+                },
+                metadata={"category": "management", "auth_required": True, "admin_only": True},
+            ),
         ]
 
     async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
@@ -485,6 +713,38 @@ class KanbanModule(BaseModule):
                 return await self._update_checklist_item(args, context)
             if tool_name == "kanban.checklists.items.delete":
                 return await self._delete_checklist_item(args, context)
+            if tool_name == "kanban.workflow.policy.get":
+                return await self._workflow_policy_get(args, context)
+            if tool_name == "kanban.workflow.policy.upsert":
+                return await self._workflow_policy_upsert(args, context)
+            if tool_name == "kanban.workflow.statuses.list":
+                return await self._workflow_statuses_list(args, context)
+            if tool_name == "kanban.workflow.transitions.list":
+                return await self._workflow_transitions_list(args, context)
+            if tool_name == "kanban.workflow.task.state.get":
+                return await self._workflow_task_state_get(args, context)
+            if tool_name == "kanban.workflow.task.state.patch":
+                return await self._workflow_task_state_patch(args, context)
+            if tool_name == "kanban.workflow.task.claim":
+                return await self._workflow_task_claim(args, context)
+            if tool_name == "kanban.workflow.task.release":
+                return await self._workflow_task_release(args, context)
+            if tool_name == "kanban.workflow.task.transition":
+                return await self._workflow_task_transition(args, context)
+            if tool_name == "kanban.workflow.task.approval.decide":
+                return await self._workflow_task_approval_decide(args, context)
+            if tool_name == "kanban.workflow.task.events.list":
+                return await self._workflow_task_events_list(args, context)
+            if tool_name == "kanban.workflow.control.pause":
+                return await self._workflow_control_pause(args, context)
+            if tool_name == "kanban.workflow.control.resume":
+                return await self._workflow_control_resume(args, context)
+            if tool_name == "kanban.workflow.control.drain":
+                return await self._workflow_control_drain(args, context)
+            if tool_name == "kanban.workflow.recovery.list_stale_claims":
+                return await self._workflow_recovery_list_stale_claims(args, context)
+            if tool_name == "kanban.workflow.recovery.force_reassign":
+                return await self._workflow_recovery_force_reassign(args, context)
         except (InputError, ConflictError, NotFoundError, KanbanDBError) as exc:
             raise ValueError(str(exc)) from exc
         raise ValueError(f"Unknown tool: {tool_name}")
@@ -599,6 +859,98 @@ class KanbanModule(BaseModule):
                 raise ValueError("must provide name or checked")
         elif tool_name == "kanban.checklists.items.delete":
             _ensure_positive_int(arguments.get("item_id"), "item_id")
+        elif tool_name in {"kanban.workflow.policy.get", "kanban.workflow.statuses.list", "kanban.workflow.transitions.list"}:
+            _ensure_positive_int(arguments.get("board_id"), "board_id")
+        elif tool_name == "kanban.workflow.policy.upsert":
+            _ensure_positive_int(arguments.get("board_id"), "board_id")
+            lease_ttl = arguments.get("default_lease_ttl_sec")
+            if lease_ttl is not None:
+                _ensure_positive_int(lease_ttl, "default_lease_ttl_sec")
+        elif tool_name == "kanban.workflow.task.state.get":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+        elif tool_name == "kanban.workflow.task.state.patch":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            _ensure_positive_int(arguments.get("expected_version"), "expected_version")
+            idem = arguments.get("idempotency_key")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+        elif tool_name == "kanban.workflow.task.claim":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            owner = arguments.get("owner")
+            if not isinstance(owner, str) or not owner.strip():
+                raise ValueError("owner must be a non-empty string")
+            idem = arguments.get("idempotency_key")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+            ttl = arguments.get("lease_ttl_sec")
+            if ttl is not None:
+                _ensure_positive_int(ttl, "lease_ttl_sec")
+        elif tool_name == "kanban.workflow.task.release":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            owner = arguments.get("owner")
+            if not isinstance(owner, str) or not owner.strip():
+                raise ValueError("owner must be a non-empty string")
+            idem = arguments.get("idempotency_key")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+        elif tool_name == "kanban.workflow.task.transition":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            _ensure_positive_int(arguments.get("expected_version"), "expected_version")
+            to_status_key = arguments.get("to_status_key")
+            actor = arguments.get("actor")
+            idem = arguments.get("idempotency_key")
+            corr = arguments.get("correlation_id")
+            if not isinstance(to_status_key, str) or not to_status_key.strip():
+                raise ValueError("to_status_key must be a non-empty string")
+            if not isinstance(actor, str) or not actor.strip():
+                raise ValueError("actor must be a non-empty string")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+            if not isinstance(corr, str) or not corr.strip():
+                raise ValueError("correlation_id must be a non-empty string")
+        elif tool_name == "kanban.workflow.task.approval.decide":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            _ensure_positive_int(arguments.get("expected_version"), "expected_version")
+            reviewer = arguments.get("reviewer")
+            decision = arguments.get("decision")
+            idem = arguments.get("idempotency_key")
+            corr = arguments.get("correlation_id")
+            if not isinstance(reviewer, str) or not reviewer.strip():
+                raise ValueError("reviewer must be a non-empty string")
+            if decision not in {"approved", "rejected"}:
+                raise ValueError("decision must be 'approved' or 'rejected'")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+            if not isinstance(corr, str) or not corr.strip():
+                raise ValueError("correlation_id must be a non-empty string")
+        elif tool_name == "kanban.workflow.task.events.list":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            limit = int(arguments.get("limit", 100))
+            offset = int(arguments.get("offset", 0))
+            if limit < 1 or limit > 500:
+                raise ValueError("limit must be 1..500")
+            if offset < 0:
+                raise ValueError("offset must be >= 0")
+        elif tool_name in {"kanban.workflow.control.pause", "kanban.workflow.control.resume", "kanban.workflow.control.drain"}:
+            _ensure_positive_int(arguments.get("board_id"), "board_id")
+        elif tool_name == "kanban.workflow.recovery.list_stale_claims":
+            board_id = arguments.get("board_id")
+            if board_id is not None:
+                _ensure_positive_int(board_id, "board_id")
+            limit = int(arguments.get("limit", 100))
+            if limit < 1 or limit > 500:
+                raise ValueError("limit must be 1..500")
+        elif tool_name == "kanban.workflow.recovery.force_reassign":
+            _ensure_positive_int(arguments.get("card_id"), "card_id")
+            new_owner = arguments.get("new_owner")
+            idem = arguments.get("idempotency_key")
+            corr = arguments.get("correlation_id")
+            if not isinstance(new_owner, str) or not new_owner.strip():
+                raise ValueError("new_owner must be a non-empty string")
+            if not isinstance(idem, str) or not idem.strip():
+                raise ValueError("idempotency_key must be a non-empty string")
+            if not isinstance(corr, str) or not corr.strip():
+                raise ValueError("correlation_id must be a non-empty string")
 
     def _open_db(self, context: Any) -> KanbanDB:
         if context is None or not getattr(context, "db_paths", None):
@@ -1181,3 +1533,262 @@ class KanbanModule(BaseModule):
         db = self._open_db(context)
         deleted = db.delete_checklist_item(item_id)
         return {"deleted": bool(deleted), "item_id": item_id}
+
+    def _is_admin(self, context: Any | None) -> bool:
+        try:
+            if bool(getattr(context, "is_admin", False)):
+                return True
+            roles = (getattr(context, "metadata", {}) or {}).get("roles")
+            return isinstance(roles, list) and any(str(r).lower() == "admin" for r in roles)
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    def _require_admin(self, context: Any | None) -> None:
+        if not self._is_admin(context):
+            raise ValueError("forbidden: admin privileges required")
+
+    async def _workflow_policy_get(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_policy_get_sync, context, board_id)
+
+    def _workflow_policy_get_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        db = self._open_db(context)
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
+        return {"policy": policy}
+
+    async def _workflow_policy_upsert(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_policy_upsert_sync, context, board_id, args)
+
+    def _workflow_policy_upsert_sync(self, context: Any | None, board_id: int, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        policy = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=args.get("statuses"),
+            transitions=args.get("transitions"),
+            is_paused=bool(args.get("is_paused", False)),
+            is_draining=bool(args.get("is_draining", False)),
+            default_lease_ttl_sec=int(args.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(args.get("strict_projection", True)),
+            metadata=args.get("metadata"),
+        )
+        return {"policy": policy}
+
+    async def _workflow_statuses_list(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_statuses_list_sync, context, board_id)
+
+    def _workflow_statuses_list_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        db = self._open_db(context)
+        return {"board_id": board_id, "statuses": db.list_workflow_statuses(board_id)}
+
+    async def _workflow_transitions_list(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_transitions_list_sync, context, board_id)
+
+    def _workflow_transitions_list_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        db = self._open_db(context)
+        return {"board_id": board_id, "transitions": db.list_workflow_transitions(board_id)}
+
+    async def _workflow_task_state_get(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        card_id = _ensure_positive_int(args.get("card_id"), "card_id")
+        return await asyncio.to_thread(self._workflow_task_state_get_sync, context, card_id)
+
+    def _workflow_task_state_get_sync(self, context: Any | None, card_id: int) -> dict[str, Any]:
+        db = self._open_db(context)
+        return {"state": db.get_card_workflow_state(card_id)}
+
+    async def _workflow_task_state_patch(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_task_state_patch_sync, context, args)
+
+    def _workflow_task_state_patch_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        state = db.patch_card_workflow_state(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            workflow_status_key=args.get("workflow_status_key"),
+            expected_version=_ensure_positive_int(args.get("expected_version"), "expected_version"),
+            lease_owner=args.get("lease_owner"),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=args.get("correlation_id"),
+            last_actor=args.get("last_actor"),
+        )
+        return {"state": state}
+
+    async def _workflow_task_claim(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_task_claim_sync, context, args)
+
+    def _workflow_task_claim_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        state = db.claim_card_workflow(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            owner=str(args.get("owner")).strip(),
+            lease_ttl_sec=args.get("lease_ttl_sec"),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=args.get("correlation_id"),
+        )
+        return {"state": state}
+
+    async def _workflow_task_release(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_task_release_sync, context, args)
+
+    def _workflow_task_release_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        state = db.release_card_workflow(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            owner=str(args.get("owner")).strip(),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=args.get("correlation_id"),
+        )
+        return {"state": state}
+
+    async def _workflow_task_transition(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_task_transition_sync, context, args)
+
+    def _workflow_task_transition_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        state = db.transition_card_workflow(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            to_status_key=str(args.get("to_status_key")).strip(),
+            actor=str(args.get("actor")).strip(),
+            expected_version=_ensure_positive_int(args.get("expected_version"), "expected_version"),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=str(args.get("correlation_id")).strip(),
+            reason=args.get("reason"),
+        )
+        return {"state": state}
+
+    async def _workflow_task_approval_decide(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_task_approval_decide_sync, context, args)
+
+    def _workflow_task_approval_decide_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        db = self._open_db(context)
+        state = db.decide_card_workflow_approval(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            reviewer=str(args.get("reviewer")).strip(),
+            decision=str(args.get("decision")).strip(),
+            expected_version=_ensure_positive_int(args.get("expected_version"), "expected_version"),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=str(args.get("correlation_id")).strip(),
+            reason=args.get("reason"),
+        )
+        return {"state": state}
+
+    async def _workflow_task_events_list(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        card_id = _ensure_positive_int(args.get("card_id"), "card_id")
+        limit = int(args.get("limit", 100))
+        offset = int(args.get("offset", 0))
+        return await asyncio.to_thread(self._workflow_task_events_list_sync, context, card_id, limit, offset)
+
+    def _workflow_task_events_list_sync(
+        self,
+        context: Any | None,
+        card_id: int,
+        limit: int,
+        offset: int,
+    ) -> dict[str, Any]:
+        db = self._open_db(context)
+        events = db.list_card_workflow_events(card_id=card_id, limit=limit, offset=offset)
+        return {"card_id": card_id, "events": events, "limit": limit, "offset": offset}
+
+    async def _workflow_control_pause(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_control_pause_sync, context, board_id)
+
+    def _workflow_control_pause_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        self._require_admin(context)
+        db = self._open_db(context)
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=True,
+            is_draining=bool(policy.get("is_draining", False)),
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return {"success": True, "policy": updated}
+
+    async def _workflow_control_resume(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_control_resume_sync, context, board_id)
+
+    def _workflow_control_resume_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        self._require_admin(context)
+        db = self._open_db(context)
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=False,
+            is_draining=bool(policy.get("is_draining", False)),
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return {"success": True, "policy": updated}
+
+    async def _workflow_control_drain(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = _ensure_positive_int(args.get("board_id"), "board_id")
+        return await asyncio.to_thread(self._workflow_control_drain_sync, context, board_id)
+
+    def _workflow_control_drain_sync(self, context: Any | None, board_id: int) -> dict[str, Any]:
+        self._require_admin(context)
+        db = self._open_db(context)
+        policy = db.get_workflow_policy(board_id)
+        if not policy:
+            raise NotFoundError("Workflow policy not found", entity="workflow_policy", entity_id=board_id)
+        updated = db.upsert_workflow_policy(
+            board_id=board_id,
+            statuses=policy.get("statuses"),
+            transitions=policy.get("transitions"),
+            is_paused=bool(policy.get("is_paused", False)),
+            is_draining=True,
+            default_lease_ttl_sec=int(policy.get("default_lease_ttl_sec", 900)),
+            strict_projection=bool(policy.get("strict_projection", True)),
+            metadata=policy.get("metadata"),
+        )
+        return {"success": True, "policy": updated}
+
+    async def _workflow_recovery_list_stale_claims(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        board_id = args.get("board_id")
+        board_id_val = _ensure_positive_int(board_id, "board_id") if board_id is not None else None
+        limit = int(args.get("limit", 100))
+        return await asyncio.to_thread(
+            self._workflow_recovery_list_stale_claims_sync,
+            context,
+            board_id_val,
+            limit,
+        )
+
+    def _workflow_recovery_list_stale_claims_sync(
+        self,
+        context: Any | None,
+        board_id: int | None,
+        limit: int,
+    ) -> dict[str, Any]:
+        db = self._open_db(context)
+        return {"stale_claims": db.list_stale_workflow_claims(board_id=board_id, limit=limit)}
+
+    async def _workflow_recovery_force_reassign(self, args: dict[str, Any], context: Any | None) -> dict[str, Any]:
+        return await asyncio.to_thread(self._workflow_recovery_force_reassign_sync, context, args)
+
+    def _workflow_recovery_force_reassign_sync(self, context: Any | None, args: dict[str, Any]) -> dict[str, Any]:
+        self._require_admin(context)
+        db = self._open_db(context)
+        state = db.force_reassign_workflow_claim(
+            card_id=_ensure_positive_int(args.get("card_id"), "card_id"),
+            new_owner=str(args.get("new_owner")).strip(),
+            idempotency_key=str(args.get("idempotency_key")).strip(),
+            correlation_id=str(args.get("correlation_id")).strip(),
+            reason=args.get("reason"),
+        )
+        return {"state": state}

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
@@ -1,10 +1,11 @@
 import pytest
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.kanban_module import KanbanModule
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
-from tldw_Server_API.app.core.DB_Management.Kanban_DB import NotFoundError, InputError
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import ConflictError, NotFoundError, InputError
 
 
 class FakeKanbanDB:
@@ -24,6 +25,10 @@ class FakeKanbanDB:
         self._comment_counter = 0
         self._checklist_counter = 0
         self._checklist_item_counter = 0
+        self._workflow_policy_counter = 0
+        self._workflow_policies: Dict[int, Dict[str, Any]] = {}
+        self._workflow_states: Dict[int, Dict[str, Any]] = {}
+        self._workflow_events: Dict[int, List[Dict[str, Any]]] = {}
 
     def create_board(
         self,
@@ -412,6 +417,432 @@ class FakeKanbanDB:
         self._checklist_items.pop(item_id, None)
         return True
 
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    def _ensure_workflow_policy_for_board(self, board_id: int) -> Dict[str, Any]:
+        policy = self._workflow_policies.get(board_id)
+        if policy:
+            return policy
+        return self.upsert_workflow_policy(board_id=board_id)
+
+    def _ensure_workflow_state_for_card(self, card_id: int) -> Dict[str, Any]:
+        state = self._workflow_states.get(card_id)
+        if state:
+            return state
+        card = self._cards.get(card_id)
+        if not card:
+            raise NotFoundError("Card not found", entity="card", entity_id=card_id)
+        policy = self._ensure_workflow_policy_for_board(card["board_id"])
+        default_status = policy["statuses"][0]["status_key"]
+        now = self._now()
+        created = {
+            "card_id": card_id,
+            "policy_id": policy["id"],
+            "workflow_status_key": default_status,
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "approval_state": "none",
+            "pending_transition_id": None,
+            "retry_counters": None,
+            "last_transition_at": None,
+            "last_actor": None,
+            "version": 1,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._workflow_states[card_id] = created
+        return dict(created)
+
+    def _append_workflow_event(
+        self,
+        card_id: int,
+        event_type: str,
+        from_status_key: Optional[str],
+        to_status_key: Optional[str],
+        actor: str,
+        idempotency_key: str,
+        correlation_id: Optional[str],
+        reason: Optional[str],
+        before_snapshot: Optional[Dict[str, Any]],
+        after_snapshot: Optional[Dict[str, Any]],
+    ) -> None:
+        events = self._workflow_events.setdefault(card_id, [])
+        event_id = len(events) + 1
+        events.append(
+            {
+                "id": event_id,
+                "card_id": card_id,
+                "event_type": event_type,
+                "from_status_key": from_status_key,
+                "to_status_key": to_status_key,
+                "actor": actor,
+                "reason": reason,
+                "idempotency_key": idempotency_key,
+                "correlation_id": correlation_id,
+                "before_snapshot": before_snapshot,
+                "after_snapshot": after_snapshot,
+                "created_at": self._now(),
+            }
+        )
+
+    def upsert_workflow_policy(
+        self,
+        *,
+        board_id: int,
+        statuses: Optional[List[Dict[str, Any]]] = None,
+        transitions: Optional[List[Dict[str, Any]]] = None,
+        is_paused: bool = False,
+        is_draining: bool = False,
+        default_lease_ttl_sec: int = 900,
+        strict_projection: bool = True,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if board_id not in self._boards:
+            raise NotFoundError("Board not found", entity="board", entity_id=board_id)
+        existing = self._workflow_policies.get(board_id)
+        if existing:
+            policy = dict(existing)
+            policy["version"] = int(policy.get("version", 1)) + 1
+        else:
+            self._workflow_policy_counter += 1
+            now = self._now()
+            policy = {
+                "id": self._workflow_policy_counter,
+                "board_id": board_id,
+                "version": 1,
+                "created_at": now,
+            }
+        policy["statuses"] = statuses if statuses is not None else policy.get("statuses") or [
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0, "is_active": True, "is_terminal": False}
+        ]
+        policy["transitions"] = transitions if transitions is not None else policy.get("transitions") or []
+        policy["is_paused"] = bool(is_paused)
+        policy["is_draining"] = bool(is_draining)
+        policy["default_lease_ttl_sec"] = int(default_lease_ttl_sec)
+        policy["strict_projection"] = bool(strict_projection)
+        policy["metadata"] = policy.get("metadata") if metadata is None and existing else metadata
+        policy["updated_at"] = self._now()
+        self._workflow_policies[board_id] = policy
+        return dict(policy)
+
+    def get_workflow_policy(self, board_id: int) -> Optional[Dict[str, Any]]:
+        policy = self._workflow_policies.get(board_id)
+        return dict(policy) if policy else None
+
+    def list_workflow_statuses(self, board_id: int) -> List[Dict[str, Any]]:
+        policy = self._ensure_workflow_policy_for_board(board_id)
+        return [dict(status) for status in policy.get("statuses", [])]
+
+    def list_workflow_transitions(self, board_id: int) -> List[Dict[str, Any]]:
+        policy = self._ensure_workflow_policy_for_board(board_id)
+        return [dict(transition) for transition in policy.get("transitions", [])]
+
+    def get_card_workflow_state(self, card_id: int) -> Dict[str, Any]:
+        return dict(self._ensure_workflow_state_for_card(card_id))
+
+    def patch_card_workflow_state(
+        self,
+        *,
+        card_id: int,
+        workflow_status_key: Optional[str],
+        expected_version: int,
+        lease_owner: Optional[str],
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+        last_actor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        if int(expected_version) != int(state["version"]):
+            raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)
+        before = dict(state)
+        if workflow_status_key is not None:
+            state["workflow_status_key"] = workflow_status_key
+        state["lease_owner"] = lease_owner
+        state["last_actor"] = last_actor
+        state["last_transition_at"] = self._now()
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="state_patched",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=last_actor or "tester",
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason=None,
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
+    def claim_card_workflow(
+        self,
+        *,
+        card_id: int,
+        owner: str,
+        lease_ttl_sec: Optional[int] = None,
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        before = dict(state)
+        ttl = int(lease_ttl_sec or 900)
+        state["lease_owner"] = owner
+        state["lease_expires_at"] = (datetime.now(timezone.utc) + timedelta(seconds=ttl)).strftime("%Y-%m-%d %H:%M:%S")
+        state["last_actor"] = owner
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="workflow_claimed",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=owner,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason="claim_acquired",
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
+    def release_card_workflow(
+        self,
+        *,
+        card_id: int,
+        owner: str,
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        if state.get("lease_owner") and state.get("lease_owner") != owner:
+            raise ConflictError("lease_mismatch", entity="card_workflow_state", entity_id=card_id)
+        before = dict(state)
+        state["lease_owner"] = None
+        state["lease_expires_at"] = None
+        state["last_actor"] = owner
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="workflow_released",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=owner,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason="claim_released",
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
+    def transition_card_workflow(
+        self,
+        *,
+        card_id: int,
+        to_status_key: str,
+        actor: str,
+        expected_version: int,
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        if int(expected_version) != int(state["version"]):
+            raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)
+        card = self._cards.get(card_id)
+        if not card:
+            raise NotFoundError("Card not found", entity="card", entity_id=card_id)
+        policy = self._ensure_workflow_policy_for_board(card["board_id"])
+        if bool(policy.get("is_paused", False)):
+            raise ConflictError("policy_paused", entity="workflow_policy", entity_id=policy["id"])
+        transitions = policy.get("transitions", [])
+        edge = next(
+            (
+                t for t in transitions
+                if t.get("from_status_key") == state["workflow_status_key"]
+                and t.get("to_status_key") == to_status_key
+                and bool(t.get("is_active", True))
+            ),
+            None,
+        )
+        if edge is None:
+            raise ConflictError("transition_not_allowed", entity="card_workflow_state", entity_id=card_id)
+        if bool(edge.get("requires_claim", True)):
+            if state.get("lease_owner") != actor:
+                raise ConflictError("lease_required", entity="card_workflow_state", entity_id=card_id)
+        before = dict(state)
+        if bool(edge.get("requires_approval", False)):
+            state["approval_state"] = "awaiting_approval"
+            state["pending_transition_id"] = int(edge.get("id", 1))
+            state["last_actor"] = actor
+            state["version"] = int(state["version"]) + 1
+            state["updated_at"] = self._now()
+            self._workflow_states[card_id] = state
+            self._append_workflow_event(
+                card_id=card_id,
+                event_type="workflow_approval_requested",
+                from_status_key=before["workflow_status_key"],
+                to_status_key=to_status_key,
+                actor=actor,
+                idempotency_key=idempotency_key,
+                correlation_id=correlation_id,
+                reason=reason,
+                before_snapshot=before,
+                after_snapshot=dict(state),
+            )
+            return dict(state)
+        state["workflow_status_key"] = to_status_key
+        state["approval_state"] = "none"
+        state["pending_transition_id"] = None
+        state["last_transition_at"] = self._now()
+        state["last_actor"] = actor
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="workflow_transitioned",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=actor,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason=reason,
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
+    def decide_card_workflow_approval(
+        self,
+        *,
+        card_id: int,
+        reviewer: str,
+        decision: str,
+        expected_version: int,
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        if int(expected_version) != int(state["version"]):
+            raise ConflictError("version_conflict", entity="card_workflow_state", entity_id=card_id)
+        if state.get("approval_state") != "awaiting_approval":
+            raise ConflictError("approval_required", entity="card_workflow_state", entity_id=card_id)
+        card = self._cards.get(card_id)
+        if not card:
+            raise NotFoundError("Card not found", entity="card", entity_id=card_id)
+        policy = self._ensure_workflow_policy_for_board(card["board_id"])
+        transition = next(
+            (
+                t for t in policy.get("transitions", [])
+                if t.get("from_status_key") == state["workflow_status_key"]
+                and bool(t.get("requires_approval", False))
+            ),
+            None,
+        )
+        if transition is None:
+            raise ConflictError("transition_not_allowed", entity="card_workflow_state", entity_id=card_id)
+        before = dict(state)
+        if decision == "approved":
+            state["workflow_status_key"] = transition.get("approve_to_status_key") or transition.get("to_status_key")
+            state["approval_state"] = "approved"
+        else:
+            state["workflow_status_key"] = transition.get("reject_to_status_key") or state["workflow_status_key"]
+            state["approval_state"] = "rejected"
+        state["pending_transition_id"] = None
+        state["last_transition_at"] = self._now()
+        state["last_actor"] = reviewer
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="workflow_approval_decided",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=reviewer,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason=reason or decision,
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
+    def list_card_workflow_events(self, *, card_id: int, limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
+        if card_id not in self._cards:
+            raise NotFoundError("Card not found", entity="card", entity_id=card_id)
+        events = list(self._workflow_events.get(card_id, []))
+        events.sort(key=lambda row: row["id"], reverse=True)
+        return events[offset: offset + limit]
+
+    def list_stale_workflow_claims(self, *, board_id: Optional[int] = None, limit: int = 100) -> List[Dict[str, Any]]:
+        now = self._now()
+        stale: List[Dict[str, Any]] = []
+        for card_id, state in self._workflow_states.items():
+            lease_owner = state.get("lease_owner")
+            lease_expires_at = state.get("lease_expires_at")
+            if not lease_owner or not lease_expires_at or str(lease_expires_at) > now:
+                continue
+            card = self._cards.get(card_id)
+            if not card:
+                continue
+            if board_id is not None and card.get("board_id") != board_id:
+                continue
+            stale.append(
+                {
+                    "card_id": card_id,
+                    "board_id": card["board_id"],
+                    "list_id": card["list_id"],
+                    "title": card["title"],
+                    "workflow_status_key": state["workflow_status_key"],
+                    "lease_owner": lease_owner,
+                    "lease_expires_at": lease_expires_at,
+                    "version": state["version"],
+                    "updated_at": state["updated_at"],
+                }
+            )
+        return stale[:limit]
+
+    def force_reassign_workflow_claim(
+        self,
+        *,
+        card_id: int,
+        new_owner: str,
+        idempotency_key: str,
+        correlation_id: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        state = self._ensure_workflow_state_for_card(card_id)
+        before = dict(state)
+        state["lease_owner"] = new_owner
+        state["lease_expires_at"] = (datetime.now(timezone.utc) + timedelta(seconds=900)).strftime("%Y-%m-%d %H:%M:%S")
+        state["last_actor"] = new_owner
+        state["version"] = int(state["version"]) + 1
+        state["updated_at"] = self._now()
+        self._workflow_states[card_id] = state
+        self._append_workflow_event(
+            card_id=card_id,
+            event_type="workflow_claim_reassigned",
+            from_status_key=before["workflow_status_key"],
+            to_status_key=state["workflow_status_key"],
+            actor=new_owner,
+            idempotency_key=idempotency_key,
+            correlation_id=correlation_id,
+            reason=reason,
+            before_snapshot=before,
+            after_snapshot=dict(state),
+        )
+        return dict(state)
+
 
 @pytest.mark.asyncio
 async def test_kanban_module_basic_flow(tmp_path):
@@ -532,3 +963,145 @@ async def test_kanban_module_basic_flow(tmp_path):
         context=ctx,
     )
     assert searched["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_kanban_workflow_transition_tool_requires_expected_version_and_idempotency(tmp_path):
+    mod = KanbanModule(ModuleConfig(name="kanban"))
+    fake_db = FakeKanbanDB()
+    mod._open_db = lambda ctx: fake_db  # type: ignore[assignment]
+
+    ctx = SimpleNamespace(user_id="1", db_paths={"kanban": tmp_path / "kanban.db"})
+
+    with pytest.raises(ValueError, match="expected_version"):
+        await mod.execute_tool(
+            "kanban.workflow.task.transition",
+            {
+                "card_id": 1,
+                "to_status_key": "impl",
+                "actor": "builder",
+                "correlation_id": "corr-missing-version",
+            },
+            context=ctx,
+        )
+
+    with pytest.raises(ValueError, match="idempotency_key"):
+        await mod.execute_tool(
+            "kanban.workflow.task.transition",
+            {
+                "card_id": 1,
+                "to_status_key": "impl",
+                "actor": "builder",
+                "expected_version": 1,
+                "correlation_id": "corr-missing-idem",
+            },
+            context=ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_kanban_workflow_control_tools_require_admin(tmp_path):
+    mod = KanbanModule(ModuleConfig(name="kanban"))
+    fake_db = FakeKanbanDB()
+    mod._open_db = lambda ctx: fake_db  # type: ignore[assignment]
+
+    non_admin_ctx = SimpleNamespace(user_id="1", db_paths={"kanban": tmp_path / "kanban.db"}, metadata={"roles": []})
+
+    board = await mod.execute_tool("kanban.boards.create", {"name": "Workflow Board"}, context=non_admin_ctx)
+    board_id = board["board"]["id"]
+    created_list = await mod.execute_tool(
+        "kanban.lists.create",
+        {"board_id": board_id, "name": "Todo"},
+        context=non_admin_ctx,
+    )
+    card = await mod.execute_tool(
+        "kanban.cards.create",
+        {"list_id": created_list["list"]["id"], "title": "Workflow Card"},
+        context=non_admin_ctx,
+    )
+    card_id = card["card"]["id"]
+
+    with pytest.raises(ValueError, match="forbidden"):
+        await mod.execute_tool("kanban.workflow.control.pause", {"board_id": board_id}, context=non_admin_ctx)
+
+    with pytest.raises(ValueError, match="forbidden"):
+        await mod.execute_tool(
+            "kanban.workflow.recovery.force_reassign",
+            {
+                "card_id": card_id,
+                "new_owner": "builder",
+                "idempotency_key": "mcp-force-reassign",
+                "correlation_id": "corr-force-reassign",
+                "reason": "stale lease",
+            },
+            context=non_admin_ctx,
+        )
+
+
+@pytest.mark.asyncio
+async def test_kanban_workflow_tool_roundtrip(tmp_path):
+    mod = KanbanModule(ModuleConfig(name="kanban"))
+    fake_db = FakeKanbanDB()
+    mod._open_db = lambda ctx: fake_db  # type: ignore[assignment]
+
+    admin_ctx = SimpleNamespace(
+        user_id="1",
+        db_paths={"kanban": tmp_path / "kanban.db"},
+        metadata={"roles": ["admin"]},
+    )
+
+    board = await mod.execute_tool("kanban.boards.create", {"name": "WF Board"}, context=admin_ctx)
+    board_id = board["board"]["id"]
+    lst = await mod.execute_tool("kanban.lists.create", {"board_id": board_id, "name": "Todo"}, context=admin_ctx)
+    card = await mod.execute_tool(
+        "kanban.cards.create",
+        {"list_id": lst["list"]["id"], "title": "WF Card"},
+        context=admin_ctx,
+    )
+    card_id = card["card"]["id"]
+
+    policy = await mod.execute_tool(
+        "kanban.workflow.policy.upsert",
+        {
+            "board_id": board_id,
+            "statuses": [
+                {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+                {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+            ],
+            "transitions": [
+                {
+                    "id": 1,
+                    "from_status_key": "todo",
+                    "to_status_key": "impl",
+                    "requires_claim": False,
+                    "requires_approval": False,
+                    "is_active": True,
+                }
+            ],
+        },
+        context=admin_ctx,
+    )
+    assert policy["policy"]["board_id"] == board_id
+
+    state = await mod.execute_tool("kanban.workflow.task.state.get", {"card_id": card_id}, context=admin_ctx)
+    transitioned = await mod.execute_tool(
+        "kanban.workflow.task.transition",
+        {
+            "card_id": card_id,
+            "to_status_key": "impl",
+            "actor": "builder",
+            "expected_version": state["state"]["version"],
+            "idempotency_key": "mcp-transition-1",
+            "correlation_id": "corr-mcp-transition-1",
+            "reason": "begin impl",
+        },
+        context=admin_ctx,
+    )
+    assert transitioned["state"]["workflow_status_key"] == "impl"
+
+    events = await mod.execute_tool(
+        "kanban.workflow.task.events.list",
+        {"card_id": card_id, "limit": 10, "offset": 0},
+        context=admin_ctx,
+    )
+    assert events["events"][0]["correlation_id"] == "corr-mcp-transition-1"

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_kanban_module.py
@@ -530,6 +530,23 @@ class FakeKanbanDB:
         policy = self._workflow_policies.get(board_id)
         return dict(policy) if policy else None
 
+    def update_workflow_policy_flags(
+        self,
+        *,
+        board_id: int,
+        is_paused: Optional[bool] = None,
+        is_draining: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        policy = self._ensure_workflow_policy_for_board(board_id)
+        policy["version"] = int(policy.get("version", 1)) + 1
+        if is_paused is not None:
+            policy["is_paused"] = bool(is_paused)
+        if is_draining is not None:
+            policy["is_draining"] = bool(is_draining)
+        policy["updated_at"] = self._now()
+        self._workflow_policies[board_id] = policy
+        return dict(policy)
+
     def list_workflow_statuses(self, board_id: int) -> List[Dict[str, Any]]:
         policy = self._ensure_workflow_policy_for_board(board_id)
         return [dict(status) for status in policy.get("statuses", [])]
@@ -1105,3 +1122,46 @@ async def test_kanban_workflow_tool_roundtrip(tmp_path):
         context=admin_ctx,
     )
     assert events["events"][0]["correlation_id"] == "corr-mcp-transition-1"
+
+
+@pytest.mark.asyncio
+async def test_kanban_workflow_policy_upsert_omits_metadata_when_not_supplied(tmp_path):
+    mod = KanbanModule(ModuleConfig(name="kanban"))
+
+    class SpyDB:
+        def __init__(self) -> None:
+            self.last_kwargs: Dict[str, Any] | None = None
+
+        def upsert_workflow_policy(self, **kwargs: Any) -> Dict[str, Any]:
+            self.last_kwargs = dict(kwargs)
+            return {
+                "id": 1,
+                "board_id": int(kwargs["board_id"]),
+                "version": 1,
+                "is_paused": bool(kwargs.get("is_paused", False)),
+                "is_draining": bool(kwargs.get("is_draining", False)),
+                "default_lease_ttl_sec": int(kwargs.get("default_lease_ttl_sec", 900)),
+                "strict_projection": bool(kwargs.get("strict_projection", True)),
+                "metadata": {"persisted": True},
+                "statuses": [],
+                "transitions": [],
+                "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+                "updated_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"),
+            }
+
+    spy_db = SpyDB()
+    mod._open_db = lambda ctx: spy_db  # type: ignore[assignment]
+    ctx = SimpleNamespace(user_id="1", db_paths={"kanban": tmp_path / "kanban.db"}, metadata={"roles": ["admin"]})
+
+    out = await mod.execute_tool(
+        "kanban.workflow.policy.upsert",
+        {
+            "board_id": 42,
+            "default_lease_ttl_sec": 1800,
+        },
+        context=ctx,
+    )
+
+    assert out["policy"]["board_id"] == 42
+    assert spy_db.last_kwargs is not None
+    assert "metadata" not in spy_db.last_kwargs

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1052,6 +1052,7 @@ else:
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links import router as kanban_links_router
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists import router as kanban_lists_router
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search import router as kanban_search_router
+        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow import router as kanban_workflow_router
 
         _HAS_KANBAN = True
     except ImportError as _kanban_err:
@@ -5498,6 +5499,7 @@ elif _MINIMAL_TEST_APP:
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_links import router as kanban_links_router
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_lists import router as kanban_lists_router
         from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_search import router as kanban_search_router
+        from tldw_Server_API.app.api.v1.endpoints.kanban.kanban_workflow import router as kanban_workflow_router
 
         app.include_router(kanban_boards_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
         app.include_router(kanban_lists_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
@@ -5507,6 +5509,7 @@ elif _MINIMAL_TEST_APP:
         app.include_router(kanban_comments_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
         app.include_router(kanban_search_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
         app.include_router(kanban_links_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
+        app.include_router(kanban_workflow_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"])
     except _IMPORT_EXCEPTIONS as _kanban_min_err:
         logger.debug(f"Skipping kanban router in minimal test app: {_kanban_min_err}")
     # Auth endpoints (login/register/refresh/logout/me)
@@ -6067,6 +6070,9 @@ else:
         )
         _include_if_enabled(
             "kanban", kanban_links_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"]
+        )
+        _include_if_enabled(
+            "kanban", kanban_workflow_router, prefix=f"{API_V1_PREFIX}/kanban", tags=["kanban"]
         )
     if _HAS_READING_HIGHLIGHTS:
         _include_if_enabled(

--- a/tldw_Server_API/tests/kanban/test_workflow_authz.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_authz.py
@@ -100,3 +100,46 @@ def test_force_reassign_workflow_claim_forbidden_for_non_admin(non_admin_workflo
     payload: dict[str, Any] = reassign_resp.json()
     assert isinstance(payload.get("detail"), dict)
     assert payload["detail"]["code"] == "forbidden"
+
+
+def test_patch_workflow_state_forbidden_for_non_admin(non_admin_workflow_client):
+    """Non-admin callers should be blocked from direct workflow state patching."""
+    client, _db = non_admin_workflow_client
+    board_resp = client.post(
+        "/api/v1/kanban/boards",
+        json={"name": "Authz Workflow Board 3", "client_id": "authz-workflow-board-3"},
+    )
+    assert board_resp.status_code == 201, board_resp.text
+    board_id = board_resp.json()["id"]
+
+    list_resp = client.post(
+        f"/api/v1/kanban/boards/{board_id}/lists",
+        json={"name": "Authz Workflow List 3", "client_id": "authz-workflow-list-3"},
+    )
+    assert list_resp.status_code == 201, list_resp.text
+    list_id = list_resp.json()["id"]
+
+    card_resp = client.post(
+        f"/api/v1/kanban/lists/{list_id}/cards",
+        json={"title": "Authz Workflow Card 3", "client_id": "authz-workflow-card-3"},
+    )
+    assert card_resp.status_code == 201, card_resp.text
+    card_id = card_resp.json()["id"]
+
+    state_resp = client.get(f"/api/v1/kanban/workflow/cards/{card_id}/state")
+    assert state_resp.status_code == 200, state_resp.text
+    state = state_resp.json()
+
+    patch_resp = client.patch(
+        f"/api/v1/kanban/workflow/cards/{card_id}/state",
+        json={
+            "workflow_status_key": state["workflow_status_key"],
+            "expected_version": state["version"],
+            "idempotency_key": "authz-state-patch",
+            "actor": "non-admin-user",
+        },
+    )
+    assert patch_resp.status_code == 403, patch_resp.text
+    payload: dict[str, Any] = patch_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "forbidden"

--- a/tldw_Server_API/tests/kanban/test_workflow_authz.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_authz.py
@@ -1,0 +1,102 @@
+"""Authorization tests for privileged Kanban workflow endpoints."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import KanbanDB
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def non_admin_workflow_client(tmp_path, monkeypatch):
+    """Create workflow test client as a non-admin user."""
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_dbs"))
+    db_path = DatabasePaths.get_kanban_db_path("integration_non_admin_workflow_user")
+    db = KanbanDB(str(db_path), user_id="integration_non_admin_workflow_user")
+
+    async def override_user():
+        return User(id=1, username="workflow-user", email="workflow@user.local", is_active=True, is_admin=False)
+
+    from tldw_Server_API.app.api.v1.API_Deps.kanban_deps import get_kanban_db_for_user
+
+    def override_db_dep():
+        return db
+
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+
+    from tldw_Server_API.app import main as app_main
+
+    importlib.reload(app_main)
+    fastapi_app = app_main.app
+    fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_kanban_db_for_user] = override_db_dep
+
+    with TestClient(fastapi_app) as client:
+        yield client, db
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_pause_workflow_policy_forbidden_for_non_admin(non_admin_workflow_client):
+    """Non-admin callers should be blocked from privileged workflow controls."""
+    client, _db = non_admin_workflow_client
+    board_resp = client.post(
+        "/api/v1/kanban/boards",
+        json={"name": "Authz Workflow Board", "client_id": "authz-workflow-board-1"},
+    )
+    assert board_resp.status_code == 201, board_resp.text
+    board_id = board_resp.json()["id"]
+
+    pause_resp = client.post(f"/api/v1/kanban/workflow/control/boards/{board_id}/pause")
+    assert pause_resp.status_code == 403, pause_resp.text
+    payload: dict[str, Any] = pause_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "forbidden"
+
+
+def test_force_reassign_workflow_claim_forbidden_for_non_admin(non_admin_workflow_client):
+    """Non-admin callers should be blocked from force-reassign recovery operation."""
+    client, _db = non_admin_workflow_client
+    board_resp = client.post(
+        "/api/v1/kanban/boards",
+        json={"name": "Authz Workflow Board 2", "client_id": "authz-workflow-board-2"},
+    )
+    assert board_resp.status_code == 201, board_resp.text
+    board_id = board_resp.json()["id"]
+
+    list_resp = client.post(
+        f"/api/v1/kanban/boards/{board_id}/lists",
+        json={"name": "Authz Workflow List 2", "client_id": "authz-workflow-list-2"},
+    )
+    assert list_resp.status_code == 201, list_resp.text
+    list_id = list_resp.json()["id"]
+
+    card_resp = client.post(
+        f"/api/v1/kanban/lists/{list_id}/cards",
+        json={"title": "Authz Workflow Card 2", "client_id": "authz-workflow-card-2"},
+    )
+    assert card_resp.status_code == 201, card_resp.text
+    card_id = card_resp.json()["id"]
+
+    reassign_resp = client.post(
+        f"/api/v1/kanban/workflow/recovery/cards/{card_id}/force-reassign",
+        json={
+            "new_owner": "builder-2",
+            "idempotency_key": "authz-force-reassign",
+            "correlation_id": "corr-authz-force-reassign",
+            "reason": "authz check",
+        },
+    )
+    assert reassign_resp.status_code == 403, reassign_resp.text
+    payload: dict[str, Any] = reassign_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "forbidden"

--- a/tldw_Server_API/tests/kanban/test_workflow_endpoints.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_endpoints.py
@@ -1,0 +1,154 @@
+"""Integration tests for Kanban workflow endpoints."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import KanbanDB
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def workflow_client_with_kanban_db(tmp_path, monkeypatch):
+    """Create a workflow-aware test client with a temporary Kanban database."""
+    monkeypatch.setenv("USER_DB_BASE_DIR", str(tmp_path / "user_dbs"))
+    db_path = DatabasePaths.get_kanban_db_path("integration_workflow_user")
+    db = KanbanDB(str(db_path), user_id="integration_workflow_user")
+
+    async def override_user():
+        return User(id=1, username="workflow-tester", email="workflow@test.local", is_active=True, is_admin=True)
+
+    from tldw_Server_API.app.api.v1.API_Deps.kanban_deps import get_kanban_db_for_user
+
+    def override_db_dep():
+        return db
+
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+
+    from tldw_Server_API.app import main as app_main
+
+    importlib.reload(app_main)
+    fastapi_app = app_main.app
+    fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_kanban_db_for_user] = override_db_dep
+
+    with TestClient(fastapi_app) as client:
+        yield client, db
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def _create_board_list_card(client: TestClient) -> tuple[int, int, int]:
+    board_resp = client.post(
+        "/api/v1/kanban/boards",
+        json={"name": "Workflow API Board", "client_id": "workflow-board-1"},
+    )
+    assert board_resp.status_code == 201, board_resp.text
+    board_id = board_resp.json()["id"]
+
+    list_resp = client.post(
+        f"/api/v1/kanban/boards/{board_id}/lists",
+        json={"name": "Workflow API List", "client_id": "workflow-list-1"},
+    )
+    assert list_resp.status_code == 201, list_resp.text
+    list_id = list_resp.json()["id"]
+
+    card_resp = client.post(
+        f"/api/v1/kanban/lists/{list_id}/cards",
+        json={"title": "Workflow API Card", "client_id": "workflow-card-1"},
+    )
+    assert card_resp.status_code == 201, card_resp.text
+    card_id = card_resp.json()["id"]
+
+    return board_id, list_id, card_id
+
+
+def test_transition_endpoint_enforces_policy_and_returns_structured_error(workflow_client_with_kanban_db):
+    """Transition endpoint should return stable structured error for lease failures."""
+    client, db = workflow_client_with_kanban_db
+    board_id, _list_id, card_id = _create_board_list_card(client)
+
+    db.upsert_workflow_policy(
+        board_id=board_id,
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": True,
+                "requires_approval": False,
+            }
+        ],
+    )
+    state = db.get_card_workflow_state(card_id)
+
+    transition_resp = client.post(
+        f"/api/v1/kanban/workflow/cards/{card_id}/transition",
+        json={
+            "to_status_key": "impl",
+            "actor": "builder",
+            "expected_version": state["version"],
+            "idempotency_key": "api-transition-no-lease",
+            "correlation_id": "corr-api-transition-no-lease",
+            "reason": "start implementation",
+        },
+    )
+
+    assert transition_resp.status_code == 409, transition_resp.text
+    payload: dict[str, Any] = transition_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "lease_required"
+    assert "lease_required" in payload["detail"]["message"]
+
+
+def test_transition_endpoint_returns_policy_paused_code(workflow_client_with_kanban_db):
+    """Transition endpoint should return policy_paused when board policy is paused."""
+    client, db = workflow_client_with_kanban_db
+    board_id, _list_id, card_id = _create_board_list_card(client)
+
+    db.upsert_workflow_policy(
+        board_id=board_id,
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": False,
+                "requires_approval": False,
+            }
+        ],
+        is_paused=True,
+    )
+    state = db.get_card_workflow_state(card_id)
+
+    transition_resp = client.post(
+        f"/api/v1/kanban/workflow/cards/{card_id}/transition",
+        json={
+            "to_status_key": "impl",
+            "actor": "builder",
+            "expected_version": state["version"],
+            "idempotency_key": "api-transition-paused",
+            "correlation_id": "corr-api-transition-paused",
+            "reason": "attempt while paused",
+        },
+    )
+
+    assert transition_resp.status_code == 409, transition_resp.text
+    payload: dict[str, Any] = transition_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "policy_paused"
+    assert "policy_paused" in payload["detail"]["message"]

--- a/tldw_Server_API/tests/kanban/test_workflow_endpoints.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_endpoints.py
@@ -152,3 +152,55 @@ def test_transition_endpoint_returns_policy_paused_code(workflow_client_with_kan
     assert isinstance(payload.get("detail"), dict)
     assert payload["detail"]["code"] == "policy_paused"
     assert "policy_paused" in payload["detail"]["message"]
+
+
+def test_patch_state_version_conflict_returns_stable_code(workflow_client_with_kanban_db):
+    """State patch should return stable version_conflict code on CAS mismatch."""
+    client, _db = workflow_client_with_kanban_db
+    _board_id, _list_id, card_id = _create_board_list_card(client)
+
+    state_resp = client.get(f"/api/v1/kanban/workflow/cards/{card_id}/state")
+    assert state_resp.status_code == 200, state_resp.text
+    state = state_resp.json()
+
+    patch_resp = client.patch(
+        f"/api/v1/kanban/workflow/cards/{card_id}/state",
+        json={
+            "workflow_status_key": state["workflow_status_key"],
+            "expected_version": state["version"] + 10,
+            "idempotency_key": "api-patch-version-conflict",
+            "correlation_id": "corr-api-patch-version-conflict",
+            "actor": "repair-admin",
+        },
+    )
+
+    assert patch_resp.status_code == 409, patch_resp.text
+    payload: dict[str, Any] = patch_resp.json()
+    assert isinstance(payload.get("detail"), dict)
+    assert payload["detail"]["code"] == "version_conflict"
+
+
+def test_policy_upsert_preserves_metadata_when_omitted(workflow_client_with_kanban_db):
+    """Policy metadata should be preserved when omitted from upsert payload."""
+    client, _db = workflow_client_with_kanban_db
+    board_id, _list_id, _card_id = _create_board_list_card(client)
+
+    first = client.put(
+        f"/api/v1/kanban/workflow/boards/{board_id}/policy",
+        json={
+            "default_lease_ttl_sec": 900,
+            "metadata": {"owner": "workflow-team"},
+        },
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["metadata"] == {"owner": "workflow-team"}
+
+    second = client.put(
+        f"/api/v1/kanban/workflow/boards/{board_id}/policy",
+        json={
+            "default_lease_ttl_sec": 1200,
+        },
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["default_lease_ttl_sec"] == 1200
+    assert second.json()["metadata"] == {"owner": "workflow-team"}

--- a/tldw_Server_API/tests/kanban/test_workflow_idempotency_and_concurrency.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_idempotency_and_concurrency.py
@@ -1,0 +1,58 @@
+"""Workflow idempotency and optimistic-concurrency regression tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import KanbanDB
+
+
+def test_reused_transition_idempotency_key_replays_without_duplicate_event(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+    sample_card: dict[str, Any],
+) -> None:
+    """Reusing transition idempotency key should replay state and avoid duplicate events."""
+    kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": False,
+                "requires_approval": False,
+            }
+        ],
+    )
+
+    initial_state = kanban_db.get_card_workflow_state(sample_card["id"])
+    transitioned = kanban_db.transition_card_workflow(
+        card_id=sample_card["id"],
+        to_status_key="impl",
+        actor="builder",
+        expected_version=initial_state["version"],
+        idempotency_key="idempotent-transition-1",
+        correlation_id="corr-idempotent-transition-1",
+        reason="start implementation",
+    )
+    assert transitioned["workflow_status_key"] == "impl"
+
+    replayed = kanban_db.transition_card_workflow(
+        card_id=sample_card["id"],
+        to_status_key="impl",
+        actor="builder",
+        expected_version=initial_state["version"],
+        idempotency_key="idempotent-transition-1",
+        correlation_id="corr-idempotent-transition-1",
+        reason="start implementation",
+    )
+    assert replayed["version"] == transitioned["version"]
+    assert replayed["workflow_status_key"] == transitioned["workflow_status_key"]
+
+    events = kanban_db.list_card_workflow_events(card_id=sample_card["id"])
+    transition_events = [event for event in events if event["event_type"] == "workflow_transitioned"]
+    assert len(transition_events) == 1

--- a/tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py
@@ -1,0 +1,74 @@
+"""Workflow policy/state DB method tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import KanbanDB
+
+
+def test_upsert_and_get_workflow_policy_roundtrip(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+) -> None:
+    """Policy upsert should persist statuses/transitions and roundtrip cleanly."""
+    saved = kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+            {"status_key": "done", "display_name": "Done", "sort_order": 2, "is_terminal": True},
+        ],
+        transitions=[
+            {"from_status_key": "todo", "to_status_key": "impl", "requires_claim": True},
+            {"from_status_key": "impl", "to_status_key": "done", "requires_claim": True},
+        ],
+        is_paused=False,
+        is_draining=False,
+        default_lease_ttl_sec=1200,
+        strict_projection=True,
+        metadata={"source": "test"},
+    )
+
+    assert saved["board_id"] == sample_board["id"]
+    assert saved["default_lease_ttl_sec"] == 1200
+    assert len(saved["statuses"]) == 3
+    assert len(saved["transitions"]) == 2
+
+    fetched = kanban_db.get_workflow_policy(sample_board["id"])
+    assert fetched is not None
+    assert fetched["id"] == saved["id"]
+    assert fetched["metadata"] == {"source": "test"}
+
+    statuses = kanban_db.list_workflow_statuses(sample_board["id"])
+    assert [status["status_key"] for status in statuses] == ["todo", "impl", "done"]
+
+    transitions = kanban_db.list_workflow_transitions(sample_board["id"])
+    assert {(edge["from_status_key"], edge["to_status_key"]) for edge in transitions} == {
+        ("todo", "impl"),
+        ("impl", "done"),
+    }
+
+
+def test_get_and_patch_card_workflow_state_lazy_bootstrap(
+    kanban_db: KanbanDB,
+    sample_card: dict[str, Any],
+) -> None:
+    """Legacy cards should lazily get workflow state and allow versioned patches."""
+    state = kanban_db.get_card_workflow_state(sample_card["id"])
+
+    assert state["card_id"] == sample_card["id"]
+    assert state["workflow_status_key"] == "todo"
+    assert state["version"] == 1
+
+    updated = kanban_db.patch_card_workflow_state(
+        card_id=sample_card["id"],
+        workflow_status_key="impl",
+        expected_version=state["version"],
+        lease_owner=None,
+        idempotency_key="policy-state-test-1",
+        last_actor="test-suite",
+    )
+
+    assert updated["workflow_status_key"] == "impl"
+    assert updated["version"] == state["version"] + 1

--- a/tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_policy_state_db.py
@@ -72,3 +72,22 @@ def test_get_and_patch_card_workflow_state_lazy_bootstrap(
 
     assert updated["workflow_status_key"] == "impl"
     assert updated["version"] == state["version"] + 1
+
+
+def test_upsert_workflow_policy_preserves_metadata_when_omitted(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+) -> None:
+    """Omitted metadata should preserve existing value instead of clearing it."""
+    first = kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        metadata={"retain": True},
+    )
+    assert first["metadata"] == {"retain": True}
+
+    second = kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        default_lease_ttl_sec=1800,
+    )
+    assert second["default_lease_ttl_sec"] == 1800
+    assert second["metadata"] == {"retain": True}

--- a/tldw_Server_API/tests/kanban/test_workflow_projection_failures.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_projection_failures.py
@@ -1,0 +1,53 @@
+"""Workflow projection strictness regression tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import ConflictError, KanbanDB
+
+
+def test_projection_fails_when_target_list_archived(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+    sample_card: dict[str, Any],
+) -> None:
+    """Strict projection should block transition when mapped list target is archived."""
+    target_list = kanban_db.create_list(
+        board_id=sample_board["id"],
+        name="Implementation List",
+        client_id="impl-list-client-1",
+    )
+    kanban_db.archive_list(target_list["id"], archive=True)
+
+    kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": False,
+                "requires_approval": False,
+                "auto_move_list_id": target_list["id"],
+            }
+        ],
+        strict_projection=True,
+    )
+
+    state = kanban_db.get_card_workflow_state(sample_card["id"])
+    with pytest.raises(ConflictError, match="projection_failed"):
+        kanban_db.transition_card_workflow(
+            card_id=sample_card["id"],
+            to_status_key="impl",
+            actor="builder",
+            expected_version=state["version"],
+            idempotency_key="projection-failure-1",
+            correlation_id="corr-projection-failure-1",
+            reason="attempt projected move to archived list",
+        )

--- a/tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_schema_bootstrap.py
@@ -1,0 +1,81 @@
+"""Workflow schema bootstrap tests for KanbanDB."""
+
+import sqlite3
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import KanbanDB
+
+
+REQUIRED_WORKFLOW_TABLES = {
+    "board_workflow_policies",
+    "board_workflow_statuses",
+    "board_workflow_transitions",
+    "kanban_card_workflow_state",
+    "kanban_card_workflow_events",
+    "kanban_card_workflow_approvals",
+}
+
+
+def test_workflow_tables_exist_after_db_init(kanban_db: KanbanDB) -> None:
+    """KanbanDB schema bootstrap should create workflow control tables."""
+    conn = sqlite3.connect(kanban_db.db_path)
+    try:
+        rows = conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    finally:
+        conn.close()
+
+    table_names = {row[0] for row in rows}
+    missing_tables = REQUIRED_WORKFLOW_TABLES - table_names
+
+    assert not missing_tables, f"Missing workflow tables: {sorted(missing_tables)}"  # nosec B101
+
+
+def test_workflow_status_foreign_keys_enforced(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, object],
+    sample_card: dict[str, object],
+) -> None:
+    """Workflow status references must reject unknown status keys."""
+    conn = sqlite3.connect(kanban_db.db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute(
+            "INSERT INTO board_workflow_policies (board_id) VALUES (?)",
+            (sample_board["id"],),
+        )
+        policy_id = conn.execute(
+            "SELECT id FROM board_workflow_policies WHERE board_id = ?",
+            (sample_board["id"],),
+        ).fetchone()[0]
+        conn.execute(
+            "INSERT INTO board_workflow_statuses (policy_id, status_key, display_name) VALUES (?, ?, ?)",
+            (policy_id, "todo", "To Do"),
+        )
+        conn.execute(
+            "INSERT INTO board_workflow_statuses (policy_id, status_key, display_name) VALUES (?, ?, ?)",
+            (policy_id, "impl", "Implement"),
+        )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO board_workflow_transitions (policy_id, from_status_key, to_status_key) VALUES (?, ?, ?)",
+                (policy_id, "todo", "missing"),
+            )
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO kanban_card_workflow_state (card_id, policy_id, workflow_status_key) VALUES (?, ?, ?)",
+                (sample_card["id"], policy_id, "missing"),
+            )
+
+        conn.execute(
+            "INSERT INTO board_workflow_transitions (policy_id, from_status_key, to_status_key) VALUES (?, ?, ?)",
+            (policy_id, "todo", "impl"),
+        )
+        conn.execute(
+            "INSERT INTO kanban_card_workflow_state (card_id, policy_id, workflow_status_key) VALUES (?, ?, ?)",
+            (sample_card["id"], policy_id, "todo"),
+        )
+    finally:
+        conn.close()

--- a/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
@@ -200,3 +200,25 @@ def test_stale_claim_listing_and_force_reassign(
     )
     assert reassigned["lease_owner"] == "inspector"
     assert reassigned["version"] > state["version"]
+
+
+def test_claim_rejects_lease_theft_when_active_lease_exists(
+    kanban_db: KanbanDB,
+    sample_card: dict[str, Any],
+) -> None:
+    """Claims from a different owner must fail while an active lease exists."""
+    first_claim = kanban_db.claim_card_workflow(
+        card_id=sample_card["id"],
+        owner="builder-a",
+        lease_ttl_sec=300,
+        idempotency_key="claim-owner-a",
+    )
+    assert first_claim["lease_owner"] == "builder-a"
+
+    with pytest.raises(ConflictError, match="lease_mismatch"):
+        kanban_db.claim_card_workflow(
+            card_id=sample_card["id"],
+            owner="builder-b",
+            lease_ttl_sec=300,
+            idempotency_key="claim-owner-b",
+        )

--- a/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
@@ -1,0 +1,157 @@
+"""Workflow transition safety-contract tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Kanban_DB import ConflictError, KanbanDB
+
+
+def test_transition_requires_lease_and_expected_version(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+    sample_card: dict[str, Any],
+) -> None:
+    """Transitions should enforce lease ownership and optimistic versioning."""
+    kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": True,
+                "requires_approval": False,
+            }
+        ],
+    )
+
+    initial_state = kanban_db.get_card_workflow_state(sample_card["id"])
+
+    with pytest.raises(ConflictError, match="lease_required"):
+        kanban_db.transition_card_workflow(
+            card_id=sample_card["id"],
+            to_status_key="impl",
+            actor="builder",
+            expected_version=initial_state["version"],
+            idempotency_key="transition-without-lease",
+            reason="start implementation",
+        )
+
+    kanban_db.claim_card_workflow(
+        card_id=sample_card["id"],
+        owner="builder",
+        lease_ttl_sec=300,
+        idempotency_key="claim-builder",
+    )
+
+    with pytest.raises(ConflictError, match="version_conflict"):
+        kanban_db.transition_card_workflow(
+            card_id=sample_card["id"],
+            to_status_key="impl",
+            actor="builder",
+            expected_version=initial_state["version"],
+            idempotency_key="transition-wrong-version",
+            reason="start implementation",
+        )
+
+
+def test_transition_approval_flow_and_decision(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+    sample_card: dict[str, Any],
+) -> None:
+    """Approval-gated transitions should create pending approvals and route on decision."""
+    kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": False,
+                "requires_approval": True,
+                "approve_to_status_key": "impl",
+                "reject_to_status_key": "todo",
+            }
+        ],
+    )
+
+    initial_state = kanban_db.get_card_workflow_state(sample_card["id"])
+    pending_state = kanban_db.transition_card_workflow(
+        card_id=sample_card["id"],
+        to_status_key="impl",
+        actor="planner",
+        expected_version=initial_state["version"],
+        idempotency_key="approval-request",
+        reason="request plan review",
+    )
+
+    assert pending_state["workflow_status_key"] == "todo"
+    assert pending_state["approval_state"] == "awaiting_approval"
+    assert pending_state["pending_transition_id"] is not None
+
+    decided_state = kanban_db.decide_card_workflow_approval(
+        card_id=sample_card["id"],
+        reviewer="critic",
+        decision="approved",
+        expected_version=pending_state["version"],
+        idempotency_key="approval-decision",
+        reason="looks good",
+    )
+
+    assert decided_state["workflow_status_key"] == "impl"
+    assert decided_state["approval_state"] == "approved"
+    assert decided_state["pending_transition_id"] is None
+
+    events = kanban_db.list_card_workflow_events(card_id=sample_card["id"])
+    event_types = {event["event_type"] for event in events}
+    assert "workflow_approval_requested" in event_types
+    assert "workflow_approval_decided" in event_types
+
+
+def test_stale_claim_listing_and_force_reassign(
+    kanban_db: KanbanDB,
+    sample_card: dict[str, Any],
+) -> None:
+    """Stale claim listing should surface expired claims and support force reassign."""
+    state = kanban_db.get_card_workflow_state(sample_card["id"])
+    claimed = kanban_db.claim_card_workflow(
+        card_id=sample_card["id"],
+        owner="builder",
+        lease_ttl_sec=300,
+        idempotency_key="claim-for-stale-test",
+    )
+    assert claimed["lease_owner"] == "builder"
+
+    conn = sqlite3.connect(kanban_db.db_path)
+    try:
+        conn.execute(
+            "UPDATE kanban_card_workflow_state SET lease_expires_at = ? WHERE card_id = ?",
+            ("2000-01-01 00:00:00", sample_card["id"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    stale_claims = kanban_db.list_stale_workflow_claims()
+    stale_card_ids = {claim["card_id"] for claim in stale_claims}
+    assert sample_card["id"] in stale_card_ids
+
+    reassigned = kanban_db.force_reassign_workflow_claim(
+        card_id=sample_card["id"],
+        new_owner="inspector",
+        idempotency_key="force-reassign-stale",
+        reason="stale claim recovered",
+    )
+    assert reassigned["lease_owner"] == "inspector"
+    assert reassigned["version"] > state["version"]

--- a/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
+++ b/tldw_Server_API/tests/kanban/test_workflow_transition_contract.py
@@ -41,6 +41,7 @@ def test_transition_requires_lease_and_expected_version(
             actor="builder",
             expected_version=initial_state["version"],
             idempotency_key="transition-without-lease",
+            correlation_id="corr-transition-without-lease",
             reason="start implementation",
         )
 
@@ -58,7 +59,44 @@ def test_transition_requires_lease_and_expected_version(
             actor="builder",
             expected_version=initial_state["version"],
             idempotency_key="transition-wrong-version",
+            correlation_id="corr-transition-wrong-version",
             reason="start implementation",
+        )
+
+
+def test_transition_blocked_when_policy_paused(
+    kanban_db: KanbanDB,
+    sample_board: dict[str, Any],
+    sample_card: dict[str, Any],
+) -> None:
+    """Transitions should be blocked when workflow policy is paused."""
+    kanban_db.upsert_workflow_policy(
+        board_id=sample_board["id"],
+        statuses=[
+            {"status_key": "todo", "display_name": "To Do", "sort_order": 0},
+            {"status_key": "impl", "display_name": "Implement", "sort_order": 1},
+        ],
+        transitions=[
+            {
+                "from_status_key": "todo",
+                "to_status_key": "impl",
+                "requires_claim": False,
+                "requires_approval": False,
+            }
+        ],
+        is_paused=True,
+    )
+
+    state = kanban_db.get_card_workflow_state(sample_card["id"])
+    with pytest.raises(ConflictError, match="policy_paused"):
+        kanban_db.transition_card_workflow(
+            card_id=sample_card["id"],
+            to_status_key="impl",
+            actor="builder",
+            expected_version=state["version"],
+            idempotency_key="paused-transition",
+            correlation_id="corr-paused-transition",
+            reason="attempt while paused",
         )
 
 
@@ -93,6 +131,7 @@ def test_transition_approval_flow_and_decision(
         actor="planner",
         expected_version=initial_state["version"],
         idempotency_key="approval-request",
+        correlation_id="corr-approval-request",
         reason="request plan review",
     )
 
@@ -106,6 +145,7 @@ def test_transition_approval_flow_and_decision(
         decision="approved",
         expected_version=pending_state["version"],
         idempotency_key="approval-decision",
+        correlation_id="corr-approval-decision",
         reason="looks good",
     )
 
@@ -117,6 +157,10 @@ def test_transition_approval_flow_and_decision(
     event_types = {event["event_type"] for event in events}
     assert "workflow_approval_requested" in event_types
     assert "workflow_approval_decided" in event_types
+
+    event_by_type = {event["event_type"]: event for event in events}
+    assert event_by_type["workflow_approval_requested"]["correlation_id"] == "corr-approval-request"
+    assert event_by_type["workflow_approval_decided"]["correlation_id"] == "corr-approval-decision"
 
 
 def test_stale_claim_listing_and_force_reassign(
@@ -151,6 +195,7 @@ def test_stale_claim_listing_and_force_reassign(
         card_id=sample_card["id"],
         new_owner="inspector",
         idempotency_key="force-reassign-stale",
+        correlation_id="corr-force-reassign-stale",
         reason="stale claim recovered",
     )
     assert reassigned["lease_owner"] == "inspector"


### PR DESCRIPTION
Summary:\n- document safe Kanban workflow-control usage in MCP Unified user docs\n- add workflow control-plane documentation to the Kanban board guide\n- add catalog guidance for kanban-safe-orchestrator tool grouping\n- add new Docs/Prompts/Skills/kanban/SKILL.md mapped to tldw_server MCP primitives\n\nValidation:\n- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate\n- python -m pytest -q tldw_Server_API/tests/kanban/test_workflow_endpoints.py tldw_Server_API/tests/kanban/test_workflow_authz.py tldw_Server_API/tests/kanban/test_workflow_transition_contract.py --maxfail=1\n\nNotes:\n- mkdocs build currently fails in this checkout due pre-existing config mismatch: Docs/mkdocs.yml references Docs/Published, which is absent in this tree.