### PR TITLE
refactor(writing-playground): restructure inspector panel IA

### DIFF
--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlayground.types.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlayground.types.ts
@@ -1,6 +1,10 @@
 import type { ReactNode } from "react"
 
-export type InspectorTabKey = "generation" | "planning" | "diagnostics"
+export type InspectorTabKey = "sampling" | "context" | "setup" | "inspect"
+
+export interface EssentialsStripProps {
+  children: ReactNode
+}
 
 export interface WritingPlaygroundShellProps {
   children: ReactNode

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundActiveSessionGuard.tsx
@@ -1,0 +1,45 @@
+import type { FC, ReactNode } from "react"
+import { Alert, Empty, Skeleton } from "antd"
+import type { TranslateFn } from "./WritingPlaygroundDiagnostics.types"
+
+type WritingPlaygroundActiveSessionGuardProps = {
+  hasActiveSession: boolean
+  isLoading: boolean
+  hasError: boolean
+  t: TranslateFn
+  children: ReactNode
+}
+
+export const WritingPlaygroundActiveSessionGuard: FC<
+  WritingPlaygroundActiveSessionGuardProps
+> = ({ hasActiveSession, isLoading, hasError, t, children }) => {
+  if (!hasActiveSession) {
+    return (
+      <Empty
+        description={t(
+          "option:writingPlayground.settingsEmpty",
+          "Select a session to edit settings."
+        )}
+      />
+    )
+  }
+
+  if (isLoading) {
+    return <Skeleton active />
+  }
+
+  if (hasError) {
+    return (
+      <Alert
+        type="error"
+        showIcon
+        title={t(
+          "option:writingPlayground.settingsError",
+          "Unable to load session settings."
+        )}
+      />
+    )
+  }
+
+  return <>{children}</>
+}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnostics.types.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnostics.types.ts
@@ -69,6 +69,7 @@ export type WordcloudPanelState = {
 } & Omit<WordcloudCardProps, "t">
 
 export type WritingPlaygroundDiagnosticsPanelProps = {
+  title?: string
   t: TranslateFn
   status: "warning" | "busy" | "ready"
   showOffline: boolean

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundDiagnosticsPanel.tsx
@@ -8,6 +8,7 @@ import type { WritingPlaygroundDiagnosticsPanelProps } from "./WritingPlayground
 export const WritingPlaygroundDiagnosticsPanel: FC<
   WritingPlaygroundDiagnosticsPanelProps
 > = ({
+  title,
   t,
   status,
   showOffline,
@@ -24,7 +25,7 @@ export const WritingPlaygroundDiagnosticsPanel: FC<
   return (
     <Card
       data-testid="writing-playground-diagnostics-card"
-      title={t("option:writingPlayground.sidebarDiagnostics", "Diagnostics")}>
+      title={title ?? t("option:writingPlayground.sidebarDiagnostics", "Diagnostics")}>
       <div className="flex flex-col gap-2">
         <Tag color={status === "warning" ? "gold" : status === "busy" ? "blue" : "green"}>
           {status === "warning"

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundInspectorPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundInspectorPanel.tsx
@@ -10,27 +10,35 @@ type TabDefinition = {
 type WritingPlaygroundInspectorPanelProps = {
   activeTab: InspectorTabKey
   onTabChange: (tab: InspectorTabKey) => void
-  generation: ReactNode
-  planning: ReactNode
-  diagnostics: ReactNode
+  essentialsStrip?: ReactNode
+  sampling: ReactNode
+  context: ReactNode
+  setup: ReactNode
+  inspect: ReactNode
   tabLabels?: Partial<Record<InspectorTabKey, string>>
+  tabBadges?: Partial<Record<InspectorTabKey, ReactNode>>
 }
 
 const TAB_DEFINITIONS: TabDefinition[] = [
   {
-    key: "generation",
-    label: "Generation",
-    testId: "writing-inspector-tab-generation"
+    key: "sampling",
+    label: "Sampling",
+    testId: "writing-inspector-tab-sampling"
   },
   {
-    key: "planning",
-    label: "Planning",
-    testId: "writing-inspector-tab-planning"
+    key: "context",
+    label: "Context",
+    testId: "writing-inspector-tab-context"
   },
   {
-    key: "diagnostics",
-    label: "Diagnostics",
-    testId: "writing-inspector-tab-diagnostics"
+    key: "setup",
+    label: "Setup",
+    testId: "writing-inspector-tab-setup"
+  },
+  {
+    key: "inspect",
+    label: "Inspect",
+    testId: "writing-inspector-tab-inspect"
   }
 ]
 
@@ -39,10 +47,13 @@ export const WritingPlaygroundInspectorPanel: FC<
 > = ({
   activeTab,
   onTabChange,
-  generation,
-  planning,
-  diagnostics,
-  tabLabels
+  essentialsStrip,
+  sampling,
+  context,
+  setup,
+  inspect,
+  tabLabels,
+  tabBadges
 }) => {
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
 
@@ -57,13 +68,18 @@ export const WritingPlaygroundInspectorPanel: FC<
   }
 
   const panelMap: Record<InspectorTabKey, ReactNode> = {
-    generation,
-    planning,
-    diagnostics
+    sampling,
+    context,
+    setup,
+    inspect
   }
 
   return (
     <div data-testid="writing-playground-inspector-panel" className="flex flex-col gap-3">
+      {essentialsStrip ? (
+        <div data-testid="writing-essentials-strip">{essentialsStrip}</div>
+      ) : null}
+
       <div
         role="tablist"
         aria-label="Writing inspector tabs"
@@ -112,6 +128,9 @@ export const WritingPlaygroundInspectorPanel: FC<
                 }
               }}>
               {tabLabels?.[tab.key] || tab.label}
+              {tabBadges?.[tab.key] ? (
+                <span className="ml-1">{tabBadges[tab.key]}</span>
+              ) : null}
             </button>
           )
         })}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundInspectorPanel.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/WritingPlaygroundInspectorPanel.tsx
@@ -129,7 +129,7 @@ export const WritingPlaygroundInspectorPanel: FC<
               }}>
               {tabLabels?.[tab.key] || tab.label}
               {tabBadges?.[tab.key] ? (
-                <span className="ml-1">{tabBadges[tab.key]}</span>
+                <span className="ml-1" aria-hidden="true">{tabBadges[tab.key]}</span>
               ) : null}
             </button>
           )

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.active-session-guard.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.active-session-guard.test.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { WritingPlaygroundActiveSessionGuard } from "../WritingPlaygroundActiveSessionGuard"
+
+const t = (key: string, defaultValue: string) => defaultValue || key
+
+describe("WritingPlaygroundActiveSessionGuard", () => {
+  it("renders the empty state when there is no active session", () => {
+    render(
+      <WritingPlaygroundActiveSessionGuard
+        hasActiveSession={false}
+        isLoading={false}
+        hasError={false}
+        t={t}>
+        <div>ready content</div>
+      </WritingPlaygroundActiveSessionGuard>
+    )
+
+    expect(
+      screen.getByText("Select a session to edit settings.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders a loading skeleton when the active session is loading", () => {
+    const { container } = render(
+      <WritingPlaygroundActiveSessionGuard
+        hasActiveSession
+        isLoading
+        hasError={false}
+        t={t}>
+        <div>ready content</div>
+      </WritingPlaygroundActiveSessionGuard>
+    )
+
+    expect(container.querySelector(".ant-skeleton")).not.toBeNull()
+  })
+
+  it("renders the error state when the active session fails to load", () => {
+    render(
+      <WritingPlaygroundActiveSessionGuard
+        hasActiveSession
+        isLoading={false}
+        hasError
+        t={t}>
+        <div>ready content</div>
+      </WritingPlaygroundActiveSessionGuard>
+    )
+
+    expect(
+      screen.getByText("Unable to load session settings.")
+    ).toBeInTheDocument()
+  })
+
+  it("renders children when the active session is ready", () => {
+    render(
+      <WritingPlaygroundActiveSessionGuard
+        hasActiveSession
+        isLoading={false}
+        hasError={false}
+        t={t}>
+        <div>ready content</div>
+      </WritingPlaygroundActiveSessionGuard>
+    )
+
+    expect(screen.getByText("ready content")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 vi.mock("@tanstack/react-query", () => {
@@ -228,6 +228,18 @@ describe("WritingPlayground inspector tabs", () => {
     ).toBeInTheDocument()
   })
 
+  it("disables essentials settings controls when no session is selected", () => {
+    render(<WritingPlayground />)
+
+    const spinbuttons = screen.getAllByRole("spinbutton")
+    expect(spinbuttons.length).toBeGreaterThan(0)
+    for (const input of spinbuttons) {
+      expect(input).toBeDisabled()
+    }
+
+    expect(screen.getByTestId("writing-essentials-generate")).toBeDisabled()
+  })
+
   it("has four tabs: Sampling, Context, Setup, Inspect", () => {
     render(<WritingPlayground />)
 
@@ -235,5 +247,18 @@ describe("WritingPlayground inspector tabs", () => {
     expect(screen.getByRole("tab", { name: "Context" })).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "Setup" })).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "Inspect" })).toBeInTheDocument()
+  })
+
+  it("renders an Inspect panel title that matches the tab label", () => {
+    render(<WritingPlayground />)
+
+    fireEvent.click(screen.getByRole("tab", { name: "Inspect" }))
+
+    expect(
+      within(screen.getByTestId("writing-playground-diagnostics-card")).getByText(
+        "Inspect"
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Diagnostics")).not.toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.inspector-tabs.test.tsx
@@ -148,53 +148,53 @@ describe("WritingPlayground inspector tabs", () => {
     })
     expect(tablist).toBeInTheDocument()
 
-    const generationTab = screen.getByRole("tab", { name: "Generation" })
-    const planningTab = screen.getByRole("tab", { name: "Planning" })
+    const samplingTab = screen.getByRole("tab", { name: "Sampling" })
+    const contextTab = screen.getByRole("tab", { name: "Context" })
 
-    expect(generationTab).toHaveAttribute("aria-selected", "true")
-    expect(planningTab).toHaveAttribute("aria-selected", "false")
+    expect(samplingTab).toHaveAttribute("aria-selected", "true")
+    expect(contextTab).toHaveAttribute("aria-selected", "false")
 
-    fireEvent.click(planningTab)
+    fireEvent.click(contextTab)
 
-    expect(planningTab).toHaveAttribute("aria-selected", "true")
-    expect(generationTab).toHaveAttribute("aria-selected", "false")
+    expect(contextTab).toHaveAttribute("aria-selected", "true")
+    expect(samplingTab).toHaveAttribute("aria-selected", "false")
   })
 
   it("supports keyboard arrow navigation between tabs", () => {
     render(<WritingPlayground />)
 
-    const generationTab = screen.getByRole("tab", { name: "Generation" })
-    const planningTab = screen.getByRole("tab", { name: "Planning" })
+    const samplingTab = screen.getByRole("tab", { name: "Sampling" })
+    const contextTab = screen.getByRole("tab", { name: "Context" })
 
-    generationTab.focus()
-    fireEvent.keyDown(generationTab, { key: "ArrowRight" })
+    samplingTab.focus()
+    fireEvent.keyDown(samplingTab, { key: "ArrowRight" })
 
-    expect(planningTab).toHaveAttribute("aria-selected", "true")
-    expect(generationTab).toHaveAttribute("aria-selected", "false")
-    expect(planningTab).toHaveFocus()
+    expect(contextTab).toHaveAttribute("aria-selected", "true")
+    expect(samplingTab).toHaveAttribute("aria-selected", "false")
+    expect(contextTab).toHaveFocus()
   })
 
   it("supports Home/End and wraparound focus traversal", () => {
     render(<WritingPlayground />)
 
-    const generationTab = screen.getByRole("tab", { name: "Generation" })
-    const diagnosticsTab = screen.getByRole("tab", { name: "Diagnostics" })
+    const samplingTab = screen.getByRole("tab", { name: "Sampling" })
+    const inspectTab = screen.getByRole("tab", { name: "Inspect" })
 
-    generationTab.focus()
-    fireEvent.keyDown(generationTab, { key: "ArrowLeft" })
-    expect(diagnosticsTab).toHaveAttribute("aria-selected", "true")
-    expect(diagnosticsTab).toHaveFocus()
+    samplingTab.focus()
+    fireEvent.keyDown(samplingTab, { key: "ArrowLeft" })
+    expect(inspectTab).toHaveAttribute("aria-selected", "true")
+    expect(inspectTab).toHaveFocus()
 
-    fireEvent.keyDown(diagnosticsTab, { key: "Home" })
-    expect(generationTab).toHaveAttribute("aria-selected", "true")
-    expect(generationTab).toHaveFocus()
+    fireEvent.keyDown(inspectTab, { key: "Home" })
+    expect(samplingTab).toHaveAttribute("aria-selected", "true")
+    expect(samplingTab).toHaveFocus()
 
-    fireEvent.keyDown(generationTab, { key: "End" })
-    expect(diagnosticsTab).toHaveAttribute("aria-selected", "true")
-    expect(diagnosticsTab).toHaveFocus()
+    fireEvent.keyDown(samplingTab, { key: "End" })
+    expect(inspectTab).toHaveAttribute("aria-selected", "true")
+    expect(inspectTab).toHaveFocus()
   })
 
-  it("shows template/theme management actions in Planning, not Generation", () => {
+  it("shows template/theme management actions in Setup tab", () => {
     render(<WritingPlayground />)
 
     expect(
@@ -204,7 +204,7 @@ describe("WritingPlayground inspector tabs", () => {
       screen.queryByRole("button", { name: "Manage themes" })
     ).not.toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("tab", { name: "Planning" }))
+    fireEvent.click(screen.getByRole("tab", { name: "Setup" }))
 
     expect(
       screen.getByRole("button", { name: "Manage templates" })
@@ -214,13 +214,26 @@ describe("WritingPlayground inspector tabs", () => {
     ).toBeInTheDocument()
   })
 
-  it("renders non-placeholder diagnostics content", () => {
+  it("renders essentials strip with model input and generate button", () => {
     render(<WritingPlayground />)
 
-    fireEvent.click(screen.getByRole("tab", { name: "Diagnostics" }))
-
     expect(
-      screen.queryByText("Diagnostics tools will be moved here.")
-    ).not.toBeInTheDocument()
+      screen.getByTestId("writing-essentials-strip")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("writing-essentials-model")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId("writing-essentials-generate")
+    ).toBeInTheDocument()
+  })
+
+  it("has four tabs: Sampling, Context, Setup, Inspect", () => {
+    render(<WritingPlayground />)
+
+    expect(screen.getByRole("tab", { name: "Sampling" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Context" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Setup" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "Inspect" })).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-draft-mode.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-draft-mode.guard.test.ts
@@ -2,12 +2,11 @@ import fs from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
-describe("writing draft mode guard", () => {
-  it("keeps editor + quick controls in draft mode", () => {
+describe("writing essentials strip guard", () => {
+  it("includes essentials strip controls in index", () => {
     const source = fs.readFileSync(path.resolve(__dirname, "../index.tsx"), "utf8")
-    expect(source).toContain('workspaceMode === "draft"')
-    expect(source).toContain("writing-section-draft-editor")
-    expect(source).toContain("writing-section-draft-inspector")
+    expect(source).toContain("writing-essentials-model")
+    expect(source).toContain("writing-essentials-generate")
     expect(source).toContain("temperature")
     expect(source).toContain("max_tokens")
     expect(source).toContain("token_streaming")

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-manage-mode.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-manage-mode.guard.test.ts
@@ -2,13 +2,11 @@ import fs from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
-describe("writing manage mode guard", () => {
-  it("keeps all advanced sections behind manage mode", () => {
+describe("writing prompt chunks guard", () => {
+  it("includes prompt chunks display behind showPromptChunks toggle", () => {
     const source = fs.readFileSync(path.resolve(__dirname, "../index.tsx"), "utf8")
-    expect(source).toContain('workspaceMode === "manage"')
-    expect(source).toContain("writing-section-manage-styling")
-    expect(source).toContain("writing-section-manage-generation")
-    expect(source).toContain("writing-section-manage-context")
-    expect(source).toContain("writing-section-manage-analysis")
+    expect(source).toContain("showPromptChunks")
+    expect(source).toContain("writing-section-prompt-chunks")
+    expect(source).toContain("promptChunkData")
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-workspace-mode.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/__tests__/writing-workspace-mode.guard.test.ts
@@ -3,11 +3,11 @@ import path from "node:path"
 import { describe, expect, it } from "vitest"
 
 describe("writing workspace mode guard", () => {
-  it("includes draft/manage mode switch and test ids", () => {
+  it("no longer includes draft/manage mode switch (removed in IA restructure)", () => {
     const source = fs.readFileSync(path.resolve(__dirname, "../index.tsx"), "utf8")
-    expect(source).toContain("writing-workspace-mode-switch")
-    expect(source).toContain("writing-mode-draft")
-    expect(source).toContain("writing-mode-manage")
-    expect(source).toContain("writing-section-sessions")
+    expect(source).not.toContain("writing-workspace-mode-switch")
+    expect(source).not.toContain("writing-mode-draft")
+    expect(source).not.toContain("writing-mode-manage")
+    expect(source).toContain("writing-view-prompt-chunks")
   })
 })

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -176,14 +176,6 @@ import {
   DEFAULT_THEME_CATALOG,
   buildDuplicateName
 } from "./writing-template-theme-utils"
-import {
-  DEFAULT_WRITING_WORKSPACE_MODE,
-  type WritingWorkspaceMode
-} from "./writing-workspace-mode-utils"
-import {
-  WRITING_WORKSPACE_MODE_STORAGE_KEY,
-  resolveInitialWorkspaceMode
-} from "./writing-workspace-mode-prefs"
 
 const { Title, Paragraph } = Typography
 
@@ -1248,15 +1240,9 @@ export const WritingPlayground = () => {
   const {
     activeSessionId,
     activeSessionName,
-    workspaceMode,
     setActiveSessionId,
-    setActiveSessionName,
-    setWorkspaceMode
+    setActiveSessionName
   } = useWritingPlaygroundStore()
-  const [storedWorkspaceMode, setStoredWorkspaceMode] = useStorage<string>(
-    WRITING_WORKSPACE_MODE_STORAGE_KEY,
-    DEFAULT_WRITING_WORKSPACE_MODE
-  )
   const [selectedModel, setSelectedModel] = useStorage<string>("selectedModel")
   const apiProviderOverride = useStoreChatModelSettings(
     (state) => state.apiProvider
@@ -1271,22 +1257,7 @@ export const WritingPlayground = () => {
       rate: 1,
       voiceURI: null
     })
-  const resolvedWorkspaceMode = React.useMemo(
-    () => resolveInitialWorkspaceMode(storedWorkspaceMode),
-    [storedWorkspaceMode]
-  )
-  React.useEffect(() => {
-    if (workspaceMode === resolvedWorkspaceMode) return
-    setWorkspaceMode(resolvedWorkspaceMode)
-  }, [resolvedWorkspaceMode, setWorkspaceMode, workspaceMode])
-  const handleWorkspaceModeChange = React.useCallback(
-    (nextMode: WritingWorkspaceMode) => {
-      if (workspaceMode === nextMode) return
-      setWorkspaceMode(nextMode)
-      void setStoredWorkspaceMode(nextMode)
-    },
-    [setStoredWorkspaceMode, setWorkspaceMode, workspaceMode]
-  )
+  const [showPromptChunks, setShowPromptChunks] = React.useState(false)
   const [createModalOpen, setCreateModalOpen] = React.useState(false)
   const [newSessionName, setNewSessionName] = React.useState("")
   const [sessionImporting, setSessionImporting] = React.useState(false)
@@ -1301,7 +1272,7 @@ export const WritingPlayground = () => {
   const [editorText, setEditorText] = React.useState("")
   const [editorView, setEditorView] = React.useState<EditorViewMode>("edit")
   const [activeInspectorTab, setActiveInspectorTab] =
-    React.useState<InspectorTabKey>("generation")
+    React.useState<InspectorTabKey>("sampling")
   const [settings, setSettings] =
     React.useState<WritingSessionSettings>(() => cloneDefaultSettings())
   const [stopStringsInput, setStopStringsInput] = React.useState("")
@@ -5433,45 +5404,6 @@ export const WritingPlayground = () => {
             {t("option:writingPlayground.title", "Writing Playground")}
           </Title>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium text-text-muted">
-            {t("option:writingPlayground.workspaceModeLabel", "Workspace mode")}
-          </span>
-          <Segmented
-            data-testid="writing-workspace-mode-switch"
-            size="small"
-            value={workspaceMode}
-            onChange={(value) => {
-              handleWorkspaceModeChange(String(value) as WritingWorkspaceMode)
-            }}
-            options={[
-              {
-                value: "draft",
-                label: (
-                  <span data-testid="writing-mode-draft">
-                    {t("option:writingPlayground.modeDraft", "Draft")}
-                  </span>
-                )
-              },
-              {
-                value: "manage",
-                label: (
-                  <span data-testid="writing-mode-manage">
-                    {t("option:writingPlayground.modeManage", "Manage")}
-                  </span>
-                )
-              }
-            ]}
-          />
-          <span
-            aria-live="polite"
-            className="sr-only"
-            data-testid="writing-mode-live-region">
-            {workspaceMode === "draft"
-              ? t("option:writingPlayground.modeDraft", "Draft")
-              : t("option:writingPlayground.modeManage", "Manage")}
-          </span>
-        </div>
       </div>
       <div>
         <Paragraph type="secondary">
@@ -5707,7 +5639,7 @@ export const WritingPlayground = () => {
 
             <div
               data-testid="writing-playground-content-grid"
-              className="writing-playground-grid-side grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+              className="writing-playground-grid-side grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
               <WritingPlaygroundEditorPanel>
               {activeSession ? (
                 activeSessionLoading ? (
@@ -5813,6 +5745,15 @@ export const WritingPlayground = () => {
                           disabled={isGenerating || !canRedoGeneration}
                           onClick={handleRedoGeneration}>
                           {t("option:writingPlayground.redoGeneration", "Redo")}
+                        </Button>
+                        <Button
+                          size="small"
+                          icon={<Columns2 className="h-3.5 w-3.5" />}
+                          data-testid="writing-view-prompt-chunks"
+                          onClick={() => setShowPromptChunks((prev) => !prev)}>
+                          {showPromptChunks
+                            ? t("option:writingPlayground.hidePromptChunks", "Hide chunks")
+                            : t("option:writingPlayground.viewPromptChunks", "View chunks")}
                         </Button>
                         <Button
                           size="small"
@@ -6229,8 +6170,8 @@ export const WritingPlayground = () => {
                         ) : null}
                       </div>
                     ) : null}
-                    {workspaceMode === "manage" ? (
-                      <div data-testid="writing-section-manage-analysis">
+                    {showPromptChunks ? (
+                      <div data-testid="writing-section-prompt-chunks">
                         <Collapse
                           ghost
                           size="small"
@@ -6311,41 +6252,50 @@ export const WritingPlayground = () => {
                 activeTab={activeInspectorTab}
                 onTabChange={setActiveInspectorTab}
                 tabLabels={{
-                  generation: t(
-                    "option:writingPlayground.sidebarGeneration",
-                    "Generation"
+                  sampling: t(
+                    "option:writingPlayground.sidebarSampling",
+                    "Sampling"
                   ),
-                  planning: t("option:writingPlayground.sidebarPlanning", "Planning"),
-                  diagnostics: t(
-                    "option:writingPlayground.sidebarDiagnostics",
-                    "Diagnostics"
+                  context: t("option:writingPlayground.sidebarContext", "Context"),
+                  setup: t("option:writingPlayground.sidebarSetup", "Setup"),
+                  inspect: t(
+                    "option:writingPlayground.sidebarInspect",
+                    "Inspect"
                   )
                 }}
-                generation={(
+                tabBadges={{
+                  inspect: responseInspectorRowsAll.length > 0 ? (
+                    <Tag size="small" color="blue" className="!m-0 !px-1 !text-[10px]">
+                      {responseInspectorRowsAll.length}
+                    </Tag>
+                  ) : null
+                }}
+                essentialsStrip={(
                   <Card
                     data-testid="writing-playground-settings-card"
-                    title={t("option:writingPlayground.settingsTitle", "Settings")}>
-              {activeSession ? (
-                activeSessionLoading ? (
-                  <Skeleton active />
-                ) : activeSessionError ? (
-                  <Alert
-                    type="error"
-                    showIcon
-                    title={t(
-                      "option:writingPlayground.settingsError",
-                      "Unable to load session settings."
-                    )}
-                  />
-                ) : (
-                  <div className="flex flex-col gap-4">
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    size="small"
+                    className="!border-border">
+                    <div className="flex flex-col gap-2">
                       <div className="flex flex-col gap-1">
                         <span className="text-xs text-text-muted">
-                          {t(
-                            "option:writingPlayground.temperatureLabel",
-                            "Temperature"
+                          {t("option:writingPlayground.modelLabel", "Model")}
+                        </span>
+                        <Input
+                          size="small"
+                          value={selectedModel || ""}
+                          placeholder={t(
+                            "option:writingPlayground.modelPlaceholder",
+                            "e.g. gpt-4o"
                           )}
+                          onChange={(event) => {
+                            void setSelectedModel(event.target.value)
+                          }}
+                          data-testid="writing-essentials-model"
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs text-text-muted">
+                          {t("option:writingPlayground.temperatureLabel", "Temperature")}
                         </span>
                         <InputNumber
                           size="small"
@@ -6387,30 +6337,7 @@ export const WritingPlayground = () => {
                       </div>
                       <div className="flex flex-col gap-1">
                         <span className="text-xs text-text-muted">
-                          {t("option:writingPlayground.topKLabel", "Top K")}
-                        </span>
-                        <InputNumber
-                          size="small"
-                          min={0}
-                          max={2048}
-                          step={1}
-                          value={settings.top_k}
-                          disabled={settingsDisabled}
-                          onChange={(value) =>
-                            updateSetting({
-                              top_k:
-                                value == null ? DEFAULT_SETTINGS.top_k : value
-                            })
-                          }
-                          className="w-full"
-                        />
-                      </div>
-                      <div className="flex flex-col gap-1">
-                        <span className="text-xs text-text-muted">
-                          {t(
-                            "option:writingPlayground.maxTokensLabel",
-                            "Max tokens"
-                          )}
+                          {t("option:writingPlayground.maxTokensLabel", "Max tokens")}
                         </span>
                         <InputNumber
                           size="small"
@@ -6425,6 +6352,104 @@ export const WritingPlayground = () => {
                                 value == null
                                   ? DEFAULT_SETTINGS.max_tokens
                                   : Math.max(1, Math.round(value))
+                            })
+                          }
+                          className="w-full"
+                        />
+                      </div>
+                      <Checkbox
+                        checked={settings.token_streaming}
+                        disabled={settingsDisabled}
+                        onChange={(event) =>
+                          updateSetting({
+                            token_streaming: event.target.checked
+                          })
+                        }>
+                        {t(
+                          "option:writingPlayground.tokenStreamingLabel",
+                          "Streaming"
+                        )}
+                      </Checkbox>
+                      <Button
+                        type="primary"
+                        block
+                        onClick={() => {
+                          if (isGenerating && settings.token_streaming) {
+                            handleCancelGeneration()
+                          } else {
+                            void handleGenerate()
+                          }
+                        }}
+                        loading={isGenerating && !settings.token_streaming}
+                        disabled={isGenerating ? !settings.token_streaming : !canGenerate}
+                        data-testid="writing-essentials-generate">
+                        {isGenerating
+                          ? t("option:writingPlayground.stopAction", "Stop")
+                          : t("option:writingPlayground.generateAction", "Generate")}
+                      </Button>
+                      <div className="flex items-center gap-2 text-xs text-text-muted">
+                        <Tag
+                          color={
+                            diagnosticsSummary.status === "warning"
+                              ? "gold"
+                              : diagnosticsSummary.status === "busy"
+                                ? "blue"
+                                : "green"
+                          }
+                          className="!m-0">
+                          {diagnosticsSummary.status === "warning"
+                            ? t("option:writingPlayground.diagnosticsWarning", "Warning")
+                            : diagnosticsSummary.status === "busy"
+                              ? t("option:writingPlayground.diagnosticsBusy", "Busy")
+                              : t("option:writingPlayground.diagnosticsReady", "Ready")}
+                        </Tag>
+                        {selectedTemplateName ? (
+                          <button
+                            type="button"
+                            className="truncate text-xs text-text-muted hover:text-text transition-colors"
+                            onClick={() => setActiveInspectorTab("setup")}>
+                            {t("option:writingPlayground.essentialsTpl", "tpl: {{name}}", {
+                              name: selectedTemplateName
+                            })}
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  </Card>
+                )}
+                sampling={(
+                  <Card
+                    title={t("option:writingPlayground.samplingTitle", "Sampling")}>
+              {activeSession ? (
+                activeSessionLoading ? (
+                  <Skeleton active />
+                ) : activeSessionError ? (
+                  <Alert
+                    type="error"
+                    showIcon
+                    title={t(
+                      "option:writingPlayground.settingsError",
+                      "Unable to load session settings."
+                    )}
+                  />
+                ) : (
+                  <div className="flex flex-col gap-4">
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                      <div className="flex flex-col gap-1">
+                        <span className="text-xs text-text-muted">
+                          {t("option:writingPlayground.topKLabel", "Top K")}
+                        </span>
+                        <InputNumber
+                          size="small"
+                          min={0}
+                          max={2048}
+                          step={1}
+                          value={settings.top_k}
+                          disabled={settingsDisabled}
+                          onChange={(value) =>
+                            updateSetting({
+                              top_k:
+                                value == null ? DEFAULT_SETTINGS.top_k : value
                             })
                           }
                           className="w-full"
@@ -6498,27 +6523,6 @@ export const WritingPlayground = () => {
                           }
                           className="w-full"
                         />
-                      </div>
-                      <div className="flex flex-col gap-2 sm:col-span-2">
-                        <Checkbox
-                          checked={settings.token_streaming}
-                          disabled={settingsDisabled}
-                          onChange={(event) =>
-                            updateSetting({
-                              token_streaming: event.target.checked
-                            })
-                          }>
-                          {t(
-                            "option:writingPlayground.tokenStreamingLabel",
-                            "Token streaming"
-                          )}
-                        </Checkbox>
-                        <span className="text-xs text-text-muted">
-                          {t(
-                            "option:writingPlayground.tokenStreamingHint",
-                            "Stream tokens as they arrive. Disable for one-shot generation."
-                          )}
-                        </span>
                       </div>
                       <div className="flex flex-col gap-2 sm:col-span-2">
                         <Checkbox
@@ -7026,30 +7030,19 @@ export const WritingPlayground = () => {
               )}
                   </Card>
                 )}
-                planning={(
+                context={(
                   <Card
-                    title={t("option:writingPlayground.sidebarPlanning", "Planning")}
+                    title={t("option:writingPlayground.sidebarContext", "Context")}
                     extra={
-                      <div className="flex items-center gap-2">
-                        <Button
-                          size="small"
-                          onClick={handleOpenTemplatesModal}
-                          disabled={templateSelectDisabled}>
-                          {t(
-                            "option:writingPlayground.manageTemplates",
-                            "Manage templates"
-                          )}
-                        </Button>
-                        <Button
-                          size="small"
-                          onClick={handleOpenThemesModal}
-                          disabled={themeSelectDisabled}>
-                          {t(
-                            "option:writingPlayground.manageThemes",
-                            "Manage themes"
-                          )}
-                        </Button>
-                      </div>
+                      <Button
+                        size="small"
+                        disabled={settingsDisabled}
+                        onClick={() => setContextPreviewModalOpen(true)}>
+                        {t(
+                          "option:writingPlayground.contextPreviewAction",
+                          "Preview"
+                        )}
+                      </Button>
                     }>
                     {activeSession ? (
                       activeSessionLoading ? (
@@ -7065,126 +7058,6 @@ export const WritingPlayground = () => {
                         />
                       ) : (
                         <div className="flex flex-col gap-4">
-                          <div className="flex flex-col gap-3">
-                            <div className="flex flex-col gap-1">
-                              <span className="text-xs text-text-muted">
-                                {t(
-                                  "option:writingPlayground.templateLabel",
-                                  "Template"
-                                )}
-                              </span>
-                              <Select
-                                allowClear
-                                size="small"
-                                options={templateOptions}
-                                loading={templatesLoading}
-                                value={selectedTemplateName ?? undefined}
-                                disabled={templateSelectDisabled}
-                                placeholder={t(
-                                  "option:writingPlayground.templatePlaceholder",
-                                  "Server default"
-                                )}
-                                onChange={(value) =>
-                                  handleTemplateChange(value ? String(value) : null)
-                                }
-                              />
-                              <span className="text-xs text-text-muted">
-                                {templatesError
-                                  ? t(
-                                      "option:writingPlayground.templateError",
-                                      "Unable to load templates."
-                                    )
-                                  : !hasTemplates
-                                    ? t(
-                                        "option:writingPlayground.templateUnavailable",
-                                        "Templates unavailable."
-                                      )
-                                    : t(
-                                        "option:writingPlayground.templateHint",
-                                        "Choose an instruct template for chat parsing and FIM."
-                                      )}
-                              </span>
-                            </div>
-                            <div className="flex flex-col gap-1">
-                              <span className="text-xs text-text-muted">
-                                {t("option:writingPlayground.themeLabel", "Theme")}
-                              </span>
-                              <Select
-                                allowClear
-                                size="small"
-                                options={themeOptions}
-                                loading={themesLoading}
-                                value={selectedThemeName ?? undefined}
-                                disabled={themeSelectDisabled}
-                                placeholder={t(
-                                  "option:writingPlayground.themePlaceholder",
-                                  "Server default"
-                                )}
-                                onChange={(value) =>
-                                  handleThemeChange(value ? String(value) : null)
-                                }
-                              />
-                              <span className="text-xs text-text-muted">
-                                {themesError
-                                  ? t(
-                                      "option:writingPlayground.themeError",
-                                      "Unable to load themes."
-                                    )
-                                  : !hasThemes
-                                    ? t(
-                                        "option:writingPlayground.themeUnavailable",
-                                        "Themes unavailable."
-                                      )
-                                    : t(
-                                        "option:writingPlayground.themeHint",
-                                        "Apply a theme to style the editor."
-                                      )}
-                              </span>
-                            </div>
-                            <div className="flex flex-col gap-1">
-                              <Checkbox
-                                checked={chatMode}
-                                disabled={settingsDisabled}
-                                onChange={(event) =>
-                                  handleChatModeChange(event.target.checked)
-                                }>
-                                {t(
-                                  "option:writingPlayground.chatModeLabel",
-                                  "Chat mode"
-                                )}
-                              </Checkbox>
-                              <span className="text-xs text-text-muted">
-                                {t(
-                                  "option:writingPlayground.chatModeHint",
-                                  "Parse prompt text into messages using the selected template."
-                                )}
-                              </span>
-                            </div>
-                          </div>
-                          <Collapse
-                            ghost
-                            size="small"
-                            defaultActiveKey={[]}
-                            items={[
-                              {
-                                key: "context-controls",
-                                label: t(
-                                  "option:writingPlayground.contextControlsLabel",
-                                  "Context controls"
-                                ),
-                                children: (
-                                  <div className="flex flex-col gap-4">
-                                    <div className="flex items-center justify-end">
-                                      <Button
-                                        size="small"
-                                        disabled={settingsDisabled}
-                                        onClick={() => setContextPreviewModalOpen(true)}>
-                                        {t(
-                                          "option:writingPlayground.contextPreviewAction",
-                                          "Show context preview"
-                                        )}
-                                      </Button>
-                                    </div>
                                     <div className="rounded-md border border-border bg-surface p-3">
                                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                         <div className="flex flex-col gap-1">
@@ -7723,11 +7596,6 @@ export const WritingPlayground = () => {
                                         )}
                                       </div>
                                     </div>
-                                  </div>
-                                )
-                              }
-                            ]}
-                          />
                         </div>
                       )
                     ) : (
@@ -7740,7 +7608,152 @@ export const WritingPlayground = () => {
                     )}
                   </Card>
                 )}
-                diagnostics={(
+                setup={(
+                  <Card
+                    title={t("option:writingPlayground.sidebarSetup", "Setup")}
+                    extra={
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="small"
+                          onClick={handleOpenTemplatesModal}
+                          disabled={templateSelectDisabled}>
+                          {t(
+                            "option:writingPlayground.manageTemplates",
+                            "Manage templates"
+                          )}
+                        </Button>
+                        <Button
+                          size="small"
+                          onClick={handleOpenThemesModal}
+                          disabled={themeSelectDisabled}>
+                          {t(
+                            "option:writingPlayground.manageThemes",
+                            "Manage themes"
+                          )}
+                        </Button>
+                      </div>
+                    }>
+                    {activeSession ? (
+                      activeSessionLoading ? (
+                        <Skeleton active />
+                      ) : activeSessionError ? (
+                        <Alert
+                          type="error"
+                          showIcon
+                          title={t(
+                            "option:writingPlayground.settingsError",
+                            "Unable to load session settings."
+                          )}
+                        />
+                      ) : (
+                        <div className="flex flex-col gap-3">
+                          <div className="flex flex-col gap-1">
+                            <span className="text-xs text-text-muted">
+                              {t(
+                                "option:writingPlayground.templateLabel",
+                                "Template"
+                              )}
+                            </span>
+                            <Select
+                              allowClear
+                              size="small"
+                              options={templateOptions}
+                              loading={templatesLoading}
+                              value={selectedTemplateName ?? undefined}
+                              disabled={templateSelectDisabled}
+                              placeholder={t(
+                                "option:writingPlayground.templatePlaceholder",
+                                "Server default"
+                              )}
+                              onChange={(value) =>
+                                handleTemplateChange(value ? String(value) : null)
+                              }
+                            />
+                            <span className="text-xs text-text-muted">
+                              {templatesError
+                                ? t(
+                                    "option:writingPlayground.templateError",
+                                    "Unable to load templates."
+                                  )
+                                : !hasTemplates
+                                  ? t(
+                                      "option:writingPlayground.templateUnavailable",
+                                      "Templates unavailable."
+                                    )
+                                  : t(
+                                      "option:writingPlayground.templateHint",
+                                      "Choose an instruct template for chat parsing and FIM."
+                                    )}
+                            </span>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <span className="text-xs text-text-muted">
+                              {t("option:writingPlayground.themeLabel", "Theme")}
+                            </span>
+                            <Select
+                              allowClear
+                              size="small"
+                              options={themeOptions}
+                              loading={themesLoading}
+                              value={selectedThemeName ?? undefined}
+                              disabled={themeSelectDisabled}
+                              placeholder={t(
+                                "option:writingPlayground.themePlaceholder",
+                                "Server default"
+                              )}
+                              onChange={(value) =>
+                                handleThemeChange(value ? String(value) : null)
+                              }
+                            />
+                            <span className="text-xs text-text-muted">
+                              {themesError
+                                ? t(
+                                    "option:writingPlayground.themeError",
+                                    "Unable to load themes."
+                                  )
+                                : !hasThemes
+                                  ? t(
+                                      "option:writingPlayground.themeUnavailable",
+                                      "Themes unavailable."
+                                    )
+                                  : t(
+                                      "option:writingPlayground.themeHint",
+                                      "Apply a theme to style the editor."
+                                    )}
+                            </span>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <Checkbox
+                              checked={chatMode}
+                              disabled={settingsDisabled}
+                              onChange={(event) =>
+                                handleChatModeChange(event.target.checked)
+                              }>
+                              {t(
+                                "option:writingPlayground.chatModeLabel",
+                                "Chat mode"
+                              )}
+                            </Checkbox>
+                            <span className="text-xs text-text-muted">
+                              {t(
+                                "option:writingPlayground.chatModeHint",
+                                "Parse prompt text into messages using the selected template."
+                              )}
+                            </span>
+                          </div>
+                        </div>
+                      )
+                    ) : (
+                      <Empty
+                        description={t(
+                          "option:writingPlayground.settingsEmpty",
+                          "Select a session to edit settings."
+                        )}
+                      />
+                    )}
+                  </Card>
+                )}
+                inspect={(
                   <WritingPlaygroundDiagnosticsPanel
                     t={t}
                     status={diagnosticsSummary.status}

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -5110,7 +5110,7 @@ export const WritingPlayground = () => {
     Boolean(selectedModel) &&
     hasChat &&
     !isGenerating
-  const settingsDisabled = isGenerating
+  const settingsDisabled = isGenerating || !activeSessionDetail
   const serverSupportsTokenize = writingCaps?.server?.tokenize === true
   const serverSupportsTokenCount = writingCaps?.server?.token_count === true
   const serverSupportsWordclouds = writingCaps?.server?.wordclouds === true
@@ -5695,42 +5695,6 @@ export const WritingPlayground = () => {
                               }
                             )}
                           </Tag>
-                        ) : null}
-                        <Tooltip
-                          title={t(
-                            "option:writingPlayground.generateShortcutTooltip",
-                            "Ctrl/Cmd+Enter to generate"
-                          )}>
-                          <Button
-                            type="primary"
-                            size="small"
-                            onClick={() => {
-                              void handleGenerate()
-                            }}
-                            loading={isGenerating}
-                            disabled={!canGenerate}>
-                            {t(
-                              "option:writingPlayground.generateAction",
-                              "Generate"
-                            )}
-                          </Button>
-                        </Tooltip>
-                        {isGenerating && settings.token_streaming ? (
-                          <Tooltip
-                            title={t(
-                              "option:writingPlayground.stopShortcutTooltip",
-                              "Esc to stop"
-                            )}>
-                            <Button
-                              size="small"
-                              onClick={handleCancelGeneration}
-                              danger>
-                              {t(
-                                "option:writingPlayground.stopAction",
-                                "Stop"
-                              )}
-                            </Button>
-                          </Tooltip>
                         ) : null}
                         <Button
                           size="small"

--- a/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/WritingPlayground/index.tsx
@@ -134,6 +134,7 @@ import {
   estimateTokenCountFromText
 } from "./writing-generation-stats-utils"
 import { buildDiagnosticsSummary } from "./writing-diagnostics-utils"
+import { WritingPlaygroundActiveSessionGuard } from "./WritingPlaygroundActiveSessionGuard"
 import { WritingPlaygroundShell } from "./WritingPlaygroundShell"
 import { WritingPlaygroundLibraryPanel } from "./WritingPlaygroundLibraryPanel"
 import { WritingPlaygroundEditorPanel } from "./WritingPlaygroundEditorPanel"
@@ -6384,20 +6385,12 @@ export const WritingPlayground = () => {
                 sampling={(
                   <Card
                     title={t("option:writingPlayground.samplingTitle", "Sampling")}>
-              {activeSession ? (
-                activeSessionLoading ? (
-                  <Skeleton active />
-                ) : activeSessionError ? (
-                  <Alert
-                    type="error"
-                    showIcon
-                    title={t(
-                      "option:writingPlayground.settingsError",
-                      "Unable to load session settings."
-                    )}
-                  />
-                ) : (
-                  <div className="flex flex-col gap-4">
+                    <WritingPlaygroundActiveSessionGuard
+                      hasActiveSession={Boolean(activeSession)}
+                      isLoading={activeSessionLoading}
+                      hasError={Boolean(activeSessionError)}
+                      t={t}>
+                      <div className="flex flex-col gap-4">
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                       <div className="flex flex-col gap-1">
                         <span className="text-xs text-text-muted">
@@ -6982,16 +6975,8 @@ export const WritingPlayground = () => {
                         ]}
                       />
                     )}
-                  </div>
-                )
-              ) : (
-                <Empty
-                  description={t(
-                    "option:writingPlayground.settingsEmpty",
-                    "Select a session to edit settings."
-                  )}
-                />
-              )}
+                      </div>
+                    </WritingPlaygroundActiveSessionGuard>
                   </Card>
                 )}
                 context={(
@@ -7008,20 +6993,12 @@ export const WritingPlayground = () => {
                         )}
                       </Button>
                     }>
-                    {activeSession ? (
-                      activeSessionLoading ? (
-                        <Skeleton active />
-                      ) : activeSessionError ? (
-                        <Alert
-                          type="error"
-                          showIcon
-                          title={t(
-                            "option:writingPlayground.settingsError",
-                            "Unable to load session settings."
-                          )}
-                        />
-                      ) : (
-                        <div className="flex flex-col gap-4">
+                    <WritingPlaygroundActiveSessionGuard
+                      hasActiveSession={Boolean(activeSession)}
+                      isLoading={activeSessionLoading}
+                      hasError={Boolean(activeSessionError)}
+                      t={t}>
+                      <div className="flex flex-col gap-4">
                                     <div className="rounded-md border border-border bg-surface p-3">
                                       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                                         <div className="flex flex-col gap-1">
@@ -7560,16 +7537,8 @@ export const WritingPlayground = () => {
                                         )}
                                       </div>
                                     </div>
-                        </div>
-                      )
-                    ) : (
-                      <Empty
-                        description={t(
-                          "option:writingPlayground.settingsEmpty",
-                          "Select a session to edit settings."
-                        )}
-                      />
-                    )}
+                      </div>
+                    </WritingPlaygroundActiveSessionGuard>
                   </Card>
                 )}
                 setup={(
@@ -7597,20 +7566,12 @@ export const WritingPlayground = () => {
                         </Button>
                       </div>
                     }>
-                    {activeSession ? (
-                      activeSessionLoading ? (
-                        <Skeleton active />
-                      ) : activeSessionError ? (
-                        <Alert
-                          type="error"
-                          showIcon
-                          title={t(
-                            "option:writingPlayground.settingsError",
-                            "Unable to load session settings."
-                          )}
-                        />
-                      ) : (
-                        <div className="flex flex-col gap-3">
+                    <WritingPlaygroundActiveSessionGuard
+                      hasActiveSession={Boolean(activeSession)}
+                      isLoading={activeSessionLoading}
+                      hasError={Boolean(activeSessionError)}
+                      t={t}>
+                      <div className="flex flex-col gap-3">
                           <div className="flex flex-col gap-1">
                             <span className="text-xs text-text-muted">
                               {t(
@@ -7705,20 +7666,13 @@ export const WritingPlayground = () => {
                               )}
                             </span>
                           </div>
-                        </div>
-                      )
-                    ) : (
-                      <Empty
-                        description={t(
-                          "option:writingPlayground.settingsEmpty",
-                          "Select a session to edit settings."
-                        )}
-                      />
-                    )}
+                      </div>
+                    </WritingPlaygroundActiveSessionGuard>
                   </Card>
                 )}
                 inspect={(
                   <WritingPlaygroundDiagnosticsPanel
+                    title={t("option:writingPlayground.sidebarInspect", "Inspect")}
                     t={t}
                     status={diagnosticsSummary.status}
                     showOffline={showOffline}

--- a/apps/packages/ui/src/store/__tests__/writing-playground-store.test.ts
+++ b/apps/packages/ui/src/store/__tests__/writing-playground-store.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from "vitest"
 import { useWritingPlaygroundStore } from "../writing-playground"
 
 describe("writing playground store", () => {
-  it("defaults workspace mode to draft", () => {
+  it("defaults activeSessionId to null", () => {
     const state = useWritingPlaygroundStore.getState()
-    expect(state.workspaceMode).toBe("draft")
+    expect(state.activeSessionId).toBeNull()
   })
 
-  it("updates workspace mode", () => {
-    useWritingPlaygroundStore.getState().setWorkspaceMode("manage")
-    expect(useWritingPlaygroundStore.getState().workspaceMode).toBe("manage")
-    useWritingPlaygroundStore.getState().setWorkspaceMode("draft")
+  it("updates activeSessionId", () => {
+    useWritingPlaygroundStore.getState().setActiveSessionId("test-id")
+    expect(useWritingPlaygroundStore.getState().activeSessionId).toBe("test-id")
+    useWritingPlaygroundStore.getState().setActiveSessionId(null)
   })
 })

--- a/apps/packages/ui/src/store/writing-playground.tsx
+++ b/apps/packages/ui/src/store/writing-playground.tsx
@@ -3,17 +3,13 @@ import { createWithEqualityFn } from "zustand/traditional"
 type WritingPlaygroundState = {
   activeSessionId: string | null
   activeSessionName: string | null
-  workspaceMode: "draft" | "manage"
   setActiveSessionId: (activeSessionId: string | null) => void
   setActiveSessionName: (activeSessionName: string | null) => void
-  setWorkspaceMode: (workspaceMode: "draft" | "manage") => void
 }
 
 export const useWritingPlaygroundStore = createWithEqualityFn<WritingPlaygroundState>((set) => ({
   activeSessionId: null,
   activeSessionName: null,
-  workspaceMode: "draft",
   setActiveSessionId: (activeSessionId) => set({ activeSessionId }),
-  setActiveSessionName: (activeSessionName) => set({ activeSessionName }),
-  setWorkspaceMode: (workspaceMode) => set({ workspaceMode })
+  setActiveSessionName: (activeSessionName) => set({ activeSessionName })
 }))


### PR DESCRIPTION
## Summary
- Restructure the right-panel inspector from 3 technical tabs (Generation/Planning/Diagnostics) to a two-layer design: a persistent **Essentials Strip** (model, temp, top-p, max tokens, streaming, generate button, status badge) pinned above 4 intent-named tabs (**Sampling**, **Context**, **Setup**, **Inspect**)
- Remove the Draft/Manage workspace mode toggle entirely; prompt chunks analysis is now a "View Chunks" button in the editor toolbar
- Widen right panel from 320px to 340px; add logprob count badge on the Inspect tab

## Test plan
- [x] All 32 test files pass (135 tests)
- [ ] Visual check: Load `/writing-playground` at ≥1100px — confirm 3-panel layout with Essentials Strip pinned above 4 tabs
- [ ] Tab navigation: Verify arrow key navigation works across 4 tabs, ARIA attributes correct
- [ ] Progressive disclosure: Confirm only 7 controls visible by default; Advanced section collapsed
- [ ] Responsive: Resize below 1100px — confirm compact layout stacks correctly
- [ ] Draft/Manage removal: Confirm no mode toggle exists; "View chunks" button works in editor toolbar
- [ ] Feature parity: Verify all controls that existed before are still accessible (just reorganized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)