### PR TITLE
feat(connectors): add external file sync orchestration

### DIFF
--- a/Docs/API-related/Media_Ingest_Jobs_API.md
+++ b/Docs/API-related/Media_Ingest_Jobs_API.md
@@ -4,6 +4,22 @@ Submit background media ingestion jobs with cancellation support.
 
 Base path: `/api/v1/media`
 
+## Related Connector Sync Jobs
+
+External file-hosting sync does not use the `/api/v1/media/ingest/jobs` endpoints directly.
+Google Drive and Microsoft OneDrive source sync runs are queued through the connectors API and the core Jobs domain `connectors`.
+
+- Connector endpoints:
+  - `GET /api/v1/connectors/sources/{source_id}/sync` - source-level sync status, cursor state, webhook status, and active job summary
+  - `POST /api/v1/connectors/sources/{source_id}/sync` - queue a manual `incremental_sync` job
+  - `POST /api/v1/connectors/providers/{provider}/webhook` - webhook callback that validates, dedupes, and queues `incremental_sync`
+- Connector job types currently used for file-hosting sync:
+  - `import` - source creation / legacy bootstrap path
+  - `incremental_sync` - cursor-backed delta sync
+  - `subscription_renewal` - webhook renewal before expiry
+  - `repair_rescan` - scheduled replay/full-rescan recovery when a source is marked `needs_full_rescan`
+- Sync job result payloads include `processed`, `skipped`, `failed`, and, for file-hosting sync, `degraded` counts.
+
 ## Endpoints
 
 - POST `/ingest/jobs` - Submit jobs (one job per item)

--- a/Docs/Code_Documentation/Jobs_Module.md
+++ b/Docs/Code_Documentation/Jobs_Module.md
@@ -10,6 +10,41 @@ The Jobs module provides a reusable, DB-backed job queue with leasing, retries, 
 
 Use these names across domains to keep operations consistent.
 
+## Connectors Domain
+
+The external connectors stack now uses the Jobs module for user-visible and recurring file sync work.
+
+- Domain: `connectors`
+- Queue: `default`
+- Current job types:
+  - `import`
+  - `incremental_sync`
+  - `subscription_renewal`
+  - `repair_rescan`
+- Trigger paths:
+  - connector source creation can enqueue `import`
+  - `POST /api/v1/connectors/sources/{source_id}/sync` enqueues `incremental_sync`
+  - provider webhooks enqueue `incremental_sync` after validation and dedupe
+  - the recurring connectors sync scheduler enqueues `incremental_sync`, `subscription_renewal`, or `repair_rescan`
+
+### Source-Scoped Fencing
+
+Connector sync jobs are not only deduped at Jobs level. They also reserve a source-scoped fence in `external_source_sync_state`.
+
+- `active_job_id` and `active_job_started_at` track the current source owner
+- duplicate submissions for the same source return the already-active job when it is still live
+- stale fences are cleared before reserving a new job
+- workers renew their Jobs lease and update source sync state while running
+- file-hosting sync jobs report `processed`, `skipped`, `failed`, and `degraded` counts in the job result
+
+### Recurring Connector Scheduler
+
+`tldw_Server_API/app/services/connectors_sync_scheduler.py` is an APScheduler bridge that scans sources and enqueues Jobs. It does not perform sync work itself.
+
+- `CONNECTORS_SYNC_SCHEDULER_ENABLED=true` starts the service at app startup
+- `CONNECTORS_SYNC_SCHEDULER_SCAN_SEC` controls scan cadence (default `300`)
+- `CONNECTORS_SYNC_RENEWAL_LOOKAHEAD_SEC` controls how early expiring webhook subscriptions are renewed (default `3600`)
+
 ## Admin Quick Reference
 
 - Safe reads

--- a/Docs/Plans/2026-03-07-external-file-hosting-sync-design.md
+++ b/Docs/Plans/2026-03-07-external-file-hosting-sync-design.md
@@ -1,0 +1,446 @@
+# External File Hosting Sync Design
+
+Date: 2026-03-07
+Status: Approved
+
+## Summary
+
+Add version-aware import and sync support for external file-hosting providers, starting with Google Drive and Microsoft OneDrive, while designing the system so Dropbox, Box, and SharePoint can be added later without schema churn.
+
+The system should reconcile upstream file state with existing local media items, create new `DocumentVersions` when remote content changes, preserve the last good local version if a new upstream revision fails ingestion, and archive local items when the upstream file is removed or access is revoked.
+
+## Product Decisions (Approved)
+
+- Local update model: versioned
+- Initial provider scope: Google Drive and OneDrive, with Dropbox/Box/SharePoint-ready abstractions
+- Trigger model: hybrid event-driven, using provider webhooks/subscriptions with polling fallback
+- Source types in v1: folders/libraries, individual files, and shared links
+- Failed new upstream revision policy: keep the last good local version active
+- Upstream removal policy: archive locally but keep searchable history and versions
+
+## Goals
+
+- Reuse the existing connectors stack instead of building a parallel integration subsystem.
+- Support one-time bootstrap import plus ongoing sync for Google Drive and OneDrive.
+- Maintain a stable mapping from a remote object to a local `Media` item.
+- Create new `DocumentVersions` when remote content changes.
+- Distinguish content changes from metadata-only changes such as rename or move.
+- Archive local items when the upstream object is removed or becomes inaccessible.
+- Keep sync execution visible in the existing Jobs system.
+- Support webhook-first freshness without depending on webhooks for correctness.
+
+## Non-Goals
+
+- Shipping Dropbox, Box, or SharePoint as first-class UI options in the initial release.
+- Replacing the existing connectors API surface.
+- Introducing a separate version store outside `Media` and `DocumentVersions`.
+- Performing heavy sync work directly in webhook handlers.
+- Full enterprise admin UX for every provider-specific source type in v1.
+
+## Existing Repo Anchors
+
+The design extends existing code instead of replacing it:
+
+- Connectors API and CRUD:
+  - `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- Connectors service and provider registry:
+  - `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+  - `tldw_Server_API/app/core/External_Sources/google_drive.py`
+  - `tldw_Server_API/app/core/External_Sources/notion.py`
+  - `tldw_Server_API/app/core/External_Sources/gmail.py`
+- Existing async worker patterns:
+  - `tldw_Server_API/app/services/connectors_worker.py`
+- Existing media update and versioning primitives:
+  - `tldw_Server_API/app/core/Ingestion_Media_Processing/Media_Update_lib.py`
+  - `tldw_Server_API/app/core/DB_Management/Media_DB_v2.py`
+- Existing Jobs system:
+  - `Docs/Code_Documentation/Jobs_Module.md`
+
+## Recommended Architecture
+
+### 1. Provider Sync Adapters
+
+Add a provider sync adapter contract under `External_Sources/` for file-hosting providers. Each adapter should isolate provider-specific behavior:
+
+- `browse_source`
+- `resolve_shared_link`
+- `list_children`
+- `list_changes`
+- `get_item_metadata`
+- `download_or_export`
+- `subscribe_webhook`
+- `renew_webhook`
+- `revoke_webhook`
+
+This keeps Drive-, Graph-, Dropbox-, or Box-specific logic out of the shared reconciliation path.
+
+### 2. Shared Sync Coordinator
+
+Add one shared sync coordinator service that owns the generic lifecycle:
+
+- source loading
+- token refresh
+- cursor and webhook bookkeeping
+- dedupe
+- retry and backoff
+- change normalization
+- remote-to-local reconciliation
+- version creation
+- archive-on-removal behavior
+- degraded-state handling when the latest remote revision fails
+
+The current Gmail sync code in `connectors_worker.py` is the strongest behavioral precedent for cursor handling, retry state, and run finalization.
+
+### 3. Jobs as the Execution Backbone
+
+Use the existing Jobs system for all user-visible or admin-visible async work. Planned job types:
+
+- `bootstrap_scan`
+- `incremental_sync`
+- `manual_resync`
+- `subscription_renewal`
+- `repair_rescan`
+
+APScheduler should only enqueue work. It should not own sync state or replace Jobs.
+
+### 4. Webhooks as Triggers Only
+
+Webhook endpoints should:
+
+- validate the provider request
+- dedupe provider events
+- mark the relevant source as needing sync
+- enqueue an `incremental_sync` job
+- return immediately
+
+Webhook handlers must not download files or ingest content inline.
+
+## Data Model
+
+Keep the existing connector tables:
+
+- `external_accounts`
+- `external_sources`
+- `external_items`
+
+Add purpose-specific sync tables.
+
+### `external_source_sync_state`
+
+One row per source. Tracks source-level sync health and cursors.
+
+Suggested fields:
+
+- `source_id`
+- `sync_mode` (`manual`, `poll`, `hybrid`)
+- `cursor`
+- `cursor_kind`
+- `last_bootstrap_at`
+- `last_sync_started_at`
+- `last_sync_succeeded_at`
+- `last_sync_failed_at`
+- `last_error`
+- `retry_backoff_count`
+- `webhook_status`
+- `webhook_subscription_id`
+- `webhook_expires_at`
+- `needs_full_rescan`
+- `consecutive_failures`
+
+### `external_item_bindings`
+
+One row per remote object bound to one local `Media` item.
+
+Suggested fields:
+
+- `id`
+- `source_id`
+- `provider`
+- `remote_id`
+- `remote_parent_id`
+- `remote_path`
+- `remote_name`
+- `remote_etag`
+- `remote_revision`
+- `remote_hash`
+- `remote_modified_at`
+- `remote_deleted_at`
+- `access_revoked_at`
+- `media_id`
+- `current_version_number`
+- `last_seen_at`
+- `last_content_sync_at`
+- `last_metadata_sync_at`
+- `sync_status` (`active`, `degraded`, `archived_upstream_removed`, `orphaned`)
+
+Constraints:
+
+- unique key on `(source_id, provider, remote_id)`
+
+### `external_item_events`
+
+Append-only audit trail for per-item state transitions.
+
+Suggested fields:
+
+- `binding_id`
+- `event_type` (`created`, `content_updated`, `metadata_updated`, `deleted_upstream`, `restored_upstream`, `access_revoked`, `ingest_failed`, `archived`)
+- `job_id`
+- `occurred_at`
+- `payload_json`
+
+## Local Persistence Model
+
+Do not create a separate content version subsystem. Use the existing Media DB model:
+
+- One stable `Media` row per bound remote object
+- One new `DocumentVersion` per upstream content revision
+
+This aligns with existing helpers such as:
+
+- `create_document_version(...)`
+- `process_media_update(...)`
+- `get_all_document_versions(...)`
+
+Provider metadata should be persisted in two places:
+
+1. Stable operational mapping in `external_item_bindings`
+2. Per-revision provider snapshot in `DocumentVersions.safe_metadata`
+
+Suggested `safe_metadata` payload on each synced version:
+
+- `provider`
+- `source_id`
+- `remote_id`
+- `remote_revision`
+- `remote_etag`
+- `remote_hash`
+- `remote_path`
+- `remote_url`
+- `sync_job_id`
+- `sync_kind`
+- `upstream_deleted`
+- `export_mime`
+- `provider_metadata`
+
+## Sync Lifecycle
+
+### 1. Bootstrap Import
+
+When a source is first connected:
+
+1. enqueue `bootstrap_scan`
+2. enumerate the source recursively
+3. resolve shared links to canonical remote IDs when possible
+4. create `external_item_bindings` for discovered files
+5. ingest supported items into `Media`
+6. create initial `DocumentVersions`
+7. persist the initial cursor or delta token
+8. create and store webhook subscription state if supported
+
+### 2. Incremental Sync
+
+Triggered by polling, manual run, or webhook:
+
+1. load source state from `external_source_sync_state`
+2. if `needs_full_rescan` is true, run a bounded repair rescan instead of delta
+3. call the provider adapter for `list_changes(cursor)`
+4. normalize provider responses into shared change types
+5. reconcile each normalized change against `external_item_bindings`
+6. persist updated cursor or delta token
+7. finalize job result and source sync health
+
+### 3. Normalized Change Types
+
+Provider-specific events should be normalized into:
+
+- `created`
+- `content_updated`
+- `metadata_updated`
+- `deleted`
+- `restored`
+- `permission_lost`
+
+### 4. Reconciliation Rules
+
+#### `created`
+
+- If no binding exists, ingest and bind.
+- If a binding exists but is archived, restore it and refresh metadata.
+
+#### `content_updated`
+
+- Download or export the latest content.
+- Compare provider revision and content hash.
+- If unchanged, no-op.
+- If changed, create a new `DocumentVersion` for the existing `media_id`.
+- Update binding fields including revision, hash, modification time, and current version number.
+
+#### `metadata_updated`
+
+- Update binding metadata only.
+- Do not create a new `DocumentVersion` for rename, move, or path-only changes.
+
+#### `deleted` or `permission_lost`
+
+- Mark the binding as `archived_upstream_removed` or `orphaned`.
+- Archive the local media item from default active views.
+- Preserve version history and audit trail.
+
+#### `restored`
+
+- Unarchive the local media item.
+- Refresh metadata.
+- Optionally force a content refresh if the provider cannot prove the latest content hash or revision.
+
+## Failure and Recovery Rules
+
+### Keep the Last Good Version Active
+
+If the newest remote revision fails download, conversion, or ingestion:
+
+- leave the current local media item and latest good `DocumentVersion` active
+- mark the binding `degraded`
+- record an `ingest_failed` event
+- surface the failure at source and job level
+
+### Cursor Recovery
+
+If a provider cursor or delta token becomes invalid or expires:
+
+- mark `needs_full_rescan = true`
+- record source-level failure state
+- enqueue or allow a bounded repair rescan
+
+### Partial Failures
+
+If a source sync partially succeeds:
+
+- persist successfully processed item updates
+- keep the job result explicit about processed, skipped, and failed counts
+- do not roll back already-ingested items
+
+## API and Worker Additions
+
+The existing connectors API should remain the entry point. Additive endpoints or behaviors may include:
+
+- source sync trigger for file-hosting sources
+- source sync status fields
+- webhook callback endpoints per provider
+- subscription status and expiry visibility
+
+Jobs should remain queryable through the existing Jobs surfaces rather than a connectors-specific status system.
+
+## Provider Notes
+
+### Google Drive
+
+- Use IDs as canonical identity, not paths.
+- Prefer `changes.getStartPageToken` and `changes.list` for incremental sync.
+- Support Google-native exports:
+  - Docs -> text or markdown-oriented export
+  - Sheets -> CSV
+  - Slides -> PDF plus existing PDF text extraction path
+- Shared drives should be supported at the adapter layer from the start.
+
+### OneDrive
+
+- Build on Microsoft Graph delta APIs.
+- Treat personal and business drives through the same adapter contract.
+- Preserve `drive_id` and related Graph identity metadata in binding or provider metadata, not just item ID.
+- Subscription renewal must be a first-class recurring job because Graph subscriptions expire.
+
+### SharePoint
+
+- Not a first-class v1 UI target.
+- Design the OneDrive or Graph adapter so SharePoint document libraries are source variants without schema changes.
+- Source metadata must be able to carry `site_id`, `drive_id`, and library context.
+
+### Dropbox and Box
+
+- Both should fit the same binding and shared coordinator model later.
+- No schema redesign should be required when they are added.
+
+## Security and Governance
+
+- Reuse existing OAuth account and policy enforcement in the connectors module.
+- Encrypt tokens at rest and never log them.
+- Keep provider accounts and sources scoped to the authenticated user or tenant.
+- Validate webhook signatures and dedupe provider events.
+- Respect existing org policy controls for enabled providers, file types, and size limits.
+
+## Observability
+
+Track at minimum:
+
+- source sync runs by provider and outcome
+- item reconciliation counts by event type
+- degraded item count
+- webhook delivery or renewal failures
+- cursor invalidation or full rescan occurrences
+- subscription expiry proximity for providers that require renewal
+
+The Gmail sync metrics model is a useful precedent for per-source health and recovery instrumentation.
+
+## Testing Strategy
+
+### Unit Tests
+
+- provider change normalization
+- reconciliation decisions
+- archive and restore transitions
+- degraded-state handling
+- cursor invalidation and fallback to rescan
+- shared-link resolution
+
+### Integration Tests
+
+- bootstrap scan creates bindings, media items, and document versions
+- content update creates a new `DocumentVersion` on the same `media_id`
+- rename or move updates metadata without creating a content version
+- upstream deletion archives the local item
+- webhook requests enqueue sync jobs but do not execute heavy work inline
+
+### Property-Based Tests
+
+- idempotent repeated delta application
+- duplicate webhook delivery
+- out-of-order metadata and content events
+
+### Regression Tests
+
+- existing connectors import behavior remains intact
+- Gmail and email sync behavior remains isolated from file-hosting sync semantics
+- media versioning endpoints continue to work with synced items
+
+## Rollout Plan
+
+### Phase 1
+
+- Add sync state and binding tables
+- Add provider sync adapter contract
+- Implement Drive and OneDrive bootstrap import plus manual or scheduled sync
+- Create new `DocumentVersions` for remote content changes
+- Archive-on-removal behavior
+
+### Phase 2
+
+- Add webhook ingress and subscription renewal flows
+- Add degraded-item repair and cursor-rescan flows
+- Improve source and job observability
+
+### Phase 3
+
+- Add SharePoint-oriented source UX
+- Add Dropbox and Box adapters
+- Add richer admin and conflict tooling
+
+## Acceptance Criteria
+
+- A Drive or OneDrive source can bootstrap import into local `Media`.
+- Subsequent upstream content changes create new `DocumentVersions` on the same `media_id`.
+- Metadata-only changes do not create extra content versions.
+- Failed latest upstream revisions do not replace the last good local version.
+- Upstream deletions or permission loss archive local items while preserving history.
+- Sync runs are visible in the existing Jobs system.
+- Provider webhook support improves freshness but polling fallback preserves correctness.

--- a/Docs/Plans/2026-03-07-external-file-hosting-sync-design.md
+++ b/Docs/Plans/2026-03-07-external-file-hosting-sync-design.md
@@ -121,9 +121,10 @@ Keep the existing connector tables:
 
 - `external_accounts`
 - `external_sources`
-- `external_items`
 
-Add purpose-specific sync tables.
+Evolve `external_items` into the canonical remote-object binding table instead of adding a second item-mapping table. The current connectors implementation already uses `external_items` for dedupe and ingest state, so v1 should extend that table in place rather than create a competing source of truth.
+
+Add purpose-specific sync tables alongside it.
 
 ### `external_source_sync_state`
 
@@ -146,17 +147,20 @@ Suggested fields:
 - `webhook_expires_at`
 - `needs_full_rescan`
 - `consecutive_failures`
+- `active_job_id`
+- `active_run_token`
+- `active_lease_expires_at`
 
-### `external_item_bindings`
+### `external_items`
 
-One row per remote object bound to one local `Media` item.
+One row per remote object bound to one local `Media` item. This table replaces the “dedupe only” role it has today and becomes the single source of truth for remote identity, local binding, and item-level sync state.
 
 Suggested fields:
 
 - `id`
 - `source_id`
 - `provider`
-- `remote_id`
+- `external_id`
 - `remote_parent_id`
 - `remote_path`
 - `remote_name`
@@ -175,7 +179,7 @@ Suggested fields:
 
 Constraints:
 
-- unique key on `(source_id, provider, remote_id)`
+- unique key on `(source_id, provider, external_id)`
 
 ### `external_item_events`
 
@@ -183,7 +187,7 @@ Append-only audit trail for per-item state transitions.
 
 Suggested fields:
 
-- `binding_id`
+- `external_item_id`
 - `event_type` (`created`, `content_updated`, `metadata_updated`, `deleted_upstream`, `restored_upstream`, `access_revoked`, `ingest_failed`, `archived`)
 - `job_id`
 - `occurred_at`
@@ -199,13 +203,23 @@ Do not create a separate content version subsystem. Use the existing Media DB mo
 This aligns with existing helpers such as:
 
 - `create_document_version(...)`
-- `process_media_update(...)`
+- `add_media_with_keywords(..., overwrite=True)`
 - `get_all_document_versions(...)`
 
 Provider metadata should be persisted in two places:
 
-1. Stable operational mapping in `external_item_bindings`
+1. Stable operational mapping in `external_items`
 2. Per-revision provider snapshot in `DocumentVersions.safe_metadata`
+
+### Migration and Backfill
+
+Existing connector imports may already have rows in `external_items` that contain only dedupe fields. Before incremental sync is enabled for an existing source:
+
+- backfill the new binding columns in `external_items`
+- resolve or infer the bound `media_id` where possible
+- if a binding cannot be safely inferred, mark the source `needs_full_rescan = true` and require a bounded repair bootstrap before enabling incremental sync
+
+The rollout must not allow two parallel sources of truth for remote object state.
 
 Suggested `safe_metadata` payload on each synced version:
 
@@ -232,7 +246,7 @@ When a source is first connected:
 1. enqueue `bootstrap_scan`
 2. enumerate the source recursively
 3. resolve shared links to canonical remote IDs when possible
-4. create `external_item_bindings` for discovered files
+4. create or backfill `external_items` bindings for discovered files
 5. ingest supported items into `Media`
 6. create initial `DocumentVersions`
 7. persist the initial cursor or delta token
@@ -246,7 +260,7 @@ Triggered by polling, manual run, or webhook:
 2. if `needs_full_rescan` is true, run a bounded repair rescan instead of delta
 3. call the provider adapter for `list_changes(cursor)`
 4. normalize provider responses into shared change types
-5. reconcile each normalized change against `external_item_bindings`
+5. reconcile each normalized change against `external_items`
 6. persist updated cursor or delta token
 7. finalize job result and source sync health
 
@@ -273,8 +287,16 @@ Provider-specific events should be normalized into:
 - Download or export the latest content.
 - Compare provider revision and content hash.
 - If unchanged, no-op.
-- If changed, create a new `DocumentVersion` for the existing `media_id`.
+- If changed, update the existing `Media` row and create a new `DocumentVersion` in the same transaction.
+- The content-update path must atomically update:
+  - `Media.content`
+  - `Media.content_hash`
+  - `Media.last_modified`
+  - `Media.version`
+  - `media_fts`
+  - the new `DocumentVersion`
 - Update binding fields including revision, hash, modification time, and current version number.
+- Do not use `process_media_update()` as-is for this path, because it only appends a document version and does not refresh the canonical `Media` content or FTS state.
 
 #### `metadata_updated`
 
@@ -284,12 +306,12 @@ Provider-specific events should be normalized into:
 #### `deleted` or `permission_lost`
 
 - Mark the binding as `archived_upstream_removed` or `orphaned`.
-- Archive the local media item from default active views.
+- Archive the local media item from default active views using the existing trash semantics (`mark_as_trash`), not hard delete.
 - Preserve version history and audit trail.
 
 #### `restored`
 
-- Unarchive the local media item.
+- Unarchive the local media item using the existing restore semantics (`restore_from_trash`).
 - Refresh metadata.
 - Optionally force a content refresh if the provider cannot prove the latest content hash or revision.
 
@@ -320,6 +342,17 @@ If a source sync partially succeeds:
 - keep the job result explicit about processed, skipped, and failed counts
 - do not roll back already-ingested items
 
+## Source-Scoped Concurrency and Idempotency
+
+Hybrid triggering means polling, manual sync, and webhook-triggered sync can all target the same source. The system must therefore enforce source-scoped fencing:
+
+- at most one active processing sync run per source
+- every enqueued sync job uses a Jobs `idempotency_key` derived from `source_id`, `sync_kind`, and the strongest available cursor or event identity
+- `external_source_sync_state` tracks `active_job_id`, `active_run_token`, and lease expiry so stale or duplicated jobs can no-op safely
+- webhook retries or duplicate poll submissions must converge on the same queued job whenever possible
+
+Correctness must not depend on provider-side event uniqueness.
+
 ## API and Worker Additions
 
 The existing connectors API should remain the entry point. Additive endpoints or behaviors may include:
@@ -328,6 +361,13 @@ The existing connectors API should remain the entry point. Additive endpoints or
 - source sync status fields
 - webhook callback endpoints per provider
 - subscription status and expiry visibility
+
+The connector schema surface must also expand early enough to represent the approved v1 scope:
+
+- add provider `onedrive`
+- add source type `file`
+- keep existing Notion types (`page`, `database`) for backward compatibility
+- represent Microsoft library or site context through source `options` metadata until a distinct `library` type is justified
 
 Jobs should remain queryable through the existing Jobs surfaces rather than a connectors-specific status system.
 

--- a/Docs/Plans/2026-03-07-external-file-hosting-sync-implementation-plan.md
+++ b/Docs/Plans/2026-03-07-external-file-hosting-sync-implementation-plan.md
@@ -1,0 +1,707 @@
+# External File Hosting Sync Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add version-aware bootstrap import and ongoing sync for Google Drive and Microsoft OneDrive using the existing connectors stack, Jobs execution model, and native `Media` / `DocumentVersions` persistence.
+
+**Architecture:** Extend `External_Sources/` with a provider sync adapter contract and a shared sync coordinator. Evolve `external_items` into the canonical remote-to-media binding table, persist source-level cursors and run fences in the AuthNZ connector storage layer, run all sync work through the existing connectors Jobs worker using source-scoped idempotency, and reconcile remote content changes into atomic `Media` + `DocumentVersions` updates while archiving items on upstream removal.
+
+**Tech Stack:** FastAPI, existing connectors OAuth services, JobManager, APScheduler, SQLite/PostgreSQL via existing connector service abstractions, Media DB v2, pytest, loguru
+
+---
+
+### Task 1: Add the sync adapter contract
+
+**Files:**
+- Create: `tldw_Server_API/app/core/External_Sources/sync_adapter.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connector_base.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py`
+
+**Step 1: Write the failing test**
+
+```python
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
+
+
+def test_file_sync_change_normalizes_required_fields():
+    change = FileSyncChange(
+        event_type="content_updated",
+        remote_id="abc123",
+        remote_name="report.pdf",
+    )
+    assert change.event_type == "content_updated"
+    assert change.remote_id == "abc123"
+    assert change.remote_name == "report.pdf"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+```
+
+Expected: FAIL because `sync_adapter.py` and `FileSyncChange` do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create:
+
+```python
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class FileSyncChange:
+    event_type: str
+    remote_id: str
+    remote_name: str | None = None
+    metadata: dict[str, Any] | None = None
+```
+
+Then add a protocol or base class for:
+
+- `list_children`
+- `list_changes`
+- `get_item_metadata`
+- `download_or_export`
+- `resolve_shared_link`
+- `subscribe_webhook`
+- `renew_webhook`
+- `revoke_webhook`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/sync_adapter.py \
+        tldw_Server_API/app/core/External_Sources/connector_base.py \
+        tldw_Server_API/app/core/External_Sources/connectors_service.py \
+        tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+git commit -m "feat(connectors): add file sync adapter contract"
+```
+
+### Task 2: Extend connector storage into canonical sync state and bindings
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/README.md`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py`
+
+**Step 1: Write the failing test**
+
+```python
+async def test_external_items_upgrade_preserves_legacy_row_and_adds_binding_fields(db_backend):
+    source_id = await create_test_source(db_backend)
+    await upsert_source_sync_state(db_backend, source_id=source_id, sync_mode="hybrid")
+    binding = await upsert_external_item_binding(
+        db_backend,
+        source_id=source_id,
+        provider="drive",
+        external_id="file-1",
+        media_id=99,
+        sync_status="active",
+    )
+    state = await get_source_sync_state(db_backend, source_id=source_id)
+    assert binding["external_id"] == "file-1"
+    assert state["sync_mode"] == "hybrid"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+```
+
+Expected: FAIL because the new binding fields and sync-state helpers do not exist.
+
+**Step 3: Write minimal implementation**
+
+Add SQLite and PostgreSQL DDL and forward migrations for:
+
+- `external_source_sync_state`
+- new binding columns on `external_items`
+- `external_item_events`
+
+Implement service helpers for:
+
+- `get_source_sync_state`
+- `upsert_source_sync_state`
+- `upsert_external_item_binding`
+- `get_external_item_binding`
+- `list_external_items_for_source`
+- `record_item_event`
+- `mark_external_item_archived`
+
+Also implement a legacy-row upgrade path:
+
+- preserve existing `external_items` data
+- backfill new nullable columns
+- mark sources `needs_full_rescan` when a safe `media_id` binding cannot be inferred
+
+Keep these helpers in `connectors_service.py` until there is a clear need to split the module.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/connectors_service.py \
+        tldw_Server_API/app/core/External_Sources/README.md \
+        tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+git commit -m "feat(connectors): extend connector sync storage"
+```
+
+### Task 3: Extend Google Drive to support file-hosting sync primitives
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/External_Sources/google_drive.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/__init__.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py`
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_drive_changes_list_returns_normalized_page_token(fake_drive_connector):
+    changes, next_cursor, cursor_hint = await fake_drive_connector.list_changes(
+        account={"tokens": {"access_token": "token"}},
+        cursor="start-token",
+    )
+    assert changes[0]["remote_id"] == "file-1"
+    assert next_cursor == "page-2"
+    assert cursor_hint == "new-start-token"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+```
+
+Expected: FAIL because `list_changes` and related helpers do not exist.
+
+**Step 3: Write minimal implementation**
+
+Add Drive-specific methods for:
+
+- `get_start_page_token`
+- `list_changes`
+- `get_item_metadata`
+- `resolve_shared_link`
+- `download_or_export`
+
+Normalize Google change records into the shared contract using stable IDs, revision hints, hash, parent IDs, and deletion markers.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/google_drive.py \
+        tldw_Server_API/app/core/External_Sources/__init__.py \
+        tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+git commit -m "feat(connectors): add google drive sync primitives"
+```
+
+### Task 4: Add the OneDrive connector and Graph delta support
+
+**Files:**
+- Create: `tldw_Server_API/app/core/External_Sources/onedrive.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/__init__.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/connectors.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_onedrive_connector.py`
+
+**Step 1: Write the failing test**
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_onedrive_delta_returns_drive_and_item_identity(fake_onedrive_connector):
+    changes, next_cursor, delta_link = await fake_onedrive_connector.list_changes(
+        account={"tokens": {"access_token": "token"}},
+        cursor=None,
+    )
+    first = changes[0]
+    assert first["remote_id"] == "item-1"
+    assert first["metadata"]["drive_id"] == "drive-123"
+    assert delta_link == "https://graph.microsoft.com/delta-token"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+```
+
+Expected: FAIL because the connector does not exist yet and the API/schema do not accept `onedrive` or `file` sources.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- OAuth authorize and token exchange
+- token refresh
+- browsing source items
+- Graph delta support
+- file metadata retrieval
+- file download
+- webhook subscription create, renew, and revoke helpers
+- provider registration in connector endpoints
+- schema expansion so providers include `onedrive`
+- source schema expansion so file-hosting sources can use `type="file"`
+
+Register the provider name in the connector registry.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/onedrive.py \
+        tldw_Server_API/app/core/External_Sources/__init__.py \
+        tldw_Server_API/app/core/External_Sources/connectors_service.py \
+        tldw_Server_API/app/api/v1/endpoints/connectors.py \
+        tldw_Server_API/app/api/v1/schemas/connectors.py \
+        tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+git commit -m "feat(connectors): add onedrive connector"
+```
+
+### Task 5: Build the shared sync coordinator and reconciliation logic
+
+**Files:**
+- Create: `tldw_Server_API/app/core/External_Sources/sync_coordinator.py`
+- Modify: `tldw_Server_API/app/core/Ingestion_Media_Processing/Media_Update_lib.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/Media_DB_v2.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_sync_coordinator.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_content_update_creates_new_document_version_for_existing_media(fake_sync_context):
+    result = reconcile_change(
+        change={"event_type": "content_updated", "remote_id": "file-1", "remote_revision": "r2"},
+        context=fake_sync_context,
+    )
+    assert result.action == "version_created"
+    assert result.media_id == 42
+    assert result.current_version_number == 2
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
+```
+
+Expected: FAIL because `sync_coordinator.py` and reconciliation helpers do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement a coordinator that can:
+
+- bootstrap import
+- incremental sync from a stored cursor
+- normalize per-provider change records
+- detect content change vs metadata-only change
+- create a new `DocumentVersion` for content updates
+- archive local media for upstream deletion or permission loss
+- keep the last good local version active when ingestion fails
+- record per-item events and update binding state
+
+For content updates, add or wrap a helper that atomically:
+
+- updates `Media.content`
+- updates `Media.content_hash`
+- updates `Media.last_modified`
+- increments `Media.version`
+- refreshes `media_fts`
+- creates the new `DocumentVersion`
+
+Do not use `process_media_update()` as-is for this path. Reuse the existing full-update semantics already present in `Media_DB_v2` rather than inventing a second versioning behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/External_Sources/sync_coordinator.py \
+        tldw_Server_API/app/core/Ingestion_Media_Processing/Media_Update_lib.py \
+        tldw_Server_API/app/core/DB_Management/Media_DB_v2.py \
+        tldw_Server_API/app/core/External_Sources/connectors_service.py \
+        tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
+git commit -m "feat(connectors): add shared file sync coordinator"
+```
+
+### Task 6: Add source-scoped sync enqueueing and worker fencing
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/connectors_worker.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_duplicate_incremental_sync_submissions_share_idempotent_job_id():
+    job1 = enqueue_source_sync_job(source_id=11, user_id=3, provider="drive", sync_kind="incremental_sync", cursor_hint="abc")
+    job2 = enqueue_source_sync_job(source_id=11, user_id=3, provider="drive", sync_kind="incremental_sync", cursor_hint="abc")
+    assert job1["id"] == job2["id"]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+```
+
+Expected: FAIL because the connector layer does not yet submit idempotent source-scoped sync jobs.
+
+**Step 3: Write minimal implementation**
+
+Add enqueue helpers that:
+
+- derive a Jobs `idempotency_key` from `source_id`, `sync_kind`, and cursor or event identity
+- store `active_job_id`, `active_run_token`, and lease metadata in `external_source_sync_state`
+- prevent overlapping active sync runs for a single source
+
+Then update the worker to:
+
+- route `bootstrap_scan`, `incremental_sync`, `manual_resync`, `subscription_renewal`, and `repair_rescan`
+- continue supporting existing import and Gmail behaviors
+- renew job leases during long sync runs
+- report processed, skipped, failed, and degraded counts in job results
+- no-op safely when a stale or duplicate job loses the source fence
+
+Keep provider-specific logic out of the worker; it should call the shared coordinator.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/connectors_worker.py \
+        tldw_Server_API/app/core/External_Sources/connectors_service.py \
+        tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+git commit -m "feat(connectors): add source-scoped sync fencing"
+```
+
+### Task 7: Expose sync-aware API fields and manual triggers
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/connectors.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_list_sources_includes_sync_state(client, auth_headers):
+    response = client.get("/api/v1/connectors/sources", headers=auth_headers)
+    body = response.json()
+    assert "sync" in body["items"][0]
+    assert "state" in body["items"][0]["sync"]
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+```
+
+Expected: FAIL because source responses do not include sync metadata yet.
+
+**Step 3: Write minimal implementation**
+
+Extend schemas and endpoints to:
+
+- return source-level sync status
+- expose last sync timestamps, webhook status, and degraded counts where available
+- allow a manual sync trigger for file-hosting sources
+- keep existing endpoints backward compatible for current connector consumers
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/connectors.py \
+        tldw_Server_API/app/api/v1/schemas/connectors.py \
+        tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+git commit -m "feat(connectors): expose sync status in connectors api"
+```
+
+### Task 8: Add webhook ingress and subscription renewal
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/connectors.py`
+- Modify: `tldw_Server_API/app/services/connectors_worker.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/google_drive.py`
+- Modify: `tldw_Server_API/app/core/External_Sources/onedrive.py`
+- Test: `tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_webhook_callback_enqueues_incremental_sync_and_returns_fast(client, signed_webhook_headers):
+    response = client.post(
+        "/api/v1/connectors/providers/onedrive/webhook",
+        headers=signed_webhook_headers,
+        json={"value": [{"subscriptionId": "sub-1"}]},
+    )
+    assert response.status_code == 202
+    assert response.json()["status"] == "queued"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
+```
+
+Expected: FAIL because webhook endpoints and renewal behavior are not implemented.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- provider webhook callback endpoints
+- signature or subscription validation
+- dedupe receipt storage in connector service
+- queueing of `incremental_sync`
+- `subscription_renewal` worker behavior for expiring subscriptions
+
+Do not do content fetch or ingest in the request path.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/connectors.py \
+        tldw_Server_API/app/services/connectors_worker.py \
+        tldw_Server_API/app/core/External_Sources/google_drive.py \
+        tldw_Server_API/app/core/External_Sources/onedrive.py \
+        tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
+git commit -m "feat(connectors): add webhook-triggered file sync"
+```
+
+### Task 9: Add end-to-end bootstrap and versioning integration tests
+
+**Files:**
+- Create: `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py`
+- Modify: `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py`
+- Modify: `tldw_Server_API/tests/External_Sources/fixtures/`
+
+**Step 1: Write the failing test**
+
+```python
+def test_drive_file_update_creates_new_document_version_for_same_media_id(client_with_auth, fake_drive_sync):
+    source_id = create_drive_source(client_with_auth)
+    run_bootstrap_sync(client_with_auth, source_id)
+    media_id = fetch_bound_media_id(source_id, external_id="file-1")
+    run_incremental_sync(client_with_auth, source_id, revision="r2")
+    versions = list_versions(client_with_auth, media_id)
+    assert len(versions) == 2
+    assert versions[-1]["version_number"] == 2
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py
+```
+
+Expected: FAIL because the full flow is not wired together yet.
+
+**Step 3: Write minimal implementation**
+
+Fill in any missing test fixtures, endpoint wiring, or worker integration needed to make:
+
+- bootstrap import
+- incremental content update
+- metadata-only update
+- upstream delete to archive
+- last-good-version preservation on ingest failure
+
+work end-to-end through the real service boundaries.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py \
+        tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py \
+        tldw_Server_API/tests/External_Sources/fixtures
+git commit -m "test(connectors): cover external file sync versioning flow"
+```
+
+### Task 10: Verify, document, and harden the touched scope
+
+**Files:**
+- Modify: `Docs/API-related/Media_Ingest_Jobs_API.md`
+- Modify: `Docs/Code_Documentation/Jobs_Module.md`
+- Modify: `tldw_Server_API/app/core/External_Sources/README.md`
+
+**Step 1: Write the failing doc and security checklist**
+
+Create a checklist in your working notes with:
+
+- touched tests to run
+- docs to update
+- bandit scope to scan
+- any feature flags or env vars introduced
+
+**Step 2: Run verification commands before finalizing**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v \
+  tldw_Server_API/tests/External_Sources \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py
+```
+
+Expected: PASS
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/External_Sources \
+  tldw_Server_API/app/services/connectors_worker.py \
+  tldw_Server_API/app/api/v1/endpoints/connectors.py \
+  -f json -o /tmp/bandit_external_file_sync.json
+```
+
+Expected: JSON report written with no new high-severity findings in touched code.
+
+**Step 3: Write minimal documentation updates**
+
+Document:
+
+- new sync-capable providers
+- new source sync fields and job types
+- webhook trigger behavior
+- key env vars or feature flags
+
+**Step 4: Re-run targeted tests after doc-safe code changes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest -v tldw_Server_API/tests/External_Sources
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add Docs/API-related/Media_Ingest_Jobs_API.md \
+        Docs/Code_Documentation/Jobs_Module.md \
+        tldw_Server_API/app/core/External_Sources/README.md
+git commit -m "docs(connectors): document external file sync"
+```

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -48,6 +48,7 @@ from tldw_Server_API.app.core.External_Sources.connectors_service import (
     get_account_for_user,
     get_account_tokens,
     get_policy,
+    get_source_binding_health,
     get_source_by_id,
     get_source_by_webhook_subscription,
     get_source_sync_state,
@@ -177,10 +178,14 @@ def _load_active_job(sync_state: dict[str, Any] | None) -> dict[str, Any] | None
         return None
 
 
-def _build_source_sync_summary(sync_state: dict[str, Any] | None) -> ConnectorSourceSyncSummary | None:
+def _build_source_sync_summary(
+    sync_state: dict[str, Any] | None,
+    binding_health: dict[str, int] | None = None,
+) -> ConnectorSourceSyncSummary | None:
     if not sync_state:
         return None
     active_job = _load_active_job(sync_state)
+    binding_health = binding_health or {}
     return ConnectorSourceSyncSummary(
         state=_derive_sync_state(sync_state, active_job),
         sync_mode=str(sync_state.get("sync_mode") or "manual"),
@@ -190,6 +195,8 @@ def _build_source_sync_summary(sync_state: dict[str, Any] | None) -> ConnectorSo
         webhook_status=sync_state.get("webhook_status"),
         needs_full_rescan=bool(sync_state.get("needs_full_rescan")),
         active_job_id=str(sync_state.get("active_job_id") or "").strip() or None,
+        tracked_item_count=int(binding_health.get("tracked_item_count") or 0),
+        degraded_item_count=int(binding_health.get("degraded_item_count") or 0),
     )
 
 
@@ -620,6 +627,7 @@ async def get_sources(
     out: list[ConnectorSource] = []
     for r in rows:
         sync_state = await get_source_sync_state(db, source_id=int(r.get("id")))
+        binding_health = await get_source_binding_health(db, source_id=int(r.get("id")))
         out.append(
             ConnectorSource(
                 id=int(r.get("id")),
@@ -631,7 +639,7 @@ async def get_sources(
                 options=SyncOptions(**(r.get("options") or {})),
                 enabled=bool(r.get("enabled", True)),
                 last_synced_at=str(r.get("last_synced_at")) if r.get("last_synced_at") else None,
-                sync=_build_source_sync_summary(sync_state),
+                sync=_build_source_sync_summary(sync_state, binding_health),
             )
         )
     return out
@@ -694,6 +702,7 @@ async def get_source_sync_status(
         raise HTTPException(status_code=404, detail="Source not found")
 
     sync_state = await get_source_sync_state(db, source_id=source_id) or {}
+    binding_health = await get_source_binding_health(db, source_id=source_id)
     active_job = _load_active_job(sync_state)
     active_job_id = str(sync_state.get("active_job_id") or "").strip() or None
 
@@ -717,6 +726,8 @@ async def get_source_sync_status(
         active_job_id=active_job_id,
         active_job_started_at=_as_str_or_none(sync_state.get("active_job_started_at")),
         active_job=_summarize_job(active_job),
+        tracked_item_count=int(binding_health.get("tracked_item_count") or 0),
+        degraded_item_count=int(binding_health.get("degraded_item_count") or 0),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -128,7 +128,7 @@ def _gmail_connector_enabled() -> bool:
 
 def _ensure_connector_provider_enabled(provider: str) -> str:
     normalized = str(provider or "").strip().lower()
-    if normalized not in {"drive", "notion", "gmail"}:
+    if normalized not in {"drive", "notion", "gmail", "onedrive"}:
         raise HTTPException(status_code=404, detail=f"Unknown connector provider: {provider}")
     if normalized == "gmail" and not _gmail_connector_enabled():
         raise HTTPException(status_code=404, detail="Connector provider 'gmail' is disabled.")
@@ -139,6 +139,7 @@ def _ensure_connector_provider_enabled(provider: str) -> str:
 async def list_providers() -> list[ConnectorProvider]:
     providers: list[ConnectorProvider] = [
         ConnectorProvider(name="drive", scopes_required=["drive.readonly"], auth_type="oauth2"),
+        ConnectorProvider(name="onedrive", scopes_required=["Files.Read"], auth_type="oauth2"),
         ConnectorProvider(name="notion", scopes_required=[], auth_type="oauth2"),
     ]
     if _gmail_connector_enabled():
@@ -350,6 +351,8 @@ async def browse_provider_sources(
     # For Drive, parent_remote_id None implies root
     try:
         if provider == "drive":
+            items, next_cursor = await conn.list_files({"tokens": tokens, "email": email}, parent_remote_id or "root", page_size=page_size, cursor=cursor)
+        elif provider == "onedrive":
             items, next_cursor = await conn.list_files({"tokens": tokens, "email": email}, parent_remote_id or "root", page_size=page_size, cursor=cursor)
         elif provider == "notion":
             # Notion: treat parent_remote_id as workspace hint; we search globally for now

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -40,6 +40,7 @@ from tldw_Server_API.app.core.External_Sources import (
     get_connector_by_name,
 )
 from tldw_Server_API.app.core.External_Sources.connectors_service import (
+    FILE_SYNC_PROVIDERS,
     consume_oauth_state,
     count_connectors_jobs_today,
     create_account,
@@ -325,6 +326,15 @@ def _gmail_connector_enabled() -> bool:
         return bool(settings.get("EMAIL_GMAIL_CONNECTOR_ENABLED", False))
     except Exception:
         return False
+
+
+def _manual_sync_job_type(source: dict[str, Any], sync_state: dict[str, Any] | None) -> str:
+    provider = str(source.get("provider") or "").strip().lower()
+    if provider not in FILE_SYNC_PROVIDERS:
+        return "import"
+    if bool((sync_state or {}).get("needs_full_rescan")):
+        return "repair_rescan"
+    return "incremental_sync"
 
 
 def _ensure_connector_provider_enabled(provider: str) -> str:
@@ -805,6 +815,7 @@ async def trigger_source_sync(
     source = await get_source_by_id(db, user_id, source_id)
     if not source:
         raise HTTPException(status_code=404, detail="Source not found")
+    sync_state = await get_source_sync_state(db, source_id=source_id) or {}
 
     job = await _queue_source_job(
         source_id=source_id,
@@ -812,7 +823,7 @@ async def trigger_source_sync(
         principal=principal,
         org_policy=org_policy,
         count_jobs_fn=count_jobs_fn,
-        job_type="incremental_sync",
+        job_type=_manual_sync_job_type(source, sync_state),
     )
     return ConnectorSourceSyncTriggerResponse(
         source_id=int(source_id),

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -5,6 +5,7 @@ import json
 import os
 import secrets
 from typing import Any, Callable
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, PlainTextResponse
@@ -29,6 +30,8 @@ from tldw_Server_API.app.api.v1.schemas.connectors import (
     ConnectorSourceCreateRequest,
     ConnectorSourcePatchRequest,
     ConnectorSourceSyncStatus,
+    ConnectorSourceSyncTriggerResponse,
+    ConnectorWebhookCallbackResponse,
     ImportJob,
     SyncOptions,
 )
@@ -91,6 +94,31 @@ def _resolve_redirect_base(request: Request | None, conn) -> str:
             "Redirect base could not be resolved; OAuth redirect_uri may be invalid (expected only in tests)"
         )
     return resolved
+
+
+def _is_local_callback_base(base_url: str) -> bool:
+    try:
+        host = str(urlparse(base_url).hostname or "").strip().lower()
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return host in {"localhost", "127.0.0.1", "testserver"} or host.endswith(".localhost")
+
+
+def _resolve_webhook_callback_base(request: Request | None, conn) -> str:
+    configured_base = (os.getenv("CONNECTOR_REDIRECT_BASE_URL") or getattr(conn, "redirect_base", "") or "").rstrip("/")
+    if configured_base:
+        return configured_base
+    request_base = _resolve_redirect_base(request, conn)
+    if request_base and (
+        os.getenv("TEST_MODE", "").strip().lower() == "true"
+        or os.getenv("TESTING", "").strip().lower() == "true"
+        or _is_local_callback_base(request_base)
+    ):
+        return request_base
+    raise HTTPException(
+        status_code=500,
+        detail="CONNECTOR_REDIRECT_BASE_URL must be configured before enabling webhook subscriptions",
+    )
 
 
 def _get_user_id(principal: AuthPrincipal) -> int:
@@ -174,7 +202,8 @@ def _load_active_job(sync_state: dict[str, Any] | None) -> dict[str, Any] | None
         from tldw_Server_API.app.core.Jobs.manager import JobManager
 
         return JobManager().get_job(int(active_job_id))
-    except Exception:
+    except Exception as exc:
+        logger.warning("Failed to load active connectors job {}: {}", active_job_id, exc)
         return None
 
 
@@ -223,6 +252,38 @@ def _drive_webhook_receipt_key(request: Request) -> tuple[str | None, str | None
     receipt_key = f"{channel_id}:{message_number}:{resource_state}:{resource_id or ''}"
     payload_hash = hashlib.sha256(receipt_key.encode("utf-8")).hexdigest()
     return channel_id, receipt_key, payload_hash
+
+
+def _webhook_response(
+    *,
+    provider: str,
+    status: str,
+    queued_jobs: int = 0,
+    duplicate_notifications: int = 0,
+    ignored_notifications: int = 0,
+    source_ids: list[int] | None = None,
+) -> JSONResponse:
+    payload = ConnectorWebhookCallbackResponse(
+        provider=provider,
+        status=status,
+        queued_jobs=queued_jobs,
+        duplicate_notifications=duplicate_notifications,
+        ignored_notifications=ignored_notifications,
+        source_ids=source_ids or [],
+    )
+    return JSONResponse(status_code=202, content=payload.model_dump())
+
+
+def _provider_webhook_secret(source: dict[str, Any] | None) -> str | None:
+    metadata = dict((source or {}).get("webhook_metadata") or {})
+    secret = str(metadata.get("clientState") or metadata.get("token") or "").strip()
+    return secret or None
+
+
+def _matches_webhook_secret(expected: str | None, received: str | None) -> bool:
+    if not expected or not received:
+        return False
+    return secrets.compare_digest(expected, received)
 
 
 async def _queue_source_job(
@@ -558,7 +619,7 @@ async def add_source(
             tokens = await get_account_tokens(db, user_id, account_id)
             if tokens:
                 conn = get_connector_by_name(provider)
-                callback_base = _resolve_redirect_base(request, conn)
+                callback_base = _resolve_webhook_callback_base(request, conn)
                 callback_url = f"{callback_base}/api/v1/connectors/providers/{provider}/webhook"
                 resource_id = str(remote_id or "root").strip("/") or "root"
                 if provider == "onedrive":
@@ -731,7 +792,7 @@ async def get_source_sync_status(
     )
 
 
-@router.post("/sources/{source_id}/sync")
+@router.post("/sources/{source_id}/sync", response_model=ConnectorSourceSyncTriggerResponse)
 async def trigger_source_sync(
     source_id: int,
     request: Request,
@@ -739,7 +800,7 @@ async def trigger_source_sync(
     principal: AuthPrincipal = Depends(get_auth_principal),
     org_policy: dict[str, Any] = Depends(get_org_policy_from_principal),
     count_jobs_fn: Callable[[int], int] = Depends(get_connectors_job_counter),
-) -> dict[str, Any]:
+) -> ConnectorSourceSyncTriggerResponse:
     user_id = _get_user_id(principal)
     source = await get_source_by_id(db, user_id, source_id)
     if not source:
@@ -753,21 +814,21 @@ async def trigger_source_sync(
         count_jobs_fn=count_jobs_fn,
         job_type="incremental_sync",
     )
-    return {
-        "source_id": int(source_id),
-        "provider": str(source.get("provider")),
-        "status": "queued",
-        "job": job.model_dump(),
-    }
+    return ConnectorSourceSyncTriggerResponse(
+        source_id=int(source_id),
+        provider=str(source.get("provider")),
+        status="queued",
+        job=job,
+    )
 
 
-@router.api_route("/providers/{provider}/webhook", methods=["GET", "POST"])
+@router.api_route("/providers/{provider}/webhook", methods=["GET", "POST"], response_model=ConnectorWebhookCallbackResponse)
 async def provider_webhook_callback(
     provider: str,
     request: Request,
     validation_token: str | None = Query(None, alias="validationToken"),
     db=Depends(get_db_transaction),
-) -> Any:
+) -> ConnectorWebhookCallbackResponse | PlainTextResponse:
     provider = _ensure_connector_provider_enabled(provider)
     if validation_token is not None:
         return PlainTextResponse(validation_token)
@@ -776,17 +837,7 @@ async def provider_webhook_callback(
         request_id = ensure_request_id(request)
         channel_id, receipt_key, payload_hash = _drive_webhook_receipt_key(request)
         if not channel_id or not receipt_key:
-            return JSONResponse(
-                status_code=202,
-                content={
-                    "provider": provider,
-                    "status": "ignored",
-                    "queued_jobs": 0,
-                    "duplicate_notifications": 0,
-                    "ignored_notifications": 1,
-                    "source_ids": [],
-                },
-            )
+            return _webhook_response(provider=provider, status="ignored", ignored_notifications=1)
 
         source = await get_source_by_webhook_subscription(
             db,
@@ -794,17 +845,16 @@ async def provider_webhook_callback(
             subscription_id=channel_id,
         )
         if not source:
-            return JSONResponse(
-                status_code=202,
-                content={
-                    "provider": provider,
-                    "status": "ignored",
-                    "queued_jobs": 0,
-                    "duplicate_notifications": 0,
-                    "ignored_notifications": 1,
-                    "source_ids": [],
-                },
+            return _webhook_response(provider=provider, status="ignored", ignored_notifications=1)
+        expected_secret = _provider_webhook_secret(source)
+        received_secret = str(request.headers.get("X-Goog-Channel-Token") or "").strip() or None
+        if not _matches_webhook_secret(expected_secret, received_secret):
+            logger.warning(
+                "Rejected drive webhook with invalid secret for source_id={} channel_id={}",
+                source.get("id"),
+                channel_id,
             )
+            return _webhook_response(provider=provider, status="ignored", ignored_notifications=1)
 
         source_id = int(source.get("id"))
         is_new = await record_webhook_receipt(
@@ -815,16 +865,10 @@ async def provider_webhook_callback(
             payload_hash=payload_hash,
         )
         if not is_new:
-            return JSONResponse(
-                status_code=202,
-                content={
-                    "provider": provider,
-                    "status": "duplicate",
-                    "queued_jobs": 0,
-                    "duplicate_notifications": 1,
-                    "ignored_notifications": 0,
-                    "source_ids": [],
-                },
+            return _webhook_response(
+                provider=provider,
+                status="duplicate",
+                duplicate_notifications=1,
             )
 
         await create_import_job(
@@ -833,16 +877,11 @@ async def provider_webhook_callback(
             request_id=request_id,
             job_type="incremental_sync",
         )
-        return JSONResponse(
-            status_code=202,
-            content={
-                "provider": provider,
-                "status": "queued",
-                "queued_jobs": 1,
-                "duplicate_notifications": 0,
-                "ignored_notifications": 0,
-                "source_ids": [source_id],
-            },
+        return _webhook_response(
+            provider=provider,
+            status="queued",
+            queued_jobs=1,
+            source_ids=[source_id],
         )
 
     if provider != "onedrive":
@@ -880,6 +919,16 @@ async def provider_webhook_callback(
         if not source:
             ignored_notifications += 1
             continue
+        expected_secret = _provider_webhook_secret(source)
+        received_secret = str(notification.get("clientState") or "").strip() or None
+        if not _matches_webhook_secret(expected_secret, received_secret):
+            logger.warning(
+                "Rejected onedrive webhook with invalid secret for source_id={} subscription_id={}",
+                source.get("id"),
+                subscription_id,
+            )
+            ignored_notifications += 1
+            continue
         source_id = int(source.get("id"))
         is_new = await record_webhook_receipt(
             db,
@@ -904,16 +953,13 @@ async def provider_webhook_callback(
         queued_jobs += 1
 
     status = "queued" if queued_jobs else ("duplicate" if duplicate_notifications else "ignored")
-    return JSONResponse(
-        status_code=202,
-        content={
-            "provider": provider,
-            "status": status,
-            "queued_jobs": queued_jobs,
-            "duplicate_notifications": duplicate_notifications,
-            "ignored_notifications": ignored_notifications,
-            "source_ids": queued_source_ids,
-        },
+    return _webhook_response(
+        provider=provider,
+        status=status,
+        queued_jobs=queued_jobs,
+        duplicate_notifications=duplicate_notifications,
+        ignored_notifications=ignored_notifications,
+        source_ids=queued_source_ids,
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/connectors.py
+++ b/tldw_Server_API/app/api/v1/endpoints/connectors.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import secrets
 from typing import Any, Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
 from loguru import logger
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_500_INTERNAL_SERVER_ERROR
 
@@ -22,8 +25,10 @@ from tldw_Server_API.app.api.v1.schemas.connectors import (
     ConnectorPolicy,
     ConnectorProvider,
     ConnectorSource,
+    ConnectorSourceSyncSummary,
     ConnectorSourceCreateRequest,
     ConnectorSourcePatchRequest,
+    ConnectorSourceSyncStatus,
     ImportJob,
     SyncOptions,
 )
@@ -43,9 +48,14 @@ from tldw_Server_API.app.core.External_Sources.connectors_service import (
     get_account_for_user,
     get_account_tokens,
     get_policy,
+    get_source_by_id,
+    get_source_by_webhook_subscription,
+    get_source_sync_state,
     list_accounts,
     list_sources,
+    record_webhook_receipt,
     update_source,
+    upsert_source_sync_state,
     upsert_policy,
 )
 from tldw_Server_API.app.core.External_Sources.policy import (
@@ -117,6 +127,129 @@ def _principal_role_for_policy(principal: AuthPrincipal) -> str:
 def get_connectors_job_counter() -> Callable[[int], int]:
     """Dependency to supply the connectors job counter (overrideable in tests)."""
     return count_connectors_jobs_today
+
+
+def _as_str_or_none(value: Any) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _derive_sync_state(sync_state: dict[str, Any] | None, active_job: dict[str, Any] | None) -> str:
+    status = str((active_job or {}).get("status") or "").strip().lower()
+    if status == "processing":
+        return "running"
+    if status == "queued":
+        return "queued"
+    if sync_state and sync_state.get("needs_full_rescan"):
+        return "needs_full_rescan"
+    if sync_state and sync_state.get("last_sync_failed_at"):
+        return "failed"
+    if sync_state and sync_state.get("last_sync_succeeded_at"):
+        return "succeeded"
+    return "idle"
+
+
+def _summarize_job(job: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not job:
+        return None
+    result = job.get("result") if isinstance(job.get("result"), dict) else {}
+    return {
+        "id": str(job.get("id") or job.get("job_id") or job.get("uuid")),
+        "type": str(job.get("job_type") or "import"),
+        "status": str(job.get("status") or "queued"),
+        "progress_pct": int(job.get("progress_percent") or 0),
+        "counts": {
+            "processed": int((result or {}).get("processed") or 0),
+            "skipped": int((result or {}).get("skipped") or 0),
+            "failed": int((result or {}).get("failed") or 0),
+        },
+    }
+
+
+def _load_active_job(sync_state: dict[str, Any] | None) -> dict[str, Any] | None:
+    active_job_id = str((sync_state or {}).get("active_job_id") or "").strip() or None
+    if not active_job_id:
+        return None
+    try:
+        from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+        return JobManager().get_job(int(active_job_id))
+    except Exception:
+        return None
+
+
+def _build_source_sync_summary(sync_state: dict[str, Any] | None) -> ConnectorSourceSyncSummary | None:
+    if not sync_state:
+        return None
+    active_job = _load_active_job(sync_state)
+    return ConnectorSourceSyncSummary(
+        state=_derive_sync_state(sync_state, active_job),
+        sync_mode=str(sync_state.get("sync_mode") or "manual"),
+        last_sync_succeeded_at=_as_str_or_none(sync_state.get("last_sync_succeeded_at")),
+        last_sync_failed_at=_as_str_or_none(sync_state.get("last_sync_failed_at")),
+        last_error=sync_state.get("last_error"),
+        webhook_status=sync_state.get("webhook_status"),
+        needs_full_rescan=bool(sync_state.get("needs_full_rescan")),
+        active_job_id=str(sync_state.get("active_job_id") or "").strip() or None,
+    )
+
+
+def _webhook_payload_hash(payload: dict[str, Any]) -> str:
+    normalized = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _webhook_receipt_key(notification: dict[str, Any]) -> tuple[str | None, str | None]:
+    subscription_id = str(notification.get("subscriptionId") or "").strip() or None
+    if not subscription_id:
+        return None, None
+    payload_hash = _webhook_payload_hash(notification)
+    return f"{subscription_id}:{payload_hash}", payload_hash
+
+
+def _drive_webhook_receipt_key(request: Request) -> tuple[str | None, str | None, str | None]:
+    channel_id = str(request.headers.get("X-Goog-Channel-Id") or "").strip() or None
+    message_number = str(request.headers.get("X-Goog-Message-Number") or "").strip() or None
+    resource_state = str(request.headers.get("X-Goog-Resource-State") or "").strip() or None
+    resource_id = str(request.headers.get("X-Goog-Resource-Id") or "").strip() or None
+    if not channel_id or not message_number or not resource_state:
+        return channel_id, None, None
+    receipt_key = f"{channel_id}:{message_number}:{resource_state}:{resource_id or ''}"
+    payload_hash = hashlib.sha256(receipt_key.encode("utf-8")).hexdigest()
+    return channel_id, receipt_key, payload_hash
+
+
+async def _queue_source_job(
+    *,
+    source_id: int,
+    request: Request,
+    principal: AuthPrincipal,
+    org_policy: dict[str, Any],
+    count_jobs_fn: Callable[[int], int],
+    job_type: str = "import",
+) -> ImportJob:
+    user_id = _get_user_id(principal)
+    role = _principal_role_for_policy(principal)
+    qpr = org_policy.get("quotas_per_role") or {}
+    limits = qpr.get(role) or {}
+    max_jobs = int(limits.get("max_jobs_per_day") or 0)
+    if max_jobs > 0:
+        try:
+            today_count = count_jobs_fn(user_id)
+        except Exception as exc:
+            logger.exception(f"Quota check failed for user_id={user_id}: {exc}")
+            raise HTTPException(
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Daily import quota check failed",
+            ) from exc
+        if today_count >= max_jobs:
+            raise HTTPException(status_code=429, detail="Daily import quota reached for your role")
+    rid = ensure_request_id(request) if request is not None else None
+    tp = ensure_traceparent(request) if request is not None else ""
+    job = await create_import_job(user_id, source_id, request_id=rid, job_type=job_type)
+    get_ps_logger(request_id=rid, ps_component="endpoint", ps_job_kind="connectors", traceparent=tp).info(
+        "Queued connectors job: type=%s job_id=%s source_id=%s", job_type, job.get("id"), source_id
+    )
+    return ImportJob(**job)
 
 
 def _gmail_connector_enabled() -> bool:
@@ -367,6 +500,7 @@ async def browse_provider_sources(
 
 @router.post("/sources", response_model=ConnectorSource)
 async def add_source(
+    request: Request,
     payload: ConnectorSourceCreateRequest,
     db=Depends(get_db_transaction),
     principal: AuthPrincipal = Depends(get_auth_principal),
@@ -412,6 +546,58 @@ async def add_source(
         options=options,
         enabled=True,
     )
+    if provider in {"onedrive", "drive"}:
+        try:
+            tokens = await get_account_tokens(db, user_id, account_id)
+            if tokens:
+                conn = get_connector_by_name(provider)
+                callback_base = _resolve_redirect_base(request, conn)
+                callback_url = f"{callback_base}/api/v1/connectors/providers/{provider}/webhook"
+                resource_id = str(remote_id or "root").strip("/") or "root"
+                if provider == "onedrive":
+                    resource = {
+                        "resource": "me/drive/root" if resource_id == "root" else f"me/drive/items/{resource_id}",
+                        "change_type": "updated",
+                        "clientState": secrets.token_urlsafe(24),
+                    }
+                else:
+                    resource = {
+                        "pageToken": options.get("cursor"),
+                        "clientState": secrets.token_urlsafe(24),
+                    }
+                subscription = await conn.subscribe_webhook(
+                    {**acct, "tokens": tokens},
+                    resource=resource,
+                    callback_url=callback_url,
+                )
+                sync_updates: dict[str, Any] = {
+                    "sync_mode": "hybrid",
+                    "webhook_status": "pending",
+                }
+                if subscription:
+                    sync_updates["webhook_status"] = "active"
+                    sync_updates["webhook_subscription_id"] = subscription.subscription_id
+                    sync_updates["webhook_expires_at"] = subscription.expires_at
+                    sync_updates["webhook_metadata"] = subscription.metadata or {}
+                    if provider == "drive":
+                        page_token = str((subscription.metadata or {}).get("pageToken") or "").strip()
+                        if page_token:
+                            sync_updates["cursor"] = page_token
+                            sync_updates["cursor_kind"] = "drive_start_page_token"
+                await upsert_source_sync_state(
+                    db,
+                    source_id=int(row.get("id")),
+                    **sync_updates,
+                )
+        except Exception as exc:
+            logger.warning(f"{provider} webhook provisioning failed for source {row.get('id')}: {exc}")
+            await upsert_source_sync_state(
+                db,
+                source_id=int(row.get("id")),
+                sync_mode="hybrid",
+                webhook_status="failed",
+                last_error=str(exc),
+            )
     return ConnectorSource(
         id=int(row.get("id")),
         account_id=int(row.get("account_id")),
@@ -433,6 +619,7 @@ async def get_sources(
     rows = await list_sources(db, user_id)
     out: list[ConnectorSource] = []
     for r in rows:
+        sync_state = await get_source_sync_state(db, source_id=int(r.get("id")))
         out.append(
             ConnectorSource(
                 id=int(r.get("id")),
@@ -444,6 +631,7 @@ async def get_sources(
                 options=SyncOptions(**(r.get("options") or {})),
                 enabled=bool(r.get("enabled", True)),
                 last_synced_at=str(r.get("last_synced_at")) if r.get("last_synced_at") else None,
+                sync=_build_source_sync_summary(sync_state),
             )
         )
     return out
@@ -484,33 +672,238 @@ async def import_source(
     org_policy: dict[str, Any] = Depends(get_org_policy_from_principal),
     count_jobs_fn: Callable[[int], int] = Depends(get_connectors_job_counter),
 ) -> ImportJob:
-    # Enforce per-role daily quota from org policy for all modes; single-user
-    # admin callers naturally bypass via their configured role/quotas.
-    user_id = _get_user_id(principal)
-    role = _principal_role_for_policy(principal)
-    qpr = org_policy.get("quotas_per_role") or {}
-    limits = qpr.get(role) or {}
-    max_jobs = int(limits.get("max_jobs_per_day") or 0)
-    if max_jobs > 0:
-        try:
-            today_count = count_jobs_fn(user_id)
-        except Exception as exc:
-            logger.exception(f"Quota check failed for user_id={user_id}: {exc}")
-            raise HTTPException(
-                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Daily import quota check failed",
-            ) from exc
-        if today_count >= max_jobs:
-            raise HTTPException(status_code=429, detail="Daily import quota reached for your role")
-    # Correlate request → job
-    rid = ensure_request_id(request) if request is not None else None
-    tp = ensure_traceparent(request) if request is not None else ""
-    job = await create_import_job(user_id, source_id, request_id=rid)
-    # Structured log for queued import
-    get_ps_logger(request_id=rid, ps_component="endpoint", ps_job_kind="connectors", traceparent=tp).info(
-        "Queued connectors import job: job_id=%s source_id=%s", job.get("id"), source_id
+    return await _queue_source_job(
+        source_id=source_id,
+        request=request,
+        principal=principal,
+        org_policy=org_policy,
+        count_jobs_fn=count_jobs_fn,
+        job_type="import",
     )
-    return ImportJob(**job)
+
+
+@router.get("/sources/{source_id}/sync", response_model=ConnectorSourceSyncStatus)
+async def get_source_sync_status(
+    source_id: int,
+    db=Depends(get_db_transaction),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> ConnectorSourceSyncStatus:
+    user_id = _get_user_id(principal)
+    source = await get_source_by_id(db, user_id, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    sync_state = await get_source_sync_state(db, source_id=source_id) or {}
+    active_job = _load_active_job(sync_state)
+    active_job_id = str(sync_state.get("active_job_id") or "").strip() or None
+
+    return ConnectorSourceSyncStatus(
+        source_id=int(source_id),
+        provider=str(source.get("provider")),
+        enabled=bool(source.get("enabled", True)),
+        state=_derive_sync_state(sync_state, active_job),
+        sync_mode=str(sync_state.get("sync_mode") or "manual"),
+        cursor=sync_state.get("cursor"),
+        cursor_kind=sync_state.get("cursor_kind"),
+        last_bootstrap_at=_as_str_or_none(sync_state.get("last_bootstrap_at")),
+        last_sync_started_at=_as_str_or_none(sync_state.get("last_sync_started_at")),
+        last_sync_succeeded_at=_as_str_or_none(sync_state.get("last_sync_succeeded_at")),
+        last_sync_failed_at=_as_str_or_none(sync_state.get("last_sync_failed_at")),
+        last_error=sync_state.get("last_error"),
+        retry_backoff_count=int(sync_state.get("retry_backoff_count") or 0),
+        webhook_status=sync_state.get("webhook_status"),
+        webhook_expires_at=_as_str_or_none(sync_state.get("webhook_expires_at")),
+        needs_full_rescan=bool(sync_state.get("needs_full_rescan")),
+        active_job_id=active_job_id,
+        active_job_started_at=_as_str_or_none(sync_state.get("active_job_started_at")),
+        active_job=_summarize_job(active_job),
+    )
+
+
+@router.post("/sources/{source_id}/sync")
+async def trigger_source_sync(
+    source_id: int,
+    request: Request,
+    db=Depends(get_db_transaction),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    org_policy: dict[str, Any] = Depends(get_org_policy_from_principal),
+    count_jobs_fn: Callable[[int], int] = Depends(get_connectors_job_counter),
+) -> dict[str, Any]:
+    user_id = _get_user_id(principal)
+    source = await get_source_by_id(db, user_id, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    job = await _queue_source_job(
+        source_id=source_id,
+        request=request,
+        principal=principal,
+        org_policy=org_policy,
+        count_jobs_fn=count_jobs_fn,
+        job_type="incremental_sync",
+    )
+    return {
+        "source_id": int(source_id),
+        "provider": str(source.get("provider")),
+        "status": "queued",
+        "job": job.model_dump(),
+    }
+
+
+@router.api_route("/providers/{provider}/webhook", methods=["GET", "POST"])
+async def provider_webhook_callback(
+    provider: str,
+    request: Request,
+    validation_token: str | None = Query(None, alias="validationToken"),
+    db=Depends(get_db_transaction),
+) -> Any:
+    provider = _ensure_connector_provider_enabled(provider)
+    if validation_token is not None:
+        return PlainTextResponse(validation_token)
+
+    if provider == "drive":
+        request_id = ensure_request_id(request)
+        channel_id, receipt_key, payload_hash = _drive_webhook_receipt_key(request)
+        if not channel_id or not receipt_key:
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "provider": provider,
+                    "status": "ignored",
+                    "queued_jobs": 0,
+                    "duplicate_notifications": 0,
+                    "ignored_notifications": 1,
+                    "source_ids": [],
+                },
+            )
+
+        source = await get_source_by_webhook_subscription(
+            db,
+            provider=provider,
+            subscription_id=channel_id,
+        )
+        if not source:
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "provider": provider,
+                    "status": "ignored",
+                    "queued_jobs": 0,
+                    "duplicate_notifications": 0,
+                    "ignored_notifications": 1,
+                    "source_ids": [],
+                },
+            )
+
+        source_id = int(source.get("id"))
+        is_new = await record_webhook_receipt(
+            db,
+            provider=provider,
+            receipt_key=receipt_key,
+            source_id=source_id,
+            payload_hash=payload_hash,
+        )
+        if not is_new:
+            return JSONResponse(
+                status_code=202,
+                content={
+                    "provider": provider,
+                    "status": "duplicate",
+                    "queued_jobs": 0,
+                    "duplicate_notifications": 1,
+                    "ignored_notifications": 0,
+                    "source_ids": [],
+                },
+            )
+
+        await create_import_job(
+            int(source.get("user_id")),
+            source_id,
+            request_id=request_id,
+            job_type="incremental_sync",
+        )
+        return JSONResponse(
+            status_code=202,
+            content={
+                "provider": provider,
+                "status": "queued",
+                "queued_jobs": 1,
+                "duplicate_notifications": 0,
+                "ignored_notifications": 0,
+                "source_ids": [source_id],
+            },
+        )
+
+    if provider != "onedrive":
+        raise HTTPException(status_code=404, detail="Webhook callback not supported for this provider")
+
+    try:
+        payload = await request.json()
+    except Exception:
+        payload = {}
+    notifications = payload.get("value") if isinstance(payload, dict) else []
+    if not isinstance(notifications, list):
+        notifications = []
+
+    request_id = ensure_request_id(request)
+    queued_source_ids: list[int] = []
+    queued_jobs = 0
+    duplicate_notifications = 0
+    ignored_notifications = 0
+    seen_source_ids: set[int] = set()
+
+    for notification in notifications:
+        if not isinstance(notification, dict):
+            ignored_notifications += 1
+            continue
+        receipt_key, payload_hash = _webhook_receipt_key(notification)
+        subscription_id = str(notification.get("subscriptionId") or "").strip()
+        if not receipt_key or not subscription_id:
+            ignored_notifications += 1
+            continue
+        source = await get_source_by_webhook_subscription(
+            db,
+            provider=provider,
+            subscription_id=subscription_id,
+        )
+        if not source:
+            ignored_notifications += 1
+            continue
+        source_id = int(source.get("id"))
+        is_new = await record_webhook_receipt(
+            db,
+            provider=provider,
+            receipt_key=receipt_key,
+            source_id=source_id,
+            payload_hash=payload_hash,
+        )
+        if not is_new:
+            duplicate_notifications += 1
+            continue
+        if source_id in seen_source_ids:
+            continue
+        seen_source_ids.add(source_id)
+        await create_import_job(
+            int(source.get("user_id")),
+            source_id,
+            request_id=request_id,
+            job_type="incremental_sync",
+        )
+        queued_source_ids.append(source_id)
+        queued_jobs += 1
+
+    status = "queued" if queued_jobs else ("duplicate" if duplicate_notifications else "ignored")
+    return JSONResponse(
+        status_code=202,
+        content={
+            "provider": provider,
+            "status": status,
+            "queued_jobs": queued_jobs,
+            "duplicate_notifications": duplicate_notifications,
+            "ignored_notifications": ignored_notifications,
+            "source_ids": queued_source_ids,
+        },
+    )
 
 
 @router.get("/jobs/{job_id}")

--- a/tldw_Server_API/app/api/v1/schemas/connectors.py
+++ b/tldw_Server_API/app/api/v1/schemas/connectors.py
@@ -27,6 +27,17 @@ class SyncOptions(BaseModel):
     export_format_overrides: dict[str, str] = Field(default_factory=dict)
 
 
+class ConnectorSourceSyncSummary(BaseModel):
+    state: str = "idle"
+    sync_mode: str = "manual"
+    last_sync_succeeded_at: str | None = None
+    last_sync_failed_at: str | None = None
+    last_error: str | None = None
+    webhook_status: str | None = None
+    needs_full_rescan: bool = False
+    active_job_id: str | None = None
+
+
 class ConnectorSource(BaseModel):
     id: int
     account_id: int
@@ -37,18 +48,49 @@ class ConnectorSource(BaseModel):
     options: SyncOptions = Field(default_factory=SyncOptions)
     enabled: bool = True
     last_synced_at: str | None = None
+    sync: ConnectorSourceSyncSummary | None = None
 
 
 class ImportJob(BaseModel):
     id: str = Field(..., description="Job identifier (UUID)")
     source_id: int
-    type: Literal["import", "sync"] = "import"
+    type: str = "import"
     status: Literal["queued", "running", "succeeded", "failed", "canceled"] = "queued"
     progress_pct: int = 0
     counts: dict[str, int] = Field(default_factory=lambda: {"processed": 0, "skipped": 0, "failed": 0})
     started_at: str | None = None
     finished_at: str | None = None
     error: str | None = None
+
+
+class ConnectorSyncJobSummary(BaseModel):
+    id: str
+    type: str = "import"
+    status: str
+    progress_pct: int = 0
+    counts: dict[str, int] = Field(default_factory=lambda: {"processed": 0, "skipped": 0, "failed": 0})
+
+
+class ConnectorSourceSyncStatus(BaseModel):
+    source_id: int
+    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    enabled: bool = True
+    state: str = "idle"
+    sync_mode: str = "manual"
+    cursor: str | None = None
+    cursor_kind: str | None = None
+    last_bootstrap_at: str | None = None
+    last_sync_started_at: str | None = None
+    last_sync_succeeded_at: str | None = None
+    last_sync_failed_at: str | None = None
+    last_error: str | None = None
+    retry_backoff_count: int = 0
+    webhook_status: str | None = None
+    webhook_expires_at: str | None = None
+    needs_full_rescan: bool = False
+    active_job_id: str | None = None
+    active_job_started_at: str | None = None
+    active_job: ConnectorSyncJobSummary | None = None
 
 
 class AuthorizeURLResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/connectors.py
+++ b/tldw_Server_API/app/api/v1/schemas/connectors.py
@@ -97,6 +97,22 @@ class ConnectorSourceSyncStatus(BaseModel):
     degraded_item_count: int = 0
 
 
+class ConnectorSourceSyncTriggerResponse(BaseModel):
+    source_id: int
+    provider: Literal["drive", "notion", "gmail", "onedrive"]
+    status: Literal["queued"] = "queued"
+    job: ImportJob
+
+
+class ConnectorWebhookCallbackResponse(BaseModel):
+    provider: Literal["drive", "onedrive"]
+    status: Literal["queued", "duplicate", "ignored"] = "ignored"
+    queued_jobs: int = 0
+    duplicate_notifications: int = 0
+    ignored_notifications: int = 0
+    source_ids: list[int] = Field(default_factory=list)
+
+
 class AuthorizeURLResponse(BaseModel):
     auth_url: str
     state: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/connectors.py
+++ b/tldw_Server_API/app/api/v1/schemas/connectors.py
@@ -36,6 +36,8 @@ class ConnectorSourceSyncSummary(BaseModel):
     webhook_status: str | None = None
     needs_full_rescan: bool = False
     active_job_id: str | None = None
+    tracked_item_count: int = 0
+    degraded_item_count: int = 0
 
 
 class ConnectorSource(BaseModel):
@@ -91,6 +93,8 @@ class ConnectorSourceSyncStatus(BaseModel):
     active_job_id: str | None = None
     active_job_started_at: str | None = None
     active_job: ConnectorSyncJobSummary | None = None
+    tracked_item_count: int = 0
+    degraded_item_count: int = 0
 
 
 class AuthorizeURLResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/connectors.py
+++ b/tldw_Server_API/app/api/v1/schemas/connectors.py
@@ -6,14 +6,14 @@ from pydantic import BaseModel, Field
 
 
 class ConnectorProvider(BaseModel):
-    name: Literal["drive", "notion", "gmail"]
+    name: Literal["drive", "notion", "gmail", "onedrive"]
     auth_type: Literal["oauth2", "token"] = "oauth2"
     scopes_required: list[str] = Field(default_factory=list)
 
 
 class ConnectorAccount(BaseModel):
     id: int
-    provider: Literal["drive", "notion", "gmail"]
+    provider: Literal["drive", "notion", "gmail", "onedrive"]
     display_name: str
     created_at: str | None = None
     connected: bool = True
@@ -30,9 +30,9 @@ class SyncOptions(BaseModel):
 class ConnectorSource(BaseModel):
     id: int
     account_id: int
-    provider: Literal["drive", "notion", "gmail"]
+    provider: Literal["drive", "notion", "gmail", "onedrive"]
     remote_id: str
-    type: Literal["folder", "page", "database", "link"]
+    type: Literal["folder", "file", "page", "database", "link"]
     path: str | None = None
     options: SyncOptions = Field(default_factory=SyncOptions)
     enabled: bool = True
@@ -58,7 +58,7 @@ class AuthorizeURLResponse(BaseModel):
 
 class ConnectorPolicy(BaseModel):
     org_id: int
-    enabled_providers: list[Literal["drive", "notion", "gmail"]] = Field(default_factory=lambda: ["drive", "notion"])
+    enabled_providers: list[Literal["drive", "notion", "gmail", "onedrive"]] = Field(default_factory=lambda: ["drive", "notion"])
     allowed_export_formats: list[Literal["md", "txt", "pdf"]] = Field(default_factory=lambda: ["md", "txt", "pdf"])
     allowed_file_types: list[str] = Field(default_factory=list, description="Extensions or MIME prefixes")
     max_file_size_mb: int = 500
@@ -78,9 +78,9 @@ class ConnectorSourceCreateRequest(BaseModel):
     model_config = {"extra": 'forbid'}
 
     account_id: int
-    provider: Literal["drive", "notion", "gmail"]
+    provider: Literal["drive", "notion", "gmail", "onedrive"]
     remote_id: str
-    type: Literal["folder", "page", "database", "link"]
+    type: Literal["folder", "file", "page", "database", "link"]
     path: str | None = None
     options: dict[str, Any] = Field(default_factory=dict)
 

--- a/tldw_Server_API/app/core/DB_Management/Media_DB_v2.py
+++ b/tldw_Server_API/app/core/DB_Management/Media_DB_v2.py
@@ -16031,15 +16031,15 @@ class MediaDatabase:
                         new_content_hash,
                     )
             except _MEDIA_NONCRITICAL_EXCEPTIONS as _anch_err:
-                logging.debug(f"Highlight re-anchoring hook (sync update) failed: {_anch_err}")
+                logger.debug("Highlight re-anchoring hook (sync update) failed: {}", _anch_err)
             try:
                 from tldw_Server_API.app.core.RAG.rag_service.agentic_chunker import (
                     invalidate_intra_doc_vectors,  # lazy import
                 )
 
                 invalidate_intra_doc_vectors(str(media_id))
-            except _MEDIA_NONCRITICAL_EXCEPTIONS:
-                pass
+            except _MEDIA_NONCRITICAL_EXCEPTIONS as _rag_err:
+                logger.debug("Intra-doc vector invalidation skipped for media {}: {}", media_id, _rag_err)
         except (InputError, ConflictError, DatabaseError, sqlite3.Error, TypeError) as e:
             logger.error(f"Synced content update error media {media_id}: {e}", exc_info=True)
             if isinstance(e, (InputError, ConflictError, DatabaseError, TypeError)):

--- a/tldw_Server_API/app/core/DB_Management/Media_DB_v2.py
+++ b/tldw_Server_API/app/core/DB_Management/Media_DB_v2.py
@@ -15929,6 +15929,134 @@ class MediaDatabase:
             logger.error(f"Unexpected error restoring media {media_id} trash: {e}", exc_info=True)
             raise DatabaseError(f"Unexpected restore trash error: {e}") from e  # noqa: TRY003
 
+    def apply_synced_document_content_update(
+        self,
+        *,
+        media_id: int,
+        content: str,
+        prompt: str | None = None,
+        analysis_content: str | None = None,
+        safe_metadata: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Apply an externally-sourced document content update atomically.
+
+        This helper keeps file-sync reconciliation aligned with the main media
+        update semantics by updating the active ``Media`` row, refreshing FTS,
+        and creating a new ``DocumentVersion`` in one transaction.
+        """
+        if content is None:
+            raise InputError("Content is required for synced document updates.")  # noqa: TRY003
+
+        client_id = self.client_id
+        current_time = self._get_current_utc_timestamp_str()
+
+        try:
+            with self.transaction() as conn:
+                media_info = self._fetchone_with_connection(
+                    conn,
+                    "SELECT uuid, version, title FROM Media WHERE id = ? AND deleted = 0",
+                    (media_id,),
+                )
+                if not media_info:
+                    raise InputError(f"Media {media_id} not found or deleted.")  # noqa: TRY003, TRY301
+
+                media_uuid = media_info["uuid"]
+                current_media_version = media_info["version"]
+                current_title = media_info["title"]
+                new_media_version = current_media_version + 1
+                new_content_hash = hashlib.sha256(content.encode()).hexdigest()
+
+                update_cursor = self._execute_with_connection(
+                    conn,
+                    """
+                    UPDATE Media
+                    SET content = ?,
+                        content_hash = ?,
+                        last_modified = ?,
+                        version = ?,
+                        client_id = ?,
+                        chunking_status = 'pending',
+                        vector_processing = 0
+                    WHERE id = ? AND version = ?
+                    """,
+                    (
+                        content,
+                        new_content_hash,
+                        current_time,
+                        new_media_version,
+                        client_id,
+                        media_id,
+                        current_media_version,
+                    ),
+                )
+                if getattr(update_cursor, "rowcount", 0) == 0:
+                    raise ConflictError("Media", media_id)  # noqa: TRY301
+
+                new_doc_version_info = self.create_document_version(
+                    media_id=media_id,
+                    content=content,
+                    prompt=prompt,
+                    analysis_content=analysis_content,
+                    safe_metadata=safe_metadata,
+                )
+
+                updated_media_data = self._fetchone_with_connection(
+                    conn,
+                    "SELECT * FROM Media WHERE id = ?",
+                    (media_id,),
+                ) or {}
+                updated_media_data["created_doc_ver_uuid"] = new_doc_version_info.get("uuid")
+                updated_media_data["created_doc_ver_num"] = new_doc_version_info.get("version_number")
+                self._log_sync_event(
+                    conn,
+                    "Media",
+                    media_uuid,
+                    "update",
+                    new_media_version,
+                    updated_media_data,
+                )
+                self._update_fts_media(conn, media_id, current_title, content)
+
+            logger.info(
+                "Applied synced content update for media {}. New doc version: {}, new media version: {}",
+                media_id,
+                new_doc_version_info.get("version_number"),
+                new_media_version,
+            )
+            try:
+                if _CollectionsDB is not None and client_id is not None:
+                    _CollectionsDB.from_backend(user_id=str(client_id), backend=self.backend).mark_highlights_stale_if_content_changed(
+                        media_id,
+                        new_content_hash,
+                    )
+            except _MEDIA_NONCRITICAL_EXCEPTIONS as _anch_err:
+                logging.debug(f"Highlight re-anchoring hook (sync update) failed: {_anch_err}")
+            try:
+                from tldw_Server_API.app.core.RAG.rag_service.agentic_chunker import (
+                    invalidate_intra_doc_vectors,  # lazy import
+                )
+
+                invalidate_intra_doc_vectors(str(media_id))
+            except _MEDIA_NONCRITICAL_EXCEPTIONS:
+                pass
+        except (InputError, ConflictError, DatabaseError, sqlite3.Error, TypeError) as e:
+            logger.error(f"Synced content update error media {media_id}: {e}", exc_info=True)
+            if isinstance(e, (InputError, ConflictError, DatabaseError, TypeError)):
+                raise
+            raise DatabaseError(f"Synced content update failed: {e}") from e  # noqa: TRY003
+        except _MEDIA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"Unexpected synced content update error media {media_id}: {e}", exc_info=True)
+            raise DatabaseError(f"Unexpected synced content update error: {e}") from e  # noqa: TRY003
+        else:
+            return {
+                "media_id": media_id,
+                "content_hash": new_content_hash,
+                "new_media_version": new_media_version,
+                "document_version_number": new_doc_version_info.get("version_number"),
+                "document_version_uuid": new_doc_version_info.get("uuid"),
+            }
+
     def rollback_to_version(self, media_id: int, target_version_number: int) -> dict[str, Any]:
         """
         Rolls back the main Media content to a previous DocumentVersion state.

--- a/tldw_Server_API/app/core/External_Sources/README.md
+++ b/tldw_Server_API/app/core/External_Sources/README.md
@@ -7,6 +7,8 @@
   - OAuth linking, account listing/removal
   - Browsing remote sources (Drive folders, Notion pages/databases)
   - Creating sources with per-org policy enforcement; queuing import jobs
+  - Source-level sync cursors, webhook state, and legacy-import rescan markers
+  - Canonical remote-to-media bindings and append-only item sync events
   - Org policy admin: allowed providers, paths, domains, quotas
 - Inputs/Outputs:
   - Inputs: OAuth code/state, provider selection, source path/IDs, policy documents
@@ -29,7 +31,8 @@
   - Internal: AuthNZ DB pool, policy helpers, Logging context
   - External: Google/Notion APIs (networked); tokens stored via DB
 - Data Models & DB:
-  - AuthNZ DB tables: `external_accounts`, `external_sources`, `external_items`, `org_connector_policy`, `external_oauth_state` (SQLite/PG variants)
+  - AuthNZ DB tables: `external_accounts`, `external_sources`, `external_items`, `external_source_sync_state`, `external_item_events`, `org_connector_policy`, `external_oauth_state` (SQLite/PG variants)
+  - `external_items` is the canonical remote binding row; legacy rows without `media_id` are marked for full rescan during migration
 - Configuration:
   - `CONNECTOR_REDIRECT_BASE_URL` for OAuth callbacks (fallback to request host/connector redirect base); provider keys via env/config
   - `CONNECTOR_OAUTH_STATE_TTL_MINUTES` to control OAuth state validity (default: 10)
@@ -56,4 +59,4 @@
 - Pitfalls & Gotchas:
   - Quotas per role; pagination cursors; workspace and domain constraints
 - Roadmap/TODOs:
-  - Additional providers; bulk sync workers with backpressure
+  - Additional providers; shared sync coordinator, delta polling, and webhook reconciliation

--- a/tldw_Server_API/app/core/External_Sources/README.md
+++ b/tldw_Server_API/app/core/External_Sources/README.md
@@ -2,61 +2,95 @@
 
 ## 1. Descriptive of Current Feature Set
 
-- Purpose: Connect external providers (Google Drive, Notion) to import/sync content into user collections.
+- Purpose: Connect external providers to import and sync content into local media collections.
 - Capabilities:
   - OAuth linking, account listing/removal
-  - Browsing remote sources (Drive folders, Notion pages/databases)
+  - Browsing remote sources (Drive folders/files, OneDrive folders/files, Notion pages/databases, Gmail labels/messages)
   - Creating sources with per-org policy enforcement; queuing import jobs
   - Source-level sync cursors, webhook state, and legacy-import rescan markers
   - Canonical remote-to-media bindings and append-only item sync events
+  - Shared file-sync reconciliation for Google Drive and OneDrive:
+    - bootstrap import into `Media`
+    - delta sync into `DocumentVersions`
+    - archive on upstream delete
+    - degraded state when a new upstream revision fails ingestion
+  - Manual sync status/trigger endpoints and webhook-triggered incremental sync
+  - APScheduler bridge that enqueues renewal, replay, and incremental sync jobs
   - Org policy admin: allowed providers, paths, domains, quotas
 - Inputs/Outputs:
   - Inputs: OAuth code/state, provider selection, source path/IDs, policy documents
-  - Outputs: accounts, sources, import job descriptors; ingested content in Collections DB
+  - Outputs: accounts, sources, sync status, import/sync job descriptors; ingested content in Media DB v2
 - Related Endpoints:
   - Connectors API: `tldw_Server_API/app/api/v1/endpoints/connectors.py:46` (providers/catalog, authorize/callback, accounts, sources, jobs, policy)
+  - Sync status: `tldw_Server_API/app/api/v1/endpoints/connectors.py:685`
+  - Manual sync trigger: `tldw_Server_API/app/api/v1/endpoints/connectors.py:723`
+  - Provider webhooks: `tldw_Server_API/app/api/v1/endpoints/connectors.py:753`
 - Related Schemas:
   - `tldw_Server_API/app/api/v1/schemas/connectors.py:1`
 
 ## 2. Technical Details of Features
 
 - Architecture & Data Flow:
-  - Provider connectors implement a small interface; service functions write to AuthNZ DB tables via async pool
+  - Provider connectors implement a small interface; file-hosting providers also implement the sync adapter contract (`list_changes`, `download_or_export`, webhook subscribe/renew/revoke)
+  - Service functions write connector account/source/binding state to AuthNZ DB tables via async pool
+  - The shared sync coordinator reconciles remote change events into local `Media` and `DocumentVersions`
   - OAuth state is generated on authorize, stored in AuthNZ DB, and consumed once during callback
   - Endpoints enforce org-level policy in multi-user mode; single-user mode bypasses org checks
+  - Webhook callbacks only validate, dedupe, and enqueue Jobs; they never perform ingestion inline
+  - The recurring scheduler scans sources and enqueues `incremental_sync`, `subscription_renewal`, or `repair_rescan`
 - Key Classes/Functions:
   - Connectors service: `core/External_Sources/connectors_service.py` (DDL ensure, policy upsert/get, accounts/sources CRUD)
-  - Providers: `google_drive.py`, `notion.py`; registry: `get_connector_by_name`
+  - Shared reconciliation: `core/External_Sources/sync_coordinator.py`
+  - Worker execution: `app/services/connectors_worker.py`
+  - Recurring scheduler: `app/services/connectors_sync_scheduler.py`
+  - Providers: `google_drive.py`, `onedrive.py`, `gmail.py`, `notion.py`; registry: `get_connector_by_name`
 - Dependencies:
   - Internal: AuthNZ DB pool, policy helpers, Logging context
-  - External: Google/Notion APIs (networked); tokens stored via DB
+  - External: Google Drive API, Microsoft Graph, Gmail API, Notion APIs; tokens stored via DB
 - Data Models & DB:
   - AuthNZ DB tables: `external_accounts`, `external_sources`, `external_items`, `external_source_sync_state`, `external_item_events`, `org_connector_policy`, `external_oauth_state` (SQLite/PG variants)
   - `external_items` is the canonical remote binding row; legacy rows without `media_id` are marked for full rescan during migration
+  - `external_source_sync_state` stores cursor, webhook, retry, and active-job fence state per source
+  - File content versions remain in Media DB v2 `DocumentVersions`; connector tables do not duplicate content bodies
 - Configuration:
   - `CONNECTOR_REDIRECT_BASE_URL` for OAuth callbacks (fallback to request host/connector redirect base); provider keys via env/config
   - `CONNECTOR_OAUTH_STATE_TTL_MINUTES` to control OAuth state validity (default: 10)
+  - `CONNECTORS_SYNC_SCHEDULER_ENABLED` to start recurring source scans
+  - `CONNECTORS_SYNC_SCHEDULER_SCAN_SEC` to control scan cadence (default: 300)
+  - `CONNECTORS_SYNC_RENEWAL_LOOKAHEAD_SEC` to renew subscriptions before expiry (default: 3600)
+  - `EMAIL_GMAIL_CONNECTOR_ENABLED` to expose the Gmail provider in connector APIs
 - Concurrency & Performance:
-  - Import jobs queued with daily quotas by role; pagination support
+  - Import/sync jobs are queued through Jobs with source-scoped fencing and idempotent reservation
+  - Pagination and cursor-based delta sync are used for large sources
 - Error Handling:
   - Consistent HTTP 4xx/5xx; policy evaluation yields 403 with reason; token refresh envelope helpers covered by tests
+  - Failed upstream revisions keep the last good local version active and mark the binding `degraded`
 - Security:
   - RBAC by role; email/workspace validations; path/domain allow/deny lists; token handling in AuthNZ DB
+  - Webhook deliveries are deduped via `external_webhook_receipts`
 
 ## 3. Developer-Related/Relevant Information for Contributors
 
 - Folder Structure:
   - `External_Sources/` (provider adapters, policy), service helpers, endpoints under `/api/v1/endpoints/connectors.py`
 - Extension Points:
-  - Add a provider module and wire into `get_connector_by_name`; implement browse, list, and token exchange as needed
+  - Add a provider module and wire into `get_connector_by_name`; implement browse, list, token exchange, and sync adapter methods as needed
 - Coding Patterns:
   - Async DB via pool; structured logs; keep endpoints thin (service owns DDL and logic)
+  - File-hosting providers should keep provider-specific delta/webhook details inside the adapter and let the coordinator own reconciliation semantics
 - Tests:
   - `tldw_Server_API/tests/External_Sources/test_policy_and_connectors.py:1`
   - `tldw_Server_API/tests/External_Sources/test_token_refresh_envelope.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py:1`
+  - `tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py:1`
+  - `tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py:1`
 - Local Dev Tips:
   - Use TEST_MODE and mock provider modules in tests; set callback base URL via env for manual flows
 - Pitfalls & Gotchas:
   - Quotas per role; pagination cursors; workspace and domain constraints
+  - Legacy `external_items` rows without `media_id` must be replayed before cursor-only sync is trustworthy
+  - Webhook callbacks should only enqueue work; never add ingestion logic to the request path
+  - Manual sync queues a job and returns immediately; it does not run inline with the API request
 - Roadmap/TODOs:
-  - Additional providers; shared sync coordinator, delta polling, and webhook reconciliation
+  - Additional file-hosting providers such as Dropbox, Box, and SharePoint
+  - Richer admin/source observability beyond the current per-source sync status endpoint

--- a/tldw_Server_API/app/core/External_Sources/__init__.py
+++ b/tldw_Server_API/app/core/External_Sources/__init__.py
@@ -3,6 +3,7 @@ from .connectors_service import get_connector_by_name
 from .gmail import GmailConnector
 from .google_drive import GoogleDriveConnector
 from .notion import NotionConnector
+from .onedrive import OneDriveConnector
 from .policy import evaluate_policy_constraints, get_default_policy_from_env
 from .sync_adapter import FileSyncAdapter, FileSyncChange, FileSyncWebhookSubscription
 
@@ -14,6 +15,7 @@ __all__ = [
     "GmailConnector",
     "GoogleDriveConnector",
     "NotionConnector",
+    "OneDriveConnector",
     "get_default_policy_from_env",
     "evaluate_policy_constraints",
     "get_connector_by_name",

--- a/tldw_Server_API/app/core/External_Sources/__init__.py
+++ b/tldw_Server_API/app/core/External_Sources/__init__.py
@@ -4,9 +4,13 @@ from .gmail import GmailConnector
 from .google_drive import GoogleDriveConnector
 from .notion import NotionConnector
 from .policy import evaluate_policy_constraints, get_default_policy_from_env
+from .sync_adapter import FileSyncAdapter, FileSyncChange, FileSyncWebhookSubscription
 
 __all__ = [
     "BaseConnector",
+    "FileSyncAdapter",
+    "FileSyncChange",
+    "FileSyncWebhookSubscription",
     "GmailConnector",
     "GoogleDriveConnector",
     "NotionConnector",

--- a/tldw_Server_API/app/core/External_Sources/connector_base.py
+++ b/tldw_Server_API/app/core/External_Sources/connector_base.py
@@ -26,7 +26,7 @@ class BaseConnector(ABC):
 
     async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
         """Refresh tokens. Default: not implemented in scaffold."""
-        return {"access_token": None, "expires_in": None}
+        return {"access_token": None, "expires_in": None}  # nosec B105 - scaffold placeholder, not a credential
 
     async def list_sources(
         self,

--- a/tldw_Server_API/app/core/External_Sources/connector_base.py
+++ b/tldw_Server_API/app/core/External_Sources/connector_base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from .sync_adapter import FileSyncWebhookSubscription
+
 
 class BaseConnector(ABC):
     name: str
@@ -26,14 +28,138 @@ class BaseConnector(ABC):
         """Refresh tokens. Default: not implemented in scaffold."""
         return {"access_token": None, "expires_in": None}
 
-    async def list_sources(self, account: dict[str, Any], parent_remote_id: str | None = None) -> list[dict[str, Any]]:
+    async def list_sources(
+        self,
+        account: dict[str, Any],
+        parent_remote_id: str | None = None,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         """List folders/pages/databases; scaffold returns empty list."""
-        return []
+        _ = page_size
+        _ = cursor
+        return [], None
 
-    async def list_files(self, account: dict[str, Any], remote_id: str) -> list[dict[str, Any]]:
+    async def list_files(
+        self,
+        account: dict[str, Any],
+        remote_id: str,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         """List files under a folder/page; scaffold returns empty list."""
-        return []
+        _ = page_size
+        _ = cursor
+        return [], None
 
-    async def download_file(self, account: dict[str, Any], file_id: str) -> bytes:
+    async def download_file(self, account: dict[str, Any], file_id: str, **kwargs: Any) -> bytes:
         """Download file contents; scaffold returns empty bytes."""
+        _ = kwargs
         return b""
+
+    async def list_children(
+        self,
+        account: dict[str, Any],
+        parent_remote_id: str,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        """Alias file-hosting providers onto the existing list_files contract."""
+        return await self.list_files(
+            account,
+            parent_remote_id,
+            page_size=page_size,
+            cursor=cursor,
+        )
+
+    async def list_changes(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[Any], str | None, str | None]:
+        """Return provider-native deltas; providers override when they support sync."""
+        _ = account
+        _ = cursor
+        _ = page_size
+        raise NotImplementedError(f"{self.name} does not support change listing")
+
+    async def get_item_metadata(
+        self,
+        account: dict[str, Any],
+        remote_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch item metadata needed for sync reconciliation."""
+        _ = account
+        _ = remote_id
+        raise NotImplementedError(f"{self.name} does not support metadata lookup")
+
+    async def download_or_export(
+        self,
+        account: dict[str, Any],
+        remote_id: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> bytes:
+        """Bridge the sync adapter contract onto the existing download_file API."""
+        download_kwargs: dict[str, Any] = {}
+        if metadata:
+            mime_type = metadata.get("mime_type") or metadata.get("mimeType")
+            export_mime = metadata.get("export_mime")
+            if mime_type:
+                download_kwargs["mime_type"] = mime_type
+            if export_mime:
+                download_kwargs["export_mime"] = export_mime
+        try:
+            return await self.download_file(account, remote_id, **download_kwargs)
+        except TypeError:
+            return await self.download_file(account, remote_id)
+
+    async def resolve_shared_link(
+        self,
+        account: dict[str, Any],
+        shared_link: str,
+    ) -> dict[str, Any] | None:
+        """Resolve a shared link to a canonical remote item identifier."""
+        _ = account
+        _ = shared_link
+        return None
+
+    async def subscribe_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        resource: dict[str, Any],
+        callback_url: str,
+    ) -> FileSyncWebhookSubscription | None:
+        """Create a provider webhook subscription when supported."""
+        _ = account
+        _ = resource
+        _ = callback_url
+        return None
+
+    async def renew_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> FileSyncWebhookSubscription | None:
+        """Renew a provider webhook subscription when supported."""
+        _ = account
+        _ = subscription
+        return None
+
+    async def revoke_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> bool:
+        """Revoke a provider webhook subscription when supported."""
+        _ = account
+        _ = subscription
+        return False

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -77,6 +77,13 @@ def _utc_now_text() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _normalize_utc_timestamp_text(value: Any) -> str:
+    if isinstance(value, datetime):
+        normalized = value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return normalized.strftime("%Y-%m-%d %H:%M:%S")
+    return str(value or "").strip()
+
+
 def _normalize_bool(value: Any) -> bool:
     if isinstance(value, bool):
         return value
@@ -1270,6 +1277,38 @@ async def record_webhook_receipt(
     )
     await getattr(db, "commit", lambda: None)()
     return int(getattr(cur, "rowcount", 0) or 0) > 0
+
+
+async def prune_webhook_receipts(
+    db,
+    *,
+    older_than: str | datetime,
+) -> int:
+    await _ensure_tables(db)
+    cutoff = _normalize_utc_timestamp_text(older_than)
+    if not cutoff:
+        return 0
+
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        rows = await db.fetch(
+            """
+            DELETE FROM external_webhook_receipts
+            WHERE received_at < $1
+            RETURNING id
+            """,
+            cutoff,
+        )
+        return len(rows)
+
+    cur = await db.execute(
+        """
+        DELETE FROM external_webhook_receipts
+        WHERE received_at < ?
+        """,
+        (cutoff,),
+    )
+    return int(getattr(cur, "rowcount", 0) or 0)
 
 
 async def reserve_source_sync_job(

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -11,6 +11,7 @@ from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 from tldw_Server_API.app.core.External_Sources.gmail import GmailConnector
 from tldw_Server_API.app.core.External_Sources.google_drive import GoogleDriveConnector
 from tldw_Server_API.app.core.External_Sources.notion import NotionConnector
+from tldw_Server_API.app.core.External_Sources.onedrive import OneDriveConnector
 from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncAdapter
 
 _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
@@ -32,7 +33,7 @@ _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
     ValueError,
 )
 
-FILE_SYNC_PROVIDERS = frozenset({"drive"})
+FILE_SYNC_PROVIDERS = frozenset({"drive", "onedrive"})
 _SYNC_STATE_FIELDS = (
     "sync_mode",
     "cursor",
@@ -213,6 +214,8 @@ def get_connector_by_name(name: str):
     n = name.lower()
     if n == "drive":
         return GoogleDriveConnector()
+    if n == "onedrive":
+        return OneDriveConnector()
     if n == "notion":
         return NotionConnector()
     if n == "gmail":

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -47,6 +47,7 @@ _SYNC_STATE_FIELDS = (
     "webhook_status",
     "webhook_subscription_id",
     "webhook_expires_at",
+    "webhook_metadata",
     "needs_full_rescan",
     "active_job_id",
     "active_job_started_at",
@@ -113,6 +114,7 @@ def _normalize_sync_state_row(row: Any) -> dict[str, Any] | None:
         return None
     data = _row_to_dict(row)
     data["needs_full_rescan"] = _normalize_bool(data.get("needs_full_rescan"))
+    data["webhook_metadata"] = _json_loads(data.get("webhook_metadata"), {})
     return data
 
 
@@ -125,6 +127,35 @@ def _normalize_external_item_row(row: Any) -> dict[str, Any] | None:
     if "sync_status" not in data or data.get("sync_status") is None:
         data["sync_status"] = "active"
     return data
+
+
+def _job_is_active(job: dict[str, Any] | None) -> bool:
+    if not job:
+        return False
+    return str(job.get("status") or "").strip().lower() in {"queued", "processing"}
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+        return int(default)
+
+
+def _format_connectors_job(job: dict[str, Any], *, source_id: int, default_type: str) -> dict[str, Any]:
+    result = job.get("result") if isinstance(job.get("result"), dict) else {}
+    return {
+        "id": str(job.get("id") or job.get("job_id") or job.get("uuid")),
+        "source_id": source_id,
+        "type": str(job.get("job_type") or default_type),
+        "status": str(job.get("status") or "queued"),
+        "progress_pct": _coerce_int(job.get("progress_percent") or job.get("progress_pct") or 0),
+        "counts": {
+            "processed": _coerce_int((result or {}).get("processed"), 0),
+            "skipped": _coerce_int((result or {}).get("skipped"), 0),
+            "failed": _coerce_int((result or {}).get("failed"), 0),
+        },
+    }
 
 
 async def _sqlite_column_names(db, table_name: str) -> set[str]:
@@ -345,10 +376,17 @@ async def _ensure_tables(db) -> None:
                     webhook_status TEXT,
                     webhook_subscription_id TEXT,
                     webhook_expires_at TIMESTAMP NULL,
+                    webhook_metadata JSONB,
                     needs_full_rescan BOOLEAN DEFAULT FALSE,
                     active_job_id TEXT,
                     active_job_started_at TIMESTAMP NULL
                 )
+                """
+            )
+            await db.execute(
+                """
+                ALTER TABLE external_source_sync_state
+                ADD COLUMN IF NOT EXISTS webhook_metadata JSONB
                 """
             )
             await db.execute(
@@ -360,6 +398,19 @@ async def _ensure_tables(db) -> None:
                     job_id TEXT,
                     payload_json JSONB,
                     occurred_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_webhook_receipts (
+                    id SERIAL PRIMARY KEY,
+                    provider TEXT NOT NULL,
+                    receipt_key TEXT NOT NULL,
+                    source_id INTEGER NULL REFERENCES external_sources(id) ON DELETE SET NULL,
+                    payload_hash TEXT,
+                    received_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(provider, receipt_key)
                 )
                 """
             )
@@ -471,11 +522,18 @@ async def _ensure_tables(db) -> None:
                     webhook_status TEXT,
                     webhook_subscription_id TEXT,
                     webhook_expires_at TEXT,
+                    webhook_metadata TEXT,
                     needs_full_rescan INTEGER DEFAULT 0,
                     active_job_id TEXT,
                     active_job_started_at TEXT
                 )
                 """,
+            )
+            await _ensure_sqlite_column(
+                db,
+                "external_source_sync_state",
+                "webhook_metadata",
+                "webhook_metadata TEXT",
             )
             await db.execute(
                 """
@@ -486,6 +544,19 @@ async def _ensure_tables(db) -> None:
                     job_id TEXT,
                     payload_json TEXT,
                     occurred_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_webhook_receipts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    provider TEXT NOT NULL,
+                    receipt_key TEXT NOT NULL,
+                    source_id INTEGER,
+                    payload_hash TEXT,
+                    received_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(provider, receipt_key)
                 )
                 """,
             )
@@ -970,6 +1041,7 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
         data.get("webhook_status"),
         data.get("webhook_subscription_id"),
         data.get("webhook_expires_at"),
+        (data.get("webhook_metadata") or {}),
         bool(data.get("needs_full_rescan")),
         data.get("active_job_id"),
         data.get("active_job_started_at"),
@@ -991,12 +1063,13 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
                 webhook_status,
                 webhook_subscription_id,
                 webhook_expires_at,
+                webhook_metadata,
                 needs_full_rescan,
                 active_job_id,
                 active_job_started_at
             ) VALUES (
                 $1, $2, $3, $4, $5, $6, $7, $8,
-                $9, $10, $11, $12, $13, $14, $15, $16
+                $9, $10, $11, $12, $13, $14, $15, $16, $17
             )
             ON CONFLICT (source_id) DO UPDATE SET
                 sync_mode = EXCLUDED.sync_mode,
@@ -1011,6 +1084,7 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
                 webhook_status = EXCLUDED.webhook_status,
                 webhook_subscription_id = EXCLUDED.webhook_subscription_id,
                 webhook_expires_at = EXCLUDED.webhook_expires_at,
+                webhook_metadata = EXCLUDED.webhook_metadata,
                 needs_full_rescan = EXCLUDED.needs_full_rescan,
                 active_job_id = EXCLUDED.active_job_id,
                 active_job_started_at = EXCLUDED.active_job_started_at
@@ -1036,10 +1110,11 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
             webhook_status,
             webhook_subscription_id,
             webhook_expires_at,
+            webhook_metadata,
             needs_full_rescan,
             active_job_id,
             active_job_started_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(source_id) DO UPDATE SET
             sync_mode = excluded.sync_mode,
             cursor = excluded.cursor,
@@ -1053,6 +1128,7 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
             webhook_status = excluded.webhook_status,
             webhook_subscription_id = excluded.webhook_subscription_id,
             webhook_expires_at = excluded.webhook_expires_at,
+            webhook_metadata = excluded.webhook_metadata,
             needs_full_rescan = excluded.needs_full_rescan,
             active_job_id = excluded.active_job_id,
             active_job_started_at = excluded.active_job_started_at
@@ -1071,12 +1147,333 @@ async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dic
             values[10],
             values[11],
             values[12],
-            1 if values[13] else 0,
+            json.dumps(values[13] or {}),
             values[14],
             values[15],
+            values[16],
         ),
     )
     await getattr(db, "commit", lambda: None)()
+    return await get_source_sync_state(db, source_id=source_id) or {}
+
+
+async def get_source_by_webhook_subscription(
+    db,
+    *,
+    provider: str,
+    subscription_id: str,
+) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            SELECT
+                s.id,
+                s.account_id,
+                s.provider,
+                s.remote_id,
+                s.type,
+                s.path,
+                s.options,
+                s.enabled,
+                s.last_synced_at,
+                a.user_id,
+                a.email
+            FROM external_source_sync_state st
+            JOIN external_sources s ON s.id = st.source_id
+            JOIN external_accounts a ON a.id = s.account_id
+            WHERE s.provider = $1
+              AND st.webhook_subscription_id = $2
+            LIMIT 1
+            """,
+            provider,
+            subscription_id,
+        )
+        if not row:
+            return None
+        data = dict(row)
+        data["options"] = _json_loads(data.get("options"), {})
+        return data
+
+    cur = await db.execute(
+        """
+        SELECT
+            s.id,
+            s.account_id,
+            s.provider,
+            s.remote_id,
+            s.type,
+            s.path,
+            s.options,
+            s.enabled,
+            s.last_synced_at,
+            a.user_id,
+            a.email
+        FROM external_source_sync_state st
+        JOIN external_sources s ON s.id = st.source_id
+        JOIN external_accounts a ON a.id = s.account_id
+        WHERE s.provider = ?
+          AND st.webhook_subscription_id = ?
+        LIMIT 1
+        """,
+        (provider, subscription_id),
+    )
+    row = await cur.fetchone()
+    if not row:
+        return None
+    data = dict(row)
+    data["options"] = _json_loads(data.get("options"), {})
+    return data
+
+
+async def record_webhook_receipt(
+    db,
+    *,
+    provider: str,
+    receipt_key: str,
+    source_id: int | None = None,
+    payload_hash: str | None = None,
+) -> bool:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            INSERT INTO external_webhook_receipts (
+                provider,
+                receipt_key,
+                source_id,
+                payload_hash
+            ) VALUES ($1, $2, $3, $4)
+            ON CONFLICT (provider, receipt_key) DO NOTHING
+            RETURNING id
+            """,
+            provider,
+            receipt_key,
+            source_id,
+            payload_hash,
+        )
+        return bool(row)
+
+    cur = await db.execute(
+        """
+        INSERT OR IGNORE INTO external_webhook_receipts (
+            provider,
+            receipt_key,
+            source_id,
+            payload_hash
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (provider, receipt_key, source_id, payload_hash),
+    )
+    await getattr(db, "commit", lambda: None)()
+    return int(getattr(cur, "rowcount", 0) or 0) > 0
+
+
+async def reserve_source_sync_job(
+    db,
+    *,
+    source_id: int,
+    job_id: str,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    if not await get_source_sync_state(db, source_id=source_id):
+        await upsert_source_sync_state(db, source_id=source_id)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            UPDATE external_source_sync_state
+            SET active_job_id = $1,
+                active_job_started_at = NULL
+            WHERE source_id = $2
+              AND (active_job_id IS NULL OR active_job_id = $1)
+            RETURNING *
+            """,
+            str(job_id),
+            source_id,
+        )
+        return _normalize_sync_state_row(row) or await get_source_sync_state(db, source_id=source_id) or {}
+    cur = await db.execute(
+        """
+        UPDATE external_source_sync_state
+        SET active_job_id = ?,
+            active_job_started_at = NULL
+        WHERE source_id = ?
+          AND (active_job_id IS NULL OR active_job_id = ?)
+        """,
+        (str(job_id), source_id, str(job_id)),
+    )
+    await getattr(db, "commit", lambda: None)()
+    if getattr(cur, "rowcount", 0) == 0:
+        return await get_source_sync_state(db, source_id=source_id) or {}
+    return await get_source_sync_state(db, source_id=source_id) or {}
+
+
+async def start_source_sync_job(
+    db,
+    *,
+    source_id: int,
+    job_id: str,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    if not await get_source_sync_state(db, source_id=source_id):
+        await upsert_source_sync_state(db, source_id=source_id)
+    started_at = _utc_now_text()
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            UPDATE external_source_sync_state
+            SET active_job_id = $1,
+                active_job_started_at = $2,
+                last_sync_started_at = $2,
+                last_error = NULL
+            WHERE source_id = $3
+              AND (active_job_id IS NULL OR active_job_id = $1)
+            RETURNING *
+            """,
+            str(job_id),
+            started_at,
+            source_id,
+        )
+        return _normalize_sync_state_row(row) or await get_source_sync_state(db, source_id=source_id) or {}
+    cur = await db.execute(
+        """
+        UPDATE external_source_sync_state
+        SET active_job_id = ?,
+            active_job_started_at = ?,
+            last_sync_started_at = ?,
+            last_error = NULL
+        WHERE source_id = ?
+          AND (active_job_id IS NULL OR active_job_id = ?)
+        """,
+        (str(job_id), started_at, started_at, source_id, str(job_id)),
+    )
+    await getattr(db, "commit", lambda: None)()
+    if getattr(cur, "rowcount", 0) == 0:
+        return await get_source_sync_state(db, source_id=source_id) or {}
+    return await get_source_sync_state(db, source_id=source_id) or {}
+
+
+async def finish_source_sync_job(
+    db,
+    *,
+    source_id: int,
+    job_id: str,
+    outcome: str,
+    error: str | None = None,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    completed_at = _utc_now_text()
+    outcome_key = str(outcome or "").strip().lower()
+    is_pg = _is_postgres_connection(db)
+
+    if outcome_key == "success":
+        if is_pg:
+            row = await db.fetchrow(
+                """
+                UPDATE external_source_sync_state
+                SET active_job_id = NULL,
+                    active_job_started_at = NULL,
+                    last_sync_succeeded_at = $1,
+                    last_error = NULL,
+                    retry_backoff_count = 0
+                WHERE source_id = $2
+                  AND (active_job_id IS NULL OR active_job_id = $3)
+                RETURNING *
+                """,
+                completed_at,
+                source_id,
+                str(job_id),
+            )
+            return _normalize_sync_state_row(row) or await get_source_sync_state(db, source_id=source_id) or {}
+        cur = await db.execute(
+            """
+            UPDATE external_source_sync_state
+            SET active_job_id = NULL,
+                active_job_started_at = NULL,
+                last_sync_succeeded_at = ?,
+                last_error = NULL,
+                retry_backoff_count = 0
+            WHERE source_id = ?
+              AND (active_job_id IS NULL OR active_job_id = ?)
+            """,
+            (completed_at, source_id, str(job_id)),
+        )
+        await getattr(db, "commit", lambda: None)()
+        if getattr(cur, "rowcount", 0) == 0:
+            return await get_source_sync_state(db, source_id=source_id) or {}
+        return await get_source_sync_state(db, source_id=source_id) or {}
+
+    if outcome_key == "failure":
+        if is_pg:
+            row = await db.fetchrow(
+                """
+                UPDATE external_source_sync_state
+                SET active_job_id = NULL,
+                    active_job_started_at = NULL,
+                    last_sync_failed_at = $1,
+                    last_error = $2,
+                    retry_backoff_count = COALESCE(retry_backoff_count, 0) + 1
+                WHERE source_id = $3
+                  AND (active_job_id IS NULL OR active_job_id = $4)
+                RETURNING *
+                """,
+                completed_at,
+                error,
+                source_id,
+                str(job_id),
+            )
+            return _normalize_sync_state_row(row) or await get_source_sync_state(db, source_id=source_id) or {}
+        cur = await db.execute(
+            """
+            UPDATE external_source_sync_state
+            SET active_job_id = NULL,
+                active_job_started_at = NULL,
+                last_sync_failed_at = ?,
+                last_error = ?,
+                retry_backoff_count = COALESCE(retry_backoff_count, 0) + 1
+            WHERE source_id = ?
+              AND (active_job_id IS NULL OR active_job_id = ?)
+            """,
+            (completed_at, error, source_id, str(job_id)),
+        )
+        await getattr(db, "commit", lambda: None)()
+        if getattr(cur, "rowcount", 0) == 0:
+            return await get_source_sync_state(db, source_id=source_id) or {}
+        return await get_source_sync_state(db, source_id=source_id) or {}
+
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            UPDATE external_source_sync_state
+            SET active_job_id = NULL,
+                active_job_started_at = NULL,
+                last_error = NULL
+            WHERE source_id = $1
+              AND (active_job_id IS NULL OR active_job_id = $2)
+            RETURNING *
+            """,
+            source_id,
+            str(job_id),
+        )
+        return _normalize_sync_state_row(row) or await get_source_sync_state(db, source_id=source_id) or {}
+    cur = await db.execute(
+        """
+        UPDATE external_source_sync_state
+        SET active_job_id = NULL,
+            active_job_started_at = NULL,
+            last_error = NULL
+        WHERE source_id = ?
+          AND (active_job_id IS NULL OR active_job_id = ?)
+        """,
+        (source_id, str(job_id)),
+    )
+    await getattr(db, "commit", lambda: None)()
+    if getattr(cur, "rowcount", 0) == 0:
+        return await get_source_sync_state(db, source_id=source_id) or {}
     return await get_source_sync_state(db, source_id=source_id) or {}
 
 
@@ -1416,6 +1813,107 @@ async def mark_external_item_archived(
     )
 
 
+async def restore_external_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    external_id: str,
+    name: str | None = None,
+    version: str | None = None,
+    modified_at: str | None = None,
+    remote_parent_id: str | None = None,
+    remote_path: str | None = None,
+    content_hash: str | None = None,
+    current_version_number: int | None = None,
+    provider_metadata: dict[str, Any] | None = None,
+    sync_status: str = "active",
+) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    restored_at = _utc_now_text()
+    is_pg = _is_postgres_connection(db)
+    provider_metadata_value = provider_metadata or None
+    sqlite_provider_metadata = json.dumps(provider_metadata_value) if provider_metadata_value is not None else None
+
+    if is_pg:
+        await db.execute(
+            """
+            UPDATE external_items
+            SET sync_status = $1,
+                name = COALESCE($2, name),
+                version = COALESCE($3, version),
+                modified_at = COALESCE($4, modified_at),
+                remote_parent_id = COALESCE($5, remote_parent_id),
+                remote_path = COALESCE($6, remote_path),
+                hash = COALESCE($7, hash),
+                current_version_number = COALESCE($8, current_version_number),
+                remote_deleted_at = NULL,
+                access_revoked_at = NULL,
+                last_seen_at = $9,
+                last_metadata_sync_at = $9,
+                provider_metadata = COALESCE($10, provider_metadata)
+            WHERE source_id = $11 AND provider = $12 AND external_id = $13
+            """,
+            sync_status,
+            name,
+            version,
+            modified_at,
+            remote_parent_id,
+            remote_path,
+            content_hash,
+            current_version_number,
+            restored_at,
+            provider_metadata_value,
+            source_id,
+            provider,
+            external_id,
+        )
+    else:
+        await db.execute(
+            """
+            UPDATE external_items
+            SET sync_status = ?,
+                name = COALESCE(?, name),
+                version = COALESCE(?, version),
+                modified_at = COALESCE(?, modified_at),
+                remote_parent_id = COALESCE(?, remote_parent_id),
+                remote_path = COALESCE(?, remote_path),
+                hash = COALESCE(?, hash),
+                current_version_number = COALESCE(?, current_version_number),
+                remote_deleted_at = NULL,
+                access_revoked_at = NULL,
+                last_seen_at = ?,
+                last_metadata_sync_at = ?,
+                provider_metadata = COALESCE(?, provider_metadata)
+            WHERE source_id = ? AND provider = ? AND external_id = ?
+            """,
+            (
+                sync_status,
+                name,
+                version,
+                modified_at,
+                remote_parent_id,
+                remote_path,
+                content_hash,
+                current_version_number,
+                restored_at,
+                restored_at,
+                sqlite_provider_metadata,
+                source_id,
+                provider,
+                external_id,
+            ),
+        )
+        await getattr(db, "commit", lambda: None)()
+
+    return await get_external_item_binding(
+        db,
+        source_id=source_id,
+        provider=provider,
+        external_id=external_id,
+    )
+
+
 async def should_ingest_item(
     db, *, source_id: int, provider: str, external_id: str, version: str | None, modified_at: str | None, content_hash: str | None
 ) -> bool:
@@ -1618,6 +2116,131 @@ async def list_sources(db, user_id: int) -> list[dict[str, Any]]:
     return out
 
 
+async def list_sources_for_scheduler(db) -> list[dict[str, Any]]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        rows = await db.fetch(
+            """
+            SELECT
+                s.id,
+                s.account_id,
+                s.provider,
+                s.remote_id,
+                s.type,
+                s.path,
+                s.options,
+                s.enabled,
+                s.last_synced_at,
+                a.user_id,
+                a.email,
+                st.sync_mode,
+                st.cursor,
+                st.cursor_kind,
+                st.last_bootstrap_at,
+                st.last_sync_started_at,
+                st.last_sync_succeeded_at,
+                st.last_sync_failed_at,
+                st.last_error,
+                st.retry_backoff_count,
+                st.webhook_status,
+                st.webhook_subscription_id,
+                st.webhook_expires_at,
+                st.webhook_metadata,
+                st.needs_full_rescan,
+                st.active_job_id,
+                st.active_job_started_at
+            FROM external_sources s
+            JOIN external_accounts a ON s.account_id = a.id
+            LEFT JOIN external_source_sync_state st ON st.source_id = s.id
+            ORDER BY s.id ASC
+            """
+        )
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            data = dict(row)
+            data["options"] = _json_loads(data.get("options"), {})
+            data["webhook_metadata"] = _json_loads(data.get("webhook_metadata"), {})
+            out.append(data)
+        return out
+    cur = await db.execute(
+        """
+        SELECT
+            s.id,
+            s.account_id,
+            s.provider,
+            s.remote_id,
+            s.type,
+            s.path,
+            s.options,
+            s.enabled,
+            s.last_synced_at,
+            a.user_id,
+            a.email,
+            st.sync_mode,
+            st.cursor,
+            st.cursor_kind,
+            st.last_bootstrap_at,
+            st.last_sync_started_at,
+            st.last_sync_succeeded_at,
+            st.last_sync_failed_at,
+            st.last_error,
+            st.retry_backoff_count,
+            st.webhook_status,
+            st.webhook_subscription_id,
+            st.webhook_expires_at,
+            st.webhook_metadata,
+            st.needs_full_rescan,
+            st.active_job_id,
+            st.active_job_started_at
+        FROM external_sources s
+        JOIN external_accounts a ON s.account_id = a.id
+        LEFT JOIN external_source_sync_state st ON st.source_id = s.id
+        ORDER BY s.id ASC
+        """
+    )
+    rows = await cur.fetchall()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            out.append(
+                {
+                    "id": row[0],
+                    "account_id": row[1],
+                    "provider": row[2],
+                    "remote_id": row[3],
+                    "type": row[4],
+                    "path": row[5],
+                    "options": _json_loads(row[6], {}),
+                    "enabled": bool(row[7]),
+                    "last_synced_at": row[8],
+                    "user_id": row[9],
+                    "email": row[10],
+                    "sync_mode": row[11],
+                    "cursor": row[12],
+                    "cursor_kind": row[13],
+                    "last_bootstrap_at": row[14],
+                    "last_sync_started_at": row[15],
+                    "last_sync_succeeded_at": row[16],
+                    "last_sync_failed_at": row[17],
+                    "last_error": row[18],
+                    "retry_backoff_count": row[19],
+                    "webhook_status": row[20],
+                    "webhook_subscription_id": row[21],
+                    "webhook_expires_at": row[22],
+                    "webhook_metadata": _json_loads(row[23], {}),
+                    "needs_full_rescan": bool(row[24]) if row[24] is not None else False,
+                    "active_job_id": row[25],
+                    "active_job_started_at": row[26],
+                }
+            )
+        except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+            data = dict(row)
+            data["options"] = _json_loads(data.get("options"), {})
+            out.append(data)
+    return out
+
+
 async def update_source(db, user_id: int, source_id: int, *, enabled: bool | None = None, options: dict[str, Any] | None = None) -> dict[str, Any] | None:
     await _ensure_tables(db)
     is_pg = _is_postgres_connection(db)
@@ -1696,30 +2319,80 @@ async def update_source(db, user_id: int, source_id: int, *, enabled: bool | Non
         return row
 
 
-async def create_import_job(user_id: int, source_id: int, *, request_id: str | None = None) -> dict[str, Any]:
+async def create_import_job(
+    user_id: int,
+    source_id: int,
+    *,
+    request_id: str | None = None,
+    job_type: str = "import",
+) -> dict[str, Any]:
     """Create a generic job in the core Jobs manager for connector import.
 
     Scaffold behavior: creates a job with payload but does not perform ingestion.
     """
     try:
+        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
         from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+        pool = await get_db_pool()
         jm = JobManager()
+        async with pool.transaction() as db:
+            src = await get_source_by_id(db, user_id, source_id)
+            if not src:
+                raise ValueError("source not found or not owned by user")  # noqa: TRY003
+            sync_state = await get_source_sync_state(db, source_id=source_id)
+            active_job_id = str((sync_state or {}).get("active_job_id") or "").strip() or None
+            if active_job_id:
+                active_job = None
+                with contextlib.suppress(_CONNECTORS_NONCRITICAL_EXCEPTIONS):
+                    active_job = jm.get_job(int(active_job_id))
+                if _job_is_active(active_job):
+                    return _format_connectors_job(active_job or {}, source_id=source_id, default_type=job_type)
+                await finish_source_sync_job(
+                    db,
+                    source_id=source_id,
+                    job_id=active_job_id,
+                    outcome="cleared",
+                )
+
         payload = {
             "source_id": source_id,
             "user_id": user_id,
         }
         if request_id:
             payload["request_id"] = request_id
-        job = jm.create_job(domain="connectors", queue="default", job_type="import", owner_user_id=str(user_id), payload=payload, priority=50, request_id=request_id)
+        idempotency_key = (
+            f"connectors-source:{source_id}:job:{job_type}:request:{request_id}"
+            if request_id
+            else None
+        )
+        job = jm.create_job(
+            domain="connectors",
+            queue="default",
+            job_type=job_type,
+            owner_user_id=str(user_id),
+            payload=payload,
+            priority=5,
+            request_id=request_id,
+            idempotency_key=idempotency_key,
+        )
         job_id = job.get("id") or job.get("job_id") or job.get("uuid")
-        return {
-            "id": str(job_id),
-            "source_id": source_id,
-            "type": "import",
-            "status": "queued",
-            "progress_pct": 0,
-            "counts": {"processed": 0, "skipped": 0, "failed": 0},
-        }
+        async with pool.transaction() as db:
+            sync_state = await reserve_source_sync_job(
+                db,
+                source_id=source_id,
+                job_id=str(job_id),
+            )
+            reserved_job_id = str((sync_state or {}).get("active_job_id") or "").strip() or None
+            if reserved_job_id and reserved_job_id != str(job_id):
+                with contextlib.suppress(_CONNECTORS_NONCRITICAL_EXCEPTIONS):
+                    jm.cancel_job(int(job_id), reason="superseded_by_active_source_job")
+                active_job = None
+                with contextlib.suppress(_CONNECTORS_NONCRITICAL_EXCEPTIONS):
+                    active_job = jm.get_job(int(reserved_job_id))
+                if _job_is_active(active_job):
+                    return _format_connectors_job(active_job or {}, source_id=source_id, default_type=job_type)
+        return _format_connectors_job(job, source_id=source_id, default_type=job_type)
     except _CONNECTORS_NONCRITICAL_EXCEPTIONS as e:
         logger.warning(f"Failed to create connectors job via JobManager: {e}")
         # Fallback to synthetic ID
@@ -1728,7 +2401,7 @@ async def create_import_job(user_id: int, source_id: int, *, request_id: str | N
         return {
             "id": jid,
             "source_id": source_id,
-            "type": "import",
+            "type": job_type,
             "status": "queued",
             "progress_pct": 0,
             "counts": {"processed": 0, "skipped": 0, "failed": 0},

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 from tldw_Server_API.app.core.External_Sources.gmail import GmailConnector
 from tldw_Server_API.app.core.External_Sources.google_drive import GoogleDriveConnector
 from tldw_Server_API.app.core.External_Sources.notion import NotionConnector
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncAdapter
 
 _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -29,6 +30,8 @@ _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     ValueError,
 )
+
+FILE_SYNC_PROVIDERS = frozenset({"drive"})
 
 
 def _is_db_pool_object(db: Any) -> bool:
@@ -63,6 +66,16 @@ def get_connector_by_name(name: str):
     if n == "gmail":
         return GmailConnector()
     raise ValueError(f"Unknown connector provider: {name}")
+
+
+def get_file_sync_connector_by_name(name: str) -> FileSyncAdapter:
+    normalized = name.lower()
+    if normalized not in FILE_SYNC_PROVIDERS:
+        raise ValueError(f"Connector provider does not support file sync: {name}")
+    connector = get_connector_by_name(normalized)
+    if not isinstance(connector, FileSyncAdapter):  # pragma: no cover - defensive guard
+        raise TypeError(f"Connector provider does not implement the file sync adapter contract: {name}")
+    return connector
 
 
 async def _ensure_tables(db) -> None:

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -1527,6 +1527,46 @@ async def list_external_items_for_source(db, *, source_id: int) -> list[dict[str
     return [_normalize_external_item_row(row) or {} for row in rows]
 
 
+async def get_source_binding_health(db, *, source_id: int) -> dict[str, int]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            SELECT
+                COUNT(*) AS tracked_item_count,
+                COALESCE(SUM(CASE WHEN COALESCE(sync_status, 'active') = 'degraded' THEN 1 ELSE 0 END), 0)
+                    AS degraded_item_count
+            FROM external_items
+            WHERE source_id = $1
+            """,
+            source_id,
+        )
+        data = _row_to_dict(row)
+        return {
+            "tracked_item_count": int(data.get("tracked_item_count") or 0),
+            "degraded_item_count": int(data.get("degraded_item_count") or 0),
+        }
+
+    cur = await db.execute(
+        """
+        SELECT
+            COUNT(*) AS tracked_item_count,
+            COALESCE(SUM(CASE WHEN COALESCE(sync_status, 'active') = 'degraded' THEN 1 ELSE 0 END), 0)
+                AS degraded_item_count
+        FROM external_items
+        WHERE source_id = ?
+        """,
+        (source_id,),
+    )
+    row = await cur.fetchone()
+    data = _row_to_dict(row)
+    return {
+        "tracked_item_count": int(data.get("tracked_item_count") or 0),
+        "degraded_item_count": int(data.get("degraded_item_count") or 0),
+    }
+
+
 async def upsert_external_item_binding(
     db,
     *,

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -560,10 +560,7 @@ async def _ensure_tables(db) -> None:
                 )
                 """,
             )
-            await getattr(db, "commit", lambda: None)()
         await _mark_sources_needing_rescan(db, is_pg=is_pg)
-        if not is_pg:
-            await getattr(db, "commit", lambda: None)()
     except _CONNECTORS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Failed to ensure connector tables: {e}")
         raise
@@ -1178,6 +1175,7 @@ async def get_source_by_webhook_subscription(
                 s.options,
                 s.enabled,
                 s.last_synced_at,
+                st.webhook_metadata,
                 a.user_id,
                 a.email
             FROM external_source_sync_state st
@@ -1194,6 +1192,7 @@ async def get_source_by_webhook_subscription(
             return None
         data = dict(row)
         data["options"] = _json_loads(data.get("options"), {})
+        data["webhook_metadata"] = _json_loads(data.get("webhook_metadata"), {})
         return data
 
     cur = await db.execute(
@@ -1208,6 +1207,7 @@ async def get_source_by_webhook_subscription(
             s.options,
             s.enabled,
             s.last_synced_at,
+            st.webhook_metadata,
             a.user_id,
             a.email
         FROM external_source_sync_state st
@@ -1224,6 +1224,7 @@ async def get_source_by_webhook_subscription(
         return None
     data = dict(row)
     data["options"] = _json_loads(data.get("options"), {})
+    data["webhook_metadata"] = _json_loads(data.get("webhook_metadata"), {})
     return data
 
 

--- a/tldw_Server_API/app/core/External_Sources/connectors_service.py
+++ b/tldw_Server_API/app/core/External_Sources/connectors_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -32,6 +33,157 @@ _CONNECTORS_NONCRITICAL_EXCEPTIONS = (
 )
 
 FILE_SYNC_PROVIDERS = frozenset({"drive"})
+_SYNC_STATE_FIELDS = (
+    "sync_mode",
+    "cursor",
+    "cursor_kind",
+    "last_bootstrap_at",
+    "last_sync_started_at",
+    "last_sync_succeeded_at",
+    "last_sync_failed_at",
+    "last_error",
+    "retry_backoff_count",
+    "webhook_status",
+    "webhook_subscription_id",
+    "webhook_expires_at",
+    "needs_full_rescan",
+    "active_job_id",
+    "active_job_started_at",
+)
+_EXTERNAL_ITEM_BINDING_FIELDS = (
+    "name",
+    "mime",
+    "size",
+    "modified_at",
+    "version",
+    "hash",
+    "media_id",
+    "sync_status",
+    "current_version_number",
+    "remote_parent_id",
+    "remote_path",
+    "last_seen_at",
+    "last_content_sync_at",
+    "last_metadata_sync_at",
+    "remote_deleted_at",
+    "access_revoked_at",
+    "provider_metadata",
+)
+
+
+def _utc_now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _normalize_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "t", "yes", "y"}
+    return False
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    if row is None:
+        return {}
+    if isinstance(row, dict):
+        return dict(row)
+    keys = getattr(row, "keys", None)
+    if callable(keys):
+        return {key: row[key] for key in row.keys()}
+    return dict(row)
+
+
+def _json_loads(value: Any, default: Any) -> Any:
+    if value in (None, ""):
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except _CONNECTORS_NONCRITICAL_EXCEPTIONS:
+        return default
+
+
+def _normalize_sync_state_row(row: Any) -> dict[str, Any] | None:
+    if not row:
+        return None
+    data = _row_to_dict(row)
+    data["needs_full_rescan"] = _normalize_bool(data.get("needs_full_rescan"))
+    return data
+
+
+def _normalize_external_item_row(row: Any) -> dict[str, Any] | None:
+    if not row:
+        return None
+    data = _row_to_dict(row)
+    if "provider_metadata" in data:
+        data["provider_metadata"] = _json_loads(data.get("provider_metadata"), {})
+    if "sync_status" not in data or data.get("sync_status") is None:
+        data["sync_status"] = "active"
+    return data
+
+
+async def _sqlite_column_names(db, table_name: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table_name})")
+    rows = await cur.fetchall()
+    names: set[str] = set()
+    for row in rows:
+        if hasattr(row, "keys"):
+            names.add(str(row["name"]))
+        else:
+            names.add(str(row[1]))
+    return names
+
+
+async def _ensure_sqlite_column(db, table_name: str, column_name: str, column_sql: str) -> None:
+    if column_name in await _sqlite_column_names(db, table_name):
+        return
+    await db.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_sql}")
+
+
+async def _mark_sources_needing_rescan(db, *, is_pg: bool) -> None:
+    if is_pg:
+        await db.execute(
+            """
+            INSERT INTO external_source_sync_state (
+                source_id,
+                sync_mode,
+                needs_full_rescan
+            )
+            SELECT DISTINCT source_id, 'manual', TRUE
+            FROM external_items
+            WHERE media_id IS NULL
+            ON CONFLICT (source_id) DO UPDATE SET
+                needs_full_rescan = TRUE
+            """
+        )
+        return
+    await db.execute(
+        """
+        INSERT OR IGNORE INTO external_source_sync_state (
+            source_id,
+            sync_mode,
+            needs_full_rescan
+        )
+        SELECT DISTINCT source_id, 'manual', 1
+        FROM external_items
+        WHERE media_id IS NULL
+        """
+    )
+    await db.execute(
+        """
+        UPDATE external_source_sync_state
+        SET needs_full_rescan = 1
+        WHERE source_id IN (
+            SELECT DISTINCT source_id
+            FROM external_items
+            WHERE media_id IS NULL
+        )
+        """
+    )
 
 
 def _is_db_pool_object(db: Any) -> bool:
@@ -163,6 +315,51 @@ async def _ensure_tables(db) -> None:
                 )
                 """
             )
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS media_id INTEGER")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS sync_status TEXT")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS current_version_number INTEGER")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS remote_parent_id TEXT")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS remote_path TEXT")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMP NULL")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS last_content_sync_at TIMESTAMP NULL")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS last_metadata_sync_at TIMESTAMP NULL")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS remote_deleted_at TIMESTAMP NULL")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS access_revoked_at TIMESTAMP NULL")
+            await db.execute("ALTER TABLE external_items ADD COLUMN IF NOT EXISTS provider_metadata JSONB")
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_source_sync_state (
+                    source_id INTEGER PRIMARY KEY REFERENCES external_sources(id) ON DELETE CASCADE,
+                    sync_mode TEXT NOT NULL DEFAULT 'manual',
+                    cursor TEXT,
+                    cursor_kind TEXT,
+                    last_bootstrap_at TIMESTAMP NULL,
+                    last_sync_started_at TIMESTAMP NULL,
+                    last_sync_succeeded_at TIMESTAMP NULL,
+                    last_sync_failed_at TIMESTAMP NULL,
+                    last_error TEXT,
+                    retry_backoff_count INTEGER DEFAULT 0,
+                    webhook_status TEXT,
+                    webhook_subscription_id TEXT,
+                    webhook_expires_at TIMESTAMP NULL,
+                    needs_full_rescan BOOLEAN DEFAULT FALSE,
+                    active_job_id TEXT,
+                    active_job_started_at TIMESTAMP NULL
+                )
+                """
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_item_events (
+                    id SERIAL PRIMARY KEY,
+                    external_item_id INTEGER NOT NULL REFERENCES external_items(id) ON DELETE CASCADE,
+                    event_type TEXT NOT NULL,
+                    job_id TEXT,
+                    payload_json JSONB,
+                    occurred_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
         else:
             await db.execute(
                 """
@@ -244,6 +441,55 @@ async def _ensure_tables(db) -> None:
                 )
                 """,
             )
+            await _ensure_sqlite_column(db, "external_items", "media_id", "media_id INTEGER")
+            await _ensure_sqlite_column(db, "external_items", "sync_status", "sync_status TEXT")
+            await _ensure_sqlite_column(db, "external_items", "current_version_number", "current_version_number INTEGER")
+            await _ensure_sqlite_column(db, "external_items", "remote_parent_id", "remote_parent_id TEXT")
+            await _ensure_sqlite_column(db, "external_items", "remote_path", "remote_path TEXT")
+            await _ensure_sqlite_column(db, "external_items", "last_seen_at", "last_seen_at TEXT")
+            await _ensure_sqlite_column(db, "external_items", "last_content_sync_at", "last_content_sync_at TEXT")
+            await _ensure_sqlite_column(db, "external_items", "last_metadata_sync_at", "last_metadata_sync_at TEXT")
+            await _ensure_sqlite_column(db, "external_items", "remote_deleted_at", "remote_deleted_at TEXT")
+            await _ensure_sqlite_column(db, "external_items", "access_revoked_at", "access_revoked_at TEXT")
+            await _ensure_sqlite_column(db, "external_items", "provider_metadata", "provider_metadata TEXT")
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_source_sync_state (
+                    source_id INTEGER PRIMARY KEY,
+                    sync_mode TEXT NOT NULL DEFAULT 'manual',
+                    cursor TEXT,
+                    cursor_kind TEXT,
+                    last_bootstrap_at TEXT,
+                    last_sync_started_at TEXT,
+                    last_sync_succeeded_at TEXT,
+                    last_sync_failed_at TEXT,
+                    last_error TEXT,
+                    retry_backoff_count INTEGER DEFAULT 0,
+                    webhook_status TEXT,
+                    webhook_subscription_id TEXT,
+                    webhook_expires_at TEXT,
+                    needs_full_rescan INTEGER DEFAULT 0,
+                    active_job_id TEXT,
+                    active_job_started_at TEXT
+                )
+                """,
+            )
+            await db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS external_item_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    external_item_id INTEGER NOT NULL,
+                    event_type TEXT NOT NULL,
+                    job_id TEXT,
+                    payload_json TEXT,
+                    occurred_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+            )
+            await getattr(db, "commit", lambda: None)()
+        await _mark_sources_needing_rescan(db, is_pg=is_pg)
+        if not is_pg:
+            await getattr(db, "commit", lambda: None)()
     except _CONNECTORS_NONCRITICAL_EXCEPTIONS as e:
         logger.error(f"Failed to ensure connector tables: {e}")
         raise
@@ -681,6 +927,492 @@ async def get_source_by_id(db, user_id: int, source_id: int) -> dict[str, Any] |
         return dict(r)
 
 
+async def get_source_sync_state(db, *, source_id: int) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            "SELECT * FROM external_source_sync_state WHERE source_id = $1",
+            source_id,
+        )
+        return _normalize_sync_state_row(row)
+    cur = await db.execute(
+        "SELECT * FROM external_source_sync_state WHERE source_id = ?",
+        (source_id,),
+    )
+    row = await cur.fetchone()
+    return _normalize_sync_state_row(row)
+
+
+async def upsert_source_sync_state(db, *, source_id: int, **updates: Any) -> dict[str, Any]:
+    await _ensure_tables(db)
+    existing = await get_source_sync_state(db, source_id=source_id) or {}
+    data = {"source_id": source_id, "sync_mode": "manual", **existing}
+    for field in _SYNC_STATE_FIELDS:
+        if field in updates and updates[field] is not None:
+            data[field] = updates[field]
+
+    is_pg = _is_postgres_connection(db)
+    values = [
+        data.get("source_id"),
+        data.get("sync_mode") or "manual",
+        data.get("cursor"),
+        data.get("cursor_kind"),
+        data.get("last_bootstrap_at"),
+        data.get("last_sync_started_at"),
+        data.get("last_sync_succeeded_at"),
+        data.get("last_sync_failed_at"),
+        data.get("last_error"),
+        int(data.get("retry_backoff_count") or 0),
+        data.get("webhook_status"),
+        data.get("webhook_subscription_id"),
+        data.get("webhook_expires_at"),
+        bool(data.get("needs_full_rescan")),
+        data.get("active_job_id"),
+        data.get("active_job_started_at"),
+    ]
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            INSERT INTO external_source_sync_state (
+                source_id,
+                sync_mode,
+                cursor,
+                cursor_kind,
+                last_bootstrap_at,
+                last_sync_started_at,
+                last_sync_succeeded_at,
+                last_sync_failed_at,
+                last_error,
+                retry_backoff_count,
+                webhook_status,
+                webhook_subscription_id,
+                webhook_expires_at,
+                needs_full_rescan,
+                active_job_id,
+                active_job_started_at
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8,
+                $9, $10, $11, $12, $13, $14, $15, $16
+            )
+            ON CONFLICT (source_id) DO UPDATE SET
+                sync_mode = EXCLUDED.sync_mode,
+                cursor = EXCLUDED.cursor,
+                cursor_kind = EXCLUDED.cursor_kind,
+                last_bootstrap_at = EXCLUDED.last_bootstrap_at,
+                last_sync_started_at = EXCLUDED.last_sync_started_at,
+                last_sync_succeeded_at = EXCLUDED.last_sync_succeeded_at,
+                last_sync_failed_at = EXCLUDED.last_sync_failed_at,
+                last_error = EXCLUDED.last_error,
+                retry_backoff_count = EXCLUDED.retry_backoff_count,
+                webhook_status = EXCLUDED.webhook_status,
+                webhook_subscription_id = EXCLUDED.webhook_subscription_id,
+                webhook_expires_at = EXCLUDED.webhook_expires_at,
+                needs_full_rescan = EXCLUDED.needs_full_rescan,
+                active_job_id = EXCLUDED.active_job_id,
+                active_job_started_at = EXCLUDED.active_job_started_at
+            RETURNING *
+            """,
+            *values,
+        )
+        return _normalize_sync_state_row(row) or {}
+
+    await db.execute(
+        """
+        INSERT INTO external_source_sync_state (
+            source_id,
+            sync_mode,
+            cursor,
+            cursor_kind,
+            last_bootstrap_at,
+            last_sync_started_at,
+            last_sync_succeeded_at,
+            last_sync_failed_at,
+            last_error,
+            retry_backoff_count,
+            webhook_status,
+            webhook_subscription_id,
+            webhook_expires_at,
+            needs_full_rescan,
+            active_job_id,
+            active_job_started_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(source_id) DO UPDATE SET
+            sync_mode = excluded.sync_mode,
+            cursor = excluded.cursor,
+            cursor_kind = excluded.cursor_kind,
+            last_bootstrap_at = excluded.last_bootstrap_at,
+            last_sync_started_at = excluded.last_sync_started_at,
+            last_sync_succeeded_at = excluded.last_sync_succeeded_at,
+            last_sync_failed_at = excluded.last_sync_failed_at,
+            last_error = excluded.last_error,
+            retry_backoff_count = excluded.retry_backoff_count,
+            webhook_status = excluded.webhook_status,
+            webhook_subscription_id = excluded.webhook_subscription_id,
+            webhook_expires_at = excluded.webhook_expires_at,
+            needs_full_rescan = excluded.needs_full_rescan,
+            active_job_id = excluded.active_job_id,
+            active_job_started_at = excluded.active_job_started_at
+        """,
+        (
+            values[0],
+            values[1],
+            values[2],
+            values[3],
+            values[4],
+            values[5],
+            values[6],
+            values[7],
+            values[8],
+            values[9],
+            values[10],
+            values[11],
+            values[12],
+            1 if values[13] else 0,
+            values[14],
+            values[15],
+        ),
+    )
+    await getattr(db, "commit", lambda: None)()
+    return await get_source_sync_state(db, source_id=source_id) or {}
+
+
+async def get_external_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    external_id: str,
+) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            SELECT *
+            FROM external_items
+            WHERE source_id = $1 AND provider = $2 AND external_id = $3
+            """,
+            source_id,
+            provider,
+            external_id,
+        )
+        return _normalize_external_item_row(row)
+    cur = await db.execute(
+        """
+        SELECT *
+        FROM external_items
+        WHERE source_id = ? AND provider = ? AND external_id = ?
+        """,
+        (source_id, provider, external_id),
+    )
+    row = await cur.fetchone()
+    return _normalize_external_item_row(row)
+
+
+async def list_external_items_for_source(db, *, source_id: int) -> list[dict[str, Any]]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        rows = await db.fetch(
+            "SELECT * FROM external_items WHERE source_id = $1 ORDER BY id ASC",
+            source_id,
+        )
+        return [_normalize_external_item_row(row) or {} for row in rows]
+    cur = await db.execute(
+        "SELECT * FROM external_items WHERE source_id = ? ORDER BY id ASC",
+        (source_id,),
+    )
+    rows = await cur.fetchall()
+    return [_normalize_external_item_row(row) or {} for row in rows]
+
+
+async def upsert_external_item_binding(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    external_id: str,
+    name: str | None = None,
+    mime: str | None = None,
+    size: int | None = None,
+    version: str | None = None,
+    modified_at: str | None = None,
+    content_hash: str | None = None,
+    media_id: int | None = None,
+    sync_status: str | None = None,
+    current_version_number: int | None = None,
+    remote_parent_id: str | None = None,
+    remote_path: str | None = None,
+    last_seen_at: str | None = None,
+    last_content_sync_at: str | None = None,
+    last_metadata_sync_at: str | None = None,
+    remote_deleted_at: str | None = None,
+    access_revoked_at: str | None = None,
+    provider_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    last_seen_value = last_seen_at or _utc_now_text()
+    provider_metadata_value = provider_metadata or None
+    sqlite_provider_metadata = json.dumps(provider_metadata_value) if provider_metadata_value is not None else None
+    sync_status_value = sync_status or "active"
+
+    if is_pg:
+        await db.execute(
+            """
+            INSERT INTO external_items (
+                source_id,
+                provider,
+                external_id,
+                name,
+                mime,
+                size,
+                modified_at,
+                version,
+                hash,
+                last_ingested_at,
+                media_id,
+                sync_status,
+                current_version_number,
+                remote_parent_id,
+                remote_path,
+                last_seen_at,
+                last_content_sync_at,
+                last_metadata_sync_at,
+                remote_deleted_at,
+                access_revoked_at,
+                provider_metadata
+            ) VALUES (
+                $1, $2, $3, $4, $5, $6, $7, $8, $9, CURRENT_TIMESTAMP,
+                $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
+            )
+            ON CONFLICT (source_id, provider, external_id) DO UPDATE SET
+                name = COALESCE(EXCLUDED.name, external_items.name),
+                mime = COALESCE(EXCLUDED.mime, external_items.mime),
+                size = COALESCE(EXCLUDED.size, external_items.size),
+                modified_at = COALESCE(EXCLUDED.modified_at, external_items.modified_at),
+                version = COALESCE(EXCLUDED.version, external_items.version),
+                hash = COALESCE(EXCLUDED.hash, external_items.hash),
+                last_ingested_at = CURRENT_TIMESTAMP,
+                media_id = COALESCE(EXCLUDED.media_id, external_items.media_id),
+                sync_status = COALESCE(EXCLUDED.sync_status, external_items.sync_status),
+                current_version_number = COALESCE(EXCLUDED.current_version_number, external_items.current_version_number),
+                remote_parent_id = COALESCE(EXCLUDED.remote_parent_id, external_items.remote_parent_id),
+                remote_path = COALESCE(EXCLUDED.remote_path, external_items.remote_path),
+                last_seen_at = COALESCE(EXCLUDED.last_seen_at, external_items.last_seen_at),
+                last_content_sync_at = COALESCE(EXCLUDED.last_content_sync_at, external_items.last_content_sync_at),
+                last_metadata_sync_at = COALESCE(EXCLUDED.last_metadata_sync_at, external_items.last_metadata_sync_at),
+                remote_deleted_at = COALESCE(EXCLUDED.remote_deleted_at, external_items.remote_deleted_at),
+                access_revoked_at = COALESCE(EXCLUDED.access_revoked_at, external_items.access_revoked_at),
+                provider_metadata = COALESCE(EXCLUDED.provider_metadata, external_items.provider_metadata)
+            """,
+            source_id,
+            provider,
+            external_id,
+            name,
+            mime,
+            size,
+            modified_at,
+            version,
+            content_hash,
+            media_id,
+            sync_status_value,
+            current_version_number,
+            remote_parent_id,
+            remote_path,
+            last_seen_value,
+            last_content_sync_at,
+            last_metadata_sync_at,
+            remote_deleted_at,
+            access_revoked_at,
+            provider_metadata_value,
+        )
+    else:
+        await db.execute(
+            """
+            INSERT INTO external_items (
+                source_id,
+                provider,
+                external_id,
+                name,
+                mime,
+                size,
+                modified_at,
+                version,
+                hash,
+                last_ingested_at,
+                media_id,
+                sync_status,
+                current_version_number,
+                remote_parent_id,
+                remote_path,
+                last_seen_at,
+                last_content_sync_at,
+                last_metadata_sync_at,
+                remote_deleted_at,
+                access_revoked_at,
+                provider_metadata
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            ON CONFLICT(source_id, provider, external_id) DO UPDATE SET
+                name = COALESCE(excluded.name, external_items.name),
+                mime = COALESCE(excluded.mime, external_items.mime),
+                size = COALESCE(excluded.size, external_items.size),
+                modified_at = COALESCE(excluded.modified_at, external_items.modified_at),
+                version = COALESCE(excluded.version, external_items.version),
+                hash = COALESCE(excluded.hash, external_items.hash),
+                last_ingested_at = CURRENT_TIMESTAMP,
+                media_id = COALESCE(excluded.media_id, external_items.media_id),
+                sync_status = COALESCE(excluded.sync_status, external_items.sync_status),
+                current_version_number = COALESCE(excluded.current_version_number, external_items.current_version_number),
+                remote_parent_id = COALESCE(excluded.remote_parent_id, external_items.remote_parent_id),
+                remote_path = COALESCE(excluded.remote_path, external_items.remote_path),
+                last_seen_at = COALESCE(excluded.last_seen_at, external_items.last_seen_at),
+                last_content_sync_at = COALESCE(excluded.last_content_sync_at, external_items.last_content_sync_at),
+                last_metadata_sync_at = COALESCE(excluded.last_metadata_sync_at, external_items.last_metadata_sync_at),
+                remote_deleted_at = COALESCE(excluded.remote_deleted_at, external_items.remote_deleted_at),
+                access_revoked_at = COALESCE(excluded.access_revoked_at, external_items.access_revoked_at),
+                provider_metadata = COALESCE(excluded.provider_metadata, external_items.provider_metadata)
+            """,
+            (
+                source_id,
+                provider,
+                external_id,
+                name,
+                mime,
+                size,
+                modified_at,
+                version,
+                content_hash,
+                media_id,
+                sync_status_value,
+                current_version_number,
+                remote_parent_id,
+                remote_path,
+                last_seen_value,
+                last_content_sync_at,
+                last_metadata_sync_at,
+                remote_deleted_at,
+                access_revoked_at,
+                sqlite_provider_metadata,
+            ),
+        )
+        await getattr(db, "commit", lambda: None)()
+
+    return await get_external_item_binding(
+        db,
+        source_id=source_id,
+        provider=provider,
+        external_id=external_id,
+    ) or {}
+
+
+async def record_item_event(
+    db,
+    *,
+    external_item_id: int,
+    event_type: str,
+    job_id: str | None = None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    await _ensure_tables(db)
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        row = await db.fetchrow(
+            """
+            INSERT INTO external_item_events (
+                external_item_id,
+                event_type,
+                job_id,
+                payload_json
+            ) VALUES ($1, $2, $3, $4)
+            RETURNING *
+            """,
+            external_item_id,
+            event_type,
+            job_id,
+            payload or {},
+        )
+        out = _row_to_dict(row)
+        out["payload_json"] = _json_loads(out.get("payload_json"), {})
+        return out
+    cur = await db.execute(
+        """
+        INSERT INTO external_item_events (
+            external_item_id,
+            event_type,
+            job_id,
+            payload_json
+        ) VALUES (?, ?, ?, ?)
+        """,
+        (
+            external_item_id,
+            event_type,
+            job_id,
+            json.dumps(payload or {}),
+        ),
+    )
+    await getattr(db, "commit", lambda: None)()
+    row_id = cur.lastrowid
+    cur2 = await db.execute(
+        "SELECT * FROM external_item_events WHERE id = ?",
+        (row_id,),
+    )
+    row = await cur2.fetchone()
+    out = _row_to_dict(row)
+    out["payload_json"] = _json_loads(out.get("payload_json"), {})
+    return out
+
+
+async def mark_external_item_archived(
+    db,
+    *,
+    source_id: int,
+    provider: str,
+    external_id: str,
+    sync_status: str = "archived_upstream_removed",
+) -> dict[str, Any] | None:
+    await _ensure_tables(db)
+    deleted_at = _utc_now_text()
+    is_pg = _is_postgres_connection(db)
+    if is_pg:
+        await db.execute(
+            """
+            UPDATE external_items
+            SET sync_status = $1,
+                remote_deleted_at = COALESCE(remote_deleted_at, $2),
+                last_metadata_sync_at = $2
+            WHERE source_id = $3 AND provider = $4 AND external_id = $5
+            """,
+            sync_status,
+            deleted_at,
+            source_id,
+            provider,
+            external_id,
+        )
+    else:
+        await db.execute(
+            """
+            UPDATE external_items
+            SET sync_status = ?,
+                remote_deleted_at = COALESCE(remote_deleted_at, ?),
+                last_metadata_sync_at = ?
+            WHERE source_id = ? AND provider = ? AND external_id = ?
+            """,
+            (sync_status, deleted_at, deleted_at, source_id, provider, external_id),
+        )
+        await getattr(db, "commit", lambda: None)()
+    return await get_external_item_binding(
+        db,
+        source_id=source_id,
+        provider=provider,
+        external_id=external_id,
+    )
+
+
 async def should_ingest_item(
     db, *, source_id: int, provider: str, external_id: str, version: str | None, modified_at: str | None, content_hash: str | None
 ) -> bool:
@@ -711,32 +1443,20 @@ async def should_ingest_item(
 async def record_ingested_item(
     db, *, source_id: int, provider: str, external_id: str, name: str | None, mime: str | None, size: int | None, version: str | None, modified_at: str | None, content_hash: str | None
 ) -> None:
-    await _ensure_tables(db)
-    is_pg = _is_postgres_connection(db)
-    if is_pg:
-        await db.execute(
-            """
-            INSERT INTO external_items (source_id, provider, external_id, name, mime, size, modified_at, version, hash, last_ingested_at)
-            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, CURRENT_TIMESTAMP)
-            ON CONFLICT (source_id, provider, external_id) DO UPDATE SET
-                name=EXCLUDED.name, mime=EXCLUDED.mime, size=EXCLUDED.size,
-                modified_at=EXCLUDED.modified_at, version=EXCLUDED.version, hash=EXCLUDED.hash,
-                last_ingested_at=CURRENT_TIMESTAMP
-            """,
-            source_id, provider, external_id, name, mime, int(size or 0), modified_at, version, content_hash,
-        )
-        return
-    await db.execute(
-        """
-        INSERT OR REPLACE INTO external_items (id, source_id, provider, external_id, name, mime, size, modified_at, version, hash, last_ingested_at)
-        VALUES (
-            COALESCE((SELECT id FROM external_items WHERE source_id = ? AND provider = ? AND external_id = ?), NULL),
-            ?,?,?,?,?,?,?,?, ?, CURRENT_TIMESTAMP
-        )
-        """,
-        (source_id, provider, external_id, source_id, provider, external_id, name, mime, int(size or 0), modified_at, version, content_hash),
+    await upsert_external_item_binding(
+        db,
+        source_id=source_id,
+        provider=provider,
+        external_id=external_id,
+        name=name,
+        mime=mime,
+        size=int(size or 0),
+        version=version,
+        modified_at=modified_at,
+        content_hash=content_hash,
+        sync_status="active",
+        last_content_sync_at=_utc_now_text(),
     )
-    await getattr(db, "commit", lambda: None)()
 
 
 def _today_utc_start_str() -> str:

--- a/tldw_Server_API/app/core/External_Sources/google_drive.py
+++ b/tldw_Server_API/app/core/External_Sources/google_drive.py
@@ -5,7 +5,7 @@ import re
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 from tldw_Server_API.app.core.http_client import afetch
 
@@ -225,9 +225,10 @@ class GoogleDriveConnector(BaseConnector):
         if not token:
             return None
         headers = {"Authorization": f"Bearer {token}"}
+        quoted_remote_id = quote(remote_id, safe="")
         resp = await afetch(
             method="GET",
-            url=f"https://www.googleapis.com/drive/v3/files/{remote_id}",
+            url=f"https://www.googleapis.com/drive/v3/files/{quoted_remote_id}",
             headers=headers,
             params={
                 "fields": "id,name,mimeType,modifiedTime,md5Checksum,size,parents,version,webViewLink,trashed",
@@ -421,6 +422,7 @@ class GoogleDriveConnector(BaseConnector):
         if not token:
             return b""
         headers = {"Authorization": f"Bearer {token}"}
+        quoted_file_id = quote(file_id, safe="")
         # If mime_type is a Google Docs type, use export
         mt = (mime_type or "").lower()
         if mt.startswith("application/vnd.google-apps."):
@@ -432,7 +434,7 @@ class GoogleDriveConnector(BaseConnector):
                 "application/vnd.google-apps.presentation": "application/pdf",
             }
             exp = export_mime or default_export_map.get(mt, "text/plain")
-            url = f"https://www.googleapis.com/drive/v3/files/{file_id}/export"
+            url = f"https://www.googleapis.com/drive/v3/files/{quoted_file_id}/export"
             resp = await afetch(
                 method="GET",
                 url=url,
@@ -448,7 +450,7 @@ class GoogleDriveConnector(BaseConnector):
                 if callable(close):
                     await close()
         # Binary download for normal files
-        url = f"https://www.googleapis.com/drive/v3/files/{file_id}"
+        url = f"https://www.googleapis.com/drive/v3/files/{quoted_file_id}"
         resp = await afetch(
             method="GET",
             url=url,

--- a/tldw_Server_API/app/core/External_Sources/google_drive.py
+++ b/tldw_Server_API/app/core/External_Sources/google_drive.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from tldw_Server_API.app.core.http_client import afetch
 
 from .connector_base import BaseConnector
+from .sync_adapter import FileSyncChange
 
 
 class GoogleDriveConnector(BaseConnector):
     name = "drive"
+    _DRIVE_FILE_LINK_RE = re.compile(r"/file/d/([^/]+)")
 
     def __init__(self, client_id: str | None = None, client_secret: str | None = None, redirect_base: str | None = None):
         super().__init__(
@@ -99,9 +102,163 @@ class GoogleDriveConnector(BaseConnector):
             "scope": tok.get("scope"),
         }
 
+    @staticmethod
+    def _access_token_from_account(account: dict[str, Any]) -> str | None:
+        return (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+
+    async def get_start_page_token(self, account: dict[str, Any]) -> str | None:
+        token = self._access_token_from_account(account)
+        if not token:
+            return None
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await afetch(
+            method="GET",
+            url="https://www.googleapis.com/drive/v3/changes/startPageToken",
+            headers=headers,
+            params={"supportsAllDrives": True},
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return data.get("startPageToken")
+
+    async def list_changes(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[FileSyncChange], str | None, str | None]:
+        token = self._access_token_from_account(account)
+        if not token:
+            return [], None, None
+        page_token = cursor or await self.get_start_page_token(account)
+        if not page_token:
+            return [], None, None
+
+        headers = {"Authorization": f"Bearer {token}"}
+        params = {
+            "pageToken": page_token,
+            "pageSize": max(1, min(int(page_size), 1000)),
+            "supportsAllDrives": True,
+            "includeItemsFromAllDrives": True,
+            "fields": (
+                "nextPageToken,newStartPageToken,"
+                "changes(fileId,removed,time,file("
+                "id,name,mimeType,modifiedTime,md5Checksum,size,parents,version,webViewLink,trashed))"
+            ),
+        }
+        resp = await afetch(
+            method="GET",
+            url="https://www.googleapis.com/drive/v3/changes",
+            headers=headers,
+            params=params,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+        changes: list[FileSyncChange] = []
+        for raw_change in data.get("changes") or []:
+            if not isinstance(raw_change, dict):
+                continue
+            file_id = str(raw_change.get("fileId") or "").strip()
+            file_data = raw_change.get("file") or {}
+            if raw_change.get("removed") or not file_data or file_data.get("trashed"):
+                if file_id:
+                    changes.append(
+                        FileSyncChange(
+                            event_type="deleted",
+                            remote_id=file_id,
+                            metadata={"change_time": raw_change.get("time")},
+                        )
+                    )
+                continue
+            remote_id = str(file_data.get("id") or file_id).strip()
+            if not remote_id:
+                continue
+            changes.append(
+                FileSyncChange(
+                    event_type="content_updated",
+                    remote_id=remote_id,
+                    remote_name=file_data.get("name"),
+                    remote_parent_id=((file_data.get("parents") or [None])[0]),
+                    remote_revision=str(file_data.get("version") or "") or None,
+                    remote_hash=file_data.get("md5Checksum"),
+                    metadata={
+                        "mime_type": file_data.get("mimeType"),
+                        "modified_time": file_data.get("modifiedTime"),
+                        "size": int(file_data.get("size") or 0),
+                        "parents": file_data.get("parents") or [],
+                        "remote_url": file_data.get("webViewLink"),
+                        "change_time": raw_change.get("time"),
+                    },
+                )
+            )
+        return changes, data.get("nextPageToken"), data.get("newStartPageToken")
+
+    async def get_item_metadata(self, account: dict[str, Any], remote_id: str) -> dict[str, Any] | None:
+        token = self._access_token_from_account(account)
+        if not token:
+            return None
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await afetch(
+            method="GET",
+            url=f"https://www.googleapis.com/drive/v3/files/{remote_id}",
+            headers=headers,
+            params={
+                "fields": "id,name,mimeType,modifiedTime,md5Checksum,size,parents,version,webViewLink,trashed",
+                "supportsAllDrives": True,
+            },
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        resolved_id = str(data.get("id") or remote_id).strip()
+        if not resolved_id:
+            return None
+        return {
+            "remote_id": resolved_id,
+            "remote_name": data.get("name"),
+            "mime_type": data.get("mimeType"),
+            "modified_time": data.get("modifiedTime"),
+            "remote_hash": data.get("md5Checksum"),
+            "size": int(data.get("size") or 0),
+            "parents": data.get("parents") or [],
+            "remote_revision": str(data.get("version") or "") or None,
+            "remote_url": data.get("webViewLink"),
+            "trashed": bool(data.get("trashed")),
+        }
+
+    async def resolve_shared_link(self, account: dict[str, Any], shared_link: str) -> dict[str, Any] | None:
+        parsed = urlparse(shared_link)
+        match = self._DRIVE_FILE_LINK_RE.search(parsed.path or "")
+        if match:
+            return await self.get_item_metadata(account, match.group(1))
+
+        query_id = (parse_qs(parsed.query).get("id") or [None])[0]
+        if query_id:
+            return await self.get_item_metadata(account, str(query_id))
+        return None
+
     async def list_files(self, account: dict[str, Any], parent_remote_id: str, *, page_size: int = 50, cursor: str | None = None):
         """List files/folders under a parent. Returns (items, next_cursor)."""
-        token = (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+        token = self._access_token_from_account(account)
         if not token:
             return [], None
         headers = {"Authorization": f"Bearer {token}"}
@@ -144,7 +301,7 @@ class GoogleDriveConnector(BaseConnector):
         return items, data.get("nextPageToken")
 
     async def download_file(self, account: dict[str, Any], file_id: str, *, mime_type: str | None = None, export_mime: str | None = None) -> bytes:
-        token = (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+        token = self._access_token_from_account(account)
         if not token:
             return b""
         headers = {"Authorization": f"Bearer {token}"}

--- a/tldw_Server_API/app/core/External_Sources/google_drive.py
+++ b/tldw_Server_API/app/core/External_Sources/google_drive.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 import os
 import re
+import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from tldw_Server_API.app.core.http_client import afetch
 
 from .connector_base import BaseConnector
-from .sync_adapter import FileSyncChange
+from .sync_adapter import FileSyncChange, FileSyncWebhookSubscription
 
 
 class GoogleDriveConnector(BaseConnector):
@@ -105,6 +107,17 @@ class GoogleDriveConnector(BaseConnector):
     @staticmethod
     def _access_token_from_account(account: dict[str, Any]) -> str | None:
         return (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+
+    @staticmethod
+    def _expiration_millis_to_iso(value: Any) -> str | None:
+        raw = str(value or "").strip()
+        if not raw:
+            return None
+        try:
+            millis = int(raw)
+        except (TypeError, ValueError):
+            return None
+        return datetime.fromtimestamp(millis / 1000, tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
     async def get_start_page_token(self, account: dict[str, Any]) -> str | None:
         token = self._access_token_from_account(account)
@@ -255,6 +268,109 @@ class GoogleDriveConnector(BaseConnector):
         if query_id:
             return await self.get_item_metadata(account, str(query_id))
         return None
+
+    async def subscribe_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        resource: dict[str, Any],
+        callback_url: str,
+    ) -> FileSyncWebhookSubscription | None:
+        token = self._access_token_from_account(account)
+        if not token:
+            return None
+        page_token = str(resource.get("pageToken") or "").strip() or await self.get_start_page_token(account)
+        if not page_token:
+            return None
+        channel_id = str(resource.get("subscription_id") or "").strip() or uuid.uuid4().hex
+        client_state = str(resource.get("clientState") or "").strip() or None
+        expiration_millis = resource.get("expiration")
+        if expiration_millis is None:
+            expiration_millis = int((datetime.now(UTC) + timedelta(days=1)).timestamp() * 1000)
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        body = {
+            "id": channel_id,
+            "type": "web_hook",
+            "address": callback_url,
+            "expiration": expiration_millis,
+        }
+        if client_state:
+            body["token"] = client_state
+        resp = await afetch(
+            method="POST",
+            url="https://www.googleapis.com/drive/v3/changes/watch",
+            headers=headers,
+            params={"pageToken": page_token, "supportsAllDrives": True, "includeItemsFromAllDrives": True},
+            json=body,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        metadata = dict(data)
+        metadata["pageToken"] = page_token
+        metadata["callback_url"] = callback_url
+        if client_state:
+            metadata["clientState"] = client_state
+        return FileSyncWebhookSubscription(
+            subscription_id=str(data.get("id") or channel_id),
+            expires_at=self._expiration_millis_to_iso(data.get("expiration") or expiration_millis),
+            metadata=metadata,
+        )
+
+    async def renew_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> FileSyncWebhookSubscription | None:
+        metadata = dict(subscription.metadata or {})
+        callback_url = str(metadata.get("callback_url") or "").strip()
+        if not callback_url:
+            return None
+        with_client_state = str(metadata.get("clientState") or "").strip() or None
+        page_token = str(metadata.get("pageToken") or "").strip() or await self.get_start_page_token(account)
+        if not page_token:
+            return None
+        await self.revoke_webhook(account, subscription=subscription)
+        resource = {"pageToken": page_token}
+        if with_client_state:
+            resource["clientState"] = with_client_state
+        return await self.subscribe_webhook(
+            account,
+            resource=resource,
+            callback_url=callback_url,
+        )
+
+    async def revoke_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> bool:
+        token = self._access_token_from_account(account)
+        resource_id = str((subscription.metadata or {}).get("resourceId") or "").strip()
+        if not token or not subscription.subscription_id or not resource_id:
+            return False
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        resp = await afetch(
+            method="POST",
+            url="https://www.googleapis.com/drive/v3/channels/stop",
+            headers=headers,
+            json={"id": subscription.subscription_id, "resourceId": resource_id},
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            return True
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
 
     async def list_files(self, account: dict[str, Any], parent_remote_id: str, *, page_size: int = 50, cursor: str | None = None):
         """List files/folders under a parent. Returns (items, next_cursor)."""

--- a/tldw_Server_API/app/core/External_Sources/onedrive.py
+++ b/tldw_Server_API/app/core/External_Sources/onedrive.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+from tldw_Server_API.app.core.http_client import afetch
+
+from .connector_base import BaseConnector
+from .sync_adapter import FileSyncChange, FileSyncWebhookSubscription
+
+
+class OneDriveConnector(BaseConnector):
+    name = "onedrive"
+
+    def __init__(self, client_id: str | None = None, client_secret: str | None = None, redirect_base: str | None = None):
+        super().__init__(
+            client_id=client_id or os.getenv("CONNECTOR_ONEDRIVE_CLIENT_ID"),
+            client_secret=client_secret or os.getenv("CONNECTOR_ONEDRIVE_CLIENT_SECRET"),
+            redirect_base=redirect_base or os.getenv("CONNECTOR_REDIRECT_BASE_URL"),
+        )
+
+    @staticmethod
+    def _access_token_from_account(account: dict[str, Any]) -> str | None:
+        return (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+
+    def authorize_url(
+        self,
+        state: str | None = None,
+        scopes: list[str] | None = None,
+        redirect_path: str = "/api/v1/connectors/providers/onedrive/callback",
+    ) -> str:
+        redirect_uri = f"{self.redirect_base}{redirect_path}"
+        if not self.client_id:
+            return f"{redirect_uri}?scaffold=1&state={state or ''}"
+        scope = " ".join(scopes or ["Files.Read", "offline_access", "openid", "email", "profile"])
+        params = {
+            "client_id": self.client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri,
+            "response_mode": "query",
+            "scope": scope,
+        }
+        if state:
+            params["state"] = state
+        return f"https://login.microsoftonline.com/common/oauth2/v2.0/authorize?{urlencode(params)}"
+
+    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        resp = await afetch(
+            method="POST",
+            url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            data={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "grant_type": "authorization_code",
+            },
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            tok = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return {
+            "access_token": tok.get("access_token"),
+            "refresh_token": tok.get("refresh_token"),
+            "expires_in": tok.get("expires_in"),
+            "token_type": tok.get("token_type"),
+            "scope": tok.get("scope"),
+            "provider": self.name,
+            "display_name": "OneDrive Account",
+            "email": None,
+        }
+
+    async def refresh_access_token(self, refresh_token: str) -> dict[str, Any] | None:
+        if not (self.client_id and self.client_secret and refresh_token):
+            return None
+        resp = await afetch(
+            method="POST",
+            url="https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            data={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "refresh_token": refresh_token,
+                "grant_type": "refresh_token",
+            },
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            tok = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return {
+            "access_token": tok.get("access_token"),
+            "refresh_token": tok.get("refresh_token") or refresh_token,
+            "expires_in": tok.get("expires_in"),
+            "token_type": tok.get("token_type"),
+            "scope": tok.get("scope"),
+        }
+
+    async def list_files(
+        self,
+        account: dict[str, Any],
+        parent_remote_id: str,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
+        token = self._access_token_from_account(account)
+        if not token:
+            return [], None
+        headers = {"Authorization": f"Bearer {token}"}
+        url = cursor or (
+            "https://graph.microsoft.com/v1.0/me/drive/root/children"
+            if parent_remote_id in {"", "root"}
+            else f"https://graph.microsoft.com/v1.0/me/drive/items/{parent_remote_id}/children"
+        )
+        params: dict[str, Any] | None = None if cursor else {
+            "$top": max(1, min(int(page_size), 200)),
+            "$select": "id,name,size,lastModifiedDateTime,webUrl,eTag,cTag,parentReference,file,folder",
+        }
+        resp = await afetch(
+            method="GET",
+            url=url,
+            headers=headers,
+            params=params,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        items: list[dict[str, Any]] = []
+        for item in data.get("value") or []:
+            if not isinstance(item, dict):
+                continue
+            items.append(
+                {
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "size": int(item.get("size") or 0),
+                    "modifiedTime": item.get("lastModifiedDateTime"),
+                    "webUrl": item.get("webUrl"),
+                    "is_folder": bool(item.get("folder")),
+                    "mimeType": ((item.get("file") or {}).get("mimeType")),
+                    "parentReference": item.get("parentReference") or {},
+                }
+            )
+        return items, data.get("@odata.nextLink")
+
+    async def list_changes(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[FileSyncChange], str | None, str | None]:
+        token = self._access_token_from_account(account)
+        if not token:
+            return [], None, None
+        headers = {"Authorization": f"Bearer {token}"}
+        url = cursor or "https://graph.microsoft.com/v1.0/me/drive/root/delta"
+        params: dict[str, Any] | None = None if cursor else {
+            "$top": max(1, min(int(page_size), 200)),
+            "$select": "id,name,size,eTag,cTag,lastModifiedDateTime,webUrl,parentReference,file,folder,deleted",
+        }
+        resp = await afetch(
+            method="GET",
+            url=url,
+            headers=headers,
+            params=params,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        changes: list[FileSyncChange] = []
+        for item in data.get("value") or []:
+            if not isinstance(item, dict):
+                continue
+            remote_id = str(item.get("id") or "").strip()
+            if not remote_id:
+                continue
+            parent_reference = item.get("parentReference") or {}
+            if item.get("deleted"):
+                changes.append(
+                    FileSyncChange(
+                        event_type="deleted",
+                        remote_id=remote_id,
+                        remote_name=item.get("name"),
+                        remote_parent_id=parent_reference.get("id"),
+                        metadata={
+                            "drive_id": parent_reference.get("driveId"),
+                            "remote_path": parent_reference.get("path"),
+                        },
+                    )
+                )
+                continue
+            file_info = item.get("file") or {}
+            hashes = file_info.get("hashes") or {}
+            changes.append(
+                FileSyncChange(
+                    event_type="content_updated",
+                    remote_id=remote_id,
+                    remote_name=item.get("name"),
+                    remote_parent_id=parent_reference.get("id"),
+                    remote_path=parent_reference.get("path"),
+                    remote_revision=item.get("eTag") or item.get("cTag"),
+                    remote_hash=hashes.get("quickXorHash") or hashes.get("sha1Hash"),
+                    metadata={
+                        "drive_id": parent_reference.get("driveId"),
+                        "mime_type": file_info.get("mimeType"),
+                        "size": int(item.get("size") or 0),
+                        "remote_url": item.get("webUrl"),
+                        "last_modified": item.get("lastModifiedDateTime"),
+                        "is_folder": bool(item.get("folder")),
+                    },
+                )
+            )
+        return changes, data.get("@odata.nextLink"), data.get("@odata.deltaLink")
+
+    async def get_item_metadata(self, account: dict[str, Any], remote_id: str) -> dict[str, Any] | None:
+        token = self._access_token_from_account(account)
+        if not token:
+            return None
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await afetch(
+            method="GET",
+            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{remote_id}",
+            headers=headers,
+            params={"$select": "id,name,size,eTag,cTag,lastModifiedDateTime,webUrl,parentReference,file,folder,deleted"},
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            item = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        resolved_id = str(item.get("id") or remote_id).strip()
+        if not resolved_id:
+            return None
+        parent_reference = item.get("parentReference") or {}
+        file_info = item.get("file") or {}
+        hashes = file_info.get("hashes") or {}
+        return {
+            "remote_id": resolved_id,
+            "remote_name": item.get("name"),
+            "mime_type": file_info.get("mimeType"),
+            "size": int(item.get("size") or 0),
+            "remote_revision": item.get("eTag") or item.get("cTag"),
+            "remote_hash": hashes.get("quickXorHash") or hashes.get("sha1Hash"),
+            "remote_url": item.get("webUrl"),
+            "remote_parent_id": parent_reference.get("id"),
+            "remote_path": parent_reference.get("path"),
+            "drive_id": parent_reference.get("driveId"),
+            "last_modified": item.get("lastModifiedDateTime"),
+            "deleted": bool(item.get("deleted")),
+            "is_folder": bool(item.get("folder")),
+        }
+
+    async def download_file(self, account: dict[str, Any], file_id: str, **kwargs: Any) -> bytes:
+        _ = kwargs
+        token = self._access_token_from_account(account)
+        if not token:
+            return b""
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await afetch(
+            method="GET",
+            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{file_id}/content",
+            headers=headers,
+            timeout=60,
+        )
+        try:
+            resp.raise_for_status()
+            return resp.content
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+
+    async def resolve_shared_link(self, account: dict[str, Any], shared_link: str) -> dict[str, Any] | None:
+        parsed = urlparse(shared_link)
+        query = parse_qs(parsed.query)
+        remote_id = (query.get("id") or query.get("resid") or [None])[0]
+        if not remote_id:
+            return None
+        return await self.get_item_metadata(account, str(remote_id))
+
+    async def subscribe_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        resource: dict[str, Any],
+        callback_url: str,
+    ) -> FileSyncWebhookSubscription | None:
+        token = self._access_token_from_account(account)
+        if not token:
+            return None
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        resp = await afetch(
+            method="POST",
+            url="https://graph.microsoft.com/v1.0/subscriptions",
+            headers=headers,
+            json={
+                "changeType": resource.get("change_type", "updated"),
+                "notificationUrl": callback_url,
+                "resource": resource.get("resource", "me/drive/root"),
+                "expirationDateTime": resource.get("expirationDateTime"),
+                "clientState": resource.get("clientState"),
+            },
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return FileSyncWebhookSubscription(
+            subscription_id=data.get("id"),
+            expires_at=data.get("expirationDateTime"),
+            metadata=data,
+        )
+
+    async def renew_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> FileSyncWebhookSubscription | None:
+        token = self._access_token_from_account(account)
+        if not token or not subscription.subscription_id:
+            return None
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        resp = await afetch(
+            method="PATCH",
+            url=f"https://graph.microsoft.com/v1.0/subscriptions/{subscription.subscription_id}",
+            headers=headers,
+            json={"expirationDateTime": subscription.metadata.get("expirationDateTime") if subscription.metadata else subscription.expires_at},
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+            data = resp.json() or {}
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return FileSyncWebhookSubscription(
+            subscription_id=data.get("id", subscription.subscription_id),
+            expires_at=data.get("expirationDateTime", subscription.expires_at),
+            metadata=data or subscription.metadata,
+        )
+
+    async def revoke_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> bool:
+        token = self._access_token_from_account(account)
+        if not token or not subscription.subscription_id:
+            return False
+        headers = {"Authorization": f"Bearer {token}"}
+        resp = await afetch(
+            method="DELETE",
+            url=f"https://graph.microsoft.com/v1.0/subscriptions/{subscription.subscription_id}",
+            headers=headers,
+            timeout=30,
+        )
+        try:
+            resp.raise_for_status()
+        finally:
+            close = getattr(resp, "aclose", None)
+            if callable(close):
+                await close()
+        return True

--- a/tldw_Server_API/app/core/External_Sources/onedrive.py
+++ b/tldw_Server_API/app/core/External_Sources/onedrive.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, quote, urlencode, urlparse
 
 from tldw_Server_API.app.core.http_client import afetch
 
@@ -238,9 +238,10 @@ class OneDriveConnector(BaseConnector):
         if not token:
             return None
         headers = {"Authorization": f"Bearer {token}"}
+        quoted_remote_id = quote(remote_id, safe="")
         resp = await afetch(
             method="GET",
-            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{remote_id}",
+            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{quoted_remote_id}",
             headers=headers,
             params={"$select": "id,name,size,eTag,cTag,lastModifiedDateTime,webUrl,parentReference,file,folder,deleted"},
             timeout=30,
@@ -280,9 +281,10 @@ class OneDriveConnector(BaseConnector):
         if not token:
             return b""
         headers = {"Authorization": f"Bearer {token}"}
+        quoted_file_id = quote(file_id, safe="")
         resp = await afetch(
             method="GET",
-            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{file_id}/content",
+            url=f"https://graph.microsoft.com/v1.0/me/drive/items/{quoted_file_id}/content",
             headers=headers,
             timeout=60,
         )

--- a/tldw_Server_API/app/core/External_Sources/onedrive.py
+++ b/tldw_Server_API/app/core/External_Sources/onedrive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 
@@ -12,6 +13,7 @@ from .sync_adapter import FileSyncChange, FileSyncWebhookSubscription
 
 class OneDriveConnector(BaseConnector):
     name = "onedrive"
+    _DEFAULT_WEBHOOK_LIFETIME_HOURS = 24
 
     def __init__(self, client_id: str | None = None, client_secret: str | None = None, redirect_base: str | None = None):
         super().__init__(
@@ -23,6 +25,12 @@ class OneDriveConnector(BaseConnector):
     @staticmethod
     def _access_token_from_account(account: dict[str, Any]) -> str | None:
         return (account.get("tokens") or {}).get("access_token") or account.get("access_token")
+
+    @classmethod
+    def _default_expiration_datetime(cls) -> str:
+        return (
+            datetime.now(UTC) + timedelta(hours=cls._DEFAULT_WEBHOOK_LIFETIME_HOURS)
+        ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
     def authorize_url(
         self,
@@ -315,6 +323,7 @@ class OneDriveConnector(BaseConnector):
         if not token:
             return None
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        requested_expiration = str(resource.get("expirationDateTime") or "").strip() or self._default_expiration_datetime()
         resp = await afetch(
             method="POST",
             url="https://graph.microsoft.com/v1.0/subscriptions",
@@ -323,7 +332,7 @@ class OneDriveConnector(BaseConnector):
                 "changeType": resource.get("change_type", "updated"),
                 "notificationUrl": callback_url,
                 "resource": resource.get("resource", "me/drive/root"),
-                "expirationDateTime": resource.get("expirationDateTime"),
+                "expirationDateTime": requested_expiration,
                 "clientState": resource.get("clientState"),
             },
             timeout=30,
@@ -335,10 +344,12 @@ class OneDriveConnector(BaseConnector):
             close = getattr(resp, "aclose", None)
             if callable(close):
                 await close()
+        metadata = dict(data or {})
+        metadata.setdefault("expirationDateTime", requested_expiration)
         return FileSyncWebhookSubscription(
             subscription_id=data.get("id"),
-            expires_at=data.get("expirationDateTime"),
-            metadata=data,
+            expires_at=data.get("expirationDateTime") or requested_expiration,
+            metadata=metadata,
         )
 
     async def renew_webhook(
@@ -351,11 +362,12 @@ class OneDriveConnector(BaseConnector):
         if not token or not subscription.subscription_id:
             return None
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        requested_expiration = self._default_expiration_datetime()
         resp = await afetch(
             method="PATCH",
             url=f"https://graph.microsoft.com/v1.0/subscriptions/{subscription.subscription_id}",
             headers=headers,
-            json={"expirationDateTime": subscription.metadata.get("expirationDateTime") if subscription.metadata else subscription.expires_at},
+            json={"expirationDateTime": requested_expiration},
             timeout=30,
         )
         try:
@@ -365,10 +377,13 @@ class OneDriveConnector(BaseConnector):
             close = getattr(resp, "aclose", None)
             if callable(close):
                 await close()
+        metadata = dict(subscription.metadata or {})
+        metadata.update(data or {})
+        metadata["expirationDateTime"] = data.get("expirationDateTime") or requested_expiration
         return FileSyncWebhookSubscription(
             subscription_id=data.get("id", subscription.subscription_id),
-            expires_at=data.get("expirationDateTime", subscription.expires_at),
-            metadata=data or subscription.metadata,
+            expires_at=data.get("expirationDateTime") or requested_expiration,
+            metadata=metadata,
         )
 
     async def revoke_webhook(

--- a/tldw_Server_API/app/core/External_Sources/sync_adapter.py
+++ b/tldw_Server_API/app/core/External_Sources/sync_adapter.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(slots=True)
+class FileSyncChange:
+    event_type: str
+    remote_id: str
+    remote_name: str | None = None
+    remote_parent_id: str | None = None
+    remote_path: str | None = None
+    remote_revision: str | None = None
+    remote_hash: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class FileSyncWebhookSubscription:
+    subscription_id: str | None = None
+    expires_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class FileSyncAdapter(Protocol):
+    async def list_children(
+        self,
+        account: dict[str, Any],
+        parent_remote_id: str,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]: ...
+
+    async def list_changes(
+        self,
+        account: dict[str, Any],
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ) -> tuple[list[FileSyncChange], str | None, str | None]: ...
+
+    async def get_item_metadata(
+        self,
+        account: dict[str, Any],
+        remote_id: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def download_or_export(
+        self,
+        account: dict[str, Any],
+        remote_id: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> bytes: ...
+
+    async def resolve_shared_link(
+        self,
+        account: dict[str, Any],
+        shared_link: str,
+    ) -> dict[str, Any] | None: ...
+
+    async def subscribe_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        resource: dict[str, Any],
+        callback_url: str,
+    ) -> FileSyncWebhookSubscription | None: ...
+
+    async def renew_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> FileSyncWebhookSubscription | None: ...
+
+    async def revoke_webhook(
+        self,
+        account: dict[str, Any],
+        *,
+        subscription: FileSyncWebhookSubscription,
+    ) -> bool: ...

--- a/tldw_Server_API/app/core/External_Sources/sync_coordinator.py
+++ b/tldw_Server_API/app/core/External_Sources/sync_coordinator.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from tldw_Server_API.app.core.DB_Management.Media_DB_v2 import MediaDatabase
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
+
+
+def _utc_now_text() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(slots=True)
+class FileSyncContentPayload:
+    text: str
+    prompt: str | None = None
+    analysis_content: str | None = None
+    safe_metadata: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class SyncReconcileResult:
+    action: str
+    media_id: int | None
+    binding_id: int | None = None
+    current_version_number: int | None = None
+    sync_status: str | None = None
+
+
+def _build_safe_metadata(
+    *,
+    source_id: int,
+    provider: str,
+    change: FileSyncChange,
+    content: FileSyncContentPayload,
+    job_id: str | None,
+) -> str:
+    safe_metadata = dict(content.safe_metadata or {})
+    safe_metadata.update(
+        {
+            "provider": provider,
+            "source_id": source_id,
+            "remote_id": change.remote_id,
+            "remote_revision": change.remote_revision,
+            "remote_hash": change.remote_hash,
+            "remote_path": change.remote_path,
+            "sync_job_id": job_id,
+            "sync_kind": change.event_type,
+        },
+    )
+    filtered = {key: value for key, value in safe_metadata.items() if value is not None}
+    return json.dumps(filtered, sort_keys=True)
+
+
+async def _get_required_binding(
+    connectors_db,
+    *,
+    source_id: int,
+    provider: str,
+    remote_id: str,
+) -> dict[str, Any]:
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source_id,
+        provider=provider,
+        external_id=remote_id,
+    )
+    if not binding:
+        raise ValueError(f"No external binding found for source={source_id} provider={provider} remote_id={remote_id}")  # noqa: TRY003
+    return binding
+
+
+async def reconcile_file_change(
+    connectors_db,
+    media_db: MediaDatabase,
+    *,
+    source_id: int,
+    provider: str,
+    change: FileSyncChange,
+    content: FileSyncContentPayload | None = None,
+    job_id: str | None = None,
+) -> SyncReconcileResult:
+    sync_now = _utc_now_text()
+    metadata = change.metadata or {}
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source_id,
+        provider=provider,
+        external_id=change.remote_id,
+    )
+
+    if not binding and change.event_type == "created":
+        if content is None or content.text is None:
+            raise ValueError("Content payload is required for event_type=created")  # noqa: TRY003
+        media_id, _, _ = media_db.add_media_with_keywords(
+            url=f"{provider}://{change.remote_id}",
+            title=change.remote_name or change.remote_id,
+            media_type="document",
+            content=content.text,
+            keywords=[],
+            prompt=content.prompt,
+            analysis_content=content.analysis_content,
+            safe_metadata=_build_safe_metadata(
+                source_id=source_id,
+                provider=provider,
+                change=change,
+                content=content,
+                job_id=job_id,
+            ),
+            overwrite=False,
+        )
+        if media_id is None:
+            raise ValueError(f"Failed to create media for source={source_id} remote_id={change.remote_id}")  # noqa: TRY003
+        binding = await svc.upsert_external_item_binding(
+            connectors_db,
+            source_id=source_id,
+            provider=provider,
+            external_id=change.remote_id,
+            name=change.remote_name,
+            mime=metadata.get("mime_type"),
+            size=metadata.get("size"),
+            version=change.remote_revision,
+            modified_at=metadata.get("modified_at"),
+            content_hash=change.remote_hash,
+            media_id=int(media_id),
+            sync_status="active",
+            current_version_number=1,
+            remote_parent_id=change.remote_parent_id,
+            remote_path=change.remote_path,
+            last_seen_at=sync_now,
+            last_content_sync_at=sync_now,
+            last_metadata_sync_at=sync_now,
+            provider_metadata=metadata if metadata else None,
+        )
+        await svc.record_item_event(
+            connectors_db,
+            external_item_id=int(binding["id"]),
+            event_type="created",
+            job_id=job_id,
+            payload={
+                "remote_revision": change.remote_revision,
+                "remote_hash": change.remote_hash,
+                "sync_status": "active",
+            },
+        )
+        return SyncReconcileResult(
+            action="created",
+            media_id=int(media_id),
+            binding_id=int(binding["id"]),
+            current_version_number=1,
+            sync_status="active",
+        )
+
+    if not binding:
+        raise ValueError(f"No external binding found for source={source_id} provider={provider} remote_id={change.remote_id}")  # noqa: TRY003
+
+    media_id = binding.get("media_id")
+    if media_id is None:
+        raise ValueError(f"External binding {binding.get('id')} is missing media_id")  # noqa: TRY003
+
+    if change.event_type in {"created", "content_updated"}:
+        if content is None or content.text is None:
+            raise ValueError(f"Content payload is required for event_type={change.event_type}")  # noqa: TRY003
+
+        update_result = media_db.apply_synced_document_content_update(
+            media_id=int(media_id),
+            content=content.text,
+            prompt=content.prompt,
+            analysis_content=content.analysis_content,
+            safe_metadata=_build_safe_metadata(
+                source_id=source_id,
+                provider=provider,
+                change=change,
+                content=content,
+                job_id=job_id,
+            ),
+        )
+        binding = await svc.upsert_external_item_binding(
+            connectors_db,
+            source_id=source_id,
+            provider=provider,
+            external_id=change.remote_id,
+            name=change.remote_name,
+            mime=metadata.get("mime_type"),
+            size=metadata.get("size"),
+            version=change.remote_revision,
+            modified_at=metadata.get("modified_at"),
+            content_hash=change.remote_hash,
+            media_id=int(media_id),
+            sync_status="active",
+            current_version_number=update_result["document_version_number"],
+            remote_parent_id=change.remote_parent_id,
+            remote_path=change.remote_path,
+            last_seen_at=sync_now,
+            last_content_sync_at=sync_now,
+            last_metadata_sync_at=sync_now,
+            provider_metadata=metadata if metadata else None,
+        )
+        await svc.record_item_event(
+            connectors_db,
+            external_item_id=int(binding["id"]),
+            event_type="content_updated",
+            job_id=job_id,
+            payload={
+                "remote_revision": change.remote_revision,
+                "remote_hash": change.remote_hash,
+                "sync_status": "active",
+            },
+        )
+        return SyncReconcileResult(
+            action="version_created",
+            media_id=int(media_id),
+            binding_id=int(binding["id"]),
+            current_version_number=update_result["document_version_number"],
+            sync_status="active",
+        )
+
+    if change.event_type in {"deleted", "permission_lost"}:
+        sync_status = "archived_upstream_removed" if change.event_type == "deleted" else "orphaned"
+        media_db.mark_as_trash(int(media_id))
+        binding = await svc.mark_external_item_archived(
+            connectors_db,
+            source_id=source_id,
+            provider=provider,
+            external_id=change.remote_id,
+            sync_status=sync_status,
+        )
+        if not binding:
+            raise ValueError(f"Failed to archive binding for remote_id={change.remote_id}")  # noqa: TRY003
+        await svc.record_item_event(
+            connectors_db,
+            external_item_id=int(binding["id"]),
+            event_type="deleted_upstream" if change.event_type == "deleted" else "access_revoked",
+            job_id=job_id,
+            payload={"sync_status": sync_status},
+        )
+        return SyncReconcileResult(
+            action="archived",
+            media_id=int(media_id),
+            binding_id=int(binding["id"]),
+            current_version_number=binding.get("current_version_number"),
+            sync_status=sync_status,
+        )
+
+    if change.event_type == "restored":
+        media_db.restore_from_trash(int(media_id))
+        binding = await svc.restore_external_item_binding(
+            connectors_db,
+            source_id=source_id,
+            provider=provider,
+            external_id=change.remote_id,
+            name=change.remote_name,
+            version=change.remote_revision,
+            modified_at=metadata.get("modified_at"),
+            remote_parent_id=change.remote_parent_id,
+            remote_path=change.remote_path,
+            content_hash=change.remote_hash,
+            provider_metadata=metadata if metadata else None,
+        )
+        if not binding:
+            raise ValueError(f"Failed to restore binding for remote_id={change.remote_id}")  # noqa: TRY003
+        await svc.record_item_event(
+            connectors_db,
+            external_item_id=int(binding["id"]),
+            event_type="restored_upstream",
+            job_id=job_id,
+            payload={"sync_status": "active"},
+        )
+        return SyncReconcileResult(
+            action="restored",
+            media_id=int(media_id),
+            binding_id=int(binding["id"]),
+            current_version_number=binding.get("current_version_number"),
+            sync_status="active",
+        )
+
+    if change.event_type == "metadata_updated":
+        binding = await svc.upsert_external_item_binding(
+            connectors_db,
+            source_id=source_id,
+            provider=provider,
+            external_id=change.remote_id,
+            name=change.remote_name,
+            mime=metadata.get("mime_type"),
+            size=metadata.get("size"),
+            version=change.remote_revision,
+            modified_at=metadata.get("modified_at"),
+            content_hash=change.remote_hash,
+            media_id=int(media_id),
+            sync_status=str(binding.get("sync_status") or "active"),
+            current_version_number=binding.get("current_version_number"),
+            remote_parent_id=change.remote_parent_id,
+            remote_path=change.remote_path,
+            last_seen_at=sync_now,
+            last_metadata_sync_at=sync_now,
+            provider_metadata=metadata if metadata else None,
+        )
+        await svc.record_item_event(
+            connectors_db,
+            external_item_id=int(binding["id"]),
+            event_type="metadata_updated",
+            job_id=job_id,
+            payload={"sync_status": binding.get("sync_status")},
+        )
+        return SyncReconcileResult(
+            action="metadata_updated",
+            media_id=int(media_id),
+            binding_id=int(binding["id"]),
+            current_version_number=binding.get("current_version_number"),
+            sync_status=binding.get("sync_status"),
+        )
+
+    raise ValueError(f"Unsupported file sync change event_type={change.event_type}")  # noqa: TRY003

--- a/tldw_Server_API/app/core/External_Sources/sync_coordinator.py
+++ b/tldw_Server_API/app/core/External_Sources/sync_coordinator.py
@@ -14,6 +14,22 @@ def _utc_now_text() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def _modified_at_from_metadata(metadata: dict[str, Any]) -> str | None:
+    for key in (
+        "modified_at",
+        "modifiedAt",
+        "modified_time",
+        "modifiedTime",
+        "last_modified",
+        "lastModified",
+        "lastModifiedDateTime",
+    ):
+        value = str(metadata.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
 @dataclass(slots=True)
 class FileSyncContentPayload:
     text: str
@@ -86,6 +102,7 @@ async def reconcile_file_change(
 ) -> SyncReconcileResult:
     sync_now = _utc_now_text()
     metadata = change.metadata or {}
+    modified_at = _modified_at_from_metadata(metadata)
     binding = await svc.get_external_item_binding(
         connectors_db,
         source_id=source_id,
@@ -124,7 +141,7 @@ async def reconcile_file_change(
             mime=metadata.get("mime_type"),
             size=metadata.get("size"),
             version=change.remote_revision,
-            modified_at=metadata.get("modified_at"),
+            modified_at=modified_at,
             content_hash=change.remote_hash,
             media_id=int(media_id),
             sync_status="active",
@@ -188,7 +205,7 @@ async def reconcile_file_change(
             mime=metadata.get("mime_type"),
             size=metadata.get("size"),
             version=change.remote_revision,
-            modified_at=metadata.get("modified_at"),
+            modified_at=modified_at,
             content_hash=change.remote_hash,
             media_id=int(media_id),
             sync_status="active",
@@ -255,7 +272,7 @@ async def reconcile_file_change(
             external_id=change.remote_id,
             name=change.remote_name,
             version=change.remote_revision,
-            modified_at=metadata.get("modified_at"),
+            modified_at=modified_at,
             remote_parent_id=change.remote_parent_id,
             remote_path=change.remote_path,
             content_hash=change.remote_hash,
@@ -288,7 +305,7 @@ async def reconcile_file_change(
             mime=metadata.get("mime_type"),
             size=metadata.get("size"),
             version=change.remote_revision,
-            modified_at=metadata.get("modified_at"),
+            modified_at=modified_at,
             content_hash=change.remote_hash,
             media_id=int(media_id),
             sync_status=str(binding.get("sync_status") or "active"),

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Media_Update_lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Media_Update_lib.py
@@ -90,6 +90,27 @@ def process_media_update(
         result["keywords_updated"] = True
     return result
 
+
+def process_synced_media_update(
+    db: MediaDatabase,
+    *,
+    media_id: int,
+    content: str,
+    prompt: Optional[str] = None,
+    summary: Optional[str] = None,
+    safe_metadata: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Apply a sync-driven content update while preserving main Media/FTS/version invariants.
+    """
+    return db.apply_synced_document_content_update(
+        media_id=media_id,
+        content=content,
+        prompt=prompt,
+        analysis_content=summary,
+        safe_metadata=safe_metadata,
+    )
+
 #
 # End of Media_Update_lib.py
 ########################################################################################################################

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -3190,6 +3190,21 @@ async def lifespan(app: FastAPI):
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.warning(f"Failed to start Reminders scheduler: {e}")
 
+    # Start Connectors sync scheduler (periodic submission into Jobs)
+    connectors_sync_sched_task = None
+    try:
+        from tldw_Server_API.app.services.connectors_sync_scheduler import (
+            start_connectors_sync_scheduler,
+        )
+
+        connectors_sync_sched_task = await start_connectors_sync_scheduler()
+        if connectors_sync_sched_task:
+            logger.info("Connectors sync scheduler started")
+        else:
+            logger.info("Connectors sync scheduler disabled (CONNECTORS_SYNC_SCHEDULER_ENABLED != true)")
+    except _STARTUP_GUARD_EXCEPTIONS as e:
+        logger.warning(f"Failed to start Connectors sync scheduler: {e}")
+
     # Display authentication mode (API key masked by default unless explicitly requested)
     try:
         from tldw_Server_API.app.core.AuthNZ.settings import get_settings, is_single_user_mode
@@ -3624,6 +3639,20 @@ async def lifespan(app: FastAPI):
             try:
                 if "reminders_sched_task" in locals() and reminders_sched_task:
                     reminders_sched_task.cancel()
+            except _STARTUP_GUARD_EXCEPTIONS:
+                pass
+        # Stop Connectors sync scheduler
+        try:
+            if "connectors_sync_sched_task" in locals():
+                from tldw_Server_API.app.services.connectors_sync_scheduler import (
+                    stop_connectors_sync_scheduler as _stop_connectors_sync_scheduler,
+                )
+
+                await _stop_connectors_sync_scheduler(connectors_sync_sched_task)
+        except _STARTUP_GUARD_EXCEPTIONS:
+            try:
+                if "connectors_sync_sched_task" in locals() and connectors_sync_sched_task:
+                    connectors_sync_sched_task.cancel()
             except _STARTUP_GUARD_EXCEPTIONS:
                 pass
         # Jobs metrics gauges worker shutdown

--- a/tldw_Server_API/app/services/connectors_sync_scheduler.py
+++ b/tldw_Server_API/app/services/connectors_sync_scheduler.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.core.External_Sources.connectors_service import (
     FILE_SYNC_PROVIDERS,
     create_import_job,
     list_sources_for_scheduler,
+    prune_webhook_receipts,
 )
 from tldw_Server_API.app.core.testing import env_flag_enabled
 
@@ -39,6 +40,7 @@ _NONCRITICAL_EXCEPTIONS = (
 _MIN_SCAN_SECONDS = 30
 _DEFAULT_SCAN_SECONDS = 300
 _DEFAULT_RENEWAL_LOOKAHEAD_SECONDS = 3600
+_DEFAULT_WEBHOOK_RECEIPT_RETENTION_SECONDS = 7 * 24 * 3600
 
 
 def _parse_utc_datetime(value: Any) -> datetime | None:
@@ -69,6 +71,22 @@ def _renewal_lookahead_seconds() -> int:
         return max(0, int(os.getenv("CONNECTORS_SYNC_RENEWAL_LOOKAHEAD_SEC", str(_DEFAULT_RENEWAL_LOOKAHEAD_SECONDS)) or _DEFAULT_RENEWAL_LOOKAHEAD_SECONDS))
     except _NONCRITICAL_EXCEPTIONS:
         return _DEFAULT_RENEWAL_LOOKAHEAD_SECONDS
+
+
+def _webhook_receipt_retention_seconds() -> int:
+    try:
+        return max(
+            0,
+            int(
+                os.getenv(
+                    "CONNECTORS_WEBHOOK_RECEIPT_RETENTION_SEC",
+                    str(_DEFAULT_WEBHOOK_RECEIPT_RETENTION_SECONDS),
+                )
+                or _DEFAULT_WEBHOOK_RECEIPT_RETENTION_SECONDS
+            ),
+        )
+    except _NONCRITICAL_EXCEPTIONS:
+        return _DEFAULT_WEBHOOK_RECEIPT_RETENTION_SECONDS
 
 
 class _ConnectorsSyncScheduler:
@@ -129,10 +147,16 @@ class _ConnectorsSyncScheduler:
 
     async def _scan_once(self) -> None:
         pool = await get_db_pool()
+        now = datetime.now(UTC)
         async with pool.transaction() as db:
+            retention_seconds = _webhook_receipt_retention_seconds()
+            if retention_seconds > 0:
+                await prune_webhook_receipt_rows(
+                    db,
+                    older_than=now - timedelta(seconds=retention_seconds),
+                )
             rows = await list_sources_for_scheduler(db)
 
-        now = datetime.now(UTC)
         for source in rows:
             job_type = self._select_job_type(source, now=now)
             if not job_type:
@@ -187,9 +211,17 @@ async def stop_connectors_sync_scheduler(task: asyncio.Task | None) -> None:
         await get_connectors_sync_scheduler().stop()
 
 
+async def prune_webhook_receipt_rows(db, *, older_than: datetime) -> int:
+    deleted = await prune_webhook_receipts(db, older_than=older_than)
+    if deleted:
+        logger.info("Pruned {} stale external webhook receipts", deleted)
+    return deleted
+
+
 __all__ = [
     "_ConnectorsSyncScheduler",
     "get_connectors_sync_scheduler",
+    "prune_webhook_receipt_rows",
     "start_connectors_sync_scheduler",
     "stop_connectors_sync_scheduler",
 ]

--- a/tldw_Server_API/app/services/connectors_sync_scheduler.py
+++ b/tldw_Server_API/app/services/connectors_sync_scheduler.py
@@ -1,0 +1,195 @@
+"""
+Recurring scheduler for external source sync and webhook renewal jobs.
+
+Env:
+  CONNECTORS_SYNC_SCHEDULER_ENABLED=true -> start service at app startup
+  CONNECTORS_SYNC_SCHEDULER_SCAN_SEC     -> periodic scan interval (default: 300)
+  CONNECTORS_SYNC_RENEWAL_LOOKAHEAD_SEC  -> renewal window before expiry (default: 3600)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.External_Sources.connectors_service import (
+    FILE_SYNC_PROVIDERS,
+    create_import_job,
+    list_sources_for_scheduler,
+)
+from tldw_Server_API.app.core.testing import env_flag_enabled
+
+_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    LookupError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+)
+_MIN_SCAN_SECONDS = 30
+_DEFAULT_SCAN_SECONDS = 300
+_DEFAULT_RENEWAL_LOOKAHEAD_SECONDS = 3600
+
+
+def _parse_utc_datetime(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except _NONCRITICAL_EXCEPTIONS:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _scan_interval_seconds() -> int:
+    try:
+        value = int(os.getenv("CONNECTORS_SYNC_SCHEDULER_SCAN_SEC", str(_DEFAULT_SCAN_SECONDS)) or _DEFAULT_SCAN_SECONDS)
+    except _NONCRITICAL_EXCEPTIONS:
+        value = _DEFAULT_SCAN_SECONDS
+    return max(_MIN_SCAN_SECONDS, value)
+
+
+def _renewal_lookahead_seconds() -> int:
+    try:
+        return max(0, int(os.getenv("CONNECTORS_SYNC_RENEWAL_LOOKAHEAD_SEC", str(_DEFAULT_RENEWAL_LOOKAHEAD_SECONDS)) or _DEFAULT_RENEWAL_LOOKAHEAD_SECONDS))
+    except _NONCRITICAL_EXCEPTIONS:
+        return _DEFAULT_RENEWAL_LOOKAHEAD_SECONDS
+
+
+class _ConnectorsSyncScheduler:
+    def __init__(self) -> None:
+        self._aps: AsyncIOScheduler | None = None
+        self._lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self) -> None:
+        async with self._lock:
+            if self._started:
+                return
+            self._aps = AsyncIOScheduler(timezone="UTC")
+            self._aps.start()
+            self._aps.add_job(
+                self._scan_once,
+                trigger=IntervalTrigger(seconds=_scan_interval_seconds(), timezone="UTC"),
+                id="connectors_sync_scan",
+                max_instances=1,
+                coalesce=True,
+                misfire_grace_time=_scan_interval_seconds(),
+            )
+            self._started = True
+            logger.info("Connectors sync scheduler started")
+
+    async def stop(self) -> None:
+        async with self._lock:
+            try:
+                if self._aps:
+                    self._aps.shutdown(wait=False)
+            except _NONCRITICAL_EXCEPTIONS:
+                pass
+            self._aps = None
+            self._started = False
+            logger.info("Connectors sync scheduler stopped")
+
+    def _select_job_type(self, source: dict[str, Any], *, now: datetime) -> str | None:
+        if not bool(source.get("enabled", True)):
+            return None
+        provider = str(source.get("provider") or "").strip().lower()
+        if provider not in FILE_SYNC_PROVIDERS:
+            return None
+        if str(source.get("active_job_id") or "").strip():
+            return None
+        sync_mode = str(source.get("sync_mode") or "manual").strip().lower()
+        renewal_due = False
+        if source.get("webhook_status") == "active" and str(source.get("webhook_subscription_id") or "").strip():
+            expires_at = _parse_utc_datetime(source.get("webhook_expires_at"))
+            if expires_at is not None:
+                renewal_due = expires_at <= (now + timedelta(seconds=_renewal_lookahead_seconds()))
+        if renewal_due:
+            return "subscription_renewal"
+        if sync_mode not in {"poll", "hybrid"}:
+            return None
+        if bool(source.get("needs_full_rescan")):
+            return "repair_rescan"
+        return "incremental_sync"
+
+    async def _scan_once(self) -> None:
+        pool = await get_db_pool()
+        async with pool.transaction() as db:
+            rows = await list_sources_for_scheduler(db)
+
+        now = datetime.now(UTC)
+        for source in rows:
+            job_type = self._select_job_type(source, now=now)
+            if not job_type:
+                continue
+            user_id = int(source.get("user_id"))
+            source_id = int(source.get("id"))
+            try:
+                await create_import_job(user_id, source_id, job_type=job_type)
+            except _NONCRITICAL_EXCEPTIONS as exc:
+                logger.warning(
+                    "Connectors sync scheduler enqueue failed for source_id={} job_type={}: {}",
+                    source_id,
+                    job_type,
+                    exc,
+                )
+
+
+_INSTANCE: _ConnectorsSyncScheduler | None = None
+
+
+def get_connectors_sync_scheduler() -> _ConnectorsSyncScheduler:
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = _ConnectorsSyncScheduler()
+    return _INSTANCE
+
+
+async def start_connectors_sync_scheduler(enabled: bool | None = None) -> asyncio.Task | None:
+    if enabled is None:
+        enabled = env_flag_enabled("CONNECTORS_SYNC_SCHEDULER_ENABLED")
+    if not enabled:
+        return None
+    scheduler = get_connectors_sync_scheduler()
+    await scheduler.start()
+
+    async def _noop() -> None:
+        while True:
+            await asyncio.sleep(60)
+
+    return asyncio.create_task(_noop(), name="connectors_sync_scheduler")
+
+
+async def stop_connectors_sync_scheduler(task: asyncio.Task | None) -> None:
+    try:
+        if task:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    except _NONCRITICAL_EXCEPTIONS:
+        pass
+    with contextlib.suppress(_NONCRITICAL_EXCEPTIONS):
+        await get_connectors_sync_scheduler().stop()
+
+
+__all__ = [
+    "_ConnectorsSyncScheduler",
+    "get_connectors_sync_scheduler",
+    "start_connectors_sync_scheduler",
+    "stop_connectors_sync_scheduler",
+]

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from typing import Any
 
 from loguru import logger
@@ -455,18 +456,50 @@ def _determine_drive_export_mime(
     return export_mime
 
 
-def _convert_document_bytes_to_text(*, raw: bytes, name: str, effective_mime: str) -> str:
+def _file_sync_skip_reason(
+    *,
+    name: str,
+    mime: str | None,
+    size: Any,
+    is_folder: bool,
+    include_types: list[str],
+    exclude_patterns: list[str],
+    allowed_file_types: list[str],
+    max_bytes: int | None,
+) -> str | None:
+    from tldw_Server_API.app.core.External_Sources.policy import is_file_type_allowed
+
+    if is_folder:
+        return "folder"
+    if exclude_patterns and any(fnmatch(name, pattern) for pattern in exclude_patterns):
+        return "excluded_by_pattern"
+    if include_types:
+        ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+        if ext not in include_types:
+            return "extension_not_included"
+    if not is_file_type_allowed(name=name, mime=mime, allowed=allowed_file_types):
+        return "disallowed_file_type"
+    if max_bytes is not None and size is not None:
+        try:
+            if int(size) > max_bytes:
+                return "file_too_large"
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+async def _convert_document_bytes_to_text(*, raw: bytes, name: str, effective_mime: str) -> str:
     content_text = ""
     try:
         if effective_mime == "application/pdf" or (not effective_mime and name.lower().endswith(".pdf")):
             try:
                 from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
 
-                res = process_pdf(file_input=raw, filename=name, parser="docling")
+                res = await asyncio.to_thread(process_pdf, file_input=raw, filename=name, parser="docling")
             except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
                 from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
 
-                res = process_pdf(file_input=raw, filename=name, parser="pymupdf4llm")
+                res = await asyncio.to_thread(process_pdf, file_input=raw, filename=name, parser="pymupdf4llm")
             if isinstance(res, dict):
                 content_text = (res.get("content") or "").strip()
         else:
@@ -957,9 +990,6 @@ async def _process_import_job(
     degraded = 0
     bootstrap_sync_storage_enabled = False
     # Policy helpers
-    from fnmatch import fnmatch
-
-    from tldw_Server_API.app.core.External_Sources.policy import is_file_type_allowed
     allowed_export_formats = [str(f).lower() for f in (policy.get("allowed_export_formats") or [])]
     allowed_export_set = set(allowed_export_formats)
     allowed_file_types = [str(t).lower() for t in (policy.get("allowed_file_types") or [])]
@@ -1120,6 +1150,28 @@ async def _process_import_job(
                         metadata = dict(change.metadata or {})
                         export_mime = None
                         mime = str(metadata.get("mime_type") or metadata.get("mimeType") or "").strip() or None
+                        name = str(change.remote_name or change.remote_id)
+                        skip_reason = _file_sync_skip_reason(
+                            name=name,
+                            mime=mime,
+                            size=metadata.get("size"),
+                            is_folder=bool(metadata.get("is_folder")),
+                            include_types=include_types,
+                            exclude_patterns=exclude_patterns,
+                            allowed_file_types=allowed_file_types,
+                            max_bytes=max_bytes,
+                        )
+                        if skip_reason:
+                            if binding:
+                                raise ValueError(f"File sync change blocked by policy: {skip_reason}")  # noqa: TRY003
+                            logger.info(
+                                "Skipping file sync change for provider={} source_id={} remote_id={} reason={}",
+                                provider,
+                                source_id,
+                                change.remote_id,
+                                skip_reason,
+                            )
+                            continue
                         if provider == "drive":
                             export_mime = _determine_drive_export_mime(
                                 mime=mime,
@@ -1135,13 +1187,13 @@ async def _process_import_job(
                             change.remote_id,
                             metadata=metadata,
                         )
-                        content_text = _convert_document_bytes_to_text(
+                        content_text = await _convert_document_bytes_to_text(
                             raw=raw,
-                            name=change.remote_name or change.remote_id,
+                            name=name,
                             effective_mime=(export_mime or mime or "").lower(),
                         )
                         content_payload = sync_coordinator.FileSyncContentPayload(
-                            text=content_text or f"[empty content for {provider}:{change.remote_id}]",
+                            text=content_text,
                             safe_metadata={"export_mime": export_mime} if export_mime else None,
                         )
 
@@ -1538,9 +1590,6 @@ async def _process_import_job(
                         )
                     processed += 1
                     continue
-                # Skip folders
-                if (it.get("is_folder") is True) or (str(it.get("mimeType") or "").startswith("application/vnd.google-apps.folder")):
-                    continue
                 fid = str(it.get("id"))
                 name = str(it.get("name") or fid)
                 modified_at = it.get("modifiedTime") or it.get("last_edited_time")
@@ -1548,26 +1597,19 @@ async def _process_import_job(
                 mime = it.get("mimeType") or ("text/markdown" if provider == "notion" else None)
                 version = it.get("md5Checksum") or None
 
-                # Enforce include/exclude on name
-                try:
-                    if exclude_patterns and any(fnmatch(name, pat) for pat in exclude_patterns):
-                        continue
-                    if include_types:
-                        ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
-                        if ext not in include_types:
-                            continue
-                except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
-                    pass
-
-                # Enforce policy: file type and size
-                if not is_file_type_allowed(name=name, mime=mime, allowed=allowed_file_types):
+                skip_reason = _file_sync_skip_reason(
+                    name=name,
+                    mime=mime,
+                    size=size,
+                    is_folder=bool(it.get("is_folder"))
+                    or str(it.get("mimeType") or "").startswith("application/vnd.google-apps.folder"),
+                    include_types=include_types,
+                    exclude_patterns=exclude_patterns,
+                    allowed_file_types=allowed_file_types,
+                    max_bytes=max_bytes,
+                )
+                if skip_reason:
                     continue
-                if max_bytes is not None and size is not None:
-                    try:
-                        if int(size) > max_bytes:
-                            continue
-                    except (TypeError, ValueError):
-                        pass
 
                 # Determine desired export for Drive Google types according to policy/overrides
                 export_mime = None
@@ -1587,10 +1629,13 @@ async def _process_import_job(
                         raw = await _attempt_with_refresh(conn.download_file, acct, fid) if provider == "notion" else await _attempt_with_refresh(conn.download_file, acct, fid, mime_type=mime)
                 except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
                     logger.warning(f"download failed for {provider}:{fid}: {e}")
+                    if provider in FILE_SYNC_PROVIDERS and bootstrap_sync_storage_enabled:
+                        failed += 1
+                        continue
                     raw = b""
 
                 effective_mime = (export_mime or mime or "").lower()
-                content_text = _convert_document_bytes_to_text(
+                content_text = await _convert_document_bytes_to_text(
                     raw=raw,
                     name=name,
                     effective_mime=effective_mime,
@@ -1649,7 +1694,7 @@ async def _process_import_job(
                             )
 
                         reconcile_content = sync_coordinator.FileSyncContentPayload(
-                            text=content_text or f"[empty content for {provider}:{fid}]",
+                            text=content_text,
                             safe_metadata={"export_mime": export_mime} if export_mime else None,
                         )
                         async with pool.transaction() as db:

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -598,10 +598,12 @@ async def _process_import_job(
         FILE_SYNC_PROVIDERS,
         get_external_item_binding,
         get_account_tokens,
+        record_item_event,
         get_source_by_id,
         get_source_sync_state,
         record_ingested_item,
         should_ingest_item,
+        upsert_external_item_binding,
         upsert_source_sync_state,
         update_account_tokens,
     )
@@ -951,6 +953,9 @@ async def _process_import_job(
 
     processed = 0
     total = 1
+    failed = 0
+    degraded = 0
+    bootstrap_sync_storage_enabled = False
     # Policy helpers
     from fnmatch import fnmatch
 
@@ -1041,6 +1046,8 @@ async def _process_import_job(
     async def _process_file_sync_changes() -> bool:
         nonlocal processed
         nonlocal total
+        nonlocal failed
+        nonlocal degraded
 
         if provider not in FILE_SYNC_PROVIDERS:
             return False
@@ -1107,48 +1114,65 @@ async def _process_import_job(
                     )
                     continue
 
-                content_payload = None
-                if change.event_type in {"created", "content_updated"}:
-                    metadata = dict(change.metadata or {})
-                    export_mime = None
-                    mime = str(metadata.get("mime_type") or metadata.get("mimeType") or "").strip() or None
-                    if provider == "drive":
-                        export_mime = _determine_drive_export_mime(
-                            mime=mime,
-                            allowed_export_formats=allowed_export_formats,
-                            allowed_export_set=allowed_export_set,
-                            export_overrides=export_overrides,
+                try:
+                    content_payload = None
+                    if change.event_type in {"created", "content_updated"}:
+                        metadata = dict(change.metadata or {})
+                        export_mime = None
+                        mime = str(metadata.get("mime_type") or metadata.get("mimeType") or "").strip() or None
+                        if provider == "drive":
+                            export_mime = _determine_drive_export_mime(
+                                mime=mime,
+                                allowed_export_formats=allowed_export_formats,
+                                allowed_export_set=allowed_export_set,
+                                export_overrides=export_overrides,
+                            )
+                            if export_mime:
+                                metadata["export_mime"] = export_mime
+                        raw = await _attempt_with_refresh(
+                            conn.download_or_export,
+                            acct,
+                            change.remote_id,
+                            metadata=metadata,
                         )
-                        if export_mime:
-                            metadata["export_mime"] = export_mime
-                    raw = await _attempt_with_refresh(
-                        conn.download_or_export,
-                        acct,
-                        change.remote_id,
-                        metadata=metadata,
-                    )
-                    content_text = _convert_document_bytes_to_text(
-                        raw=raw,
-                        name=change.remote_name or change.remote_id,
-                        effective_mime=(export_mime or mime or "").lower(),
-                    )
-                    content_payload = sync_coordinator.FileSyncContentPayload(
-                        text=content_text or f"[empty content for {provider}:{change.remote_id}]",
-                        safe_metadata={"export_mime": export_mime} if export_mime else None,
-                    )
+                        content_text = _convert_document_bytes_to_text(
+                            raw=raw,
+                            name=change.remote_name or change.remote_id,
+                            effective_mime=(export_mime or mime or "").lower(),
+                        )
+                        content_payload = sync_coordinator.FileSyncContentPayload(
+                            text=content_text or f"[empty content for {provider}:{change.remote_id}]",
+                            safe_metadata={"export_mime": export_mime} if export_mime else None,
+                        )
 
-                async with pool.transaction() as db:
-                    reconcile_result = await sync_coordinator.reconcile_file_change(
-                        db,
-                        mdb,
-                        source_id=source_id,
-                        provider=provider,
-                        change=change,
-                        content=content_payload,
-                        job_id=str(jid),
+                    async with pool.transaction() as db:
+                        reconcile_result = await sync_coordinator.reconcile_file_change(
+                            db,
+                            mdb,
+                            source_id=source_id,
+                            provider=provider,
+                            change=change,
+                            content=content_payload,
+                            job_id=str(jid),
+                        )
+                    if reconcile_result.action:
+                        processed += 1
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS as exc:
+                    failed += 1
+                    logger.warning(
+                        "File sync item reconcile failed for provider={} source_id={} remote_id={}: {}",
+                        provider,
+                        source_id,
+                        change.remote_id,
+                        exc,
                     )
-                if reconcile_result.action:
-                    processed += 1
+                    if await _mark_file_binding_degraded(
+                        binding=binding,
+                        change=change,
+                        error=exc,
+                    ):
+                        degraded += 1
+                    continue
 
             final_cursor = str(cursor_hint or next_cursor or file_cursor).strip() or file_cursor
             async with pool.transaction() as db:
@@ -1173,10 +1197,119 @@ async def _process_import_job(
             raise
         return True
 
+    async def _resolve_post_bootstrap_cursor() -> tuple[str | None, str | None]:
+        cursor_kind = _file_sync_cursor_kind(provider)
+        try:
+            async with pool.transaction() as db:
+                sync_state = await get_source_sync_state(db, source_id=source_id) or {}
+        except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+            sync_state = {}
+
+        existing_cursor = str(sync_state.get("cursor") or "").strip() or None
+        existing_kind = str(sync_state.get("cursor_kind") or "").strip() or cursor_kind
+        if existing_cursor:
+            return existing_cursor, existing_kind
+
+        try:
+            if provider == "drive" and hasattr(conn, "get_start_page_token"):
+                drive_cursor = await _attempt_with_refresh(conn.get_start_page_token, acct)
+                resolved = str(drive_cursor or "").strip() or None
+                return resolved, existing_kind
+            if hasattr(conn, "list_changes"):
+                _changes, next_cursor, cursor_hint = await _attempt_with_refresh(
+                    conn.list_changes,
+                    acct,
+                    cursor=None,
+                    page_size=1,
+                )
+                resolved = str(cursor_hint or next_cursor or "").strip() or None
+                return resolved, existing_kind
+        except _CONNECTOR_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(
+                "Failed to resolve post-bootstrap cursor for provider={} source_id={}: {}",
+                provider,
+                source_id,
+                exc,
+            )
+        return None, existing_kind
+
+    def _supports_connector_sync_storage(db: Any) -> bool:
+        return callable(getattr(db, "execute", None))
+
+    async def _mark_file_binding_degraded(*, binding: dict[str, Any] | None, change, error: Exception) -> bool:
+        if not binding or binding.get("id") is None:
+            return False
+
+        change_metadata = dict(change.metadata or {})
+        provider_metadata = dict(binding.get("provider_metadata") or {})
+        provider_metadata.update(
+            {key: value for key, value in change_metadata.items() if value is not None}
+        )
+        provider_metadata.update(
+            {
+                "failed_remote_revision": change.remote_revision,
+                "failed_remote_hash": change.remote_hash,
+                "failed_event_type": change.event_type,
+            }
+        )
+
+        async with pool.transaction() as db:
+            updated = await upsert_external_item_binding(
+                db,
+                source_id=source_id,
+                provider=provider,
+                external_id=change.remote_id,
+                name=change.remote_name or binding.get("name"),
+                mime=change_metadata.get("mime_type") or binding.get("mime"),
+                size=change_metadata.get("size") or binding.get("size"),
+                version=binding.get("version"),
+                modified_at=change_metadata.get("modified_at") or binding.get("modified_at"),
+                content_hash=binding.get("hash"),
+                media_id=binding.get("media_id"),
+                sync_status="degraded",
+                current_version_number=binding.get("current_version_number"),
+                remote_parent_id=change.remote_parent_id or binding.get("remote_parent_id"),
+                remote_path=change.remote_path or binding.get("remote_path"),
+                last_seen_at=_utc_now_db_text(),
+                last_metadata_sync_at=_utc_now_db_text(),
+                provider_metadata=provider_metadata,
+            )
+            await record_item_event(
+                db,
+                external_item_id=int(updated["id"]),
+                event_type="ingest_failed",
+                job_id=str(jid),
+                payload={
+                    "error": str(error),
+                    "change_event_type": change.event_type,
+                    "remote_revision": change.remote_revision,
+                    "remote_hash": change.remote_hash,
+                },
+            )
+        return True
+
     try:
         if await _process_subscription_renewal():
             return
         if not await _process_file_sync_changes():
+            bootstrap_file_sync_scan = provider in FILE_SYNC_PROVIDERS
+            if bootstrap_file_sync_scan:
+                async with pool.transaction() as db:
+                    bootstrap_sync_storage_enabled = _supports_connector_sync_storage(db)
+                    if bootstrap_sync_storage_enabled:
+                        await upsert_source_sync_state(
+                            db,
+                            source_id=source_id,
+                            cursor_kind=_file_sync_cursor_kind(provider),
+                            last_sync_started_at=_utc_now_db_text(),
+                            last_error=None,
+                        )
+            if bootstrap_file_sync_scan and not bootstrap_sync_storage_enabled:
+                logger.debug(
+                    "Connector sync storage unavailable during bootstrap for provider={} source_id={}; falling back to legacy import path",
+                    provider,
+                    source_id,
+                )
             items = await _enumerate_items()
             total = max(1, len(items))
 
@@ -1477,6 +1610,77 @@ async def _process_import_job(
                     )
                 if not should:
                     continue
+                if provider in FILE_SYNC_PROVIDERS and bootstrap_sync_storage_enabled:
+                    from tldw_Server_API.app.core.External_Sources import sync_coordinator
+
+                    change = sync_coordinator.FileSyncChange(
+                        event_type="created",
+                        remote_id=fid,
+                        remote_name=name,
+                        remote_revision=version,
+                        remote_hash=content_hash,
+                        metadata={
+                            "mime_type": mime,
+                            "size": size,
+                            "modified_at": modified_at,
+                        },
+                    )
+                    existing_binding = None
+                    try:
+                        async with pool.transaction() as db:
+                            existing_binding = await get_external_item_binding(
+                                db,
+                                source_id=source_id,
+                                provider=provider,
+                                external_id=fid,
+                            )
+                        if existing_binding:
+                            change = sync_coordinator.FileSyncChange(
+                                event_type="content_updated",
+                                remote_id=fid,
+                                remote_name=name,
+                                remote_revision=version,
+                                remote_hash=content_hash,
+                                metadata={
+                                    "mime_type": mime,
+                                    "size": size,
+                                    "modified_at": modified_at,
+                                },
+                            )
+
+                        reconcile_content = sync_coordinator.FileSyncContentPayload(
+                            text=content_text or f"[empty content for {provider}:{fid}]",
+                            safe_metadata={"export_mime": export_mime} if export_mime else None,
+                        )
+                        async with pool.transaction() as db:
+                            reconcile_result = await sync_coordinator.reconcile_file_change(
+                                db,
+                                mdb,
+                                source_id=source_id,
+                                provider=provider,
+                                change=change,
+                                content=reconcile_content,
+                                job_id=str(jid),
+                            )
+                        if reconcile_result.action:
+                            processed += 1
+                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                        failed += 1
+                        logger.warning(
+                            "Bootstrap file sync reconcile failed for provider={} source_id={} remote_id={}: {}",
+                            provider,
+                            source_id,
+                            fid,
+                            e,
+                        )
+                        if await _mark_file_binding_degraded(
+                            binding=existing_binding,
+                            change=change,
+                            error=e,
+                        ):
+                            degraded += 1
+                    continue
+
                 # Ingest minimal record
                 title = name
                 url = f"{provider}://{fid}"
@@ -1509,6 +1713,19 @@ async def _process_import_job(
                             modified_at=modified_at,
                             content_hash=content_hash,
                         )
+
+            if bootstrap_file_sync_scan and bootstrap_sync_storage_enabled:
+                resolved_cursor, resolved_cursor_kind = await _resolve_post_bootstrap_cursor()
+                async with pool.transaction() as db:
+                    await upsert_source_sync_state(
+                        db,
+                        source_id=source_id,
+                        cursor=resolved_cursor,
+                        cursor_kind=resolved_cursor_kind,
+                        last_bootstrap_at=_utc_now_db_text(),
+                        last_sync_succeeded_at=_utc_now_db_text(),
+                        last_error=None,
+                    )
     except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
         if gmail_sync_state_supported and gmail_sync_state_started:
             with contextlib.suppress(_CONNECTOR_NONCRITICAL_EXCEPTIONS):
@@ -1643,7 +1860,12 @@ async def _process_import_job(
                 ),
             )
 
-    result_payload: dict[str, Any] = {"processed": processed, "total": total}
+    result_payload: dict[str, Any] = {
+        "processed": processed,
+        "total": total,
+        "failed": failed,
+        "degraded": degraded,
+    }
     if provider == "gmail" and gmail_cursor_recovery_active:
         result_payload["cursor_recovery"] = (
             "full_backfill_required"

--- a/tldw_Server_API/app/services/connectors_worker.py
+++ b/tldw_Server_API/app/services/connectors_worker.py
@@ -415,6 +415,68 @@ def _merge_gmail_history_cursor(current: str | None, candidate: Any) -> str | No
         return candidate_text if candidate_text >= current_text else current_text
 
 
+def _utc_now_db_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _file_sync_cursor_kind(provider: str) -> str | None:
+    normalized = str(provider or "").strip().lower()
+    if normalized == "drive":
+        return "drive_start_page_token"
+    if normalized == "onedrive":
+        return "graph_delta_link"
+    return None
+
+
+def _determine_drive_export_mime(
+    *,
+    mime: str | None,
+    allowed_export_formats: list[str],
+    allowed_export_set: set[str],
+    export_overrides: dict[str, str],
+) -> str | None:
+    export_mime = None
+    if (mime or "").startswith("application/vnd.google-apps."):
+        override_key = mime or ""
+        ov = export_overrides.get(override_key) or export_overrides.get(override_key.split(".")[-1])
+        if ov in {"pdf", "txt", "md"} and ov in allowed_export_set:
+            export_mime = "application/pdf" if ov == "pdf" else "text/plain"
+        else:
+            if mime == "application/vnd.google-apps.presentation":
+                export_mime = "application/pdf" if "pdf" in allowed_export_formats else "text/plain"
+            elif mime == "application/vnd.google-apps.document":
+                export_mime = (
+                    "text/plain"
+                    if ("txt" in allowed_export_formats or "md" in allowed_export_formats)
+                    else ("application/pdf" if "pdf" in allowed_export_formats else "text/plain")
+                )
+            elif mime == "application/vnd.google-apps.spreadsheet":
+                export_mime = "text/csv" if "txt" in allowed_export_formats else ("application/pdf" if "pdf" in allowed_export_formats else "text/csv")
+    return export_mime
+
+
+def _convert_document_bytes_to_text(*, raw: bytes, name: str, effective_mime: str) -> str:
+    content_text = ""
+    try:
+        if effective_mime == "application/pdf" or (not effective_mime and name.lower().endswith(".pdf")):
+            try:
+                from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
+
+                res = process_pdf(file_input=raw, filename=name, parser="docling")
+            except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+                from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
+
+                res = process_pdf(file_input=raw, filename=name, parser="pymupdf4llm")
+            if isinstance(res, dict):
+                content_text = (res.get("content") or "").strip()
+        else:
+            if raw:
+                content_text = raw.decode("utf-8", errors="replace")
+    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning("content conversion failed for {}: {}", name, exc)
+    return content_text
+
+
 async def run_connectors_worker(stop_event: asyncio.Event | None = None) -> None:
     """Minimal worker that acknowledges and completes connector jobs.
 
@@ -446,8 +508,62 @@ async def run_connectors_worker(stop_event: asyncio.Event | None = None) -> None
                 user_id = int(payload.get("user_id")) if payload.get("user_id") is not None else None
                 if not source_id or not user_id:
                     raise ValueError("invalid job payload")
-                await _process_import_job(jm, jid, lease_id, worker_id, source_id, user_id)
+                from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+                from tldw_Server_API.app.core.External_Sources.connectors_service import (
+                    finish_source_sync_job,
+                    start_source_sync_job,
+                )
+
+                pool = await get_db_pool()
+                async with pool.transaction() as db:
+                    sync_state = await start_source_sync_job(
+                        db,
+                        source_id=source_id,
+                        job_id=str(jid),
+                    )
+                if str((sync_state or {}).get("active_job_id") or "") != str(jid):
+                    jm.fail_job(
+                        jid,
+                        error=f"Active sync job already exists for source {source_id}",
+                        retryable=True,
+                        backoff_seconds=30,
+                        worker_id=worker_id,
+                        lease_id=lease_id,
+                        completion_token=lease_id,
+                    )
+                    continue
+                job_type = str(job.get("job_type") or "import")
+                await _process_import_job(
+                    jm,
+                    jid,
+                    lease_id,
+                    worker_id,
+                    source_id,
+                    user_id,
+                    job_type=job_type,
+                )
+                async with pool.transaction() as db:
+                    await finish_source_sync_job(
+                        db,
+                        source_id=source_id,
+                        job_id=str(jid),
+                        outcome="success",
+                    )
             except _CONNECTOR_NONCRITICAL_EXCEPTIONS as _e:
+                with contextlib.suppress(_CONNECTOR_NONCRITICAL_EXCEPTIONS):
+                    if source_id:
+                        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+                        from tldw_Server_API.app.core.External_Sources.connectors_service import finish_source_sync_job
+
+                        pool = await get_db_pool()
+                        async with pool.transaction() as db:
+                            await finish_source_sync_job(
+                                db,
+                                source_id=source_id,
+                                job_id=str(jid),
+                                outcome="failure",
+                                error=str(_e),
+                            )
                 jm.fail_job(jid, error=str(_e), retryable=False, worker_id=worker_id, lease_id=lease_id, completion_token=lease_id)
         except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
             await asyncio.sleep(poll_sleep)
@@ -462,7 +578,16 @@ async def start_connectors_worker() -> asyncio.Task | None:
     return task
 
 
-async def _process_import_job(jm, jid: int, lease_id: str | None, worker_id: str, source_id: int, user_id: int) -> None:
+async def _process_import_job(
+    jm,
+    jid: int,
+    lease_id: str | None,
+    worker_id: str,
+    source_id: int,
+    user_id: int,
+    *,
+    job_type: str = "import",
+) -> None:
     """Fetch source/account, enumerate items, and ingest into Media DB."""
     # DB access
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -470,10 +595,14 @@ async def _process_import_job(jm, jid: int, lease_id: str | None, worker_id: str
     from tldw_Server_API.app.core.DB_Management.Media_DB_v2 import MediaDatabase
     from tldw_Server_API.app.core.External_Sources import get_connector_by_name
     from tldw_Server_API.app.core.External_Sources.connectors_service import (
+        FILE_SYNC_PROVIDERS,
+        get_external_item_binding,
         get_account_tokens,
         get_source_by_id,
+        get_source_sync_state,
         record_ingested_item,
         should_ingest_item,
+        upsert_source_sync_state,
         update_account_tokens,
     )
 
@@ -843,332 +972,543 @@ async def _process_import_job(jm, jid: int, lease_id: str | None, worker_id: str
     except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
         email_native_persist_enabled = True
 
-    try:
-        items = await _enumerate_items()
-        total = max(1, len(items))
+    async def _process_subscription_renewal() -> bool:
+        if job_type != "subscription_renewal":
+            return False
+        if provider not in FILE_SYNC_PROVIDERS or not hasattr(conn, "renew_webhook"):
+            jm.complete_job(
+                jid,
+                result={"processed": 0, "total": 0, "skipped": "unsupported_provider"},
+                worker_id=worker_id,
+                lease_id=lease_id,
+                completion_token=lease_id,
+            )
+            return True
 
-        for idx, it in enumerate(items):
-            try:
-                # Renew lease with progress
-                pct = int((idx / total) * 100)
-                jm.renew_job_lease(jid, seconds=120, worker_id=worker_id, lease_id=lease_id, progress_percent=pct)
-            except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
-                pass
-            if provider == "gmail":
-                fid = str(it.get("id") or "").strip()
-                if not fid:
-                    continue
-                history_id_hint = _normalize_gmail_history_cursor(it.get("historyId"))
-                gmail_cursor_candidate = _merge_gmail_history_cursor(
-                    gmail_cursor_candidate,
-                    history_id_hint,
-                )
-                history_message_added = bool(it.get("message_added"))
-                history_message_deleted = bool(it.get("message_deleted"))
+        from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncWebhookSubscription
 
-                labels_added_raw = it.get("labels_added")
-                labels_removed_raw = it.get("labels_removed")
-                labels_added: list[str] = []
-                labels_removed: list[str] = []
-                if isinstance(labels_added_raw, list):
-                    seen_added: set[str] = set()
-                    for label in labels_added_raw:
-                        label_text = str(label or "").strip()
-                        key = label_text.lower()
-                        if not label_text or key in seen_added:
-                            continue
-                        seen_added.add(key)
-                        labels_added.append(label_text)
-                if isinstance(labels_removed_raw, list):
-                    seen_removed: set[str] = set()
-                    for label in labels_removed_raw:
-                        label_text = str(label or "").strip()
-                        key = label_text.lower()
-                        if not label_text or key in seen_removed:
-                            continue
-                        seen_removed.add(key)
-                        labels_removed.append(label_text)
+        async with pool.transaction() as db:
+            sync_state = await get_source_sync_state(db, source_id=source_id) or {}
+        subscription_id = str(sync_state.get("webhook_subscription_id") or "").strip() or None
+        expires_at = str(sync_state.get("webhook_expires_at") or "").strip() or None
+        webhook_metadata = dict(sync_state.get("webhook_metadata") or {})
+        if not subscription_id:
+            jm.complete_job(
+                jid,
+                result={"processed": 0, "total": 0, "skipped": "missing_subscription"},
+                worker_id=worker_id,
+                lease_id=lease_id,
+                completion_token=lease_id,
+            )
+            return True
 
-                if (
-                    history_message_deleted
-                    and not history_message_added
-                    and hasattr(mdb, "reconcile_email_message_state")
-                ):
-                    try:
-                        state_res = mdb.reconcile_email_message_state(
-                            provider="gmail",
-                            source_key=str(source_id),
-                            source_message_id=fid,
-                            tenant_id=str(user_id),
-                            deleted=True,
-                        )
-                        if bool((state_res or {}).get("applied")):
-                            processed += 1
-                        continue
-                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                        logger.warning(f"gmail state reconcile failed for {fid}: {e}")
-                        gmail_sync_errors.append(f"state_reconcile:{fid}")
-                        continue
+        renewed = await _attempt_with_refresh(
+            conn.renew_webhook,
+            acct,
+            subscription=FileSyncWebhookSubscription(
+                subscription_id=subscription_id,
+                expires_at=expires_at,
+                metadata=webhook_metadata,
+            ),
+        )
+        if not renewed or not renewed.subscription_id:
+            raise ValueError(f"Webhook renewal failed for provider={provider} source_id={source_id}")  # noqa: TRY003
 
-                if (
-                    not history_message_added
-                    and not history_message_deleted
-                    and (labels_added or labels_removed)
-                    and hasattr(mdb, "apply_email_label_delta")
-                ):
-                    try:
-                        delta_res = mdb.apply_email_label_delta(
-                            provider="gmail",
-                            source_key=str(source_id),
-                            source_message_id=fid,
-                            labels_added=labels_added,
-                            labels_removed=labels_removed,
-                            tenant_id=str(user_id),
-                        )
-                        if bool((delta_res or {}).get("applied")):
-                            processed += 1
-                            continue
-                        # If we cannot resolve the local message yet, fall back to full fetch.
-                        delta_reason = str((delta_res or {}).get("reason") or "").strip().lower()
-                        if delta_reason not in {"message_not_found", "source_not_found"}:
-                            continue
-                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                        logger.warning(f"gmail label delta apply failed for {fid}: {e}")
-                        gmail_sync_errors.append(f"label_delta:{fid}")
-                        continue
+        async with pool.transaction() as db:
+            await upsert_source_sync_state(
+                db,
+                source_id=source_id,
+                webhook_status="active",
+                webhook_subscription_id=renewed.subscription_id,
+                webhook_expires_at=renewed.expires_at,
+                webhook_metadata=renewed.metadata or webhook_metadata,
+                last_error=None,
+            )
+        jm.complete_job(
+            jid,
+            result={
+                "processed": 1,
+                "total": 1,
+                "subscription_id": renewed.subscription_id,
+                "webhook_expires_at": renewed.expires_at,
+            },
+            worker_id=worker_id,
+            lease_id=lease_id,
+            completion_token=lease_id,
+        )
+        return True
 
+    async def _process_file_sync_changes() -> bool:
+        nonlocal processed
+        nonlocal total
+
+        if provider not in FILE_SYNC_PROVIDERS:
+            return False
+
+        try:
+            async with pool.transaction() as db:
+                sync_state = await get_source_sync_state(db, source_id=source_id)
+        except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+            return False
+        file_cursor = str((sync_state or {}).get("cursor") or "").strip() or None
+        if not file_cursor:
+            return False
+        if bool((sync_state or {}).get("needs_full_rescan")):
+            return False
+
+        from tldw_Server_API.app.core.External_Sources import sync_coordinator
+
+        cursor_kind = str((sync_state or {}).get("cursor_kind") or "").strip() or _file_sync_cursor_kind(provider)
+        async with pool.transaction() as db:
+            await upsert_source_sync_state(
+                db,
+                source_id=source_id,
+                cursor=file_cursor,
+                cursor_kind=cursor_kind,
+                last_sync_started_at=_utc_now_db_text(),
+                last_error=None,
+            )
+
+        try:
+            changes, next_cursor, cursor_hint = await _attempt_with_refresh(
+                conn.list_changes,
+                acct,
+                cursor=file_cursor,
+                page_size=100,
+            )
+            total = max(1, len(changes))
+            for idx, change in enumerate(changes):
                 try:
-                    message = await _attempt_with_refresh(conn.get_message, acct, message_id=fid, format="full")
-                except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"gmail get_message failed for {fid}: {e}")
-                    gmail_sync_errors.append(f"get_message:{fid}")
+                    pct = int((idx / total) * 100)
+                    jm.renew_job_lease(
+                        jid,
+                        seconds=120,
+                        worker_id=worker_id,
+                        lease_id=lease_id,
+                        progress_percent=pct,
+                    )
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+                    pass
+
+                async with pool.transaction() as db:
+                    binding = await get_external_item_binding(
+                        db,
+                        source_id=source_id,
+                        provider=provider,
+                        external_id=change.remote_id,
+                    )
+
+                if not binding and change.event_type != "created":
+                    logger.warning(
+                        "Skipping file sync change without binding for provider={} source_id={} remote_id={}",
+                        provider,
+                        source_id,
+                        change.remote_id,
+                    )
                     continue
 
-                payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
-                headers_map = _gmail_headers_map(payload)
-                subject = str(headers_map.get("subject") or "").strip() or f"Gmail message {fid}"
-                from_text = str(headers_map.get("from") or "").strip() or None
-                to_text = str(headers_map.get("to") or "").strip() or None
-                cc_text = str(headers_map.get("cc") or "").strip() or None
-                bcc_text = str(headers_map.get("bcc") or "").strip() or None
-                message_id_header = str(headers_map.get("message-id") or "").strip() or None
-                date_header = str(headers_map.get("date") or "").strip() or None
+                content_payload = None
+                if change.event_type in {"created", "content_updated"}:
+                    metadata = dict(change.metadata or {})
+                    export_mime = None
+                    mime = str(metadata.get("mime_type") or metadata.get("mimeType") or "").strip() or None
+                    if provider == "drive":
+                        export_mime = _determine_drive_export_mime(
+                            mime=mime,
+                            allowed_export_formats=allowed_export_formats,
+                            allowed_export_set=allowed_export_set,
+                            export_overrides=export_overrides,
+                        )
+                        if export_mime:
+                            metadata["export_mime"] = export_mime
+                    raw = await _attempt_with_refresh(
+                        conn.download_or_export,
+                        acct,
+                        change.remote_id,
+                        metadata=metadata,
+                    )
+                    content_text = _convert_document_bytes_to_text(
+                        raw=raw,
+                        name=change.remote_name or change.remote_id,
+                        effective_mime=(export_mime or mime or "").lower(),
+                    )
+                    content_payload = sync_coordinator.FileSyncContentPayload(
+                        text=content_text or f"[empty content for {provider}:{change.remote_id}]",
+                        safe_metadata={"export_mime": export_mime} if export_mime else None,
+                    )
 
-                body_text = _collect_gmail_body_text(payload)
-                if not body_text:
-                    body_text = str(message.get("snippet") or "").strip()
+                async with pool.transaction() as db:
+                    reconcile_result = await sync_coordinator.reconcile_file_change(
+                        db,
+                        mdb,
+                        source_id=source_id,
+                        provider=provider,
+                        change=change,
+                        content=content_payload,
+                        job_id=str(jid),
+                    )
+                if reconcile_result.action:
+                    processed += 1
 
-                attachments = _collect_gmail_attachments(payload)
-                label_ids: list[str] = []
-                seen_labels: set[str] = set()
-                for label in (message.get("labelIds") or []):
-                    label_text = str(label).strip()
-                    if not label_text:
-                        continue
-                    key = label_text.lower()
-                    if key in seen_labels:
-                        continue
-                    seen_labels.add(key)
-                    label_ids.append(label_text)
-                internal_date = _gmail_internal_date_iso(message)
-                internal_date_dt = _parse_iso_utc(internal_date)
-                if internal_date_dt is not None:
-                    if (
-                        gmail_latest_message_internal_at is None
-                        or internal_date_dt > gmail_latest_message_internal_at
-                    ):
-                        gmail_latest_message_internal_at = internal_date_dt
-                history_id = str(message.get("historyId") or "").strip() or None
-                gmail_cursor_candidate = _merge_gmail_history_cursor(
-                    gmail_cursor_candidate,
-                    history_id,
+            final_cursor = str(cursor_hint or next_cursor or file_cursor).strip() or file_cursor
+            async with pool.transaction() as db:
+                await upsert_source_sync_state(
+                    db,
+                    source_id=source_id,
+                    cursor=final_cursor,
+                    cursor_kind=cursor_kind,
+                    last_sync_succeeded_at=_utc_now_db_text(),
+                    last_error=None,
                 )
-                content_hash = hashlib.sha256(body_text.encode()).hexdigest() if body_text else None
+        except _CONNECTOR_NONCRITICAL_EXCEPTIONS as exc:
+            async with pool.transaction() as db:
+                await upsert_source_sync_state(
+                    db,
+                    source_id=source_id,
+                    cursor=file_cursor,
+                    cursor_kind=cursor_kind,
+                    last_sync_failed_at=_utc_now_db_text(),
+                    last_error=str(exc),
+                )
+            raise
+        return True
 
+    try:
+        if await _process_subscription_renewal():
+            return
+        if not await _process_file_sync_changes():
+            items = await _enumerate_items()
+            total = max(1, len(items))
+
+            for idx, it in enumerate(items):
+                try:
+                    # Renew lease with progress
+                    pct = int((idx / total) * 100)
+                    jm.renew_job_lease(
+                        jid,
+                        seconds=120,
+                        worker_id=worker_id,
+                        lease_id=lease_id,
+                        progress_percent=pct,
+                    )
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+                    pass
+                if provider == "gmail":
+                    fid = str(it.get("id") or "").strip()
+                    if not fid:
+                        continue
+                    history_id_hint = _normalize_gmail_history_cursor(it.get("historyId"))
+                    gmail_cursor_candidate = _merge_gmail_history_cursor(
+                        gmail_cursor_candidate,
+                        history_id_hint,
+                    )
+                    history_message_added = bool(it.get("message_added"))
+                    history_message_deleted = bool(it.get("message_deleted"))
+
+                    labels_added_raw = it.get("labels_added")
+                    labels_removed_raw = it.get("labels_removed")
+                    labels_added: list[str] = []
+                    labels_removed: list[str] = []
+                    if isinstance(labels_added_raw, list):
+                        seen_added: set[str] = set()
+                        for label in labels_added_raw:
+                            label_text = str(label or "").strip()
+                            key = label_text.lower()
+                            if not label_text or key in seen_added:
+                                continue
+                            seen_added.add(key)
+                            labels_added.append(label_text)
+                    if isinstance(labels_removed_raw, list):
+                        seen_removed: set[str] = set()
+                        for label in labels_removed_raw:
+                            label_text = str(label or "").strip()
+                            key = label_text.lower()
+                            if not label_text or key in seen_removed:
+                                continue
+                            seen_removed.add(key)
+                            labels_removed.append(label_text)
+
+                    if (
+                        history_message_deleted
+                        and not history_message_added
+                        and hasattr(mdb, "reconcile_email_message_state")
+                    ):
+                        try:
+                            state_res = mdb.reconcile_email_message_state(
+                                provider="gmail",
+                                source_key=str(source_id),
+                                source_message_id=fid,
+                                tenant_id=str(user_id),
+                                deleted=True,
+                            )
+                            if bool((state_res or {}).get("applied")):
+                                processed += 1
+                            continue
+                        except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                            logger.warning(f"gmail state reconcile failed for {fid}: {e}")
+                            gmail_sync_errors.append(f"state_reconcile:{fid}")
+                            continue
+
+                    if (
+                        not history_message_added
+                        and not history_message_deleted
+                        and (labels_added or labels_removed)
+                        and hasattr(mdb, "apply_email_label_delta")
+                    ):
+                        try:
+                            delta_res = mdb.apply_email_label_delta(
+                                provider="gmail",
+                                source_key=str(source_id),
+                                source_message_id=fid,
+                                labels_added=labels_added,
+                                labels_removed=labels_removed,
+                                tenant_id=str(user_id),
+                            )
+                            if bool((delta_res or {}).get("applied")):
+                                processed += 1
+                                continue
+                            # If we cannot resolve the local message yet, fall back to full fetch.
+                            delta_reason = str((delta_res or {}).get("reason") or "").strip().lower()
+                            if delta_reason not in {"message_not_found", "source_not_found"}:
+                                continue
+                        except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                            logger.warning(f"gmail label delta apply failed for {fid}: {e}")
+                            gmail_sync_errors.append(f"label_delta:{fid}")
+                            continue
+
+                    try:
+                        message = await _attempt_with_refresh(conn.get_message, acct, message_id=fid, format="full")
+                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(f"gmail get_message failed for {fid}: {e}")
+                        gmail_sync_errors.append(f"get_message:{fid}")
+                        continue
+
+                    payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
+                    headers_map = _gmail_headers_map(payload)
+                    subject = str(headers_map.get("subject") or "").strip() or f"Gmail message {fid}"
+                    from_text = str(headers_map.get("from") or "").strip() or None
+                    to_text = str(headers_map.get("to") or "").strip() or None
+                    cc_text = str(headers_map.get("cc") or "").strip() or None
+                    bcc_text = str(headers_map.get("bcc") or "").strip() or None
+                    message_id_header = str(headers_map.get("message-id") or "").strip() or None
+                    date_header = str(headers_map.get("date") or "").strip() or None
+
+                    body_text = _collect_gmail_body_text(payload)
+                    if not body_text:
+                        body_text = str(message.get("snippet") or "").strip()
+
+                    attachments = _collect_gmail_attachments(payload)
+                    label_ids: list[str] = []
+                    seen_labels: set[str] = set()
+                    for label in (message.get("labelIds") or []):
+                        label_text = str(label).strip()
+                        if not label_text:
+                            continue
+                        key = label_text.lower()
+                        if key in seen_labels:
+                            continue
+                        seen_labels.add(key)
+                        label_ids.append(label_text)
+                    internal_date = _gmail_internal_date_iso(message)
+                    internal_date_dt = _parse_iso_utc(internal_date)
+                    if internal_date_dt is not None:
+                        if (
+                            gmail_latest_message_internal_at is None
+                            or internal_date_dt > gmail_latest_message_internal_at
+                        ):
+                            gmail_latest_message_internal_at = internal_date_dt
+                    history_id = str(message.get("historyId") or "").strip() or None
+                    gmail_cursor_candidate = _merge_gmail_history_cursor(
+                        gmail_cursor_candidate,
+                        history_id,
+                    )
+                    content_hash = hashlib.sha256(body_text.encode()).hexdigest() if body_text else None
+
+                    async with pool.transaction() as db:
+                        should = await should_ingest_item(
+                            db,
+                            source_id=source_id,
+                            provider=provider,
+                            external_id=fid,
+                            version=history_id,
+                            modified_at=internal_date,
+                            content_hash=content_hash,
+                        )
+                    if not should:
+                        continue
+
+                    metadata_map: dict[str, Any] = {
+                        "source": "gmail_connector",
+                        "labels": label_ids,
+                        "email": {
+                            "source_message_id": fid,
+                            "message_id": message_id_header,
+                            "subject": subject,
+                            "date": date_header,
+                            "internal_date": internal_date,
+                            "from": from_text,
+                            "to": to_text,
+                            "cc": cc_text,
+                            "bcc": bcc_text,
+                            "labels": label_ids,
+                            "headers_map": headers_map,
+                            "attachments": attachments,
+                        },
+                    }
+                    safe_metadata_json = json.dumps(metadata_map, ensure_ascii=False)
+
+                    url = f"gmail://{source_id}/{fid}"
+                    try:
+                        media_id, _, _ = mdb.add_media_with_keywords(
+                            url=url,
+                            title=subject,
+                            media_type="email",
+                            content=body_text or f"[empty content for gmail:{fid}]",
+                            keywords=[],
+                            safe_metadata=safe_metadata_json,
+                            author=from_text,
+                            ingestion_date=internal_date,
+                            overwrite=False,
+                        )
+                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(f"add_media_with_keywords failed for gmail:{fid}: {e}")
+                        gmail_sync_errors.append(f"ingest:{fid}")
+                        continue
+
+                    if media_id and email_native_persist_enabled:
+                        try:
+                            mdb.upsert_email_message_graph(
+                                media_id=int(media_id),
+                                metadata=metadata_map,
+                                body_text=body_text,
+                                tenant_id=str(user_id),
+                                provider="gmail",
+                                source_key=str(source_id),
+                                source_message_id=fid,
+                                labels=label_ids,
+                            )
+                        except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                            logger.warning(f"email native upsert failed for gmail:{fid}: {e}")
+
+                    async with pool.transaction() as db:
+                        await record_ingested_item(
+                            db,
+                            source_id=source_id,
+                            provider=provider,
+                            external_id=fid,
+                            name=subject,
+                            mime="message/rfc822",
+                            size=None,
+                            version=history_id,
+                            modified_at=internal_date,
+                            content_hash=content_hash,
+                        )
+                    processed += 1
+                    continue
+                # Skip folders
+                if (it.get("is_folder") is True) or (str(it.get("mimeType") or "").startswith("application/vnd.google-apps.folder")):
+                    continue
+                fid = str(it.get("id"))
+                name = str(it.get("name") or fid)
+                modified_at = it.get("modifiedTime") or it.get("last_edited_time")
+                size = it.get("size")
+                mime = it.get("mimeType") or ("text/markdown" if provider == "notion" else None)
+                version = it.get("md5Checksum") or None
+
+                # Enforce include/exclude on name
+                try:
+                    if exclude_patterns and any(fnmatch(name, pat) for pat in exclude_patterns):
+                        continue
+                    if include_types:
+                        ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
+                        if ext not in include_types:
+                            continue
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
+                    pass
+
+                # Enforce policy: file type and size
+                if not is_file_type_allowed(name=name, mime=mime, allowed=allowed_file_types):
+                    continue
+                if max_bytes is not None and size is not None:
+                    try:
+                        if int(size) > max_bytes:
+                            continue
+                    except (TypeError, ValueError):
+                        pass
+
+                # Determine desired export for Drive Google types according to policy/overrides
+                export_mime = None
+                if provider == "drive":
+                    export_mime = _determine_drive_export_mime(
+                        mime=mime,
+                        allowed_export_formats=allowed_export_formats,
+                        allowed_export_set=allowed_export_set,
+                        export_overrides=export_overrides,
+                    )
+
+                # Download/export
+                try:
+                    if provider == "drive":
+                        raw = await _attempt_with_refresh(conn.download_file, acct, fid, mime_type=mime, export_mime=export_mime)
+                    else:
+                        raw = await _attempt_with_refresh(conn.download_file, acct, fid) if provider == "notion" else await _attempt_with_refresh(conn.download_file, acct, fid, mime_type=mime)
+                except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"download failed for {provider}:{fid}: {e}")
+                    raw = b""
+
+                effective_mime = (export_mime or mime or "").lower()
+                content_text = _convert_document_bytes_to_text(
+                    raw=raw,
+                    name=name,
+                    effective_mime=effective_mime,
+                )
+                # Hash for dedup
+                content_hash = hashlib.sha256(content_text.encode()).hexdigest() if content_text else None
+                # Dedup check
                 async with pool.transaction() as db:
                     should = await should_ingest_item(
                         db,
                         source_id=source_id,
                         provider=provider,
                         external_id=fid,
-                        version=history_id,
-                        modified_at=internal_date,
+                        version=version,
+                        modified_at=modified_at,
                         content_hash=content_hash,
                     )
                 if not should:
                     continue
-
-                metadata_map: dict[str, Any] = {
-                    "source": "gmail_connector",
-                    "labels": label_ids,
-                    "email": {
-                        "source_message_id": fid,
-                        "message_id": message_id_header,
-                        "subject": subject,
-                        "date": date_header,
-                        "internal_date": internal_date,
-                        "from": from_text,
-                        "to": to_text,
-                        "cc": cc_text,
-                        "bcc": bcc_text,
-                        "labels": label_ids,
-                        "headers_map": headers_map,
-                        "attachments": attachments,
-                    },
-                }
-                safe_metadata_json = json.dumps(metadata_map, ensure_ascii=False)
-
-                url = f"gmail://{source_id}/{fid}"
+                # Ingest minimal record
+                title = name
+                url = f"{provider}://{fid}"
+                ingested = False
                 try:
-                    media_id, _, _ = mdb.add_media_with_keywords(
+                    _mid, _m_uuid, _msg = mdb.add_media_with_keywords(
                         url=url,
-                        title=subject,
-                        media_type="email",
-                        content=body_text or f"[empty content for gmail:{fid}]",
+                        title=title,
+                        media_type="document",
+                        content=content_text or f"[empty content for {provider}:{fid}]",
                         keywords=[],
-                        safe_metadata=safe_metadata_json,
-                        author=from_text,
-                        ingestion_date=internal_date,
                         overwrite=False,
                     )
+                    processed += 1
+                    ingested = True
                 except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"add_media_with_keywords failed for gmail:{fid}: {e}")
-                    gmail_sync_errors.append(f"ingest:{fid}")
-                    continue
-
-                if media_id and email_native_persist_enabled:
-                    try:
-                        mdb.upsert_email_message_graph(
-                            media_id=int(media_id),
-                            metadata=metadata_map,
-                            body_text=body_text,
-                            tenant_id=str(user_id),
-                            provider="gmail",
-                            source_key=str(source_id),
-                            source_message_id=fid,
-                            labels=label_ids,
+                    logger.warning(f"add_media_with_keywords failed: {e}")
+                if ingested:
+                    # Record ingestion cache
+                    async with pool.transaction() as db:
+                        await record_ingested_item(
+                            db,
+                            source_id=source_id,
+                            provider=provider,
+                            external_id=fid,
+                            name=name,
+                            mime=mime,
+                            size=size,
+                            version=version,
+                            modified_at=modified_at,
+                            content_hash=content_hash,
                         )
-                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                        logger.warning(f"email native upsert failed for gmail:{fid}: {e}")
-
-                async with pool.transaction() as db:
-                    await record_ingested_item(
-                        db,
-                        source_id=source_id,
-                        provider=provider,
-                        external_id=fid,
-                        name=subject,
-                        mime="message/rfc822",
-                        size=None,
-                        version=history_id,
-                        modified_at=internal_date,
-                        content_hash=content_hash,
-                    )
-                processed += 1
-                continue
-            # Skip folders
-            if (it.get("is_folder") is True) or (str(it.get("mimeType") or "").startswith("application/vnd.google-apps.folder")):
-                continue
-            fid = str(it.get("id"))
-            name = str(it.get("name") or fid)
-            modified_at = it.get("modifiedTime") or it.get("last_edited_time")
-            size = it.get("size")
-            mime = it.get("mimeType") or ("text/markdown" if provider == "notion" else None)
-            version = it.get("md5Checksum") or None
-
-            # Enforce include/exclude on name
-            try:
-                if exclude_patterns and any(fnmatch(name, pat) for pat in exclude_patterns):
-                    continue
-                if include_types:
-                    ext = name.lower().rsplit(".", 1)[-1] if "." in name else ""
-                    if ext not in include_types:
-                        continue
-            except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
-                pass
-
-            # Enforce policy: file type and size
-            if not is_file_type_allowed(name=name, mime=mime, allowed=allowed_file_types):
-                continue
-            if max_bytes is not None and size is not None:
-                try:
-                    if int(size) > max_bytes:
-                        continue
-                except (TypeError, ValueError):
-                    pass
-
-            # Determine desired export for Drive Google types according to policy/overrides
-            export_mime = None
-            if provider == "drive" and (mime or "").startswith("application/vnd.google-apps."):
-                override_key = mime or ""
-                ov = export_overrides.get(override_key) or export_overrides.get(override_key.split(".")[-1])
-                if ov in {"pdf", "txt", "md"} and ov in allowed_export_set:
-                    export_mime = "application/pdf" if ov == "pdf" else "text/plain"
-                else:
-                    if mime == "application/vnd.google-apps.presentation":
-                        export_mime = "application/pdf" if "pdf" in allowed_export_formats else "text/plain"
-                    elif mime == "application/vnd.google-apps.document":
-                        export_mime = "text/plain" if ("txt" in allowed_export_formats or "md" in allowed_export_formats) else ("application/pdf" if "pdf" in allowed_export_formats else "text/plain")
-                    elif mime == "application/vnd.google-apps.spreadsheet":
-                        export_mime = "text/csv" if "txt" in allowed_export_formats else ("application/pdf" if "pdf" in allowed_export_formats else "text/csv")
-
-            # Download/export
-            try:
-                if provider == "drive":
-                    raw = await _attempt_with_refresh(conn.download_file, acct, fid, mime_type=mime, export_mime=export_mime)
-                else:
-                    raw = await _attempt_with_refresh(conn.download_file, acct, fid) if provider == "notion" else await _attempt_with_refresh(conn.download_file, acct, fid, mime_type=mime)
-            except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"download failed for {provider}:{fid}: {e}")
-                raw = b""
-
-            # Convert to text content
-            content_text = ""
-            effective_mime = (export_mime or mime or "").lower()
-            try:
-                if effective_mime == "application/pdf" or (not effective_mime and name.lower().endswith(".pdf")):
-                    # PDF pipeline with docling preferred
-                    try:
-                        from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
-                        res = process_pdf(file_input=raw, filename=name, parser="docling")
-                    except _CONNECTOR_NONCRITICAL_EXCEPTIONS:
-                        from tldw_Server_API.app.core.Ingestion_Media_Processing.PDF.PDF_Processing_Lib import process_pdf
-                        res = process_pdf(file_input=raw, filename=name, parser="pymupdf4llm")
-                    if isinstance(res, dict):
-                        content_text = (res.get("content") or "").strip()
-                else:
-                    if raw:
-                        content_text = raw.decode("utf-8", errors="replace")
-            except _CONNECTOR_NONCRITICAL_EXCEPTIONS as _e:
-                logger.warning(f"content conversion failed for {provider}:{fid}: {_e}")
-            # Hash for dedup
-            content_hash = hashlib.sha256(content_text.encode()).hexdigest() if content_text else None
-            # Dedup check
-            async with pool.transaction() as db:
-                should = await should_ingest_item(db, source_id=source_id, provider=provider, external_id=fid, version=version, modified_at=modified_at, content_hash=content_hash)
-            if not should:
-                continue
-            # Ingest minimal record
-            title = name
-            url = f"{provider}://{fid}"
-            ingested = False
-            try:
-                _mid, _m_uuid, _msg = mdb.add_media_with_keywords(
-                    url=url,
-                    title=title,
-                    media_type="document",
-                    content=content_text or f"[empty content for {provider}:{fid}]",
-                    keywords=[],
-                    overwrite=False,
-                )
-                processed += 1
-                ingested = True
-            except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"add_media_with_keywords failed: {e}")
-            if ingested:
-                # Record ingestion cache
-                async with pool.transaction() as db:
-                    await record_ingested_item(db, source_id=source_id, provider=provider, external_id=fid, name=name, mime=mime, size=size, version=version, modified_at=modified_at, content_hash=content_hash)
     except _CONNECTOR_NONCRITICAL_EXCEPTIONS as e:
         if gmail_sync_state_supported and gmail_sync_state_started:
             with contextlib.suppress(_CONNECTOR_NONCRITICAL_EXCEPTIONS):

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -4,6 +4,8 @@ from typing import Tuple
 import pytest
 from fastapi.testclient import TestClient
 
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncWebhookSubscription
+
 
 @pytest.fixture()
 def connectors_client() -> Tuple[TestClient, dict]:
@@ -115,6 +117,185 @@ def test_add_source_success(connectors_client, monkeypatch):
     assert body["id"] == 101
     assert body["provider"] == "drive"
     assert body["options"]["recursive"] is True
+
+
+@pytest.mark.integration
+def test_add_onedrive_source_provisions_webhook_subscription(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    subscribe_calls: list[dict] = []
+    sync_state_updates: list[dict] = []
+
+    async def _fake_create_source(db, *, account_id, provider, remote_id, type_, path, options, enabled=True):
+        return {
+            "id": 501,
+            "account_id": account_id,
+            "provider": provider,
+            "remote_id": remote_id,
+            "type": type_,
+            "path": path,
+            "options": options or {},
+            "enabled": enabled,
+            "last_synced_at": None,
+        }
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {"id": account_id, "user_id": user_id, "provider": "onedrive"}
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    class _FakeConn:
+        name = "onedrive"
+
+        def authorize_url(self, *a, **kw):
+            return ""
+
+        async def exchange_code(self, *a, **kw):
+            return {}
+
+        async def subscribe_webhook(self, account, *, resource, callback_url):
+            subscribe_calls.append(
+                {
+                    "account": dict(account),
+                    "resource": dict(resource),
+                    "callback_url": callback_url,
+                }
+            )
+            return FileSyncWebhookSubscription(
+                subscription_id="sub-501",
+                expires_at="2026-03-10T00:00:00Z",
+                metadata={"expirationDateTime": "2026-03-10T00:00:00Z"},
+            )
+
+    monkeypatch.setattr(ep, "create_source", _fake_create_source)
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
+    monkeypatch.setattr(ep, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+    monkeypatch.setattr(ep, "evaluate_policy_constraints", lambda *a, **kw: (True, None))
+    monkeypatch.setattr(ep, "upsert_source_sync_state", _fake_upsert_source_sync_state, raising=False)
+
+    payload = {
+        "account_id": 12,
+        "provider": "onedrive",
+        "remote_id": "root",
+        "type": "folder",
+        "path": "/",
+        "options": {"recursive": True},
+    }
+    r = client.post("/api/v1/connectors/sources", json=payload, headers=headers)
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["id"] == 501
+    assert body["provider"] == "onedrive"
+    assert len(subscribe_calls) == 1
+    assert subscribe_calls[0]["callback_url"] == "http://testserver/api/v1/connectors/providers/onedrive/webhook"
+    assert subscribe_calls[0]["resource"]["resource"] == "me/drive/root"
+    assert subscribe_calls[0]["account"]["tokens"]["access_token"] == "tok"
+    assert sync_state_updates[0]["source_id"] == 501
+    assert sync_state_updates[0]["sync_mode"] == "hybrid"
+    assert sync_state_updates[0]["webhook_status"] == "active"
+    assert sync_state_updates[0]["webhook_subscription_id"] == "sub-501"
+    assert sync_state_updates[0]["webhook_expires_at"] == "2026-03-10T00:00:00Z"
+
+
+@pytest.mark.integration
+def test_add_drive_source_provisions_webhook_subscription_and_cursor(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    subscribe_calls: list[dict] = []
+    sync_state_updates: list[dict] = []
+
+    async def _fake_create_source(db, *, account_id, provider, remote_id, type_, path, options, enabled=True):
+        return {
+            "id": 601,
+            "account_id": account_id,
+            "provider": provider,
+            "remote_id": remote_id,
+            "type": type_,
+            "path": path,
+            "options": options or {},
+            "enabled": enabled,
+            "last_synced_at": None,
+        }
+
+    async def _fake_get_account_for_user(db, user_id, account_id):
+        return {"id": account_id, "user_id": user_id, "provider": "drive"}
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    class _FakeConn:
+        name = "drive"
+
+        def authorize_url(self, *a, **kw):
+            return ""
+
+        async def exchange_code(self, *a, **kw):
+            return {}
+
+        async def subscribe_webhook(self, account, *, resource, callback_url):
+            subscribe_calls.append(
+                {
+                    "account": dict(account),
+                    "resource": dict(resource),
+                    "callback_url": callback_url,
+                }
+            )
+            return FileSyncWebhookSubscription(
+                subscription_id="drive-chan-1",
+                expires_at="2026-03-10T00:00:00Z",
+                metadata={
+                    "resourceId": "drive-resource-1",
+                    "pageToken": "drive-cursor-1",
+                    "callback_url": callback_url,
+                    "clientState": "drive-state-1",
+                },
+            )
+
+    monkeypatch.setattr(ep, "create_source", _fake_create_source)
+    monkeypatch.setattr(ep, "get_account_for_user", _fake_get_account_for_user)
+    monkeypatch.setattr(ep, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(ep, "get_connector_by_name", lambda provider: _FakeConn())
+    monkeypatch.setattr(ep, "evaluate_policy_constraints", lambda *a, **kw: (True, None))
+    monkeypatch.setattr(ep, "upsert_source_sync_state", _fake_upsert_source_sync_state, raising=False)
+
+    payload = {
+        "account_id": 13,
+        "provider": "drive",
+        "remote_id": "root",
+        "type": "folder",
+        "path": "/",
+        "options": {"recursive": True},
+    }
+    r = client.post("/api/v1/connectors/sources", json=payload, headers=headers)
+
+    assert r.status_code == 200, r.text
+    assert len(subscribe_calls) == 1
+    assert subscribe_calls[0]["callback_url"] == "http://testserver/api/v1/connectors/providers/drive/webhook"
+    assert sync_state_updates[0]["source_id"] == 601
+    assert sync_state_updates[0]["sync_mode"] == "hybrid"
+    assert sync_state_updates[0]["cursor"] == "drive-cursor-1"
+    assert sync_state_updates[0]["cursor_kind"] == "drive_start_page_token"
+    assert sync_state_updates[0]["webhook_status"] == "active"
+    assert sync_state_updates[0]["webhook_subscription_id"] == "drive-chan-1"
+    assert sync_state_updates[0]["webhook_expires_at"] == "2026-03-10T00:00:00Z"
+    assert sync_state_updates[0]["webhook_metadata"]["resourceId"] == "drive-resource-1"
 
 
 @pytest.mark.integration
@@ -235,6 +416,55 @@ def test_patch_source_forbid_extra_fields(connectors_client):
 
 
 @pytest.mark.integration
+def test_get_sources_includes_sync_summary(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_list_sources(db, user_id):
+        return [
+            {
+                "id": 22,
+                "account_id": 5,
+                "provider": "onedrive",
+                "remote_id": "root",
+                "type": "folder",
+                "path": "/",
+                "options": {"recursive": True},
+                "enabled": True,
+                "last_synced_at": None,
+            }
+        ]
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        assert source_id == 22
+        return {
+            "source_id": source_id,
+            "sync_mode": "hybrid",
+            "last_sync_failed_at": "2026-03-06 10:02:00",
+            "last_error": "delta cursor invalid",
+            "webhook_status": "active",
+            "needs_full_rescan": True,
+            "active_job_id": "88",
+        }
+
+    monkeypatch.setattr(ep, "list_sources", _fake_list_sources)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+
+    response = client.get("/api/v1/connectors/sources", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body) == 1
+    assert body[0]["id"] == 22
+    assert body[0]["sync"]["state"] == "needs_full_rescan"
+    assert body[0]["sync"]["sync_mode"] == "hybrid"
+    assert body[0]["sync"]["last_error"] == "delta cursor invalid"
+    assert body[0]["sync"]["webhook_status"] == "active"
+    assert body[0]["sync"]["needs_full_rescan"] is True
+    assert body[0]["sync"]["active_job_id"] == "88"
+
+
+@pytest.mark.integration
 def test_oauth_callback_rejects_invalid_state(connectors_client, monkeypatch):
     client, headers = connectors_client
 
@@ -301,3 +531,110 @@ def test_oauth_callback_accepts_valid_state(connectors_client, monkeypatch):
     body = r.json()
     assert body["id"] == 123
     assert body["provider"] == "notion"
+
+
+@pytest.mark.integration
+def test_get_source_sync_status_returns_state_and_active_job(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+    import tldw_Server_API.app.core.Jobs.manager as jobs_manager
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "enabled": True,
+        }
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {
+            "source_id": source_id,
+            "sync_mode": "hybrid",
+            "cursor": "delta-1",
+            "cursor_kind": "drive_start_page_token",
+            "last_sync_started_at": "2026-03-06 10:00:00",
+            "last_sync_succeeded_at": "2026-03-06 10:01:00",
+            "last_error": None,
+            "retry_backoff_count": 0,
+            "webhook_status": "active",
+            "webhook_expires_at": "2026-03-07 10:00:00",
+            "needs_full_rescan": False,
+            "active_job_id": "77",
+            "active_job_started_at": "2026-03-06 10:00:00",
+        }
+
+    class _FakeJobManager:
+        def get_job(self, job_id: int):
+            assert job_id == 77
+            return {
+                "id": job_id,
+                "job_type": "import",
+                "status": "processing",
+                "progress_percent": 35,
+                "result": {"processed": 7, "failed": 0, "skipped": 0},
+            }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(jobs_manager, "JobManager", _FakeJobManager)
+
+    response = client.get("/api/v1/connectors/sources/22/sync", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["source_id"] == 22
+    assert body["provider"] == "drive"
+    assert body["state"] == "running"
+    assert body["sync_mode"] == "hybrid"
+    assert body["cursor"] == "delta-1"
+    assert body["active_job_id"] == "77"
+    assert body["active_job"]["id"] == "77"
+    assert body["active_job"]["status"] == "processing"
+    assert body["active_job"]["progress_pct"] == 35
+
+
+@pytest.mark.integration
+def test_trigger_source_sync_endpoint_queues_job(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    queued_requests: list[dict] = []
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "onedrive",
+            "enabled": True,
+        }
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_requests.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "request_id": request_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": "job-123",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
+
+    response = client.post("/api/v1/connectors/sources/22/sync", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["source_id"] == 22
+    assert body["provider"] == "onedrive"
+    assert body["status"] == "queued"
+    assert body["job"]["id"] == "job-123"
+    assert body["job"]["type"] == "incremental_sync"
+    assert queued_requests[0]["job_type"] == "incremental_sync"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -628,6 +628,9 @@ def test_trigger_source_sync_endpoint_queues_job(connectors_client, monkeypatch)
             "enabled": True,
         }
 
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {}
+
     async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
         queued_requests.append(
             {
@@ -647,6 +650,7 @@ def test_trigger_source_sync_endpoint_queues_job(connectors_client, monkeypatch)
         }
 
     monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
     monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
 
     response = client.post("/api/v1/connectors/sources/22/sync", headers=headers)
@@ -658,3 +662,99 @@ def test_trigger_source_sync_endpoint_queues_job(connectors_client, monkeypatch)
     assert body["job"]["id"] == "job-123"
     assert body["job"]["type"] == "incremental_sync"
     assert queued_requests[0]["job_type"] == "incremental_sync"
+
+
+@pytest.mark.integration
+def test_trigger_source_sync_endpoint_falls_back_to_import_for_non_file_provider(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    queued_requests: list[dict] = []
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "notion",
+            "enabled": True,
+        }
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {}
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_requests.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "request_id": request_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": "job-456",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
+
+    response = client.post("/api/v1/connectors/sources/41/sync", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provider"] == "notion"
+    assert body["job"]["type"] == "import"
+    assert queued_requests[0]["job_type"] == "import"
+
+
+@pytest.mark.integration
+def test_trigger_source_sync_endpoint_uses_repair_rescan_when_source_requires_it(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    queued_requests: list[dict] = []
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "enabled": True,
+        }
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {"needs_full_rescan": True}
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_requests.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "request_id": request_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": "job-789",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
+
+    response = client.post("/api/v1/connectors/sources/52/sync", headers=headers)
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provider"] == "drive"
+    assert body["job"]["type"] == "repair_rescan"
+    assert queued_requests[0]["job_type"] == "repair_rescan"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_endpoints_api.py
@@ -448,8 +448,16 @@ def test_get_sources_includes_sync_summary(connectors_client, monkeypatch):
             "active_job_id": "88",
         }
 
+    async def _fake_get_source_binding_health(db, *, source_id):
+        assert source_id == 22
+        return {
+            "tracked_item_count": 4,
+            "degraded_item_count": 2,
+        }
+
     monkeypatch.setattr(ep, "list_sources", _fake_list_sources)
     monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(ep, "get_source_binding_health", _fake_get_source_binding_health)
 
     response = client.get("/api/v1/connectors/sources", headers=headers)
     assert response.status_code == 200, response.text
@@ -462,6 +470,8 @@ def test_get_sources_includes_sync_summary(connectors_client, monkeypatch):
     assert body[0]["sync"]["webhook_status"] == "active"
     assert body[0]["sync"]["needs_full_rescan"] is True
     assert body[0]["sync"]["active_job_id"] == "88"
+    assert body[0]["sync"]["tracked_item_count"] == 4
+    assert body[0]["sync"]["degraded_item_count"] == 2
 
 
 @pytest.mark.integration
@@ -575,8 +585,16 @@ def test_get_source_sync_status_returns_state_and_active_job(connectors_client, 
                 "result": {"processed": 7, "failed": 0, "skipped": 0},
             }
 
+    async def _fake_get_source_binding_health(db, *, source_id):
+        assert source_id == 22
+        return {
+            "tracked_item_count": 9,
+            "degraded_item_count": 3,
+        }
+
     monkeypatch.setattr(ep, "get_source_by_id", _fake_get_source_by_id)
     monkeypatch.setattr(ep, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(ep, "get_source_binding_health", _fake_get_source_binding_health)
     monkeypatch.setattr(jobs_manager, "JobManager", _FakeJobManager)
 
     response = client.get("/api/v1/connectors/sources/22/sync", headers=headers)
@@ -591,6 +609,8 @@ def test_get_source_sync_status_returns_state_and_active_job(connectors_client, 
     assert body["active_job"]["id"] == "77"
     assert body["active_job"]["status"] == "processing"
     assert body["active_job"]["progress_pct"] == 35
+    assert body["tracked_item_count"] == 9
+    assert body["degraded_item_count"] == 3
 
 
 @pytest.mark.integration

--- a/tldw_Server_API/tests/External_Sources/test_connectors_job_fencing.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_job_fencing.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+
+
+@pytest.fixture
+async def sqlite_db(tmp_path):
+    db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+async def _create_account_and_source(db: aiosqlite.Connection) -> tuple[dict, dict]:
+    account = await svc.create_account(
+        db,
+        user_id=7,
+        provider="drive",
+        display_name="Drive",
+        email="user@example.com",
+        tokens={"access_token": "token"},
+    )
+    source = await svc.create_source(
+        db,
+        account_id=account["id"],
+        provider="drive",
+        remote_id="root",
+        type_="folder",
+        path="/",
+        options={"recursive": True},
+    )
+    return account, source
+
+
+class _DummyTx:
+    def __init__(self, db):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _DummyPool:
+    def __init__(self, db):
+        self._db = db
+
+    def transaction(self):
+        return _DummyTx(self._db)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_source_sync_fence_lifecycle_tracks_active_job_and_outcome(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    _, source = await _create_account_and_source(sqlite_db)
+
+    reserved = await svc.reserve_source_sync_job(
+        sqlite_db,
+        source_id=source["id"],
+        job_id="job-101",
+    )
+    started = await svc.start_source_sync_job(
+        sqlite_db,
+        source_id=source["id"],
+        job_id="job-101",
+    )
+    finished = await svc.finish_source_sync_job(
+        sqlite_db,
+        source_id=source["id"],
+        job_id="job-101",
+        outcome="success",
+    )
+
+    assert reserved["active_job_id"] == "job-101"
+    assert reserved["active_job_started_at"] is None
+    assert started["active_job_id"] == "job-101"
+    assert started["active_job_started_at"] is not None
+    assert started["last_sync_started_at"] is not None
+    assert finished["active_job_id"] is None
+    assert finished["active_job_started_at"] is None
+    assert finished["last_sync_succeeded_at"] is not None
+    assert finished.get("last_error") in (None, "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_create_import_job_returns_existing_active_job_for_source(
+    sqlite_db: aiosqlite.Connection,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.Jobs.manager as jobs_manager
+
+    _, source = await _create_account_and_source(sqlite_db)
+    jobs_db = tmp_path / "jobs.sqlite3"
+    real_job_manager = jobs_manager.JobManager
+
+    class _PatchedJobManager(real_job_manager):
+        def __init__(self):
+            super().__init__(jobs_db)
+
+    async def _fake_get_db_pool():
+        return _DummyPool(sqlite_db)
+
+    monkeypatch.setattr(jobs_manager, "JobManager", _PatchedJobManager)
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+
+    first = await svc.create_import_job(user_id=7, source_id=source["id"])
+    second = await svc.create_import_job(user_id=7, source_id=source["id"])
+    state = await svc.get_source_sync_state(sqlite_db, source_id=source["id"])
+    jm = real_job_manager(jobs_db)
+    first_job = jm.get_job(int(first["id"]))
+
+    assert first["id"] == second["id"]
+    assert state is not None
+    assert state["active_job_id"] == first["id"]
+    assert state["active_job_started_at"] is None
+    assert first_job is not None
+    assert first_job["status"] == "queued"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_requeues_job_when_source_fence_is_owned_by_other_job(
+    sqlite_db: aiosqlite.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    _, source = await _create_account_and_source(sqlite_db)
+    await svc.reserve_source_sync_job(
+        sqlite_db,
+        source_id=source["id"],
+        job_id="job-other",
+    )
+
+    stop_event = __import__("asyncio").Event()
+    processed: list[tuple[int, int]] = []
+
+    class _FakeJobManager:
+        def __init__(self):
+            self.failures: list[dict] = []
+            self._calls = 0
+
+        def acquire_next_job(self, *, domain, queue, lease_seconds, worker_id):
+            self._calls += 1
+            if self._calls == 1:
+                return {
+                    "id": 42,
+                    "lease_id": "lease-1",
+                    "payload": {"source_id": source["id"], "user_id": 7},
+                }
+            stop_event.set()
+            return None
+
+        def fail_job(self, job_id, *, error, retryable, worker_id, lease_id, completion_token=None, backoff_seconds=None):
+            self.failures.append(
+                {
+                    "job_id": job_id,
+                    "error": error,
+                    "retryable": retryable,
+                    "lease_id": lease_id,
+                    "backoff_seconds": backoff_seconds,
+                }
+            )
+            return True
+
+    fake_jm = _FakeJobManager()
+
+    async def _fake_process_import_job(_jm, jid, lease_id, worker_id, source_id, user_id):
+        processed.append((source_id, user_id))
+
+    async def _fake_get_db_pool():
+        return _DummyPool(sqlite_db)
+
+    monkeypatch.setattr(worker, "JobManager", lambda: fake_jm)
+    monkeypatch.setattr(worker, "_process_import_job", _fake_process_import_job)
+    monkeypatch.setattr("tldw_Server_API.app.core.AuthNZ.database.get_db_pool", _fake_get_db_pool)
+    monkeypatch.setenv("CONNECTORS_POLL_INTERVAL_SECONDS", "0")
+
+    await worker.run_connectors_worker(stop_event)
+
+    assert processed == []
+    assert len(fake_jm.failures) == 1
+    assert fake_jm.failures[0]["job_id"] == 42
+    assert fake_jm.failures[0]["retryable"] is True
+    assert "active sync job" in fake_jm.failures[0]["error"].lower()

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
@@ -78,6 +78,7 @@ async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_increm
         ]
 
     queued_jobs: list[dict[str, object]] = []
+    prune_calls: list[str] = []
 
     async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
         queued_jobs.append(
@@ -96,6 +97,10 @@ async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_increm
             "counts": {"processed": 0, "skipped": 0, "failed": 0},
         }
 
+    async def _fake_prune_webhook_receipts(db, *, older_than):
+        prune_calls.append(str(older_than))
+        return 2
+
     monkeypatch.setattr(scheduler_mod, "get_db_pool", _fake_get_db_pool, raising=False)
     monkeypatch.setattr(
         scheduler_mod,
@@ -109,10 +114,17 @@ async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_increm
         _fake_create_import_job,
         raising=False,
     )
+    monkeypatch.setattr(
+        scheduler_mod,
+        "prune_webhook_receipts",
+        _fake_prune_webhook_receipts,
+        raising=False,
+    )
 
     scheduler = scheduler_mod._ConnectorsSyncScheduler()
     await scheduler._scan_once()
 
+    assert len(prune_calls) == 1
     assert queued_jobs == [
         {"user_id": 1, "source_id": 11, "job_type": "subscription_renewal"},
         {"user_id": 2, "source_id": 12, "job_type": "repair_rescan"},

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_scheduler.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_connectors_sync_scheduler_scan_enqueues_renewal_repair_and_incremental(monkeypatch):
+    try:
+        scheduler_mod = importlib.import_module(
+            "tldw_Server_API.app.services.connectors_sync_scheduler"
+        )
+    except ModuleNotFoundError as exc:  # pragma: no cover - red phase
+        pytest.fail(str(exc))
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_list_sources_for_scheduler(db):
+        return [
+            {
+                "id": 11,
+                "user_id": 1,
+                "provider": "drive",
+                "enabled": True,
+                "sync_mode": "hybrid",
+                "needs_full_rescan": False,
+                "webhook_status": "active",
+                "webhook_subscription_id": "drive-chan-1",
+                "webhook_expires_at": "2026-03-06T22:05:00Z",
+            },
+            {
+                "id": 12,
+                "user_id": 2,
+                "provider": "onedrive",
+                "enabled": True,
+                "sync_mode": "hybrid",
+                "needs_full_rescan": True,
+                "webhook_status": None,
+                "webhook_subscription_id": None,
+                "webhook_expires_at": None,
+            },
+            {
+                "id": 13,
+                "user_id": 3,
+                "provider": "drive",
+                "enabled": True,
+                "sync_mode": "poll",
+                "needs_full_rescan": False,
+                "webhook_status": None,
+                "webhook_subscription_id": None,
+                "webhook_expires_at": None,
+            },
+            {
+                "id": 14,
+                "user_id": 4,
+                "provider": "drive",
+                "enabled": True,
+                "sync_mode": "manual",
+                "needs_full_rescan": False,
+                "webhook_status": None,
+                "webhook_subscription_id": None,
+                "webhook_expires_at": None,
+            },
+        ]
+
+    queued_jobs: list[dict[str, object]] = []
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_jobs.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": f"job-{source_id}",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(scheduler_mod, "get_db_pool", _fake_get_db_pool, raising=False)
+    monkeypatch.setattr(
+        scheduler_mod,
+        "list_sources_for_scheduler",
+        _fake_list_sources_for_scheduler,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler_mod,
+        "create_import_job",
+        _fake_create_import_job,
+        raising=False,
+    )
+
+    scheduler = scheduler_mod._ConnectorsSyncScheduler()
+    await scheduler._scan_once()
+
+    assert queued_jobs == [
+        {"user_id": 1, "source_id": 11, "job_type": "subscription_renewal"},
+        {"user_id": 2, "source_id": 12, "job_type": "repair_rescan"},
+        {"user_id": 3, "source_id": 13, "job_type": "incremental_sync"},
+    ]

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -150,6 +150,20 @@ async def test_external_items_upgrade_preserves_legacy_row_and_adds_binding_fiel
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_ensure_tables_does_not_commit_sqlite_transaction(sqlite_db: aiosqlite.Connection, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _unexpected_commit() -> None:
+        raise AssertionError("_ensure_tables must not commit an outer sqlite transaction")
+
+    monkeypatch.setattr(sqlite_db, "commit", _unexpected_commit)
+
+    await svc._ensure_tables(sqlite_db)
+
+    state = await svc.get_source_sync_state(sqlite_db, source_id=999)
+    assert state is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
     sqlite_db: aiosqlite.Connection,
 ) -> None:
@@ -161,8 +175,10 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
         sync_mode="hybrid",
         cursor="delta-token",
         cursor_kind="drive_start_page_token",
+        webhook_subscription_id="drive-chan-1",
         webhook_metadata={
             "resourceId": "drive-resource-1",
+            "clientState": "drive-state-123",
             "pageToken": "delta-token",
         },
     )
@@ -191,6 +207,11 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
         external_id="file-1",
         sync_status="archived_upstream_removed",
     )
+    webhook_source = await svc.get_source_by_webhook_subscription(
+        sqlite_db,
+        provider="drive",
+        subscription_id="drive-chan-1",
+    )
     fetched = await svc.get_external_item_binding(
         sqlite_db,
         source_id=source["id"],
@@ -206,6 +227,9 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
     assert event["event_type"] == "content_updated"
     assert archived["sync_status"] == "archived_upstream_removed"
     assert archived["remote_deleted_at"] is not None
+    assert webhook_source is not None
+    assert webhook_source["id"] == source["id"]
+    assert webhook_source["webhook_metadata"]["clientState"] == "drive-state-123"
     assert fetched is not None
     assert fetched["sync_status"] == "archived_upstream_removed"
     assert len(items) == 1

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+
+
+@pytest.fixture
+async def sqlite_db(tmp_path: Path):
+    db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+async def _create_account_and_source(db: aiosqlite.Connection) -> tuple[dict, dict]:
+    account = await svc.create_account(
+        db,
+        user_id=7,
+        provider="drive",
+        display_name="Drive",
+        email="user@example.com",
+        tokens={"access_token": "token"},
+    )
+    source = await svc.create_source(
+        db,
+        account_id=account["id"],
+        provider="drive",
+        remote_id="root",
+        type_="folder",
+        path="/",
+        options={"recursive": True},
+    )
+    return account, source
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_external_items_upgrade_preserves_legacy_row_and_adds_binding_fields(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    await sqlite_db.execute(
+        """
+        CREATE TABLE external_accounts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            display_name TEXT,
+            email TEXT,
+            access_token TEXT,
+            refresh_token TEXT,
+            token_expires_at TEXT,
+            scopes TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    await sqlite_db.execute(
+        """
+        CREATE TABLE external_sources (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            account_id INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            remote_id TEXT NOT NULL,
+            type TEXT NOT NULL,
+            path TEXT,
+            options TEXT,
+            enabled INTEGER DEFAULT 1,
+            last_synced_at TEXT
+        )
+        """
+    )
+    await sqlite_db.execute(
+        """
+        CREATE TABLE external_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source_id INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            external_id TEXT NOT NULL,
+            name TEXT,
+            mime TEXT,
+            size INTEGER,
+            modified_at TEXT,
+            version TEXT,
+            hash TEXT,
+            last_ingested_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(source_id, provider, external_id)
+        )
+        """
+    )
+    await sqlite_db.execute(
+        """
+        INSERT INTO external_accounts (id, user_id, provider, display_name, email, access_token)
+        VALUES (1, 7, 'drive', 'Drive', 'user@example.com', 'token')
+        """
+    )
+    await sqlite_db.execute(
+        """
+        INSERT INTO external_sources (id, account_id, provider, remote_id, type, path, options, enabled)
+        VALUES (1, 1, 'drive', 'root', 'folder', '/', '{}', 1)
+        """
+    )
+    await sqlite_db.execute(
+        """
+        INSERT INTO external_items (source_id, provider, external_id, name, version, hash)
+        VALUES (1, 'drive', 'legacy-file', 'legacy.pdf', 'v1', 'h1')
+        """
+    )
+    await sqlite_db.commit()
+
+    state = await svc.upsert_source_sync_state(
+        sqlite_db,
+        source_id=1,
+        sync_mode="hybrid",
+    )
+    legacy_binding = await svc.get_external_item_binding(
+        sqlite_db,
+        source_id=1,
+        provider="drive",
+        external_id="legacy-file",
+    )
+    binding = await svc.upsert_external_item_binding(
+        sqlite_db,
+        source_id=1,
+        provider="drive",
+        external_id="file-1",
+        media_id=99,
+        sync_status="active",
+    )
+
+    pragma = await sqlite_db.execute("PRAGMA table_info(external_items)")
+    columns = {row["name"] for row in await pragma.fetchall()}
+
+    assert legacy_binding is not None
+    assert legacy_binding["external_id"] == "legacy-file"
+    assert legacy_binding["media_id"] is None
+    assert state["sync_mode"] == "hybrid"
+    assert state["needs_full_rescan"] is True
+    assert binding["external_id"] == "file-1"
+    assert binding["media_id"] == 99
+    assert {"media_id", "sync_status", "remote_path"} <= columns
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    _, source = await _create_account_and_source(sqlite_db)
+
+    state = await svc.upsert_source_sync_state(
+        sqlite_db,
+        source_id=source["id"],
+        sync_mode="hybrid",
+        cursor="delta-token",
+        cursor_kind="drive_start_page_token",
+    )
+    binding = await svc.upsert_external_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-1",
+        media_id=55,
+        sync_status="active",
+        remote_path="/folder/file-1.pdf",
+        version="v2",
+        content_hash="hash-2",
+    )
+    event = await svc.record_item_event(
+        sqlite_db,
+        external_item_id=binding["id"],
+        event_type="content_updated",
+        job_id="job-123",
+        payload={"remote_revision": "v2"},
+    )
+    archived = await svc.mark_external_item_archived(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-1",
+        sync_status="archived_upstream_removed",
+    )
+    fetched = await svc.get_external_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-1",
+    )
+    items = await svc.list_external_items_for_source(sqlite_db, source_id=source["id"])
+
+    assert state["cursor"] == "delta-token"
+    assert state["cursor_kind"] == "drive_start_page_token"
+    assert binding["media_id"] == 55
+    assert event["event_type"] == "content_updated"
+    assert archived["sync_status"] == "archived_upstream_removed"
+    assert archived["remote_deleted_at"] is not None
+    assert fetched is not None
+    assert fetched["sync_status"] == "archived_upstream_removed"
+    assert len(items) == 1
+    assert items[0]["external_id"] == "file-1"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -210,3 +210,41 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
     assert fetched["sync_status"] == "archived_upstream_removed"
     assert len(items) == 1
     assert items[0]["external_id"] == "file-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_source_binding_health_counts_tracked_and_degraded_items(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    _, source = await _create_account_and_source(sqlite_db)
+
+    await svc.upsert_external_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-active",
+        media_id=11,
+        sync_status="active",
+    )
+    await svc.upsert_external_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-degraded",
+        media_id=12,
+        sync_status="degraded",
+    )
+    await svc.upsert_external_item_binding(
+        sqlite_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-archived",
+        media_id=13,
+        sync_status="archived_upstream_removed",
+    )
+
+    health = await svc.get_source_binding_health(sqlite_db, source_id=source["id"])
+
+    assert health["tracked_item_count"] == 3
+    assert health["degraded_item_count"] == 1

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -272,3 +272,38 @@ async def test_get_source_binding_health_counts_tracked_and_degraded_items(
 
     assert health["tracked_item_count"] == 3
     assert health["degraded_item_count"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_prune_webhook_receipts_removes_only_older_rows(
+    sqlite_db: aiosqlite.Connection,
+) -> None:
+    await svc._ensure_tables(sqlite_db)
+    await sqlite_db.execute(
+        """
+        INSERT INTO external_webhook_receipts (provider, receipt_key, source_id, payload_hash, received_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("drive", "old-receipt", 1, "hash-old", "2026-03-01 00:00:00"),
+    )
+    await sqlite_db.execute(
+        """
+        INSERT INTO external_webhook_receipts (provider, receipt_key, source_id, payload_hash, received_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        ("drive", "new-receipt", 1, "hash-new", "2026-03-06 00:00:00"),
+    )
+    await sqlite_db.commit()
+
+    deleted = await svc.prune_webhook_receipts(
+        sqlite_db,
+        older_than="2026-03-05 00:00:00",
+    )
+    cur = await sqlite_db.execute(
+        "SELECT receipt_key FROM external_webhook_receipts ORDER BY receipt_key ASC"
+    )
+    remaining = [row["receipt_key"] for row in await cur.fetchall()]
+
+    assert deleted == 1
+    assert remaining == ["new-receipt"]

--- a/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_sync_storage.py
@@ -161,6 +161,10 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
         sync_mode="hybrid",
         cursor="delta-token",
         cursor_kind="drive_start_page_token",
+        webhook_metadata={
+            "resourceId": "drive-resource-1",
+            "pageToken": "delta-token",
+        },
     )
     binding = await svc.upsert_external_item_binding(
         sqlite_db,
@@ -197,6 +201,7 @@ async def test_sync_storage_helpers_track_bindings_events_and_archive_state(
 
     assert state["cursor"] == "delta-token"
     assert state["cursor_kind"] == "drive_start_page_token"
+    assert state["webhook_metadata"]["resourceId"] == "drive-resource-1"
     assert binding["media_id"] == 55
     assert event["event_type"] == "content_updated"
     assert archived["sync_status"] == "archived_upstream_removed"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
@@ -1,0 +1,490 @@
+from __future__ import annotations
+
+import os
+from typing import Tuple
+
+import aiosqlite
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncWebhookSubscription
+
+
+@pytest.fixture()
+def connectors_client() -> Tuple[TestClient, dict]:
+    os.environ.setdefault("TEST_MODE", "true")
+    os.environ.setdefault("ROUTES_STABLE_ONLY", "false")
+    os.environ["ROUTES_ENABLE"] = "connectors"
+    os.environ.setdefault("AUTH_MODE", "single_user")
+    os.environ.setdefault("TESTING", "true")
+
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.main import app
+    from tldw_Server_API.app.api.v1.endpoints import connectors as connectors_router
+
+    paths = {route.path for route in app.routes}
+    if "/api/v1/connectors/sources" not in paths:
+        app.include_router(connectors_router.router, prefix="/api/v1", tags=["connectors"])
+
+    api_key = get_settings().SINGLE_USER_API_KEY
+    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+    client = TestClient(app)
+    return client, headers
+
+
+@pytest.fixture
+async def connectors_db(tmp_path):
+    db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_webhook_receipt_dedupes_by_provider_and_key(connectors_db):
+    first = await svc.record_webhook_receipt(
+        connectors_db,
+        provider="onedrive",
+        receipt_key="sub-1:event-1",
+        source_id=77,
+    )
+    duplicate = await svc.record_webhook_receipt(
+        connectors_db,
+        provider="onedrive",
+        receipt_key="sub-1:event-1",
+        source_id=77,
+    )
+    different_provider = await svc.record_webhook_receipt(
+        connectors_db,
+        provider="drive",
+        receipt_key="sub-1:event-1",
+        source_id=77,
+    )
+
+    assert first is True
+    assert duplicate is False
+    assert different_provider is True
+
+
+@pytest.mark.integration
+def test_onedrive_webhook_validation_echoes_token(connectors_client):
+    client, _headers = connectors_client
+
+    response = client.get(
+        "/api/v1/connectors/providers/onedrive/webhook",
+        params={"validationToken": "token-123"},
+    )
+
+    assert response.status_code == 200
+    assert response.text == "token-123"
+
+
+@pytest.mark.integration
+def test_onedrive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    seen_receipts: set[str] = set()
+    queued_jobs: list[dict[str, object]] = []
+
+    async def _fake_get_source_by_webhook_subscription(db, *, provider, subscription_id):
+        assert provider == "onedrive"
+        assert subscription_id == "sub-1"
+        return {
+            "id": 77,
+            "provider": "onedrive",
+            "user_id": 42,
+            "enabled": True,
+        }
+
+    async def _fake_record_webhook_receipt(db, *, provider, receipt_key, source_id=None, payload_hash=None):
+        assert provider == "onedrive"
+        if receipt_key in seen_receipts:
+            return False
+        seen_receipts.add(receipt_key)
+        return True
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_jobs.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "request_id": request_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": "job-1",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_webhook_subscription", _fake_get_source_by_webhook_subscription)
+    monkeypatch.setattr(ep, "record_webhook_receipt", _fake_record_webhook_receipt)
+    monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
+
+    payload = {"value": [{"subscriptionId": "sub-1", "changeType": "updated"}]}
+
+    first = client.post(
+        "/api/v1/connectors/providers/onedrive/webhook",
+        json=payload,
+        headers=headers,
+    )
+    second = client.post(
+        "/api/v1/connectors/providers/onedrive/webhook",
+        json=payload,
+        headers=headers,
+    )
+
+    assert first.status_code == 202, first.text
+    assert first.json()["status"] == "queued"
+    assert first.json()["queued_jobs"] == 1
+    assert first.json()["source_ids"] == [77]
+
+    assert second.status_code == 202, second.text
+    assert second.json()["status"] == "duplicate"
+    assert second.json()["queued_jobs"] == 0
+    assert second.json()["duplicate_notifications"] == 1
+
+    assert len(queued_jobs) == 1
+    assert queued_jobs[0]["user_id"] == 42
+    assert queued_jobs[0]["source_id"] == 77
+    assert queued_jobs[0]["job_type"] == "incremental_sync"
+
+
+@pytest.mark.integration
+def test_drive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    seen_receipts: set[str] = set()
+    queued_jobs: list[dict[str, object]] = []
+
+    async def _fake_get_source_by_webhook_subscription(db, *, provider, subscription_id):
+        assert provider == "drive"
+        assert subscription_id == "drive-chan-1"
+        return {
+            "id": 88,
+            "provider": "drive",
+            "user_id": 24,
+            "enabled": True,
+        }
+
+    async def _fake_record_webhook_receipt(db, *, provider, receipt_key, source_id=None, payload_hash=None):
+        assert provider == "drive"
+        if receipt_key in seen_receipts:
+            return False
+        seen_receipts.add(receipt_key)
+        return True
+
+    async def _fake_create_import_job(user_id, source_id, *, request_id=None, job_type="import"):
+        queued_jobs.append(
+            {
+                "user_id": user_id,
+                "source_id": source_id,
+                "request_id": request_id,
+                "job_type": job_type,
+            }
+        )
+        return {
+            "id": "job-drive-1",
+            "source_id": source_id,
+            "type": job_type,
+            "status": "queued",
+            "progress_pct": 0,
+            "counts": {"processed": 0, "skipped": 0, "failed": 0},
+        }
+
+    monkeypatch.setattr(ep, "get_source_by_webhook_subscription", _fake_get_source_by_webhook_subscription)
+    monkeypatch.setattr(ep, "record_webhook_receipt", _fake_record_webhook_receipt)
+    monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
+
+    request_headers = dict(headers)
+    request_headers.update(
+        {
+            "X-Goog-Channel-Id": "drive-chan-1",
+            "X-Goog-Message-Number": "1",
+            "X-Goog-Resource-State": "change",
+            "X-Goog-Resource-Id": "drive-resource-1",
+        }
+    )
+
+    first = client.post("/api/v1/connectors/providers/drive/webhook", headers=request_headers)
+    second = client.post("/api/v1/connectors/providers/drive/webhook", headers=request_headers)
+
+    assert first.status_code == 202, first.text
+    assert first.json()["status"] == "queued"
+    assert first.json()["queued_jobs"] == 1
+    assert first.json()["source_ids"] == [88]
+
+    assert second.status_code == 202, second.text
+    assert second.json()["status"] == "duplicate"
+    assert second.json()["queued_jobs"] == 0
+    assert second.json()["duplicate_notifications"] == 1
+
+    assert len(queued_jobs) == 1
+    assert queued_jobs[0]["user_id"] == 24
+    assert queued_jobs[0]["source_id"] == 88
+    assert queued_jobs[0]["job_type"] == "incremental_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_subscription_renewal_updates_sync_state(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeOneDriveConn:
+        async def renew_webhook(self, account, *, subscription):
+            assert account["tokens"]["access_token"] == "tok"
+            assert subscription.subscription_id == "sub-1"
+            assert subscription.expires_at == "2026-03-07T00:00:00Z"
+            return FileSyncWebhookSubscription(
+                subscription_id="sub-1",
+                expires_at="2026-03-10T00:00:00Z",
+                metadata={"expirationDateTime": "2026-03-10T00:00:00Z"},
+            )
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "onedrive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {
+            "source_id": source_id,
+            "webhook_subscription_id": "sub-1",
+            "webhook_expires_at": "2026-03-07T00:00:00Z",
+            "webhook_status": "active",
+        }
+
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc_mod
+
+    async def _fake_list_memberships_for_user(_user_id: int):
+        return []
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeOneDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc_mod, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc_mod, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc_mod, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc_mod, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+
+    jm = FakeJM()
+    await worker._process_import_job(
+        jm,
+        jid=501,
+        lease_id="lease-renew",
+        worker_id="worker-renew",
+        source_id=99,
+        user_id=42,
+        job_type="subscription_renewal",
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 1
+    assert jm.completed["result"]["subscription_id"] == "sub-1"
+    assert jm.completed["result"]["webhook_expires_at"] == "2026-03-10T00:00:00Z"
+    assert sync_state_updates[-1]["webhook_status"] == "active"
+    assert sync_state_updates[-1]["webhook_subscription_id"] == "sub-1"
+    assert sync_state_updates[-1]["webhook_expires_at"] == "2026-03-10T00:00:00Z"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_drive_subscription_renewal_round_trips_webhook_metadata(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        async def renew_webhook(self, account, *, subscription):
+            assert account["tokens"]["access_token"] == "tok"
+            assert subscription.subscription_id == "drive-chan-1"
+            assert subscription.metadata["resourceId"] == "drive-resource-1"
+            assert subscription.metadata["pageToken"] == "drive-cursor-1"
+            assert subscription.metadata["callback_url"] == "https://example.com/api/v1/connectors/providers/drive/webhook"
+            return FileSyncWebhookSubscription(
+                subscription_id="drive-chan-2",
+                expires_at="2026-03-10T00:00:00Z",
+                metadata={
+                    "resourceId": "drive-resource-2",
+                    "pageToken": "drive-cursor-2",
+                    "callback_url": "https://example.com/api/v1/connectors/providers/drive/webhook",
+                    "clientState": "drive-state-1",
+                },
+            )
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {
+            "source_id": source_id,
+            "webhook_subscription_id": "drive-chan-1",
+            "webhook_expires_at": "2026-03-07T00:00:00Z",
+            "webhook_status": "active",
+            "webhook_metadata": {
+                "resourceId": "drive-resource-1",
+                "pageToken": "drive-cursor-1",
+                "callback_url": "https://example.com/api/v1/connectors/providers/drive/webhook",
+                "clientState": "drive-state-1",
+            },
+        }
+
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc_mod
+
+    async def _fake_list_memberships_for_user(_user_id: int):
+        return []
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc_mod, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc_mod, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc_mod, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc_mod, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+
+    jm = FakeJM()
+    await worker._process_import_job(
+        jm,
+        jid=4321,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+        job_type="subscription_renewal",
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 1
+    assert sync_state_updates[-1]["webhook_subscription_id"] == "drive-chan-2"
+    assert sync_state_updates[-1]["webhook_expires_at"] == "2026-03-10T00:00:00Z"
+    assert sync_state_updates[-1]["webhook_metadata"]["resourceId"] == "drive-resource-2"
+    assert sync_state_updates[-1]["webhook_metadata"]["pageToken"] == "drive-cursor-2"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_webhooks.py
@@ -101,6 +101,7 @@ def test_onedrive_webhook_enqueues_incremental_sync_and_dedupes(connectors_clien
             "provider": "onedrive",
             "user_id": 42,
             "enabled": True,
+            "webhook_metadata": {"clientState": "state-123"},
         }
 
     async def _fake_record_webhook_receipt(db, *, provider, receipt_key, source_id=None, payload_hash=None):
@@ -132,7 +133,7 @@ def test_onedrive_webhook_enqueues_incremental_sync_and_dedupes(connectors_clien
     monkeypatch.setattr(ep, "record_webhook_receipt", _fake_record_webhook_receipt)
     monkeypatch.setattr(ep, "create_import_job", _fake_create_import_job)
 
-    payload = {"value": [{"subscriptionId": "sub-1", "changeType": "updated"}]}
+    payload = {"value": [{"subscriptionId": "sub-1", "changeType": "updated", "clientState": "state-123"}]}
 
     first = client.post(
         "/api/v1/connectors/providers/onedrive/webhook",
@@ -162,6 +163,43 @@ def test_onedrive_webhook_enqueues_incremental_sync_and_dedupes(connectors_clien
 
 
 @pytest.mark.integration
+def test_onedrive_webhook_ignores_invalid_client_state(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_get_source_by_webhook_subscription(db, *, provider, subscription_id):
+        return {
+            "id": 77,
+            "provider": "onedrive",
+            "user_id": 42,
+            "enabled": True,
+            "webhook_metadata": {"clientState": "expected-state"},
+        }
+
+    async def _unexpected_record_webhook_receipt(*args, **kwargs):
+        raise AssertionError("invalid webhook notifications must be rejected before dedupe is recorded")
+
+    async def _unexpected_create_import_job(*args, **kwargs):
+        raise AssertionError("invalid webhook notifications must not enqueue sync jobs")
+
+    monkeypatch.setattr(ep, "get_source_by_webhook_subscription", _fake_get_source_by_webhook_subscription)
+    monkeypatch.setattr(ep, "record_webhook_receipt", _unexpected_record_webhook_receipt)
+    monkeypatch.setattr(ep, "create_import_job", _unexpected_create_import_job)
+
+    response = client.post(
+        "/api/v1/connectors/providers/onedrive/webhook",
+        json={"value": [{"subscriptionId": "sub-1", "changeType": "updated", "clientState": "wrong-state"}]},
+        headers=headers,
+    )
+
+    assert response.status_code == 202, response.text
+    assert response.json()["status"] == "ignored"
+    assert response.json()["queued_jobs"] == 0
+    assert response.json()["ignored_notifications"] == 1
+
+
+@pytest.mark.integration
 def test_drive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, monkeypatch):
     client, headers = connectors_client
 
@@ -178,6 +216,7 @@ def test_drive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, 
             "provider": "drive",
             "user_id": 24,
             "enabled": True,
+            "webhook_metadata": {"clientState": "drive-state-123"},
         }
 
     async def _fake_record_webhook_receipt(db, *, provider, receipt_key, source_id=None, payload_hash=None):
@@ -213,6 +252,7 @@ def test_drive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, 
     request_headers.update(
         {
             "X-Goog-Channel-Id": "drive-chan-1",
+            "X-Goog-Channel-Token": "drive-state-123",
             "X-Goog-Message-Number": "1",
             "X-Goog-Resource-State": "change",
             "X-Goog-Resource-Id": "drive-resource-1",
@@ -236,6 +276,50 @@ def test_drive_webhook_enqueues_incremental_sync_and_dedupes(connectors_client, 
     assert queued_jobs[0]["user_id"] == 24
     assert queued_jobs[0]["source_id"] == 88
     assert queued_jobs[0]["job_type"] == "incremental_sync"
+
+
+@pytest.mark.integration
+def test_drive_webhook_ignores_invalid_channel_token(connectors_client, monkeypatch):
+    client, headers = connectors_client
+
+    import tldw_Server_API.app.api.v1.endpoints.connectors as ep
+
+    async def _fake_get_source_by_webhook_subscription(db, *, provider, subscription_id):
+        return {
+            "id": 88,
+            "provider": "drive",
+            "user_id": 24,
+            "enabled": True,
+            "webhook_metadata": {"clientState": "expected-drive-state"},
+        }
+
+    async def _unexpected_record_webhook_receipt(*args, **kwargs):
+        raise AssertionError("invalid drive notifications must be rejected before dedupe is recorded")
+
+    async def _unexpected_create_import_job(*args, **kwargs):
+        raise AssertionError("invalid drive notifications must not enqueue sync jobs")
+
+    monkeypatch.setattr(ep, "get_source_by_webhook_subscription", _fake_get_source_by_webhook_subscription)
+    monkeypatch.setattr(ep, "record_webhook_receipt", _unexpected_record_webhook_receipt)
+    monkeypatch.setattr(ep, "create_import_job", _unexpected_create_import_job)
+
+    request_headers = dict(headers)
+    request_headers.update(
+        {
+            "X-Goog-Channel-Id": "drive-chan-1",
+            "X-Goog-Channel-Token": "wrong-drive-state",
+            "X-Goog-Message-Number": "1",
+            "X-Goog-Resource-State": "change",
+            "X-Goog-Resource-Id": "drive-resource-1",
+        }
+    )
+
+    response = client.post("/api/v1/connectors/providers/drive/webhook", headers=request_headers)
+
+    assert response.status_code == 202, response.text
+    assert response.json()["status"] == "ignored"
+    assert response.json()["queued_jobs"] == 0
+    assert response.json()["ignored_notifications"] == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
@@ -387,3 +387,171 @@ async def test_worker_drive_created_delta_without_binding_still_reconciles(monke
     assert reconcile_calls[0]["change"].event_type == "created"
     assert reconcile_calls[0]["content"].text == "Brand new drive sync body"
     assert reconcile_calls[0]["job_id"] == "5678"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_drive_bootstrap_reconcile_failure_is_nonfatal(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        async def list_files(self, account, parent_remote_id, *, page_size=50, cursor=None):
+            assert account["tokens"]["access_token"] == "tok"
+            assert parent_remote_id == "root"
+            assert cursor is None
+            return (
+                [
+                    {
+                        "id": "file-bootstrap",
+                        "name": "bootstrap.txt",
+                        "mimeType": "text/plain",
+                        "size": 32,
+                    }
+                ],
+                None,
+            )
+
+        async def download_file(self, account, file_id, *, mime_type=None, export_mime=None):
+            assert file_id == "file-bootstrap"
+            return b"bootstrap body"
+
+        async def get_start_page_token(self, account):
+            return "cursor-bootstrap"
+
+    class _DummyDb:
+        async def execute(self, *args, **kwargs):
+            return None
+
+        async def fetchone(self, *args, **kwargs):
+            return None
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return _DummyDb()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {"recursive": False},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_should_ingest_item(db, **kwargs):
+        return True
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {}
+
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    async def _fake_get_external_item_binding(db, *, source_id, provider, external_id):
+        return None
+
+    reconcile_calls: list[dict[str, object]] = []
+
+    async def _fake_reconcile_file_change(
+        connectors_db,
+        media_db,
+        *,
+        source_id,
+        provider,
+        change,
+        content=None,
+        job_id=None,
+    ):
+        reconcile_calls.append(
+            {
+                "source_id": source_id,
+                "provider": provider,
+                "change": change,
+                "content": content,
+                "job_id": job_id,
+            }
+        )
+        raise RuntimeError("ingest failed")
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.core.External_Sources.sync_coordinator as sync_coordinator
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "should_ingest_item", _fake_should_ingest_item)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(svc, "get_external_item_binding", _fake_get_external_item_binding)
+    monkeypatch.setattr(sync_coordinator, "reconcile_file_change", _fake_reconcile_file_change)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+
+    jm = FakeJM()
+
+    await worker._process_import_job(
+        jm,
+        jid=91011,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 0
+    assert jm.completed["result"]["failed"] == 1
+    assert jm.completed["result"]["degraded"] == 0
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0]["change"].event_type == "created"
+    assert reconcile_calls[0]["job_id"] == "91011"
+    assert sync_state_updates[0]["last_sync_started_at"] is not None
+    assert sync_state_updates[-1]["cursor"] == "cursor-bootstrap"
+    assert sync_state_updates[-1]["last_sync_succeeded_at"] is not None

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
+from tldw_Server_API.app.core.External_Sources.sync_coordinator import SyncReconcileResult
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_drive_incremental_sync_uses_delta_feed_and_advances_cursor(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        list_changes_calls: list[str | None] = []
+        download_calls: list[dict[str, object]] = []
+
+        async def list_files(self, *args, **kwargs):
+            raise AssertionError("delta sync should not fall back to recursive traversal")
+
+        async def list_changes(
+            self,
+            account,
+            *,
+            cursor: str | None = None,
+            page_size: int = 100,
+        ):
+            type(self).list_changes_calls.append(cursor)
+            assert account["tokens"]["access_token"] == "tok"
+            assert page_size == 100
+            return (
+                [
+                    FileSyncChange(
+                        event_type="content_updated",
+                        remote_id="file-1",
+                        remote_name="quarterly.txt",
+                        remote_parent_id="folder-1",
+                        remote_path="/finance/quarterly.txt",
+                        remote_revision="rev-2",
+                        remote_hash="hash-2",
+                        metadata={
+                            "mime_type": "text/plain",
+                            "size": 128,
+                            "modified_at": "2026-03-06T12:00:00Z",
+                        },
+                    )
+                ],
+                None,
+                "cursor-2",
+            )
+
+        async def download_or_export(self, account, remote_id, *, metadata=None):
+            type(self).download_calls.append(
+                {
+                    "account": dict(account),
+                    "remote_id": remote_id,
+                    "metadata": dict(metadata or {}),
+                }
+            )
+            return b"Updated drive sync body"
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        assert user_id == 42
+        assert source_id == 99
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {"recursive": True},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        assert user_id == 42
+        assert account_id == 123
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        assert source_id == 99
+        return {"source_id": source_id, "cursor": "cursor-1", "cursor_kind": "drive_start_page_token"}
+
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    async def _fake_get_external_item_binding(db, *, source_id, provider, external_id):
+        assert source_id == 99
+        assert provider == "drive"
+        assert external_id == "file-1"
+        return {
+            "id": 1,
+            "source_id": source_id,
+            "provider": provider,
+            "external_id": external_id,
+            "media_id": 77,
+            "version": "rev-1",
+            "hash": "hash-1",
+            "sync_status": "active",
+        }
+
+    reconcile_calls: list[dict[str, object]] = []
+
+    async def _fake_reconcile_file_change(
+        connectors_db,
+        media_db,
+        *,
+        source_id,
+        provider,
+        change,
+        content=None,
+        job_id=None,
+    ):
+        reconcile_calls.append(
+            {
+                "source_id": source_id,
+                "provider": provider,
+                "change": change,
+                "content": content,
+                "job_id": job_id,
+                "media_db_type": type(media_db).__name__,
+            }
+        )
+        return SyncReconcileResult(
+            action="version_created",
+            media_id=77,
+            binding_id=1,
+            current_version_number=2,
+            sync_status="active",
+        )
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.core.External_Sources.sync_coordinator as sync_coordinator
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(svc, "get_external_item_binding", _fake_get_external_item_binding)
+    monkeypatch.setattr(sync_coordinator, "reconcile_file_change", _fake_reconcile_file_change)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+
+    jm = FakeJM()
+
+    await worker._process_import_job(
+        jm,
+        jid=1234,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 1
+    assert jm.completed["result"]["total"] == 1
+    assert FakeDriveConn.list_changes_calls == ["cursor-1"]
+    assert len(FakeDriveConn.download_calls) == 1
+    assert FakeDriveConn.download_calls[0]["remote_id"] == "file-1"
+    assert FakeDriveConn.download_calls[0]["metadata"] == {
+        "mime_type": "text/plain",
+        "size": 128,
+        "modified_at": "2026-03-06T12:00:00Z",
+    }
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0]["source_id"] == 99
+    assert reconcile_calls[0]["provider"] == "drive"
+    assert reconcile_calls[0]["change"].remote_id == "file-1"
+    assert reconcile_calls[0]["content"].text == "Updated drive sync body"
+    assert reconcile_calls[0]["job_id"] == "1234"
+    assert sync_state_updates[-1]["cursor"] == "cursor-2"
+    assert sync_state_updates[-1]["cursor_kind"] == "drive_start_page_token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_worker_drive_created_delta_without_binding_still_reconciles(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        async def list_files(self, *args, **kwargs):
+            raise AssertionError("delta sync should not fall back to recursive traversal")
+
+        async def list_changes(
+            self,
+            account,
+            *,
+            cursor: str | None = None,
+            page_size: int = 100,
+        ):
+            assert account["tokens"]["access_token"] == "tok"
+            return (
+                [
+                    FileSyncChange(
+                        event_type="created",
+                        remote_id="file-new",
+                        remote_name="new-file.txt",
+                        remote_parent_id="folder-1",
+                        remote_path="/finance/new-file.txt",
+                        remote_revision="rev-1",
+                        remote_hash="hash-new",
+                        metadata={
+                            "mime_type": "text/plain",
+                            "size": 64,
+                            "modified_at": "2026-03-06T12:00:00Z",
+                        },
+                    )
+                ],
+                None,
+                "cursor-2",
+            )
+
+        async def download_or_export(self, account, remote_id, *, metadata=None):
+            assert remote_id == "file-new"
+            return b"Brand new drive sync body"
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {"recursive": True},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {"source_id": source_id, "cursor": "cursor-1", "cursor_kind": "drive_start_page_token"}
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        return {"source_id": source_id, **updates}
+
+    async def _fake_get_external_item_binding(db, *, source_id, provider, external_id):
+        assert external_id == "file-new"
+        return None
+
+    reconcile_calls: list[dict[str, object]] = []
+
+    async def _fake_reconcile_file_change(
+        connectors_db,
+        media_db,
+        *,
+        source_id,
+        provider,
+        change,
+        content=None,
+        job_id=None,
+    ):
+        reconcile_calls.append(
+            {
+                "source_id": source_id,
+                "provider": provider,
+                "change": change,
+                "content": content,
+                "job_id": job_id,
+            }
+        )
+        return SyncReconcileResult(
+            action="created",
+            media_id=88,
+            binding_id=5,
+            current_version_number=1,
+            sync_status="active",
+        )
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.core.External_Sources.sync_coordinator as sync_coordinator
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(svc, "get_external_item_binding", _fake_get_external_item_binding)
+    monkeypatch.setattr(sync_coordinator, "reconcile_file_change", _fake_reconcile_file_change)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+
+    jm = FakeJM()
+
+    await worker._process_import_job(
+        jm,
+        jid=5678,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 1
+    assert len(reconcile_calls) == 1
+    assert reconcile_calls[0]["change"].event_type == "created"
+    assert reconcile_calls[0]["content"].text == "Brand new drive sync body"
+    assert reconcile_calls[0]["job_id"] == "5678"

--- a/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
+++ b/tldw_Server_API/tests/External_Sources/test_connectors_worker_file_sync.py
@@ -391,6 +391,195 @@ async def test_worker_drive_created_delta_without_binding_still_reconciles(monke
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_worker_drive_incremental_policy_block_marks_existing_binding_degraded(monkeypatch):
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    class FakeJM:
+        def __init__(self):
+            self.completed = None
+
+        def renew_job_lease(self, *args, **kwargs):
+            return None
+
+        def complete_job(
+            self,
+            jid,
+            result=None,
+            worker_id=None,
+            lease_id=None,
+            completion_token=None,
+        ):
+            self.completed = {"jid": jid, "result": result}
+
+    class FakeDriveConn:
+        async def list_files(self, *args, **kwargs):
+            raise AssertionError("delta sync should not fall back to recursive traversal")
+
+        async def list_changes(self, account, *, cursor: str | None = None, page_size: int = 100):
+            return (
+                [
+                    FileSyncChange(
+                        event_type="content_updated",
+                        remote_id="file-1",
+                        remote_name="blocked.exe",
+                        remote_revision="rev-2",
+                        remote_hash="hash-2",
+                        metadata={
+                            "mime_type": "application/octet-stream",
+                            "size": 128,
+                            "modified_at": "2026-03-06T12:00:00Z",
+                        },
+                    )
+                ],
+                None,
+                "cursor-2",
+            )
+
+        async def download_or_export(self, account, remote_id, *, metadata=None):
+            raise AssertionError("policy-blocked changes must not download content")
+
+    class _DummyTx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummyPool:
+        def transaction(self):
+            return _DummyTx()
+
+    async def _fake_get_db_pool():
+        return _DummyPool()
+
+    async def _fake_get_source_by_id(db, user_id, source_id):
+        return {
+            "id": source_id,
+            "provider": "drive",
+            "account_id": 123,
+            "remote_id": "root",
+            "type": "folder",
+            "path": "/",
+            "options": {"recursive": True},
+            "email": "sync@example.com",
+        }
+
+    async def _fake_get_account_tokens(db, user_id, account_id):
+        return {"access_token": "tok"}
+
+    async def _fake_get_source_sync_state(db, *, source_id):
+        return {"source_id": source_id, "cursor": "cursor-1", "cursor_kind": "drive_start_page_token"}
+
+    sync_state_updates: list[dict[str, object]] = []
+
+    async def _fake_upsert_source_sync_state(db, *, source_id, **updates):
+        payload = {"source_id": source_id, **updates}
+        sync_state_updates.append(payload)
+        return payload
+
+    async def _fake_get_external_item_binding(db, *, source_id, provider, external_id):
+        return {
+            "id": 44,
+            "source_id": source_id,
+            "provider": provider,
+            "external_id": external_id,
+            "media_id": 77,
+            "version": "rev-1",
+            "hash": "hash-1",
+            "sync_status": "active",
+            "name": "blocked.exe",
+            "mime": "application/octet-stream",
+            "size": 32,
+            "current_version_number": 1,
+            "provider_metadata": {},
+        }
+
+    binding_updates: list[dict[str, object]] = []
+    recorded_events: list[dict[str, object]] = []
+
+    async def _fake_upsert_external_item_binding(db, *, source_id, provider, external_id, **updates):
+        payload = {
+            "id": 44,
+            "source_id": source_id,
+            "provider": provider,
+            "external_id": external_id,
+            **updates,
+        }
+        binding_updates.append(payload)
+        return payload
+
+    async def _fake_record_item_event(db, *, external_item_id, event_type, job_id=None, payload=None):
+        recorded_events.append(
+            {
+                "external_item_id": external_item_id,
+                "event_type": event_type,
+                "job_id": job_id,
+                "payload": dict(payload or {}),
+            }
+        )
+        return recorded_events[-1]
+
+    async def _unexpected_reconcile(*args, **kwargs):
+        raise AssertionError("policy-blocked changes must not reconcile content")
+
+    class _FakeMDB:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.Media_DB_v2 as mdb_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.core.External_Sources.connectors_service as svc
+    import tldw_Server_API.app.core.External_Sources.policy as policy_mod
+    import tldw_Server_API.app.core.External_Sources.sync_coordinator as sync_coordinator
+
+    monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: FakeDriveConn())
+    monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(svc, "get_source_by_id", _fake_get_source_by_id)
+    monkeypatch.setattr(svc, "get_account_tokens", _fake_get_account_tokens)
+    monkeypatch.setattr(svc, "get_source_sync_state", _fake_get_source_sync_state)
+    monkeypatch.setattr(svc, "upsert_source_sync_state", _fake_upsert_source_sync_state)
+    monkeypatch.setattr(svc, "get_external_item_binding", _fake_get_external_item_binding)
+    monkeypatch.setattr(svc, "upsert_external_item_binding", _fake_upsert_external_item_binding)
+    monkeypatch.setattr(svc, "record_item_event", _fake_record_item_event)
+    monkeypatch.setattr(sync_coordinator, "reconcile_file_change", _unexpected_reconcile)
+    monkeypatch.setattr(mdb_mod, "MediaDatabase", _FakeMDB)
+    monkeypatch.setattr(orgs, "list_memberships_for_user", lambda user_id: [])
+    monkeypatch.setattr(
+        policy_mod,
+        "get_default_policy_from_env",
+        lambda org_id: {
+            "allowed_export_formats": ["txt", "pdf"],
+            "allowed_file_types": ["pdf", "txt", "text/plain"],
+            "max_file_size_mb": 500,
+        },
+    )
+
+    jm = FakeJM()
+
+    await worker._process_import_job(
+        jm,
+        jid=6789,
+        lease_id="lease-1",
+        worker_id="worker-1",
+        source_id=99,
+        user_id=42,
+    )
+
+    assert jm.completed is not None
+    assert jm.completed["result"]["processed"] == 0
+    assert jm.completed["result"]["failed"] == 1
+    assert jm.completed["result"]["degraded"] == 1
+    assert binding_updates[-1]["sync_status"] == "degraded"
+    assert recorded_events[-1]["event_type"] == "ingest_failed"
+    assert "policy" in recorded_events[-1]["payload"]["error"].lower()
+    assert sync_state_updates[-1]["cursor"] == "cursor-2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_worker_drive_bootstrap_reconcile_failure_is_nonfatal(monkeypatch):
     import tldw_Server_API.app.services.connectors_worker as worker
 

--- a/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+++ b/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.External_Sources.google_drive import GoogleDriveConnector
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.content = b""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+    async def aclose(self):
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_drive_changes_list_returns_normalized_page_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "changes": [
+            {
+                "fileId": "file-1",
+                "time": "2026-03-01T00:00:00Z",
+                "file": {
+                    "id": "file-1",
+                    "name": "report.pdf",
+                    "mimeType": "application/pdf",
+                    "modifiedTime": "2026-03-01T00:00:00Z",
+                    "md5Checksum": "md5-1",
+                    "size": "42",
+                    "parents": ["folder-1"],
+                    "version": "7",
+                    "webViewLink": "https://drive.google.com/file/d/file-1/view",
+                    "trashed": False,
+                },
+            },
+            {
+                "fileId": "file-2",
+                "removed": True,
+                "time": "2026-03-01T01:00:00Z",
+            },
+        ],
+        "nextPageToken": "page-2",
+        "newStartPageToken": "new-start-token",
+    }
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        assert method == "GET"
+        assert url.endswith("/drive/v3/changes")
+        assert params["pageToken"] == "start-token"
+        return _Resp(payload)
+
+    import tldw_Server_API.app.core.External_Sources.google_drive as drive_mod
+
+    monkeypatch.setattr(drive_mod, "afetch", _fake_afetch)
+
+    connector = GoogleDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    changes, next_cursor, cursor_hint = await connector.list_changes(
+        {"tokens": {"access_token": "token"}},
+        cursor="start-token",
+    )
+
+    assert changes[0].remote_id == "file-1"
+    assert changes[0].event_type == "content_updated"
+    assert changes[0].remote_name == "report.pdf"
+    assert changes[1].remote_id == "file-2"
+    assert changes[1].event_type == "deleted"
+    assert next_cursor == "page-2"
+    assert cursor_hint == "new-start-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_drive_resolve_shared_link_returns_canonical_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    connector = GoogleDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+
+    async def _fake_get_item_metadata(account, remote_id):
+        assert remote_id == "file-123"
+        return {
+            "remote_id": remote_id,
+            "remote_name": "shared.pdf",
+            "mime_type": "application/pdf",
+        }
+
+    monkeypatch.setattr(connector, "get_item_metadata", _fake_get_item_metadata)
+
+    resolved = await connector.resolve_shared_link(
+        {"tokens": {"access_token": "token"}},
+        "https://drive.google.com/file/d/file-123/view?usp=sharing",
+    )
+
+    assert resolved is not None
+    assert resolved["remote_id"] == "file-123"
+    assert resolved["remote_name"] == "shared.pdf"

--- a/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+++ b/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
@@ -104,6 +104,39 @@ async def test_drive_resolve_shared_link_returns_canonical_metadata(monkeypatch:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_drive_get_item_metadata_url_encodes_remote_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        seen["method"] = method
+        seen["url"] = url
+        return _Resp(
+            {
+                "id": "file/../unsafe",
+                "name": "unsafe.txt",
+                "mimeType": "text/plain",
+                "version": "1",
+            }
+        )
+
+    import tldw_Server_API.app.core.External_Sources.google_drive as drive_mod
+
+    monkeypatch.setattr(drive_mod, "afetch", _fake_afetch)
+
+    connector = GoogleDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    metadata = await connector.get_item_metadata(
+        {"tokens": {"access_token": "token"}},
+        "file/../unsafe",
+    )
+
+    assert seen["method"] == "GET"
+    assert seen["url"].endswith("/drive/v3/files/file%2F..%2Funsafe")
+    assert metadata is not None
+    assert metadata["remote_id"] == "file/../unsafe"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_drive_subscribe_webhook_watches_changes_feed_and_returns_channel_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
+++ b/tldw_Server_API/tests/External_Sources/test_google_drive_sync_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tldw_Server_API.app.core.External_Sources.google_drive import GoogleDriveConnector
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncWebhookSubscription
 
 
 class _Resp:
@@ -99,3 +100,91 @@ async def test_drive_resolve_shared_link_returns_canonical_metadata(monkeypatch:
     assert resolved is not None
     assert resolved["remote_id"] == "file-123"
     assert resolved["remote_name"] == "shared.pdf"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_drive_subscribe_webhook_watches_changes_feed_and_returns_channel_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connector = GoogleDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+
+    async def _fake_get_start_page_token(account):
+        assert account["tokens"]["access_token"] == "token"
+        return "start-token"
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, json=None, timeout=None):
+        assert method == "POST"
+        assert url.endswith("/drive/v3/changes/watch")
+        assert params["pageToken"] == "start-token"
+        assert json["type"] == "web_hook"
+        assert json["address"] == "https://example.com/api/v1/connectors/providers/drive/webhook"
+        assert json["token"] == "state-123"
+        return _Resp(
+            {
+                "id": "channel-1",
+                "resourceId": "resource-1",
+                "expiration": "1772812800000",
+            }
+        )
+
+    import tldw_Server_API.app.core.External_Sources.google_drive as drive_mod
+
+    monkeypatch.setattr(connector, "get_start_page_token", _fake_get_start_page_token)
+    monkeypatch.setattr(drive_mod, "afetch", _fake_afetch)
+
+    subscription = await connector.subscribe_webhook(
+        {"tokens": {"access_token": "token"}},
+        resource={"clientState": "state-123"},
+        callback_url="https://example.com/api/v1/connectors/providers/drive/webhook",
+    )
+
+    assert subscription is not None
+    assert subscription.subscription_id == "channel-1"
+    assert subscription.expires_at == "2026-03-06T16:00:00Z"
+    assert subscription.metadata["resourceId"] == "resource-1"
+    assert subscription.metadata["pageToken"] == "start-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_drive_renew_webhook_replaces_channel_using_resource_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connector = GoogleDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_revoke(account, *, subscription):
+        calls.append(("revoke", subscription.subscription_id or ""))
+        assert subscription.metadata["resourceId"] == "resource-1"
+        return True
+
+    async def _fake_subscribe(account, *, resource, callback_url):
+        calls.append(("subscribe", resource["clientState"]))
+        assert resource["pageToken"] == "start-token"
+        return FileSyncWebhookSubscription(
+            subscription_id="channel-2",
+            expires_at="2026-03-06T18:40:00Z",
+            metadata={"resourceId": "resource-2", "pageToken": "start-token"},
+        )
+
+    monkeypatch.setattr(connector, "revoke_webhook", _fake_revoke)
+    monkeypatch.setattr(connector, "subscribe_webhook", _fake_subscribe)
+
+    renewed = await connector.renew_webhook(
+        {"tokens": {"access_token": "token"}},
+        subscription=FileSyncWebhookSubscription(
+            subscription_id="channel-1",
+            expires_at="2026-03-05T18:40:00Z",
+            metadata={
+                "resourceId": "resource-1",
+                "pageToken": "start-token",
+                "callback_url": "https://example.com/api/v1/connectors/providers/drive/webhook",
+                "clientState": "state-123",
+            },
+        ),
+    )
+
+    assert renewed is not None
+    assert renewed.subscription_id == "channel-2"
+    assert calls == [("revoke", "channel-1"), ("subscribe", "state-123")]

--- a/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.connectors import ConnectorSourceCreateRequest
+from tldw_Server_API.app.core.External_Sources.onedrive import OneDriveConnector
+
+
+class _Resp:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.content = b""
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+    async def aclose(self):
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_onedrive_delta_returns_drive_and_item_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "value": [
+            {
+                "id": "item-1",
+                "name": "report.pdf",
+                "size": 128,
+                "eTag": "etag-1",
+                "lastModifiedDateTime": "2026-03-01T00:00:00Z",
+                "webUrl": "https://onedrive.example/item-1",
+                "parentReference": {
+                    "driveId": "drive-123",
+                    "id": "parent-1",
+                    "path": "/drive/root:/Reports",
+                },
+                "file": {"mimeType": "application/pdf", "hashes": {"quickXorHash": "hash-1"}},
+            }
+        ],
+        "@odata.deltaLink": "https://graph.microsoft.com/delta-token",
+    }
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        assert method == "GET"
+        assert url == "https://graph.microsoft.com/v1.0/me/drive/root/delta"
+        return _Resp(payload)
+
+    import tldw_Server_API.app.core.External_Sources.onedrive as onedrive_mod
+
+    monkeypatch.setattr(onedrive_mod, "afetch", _fake_afetch)
+
+    connector = OneDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    changes, next_cursor, delta_link = await connector.list_changes(
+        account={"tokens": {"access_token": "token"}},
+        cursor=None,
+    )
+
+    first = changes[0]
+    assert first.remote_id == "item-1"
+    assert first.metadata["drive_id"] == "drive-123"
+    assert first.remote_parent_id == "parent-1"
+    assert next_cursor is None
+    assert delta_link == "https://graph.microsoft.com/delta-token"
+
+
+@pytest.mark.unit
+def test_connector_source_request_accepts_onedrive_file_sources() -> None:
+    payload = ConnectorSourceCreateRequest(
+        account_id=1,
+        provider="onedrive",
+        remote_id="item-1",
+        type="file",
+    )
+
+    assert payload.provider == "onedrive"
+    assert payload.type == "file"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_providers_includes_onedrive() -> None:
+    from tldw_Server_API.app.api.v1.endpoints import connectors as ep
+
+    providers = await ep.list_providers()
+    names = {item.name for item in providers}
+
+    assert "onedrive" in names

--- a/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.connectors import ConnectorSourceCreateRequest
 from tldw_Server_API.app.core.External_Sources.onedrive import OneDriveConnector
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncWebhookSubscription
 
 
 class _Resp:
@@ -111,6 +114,90 @@ async def test_onedrive_get_item_metadata_url_encodes_remote_id(monkeypatch: pyt
     assert seen["url"].endswith("/v1.0/me/drive/items/item%2F..%2Funsafe")
     assert metadata is not None
     assert metadata["remote_id"] == "item/../unsafe"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_onedrive_subscribe_webhook_defaults_future_expiration(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    async def _fake_afetch(*, method, url, headers=None, json=None, timeout=None):
+        seen["method"] = method
+        seen["url"] = url
+        seen["json"] = json
+        return _Resp(
+            {
+                "id": "sub-1",
+                "expirationDateTime": (json or {}).get("expirationDateTime"),
+            }
+        )
+
+    import tldw_Server_API.app.core.External_Sources.onedrive as onedrive_mod
+
+    monkeypatch.setattr(onedrive_mod, "afetch", _fake_afetch)
+
+    connector = OneDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    subscription = await connector.subscribe_webhook(
+        {"tokens": {"access_token": "token"}},
+        resource={
+            "resource": "me/drive/root",
+            "change_type": "updated",
+            "clientState": "state-123",
+        },
+        callback_url="http://localhost/api/v1/connectors/providers/onedrive/webhook",
+    )
+
+    requested_expiration = str((seen.get("json") or {}).get("expirationDateTime") or "")
+    requested_dt = datetime.fromisoformat(requested_expiration.replace("Z", "+00:00"))
+
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://graph.microsoft.com/v1.0/subscriptions"
+    assert requested_expiration
+    assert requested_dt > datetime.now(UTC)
+    assert subscription is not None
+    assert subscription.expires_at == requested_expiration
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_onedrive_renew_webhook_requests_new_future_expiration(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    async def _fake_afetch(*, method, url, headers=None, json=None, timeout=None):
+        seen["method"] = method
+        seen["url"] = url
+        seen["json"] = json
+        return _Resp(
+            {
+                "id": "sub-1",
+                "expirationDateTime": (json or {}).get("expirationDateTime"),
+            }
+        )
+
+    import tldw_Server_API.app.core.External_Sources.onedrive as onedrive_mod
+
+    monkeypatch.setattr(onedrive_mod, "afetch", _fake_afetch)
+
+    connector = OneDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    renewed = await connector.renew_webhook(
+        {"tokens": {"access_token": "token"}},
+        subscription=FileSyncWebhookSubscription(
+            subscription_id="sub-1",
+            expires_at="2026-03-01T00:00:00Z",
+            metadata={"expirationDateTime": "2026-03-01T00:00:00Z"},
+        ),
+    )
+
+    requested_expiration = str((seen.get("json") or {}).get("expirationDateTime") or "")
+    requested_dt = datetime.fromisoformat(requested_expiration.replace("Z", "+00:00"))
+
+    assert seen["method"] == "PATCH"
+    assert seen["url"] == "https://graph.microsoft.com/v1.0/subscriptions/sub-1"
+    assert requested_expiration
+    assert requested_expiration != "2026-03-01T00:00:00Z"
+    assert requested_dt > datetime.now(UTC)
+    assert renewed is not None
+    assert renewed.expires_at == requested_expiration
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
+++ b/tldw_Server_API/tests/External_Sources/test_onedrive_connector.py
@@ -82,6 +82,39 @@ def test_connector_source_request_accepts_onedrive_file_sources() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_onedrive_get_item_metadata_url_encodes_remote_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, str] = {}
+
+    async def _fake_afetch(*, method, url, headers=None, params=None, timeout=None):
+        seen["method"] = method
+        seen["url"] = url
+        return _Resp(
+            {
+                "id": "item/../unsafe",
+                "name": "unsafe.txt",
+                "eTag": "etag-1",
+                "file": {"mimeType": "text/plain"},
+            }
+        )
+
+    import tldw_Server_API.app.core.External_Sources.onedrive as onedrive_mod
+
+    monkeypatch.setattr(onedrive_mod, "afetch", _fake_afetch)
+
+    connector = OneDriveConnector(client_id="x", client_secret="y", redirect_base="http://localhost")
+    metadata = await connector.get_item_metadata(
+        {"tokens": {"access_token": "token"}},
+        "item/../unsafe",
+    )
+
+    assert seen["method"] == "GET"
+    assert seen["url"].endswith("/v1.0/me/drive/items/item%2F..%2Funsafe")
+    assert metadata is not None
+    assert metadata["remote_id"] == "item/../unsafe"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_list_providers_includes_onedrive() -> None:
     from tldw_Server_API.app.api.v1.endpoints import connectors as ep
 

--- a/tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
+++ b/tldw_Server_API/tests/External_Sources/test_sync_adapter_contract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.sync_adapter import (
+    FileSyncAdapter,
+    FileSyncChange,
+)
+
+
+@pytest.mark.unit
+def test_file_sync_change_normalizes_required_fields() -> None:
+    change = FileSyncChange(
+        event_type="content_updated",
+        remote_id="abc123",
+        remote_name="report.pdf",
+    )
+
+    assert change.event_type == "content_updated"
+    assert change.remote_id == "abc123"
+    assert change.remote_name == "report.pdf"
+
+
+@pytest.mark.unit
+def test_get_file_sync_connector_by_name_restricts_to_file_sync_providers() -> None:
+    connector = svc.get_file_sync_connector_by_name("drive")
+
+    assert connector.name == "drive"
+    assert isinstance(connector, FileSyncAdapter)
+
+    with pytest.raises(ValueError, match="does not support file sync"):
+        svc.get_file_sync_connector_by_name("gmail")

--- a/tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
+++ b/tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Media_DB_v2 import MediaDatabase, get_document_version
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
+from tldw_Server_API.app.core.External_Sources.sync_coordinator import (
+    FileSyncContentPayload,
+    reconcile_file_change,
+)
+
+
+@pytest.fixture
+async def connectors_db(tmp_path: Path):
+    db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    db.row_factory = aiosqlite.Row
+    db._is_sqlite = True
+    try:
+        yield db
+    finally:
+        await db.close()
+
+
+@pytest.fixture
+def media_db(tmp_path: Path) -> MediaDatabase:
+    return MediaDatabase(db_path=str(tmp_path / "media.sqlite3"), client_id="sync-test")
+
+
+async def _create_account_and_source(db: aiosqlite.Connection) -> tuple[dict, dict]:
+    account = await svc.create_account(
+        db,
+        user_id=11,
+        provider="drive",
+        display_name="Drive",
+        email="sync@example.com",
+        tokens={"access_token": "token"},
+    )
+    source = await svc.create_source(
+        db,
+        account_id=account["id"],
+        provider="drive",
+        remote_id="root",
+        type_="folder",
+        path="/",
+        options={"recursive": True},
+    )
+    return account, source
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reconcile_created_change_creates_media_binding_and_initial_version(
+    connectors_db: aiosqlite.Connection,
+    media_db: MediaDatabase,
+) -> None:
+    _, source = await _create_account_and_source(connectors_db)
+
+    result = await reconcile_file_change(
+        connectors_db,
+        media_db,
+        source_id=source["id"],
+        provider="drive",
+        change=FileSyncChange(
+            event_type="created",
+            remote_id="file-created",
+            remote_name="created.txt",
+            remote_parent_id="folder-1",
+            remote_path="/finance/created.txt",
+            remote_revision="rev-1",
+            remote_hash="remote-hash-created",
+            metadata={
+                "mime_type": "text/plain",
+                "size": 64,
+                "modified_at": "2026-03-06T12:00:00Z",
+                "remote_url": "https://drive.google.com/file/d/file-created/view",
+            },
+        ),
+        content=FileSyncContentPayload(
+            text="Brand new synced body",
+            prompt="Initial sync import",
+            analysis_content="Imported from external delta",
+            safe_metadata={"export_mime": "text/plain"},
+        ),
+        job_id="job-sync-created",
+    )
+
+    media_id = int(result.media_id or 0)
+    media_row = media_db.get_media_by_id(media_id)
+    latest_version = get_document_version(media_db, media_id)
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-created",
+    )
+    event_rows = await (await connectors_db.execute(
+        "SELECT event_type, payload_json FROM external_item_events ORDER BY id ASC"
+    )).fetchall()
+
+    assert result.action == "created"
+    assert media_id > 0
+    assert media_row is not None
+    assert media_row["title"] == "created.txt"
+    assert media_row["content"] == "Brand new synced body"
+    assert media_row["version"] == 1
+    assert latest_version is not None
+    assert latest_version["version_number"] == 1
+    assert latest_version["content"] == "Brand new synced body"
+    assert json.loads(latest_version["safe_metadata"]) == {
+        "export_mime": "text/plain",
+        "provider": "drive",
+        "remote_hash": "remote-hash-created",
+        "remote_id": "file-created",
+        "remote_path": "/finance/created.txt",
+        "remote_revision": "rev-1",
+        "source_id": source["id"],
+        "sync_job_id": "job-sync-created",
+        "sync_kind": "created",
+    }
+    assert binding is not None
+    assert binding["media_id"] == media_id
+    assert binding["name"] == "created.txt"
+    assert binding["version"] == "rev-1"
+    assert binding["hash"] == "remote-hash-created"
+    assert binding["sync_status"] == "active"
+    assert binding["current_version_number"] == 1
+    assert len(event_rows) == 1
+    assert event_rows[0]["event_type"] == "created"
+    assert json.loads(event_rows[0]["payload_json"])["remote_revision"] == "rev-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reconcile_content_update_updates_media_fts_versions_and_binding(
+    connectors_db: aiosqlite.Connection,
+    media_db: MediaDatabase,
+) -> None:
+    _, source = await _create_account_and_source(connectors_db)
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Quarterly Report",
+        content="Original sync body",
+        media_type="document",
+    )
+    await svc.upsert_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-1",
+        media_id=media_id,
+        name="quarterly.txt",
+        sync_status="active",
+        current_version_number=1,
+        version="rev-1",
+        content_hash="remote-hash-1",
+    )
+
+    result = await reconcile_file_change(
+        connectors_db,
+        media_db,
+        source_id=source["id"],
+        provider="drive",
+        change=FileSyncChange(
+            event_type="content_updated",
+            remote_id="file-1",
+            remote_name="quarterly.txt",
+            remote_parent_id="folder-1",
+            remote_path="/finance/quarterly.txt",
+            remote_revision="rev-2",
+            remote_hash="remote-hash-2",
+            metadata={
+                "mime_type": "text/plain",
+                "size": 128,
+                "modified_at": "2026-03-06T12:00:00Z",
+                "remote_url": "https://drive.google.com/file/d/file-1/view",
+            },
+        ),
+        content=FileSyncContentPayload(
+            text="Updated sync body",
+            prompt="Sync refresh",
+            analysis_content="Latest upstream revision",
+            safe_metadata={"export_mime": "text/plain"},
+        ),
+        job_id="job-sync-1",
+    )
+
+    media_row = media_db.get_media_by_id(media_id)
+    latest_version = get_document_version(media_db, media_id)
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-1",
+    )
+    event_rows = await (await connectors_db.execute(
+        "SELECT event_type, payload_json FROM external_item_events ORDER BY id ASC"
+    )).fetchall()
+    updated_results, updated_total = MediaDatabase.search_media_db(
+        media_db,
+        search_query='"Updated"',
+        search_fields=["content"],
+    )
+    original_results, original_total = MediaDatabase.search_media_db(
+        media_db,
+        search_query='"Original"',
+        search_fields=["content"],
+    )
+
+    assert result.action == "version_created"
+    assert result.media_id == media_id
+    assert media_row is not None
+    assert media_row["content"] == "Updated sync body"
+    assert media_row["content_hash"] == hashlib.sha256("Updated sync body".encode()).hexdigest()
+    assert media_row["version"] == 2
+    assert latest_version is not None
+    assert latest_version["version_number"] == 2
+    assert latest_version["content"] == "Updated sync body"
+    assert latest_version["prompt"] == "Sync refresh"
+    assert latest_version["analysis_content"] == "Latest upstream revision"
+    assert json.loads(latest_version["safe_metadata"]) == {
+        "export_mime": "text/plain",
+        "provider": "drive",
+        "remote_hash": "remote-hash-2",
+        "remote_id": "file-1",
+        "remote_path": "/finance/quarterly.txt",
+        "remote_revision": "rev-2",
+        "source_id": source["id"],
+        "sync_job_id": "job-sync-1",
+        "sync_kind": "content_updated",
+    }
+    assert binding is not None
+    assert binding["media_id"] == media_id
+    assert binding["version"] == "rev-2"
+    assert binding["hash"] == "remote-hash-2"
+    assert binding["remote_path"] == "/finance/quarterly.txt"
+    assert binding["current_version_number"] == 2
+    assert binding["sync_status"] == "active"
+    assert binding["last_content_sync_at"] is not None
+    assert binding["last_metadata_sync_at"] is not None
+    assert len(event_rows) == 1
+    assert event_rows[0]["event_type"] == "content_updated"
+    assert json.loads(event_rows[0]["payload_json"])["remote_revision"] == "rev-2"
+    assert updated_total == 1
+    assert updated_results[0]["id"] == media_id
+    assert original_total == 0
+    assert original_results == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reconcile_deleted_change_archives_media_and_binding(
+    connectors_db: aiosqlite.Connection,
+    media_db: MediaDatabase,
+) -> None:
+    _, source = await _create_account_and_source(connectors_db)
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Archive Me",
+        content="Archive body",
+        media_type="document",
+    )
+    await svc.upsert_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-archive",
+        media_id=media_id,
+        name="archive.txt",
+        sync_status="active",
+    )
+
+    result = await reconcile_file_change(
+        connectors_db,
+        media_db,
+        source_id=source["id"],
+        provider="drive",
+        change=FileSyncChange(
+            event_type="deleted",
+            remote_id="file-archive",
+            remote_name="archive.txt",
+        ),
+        job_id="job-sync-archive",
+    )
+
+    active_row = media_db.get_media_by_id(media_id)
+    trashed_row = media_db.get_media_by_id(media_id, include_trash=True)
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-archive",
+    )
+    event_rows = await (await connectors_db.execute(
+        "SELECT event_type, payload_json FROM external_item_events ORDER BY id ASC"
+    )).fetchall()
+
+    assert result.action == "archived"
+    assert result.media_id == media_id
+    assert active_row is None
+    assert trashed_row is not None
+    assert trashed_row["is_trash"] == 1
+    assert binding is not None
+    assert binding["sync_status"] == "archived_upstream_removed"
+    assert binding["remote_deleted_at"] is not None
+    assert binding["last_metadata_sync_at"] is not None
+    assert len(event_rows) == 1
+    assert event_rows[0]["event_type"] == "deleted_upstream"
+    assert json.loads(event_rows[0]["payload_json"])["sync_status"] == "archived_upstream_removed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reconcile_restored_change_restores_media_and_binding(
+    connectors_db: aiosqlite.Connection,
+    media_db: MediaDatabase,
+) -> None:
+    _, source = await _create_account_and_source(connectors_db)
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Restore Me",
+        content="Restore body",
+        media_type="document",
+    )
+    media_db.mark_as_trash(media_id)
+    await svc.upsert_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-restore",
+        media_id=media_id,
+        name="restore.txt",
+        sync_status="archived_upstream_removed",
+        remote_deleted_at="2026-03-05T00:00:00Z",
+    )
+
+    result = await reconcile_file_change(
+        connectors_db,
+        media_db,
+        source_id=source["id"],
+        provider="drive",
+        change=FileSyncChange(
+            event_type="restored",
+            remote_id="file-restore",
+            remote_name="restore-renamed.txt",
+            remote_parent_id="folder-restore",
+            remote_path="/restored/restore-renamed.txt",
+            remote_revision="rev-3",
+        ),
+        job_id="job-sync-restore",
+    )
+
+    media_row = media_db.get_media_by_id(media_id)
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="drive",
+        external_id="file-restore",
+    )
+    event_rows = await (await connectors_db.execute(
+        "SELECT event_type, payload_json FROM external_item_events ORDER BY id ASC"
+    )).fetchall()
+
+    assert result.action == "restored"
+    assert result.media_id == media_id
+    assert media_row is not None
+    assert media_row["is_trash"] == 0
+    assert binding is not None
+    assert binding["sync_status"] == "active"
+    assert binding["name"] == "restore-renamed.txt"
+    assert binding["version"] == "rev-3"
+    assert binding["remote_parent_id"] == "folder-restore"
+    assert binding["remote_path"] == "/restored/restore-renamed.txt"
+    assert binding["remote_deleted_at"] is None
+    assert binding["access_revoked_at"] is None
+    assert binding["last_metadata_sync_at"] is not None
+    assert len(event_rows) == 1
+    assert event_rows[0]["event_type"] == "restored_upstream"
+    assert json.loads(event_rows[0]["payload_json"])["sync_status"] == "active"

--- a/tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
+++ b/tldw_Server_API/tests/External_Sources/test_sync_coordinator.py
@@ -33,18 +33,26 @@ def media_db(tmp_path: Path) -> MediaDatabase:
 
 
 async def _create_account_and_source(db: aiosqlite.Connection) -> tuple[dict, dict]:
+    return await _create_account_and_source_for_provider(db, provider="drive")
+
+
+async def _create_account_and_source_for_provider(
+    db: aiosqlite.Connection,
+    *,
+    provider: str,
+) -> tuple[dict, dict]:
     account = await svc.create_account(
         db,
         user_id=11,
-        provider="drive",
-        display_name="Drive",
+        provider=provider,
+        display_name=provider.title(),
         email="sync@example.com",
         tokens={"access_token": "token"},
     )
     source = await svc.create_source(
         db,
         account_id=account["id"],
-        provider="drive",
+        provider=provider,
         remote_id="root",
         type_="folder",
         path="/",
@@ -249,6 +257,45 @@ async def test_reconcile_content_update_updates_media_fts_versions_and_binding(
     assert updated_results[0]["id"] == media_id
     assert original_total == 0
     assert original_results == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_reconcile_created_change_uses_provider_modified_timestamp_aliases(
+    connectors_db: aiosqlite.Connection,
+    media_db: MediaDatabase,
+) -> None:
+    _, source = await _create_account_and_source_for_provider(connectors_db, provider="onedrive")
+
+    await reconcile_file_change(
+        connectors_db,
+        media_db,
+        source_id=source["id"],
+        provider="onedrive",
+        change=FileSyncChange(
+            event_type="created",
+            remote_id="item-22",
+            remote_name="alias.txt",
+            remote_revision="etag-2",
+            metadata={
+                "mime_type": "text/plain",
+                "size": 33,
+                "last_modified": "2026-03-06T12:00:00Z",
+            },
+        ),
+        content=FileSyncContentPayload(text="alias timestamp body"),
+        job_id="job-sync-alias",
+    )
+
+    binding = await svc.get_external_item_binding(
+        connectors_db,
+        source_id=source["id"],
+        provider="onedrive",
+        external_id="item-22",
+    )
+
+    assert binding is not None
+    assert binding["modified_at"] == "2026-03-06T12:00:00Z"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Media_DB_v2 import (
+    MediaDatabase,
+    get_document_version,
+)
+from tldw_Server_API.app.core.External_Sources import connectors_service as svc
+from tldw_Server_API.app.core.External_Sources.sync_adapter import FileSyncChange
+
+
+pytestmark = pytest.mark.integration
+
+
+class _FakeJM:
+    def __init__(self) -> None:
+        self.completed: dict[str, object] | None = None
+
+    def renew_job_lease(self, *args, **kwargs):
+        return None
+
+    def complete_job(
+        self,
+        jid,
+        result=None,
+        worker_id=None,
+        lease_id=None,
+        completion_token=None,
+    ) -> None:
+        self.completed = {"jid": jid, "result": result}
+
+
+class _SqlitePool:
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield self._db
+
+
+class _FakeDriveConnector:
+    def __init__(self) -> None:
+        self.list_files_calls: list[str] = []
+        self.list_changes_calls: list[str | None] = []
+        self.download_file_calls: list[str] = []
+        self.download_or_export_calls: list[str] = []
+
+    async def list_files(
+        self,
+        account,
+        parent_remote_id: str,
+        *,
+        page_size: int = 50,
+        cursor: str | None = None,
+    ):
+        self.list_files_calls.append(parent_remote_id)
+        assert account["tokens"]["access_token"] == "tok"
+        assert parent_remote_id == "root"
+        assert cursor is None
+        return (
+            [
+                {
+                    "id": "file-1",
+                    "name": "quarterly.txt",
+                    "mimeType": "text/plain",
+                    "size": 128,
+                    "modifiedTime": "2026-03-07T01:00:00Z",
+                    "md5Checksum": "hash-bootstrap",
+                    "is_folder": False,
+                }
+            ],
+            None,
+        )
+
+    async def download_file(self, account, remote_id, *, mime_type=None, export_mime=None):
+        self.download_file_calls.append(remote_id)
+        assert account["tokens"]["access_token"] == "tok"
+        assert remote_id == "file-1"
+        return b"Initial drive body"
+
+    async def get_start_page_token(self, account):
+        assert account["tokens"]["access_token"] == "tok"
+        return "cursor-1"
+
+    async def list_changes(
+        self,
+        account,
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ):
+        self.list_changes_calls.append(cursor)
+        assert account["tokens"]["access_token"] == "tok"
+        assert cursor == "cursor-1"
+        return (
+            [
+                FileSyncChange(
+                    event_type="content_updated",
+                    remote_id="file-1",
+                    remote_name="quarterly.txt",
+                    remote_parent_id="root",
+                    remote_path="/quarterly.txt",
+                    remote_revision="rev-2",
+                    remote_hash="hash-rev-2",
+                    metadata={
+                        "mime_type": "text/plain",
+                        "size": 128,
+                        "modified_at": "2026-03-07T02:00:00Z",
+                    },
+                )
+            ],
+            None,
+            "cursor-2",
+        )
+
+    async def download_or_export(self, account, remote_id, *, metadata=None):
+        self.download_or_export_calls.append(remote_id)
+        assert account["tokens"]["access_token"] == "tok"
+        assert remote_id == "file-1"
+        return b"Updated drive body"
+
+
+class _FakeDriveDeleteConnector(_FakeDriveConnector):
+    async def list_changes(
+        self,
+        account,
+        *,
+        cursor: str | None = None,
+        page_size: int = 100,
+    ):
+        self.list_changes_calls.append(cursor)
+        assert account["tokens"]["access_token"] == "tok"
+        assert cursor == "cursor-1"
+        return (
+            [
+                FileSyncChange(
+                    event_type="deleted",
+                    remote_id="file-1",
+                    remote_name="quarterly.txt",
+                    metadata={},
+                )
+            ],
+            None,
+            "cursor-2",
+        )
+
+
+class _FakeDriveFailingUpdateConnector(_FakeDriveConnector):
+    async def download_or_export(self, account, remote_id, *, metadata=None):
+        self.download_or_export_calls.append(remote_id)
+        assert account["tokens"]["access_token"] == "tok"
+        raise ValueError("unsupported remote revision")
+
+
+@pytest.mark.asyncio
+async def test_drive_bootstrap_import_then_incremental_sync_creates_versioned_media(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        pool = _SqlitePool(connectors_db)
+        fake_conn = _FakeDriveConnector()
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="drive",
+            display_name="Drive",
+            email="sync@example.com",
+            tokens={"access_token": "tok", "refresh_token": "refresh"},
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="drive",
+            remote_id="root",
+            type_="folder",
+            path="/",
+            options={"recursive": True},
+        )
+
+        bootstrap_jm = _FakeJM()
+        await worker._process_import_job(
+            bootstrap_jm,
+            jid=9001,
+            lease_id="lease-bootstrap",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        binding_after_bootstrap = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        sync_state_after_bootstrap = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+
+        assert bootstrap_jm.completed is not None
+        assert bootstrap_jm.completed["result"]["processed"] == 1
+        assert binding_after_bootstrap is not None
+        assert binding_after_bootstrap["media_id"] is not None
+        assert binding_after_bootstrap["current_version_number"] == 1
+        assert sync_state_after_bootstrap is not None
+        assert sync_state_after_bootstrap["cursor"] == "cursor-1"
+        assert sync_state_after_bootstrap["last_bootstrap_at"] is not None
+
+        media_id = int(binding_after_bootstrap["media_id"])
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        version_one = get_document_version(media_db, media_id=media_id, version_number=1)
+        version_count = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM DocumentVersions WHERE media_id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()["c"]
+
+        assert version_one is not None
+        assert version_one["content"] == "Initial drive body"
+        assert version_count == 1
+
+        incremental_jm = _FakeJM()
+        await worker._process_import_job(
+            incremental_jm,
+            jid=9002,
+            lease_id="lease-incremental",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+            job_type="incremental_sync",
+        )
+
+        binding_after_incremental = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        sync_state_after_incremental = await svc.get_source_sync_state(
+            connectors_db,
+            source_id=int(source["id"]),
+        )
+        version_two = get_document_version(media_db, media_id=media_id, version_number=2)
+        media_row = media_db.execute_query(
+            "SELECT content FROM Media WHERE id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()
+        version_count_after_incremental = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM DocumentVersions WHERE media_id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()["c"]
+
+        assert incremental_jm.completed is not None
+        assert incremental_jm.completed["result"]["processed"] == 1
+        assert fake_conn.list_changes_calls == ["cursor-1"]
+        assert binding_after_incremental is not None
+        assert binding_after_incremental["current_version_number"] == 2
+        assert sync_state_after_incremental is not None
+        assert sync_state_after_incremental["cursor"] == "cursor-2"
+        assert version_two is not None
+        assert version_two["content"] == "Updated drive body"
+        assert media_row["content"] == "Updated drive body"
+        assert version_count_after_incremental == 2
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
+async def test_drive_incremental_delete_archives_existing_media(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        pool = _SqlitePool(connectors_db)
+        fake_conn = _FakeDriveDeleteConnector()
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="drive",
+            display_name="Drive",
+            email="sync@example.com",
+            tokens={"access_token": "tok", "refresh_token": "refresh"},
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="drive",
+            remote_id="root",
+            type_="folder",
+            path="/",
+            options={"recursive": True},
+        )
+
+        bootstrap_jm = _FakeJM()
+        await worker._process_import_job(
+            bootstrap_jm,
+            jid=9101,
+            lease_id="lease-bootstrap",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        binding_after_bootstrap = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        media_id = int(binding_after_bootstrap["media_id"])
+
+        delete_jm = _FakeJM()
+        await worker._process_import_job(
+            delete_jm,
+            jid=9102,
+            lease_id="lease-delete",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+            job_type="incremental_sync",
+        )
+
+        archived_binding = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        media_row = media_db.execute_query(
+            "SELECT is_trash FROM Media WHERE id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()
+
+        assert delete_jm.completed is not None
+        assert delete_jm.completed["result"]["processed"] == 1
+        assert archived_binding is not None
+        assert archived_binding["sync_status"] == "archived_upstream_removed"
+        assert archived_binding["remote_deleted_at"] is not None
+        assert media_row["is_trash"] == 1
+    finally:
+        await connectors_db.close()
+
+
+@pytest.mark.asyncio
+async def test_drive_incremental_ingest_failure_keeps_last_good_version_and_marks_binding_degraded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import json
+
+    import tldw_Server_API.app.core.AuthNZ.database as dbmod
+    import tldw_Server_API.app.core.AuthNZ.orgs_teams as orgs
+    import tldw_Server_API.app.core.DB_Management.db_path_utils as db_paths_mod
+    import tldw_Server_API.app.core.External_Sources as ext_pkg
+    import tldw_Server_API.app.services.connectors_worker as worker
+
+    connectors_db = await aiosqlite.connect(tmp_path / "connectors.sqlite3")
+    connectors_db.row_factory = aiosqlite.Row
+    connectors_db._is_sqlite = True
+
+    try:
+        media_root = tmp_path / "user_dbs"
+        monkeypatch.setenv("USER_DB_BASE_DIR", str(media_root))
+        monkeypatch.setitem(db_paths_mod.settings, "USER_DB_BASE_DIR", str(media_root))
+        media_db_path = db_paths_mod.DatabasePaths.get_media_db_path(1)
+
+        pool = _SqlitePool(connectors_db)
+        fake_conn = _FakeDriveFailingUpdateConnector()
+
+        async def _fake_get_db_pool():
+            return pool
+
+        async def _fake_list_memberships_for_user(_user_id: int):
+            return []
+
+        monkeypatch.setattr(dbmod, "get_db_pool", _fake_get_db_pool)
+        monkeypatch.setattr(orgs, "list_memberships_for_user", _fake_list_memberships_for_user)
+        monkeypatch.setattr(ext_pkg, "get_connector_by_name", lambda name: fake_conn)
+
+        account = await svc.create_account(
+            connectors_db,
+            user_id=1,
+            provider="drive",
+            display_name="Drive",
+            email="sync@example.com",
+            tokens={"access_token": "tok", "refresh_token": "refresh"},
+        )
+        source = await svc.create_source(
+            connectors_db,
+            account_id=int(account["id"]),
+            provider="drive",
+            remote_id="root",
+            type_="folder",
+            path="/",
+            options={"recursive": True},
+        )
+
+        bootstrap_jm = _FakeJM()
+        await worker._process_import_job(
+            bootstrap_jm,
+            jid=9201,
+            lease_id="lease-bootstrap",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+        )
+
+        binding_after_bootstrap = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        media_id = int(binding_after_bootstrap["media_id"])
+
+        failed_jm = _FakeJM()
+        await worker._process_import_job(
+            failed_jm,
+            jid=9202,
+            lease_id="lease-failing-update",
+            worker_id="worker-1",
+            source_id=int(source["id"]),
+            user_id=1,
+            job_type="incremental_sync",
+        )
+
+        degraded_binding = await svc.get_external_item_binding(
+            connectors_db,
+            source_id=int(source["id"]),
+            provider="drive",
+            external_id="file-1",
+        )
+        media_db = MediaDatabase(db_path=str(media_db_path), client_id="1")
+        latest_version = get_document_version(media_db, media_id=media_id)
+        version_count = media_db.execute_query(
+            "SELECT COUNT(*) AS c FROM DocumentVersions WHERE media_id = ? AND deleted = 0",
+            (media_id,),
+        ).fetchone()["c"]
+        event_rows = await (
+            await connectors_db.execute(
+                "SELECT event_type, payload_json FROM external_item_events ORDER BY id ASC"
+            )
+        ).fetchall()
+
+        assert failed_jm.completed is not None
+        assert failed_jm.completed["result"]["processed"] == 0
+        assert failed_jm.completed["result"]["failed"] == 1
+        assert failed_jm.completed["result"]["degraded"] == 1
+        assert degraded_binding is not None
+        assert degraded_binding["sync_status"] == "degraded"
+        assert degraded_binding["current_version_number"] == 1
+        assert latest_version is not None
+        assert latest_version["version_number"] == 1
+        assert latest_version["content"] == "Initial drive body"
+        assert version_count == 1
+        assert [row["event_type"] for row in event_rows] == ["created", "ingest_failed"]
+        assert json.loads(event_rows[-1]["payload_json"])["error"] == "unsupported remote revision"
+    finally:
+        await connectors_db.close()


### PR DESCRIPTION
## Summary
- add version-aware Google Drive and OneDrive external file sync on top of the connectors stack
- add source-scoped sync state, worker fencing, webhook renewal, recurring scheduler, and end-to-end integration coverage
- document the connectors sync API, Jobs usage, and scheduler/runtime behavior

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && pytest -q tldw_Server_API/tests/External_Sources tldw_Server_API/tests/MediaIngestion_NEW/integration/test_external_file_sync_integration.py`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/External_Sources tldw_Server_API/app/services/connectors_worker.py tldw_Server_API/app/api/v1/endpoints/connectors.py -f json -o /tmp/bandit_external_file_sync_full.json`
- [x] Base-branch check: `pytest -q tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py` fails on plain `dev` with `UserNotFoundError` in `storage_quota_service`, so that suite is not introduced by this PR
