### PR TITLE
feat(prompts): UX redesign with sidebar, full-page editor, and discoverability

### DIFF
--- a/apps/packages/ui/src/components/Common/CommandPalette.tsx
+++ b/apps/packages/ui/src/components/Common/CommandPalette.tsx
@@ -62,7 +62,7 @@ export interface CommandItem {
   icon: React.ReactNode
   shortcut?: CommandShortcut
   action: () => void
-  category: "navigation" | "action" | "setting" | "recent"
+  category: "navigation" | "action" | "setting" | "recent" | "prompt"
   keywords?: string[]
 }
 
@@ -447,6 +447,7 @@ export function CommandPalette({
     // by additionalCommands when that feature is implemented.
     const groups: Record<string, CommandItem[]> = {
       action: [],
+      prompt: [],
       navigation: [],
       setting: [],
       recent: [],
@@ -551,13 +552,14 @@ export function CommandPalette({
   if (!open) return null
   if (typeof document === "undefined") return null
 
-  const categories = ["recent", "action", "navigation", "setting"] as const
+  const categories = ["recent", "action", "prompt", "navigation", "setting"] as const
   const focusRingClasses =
     "focus:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
 
   const categoryLabels: Record<string, string> = {
     action: t("common:commandPalette.categoryActions", "Actions"),
     navigation: t("common:commandPalette.categoryNavigation", "Navigation"),
+    prompt: t("common:commandPalette.categoryPrompts", "Prompts"),
     setting: t("common:commandPalette.categorySettings", "Settings"),
     recent: t("common:commandPalette.categoryRecent", "Recent"),
   }

--- a/apps/packages/ui/src/components/Layouts/Layout.tsx
+++ b/apps/packages/ui/src/components/Layouts/Layout.tsx
@@ -40,6 +40,7 @@ import {
 import { useSetting } from "@/hooks/useSetting"
 import { CHAT_BACKGROUND_IMAGE_SETTING } from "@/services/settings/ui-settings"
 import { useStoreMessageOption } from "@/store/option"
+import { usePromptPaletteCommands } from "@/components/Option/Prompt/usePromptPaletteCommands"
 
 // Lazy-load Timeline to reduce initial bundle size (~1.2MB cytoscape)
 const TimelineModal = lazy(() =>
@@ -225,13 +226,16 @@ const OptionLayoutInner: React.FC<OptionLayoutProps> = ({
     }
   }
 
+  const promptPaletteCommands = usePromptPaletteCommands()
+
   const commandPaletteProps = {
     onNewChat: clearChat,
     onToggleRag: () => setChatMode(chatMode === "rag" ? "normal" : "rag"),
     onToggleWebSearch: () => setWebSearch(!webSearch),
     onIngestPage: handleIngestPage,
     onSwitchModel: () => setOpenModelSettings(true),
-    onToggleSidebar: toggleSidebar
+    onToggleSidebar: toggleSidebar,
+    additionalCommands: promptPaletteCommands,
   }
 
   // Quick Chat Helper toggle

--- a/apps/packages/ui/src/components/Option/Prompt/ContextualHint.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/ContextualHint.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from "react"
+import { X, Lightbulb } from "lucide-react"
+import type { HintId } from "./useContextualHints"
+
+type ContextualHintProps = {
+  id: HintId
+  message: string
+  visible: boolean
+  onDismiss: (id: HintId) => void
+  onShown?: (id: HintId) => void
+}
+
+export const ContextualHint: React.FC<ContextualHintProps> = ({
+  id,
+  message,
+  visible,
+  onDismiss,
+  onShown,
+}) => {
+  useEffect(() => {
+    if (visible && onShown) {
+      onShown(id)
+    }
+  }, [visible, id, onShown])
+
+  if (!visible) return null
+
+  return (
+    <div
+      className="flex items-start gap-2 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm text-text"
+      data-testid={`hint-${id}`}
+    >
+      <Lightbulb className="mt-0.5 size-4 shrink-0 text-primary" />
+      <span className="flex-1">{message}</span>
+      <button
+        type="button"
+        onClick={() => onDismiss(id)}
+        className="shrink-0 rounded p-0.5 text-text-muted hover:bg-surface2 hover:text-text"
+        aria-label="Dismiss hint"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/FacetedFilters.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/FacetedFilters.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from "react"
+import type { TagMatchMode } from "./custom-prompts-utils"
+
+type Props = {
+  typeFilter: string
+  onTypeFilterChange: (v: string) => void
+  typeCounts: Record<string, number>
+  syncFilter: string
+  onSyncFilterChange: (v: string) => void
+  syncCounts: Record<string, number>
+  tagFilter: string[]
+  onTagFilterChange: (v: string[]) => void
+  tagMatchMode: TagMatchMode
+  onTagMatchModeChange: (v: TagMatchMode) => void
+  tagCounts: Record<string, number>
+}
+
+const TYPE_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "system", label: "System" },
+  { value: "quick", label: "Quick" },
+  { value: "mixed", label: "Mixed" },
+]
+
+const SYNC_OPTIONS = [
+  { value: "all", label: "All" },
+  { value: "local", label: "Local" },
+  { value: "synced", label: "Synced" },
+  { value: "pending", label: "Pending" },
+  { value: "conflict", label: "Conflict" },
+]
+
+const INITIAL_TAG_LIMIT = 5
+
+export const FacetedFilters: React.FC<Props> = ({
+  typeFilter,
+  onTypeFilterChange,
+  typeCounts,
+  syncFilter,
+  onSyncFilterChange,
+  syncCounts,
+  tagFilter,
+  onTagFilterChange,
+  tagMatchMode,
+  onTagMatchModeChange,
+  tagCounts,
+}) => {
+  const [showAllTags, setShowAllTags] = useState(false)
+  const sortedTags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1])
+  const visibleTags = showAllTags
+    ? sortedTags
+    : sortedTags.slice(0, INITIAL_TAG_LIMIT)
+  const hiddenCount = sortedTags.length - INITIAL_TAG_LIMIT
+
+  const toggleTag = (tag: string) => {
+    if (tagFilter.includes(tag)) {
+      onTagFilterChange(tagFilter.filter((t) => t !== tag))
+    } else {
+      onTagFilterChange([...tagFilter, tag])
+    }
+  }
+
+  return (
+    <div className="space-y-4" data-testid="faceted-filters">
+      {/* Type filter */}
+      <div>
+        <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+          Type
+        </h4>
+        <div className="space-y-0.5">
+          {TYPE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              data-testid={`facet-type-${opt.value}`}
+              onClick={() => onTypeFilterChange(opt.value)}
+              className={`flex w-full items-center justify-between rounded px-2 py-1 text-sm transition-colors ${
+                typeFilter === opt.value
+                  ? "bg-primary/10 text-primary font-medium"
+                  : "text-text-muted hover:bg-surface2 hover:text-text"
+              }`}
+            >
+              <span>{opt.label}</span>
+              {typeCounts[opt.value] != null && (
+                <span className="text-xs tabular-nums">
+                  {typeCounts[opt.value]}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Sync filter */}
+      <div>
+        <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+          Sync Status
+        </h4>
+        <div className="space-y-0.5">
+          {SYNC_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              data-testid={`facet-sync-${opt.value}`}
+              onClick={() => onSyncFilterChange(opt.value)}
+              className={`flex w-full items-center justify-between rounded px-2 py-1 text-sm transition-colors ${
+                syncFilter === opt.value
+                  ? "bg-primary/10 text-primary font-medium"
+                  : "text-text-muted hover:bg-surface2 hover:text-text"
+              }`}
+            >
+              <span>{opt.label}</span>
+              {syncCounts[opt.value] != null && (
+                <span className="text-xs tabular-nums">
+                  {syncCounts[opt.value]}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tag filter */}
+      {sortedTags.length > 0 && (
+        <div>
+          <div className="mb-1.5 flex items-center justify-between">
+            <h4 className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Tags
+            </h4>
+            {tagFilter.length > 0 && (
+              <button
+                type="button"
+                onClick={() =>
+                  onTagMatchModeChange(
+                    tagMatchMode === "any" ? "all" : "any"
+                  )
+                }
+                className="text-xs text-primary hover:underline"
+                data-testid="facet-tag-match-toggle"
+              >
+                {tagMatchMode === "any" ? "Any" : "All"}
+              </button>
+            )}
+          </div>
+          <div className="space-y-0.5">
+            {visibleTags.map(([tag, count]) => (
+              <button
+                key={tag}
+                type="button"
+                data-testid={`facet-tag-${tag}`}
+                onClick={() => toggleTag(tag)}
+                className={`flex w-full items-center justify-between rounded px-2 py-1 text-sm transition-colors ${
+                  tagFilter.includes(tag)
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-muted hover:bg-surface2 hover:text-text"
+                }`}
+              >
+                <span className="truncate">{tag}</span>
+                <span className="text-xs tabular-nums">{count}</span>
+              </button>
+            ))}
+            {hiddenCount > 0 && !showAllTags && (
+              <button
+                type="button"
+                onClick={() => setShowAllTags(true)}
+                className="w-full px-2 py-1 text-xs text-primary hover:underline text-left"
+                data-testid="facet-tags-show-more"
+              >
+                Show {hiddenCount} more...
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/FilterPresets.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/FilterPresets.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react"
+import { Bookmark, X, Plus } from "lucide-react"
+import type { FilterPreset } from "./useFilterPresets"
+
+type Props = {
+  presets: FilterPreset[]
+  onLoad: (preset: FilterPreset) => void
+  onSave: (name: string) => void
+  onDelete: (id: string) => void
+}
+
+export const FilterPresets: React.FC<Props> = ({
+  presets,
+  onLoad,
+  onSave,
+  onDelete,
+}) => {
+  const [saving, setSaving] = useState(false)
+  const [name, setName] = useState("")
+
+  const handleSave = () => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    onSave(trimmed)
+    setName("")
+    setSaving(false)
+  }
+
+  return (
+    <div data-testid="filter-presets">
+      <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+        Filter Presets
+      </h4>
+      <div className="space-y-0.5">
+        {presets.map((p) => (
+          <div
+            key={p.id}
+            className="group flex items-center gap-1 rounded px-2 py-1 hover:bg-surface2"
+          >
+            <button
+              type="button"
+              onClick={() => onLoad(p)}
+              className="flex flex-1 items-center gap-1.5 text-sm text-text-muted hover:text-text truncate"
+              data-testid={`filter-preset-${p.id}`}
+            >
+              <Bookmark className="size-3.5 shrink-0" />
+              <span className="truncate">{p.name}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(p.id)}
+              className="hidden shrink-0 rounded p-0.5 text-text-muted hover:text-danger group-hover:block"
+              aria-label={`Delete preset ${p.name}`}
+              data-testid={`filter-preset-delete-${p.id}`}
+            >
+              <X className="size-3" />
+            </button>
+          </div>
+        ))}
+
+        {saving ? (
+          <div className="flex items-center gap-1 px-2 py-1">
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSave()
+                if (e.key === "Escape") setSaving(false)
+              }}
+              placeholder="Preset name..."
+              className="flex-1 rounded border border-border bg-surface px-1.5 py-0.5 text-sm outline-none focus:border-primary"
+              autoFocus
+              data-testid="filter-preset-name-input"
+            />
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!name.trim()}
+              className="rounded bg-primary px-2 py-0.5 text-xs text-white disabled:opacity-50"
+              data-testid="filter-preset-save-confirm"
+            >
+              Save
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setSaving(true)}
+            className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-sm text-text-muted hover:bg-surface2 hover:text-text"
+            data-testid="filter-preset-save-btn"
+          >
+            <Plus className="size-3.5" />
+            <span>Save current filters</span>
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptEditorPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptEditorPreview.tsx
@@ -1,0 +1,144 @@
+import React, { useMemo, useState } from "react"
+import {
+  extractTemplateVariables,
+  tokenizeTemplateVariableHighlights,
+} from "./prompt-template-variable-utils"
+import {
+  estimatePromptTokens,
+  getPromptTokenBudgetState,
+} from "./prompt-length-utils"
+
+type Props = {
+  systemPrompt: string
+  userPrompt: string
+}
+
+export const PromptEditorPreview: React.FC<Props> = ({
+  systemPrompt,
+  userPrompt,
+}) => {
+  const [varValues, setVarValues] = useState<Record<string, string>>({})
+
+  const variables = useMemo(() => {
+    const allText = `${systemPrompt} ${userPrompt}`
+    return extractTemplateVariables(allText)
+  }, [systemPrompt, userPrompt])
+
+  const substitute = (text: string) => {
+    if (!text) return text
+    let result = text
+    for (const v of variables) {
+      const regex = new RegExp(`\\{\\{\\s*${v}\\s*\\}\\}`, "g")
+      const value = varValues[v]
+      if (value) {
+        result = result.replace(regex, value)
+      }
+    }
+    return result
+  }
+
+  const renderHighlighted = (text: string) => {
+    if (!text) return <span className="text-text-muted italic">Empty</span>
+    const tokens = tokenizeTemplateVariableHighlights(text)
+    return tokens.map((token, i) => {
+      if (token.type === "variable") {
+        const val = varValues[token.name || ""]
+        if (val) {
+          return (
+            <span key={i} className="rounded bg-green-500/20 px-0.5">
+              {val}
+            </span>
+          )
+        }
+        return (
+          <span key={i} className="rounded bg-primary/20 px-0.5 text-primary">
+            {token.text}
+          </span>
+        )
+      }
+      return <span key={i}>{token.text}</span>
+    })
+  }
+
+  const sysTokens = estimatePromptTokens(systemPrompt)
+  const userTokens = estimatePromptTokens(userPrompt)
+  const totalTokens = sysTokens + userTokens
+  const budgetState = getPromptTokenBudgetState(totalTokens)
+
+  const tokenColor =
+    budgetState === "danger"
+      ? "text-danger"
+      : budgetState === "warning"
+      ? "text-warning"
+      : "text-text-muted"
+
+  return (
+    <div
+      className="flex h-full flex-col overflow-y-auto"
+      data-testid="prompt-editor-preview"
+    >
+      {/* Rendered preview */}
+      <div className="flex-1 space-y-4 p-4">
+        <div>
+          <h4 className="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">
+            System Prompt
+          </h4>
+          <div className="whitespace-pre-wrap rounded border border-border bg-surface p-3 text-sm leading-relaxed">
+            {renderHighlighted(systemPrompt)}
+          </div>
+        </div>
+
+        {userPrompt && (
+          <div>
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wider text-text-muted">
+              User Message
+            </h4>
+            <div className="whitespace-pre-wrap rounded border border-border bg-surface p-3 text-sm leading-relaxed">
+              {renderHighlighted(userPrompt)}
+            </div>
+          </div>
+        )}
+
+        {/* Template variables */}
+        {variables.length > 0 && (
+          <div>
+            <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Template Variables
+            </h4>
+            <div className="space-y-2">
+              {variables.map((v) => (
+                <div key={v} className="flex items-center gap-2">
+                  <span className="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-xs font-mono text-primary">
+                    {`{{${v}}}`}
+                  </span>
+                  <input
+                    type="text"
+                    value={varValues[v] || ""}
+                    onChange={(e) =>
+                      setVarValues((prev) => ({
+                        ...prev,
+                        [v]: e.target.value,
+                      }))
+                    }
+                    placeholder={`Enter ${v}...`}
+                    className="flex-1 rounded border border-border bg-surface px-2 py-1 text-sm outline-none focus:border-primary"
+                    data-testid={`preview-var-${v}`}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Token count footer */}
+      <div className="border-t border-border px-4 py-2">
+        <div className={`flex items-center gap-3 text-xs ${tokenColor}`}>
+          <span>System: ~{sysTokens} tokens</span>
+          <span>User: ~{userTokens} tokens</span>
+          <span className="font-medium">Total: ~{totalTokens} tokens</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptEditorPreview.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptEditorPreview.tsx
@@ -24,25 +24,12 @@ export const PromptEditorPreview: React.FC<Props> = ({
     return extractTemplateVariables(allText)
   }, [systemPrompt, userPrompt])
 
-  const substitute = (text: string) => {
-    if (!text) return text
-    let result = text
-    for (const v of variables) {
-      const regex = new RegExp(`\\{\\{\\s*${v}\\s*\\}\\}`, "g")
-      const value = varValues[v]
-      if (value) {
-        result = result.replace(regex, value)
-      }
-    }
-    return result
-  }
-
   const renderHighlighted = (text: string) => {
     if (!text) return <span className="text-text-muted italic">Empty</span>
     const tokens = tokenizeTemplateVariableHighlights(text)
     return tokens.map((token, i) => {
-      if (token.type === "variable") {
-        const val = varValues[token.name || ""]
+      if (token.isVariable) {
+        const val = varValues[token.variableName || ""]
         if (val) {
           return (
             <span key={i} className="rounded bg-green-500/20 px-0.5">

--- a/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
@@ -1,0 +1,362 @@
+import React, { useEffect, useCallback, useState } from "react"
+import { Form, Input, Select, Collapse } from "antd"
+import { useTranslation } from "react-i18next"
+import { ArrowLeft, Save, X } from "lucide-react"
+import { PromptEditorPreview } from "./PromptEditorPreview"
+import { useFormDraft, formatDraftAge } from "@/hooks/useFormDraft"
+import {
+  estimatePromptTokens,
+  getPromptTokenBudgetState,
+} from "./prompt-length-utils"
+import { validateTemplateVariableSyntax } from "./prompt-template-variable-utils"
+
+const { TextArea } = Input
+
+type PromptFullPageEditorProps = {
+  open: boolean
+  onClose: () => void
+  mode: "create" | "edit"
+  initialValues?: Record<string, any> | null
+  onSubmit: (values: any) => void
+  isLoading: boolean
+  allTags: string[]
+}
+
+const DRAFT_KEY_PREFIX = "tldw-prompt-fullpage-draft-"
+
+export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
+  open,
+  onClose,
+  mode,
+  initialValues,
+  onSubmit,
+  isLoading,
+  allTags,
+}) => {
+  const { t } = useTranslation(["settings", "common"])
+  const [form] = Form.useForm()
+  const [dirty, setDirty] = useState(false)
+  const [showMobilePreview, setShowMobilePreview] = useState(false)
+
+  const draftKey = `${DRAFT_KEY_PREFIX}${mode === "edit" ? initialValues?.id || "new" : "new"}`
+  const { recovered, clearDraft, saveDraft, draftAge } = useFormDraft(draftKey)
+
+  const systemPromptValue = Form.useWatch("system_prompt", form) || ""
+  const userPromptValue = Form.useWatch("user_prompt", form) || ""
+
+  // Set initial values
+  useEffect(() => {
+    if (!open) return
+    if (recovered) {
+      form.setFieldsValue(recovered)
+    } else if (initialValues) {
+      form.setFieldsValue({
+        name: initialValues.name || "",
+        author: initialValues.author || "",
+        details: initialValues.details || "",
+        system_prompt: initialValues.system_prompt || "",
+        user_prompt: initialValues.user_prompt || "",
+        keywords: initialValues.keywords || [],
+        changeDescription: initialValues.changeDescription || "",
+      })
+    } else {
+      form.resetFields()
+    }
+    setDirty(false)
+  }, [open, initialValues, recovered, form])
+
+  // Auto-save draft
+  useEffect(() => {
+    if (!open || !dirty) return
+    const timer = setInterval(() => {
+      saveDraft(form.getFieldsValue())
+    }, 5000)
+    return () => clearInterval(timer)
+  }, [open, dirty, form, saveDraft])
+
+  // beforeunload guard
+  useEffect(() => {
+    if (!open || !dirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+    }
+    window.addEventListener("beforeunload", handler)
+    return () => window.removeEventListener("beforeunload", handler)
+  }, [open, dirty])
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+        e.preventDefault()
+        form.submit()
+      }
+      if (e.key === "Escape") {
+        e.preventDefault()
+        handleRequestClose()
+      }
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [open, dirty, form])
+
+  const handleRequestClose = useCallback(() => {
+    if (dirty) {
+      const ok = window.confirm(
+        t("managePrompts.drawer.unsavedChanges", {
+          defaultValue: "You have unsaved changes. Discard them?",
+        })
+      )
+      if (!ok) return
+    }
+    clearDraft()
+    onClose()
+  }, [dirty, clearDraft, onClose, t])
+
+  const handleFinish = (values: any) => {
+    const keywords = Array.isArray(values.keywords)
+      ? values.keywords
+          .map((k: string) => (typeof k === "string" ? k.trim() : ""))
+          .filter((k: string) => k.length > 0)
+          .sort()
+      : []
+
+    onSubmit({
+      ...values,
+      keywords,
+      name: (values.name || "").trim(),
+      author: (values.author || "").trim(),
+      details: (values.details || "").trim(),
+      system_prompt: (values.system_prompt || "").trim(),
+      user_prompt: (values.user_prompt || "").trim(),
+    })
+    clearDraft()
+    setDirty(false)
+  }
+
+  const templateFieldValidator = (_: any, value: string) => {
+    if (!value) return Promise.resolve()
+    const result = validateTemplateVariableSyntax(value)
+    if (!result.valid && result.errors.length > 0) {
+      return Promise.reject(result.errors[0])
+    }
+    return Promise.resolve()
+  }
+
+  const sysTokens = estimatePromptTokens(systemPromptValue)
+  const userTokens = estimatePromptTokens(userPromptValue)
+  const sysBudget = getPromptTokenBudgetState(sysTokens)
+  const userBudget = getPromptTokenBudgetState(userTokens)
+
+  const tokenLabel = (count: number, budget: string) => {
+    const color =
+      budget === "danger"
+        ? "text-danger"
+        : budget === "warning"
+        ? "text-warning"
+        : "text-text-muted"
+    return (
+      <span className={`text-xs ${color}`}>
+        {count} chars / ~{Math.round(count / 4)} tokens
+      </span>
+    )
+  }
+
+  if (!open) return null
+
+  const title =
+    mode === "edit"
+      ? initialValues?.name
+        ? `Editing: ${initialValues.name}`
+        : "Edit Prompt"
+      : "New Prompt"
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+      data-testid="prompt-full-page-editor"
+    >
+      {/* Top bar */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleRequestClose}
+            className="flex items-center gap-1 rounded px-2 py-1 text-sm text-text-muted hover:bg-surface2 hover:text-text"
+            data-testid="full-editor-back"
+          >
+            <ArrowLeft className="size-4" />
+            Back to Prompts
+          </button>
+          <span className="text-sm font-medium text-text">{title}</span>
+          {draftAge && (
+            <span className="text-xs text-text-muted">
+              Draft saved {formatDraftAge(draftAge)}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleRequestClose}
+            className="rounded px-3 py-1.5 text-sm text-text-muted hover:bg-surface2"
+            data-testid="full-editor-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => form.submit()}
+            disabled={isLoading}
+            className="flex items-center gap-1 rounded bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primaryStrong disabled:opacity-50"
+            data-testid="full-editor-save"
+          >
+            <Save className="size-3.5" />
+            {isLoading ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {/* Two-column layout */}
+      <div className="flex flex-1 min-h-0">
+        {/* Editor column */}
+        <div className="flex-[55] overflow-y-auto border-r border-border p-6">
+          <Form
+            form={form}
+            layout="vertical"
+            onFinish={handleFinish}
+            onValuesChange={() => setDirty(true)}
+            className="mx-auto max-w-2xl space-y-6"
+          >
+            {/* Identity section */}
+            <div>
+              <h3 className="mb-3 text-sm font-semibold text-text">Identity</h3>
+              <div className="grid grid-cols-2 gap-4">
+                <Form.Item
+                  name="name"
+                  label="Title"
+                  rules={[{ required: true, message: "Title is required" }]}
+                >
+                  <Input
+                    placeholder="e.g. Code Review Assistant"
+                    data-testid="full-editor-name"
+                  />
+                </Form.Item>
+                <Form.Item name="author" label="Author">
+                  <Input placeholder="Optional" data-testid="full-editor-author" />
+                </Form.Item>
+              </div>
+            </div>
+
+            {/* Prompt Content */}
+            <div>
+              <h3 className="mb-3 text-sm font-semibold text-text">
+                Prompt Content
+              </h3>
+              <Form.Item
+                name="system_prompt"
+                label="AI Instructions (System Prompt)"
+                rules={[{ validator: templateFieldValidator }]}
+              >
+                <TextArea
+                  autoSize={{ minRows: 6, maxRows: 30 }}
+                  placeholder="You are a helpful assistant that..."
+                  data-testid="full-editor-system-prompt"
+                />
+              </Form.Item>
+              <div className="mb-4 -mt-2">{tokenLabel(systemPromptValue.length, sysBudget)}</div>
+
+              <Form.Item
+                name="user_prompt"
+                label="Message Template (User Prompt)"
+                rules={[{ validator: templateFieldValidator }]}
+              >
+                <TextArea
+                  autoSize={{ minRows: 4, maxRows: 20 }}
+                  placeholder="Analyze the following: {{input}}"
+                  data-testid="full-editor-user-prompt"
+                />
+              </Form.Item>
+              <div className="-mt-2">{tokenLabel(userPromptValue.length, userBudget)}</div>
+            </div>
+
+            {/* Organization */}
+            <div>
+              <h3 className="mb-3 text-sm font-semibold text-text">
+                Organization
+              </h3>
+              <Form.Item name="keywords" label="Tags">
+                <Select
+                  mode="tags"
+                  placeholder="Add tags..."
+                  options={allTags.map((t) => ({ label: t, value: t }))}
+                  data-testid="full-editor-keywords"
+                />
+              </Form.Item>
+              <Form.Item name="details" label="Notes">
+                <TextArea
+                  autoSize={{ minRows: 2, maxRows: 6 }}
+                  placeholder="Internal notes about this prompt..."
+                  data-testid="full-editor-details"
+                />
+              </Form.Item>
+            </div>
+
+            {/* Advanced (collapsed) */}
+            <Collapse
+              ghost
+              items={[
+                {
+                  key: "advanced",
+                  label: (
+                    <span className="text-sm font-medium text-text-muted">
+                      Advanced
+                    </span>
+                  ),
+                  children: (
+                    <div className="space-y-4">
+                      <Form.Item
+                        name="changeDescription"
+                        label="Change Description"
+                      >
+                        <Input placeholder="What changed in this version?" />
+                      </Form.Item>
+                    </div>
+                  ),
+                },
+              ]}
+            />
+          </Form>
+        </div>
+
+        {/* Preview column - desktop */}
+        <div className="hidden flex-[45] md:flex flex-col bg-surface">
+          <PromptEditorPreview
+            systemPrompt={systemPromptValue}
+            userPrompt={userPromptValue}
+          />
+        </div>
+      </div>
+
+      {/* Mobile preview toggle */}
+      <div className="md:hidden">
+        <button
+          type="button"
+          onClick={() => setShowMobilePreview(!showMobilePreview)}
+          className="fixed bottom-4 right-4 z-50 rounded-full bg-primary px-4 py-2 text-sm font-medium text-white shadow-lg"
+        >
+          {showMobilePreview ? "Editor" : "Preview"}
+        </button>
+        {showMobilePreview && (
+          <div className="fixed inset-0 z-40 bg-background pt-12">
+            <PromptEditorPreview
+              systemPrompt={systemPromptValue}
+              userPrompt={userPromptValue}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useCallback, useState } from "react"
 import { Form, Input, Select, Collapse } from "antd"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, Save, X } from "lucide-react"
+import { ArrowLeft, Save } from "lucide-react"
 import { PromptEditorPreview } from "./PromptEditorPreview"
 import { useFormDraft, formatDraftAge } from "@/hooks/useFormDraft"
 import {
@@ -39,7 +39,12 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   const [showMobilePreview, setShowMobilePreview] = useState(false)
 
   const draftKey = `${DRAFT_KEY_PREFIX}${mode === "edit" ? initialValues?.id || "new" : "new"}`
-  const { recovered, clearDraft, saveDraft, draftAge } = useFormDraft(draftKey)
+  const { hasDraft, draftData, clearDraft, saveDraft, applyDraft, lastSaved } = useFormDraft({
+    storageKey: draftKey,
+    formType: mode,
+    editId: mode === "edit" ? initialValues?.id : undefined,
+    autoSaveInterval: 5000,
+  })
 
   const systemPromptValue = Form.useWatch("system_prompt", form) || ""
   const userPromptValue = Form.useWatch("user_prompt", form) || ""
@@ -47,9 +52,14 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   // Set initial values
   useEffect(() => {
     if (!open) return
-    if (recovered) {
-      form.setFieldsValue(recovered)
-    } else if (initialValues) {
+    if (hasDraft && draftData) {
+      const recovered = applyDraft()
+      if (recovered) {
+        form.setFieldsValue(recovered)
+        return
+      }
+    }
+    if (initialValues) {
       form.setFieldsValue({
         name: initialValues.name || "",
         author: initialValues.author || "",
@@ -63,15 +73,12 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
       form.resetFields()
     }
     setDirty(false)
-  }, [open, initialValues, recovered, form])
+  }, [open, initialValues, hasDraft, draftData, applyDraft, form])
 
-  // Auto-save draft
+  // Mark dirty changes for auto-save
   useEffect(() => {
     if (!open || !dirty) return
-    const timer = setInterval(() => {
-      saveDraft(form.getFieldsValue())
-    }, 5000)
-    return () => clearInterval(timer)
+    saveDraft(form.getFieldsValue())
   }, [open, dirty, form, saveDraft])
 
   // beforeunload guard
@@ -83,6 +90,19 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
     window.addEventListener("beforeunload", handler)
     return () => window.removeEventListener("beforeunload", handler)
   }, [open, dirty])
+
+  const handleRequestClose = useCallback(() => {
+    if (dirty) {
+      const ok = window.confirm(
+        t("managePrompts.drawer.unsavedChanges", {
+          defaultValue: "You have unsaved changes. Discard them?",
+        })
+      )
+      if (!ok) return
+    }
+    clearDraft()
+    onClose()
+  }, [dirty, clearDraft, onClose, t])
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -99,20 +119,7 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [open, dirty, form])
-
-  const handleRequestClose = useCallback(() => {
-    if (dirty) {
-      const ok = window.confirm(
-        t("managePrompts.drawer.unsavedChanges", {
-          defaultValue: "You have unsaved changes. Discard them?",
-        })
-      )
-      if (!ok) return
-    }
-    clearDraft()
-    onClose()
-  }, [dirty, clearDraft, onClose, t])
+  }, [open, form, handleRequestClose])
 
   const handleFinish = (values: any) => {
     const keywords = Array.isArray(values.keywords)
@@ -138,8 +145,11 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   const templateFieldValidator = (_: any, value: string) => {
     if (!value) return Promise.resolve()
     const result = validateTemplateVariableSyntax(value)
-    if (!result.valid && result.errors.length > 0) {
-      return Promise.reject(result.errors[0])
+    if (!result.isValid) {
+      const msg = result.code === "unmatched_braces"
+        ? "Unmatched {{ or }} braces"
+        : `Invalid template variable: ${result.invalidTokens?.[0] ?? ""}`
+      return Promise.reject(msg)
     }
     return Promise.resolve()
   }
@@ -190,9 +200,9 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
             Back to Prompts
           </button>
           <span className="text-sm font-medium text-text">{title}</span>
-          {draftAge && (
+          {lastSaved && (
             <span className="text-xs text-text-muted">
-              Draft saved {formatDraftAge(draftAge)}
+              Draft saved {formatDraftAge(lastSaved)}
             </span>
           )}
         </div>

--- a/apps/packages/ui/src/components/Option/Prompt/PromptKeyboardShortcutsPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptKeyboardShortcutsPanel.tsx
@@ -1,0 +1,77 @@
+import React from "react"
+import { X } from "lucide-react"
+
+type ShortcutEntry = {
+  keys: string[]
+  description: string
+}
+
+const SHORTCUTS: ShortcutEntry[] = [
+  { keys: ["Enter"], description: "Open inspector" },
+  { keys: ["E"], description: "Edit prompt" },
+  { keys: ["Space"], description: "Toggle selection" },
+  { keys: ["⌘", "K"], description: "Command palette" },
+  { keys: ["⌘", "N"], description: "New prompt" },
+  { keys: ["/"], description: "Focus search" },
+  { keys: ["?"], description: "Show shortcuts" },
+  { keys: ["Escape"], description: "Close editor / inspector" },
+  { keys: ["⌘", "S"], description: "Save (in editor)" },
+]
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+export const PromptKeyboardShortcutsPanel: React.FC<Props> = ({
+  open,
+  onClose,
+}) => {
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-xl border border-border bg-surface p-4 shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="prompt-shortcuts-panel"
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-text">
+            Keyboard Shortcuts
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-text-muted hover:bg-surface2 hover:text-text"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="space-y-2">
+          {SHORTCUTS.map((s) => (
+            <div
+              key={s.description}
+              className="flex items-center justify-between py-1"
+            >
+              <span className="text-sm text-text-muted">{s.description}</span>
+              <div className="flex items-center gap-1">
+                {s.keys.map((key) => (
+                  <kbd
+                    key={key}
+                    className="rounded border border-border bg-surface2 px-1.5 py-0.5 text-xs font-medium text-text"
+                  >
+                    {key}
+                  </kbd>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptSidebar.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptSidebar.tsx
@@ -1,0 +1,225 @@
+import React from "react"
+import {
+  PanelLeftClose,
+  PanelLeftOpen,
+  NotebookPen,
+  Bot,
+  FlaskConical,
+  Trash2,
+} from "lucide-react"
+import { SmartCollections } from "./SmartCollections"
+import { FacetedFilters } from "./FacetedFilters"
+import { FilterPresets } from "./FilterPresets"
+import type { PromptSavedView } from "./prompt-workspace-types"
+import type { TagMatchMode } from "./custom-prompts-utils"
+import type { FilterPreset } from "./useFilterPresets"
+
+type SegmentType = "custom" | "copilot" | "studio" | "trash"
+
+type WorkspaceItem = {
+  id: SegmentType
+  label: string
+  icon: React.ReactNode
+  badge?: number | null
+}
+
+type PromptSidebarProps = {
+  collapsed: boolean
+  onToggleCollapsed: () => void
+  // Workspace segment
+  selectedSegment: SegmentType
+  onSegmentChange: (s: SegmentType) => void
+  trashCount?: number
+  // Smart collections (only for custom segment)
+  savedView: PromptSavedView
+  onSavedViewChange: (v: PromptSavedView) => void
+  smartCounts: Partial<Record<PromptSavedView, number>>
+  // Faceted filters
+  typeFilter: string
+  onTypeFilterChange: (v: string) => void
+  typeCounts: Record<string, number>
+  syncFilter: string
+  onSyncFilterChange: (v: string) => void
+  syncCounts: Record<string, number>
+  tagFilter: string[]
+  onTagFilterChange: (v: string[]) => void
+  tagMatchMode: TagMatchMode
+  onTagMatchModeChange: (v: TagMatchMode) => void
+  tagCounts: Record<string, number>
+  // Filter presets
+  presets: FilterPreset[]
+  onLoadPreset: (preset: FilterPreset) => void
+  onSavePreset: (name: string) => void
+  onDeletePreset: (id: string) => void
+}
+
+export const PromptSidebar: React.FC<PromptSidebarProps> = ({
+  collapsed,
+  onToggleCollapsed,
+  selectedSegment,
+  onSegmentChange,
+  trashCount,
+  savedView,
+  onSavedViewChange,
+  smartCounts,
+  typeFilter,
+  onTypeFilterChange,
+  typeCounts,
+  syncFilter,
+  onSyncFilterChange,
+  syncCounts,
+  tagFilter,
+  onTagFilterChange,
+  tagMatchMode,
+  onTagMatchModeChange,
+  tagCounts,
+  presets,
+  onLoadPreset,
+  onSavePreset,
+  onDeletePreset,
+}) => {
+  const workspaces: WorkspaceItem[] = [
+    { id: "custom", label: "Custom", icon: <NotebookPen className="size-4" /> },
+    { id: "copilot", label: "Copilot", icon: <Bot className="size-4" /> },
+    { id: "studio", label: "Studio", icon: <FlaskConical className="size-4" /> },
+    {
+      id: "trash",
+      label: "Trash",
+      icon: <Trash2 className="size-4" />,
+      badge: trashCount,
+    },
+  ]
+
+  if (collapsed) {
+    return (
+      <div
+        className="flex w-12 shrink-0 flex-col items-center gap-2 border-r border-border bg-surface py-3"
+        data-testid="prompt-sidebar-collapsed"
+      >
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          className="rounded p-1.5 text-text-muted hover:bg-surface2 hover:text-text"
+          aria-label="Expand sidebar"
+          data-testid="prompt-sidebar-expand"
+        >
+          <PanelLeftOpen className="size-4" />
+        </button>
+        <div className="my-1 h-px w-6 bg-border" />
+        {workspaces.map((ws) => (
+          <button
+            key={ws.id}
+            type="button"
+            onClick={() => onSegmentChange(ws.id)}
+            className={`relative rounded p-1.5 transition-colors ${
+              selectedSegment === ws.id
+                ? "bg-primary/10 text-primary"
+                : "text-text-muted hover:bg-surface2 hover:text-text"
+            }`}
+            title={ws.label}
+            data-testid={`sidebar-ws-icon-${ws.id}`}
+          >
+            {ws.icon}
+            {ws.badge != null && ws.badge > 0 && (
+              <span className="absolute -right-0.5 -top-0.5 flex size-3.5 items-center justify-center rounded-full bg-danger text-[9px] text-white">
+                {ws.badge > 9 ? "9+" : ws.badge}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="flex w-60 shrink-0 flex-col border-r border-border bg-surface"
+      data-testid="prompt-sidebar"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+          Prompts
+        </span>
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          className="rounded p-1 text-text-muted hover:bg-surface2 hover:text-text"
+          aria-label="Collapse sidebar"
+          data-testid="prompt-sidebar-collapse"
+        >
+          <PanelLeftClose className="size-4" />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-3 py-3 space-y-5">
+        {/* Workspaces */}
+        <div>
+          <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+            Workspaces
+          </h4>
+          <div className="space-y-0.5">
+            {workspaces.map((ws) => (
+              <button
+                key={ws.id}
+                type="button"
+                data-testid={`sidebar-ws-${ws.id}`}
+                onClick={() => onSegmentChange(ws.id)}
+                className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+                  selectedSegment === ws.id
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-text-muted hover:bg-surface2 hover:text-text"
+                }`}
+              >
+                {ws.icon}
+                <span className="flex-1 text-left">{ws.label}</span>
+                {ws.badge != null && ws.badge > 0 && (
+                  <span className="text-xs text-text-muted tabular-nums">
+                    {ws.badge}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Smart collections and filters only for custom segment */}
+        {selectedSegment === "custom" && (
+          <>
+            <div>
+              <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                Collections
+              </h4>
+              <SmartCollections
+                activeView={savedView}
+                onViewChange={onSavedViewChange}
+                counts={smartCounts}
+              />
+            </div>
+
+            <FacetedFilters
+              typeFilter={typeFilter}
+              onTypeFilterChange={onTypeFilterChange}
+              typeCounts={typeCounts}
+              syncFilter={syncFilter}
+              onSyncFilterChange={onSyncFilterChange}
+              syncCounts={syncCounts}
+              tagFilter={tagFilter}
+              onTagFilterChange={onTagFilterChange}
+              tagMatchMode={tagMatchMode}
+              onTagMatchModeChange={onTagMatchModeChange}
+              tagCounts={tagCounts}
+            />
+
+            <FilterPresets
+              presets={presets}
+              onLoad={onLoadPreset}
+              onSave={onSavePreset}
+              onDelete={onDeletePreset}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { Code, FileText, Search } from "lucide-react"
+
+type StarterPrompt = {
+  icon: React.ReactNode
+  title: string
+  description: string
+  system_prompt: string
+  user_prompt: string
+  keywords: string[]
+}
+
+const STARTER_PROMPTS: StarterPrompt[] = [
+  {
+    icon: <Code className="size-5 text-primary" />,
+    title: "Code Review Assistant",
+    description: "Reviews code for bugs, style, and best practices",
+    system_prompt:
+      "You are an expert code reviewer. Analyze code for bugs, performance issues, security vulnerabilities, and adherence to best practices. Provide specific, actionable feedback with line references.",
+    user_prompt: "Review the following code:\n\n{{code}}",
+    keywords: ["code", "review", "development"],
+  },
+  {
+    icon: <FileText className="size-5 text-primary" />,
+    title: "Meeting Summary",
+    description: "Extracts key points and action items from meeting notes",
+    system_prompt:
+      "You are a professional meeting summarizer. Extract key decisions, action items with owners, open questions, and important discussion points. Format the output clearly with sections.",
+    user_prompt:
+      "Summarize the following meeting notes:\n\n{{meeting_notes}}",
+    keywords: ["meeting", "summary", "notes"],
+  },
+  {
+    icon: <Search className="size-5 text-primary" />,
+    title: "Research Analyst",
+    description: "Analyzes topics with structured research methodology",
+    system_prompt:
+      "You are a thorough research analyst. When given a topic, provide a balanced analysis covering key facts, different perspectives, recent developments, and areas of uncertainty. Cite reasoning clearly.",
+    user_prompt: "Research and analyze the following topic:\n\n{{topic}}",
+    keywords: ["research", "analysis", "study"],
+  },
+]
+
+type Props = {
+  onUse: (prompt: {
+    name: string
+    system_prompt: string
+    user_prompt: string
+    keywords: string[]
+  }) => void
+}
+
+export const PromptStarterCards: React.FC<Props> = ({ onUse }) => {
+  return (
+    <div className="grid gap-3 sm:grid-cols-3" data-testid="prompt-starter-cards">
+      {STARTER_PROMPTS.map((sp) => (
+        <div
+          key={sp.title}
+          className="flex flex-col rounded-lg border border-border bg-surface p-4 transition-colors hover:border-primary/40"
+        >
+          <div className="mb-2 flex items-center gap-2">
+            {sp.icon}
+            <h4 className="text-sm font-medium text-text">{sp.title}</h4>
+          </div>
+          <p className="mb-3 flex-1 text-xs text-text-muted">
+            {sp.description}
+          </p>
+          <button
+            type="button"
+            onClick={() =>
+              onUse({
+                name: sp.title,
+                system_prompt: sp.system_prompt,
+                user_prompt: sp.user_prompt,
+                keywords: sp.keywords,
+              })
+            }
+            className="rounded bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/20"
+            data-testid={`starter-use-${sp.title.toLowerCase().replace(/\s+/g, "-")}`}
+          >
+            Use this template
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptsWorkspace.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptsWorkspace.tsx
@@ -12,14 +12,14 @@ export const PromptsWorkspace: React.FC = () => {
   )
   const pageShellMaxWidthClassName = chatSidebarCollapsed
     ? "max-w-none"
-    : "max-w-5xl"
+    : "max-w-7xl"
 
   return (
     <PageShell
-      className="space-y-4"
+      className=""
       maxWidthClassName={pageShellMaxWidthClassName}
     >
-      <div className="space-y-1">
+      <div className="space-y-1 mb-4">
         <h1 className="text-lg font-semibold text-text">
           {t("option:header.modePromptsPlayground", "Prompts")}
         </h1>

--- a/apps/packages/ui/src/components/Option/Prompt/SmartCollections.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/SmartCollections.tsx
@@ -1,0 +1,55 @@
+import React from "react"
+import { Layers, Star, Clock, TrendingUp, Tag as TagIcon } from "lucide-react"
+import type { PromptSavedView } from "./prompt-workspace-types"
+
+type SmartCollectionItem = {
+  id: PromptSavedView
+  label: string
+  icon: React.ReactNode
+}
+
+const COLLECTIONS: SmartCollectionItem[] = [
+  { id: "all", label: "All Prompts", icon: <Layers className="size-4" /> },
+  { id: "favorites", label: "Favorites", icon: <Star className="size-4" /> },
+  { id: "recent", label: "Recently Used", icon: <Clock className="size-4" /> },
+  { id: "most_used", label: "Most Used", icon: <TrendingUp className="size-4" /> },
+  { id: "untagged", label: "Untagged", icon: <TagIcon className="size-4" /> },
+]
+
+type Props = {
+  activeView: PromptSavedView
+  onViewChange: (view: PromptSavedView) => void
+  counts: Partial<Record<PromptSavedView, number>>
+}
+
+export const SmartCollections: React.FC<Props> = ({
+  activeView,
+  onViewChange,
+  counts,
+}) => {
+  return (
+    <div className="space-y-0.5" data-testid="smart-collections">
+      {COLLECTIONS.map((c) => (
+        <button
+          key={c.id}
+          type="button"
+          data-testid={`smart-collection-${c.id}`}
+          onClick={() => onViewChange(c.id)}
+          className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors ${
+            activeView === c.id
+              ? "bg-primary/10 text-primary font-medium"
+              : "text-text-muted hover:bg-surface2 hover:text-text"
+          }`}
+        >
+          {c.icon}
+          <span className="flex-1 text-left">{c.label}</span>
+          {counts[c.id] != null && (
+            <span className="text-xs text-text-muted tabular-nums">
+              {counts[c.id]}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptsWorkspace.layout.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptsWorkspace.layout.test.tsx
@@ -82,7 +82,7 @@ describe("PromptsWorkspace layout", () => {
     render(<PromptsWorkspace />)
 
     const shell = screen.getByTestId("prompts-page-shell")
-    expect(shell.className).toContain("max-w-5xl")
+    expect(shell.className).toContain("max-w-7xl")
     expect(shell.className).not.toContain("max-w-none")
   })
 })

--- a/apps/packages/ui/src/components/Option/Prompt/index.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/index.tsx
@@ -30,7 +30,13 @@ import {
   type PromptTableDensity
 } from "./PromptListTable"
 import { PromptListToolbar } from "./PromptListToolbar"
-import type { PromptListQueryState, PromptRowVM } from "./prompt-workspace-types"
+import { PromptSidebar } from "./PromptSidebar"
+import { PromptFullPageEditor } from "./PromptFullPageEditor"
+import { PromptStarterCards } from "./PromptStarterCards"
+import { ContextualHint } from "./ContextualHint"
+import { useContextualHints } from "./useContextualHints"
+import { useFilterPresets, type FilterPreset } from "./useFilterPresets"
+import type { PromptListQueryState, PromptRowVM, PromptSavedView } from "./prompt-workspace-types"
 import {
   buildSyncBatchPlan,
   type SyncBatchTask
@@ -303,6 +309,7 @@ export const PromptBody = () => {
   const [newCollectionDescription, setNewCollectionDescription] = useState("")
   const [tagFilter, setTagFilter] = useState<string[]>([])
   const [tagMatchMode, setTagMatchMode] = useState<TagMatchMode>("any")
+  const [syncFilter, setSyncFilter] = useState<string>("all")
   const [currentPage, setCurrentPage] = useState(1)
   const [resultsPerPage, setResultsPerPage] = useState(20)
   const [tableDensity, setTableDensity] = useState<PromptTableDensity>(() =>
@@ -368,6 +375,13 @@ export const PromptBody = () => {
   const [copilotSearchText, setCopilotSearchText] = useState("")
   const [copilotKeyFilter, setCopilotKeyFilter] = useState<string>("all")
   const [shortcutsHelpOpen, setShortcutsHelpOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [savedView, setSavedView] = useState<PromptSavedView>("all")
+  const [fullEditorOpen, setFullEditorOpen] = useState(false)
+  const [fullEditorMode, setFullEditorMode] = useState<"create" | "edit">("create")
+  const [fullEditorInitialValues, setFullEditorInitialValues] = useState<any>(null)
+  const { presets: filterPresets, savePreset: saveFilterPreset, deletePreset: deleteFilterPreset } = useFilterPresets()
+  const { shouldShow: shouldShowHint, dismiss: dismissHint, markShown: markHintShown } = useContextualHints()
   const copilotEditPromptValue = Form.useWatch("prompt", editCopilotForm)
 
   const { setSelectedQuickPrompt, setSelectedSystemPrompt } = useMessageOption()
@@ -1935,6 +1949,9 @@ export const PromptBody = () => {
         return promptType === typeFilter
       })
     }
+    if (syncFilter !== "all") {
+      items = items.filter((p) => (p.syncStatus || "local") === syncFilter)
+    }
     if (usageFilter !== "all") {
       items = items.filter((p) =>
         usageFilter === "used"
@@ -1953,25 +1970,94 @@ export const PromptBody = () => {
         matchesTagFilter(getPromptKeywords(p), tagFilter, tagMatchMode)
       )
     }
+    // Apply savedView filter
+    if (savedView === "favorites") {
+      items = items.filter((p) => !!p.favorite)
+    } else if (savedView === "recent") {
+      items = [...items]
+        .filter((p) => typeof p.lastUsedAt === "number" && p.lastUsedAt > 0)
+        .sort((a, b) => (b.lastUsedAt || 0) - (a.lastUsedAt || 0))
+        .slice(0, 20)
+    } else if (savedView === "most_used") {
+      items = [...items]
+        .filter((p) => getPromptUsageCount(p) > 0)
+        .sort((a, b) => getPromptUsageCount(b) - getPromptUsageCount(a))
+        .slice(0, 20)
+    } else if (savedView === "untagged") {
+      items = items.filter((p) => {
+        const kw = getPromptKeywords(p)
+        return !kw || kw.length === 0
+      })
+    }
     // favorites first, then newest
-    items = items.sort(
-      (a, b) =>
-        Number(!!b.favorite) - Number(!!a.favorite) ||
-        (b.createdAt || 0) - (a.createdAt || 0)
-    )
+    if (savedView === "all" || savedView === "favorites" || savedView === "untagged") {
+      items = items.sort(
+        (a, b) =>
+          Number(!!b.favorite) - Number(!!a.favorite) ||
+          (b.createdAt || 0) - (a.createdAt || 0)
+      )
+    }
     return items
   }, [
     data,
     projectFilter,
     typeFilter,
+    syncFilter,
     usageFilter,
     selectedCollection,
     tagFilter,
     tagMatchMode,
+    savedView,
     getPromptUsageCount,
     getPromptKeywords,
     getPromptType
   ])
+
+  // Compute sidebar counts from unfiltered data
+  const sidebarCounts = useMemo(() => {
+    const all = (data || []) as any[]
+    const typeCounts: Record<string, number> = { all: all.length }
+    const syncCounts: Record<string, number> = { all: all.length }
+    const tagCounts: Record<string, number> = {}
+    let favCount = 0
+    let recentCount = 0
+    let mostUsedCount = 0
+    let untaggedCount = 0
+
+    for (const p of all) {
+      // Type counts
+      const pt = getPromptType(p)
+      typeCounts[pt] = (typeCounts[pt] || 0) + 1
+      // Sync counts
+      const ss = p.syncStatus || "local"
+      syncCounts[ss] = (syncCounts[ss] || 0) + 1
+      // Tag counts
+      const kw = getPromptKeywords(p)
+      if (!kw || kw.length === 0) {
+        untaggedCount++
+      } else {
+        for (const tag of kw) {
+          tagCounts[tag] = (tagCounts[tag] || 0) + 1
+        }
+      }
+      if (p.favorite) favCount++
+      if (typeof p.lastUsedAt === "number" && p.lastUsedAt > 0) recentCount++
+      if (getPromptUsageCount(p) > 0) mostUsedCount++
+    }
+
+    return {
+      typeCounts,
+      syncCounts,
+      tagCounts,
+      smartCounts: {
+        all: all.length,
+        favorites: favCount,
+        recent: Math.min(recentCount, 20),
+        most_used: Math.min(mostUsedCount, 20),
+        untagged: untaggedCount,
+      } as Partial<Record<PromptSavedView, number>>,
+    }
+  }, [data, getPromptType, getPromptKeywords, getPromptUsageCount])
 
   const localSearchFilteredData = useMemo(() => {
     if (normalizedSearchText.length === 0) {
@@ -2084,7 +2170,7 @@ export const PromptBody = () => {
   const customPromptTableQuery: PromptListQueryState = {
     searchText,
     typeFilter: typeFilter,
-    syncFilter: "all",
+    syncFilter: syncFilter as PromptListQueryState["syncFilter"],
     usageFilter,
     tagFilter,
     tagMatchMode,
@@ -2094,7 +2180,7 @@ export const PromptBody = () => {
     },
     page: currentPage,
     pageSize: resultsPerPage,
-    savedView: "all"
+    savedView
   }
 
   const hiddenServerResultsOnPage = useMemo(() => {
@@ -2347,6 +2433,57 @@ export const PromptBody = () => {
     },
     [guardPrivateMode]
   )
+
+  const openFullEditor = React.useCallback(
+    (promptRecord?: any) => {
+      if (promptRecord?.id) {
+        const { systemText, userText } = getPromptTexts(promptRecord)
+        setFullEditorMode("edit")
+        setEditId(promptRecord.id)
+        setFullEditorInitialValues({
+          id: promptRecord.id,
+          name: promptRecord?.name || promptRecord?.title,
+          author: promptRecord?.author,
+          details: promptRecord?.details,
+          system_prompt: systemText,
+          user_prompt: userText,
+          keywords: promptRecord?.keywords ?? promptRecord?.tags ?? [],
+          changeDescription: promptRecord?.changeDescription,
+        })
+        setSearchParams({ edit: promptRecord.id }, { replace: true })
+      } else {
+        setFullEditorMode("create")
+        setFullEditorInitialValues(promptRecord || null)
+        setSearchParams({ new: "1" }, { replace: true })
+      }
+      setFullEditorOpen(true)
+    },
+    [getPromptTexts, setSearchParams]
+  )
+
+  const closeFullEditor = React.useCallback(() => {
+    setFullEditorOpen(false)
+    setFullEditorInitialValues(null)
+    const newParams = new URLSearchParams(searchParams)
+    newParams.delete("edit")
+    newParams.delete("new")
+    setSearchParams(newParams, { replace: true })
+  }, [searchParams, setSearchParams])
+
+  // Handle ?edit=<id> and ?new=1 URL params for full editor
+  useEffect(() => {
+    if (status !== "success" || !Array.isArray(data)) return
+    const editId = searchParams.get("edit")
+    const isNew = searchParams.get("new")
+    if (editId && !fullEditorOpen) {
+      const prompt = data.find((p: any) => String(p.id) === editId)
+      if (prompt) {
+        openFullEditor(prompt)
+      }
+    } else if (isNew === "1" && !fullEditorOpen) {
+      openFullEditor()
+    }
+  }, [status, data, searchParams])
 
   const copyCopilotToCustom = React.useCallback(
     (record: { key?: string; prompt?: string }) => {
@@ -2871,6 +3008,27 @@ export const PromptBody = () => {
     newParams.delete("project")
     setSearchParams(newParams, { replace: true })
   }
+
+  const handleLoadFilterPreset = React.useCallback((preset: FilterPreset) => {
+    setTypeFilter(preset.typeFilter as any)
+    setSyncFilter(preset.syncFilter as any)
+    setTagFilter(preset.tagFilter)
+    setTagMatchMode(preset.tagMatchMode)
+    setSavedView(preset.savedView)
+  }, [])
+
+  const handleSaveFilterPreset = React.useCallback(
+    (name: string) => {
+      saveFilterPreset(name, {
+        typeFilter,
+        syncFilter,
+        tagFilter,
+        tagMatchMode,
+        savedView,
+      })
+    },
+    [typeFilter, syncFilter, tagFilter, tagMatchMode, savedView, saveFilterPreset]
+  )
 
   const openConflictResolution = React.useCallback((localId: string) => {
     setConflictPromptId(localId)
@@ -3456,7 +3614,7 @@ export const PromptBody = () => {
             <div className="flex flex-wrap items-center gap-2">
               <Tooltip title={t("managePrompts.newPromptHint", { defaultValue: "New prompt (N)" })}>
               <button
-                onClick={openCreateDrawer}
+                onClick={() => openCreateDrawer()}
                 data-testid="prompts-add"
                 className="inline-flex items-center rounded-md border border-transparent bg-primary px-2 py-2 text-md font-medium leading-4 text-white shadow-sm hover:bg-primaryStrong focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 disabled:opacity-50">
                 {t("managePrompts.newPromptBtn", { defaultValue: "New prompt" })}
@@ -3790,28 +3948,48 @@ export const PromptBody = () => {
         )}
 
         {status === "success" && Array.isArray(data) && data.length === 0 && (
-          <FeatureEmptyState
-            title={t("settings:managePrompts.emptyTitle", {
-              defaultValue: "No custom prompts yet"
-            })}
-            description={t("settings:managePrompts.emptyDescription", {
-              defaultValue:
-                "Create reusable prompts for recurring tasks, workflows, and team conventions."
-            })}
-            examples={[
-              t("settings:managePrompts.emptyExample1", {
+          <>
+            <FeatureEmptyState
+              title={t("settings:managePrompts.emptyTitle", {
+                defaultValue: "No custom prompts yet"
+              })}
+              description={t("settings:managePrompts.emptyDescription", {
                 defaultValue:
-                  "Save your favorite system prompt for summaries, explanations, or translations."
-              }),
-              t("settings:managePrompts.emptyExample2", {
-                defaultValue:
-                  "Create quick prompts for common actions like drafting emails or refining notes."
-              })
-            ]}
-            primaryActionLabel={t("settings:managePrompts.emptyPrimaryCta", {
-              defaultValue: "Create prompt"
-            })}
-            onPrimaryAction={openCreateDrawer}
+                  "Create reusable prompts for recurring tasks, workflows, and team conventions."
+              })}
+              examples={[
+                t("settings:managePrompts.emptyExample1", {
+                  defaultValue:
+                    "Save your favorite system prompt for summaries, explanations, or translations."
+                }),
+                t("settings:managePrompts.emptyExample2", {
+                  defaultValue:
+                    "Create quick prompts for common actions like drafting emails or refining notes."
+                })
+              ]}
+              primaryActionLabel={t("settings:managePrompts.emptyPrimaryCta", {
+                defaultValue: "Create prompt"
+              })}
+              onPrimaryAction={openCreateDrawer}
+            />
+            <div className="mt-6">
+              <h3 className="mb-3 text-sm font-medium text-text-muted">
+                Or start with a template
+              </h3>
+              <PromptStarterCards
+                onUse={(starter) => openFullEditor(starter)}
+              />
+            </div>
+          </>
+        )}
+
+        {status === "success" && Array.isArray(data) && data.length >= 5 && shouldShowHint("keyboard-shortcuts") && (
+          <ContextualHint
+            id="keyboard-shortcuts"
+            message="Press Enter to preview, E to edit, or ? for all keyboard shortcuts."
+            visible={true}
+            onDismiss={dismissHint}
+            onShown={markHintShown}
           />
         )}
 
@@ -4421,7 +4599,42 @@ export const PromptBody = () => {
           }
         />
       )}
-      <div className="flex flex-col items-start gap-1 mb-6">
+      <div className="flex gap-0">
+        {/* Sidebar - desktop only */}
+        {!isCompactViewport && (
+          <PromptSidebar
+            collapsed={sidebarCollapsed}
+            onToggleCollapsed={() => setSidebarCollapsed((p) => !p)}
+            selectedSegment={selectedSegment}
+            onSegmentChange={(s) => setSelectedSegment(s as SegmentType)}
+            trashCount={trashData?.length}
+            savedView={savedView}
+            onSavedViewChange={setSavedView}
+            smartCounts={sidebarCounts.smartCounts}
+            typeFilter={typeFilter}
+            onTypeFilterChange={(v) => setTypeFilter(v as any)}
+            typeCounts={sidebarCounts.typeCounts}
+            syncFilter={syncFilter}
+            onSyncFilterChange={setSyncFilter}
+            syncCounts={sidebarCounts.syncCounts}
+            tagFilter={tagFilter}
+            onTagFilterChange={setTagFilter}
+            tagMatchMode={tagMatchMode}
+            onTagMatchModeChange={setTagMatchMode}
+            tagCounts={sidebarCounts.tagCounts}
+            presets={filterPresets}
+            onLoadPreset={handleLoadFilterPreset}
+            onSavePreset={handleSaveFilterPreset}
+            onDeletePreset={deleteFilterPreset}
+          />
+        )}
+
+        {/* Main content area */}
+        <div className="flex-1 min-w-0">
+
+      {/* Mobile segment tabs */}
+      {isCompactViewport && (
+      <div className="flex flex-col items-start gap-1 mb-6 px-4">
         <Segmented
           size="large"
           options={[
@@ -4519,10 +4732,16 @@ export const PromptBody = () => {
               })}
         </p>
       </div>
+      )}
+      <div className={isCompactViewport ? "px-4" : "p-4"}>
       {selectedSegment === "custom" && customPrompts()}
       {selectedSegment === "copilot" && copilotPrompts()}
       {selectedSegment === "studio" && <StudioTabContainer />}
       {selectedSegment === "trash" && trashPrompts()}
+      </div>
+
+      </div>
+      </div>
 
       <PromptDrawer
         open={drawerOpen}
@@ -4534,6 +4753,16 @@ export const PromptBody = () => {
         initialValues={drawerInitialValues}
         onSubmit={handleDrawerSubmit}
         isLoading={drawerMode === "create" ? savePromptLoading : isUpdatingPrompt}
+        allTags={allTags}
+      />
+
+      <PromptFullPageEditor
+        open={fullEditorOpen}
+        onClose={closeFullEditor}
+        mode={fullEditorMode}
+        initialValues={fullEditorInitialValues}
+        onSubmit={handleDrawerSubmit}
+        isLoading={fullEditorMode === "create" ? savePromptLoading : isUpdatingPrompt}
         allTags={allTags}
       />
 

--- a/apps/packages/ui/src/components/Option/Prompt/index.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/index.tsx
@@ -2483,7 +2483,7 @@ export const PromptBody = () => {
     } else if (isNew === "1" && !fullEditorOpen) {
       openFullEditor()
     }
-  }, [status, data, searchParams])
+  }, [status, data, searchParams, fullEditorOpen, openFullEditor])
 
   const copyCopilotToCustom = React.useCallback(
     (record: { key?: string; prompt?: string }) => {
@@ -2876,7 +2876,7 @@ export const PromptBody = () => {
       }
       if (e.key === "n" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         e.preventDefault()
-        openCreateDrawer()
+        openFullEditor()
         return
       }
       if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
@@ -2886,7 +2886,7 @@ export const PromptBody = () => {
     }
     document.addEventListener("keydown", handler)
     return () => document.removeEventListener("keydown", handler)
-  }, [drawerOpen, shortcutsHelpOpen, openCreateDrawer])
+  }, [drawerOpen, shortcutsHelpOpen, openFullEditor])
 
   const openEditDrawer = (record: any) => {
     if (guardPrivateMode()) return
@@ -2996,6 +2996,15 @@ export const PromptBody = () => {
   const handleDrawerSubmit = (values: any) => {
     const payload = normalizePromptPayload(values)
     if (drawerMode === "create") {
+      savePromptMutation(payload)
+    } else {
+      updatePromptMutation(payload)
+    }
+  }
+
+  const handleFullEditorSubmit = (values: any) => {
+    const payload = normalizePromptPayload(values)
+    if (fullEditorMode === "create") {
       savePromptMutation(payload)
     } else {
       updatePromptMutation(payload)
@@ -3273,9 +3282,9 @@ export const PromptBody = () => {
     (promptId: string) => {
       const promptRecord = getPromptRecordById(promptId)
       if (!promptRecord) return
-      openEditDrawer(promptRecord)
+      openFullEditor(promptRecord)
     },
-    [getPromptRecordById]
+    [getPromptRecordById, openFullEditor]
   )
 
   const renderCustomPromptTitleMeta = React.useCallback(
@@ -3329,7 +3338,7 @@ export const PromptBody = () => {
           inlineUseInChat={false}
           onEdit={() => {
             if (!promptRecord) return
-            openEditDrawer(promptRecord)
+            openFullEditor(promptRecord)
           }}
           onDuplicate={() => {
             if (!promptRecord) return
@@ -3614,7 +3623,7 @@ export const PromptBody = () => {
             <div className="flex flex-wrap items-center gap-2">
               <Tooltip title={t("managePrompts.newPromptHint", { defaultValue: "New prompt (N)" })}>
               <button
-                onClick={() => openCreateDrawer()}
+                onClick={() => openFullEditor()}
                 data-testid="prompts-add"
                 className="inline-flex items-center rounded-md border border-transparent bg-primary px-2 py-2 text-md font-medium leading-4 text-white shadow-sm hover:bg-primaryStrong focus:outline-none focus:ring-2 focus:ring-focus focus:ring-offset-2 disabled:opacity-50">
                 {t("managePrompts.newPromptBtn", { defaultValue: "New prompt" })}
@@ -3970,7 +3979,7 @@ export const PromptBody = () => {
               primaryActionLabel={t("settings:managePrompts.emptyPrimaryCta", {
                 defaultValue: "Create prompt"
               })}
-              onPrimaryAction={openCreateDrawer}
+              onPrimaryAction={() => openFullEditor()}
             />
             <div className="mt-6">
               <h3 className="mb-3 text-sm font-medium text-text-muted">
@@ -4761,7 +4770,7 @@ export const PromptBody = () => {
         onClose={closeFullEditor}
         mode={fullEditorMode}
         initialValues={fullEditorInitialValues}
-        onSubmit={handleDrawerSubmit}
+        onSubmit={handleFullEditorSubmit}
         isLoading={fullEditorMode === "create" ? savePromptLoading : isUpdatingPrompt}
         allTags={allTags}
       />
@@ -4774,7 +4783,7 @@ export const PromptBody = () => {
           const promptRecord = getPromptRecordById(promptId)
           if (!promptRecord) return
           closeInspector()
-          openEditDrawer(promptRecord)
+          openFullEditor(promptRecord)
         }}
         onUseInChat={(promptId) => {
           const promptRecord = getPromptRecordById(promptId)

--- a/apps/packages/ui/src/components/Option/Prompt/prompt-workspace-types.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/prompt-workspace-types.ts
@@ -1,6 +1,6 @@
 import type { PromptSourceSystem, PromptSyncStatus } from "@/db/dexie/types"
 
-export type PromptSavedView = "all" | "favorites" | "recent" | "most_used"
+export type PromptSavedView = "all" | "favorites" | "recent" | "most_used" | "untagged"
 
 export type PromptListSortKey = "title" | "modifiedAt" | null
 export type PromptListSortOrder = "ascend" | "descend" | null

--- a/apps/packages/ui/src/components/Option/Prompt/useContextualHints.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/useContextualHints.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback, useEffect } from "react"
+
+export type HintId =
+  | "keyboard-shortcuts"
+  | "template-variables"
+  | "gallery-view"
+  | "bulk-actions"
+  | "command-palette"
+
+const STORAGE_PREFIX = "tldw-prompt-hint-dismissed-"
+const MAX_SHOWS = 3
+const SHOW_COUNT_PREFIX = "tldw-prompt-hint-shown-"
+
+function isDismissed(id: HintId): boolean {
+  try {
+    return localStorage.getItem(`${STORAGE_PREFIX}${id}`) === "true"
+  } catch {
+    return false
+  }
+}
+
+function getShowCount(id: HintId): number {
+  try {
+    return parseInt(localStorage.getItem(`${SHOW_COUNT_PREFIX}${id}`) ?? "0", 10) || 0
+  } catch {
+    return 0
+  }
+}
+
+function incrementShowCount(id: HintId): void {
+  try {
+    const count = getShowCount(id) + 1
+    localStorage.setItem(`${SHOW_COUNT_PREFIX}${id}`, String(count))
+  } catch {
+    // ignore
+  }
+}
+
+function dismissHint(id: HintId): void {
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${id}`, "true")
+  } catch {
+    // ignore
+  }
+}
+
+export function useContextualHints() {
+  const [dismissed, setDismissed] = useState<Set<HintId>>(new Set())
+
+  useEffect(() => {
+    const allIds: HintId[] = [
+      "keyboard-shortcuts",
+      "template-variables",
+      "gallery-view",
+      "bulk-actions",
+      "command-palette",
+    ]
+    const set = new Set<HintId>()
+    for (const id of allIds) {
+      if (isDismissed(id) || getShowCount(id) >= MAX_SHOWS) {
+        set.add(id)
+      }
+    }
+    setDismissed(set)
+  }, [])
+
+  const shouldShow = useCallback(
+    (id: HintId): boolean => {
+      return !dismissed.has(id)
+    },
+    [dismissed]
+  )
+
+  const dismiss = useCallback((id: HintId) => {
+    dismissHint(id)
+    setDismissed((prev) => new Set(prev).add(id))
+  }, [])
+
+  const markShown = useCallback(
+    (id: HintId) => {
+      incrementShowCount(id)
+      if (getShowCount(id) >= MAX_SHOWS) {
+        dismiss(id)
+      }
+    },
+    [dismiss]
+  )
+
+  return { shouldShow, dismiss, markShown }
+}

--- a/apps/packages/ui/src/components/Option/Prompt/useFilterPresets.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/useFilterPresets.ts
@@ -1,0 +1,62 @@
+import { useState, useCallback } from "react"
+import type { PromptSavedView } from "./prompt-workspace-types"
+import type { TagMatchMode } from "./custom-prompts-utils"
+
+const STORAGE_KEY = "tldw-prompt-filter-presets-v1"
+
+export type FilterPreset = {
+  id: string
+  name: string
+  typeFilter: string
+  syncFilter: string
+  tagFilter: string[]
+  tagMatchMode: TagMatchMode
+  savedView: PromptSavedView
+}
+
+const loadPresets = (): FilterPreset[] => {
+  if (typeof window === "undefined") return []
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+const persistPresets = (presets: FilterPreset[]) => {
+  if (typeof window === "undefined") return
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(presets))
+  } catch {
+    // Ignore
+  }
+}
+
+export const useFilterPresets = () => {
+  const [presets, setPresets] = useState<FilterPreset[]>(loadPresets)
+
+  const savePreset = useCallback(
+    (name: string, filters: Omit<FilterPreset, "id" | "name">) => {
+      setPresets((prev) => {
+        const next = [
+          ...prev,
+          { ...filters, id: crypto.randomUUID(), name },
+        ]
+        persistPresets(next)
+        return next
+      })
+    },
+    []
+  )
+
+  const deletePreset = useCallback((id: string) => {
+    setPresets((prev) => {
+      const next = prev.filter((p) => p.id !== id)
+      persistPresets(next)
+      return next
+    })
+  }, [])
+
+  return { presets, savePreset, deletePreset }
+}

--- a/apps/packages/ui/src/components/Option/Prompt/usePromptPaletteCommands.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/usePromptPaletteCommands.ts
@@ -1,0 +1,66 @@
+import { useMemo, createElement } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "react-router-dom"
+import { NotebookPen } from "lucide-react"
+import { getAllPrompts } from "@/db/dexie/helpers"
+import type { CommandItem } from "@/components/Common/CommandPalette"
+
+/**
+ * Returns CommandItem[] for prompts to inject into the global CommandPalette.
+ * Shows recent/favorite prompts when no query, all matching prompts when queried.
+ */
+export function usePromptPaletteCommands(): CommandItem[] {
+  const navigate = useNavigate()
+  const { data: prompts } = useQuery({
+    queryKey: ["promptPaletteAll"],
+    queryFn: getAllPrompts,
+    staleTime: 30_000,
+  })
+
+  return useMemo(() => {
+    if (!prompts?.length) return []
+
+    // Filter out deleted prompts
+    const active = prompts.filter((p) => !p.deletedAt)
+
+    const getLastUsed = (p: (typeof active)[number]): number =>
+      ((p as Record<string, unknown>).lastUsedAt as number) ?? 0
+
+    // Build a combined list: favorites first, then recently used, capped at 10
+    const favorites = active
+      .filter((p) => p.favorite)
+      .sort((a, b) => getLastUsed(b) - getLastUsed(a))
+      .slice(0, 5)
+
+    const recent = active
+      .filter((p) => getLastUsed(p) > 0 && !p.favorite)
+      .sort((a, b) => getLastUsed(b) - getLastUsed(a))
+      .slice(0, 5)
+
+    const combined = [...favorites, ...recent]
+    // Deduplicate
+    const seen = new Set<string>()
+    const unique = combined.filter((p) => {
+      if (seen.has(p.id)) return false
+      seen.add(p.id)
+      return true
+    })
+
+    return unique.map((p) => ({
+      id: `prompt-${p.id}`,
+      label: p.name || p.title || "Untitled Prompt",
+      description: (p.system_prompt || p.content || "").slice(0, 80),
+      icon: createElement(NotebookPen, { className: "size-4" }),
+      action: () => {
+        navigate(`/prompts?edit=${p.id}`)
+      },
+      category: "prompt" as const,
+      keywords: [
+        "prompt",
+        "template",
+        ...(p.keywords ?? []),
+        ...(p.tags ?? []),
+      ],
+    }))
+  }, [prompts, navigate])
+}


### PR DESCRIPTION
## Summary
- **Faceted sidebar** (240px, collapsible): SmartCollections (All/Favorites/Recent/Most Used/Untagged), FacetedFilters (type/sync/tags with counts), FilterPresets (save/load/delete from localStorage), Workspaces (Custom/Copilot/Studio/Trash)
- **Full-page editor**: Two-column overlay (55% form / 45% live preview) replacing the cramped 480px drawer, with template variable highlighting, token counting, draft auto-save, and unsaved changes guard
- **Command palette integration**: `usePromptPaletteCommands` hook surfaces favorite/recent prompts in Cmd+K with new "prompt" category
- **Discoverability**: ContextualHint component with dismissible tips, PromptStarterCards (3 template cards in empty state), PromptKeyboardShortcutsPanel

## New Files (12)
- `SmartCollections.tsx`, `FacetedFilters.tsx`, `FilterPresets.tsx`, `PromptSidebar.tsx`
- `PromptFullPageEditor.tsx`, `PromptEditorPreview.tsx`
- `usePromptPaletteCommands.ts`, `useFilterPresets.ts`, `useContextualHints.ts`
- `ContextualHint.tsx`, `PromptStarterCards.tsx`, `PromptKeyboardShortcutsPanel.tsx`

## Modified Files (6)
- `CommandPalette.tsx` — added "prompt" category
- `Layout.tsx` — wired prompt palette commands
- `PromptsWorkspace.tsx` — updated max-width for sidebar layout
- `index.tsx` — sidebar layout, full editor state, starter cards, contextual hints
- `prompt-workspace-types.ts` — extended `PromptSavedView` with "untagged"
- `PromptsWorkspace.layout.test.tsx` — updated assertion for new max-width

## Test Plan
- [x] All 127 existing prompt tests pass (28 test files)
- [x] No new TypeScript errors from changed files
- [ ] Manual: navigate to `/prompts`, verify sidebar renders with correct counts
- [ ] Manual: click "New prompt" or starter card, verify full-page editor opens
- [ ] Manual: press Cmd+K, verify prompts appear in palette
- [ ] Manual: test at 1440px, 768px, and 375px viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)