### PR TITLE
test(media): enter lifespan in media integration fixtures

### DIFF
--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py
@@ -21,7 +21,8 @@ def client_with_auth():
     app.dependency_overrides[get_request_user] = override_user
     settings = get_settings()
     headers = {"X-API-KEY": settings.SINGLE_USER_API_KEY}
-    yield TestClient(app, headers=headers)
+    with TestClient(app, headers=headers) as client:
+        yield client
     app.dependency_overrides.clear()
 
 

--- a/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py
@@ -22,7 +22,8 @@ def client_with_auth():
     app.dependency_overrides[get_request_user] = override_user
     settings = get_settings()
     headers = {"X-API-KEY": settings.SINGLE_USER_API_KEY}
-    yield TestClient(app, headers=headers)
+    with TestClient(app, headers=headers) as client:
+        yield client
     app.dependency_overrides.clear()
 
 


### PR DESCRIPTION
## Summary
- switch the `MediaIngestion_NEW` integration fixtures to `with TestClient(...)` so FastAPI lifespan startup and shutdown run
- restore single-user AuthNZ seeding during these tests, which fixes the `StorageQuotaService` `UserNotFoundError` regression
- cover both `/api/v1/media/add` and media versions integration flows with the lifespan-aware fixture pattern

## Test Plan
- [x] `source .venv/bin/activate && pytest -q tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py`
- [x] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_versions_integration.py tldw_Server_API/tests/MediaIngestion_NEW/integration/test_media_add_endpoint_real.py -f json -o /tmp/bandit_media_versions_quota_fix.json` (expected test-only `B101` assert warnings)
