### PR TITLE
Admin-ui fixes

### DIFF
--- a/Docs/Plans/2026-03-07-admin-ui-review-fixes-design.md
+++ b/Docs/Plans/2026-03-07-admin-ui-review-fixes-design.md
@@ -1,0 +1,37 @@
+# Admin UI Review Fixes Design
+
+Date: 2026-03-07
+Branch: `codex/admin-ui-fixes`
+
+## Context
+
+Follow-up review on the admin UI hardening branch identified three regressions:
+
+1. Enterprise mode still allows API-key login if the allow-login flag is left on.
+2. Privileged-action reauthentication breaks high-risk admin actions in non-enterprise single-user deployments.
+3. Cookie-backed auth still treats cached `localStorage.user` data as a durable auth signal during bootstrap.
+
+## Design
+
+### 1. Fail-Closed Enterprise API-Key Login
+
+The server-side API-key login route must explicitly reject requests when `ADMIN_UI_ENTERPRISE_MODE` is enabled, regardless of any API-key login toggle. This makes enterprise mode authoritative and removes configuration-order ambiguity.
+
+### 2. Preserve Single-User Admin Workflows Outside Enterprise Mode
+
+Privileged admin actions will continue requiring an audit reason in all modes. Password reauthentication will remain mandatory for multi-user admins, but true single-user principals in non-enterprise mode will use a controlled fallback that skips password verification. Enterprise mode keeps strict reauthentication semantics.
+
+### 3. Bootstrap Auth Only From Real Session Signals
+
+Client auth bootstrap will trust only:
+
+- the readable session marker cookie for cookie-backed sessions
+- in-memory API-key state for the legacy non-enterprise path
+
+Cached `localStorage.user` remains a profile cache only and must not be treated as authenticated state.
+
+## Testing Strategy
+
+- Add a route test proving enterprise mode rejects API-key login even when API-key login is otherwise enabled.
+- Add backend tests proving privileged-action verification allows non-enterprise single-user principals and still rejects enterprise-mode single-user principals without a password.
+- Add auth client tests proving cached profile data alone does not count as stored auth.

--- a/Docs/Plans/2026-03-07-admin-ui-review-fixes-implementation-plan.md
+++ b/Docs/Plans/2026-03-07-admin-ui-review-fixes-implementation-plan.md
@@ -1,0 +1,31 @@
+## Stage 1: Document Approved Fix Scope
+**Goal**: Capture the validated design and concrete implementation scope for the follow-up review fixes.
+**Success Criteria**: Design doc and implementation plan exist in `Docs/Plans/`.
+**Tests**: None.
+**Status**: Complete
+
+## Stage 2: Add Regression Tests
+**Goal**: Add failing tests for enterprise API-key login rejection, single-user privileged-action fallback, and stale auth bootstrap.
+**Success Criteria**: New tests fail against the current implementation for the intended reasons.
+**Tests**:
+- `admin-ui/lib/auth.test.ts`
+- `admin-ui/app/api/auth/apikey/route` tests or equivalent backend-facing coverage
+- `tldw_Server_API/tests/Admin/...` guardrail coverage
+**Status**: Complete
+
+## Stage 3: Implement Fixes
+**Goal**: Update auth route, auth bootstrap, and privileged-action verification to match the approved design.
+**Success Criteria**: All new tests pass with minimal production changes.
+**Tests**: Stage 2 suite.
+**Status**: Complete
+
+## Stage 4: Verify and Prepare Branch
+**Goal**: Run the relevant frontend and backend verification suite and confirm the branch is ready for another review pass.
+**Success Criteria**: Lint, test, build, targeted pytest, and bandit succeed.
+**Tests**:
+- `bun run lint`
+- `bun run test`
+- `bun run build`
+- targeted `pytest`
+- targeted `bandit`
+**Status**: Complete

--- a/admin-ui/.env.example
+++ b/admin-ui/.env.example
@@ -9,6 +9,11 @@ NEXT_PUBLIC_API_VERSION=v1
 # Default login auth mode for the UI ("password" or "apikey"). Defaults to "password" when unset.
 NEXT_PUBLIC_DEFAULT_AUTH_MODE=password
 
+# Optional: allow human API-key login in the admin UI for local/single-user deployments.
+# Leave disabled for enterprise/live-customer administration.
+# NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=false
+# ADMIN_UI_ALLOW_API_KEY_LOGIN=false
+
 # Optional: X-API-KEY for single-user mode (server-side only; never expose to browsers)
 # SERVER_X_API_KEY=your-api-key-here
 

--- a/admin-ui/README.md
+++ b/admin-ui/README.md
@@ -55,8 +55,12 @@ Open `http://localhost:3001`.
 
 ## Authentication
 
-- **Single-user mode**: API key login (X-API-KEY); key stored in memory for the session.
-- **Multi-user mode**: username/password login via `/auth/login` and JWT stored in localStorage.
+- **Single-user mode**: API key login remains supported, but the validated key is moved into an
+  `httpOnly` session cookie after login instead of being persisted in web storage.
+- **Multi-user mode**: username/password login is exchanged through Next route handlers that set
+  `httpOnly` session cookies. Browser JavaScript never stores or reads admin bearer tokens.
+- **Authenticated API calls**: the UI sends privileged requests through `/api/proxy/*` on the same
+  origin, and the proxy attaches the server-managed credential to backend requests.
 
 ## System Ops Endpoints Used
 

--- a/admin-ui/README.md
+++ b/admin-ui/README.md
@@ -42,6 +42,8 @@ NEXT_PUBLIC_DEFAULT_AUTH_MODE=password
 `NEXT_PUBLIC_DEFAULT_AUTH_MODE` supports `password` (JWT) or `apikey` (single-user).
 `NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=true` is required before the UI will expose the API-key login
 tab, and `ADMIN_UI_ALLOW_API_KEY_LOGIN=true` is required before the server-side route will accept it.
+The server-side API-key login route also requires `AUTH_MODE=single_user`; it is rejected in
+multi-user deployments even if the UI toggle is enabled.
 Leave both disabled for enterprise/live-customer admin use.
 
 Optional JWT local verification (middleware) reads `JWT_SECRET_KEY`, `JWT_SECONDARY_SECRET`,

--- a/admin-ui/README.md
+++ b/admin-ui/README.md
@@ -40,6 +40,9 @@ NEXT_PUBLIC_DEFAULT_AUTH_MODE=password
 ```
 
 `NEXT_PUBLIC_DEFAULT_AUTH_MODE` supports `password` (JWT) or `apikey` (single-user).
+`NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN=true` is required before the UI will expose the API-key login
+tab, and `ADMIN_UI_ALLOW_API_KEY_LOGIN=true` is required before the server-side route will accept it.
+Leave both disabled for enterprise/live-customer admin use.
 
 Optional JWT local verification (middleware) reads `JWT_SECRET_KEY`, `JWT_SECONDARY_SECRET`,
 and `JWT_ALGORITHM` (HS256/384/512). If missing or invalid, the middleware falls back
@@ -56,7 +59,8 @@ Open `http://localhost:3001`.
 ## Authentication
 
 - **Single-user mode**: API key login remains supported, but the validated key is moved into an
-  `httpOnly` session cookie after login instead of being persisted in web storage.
+  `httpOnly` session cookie after login instead of being persisted in web storage. This path is
+  disabled by default and should only be re-enabled for local/single-user deployments.
 - **Multi-user mode**: username/password login is exchanged through Next route handlers that set
   `httpOnly` session cookies. Browser JavaScript never stores or reads admin bearer tokens.
 - **Authenticated API calls**: the UI sends privileged requests through `/api/proxy/*` on the same

--- a/admin-ui/app/api/auth/apikey/route.test.ts
+++ b/admin-ui/app/api/auth/apikey/route.test.ts
@@ -1,0 +1,46 @@
+/* @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const setApiKeySessionCookies = vi.fn();
+const buildApiUrl = vi.fn((path: string) => `https://example.test${path}`);
+
+vi.mock('@/lib/api-config', () => ({
+  buildApiUrl,
+}));
+
+vi.mock('@/lib/server-auth', () => ({
+  setApiKeySessionCookies,
+}));
+
+describe('POST /api/auth/apikey', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN = 'true';
+    process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN = 'false';
+    delete process.env.ADMIN_UI_ENTERPRISE_MODE;
+  });
+
+  it('rejects API-key login when enterprise mode is enabled', async () => {
+    process.env.ADMIN_UI_ENTERPRISE_MODE = 'true';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('./route');
+    const response = await POST(new NextRequest('http://localhost/api/auth/apikey', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'admin-key' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Admin UI API key login is disabled. Use multi-user credentials.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(setApiKeySessionCookies).not.toHaveBeenCalled();
+  });
+});

--- a/admin-ui/app/api/auth/apikey/route.test.ts
+++ b/admin-ui/app/api/auth/apikey/route.test.ts
@@ -66,4 +66,27 @@ describe('POST /api/auth/apikey', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     expect(setApiKeySessionCookies).not.toHaveBeenCalled();
   });
+
+  it('rejects API-key login when only the public UI flag is enabled', async () => {
+    process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN = 'false';
+    process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN = 'true';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('./route');
+    const response = await POST(new NextRequest('http://localhost/api/auth/apikey', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'admin-key' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Admin UI API key login is disabled. Use multi-user credentials.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(setApiKeySessionCookies).not.toHaveBeenCalled();
+  });
 });

--- a/admin-ui/app/api/auth/apikey/route.test.ts
+++ b/admin-ui/app/api/auth/apikey/route.test.ts
@@ -17,6 +17,7 @@ describe('POST /api/auth/apikey', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    process.env.AUTH_MODE = 'single_user';
     process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN = 'true';
     process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN = 'false';
     delete process.env.ADMIN_UI_ENTERPRISE_MODE;
@@ -24,6 +25,28 @@ describe('POST /api/auth/apikey', () => {
 
   it('rejects API-key login when enterprise mode is enabled', async () => {
     process.env.ADMIN_UI_ENTERPRISE_MODE = 'true';
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('./route');
+    const response = await POST(new NextRequest('http://localhost/api/auth/apikey', {
+      method: 'POST',
+      body: JSON.stringify({ apiKey: 'admin-key' }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }));
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      detail: 'Admin UI API key login is disabled. Use multi-user credentials.',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(setApiKeySessionCookies).not.toHaveBeenCalled();
+  });
+
+  it('rejects API-key login when the admin UI is not running in single-user auth mode', async () => {
+    process.env.AUTH_MODE = 'multi_user';
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 

--- a/admin-ui/app/api/auth/apikey/route.ts
+++ b/admin-ui/app/api/auth/apikey/route.ts
@@ -2,7 +2,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { buildApiUrl } from '@/lib/api-config';
 import { setApiKeySessionCookies } from '@/lib/server-auth';
 
+const isAdminApiKeyLoginEnabled = (): boolean =>
+  process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN === 'true'
+  || process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN === 'true';
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isAdminApiKeyLoginEnabled()) {
+    return NextResponse.json(
+      { detail: 'Admin UI API key login is disabled. Use multi-user credentials.' },
+      { status: 403 }
+    );
+  }
+
   const body = await request.json().catch(() => null) as { apiKey?: string } | null;
   const apiKey = body?.apiKey?.trim();
 

--- a/admin-ui/app/api/auth/apikey/route.ts
+++ b/admin-ui/app/api/auth/apikey/route.ts
@@ -3,8 +3,7 @@ import { buildApiUrl } from '@/lib/api-config';
 import { setApiKeySessionCookies } from '@/lib/server-auth';
 
 const isAdminApiKeyLoginEnabled = (): boolean =>
-  process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN === 'true'
-  || process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN === 'true';
+  process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN === 'true';
 
 const isEnterpriseAdminUiMode = (): boolean =>
   process.env.ADMIN_UI_ENTERPRISE_MODE === 'true';

--- a/admin-ui/app/api/auth/apikey/route.ts
+++ b/admin-ui/app/api/auth/apikey/route.ts
@@ -6,8 +6,11 @@ const isAdminApiKeyLoginEnabled = (): boolean =>
   process.env.ADMIN_UI_ALLOW_API_KEY_LOGIN === 'true'
   || process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN === 'true';
 
+const isEnterpriseAdminUiMode = (): boolean =>
+  process.env.ADMIN_UI_ENTERPRISE_MODE === 'true';
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (!isAdminApiKeyLoginEnabled()) {
+  if (isEnterpriseAdminUiMode() || !isAdminApiKeyLoginEnabled()) {
     return NextResponse.json(
       { detail: 'Admin UI API key login is disabled. Use multi-user credentials.' },
       { status: 403 }

--- a/admin-ui/app/api/auth/apikey/route.ts
+++ b/admin-ui/app/api/auth/apikey/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildApiUrl } from '@/lib/api-config';
+import { setApiKeySessionCookies } from '@/lib/server-auth';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.json().catch(() => null) as { apiKey?: string } | null;
+  const apiKey = body?.apiKey?.trim();
+
+  if (!apiKey) {
+    return NextResponse.json({ detail: 'API key is required' }, { status: 400 });
+  }
+
+  const response = await fetch(buildApiUrl('/users/me'), {
+    method: 'GET',
+    headers: {
+      'X-API-KEY': apiKey,
+    },
+    cache: 'no-store',
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || !payload) {
+    return NextResponse.json(payload ?? { detail: 'API key validation failed' }, { status: response.status });
+  }
+
+  const nextResponse = NextResponse.json({ user: payload }, { status: 200 });
+  setApiKeySessionCookies(nextResponse, apiKey);
+  return nextResponse;
+}

--- a/admin-ui/app/api/auth/apikey/route.ts
+++ b/admin-ui/app/api/auth/apikey/route.ts
@@ -9,8 +9,11 @@ const isAdminApiKeyLoginEnabled = (): boolean =>
 const isEnterpriseAdminUiMode = (): boolean =>
   process.env.ADMIN_UI_ENTERPRISE_MODE === 'true';
 
+const isSingleUserAuthMode = (): boolean =>
+  process.env.AUTH_MODE === 'single_user';
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  if (isEnterpriseAdminUiMode() || !isAdminApiKeyLoginEnabled()) {
+  if (isEnterpriseAdminUiMode() || !isAdminApiKeyLoginEnabled() || !isSingleUserAuthMode()) {
     return NextResponse.json(
       { detail: 'Admin UI API key login is disabled. Use multi-user credentials.' },
       { status: 403 }

--- a/admin-ui/app/api/auth/login/route.ts
+++ b/admin-ui/app/api/auth/login/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildApiUrl } from '@/lib/api-config';
+import { setJwtSessionCookies } from '@/lib/server-auth';
+
+type LoginResponsePayload = {
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  session_token?: string;
+  mfa_required?: boolean;
+  message?: string;
+};
+
+const sanitizePayload = (payload: LoginResponsePayload): Omit<LoginResponsePayload, 'access_token' | 'refresh_token'> => {
+  const sanitized = { ...payload };
+  delete sanitized.access_token;
+  delete sanitized.refresh_token;
+  return sanitized;
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.text();
+  const response = await fetch(buildApiUrl('/auth/login'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': request.headers.get('content-type') ?? 'application/x-www-form-urlencoded',
+    },
+    body,
+    cache: 'no-store',
+  });
+
+  const payload = await response.json().catch(() => null) as LoginResponsePayload | null;
+  if (!response.ok || !payload) {
+    return NextResponse.json(payload ?? { detail: 'Login failed' }, { status: response.status });
+  }
+
+  const nextResponse = NextResponse.json(sanitizePayload(payload), { status: response.status });
+  if (typeof payload.access_token === 'string') {
+    setJwtSessionCookies(nextResponse, {
+      accessToken: payload.access_token,
+      refreshToken: payload.refresh_token,
+      expiresIn: payload.expires_in,
+    });
+  }
+
+  return nextResponse;
+}

--- a/admin-ui/app/api/auth/logout/route.test.ts
+++ b/admin-ui/app/api/auth/logout/route.test.ts
@@ -1,0 +1,49 @@
+/* @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const buildApiUrl = vi.fn((path: string) => `https://example.test${path}`);
+const getBackendAuthHeaders = vi.fn(() => new Headers({ Authorization: 'Bearer test-token' }));
+const clearAdminSessionCookies = vi.fn();
+
+vi.mock('@/lib/api-config', () => ({
+  buildApiUrl,
+}));
+
+vi.mock('@/lib/server-auth', () => ({
+  clearAdminSessionCookies,
+  getBackendAuthHeaders,
+}));
+
+describe('POST /api/auth/logout', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('logs backend logout failures and still clears local session cookies', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('backend unavailable'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { POST } = await import('./route');
+    const request = new NextRequest('http://localhost/api/auth/logout', { method: 'POST' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(getBackendAuthHeaders).toHaveBeenCalledWith(request);
+    expect(fetchMock).toHaveBeenCalledWith('https://example.test/auth/logout', {
+      method: 'POST',
+      headers: new Headers({ Authorization: 'Bearer test-token' }),
+      cache: 'no-store',
+    });
+    expect(warnSpy).toHaveBeenCalledWith('Admin UI backend logout failed', {
+      error: 'backend unavailable',
+    });
+    expect(clearAdminSessionCookies).toHaveBeenCalledTimes(1);
+    expect(clearAdminSessionCookies).toHaveBeenCalledWith(expect.objectContaining({
+      cookies: expect.anything(),
+    }));
+  });
+});

--- a/admin-ui/app/api/auth/logout/route.ts
+++ b/admin-ui/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildApiUrl } from '@/lib/api-config';
+import { clearAdminSessionCookies, getBackendAuthHeaders } from '@/lib/server-auth';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const headers = getBackendAuthHeaders(request);
+
+  await fetch(buildApiUrl('/auth/logout'), {
+    method: 'POST',
+    headers,
+    cache: 'no-store',
+  }).catch(() => {
+    // Best-effort server logout. Local session cookies are still cleared below.
+  });
+
+  const response = NextResponse.json({ ok: true });
+  clearAdminSessionCookies(response);
+  return response;
+}

--- a/admin-ui/app/api/auth/logout/route.ts
+++ b/admin-ui/app/api/auth/logout/route.ts
@@ -5,13 +5,17 @@ import { clearAdminSessionCookies, getBackendAuthHeaders } from '@/lib/server-au
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const headers = getBackendAuthHeaders(request);
 
-  await fetch(buildApiUrl('/auth/logout'), {
-    method: 'POST',
-    headers,
-    cache: 'no-store',
-  }).catch(() => {
-    // Best-effort server logout. Local session cookies are still cleared below.
-  });
+  try {
+    await fetch(buildApiUrl('/auth/logout'), {
+      method: 'POST',
+      headers,
+      cache: 'no-store',
+    });
+  } catch (error) {
+    console.warn('Admin UI backend logout failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   const response = NextResponse.json({ ok: true });
   clearAdminSessionCookies(response);

--- a/admin-ui/app/api/auth/mfa/login/route.ts
+++ b/admin-ui/app/api/auth/mfa/login/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildApiUrl } from '@/lib/api-config';
+import { setJwtSessionCookies } from '@/lib/server-auth';
+
+type MfaLoginResponsePayload = {
+  access_token?: string;
+  refresh_token?: string;
+  token_type?: string;
+  expires_in?: number;
+};
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const body = await request.text();
+  const response = await fetch(buildApiUrl('/auth/mfa/login'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': request.headers.get('content-type') ?? 'application/json',
+    },
+    body,
+    cache: 'no-store',
+  });
+
+  const payload = await response.json().catch(() => null) as MfaLoginResponsePayload | null;
+  if (!response.ok || !payload) {
+    return NextResponse.json(payload ?? { detail: 'MFA login failed' }, { status: response.status });
+  }
+
+  if (typeof payload.access_token !== 'string') {
+    return NextResponse.json({ detail: 'MFA login failed' }, { status: 500 });
+  }
+
+  const nextResponse = NextResponse.json(
+    {
+      token_type: payload.token_type,
+      expires_in: payload.expires_in,
+    },
+    { status: response.status }
+  );
+
+  setJwtSessionCookies(nextResponse, {
+    accessToken: payload.access_token,
+    refreshToken: payload.refresh_token,
+    expiresIn: payload.expires_in,
+  });
+
+  return nextResponse;
+}

--- a/admin-ui/app/api/proxy/[...path]/route.ts
+++ b/admin-ui/app/api/proxy/[...path]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildApiUrl } from '@/lib/api-config';
+import {
+  appendProxyHeaders,
+  buildProxyResponse,
+  getBackendAuthHeaders,
+  getRequestBody,
+} from '@/lib/server-auth';
+
+const forward = async (request: NextRequest): Promise<NextResponse> => {
+  const backendPath = request.nextUrl.pathname.replace(/^\/api\/proxy/, '') || '/';
+  const backendUrl = new URL(buildApiUrl(backendPath));
+  backendUrl.search = request.nextUrl.search;
+
+  const headers = getBackendAuthHeaders(request);
+  appendProxyHeaders(request, headers);
+
+  const response = await fetch(backendUrl.toString(), {
+    method: request.method,
+    headers,
+    body: await getRequestBody(request),
+    cache: 'no-store',
+  });
+
+  return buildProxyResponse(response);
+};
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  return forward(request);
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  return forward(request);
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  return forward(request);
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  return forward(request);
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  return forward(request);
+}

--- a/admin-ui/app/login/__tests__/page.test.tsx
+++ b/admin-ui/app/login/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginPage from '../page';
+
+const routerPushMock = vi.hoisted(() => vi.fn());
+const loginWithPasswordMock = vi.hoisted(() => vi.fn());
+const loginWithApiKeyMock = vi.hoisted(() => vi.fn());
+const completeMfaLoginMock = vi.hoisted(() => vi.fn());
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPushMock,
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  loginWithPassword: loginWithPasswordMock,
+  loginWithApiKey: loginWithApiKeyMock,
+  completeMfaLogin: completeMfaLoginMock,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    loading,
+    loadingText,
+    ...props
+  }: JSX.IntrinsicElements['button'] & { loading?: boolean; loadingText?: string }) => (
+    <button type="button" {...props}>
+      {loading ? loadingText || children : children}
+    </button>
+  ),
+}));
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    routerPushMock.mockReset();
+    loginWithPasswordMock.mockReset();
+    loginWithApiKeyMock.mockReset();
+    completeMfaLoginMock.mockReset();
+    window.history.replaceState({}, '', '/login');
+  });
+
+  it('shows MFA challenge form instead of redirecting when password login requires MFA', async () => {
+    loginWithPasswordMock.mockResolvedValue({
+      status: 'mfa_required',
+      sessionToken: 'mfa-session-token',
+      expiresIn: 300,
+      message: 'MFA required. Submit your TOTP or backup code.',
+    });
+
+    render(<LoginPage />);
+    const user = userEvent.setup();
+
+    await user.type(screen.getByLabelText(/username or email/i), 'admin');
+    await user.type(screen.getByLabelText(/^password$/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText(/submit your totp or backup code/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/verification code/i)).toBeInTheDocument();
+    expect(routerPushMock).not.toHaveBeenCalled();
+  });
+});

--- a/admin-ui/app/login/__tests__/page.test.tsx
+++ b/admin-ui/app/login/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LoginPage from '../page';
 
@@ -37,12 +37,23 @@ vi.mock('@/components/ui/button', () => ({
 }));
 
 describe('LoginPage', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     routerPushMock.mockReset();
     loginWithPasswordMock.mockReset();
     loginWithApiKeyMock.mockReset();
     completeMfaLoginMock.mockReset();
     window.history.replaceState({}, '', '/login');
+  });
+
+  it('hides API key login by default for enterprise admin deployments', () => {
+    render(<LoginPage />);
+
+    expect(screen.queryByRole('tab', { name: /api key/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /username & password/i })).toBeInTheDocument();
   });
 
   it('shows MFA challenge form instead of redirecting when password login requires MFA', async () => {

--- a/admin-ui/app/login/page.tsx
+++ b/admin-ui/app/login/page.tsx
@@ -18,8 +18,9 @@ import {
 
 type AuthMode = 'password' | 'apikey';
 
+const API_KEY_LOGIN_ENABLED = process.env.NEXT_PUBLIC_ALLOW_ADMIN_API_KEY_LOGIN === 'true';
 const DEFAULT_AUTH_MODE: AuthMode =
-  process.env.NEXT_PUBLIC_DEFAULT_AUTH_MODE === 'apikey' ? 'apikey' : 'password';
+  API_KEY_LOGIN_ENABLED && process.env.NEXT_PUBLIC_DEFAULT_AUTH_MODE === 'apikey' ? 'apikey' : 'password';
 const APIKEY_MODE_VALUES = new Set(['apikey', 'api_key', 'api-key']);
 
 export default function LoginPage() {
@@ -140,7 +141,7 @@ export default function LoginPage() {
     document.body.dataset.loginHydrated = 'true';
     const params = new URLSearchParams(window.location.search);
     const modeParam = params.get('mode') || params.get('auth');
-    if (modeParam && APIKEY_MODE_VALUES.has(modeParam.toLowerCase())) {
+    if (API_KEY_LOGIN_ENABLED && modeParam && APIKEY_MODE_VALUES.has(modeParam.toLowerCase())) {
       setAuthMode('apikey');
     }
     setRedirectTarget(getRedirectTargetFromSearch(window.location.search));
@@ -173,21 +174,23 @@ export default function LoginPage() {
             >
               Username & Password
             </button>
-            <button
-              type="button"
-              id="apikey-tab"
-              role="tab"
-              aria-selected={authMode === 'apikey'}
-              aria-controls="apikey-panel"
-              onClick={() => handleModeChange('apikey')}
-              className={`flex-1 pb-2 text-sm font-medium ${
-                authMode === 'apikey'
-                  ? 'border-b-2 border-primary text-primary'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              API Key
-            </button>
+            {API_KEY_LOGIN_ENABLED ? (
+              <button
+                type="button"
+                id="apikey-tab"
+                role="tab"
+                aria-selected={authMode === 'apikey'}
+                aria-controls="apikey-panel"
+                onClick={() => handleModeChange('apikey')}
+                className={`flex-1 pb-2 text-sm font-medium ${
+                  authMode === 'apikey'
+                    ? 'border-b-2 border-primary text-primary'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                API Key
+              </button>
+            ) : null}
           </div>
 
           {authMode === 'password' ? (

--- a/admin-ui/app/login/page.tsx
+++ b/admin-ui/app/login/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { loginWithPassword, loginWithApiKey } from '@/lib/auth';
+import { completeMfaLogin, loginWithPassword, loginWithApiKey } from '@/lib/auth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -28,6 +28,12 @@ export default function LoginPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [serverError, setServerError] = useState('');
   const [redirectTarget, setRedirectTarget] = useState(DEFAULT_POST_LOGIN_REDIRECT);
+  const [mfaChallenge, setMfaChallenge] = useState<{
+    sessionToken: string;
+    expiresIn: number;
+    message: string;
+  } | null>(null);
+  const [mfaCode, setMfaCode] = useState('');
 
   // Password login form
   const passwordForm = useForm<LoginFormData>({
@@ -52,8 +58,15 @@ export default function LoginPage() {
 
     try {
       const result = await loginWithPassword(data.username, data.password);
-      if (result) {
+      if (result?.status === 'authenticated') {
         router.push(redirectTarget);
+      } else if (result?.status === 'mfa_required') {
+        setMfaChallenge({
+          sessionToken: result.sessionToken,
+          expiresIn: result.expiresIn,
+          message: result.message,
+        });
+        setMfaCode('');
       } else {
         setServerError('Invalid username or password.');
       }
@@ -90,9 +103,36 @@ export default function LoginPage() {
     }
   };
 
+  const handleMfaLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!mfaChallenge) return;
+    if (!mfaCode.trim()) {
+      setServerError('Verification code is required.');
+      return;
+    }
+
+    setServerError('');
+    setIsLoading(true);
+    try {
+      const result = await completeMfaLogin(mfaChallenge.sessionToken, mfaCode.trim());
+      if (result?.status === 'authenticated') {
+        router.push(redirectTarget);
+      } else {
+        setServerError('Invalid verification code.');
+      }
+    } catch (error) {
+      console.error('MFA authentication failed:', error);
+      setServerError('Authentication failed. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleModeChange = (mode: AuthMode) => {
     setAuthMode(mode);
     setServerError('');
+    setMfaChallenge(null);
+    setMfaCode('');
   };
 
   useEffect(() => {
@@ -152,63 +192,108 @@ export default function LoginPage() {
 
           {authMode === 'password' ? (
             <FormProvider {...passwordForm}>
-              <form
-                id="password-panel"
-                role="tabpanel"
-                aria-labelledby="password-tab"
-                onSubmit={passwordForm.handleSubmit(handlePasswordLogin)}
-                className="space-y-4"
-              >
-                <div className="space-y-2">
-                  <Label htmlFor="username">Username or Email</Label>
-                  <Input
-                    id="username"
-                    type="text"
-                    placeholder="admin"
-                    disabled={isLoading}
-                    autoComplete="username"
-                    {...passwordForm.register('username', {
-                      onChange: clearServerError,
-                    })}
-                    className={passwordForm.formState.errors.username ? 'border-destructive' : ''}
-                  />
-                  {passwordForm.formState.errors.username && (
-                    <p className="text-xs text-destructive">
-                      {passwordForm.formState.errors.username.message}
-                    </p>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="password">Password</Label>
-                  <Input
-                    id="password"
-                    type="password"
-                    placeholder="Enter your password"
-                    disabled={isLoading}
-                    autoComplete="current-password"
-                    {...passwordForm.register('password', {
-                      onChange: clearServerError,
-                    })}
-                    className={passwordForm.formState.errors.password ? 'border-destructive' : ''}
-                  />
-                  {passwordForm.formState.errors.password && (
-                    <p className="text-xs text-destructive">
-                      {passwordForm.formState.errors.password.message}
-                    </p>
-                  )}
-                </div>
-
-                {serverError && (
-                  <Alert variant="destructive">
-                    <AlertDescription>{serverError}</AlertDescription>
+              {mfaChallenge ? (
+                <form
+                  key="mfa-challenge"
+                  id="password-panel"
+                  role="tabpanel"
+                  aria-labelledby="password-tab"
+                  onSubmit={handleMfaLogin}
+                  className="space-y-4"
+                >
+                  <Alert>
+                    <AlertDescription>{mfaChallenge.message}</AlertDescription>
                   </Alert>
-                )}
 
-                <Button type="submit" className="w-full" disabled={isLoading} loading={isLoading} loadingText="Signing in...">
-                  Sign In
-                </Button>
-              </form>
+                  <div className="space-y-2">
+                    <Label htmlFor="verificationCode">Verification Code</Label>
+                    <Input
+                      id="verificationCode"
+                      type="text"
+                      placeholder="123456"
+                      disabled={isLoading}
+                      autoComplete="one-time-code"
+                      value={mfaCode}
+                      onChange={(event) => {
+                        clearServerError();
+                        setMfaCode(event.target.value);
+                      }}
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Enter your TOTP or backup code. Challenge expires in {mfaChallenge.expiresIn} seconds.
+                    </p>
+                  </div>
+
+                  {serverError && (
+                    <Alert variant="destructive">
+                      <AlertDescription>{serverError}</AlertDescription>
+                    </Alert>
+                  )}
+
+                  <Button type="submit" className="w-full" disabled={isLoading} loading={isLoading} loadingText="Verifying...">
+                    Verify MFA
+                  </Button>
+                </form>
+              ) : (
+                <form
+                  key="password-login"
+                  id="password-panel"
+                  role="tabpanel"
+                  aria-labelledby="password-tab"
+                  onSubmit={passwordForm.handleSubmit(handlePasswordLogin)}
+                  className="space-y-4"
+                >
+                  <div className="space-y-2">
+                    <Label htmlFor="username">Username or Email</Label>
+                    <Input
+                      id="username"
+                      type="text"
+                      placeholder="admin"
+                      disabled={isLoading}
+                      autoComplete="username"
+                      {...passwordForm.register('username', {
+                        onChange: clearServerError,
+                      })}
+                      className={passwordForm.formState.errors.username ? 'border-destructive' : ''}
+                    />
+                    {passwordForm.formState.errors.username && (
+                      <p className="text-xs text-destructive">
+                        {passwordForm.formState.errors.username.message}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="password">Password</Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      placeholder="Enter your password"
+                      disabled={isLoading}
+                      autoComplete="current-password"
+                      {...passwordForm.register('password', {
+                        onChange: clearServerError,
+                      })}
+                      className={passwordForm.formState.errors.password ? 'border-destructive' : ''}
+                    />
+                    {passwordForm.formState.errors.password && (
+                      <p className="text-xs text-destructive">
+                        {passwordForm.formState.errors.password.message}
+                      </p>
+                    )}
+                  </div>
+
+                  {serverError && (
+                    <Alert variant="destructive">
+                      <AlertDescription>{serverError}</AlertDescription>
+                    </Alert>
+                  )}
+
+                  <Button type="submit" className="w-full" disabled={isLoading} loading={isLoading} loadingText="Signing in...">
+                    Sign In
+                  </Button>
+                </form>
+              )}
             </FormProvider>
           ) : (
             <FormProvider {...apiKeyForm}>

--- a/admin-ui/app/providers.tsx
+++ b/admin-ui/app/providers.tsx
@@ -6,6 +6,7 @@ import { PermissionProvider } from '@/components/PermissionGuard';
 import { OrgContextProvider } from '@/components/OrgContextSwitcher';
 import { ToastProvider } from '@/components/ui/toast';
 import { ConfirmProvider } from '@/components/ui/confirm-dialog';
+import { PrivilegedActionDialogProvider } from '@/components/ui/privileged-action-dialog';
 import { KeyboardShortcutsProvider } from '@/components/KeyboardShortcuts';
 
 interface ProvidersProps {
@@ -17,13 +18,15 @@ export function Providers({ children }: ProvidersProps) {
     <ErrorBoundary>
       <ToastProvider>
         <ConfirmProvider>
-          <PermissionProvider>
-            <OrgContextProvider>
-              <KeyboardShortcutsProvider>
-                {children}
-              </KeyboardShortcutsProvider>
-            </OrgContextProvider>
-          </PermissionProvider>
+          <PrivilegedActionDialogProvider>
+            <PermissionProvider>
+              <OrgContextProvider>
+                <KeyboardShortcutsProvider>
+                  {children}
+                </KeyboardShortcutsProvider>
+              </OrgContextProvider>
+            </PermissionProvider>
+          </PrivilegedActionDialogProvider>
         </ConfirmProvider>
       </ToastProvider>
     </ErrorBoundary>

--- a/admin-ui/app/users/[id]/__tests__/page.test.tsx
+++ b/admin-ui/app/users/[id]/__tests__/page.test.tsx
@@ -112,7 +112,7 @@ beforeEach(() => {
     uuid: 'user-42',
     username: 'demo-user',
     email: 'demo@example.com',
-    role: 'member',
+    role: 'user',
     is_active: true,
     is_verified: true,
     storage_quota_mb: 1024,
@@ -201,7 +201,6 @@ beforeEach(() => {
   apiMock.getPermissions.mockResolvedValue([]);
   apiMock.getUserRateLimits.mockResolvedValue({});
   apiMock.resetUserPassword.mockResolvedValue({
-    temporary_password: 'TempP@ssw0rd123',
     force_password_change: false,
     message: 'Password reset successfully',
   });
@@ -218,6 +217,7 @@ describe('UserDetailPage password reset', () => {
     render(<UserDetailPage />);
 
     const resetButton = await screen.findByRole('button', { name: 'Reset Password' });
+    await user.type(screen.getByLabelText('Temporary Password to Set'), 'TempP@ssw0rd123');
     await user.click(screen.getByLabelText('Force Password Change on Next Login'));
     await user.click(resetButton);
 
@@ -229,6 +229,7 @@ describe('UserDetailPage password reset', () => {
 
     await waitFor(() => {
       expect(apiMock.resetUserPassword).toHaveBeenCalledWith('42', {
+        temporary_password: 'TempP@ssw0rd123',
         force_password_change: false,
         reason: 'Customer requested this change',
         admin_password: 'AdminPass123!',
@@ -237,10 +238,23 @@ describe('UserDetailPage password reset', () => {
 
     expect(toastSuccessMock).toHaveBeenCalledWith(
       'Password reset',
-      'A new temporary password has been generated.'
+      'Temporary password updated. Share it with the user through an approved secure channel.'
     );
-    expect(await screen.findByText('Temporary password (shown once)')).toBeInTheDocument();
-    expect(screen.getByText('TempP@ssw0rd123')).toBeInTheDocument();
+    expect(screen.queryByText('Temporary password (shown once)')).not.toBeInTheDocument();
+    expect(screen.queryByText('TempP@ssw0rd123')).not.toBeInTheDocument();
+  });
+
+  it('only exposes backend-supported platform roles in the role selector', async () => {
+    render(<UserDetailPage />);
+
+    const roleSelect = await screen.findByLabelText('Role') as HTMLSelectElement;
+    expect(roleSelect.value).toBe('user');
+    expect(screen.getByRole('option', { name: 'User' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Admin' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Service' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Member' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Super Admin' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Owner' })).not.toBeInTheDocument();
   });
 
   it('renders login history with success and failure badges', async () => {

--- a/admin-ui/app/users/[id]/__tests__/page.test.tsx
+++ b/admin-ui/app/users/[id]/__tests__/page.test.tsx
@@ -7,6 +7,7 @@ import UserDetailPage from '../page';
 import { api } from '@/lib/api-client';
 
 const confirmMock = vi.hoisted(() => vi.fn());
+const privilegedActionMock = vi.hoisted(() => vi.fn());
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
 const pushMock = vi.hoisted(() => vi.fn());
@@ -37,6 +38,10 @@ vi.mock('@/components/ResponsiveLayout', () => ({
 
 vi.mock('@/components/ui/confirm-dialog', () => ({
   useConfirm: () => confirmMock,
+}));
+
+vi.mock('@/components/ui/privileged-action-dialog', () => ({
+  usePrivilegedActionDialog: () => privilegedActionMock,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -94,6 +99,10 @@ const apiMock = api as unknown as ApiMock;
 
 beforeEach(() => {
   confirmMock.mockResolvedValue(true);
+  privilegedActionMock.mockResolvedValue({
+    reason: 'Customer requested this change',
+    adminPassword: 'AdminPass123!',
+  });
   toastSuccessMock.mockClear();
   toastErrorMock.mockClear();
   pushMock.mockClear();
@@ -213,7 +222,7 @@ describe('UserDetailPage password reset', () => {
     await user.click(resetButton);
 
     await waitFor(() => {
-      expect(confirmMock).toHaveBeenCalledWith(
+      expect(privilegedActionMock).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Reset Password' })
       );
     });
@@ -221,6 +230,8 @@ describe('UserDetailPage password reset', () => {
     await waitFor(() => {
       expect(apiMock.resetUserPassword).toHaveBeenCalledWith('42', {
         force_password_change: false,
+        reason: 'Customer requested this change',
+        admin_password: 'AdminPass123!',
       });
     });
 

--- a/admin-ui/app/users/[id]/__tests__/page.test.tsx
+++ b/admin-ui/app/users/[id]/__tests__/page.test.tsx
@@ -75,6 +75,7 @@ vi.mock('@/lib/api-client', () => {
       getUserPermissionOverrides: vi.fn(),
       getPermissions: vi.fn(),
       getUserRateLimits: vi.fn(),
+      updateUser: vi.fn(),
       resetUserPassword: vi.fn(),
     },
   };
@@ -92,6 +93,7 @@ type ApiMock = {
   getUserPermissionOverrides: ReturnType<typeof vi.fn>;
   getPermissions: ReturnType<typeof vi.fn>;
   getUserRateLimits: ReturnType<typeof vi.fn>;
+  updateUser: ReturnType<typeof vi.fn>;
   resetUserPassword: ReturnType<typeof vi.fn>;
 };
 
@@ -200,6 +202,7 @@ beforeEach(() => {
   });
   apiMock.getPermissions.mockResolvedValue([]);
   apiMock.getUserRateLimits.mockResolvedValue({});
+  apiMock.updateUser.mockResolvedValue({});
   apiMock.resetUserPassword.mockResolvedValue({
     force_password_change: false,
     message: 'Password reset successfully',
@@ -255,6 +258,43 @@ describe('UserDetailPage password reset', () => {
     expect(screen.queryByRole('option', { name: 'Member' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Super Admin' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Owner' })).not.toBeInTheDocument();
+  });
+
+  it('preserves an unsupported existing role when saving unrelated changes', async () => {
+    const user = userEvent.setup();
+    apiMock.getUser.mockResolvedValueOnce({
+      id: 42,
+      uuid: 'user-42',
+      username: 'demo-user',
+      email: 'demo@example.com',
+      role: 'member',
+      is_active: true,
+      is_verified: true,
+      storage_quota_mb: 1024,
+      storage_used_mb: 32,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      metadata: {
+        force_password_change: true,
+      },
+    });
+
+    render(<UserDetailPage />);
+
+    const roleSelect = await screen.findByLabelText('Role') as HTMLSelectElement;
+    expect(roleSelect.value).toBe('member');
+
+    const emailInput = screen.getByLabelText('Email');
+    await user.clear(emailInput);
+    await user.type(emailInput, 'legacy-updated@example.com');
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+    await waitFor(() => {
+      expect(apiMock.updateUser).toHaveBeenCalledWith('42', {
+        email: 'legacy-updated@example.com',
+      });
+    });
+    expect(privilegedActionMock).not.toHaveBeenCalled();
   });
 
   it('renders login history with success and failure badges', async () => {

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -62,10 +62,9 @@ type EffectivePermission = {
 };
 
 const roleOptions = [
-  { value: 'member', label: 'Member' },
+  { value: 'user', label: 'User' },
   { value: 'admin', label: 'Admin' },
-  { value: 'super_admin', label: 'Super Admin' },
-  { value: 'owner', label: 'Owner' },
+  { value: 'service', label: 'Service' },
 ] as const;
 
 type UserRole = (typeof roleOptions)[number]['value'];
@@ -96,7 +95,6 @@ type UserSession = {
 };
 
 type PasswordResetResponse = {
-  temporary_password?: string;
   force_password_change?: boolean;
   message?: string;
 };
@@ -357,12 +355,12 @@ export default function UserDetailPage() {
   const [teamMembershipsError, setTeamMembershipsError] = useState('');
   const [forcePasswordChangeOnNextLogin, setForcePasswordChangeOnNextLogin] = useState(true);
   const [passwordResetLoading, setPasswordResetLoading] = useState(false);
-  const [temporaryPassword, setTemporaryPassword] = useState('');
+  const [resetPasswordValue, setResetPasswordValue] = useState('');
 
   const [formData, setFormData] = useState<UserFormData>({
     username: '',
     email: '',
-    role: 'member',
+    role: 'user',
     is_active: true,
     storage_quota_mb: 0,
   });
@@ -404,7 +402,7 @@ export default function UserDetailPage() {
       setIsAuthorized(true);
       const data = await api.getUser(userId);
       const userValue = data as User & { rate_limits?: UserRateLimits; metadata?: Record<string, unknown> };
-      const roleValue = userValue.role && isValidRole(userValue.role) ? userValue.role : 'member';
+      const roleValue = userValue.role && isValidRole(userValue.role) ? userValue.role : 'user';
       setUser(userValue);
       setFormData({
         username: userValue.username || '',
@@ -779,6 +777,12 @@ export default function UserDetailPage() {
   };
 
   const handleResetPassword = async () => {
+    const normalizedTemporaryPassword = resetPasswordValue.trim();
+    if (normalizedTemporaryPassword.length < 10) {
+      showError('Password reset failed', 'Enter a temporary password with at least 10 characters.');
+      return;
+    }
+
     const approval = await promptPrivilegedAction({
       title: 'Reset Password',
       message: `Reset password for ${user?.username || user?.email || 'this user'}?`,
@@ -788,16 +792,17 @@ export default function UserDetailPage() {
 
     try {
       setPasswordResetLoading(true);
-      const result = await api.resetUserPassword(userId, {
+      await api.resetUserPassword(userId, {
+        temporary_password: normalizedTemporaryPassword,
         force_password_change: forcePasswordChangeOnNextLogin,
         reason: approval.reason,
         admin_password: approval.adminPassword,
       }) as PasswordResetResponse;
-      const tempPassword = typeof result.temporary_password === 'string'
-        ? result.temporary_password
-        : '';
-      setTemporaryPassword(tempPassword);
-      toastSuccess('Password reset', 'A new temporary password has been generated.');
+      setResetPasswordValue('');
+      toastSuccess(
+        'Password reset',
+        'Temporary password updated. Share it with the user through an approved secure channel.'
+      );
       void loadUser();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to reset password';
@@ -1247,6 +1252,22 @@ export default function UserDetailPage() {
                         Reset Password
                       </Button>
                     </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="temporary-password">Temporary Password to Set</Label>
+                      <Input
+                        id="temporary-password"
+                        type="password"
+                        autoComplete="new-password"
+                        value={resetPasswordValue}
+                        onChange={(event) => setResetPasswordValue(event.target.value)}
+                        disabled={!isAuthorized || passwordResetLoading}
+                        minLength={10}
+                        placeholder="Enter a temporary password to share securely"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        Set the temporary password yourself so it never needs to be returned to the browser.
+                      </p>
+                    </div>
                     <label className="flex items-center gap-2 text-sm">
                       <input
                         type="checkbox"
@@ -1257,14 +1278,6 @@ export default function UserDetailPage() {
                       />
                       Force Password Change on Next Login
                     </label>
-                    {temporaryPassword && (
-                      <Alert>
-                        <AlertDescription className="space-y-1">
-                          <div className="font-medium">Temporary password (shown once)</div>
-                          <code className="rounded bg-muted px-2 py-1 text-xs">{temporaryPassword}</code>
-                        </AlertDescription>
-                      </Alert>
-                    )}
                   </div>
 
                   <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -19,6 +19,7 @@ import { useToast } from '@/components/ui/toast';
 import { ArrowLeft, Key, Save, Building2, Users, Shield, Monitor, RefreshCw, Trash2, Clock, ShieldCheck, Plus, X } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api, ApiError } from '@/lib/api-client';
+import { isSingleUserMode } from '@/lib/auth';
 import { formatDateTime } from '@/lib/format';
 import { parseOptionalInt } from '@/lib/number';
 import {
@@ -331,6 +332,7 @@ export default function UserDetailPage() {
   const confirm = useConfirm();
   const promptPrivilegedAction = usePrivilegedActionDialog();
   const { success: toastSuccess, error: showError } = useToast();
+  const requirePasswordReauth = !isSingleUserMode();
 
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
@@ -701,6 +703,7 @@ export default function UserDetailPage() {
           title: 'Apply privileged user changes',
           message: 'Changing role or activation state requires a reason and reauthentication.',
           confirmText: 'Apply changes',
+          requirePassword: requirePasswordReauth,
         });
         if (!approval) {
           setSaving(false);
@@ -739,6 +742,7 @@ export default function UserDetailPage() {
       title: 'Disable MFA',
       message: `Disable MFA for ${user?.username || user?.email || 'this user'}?`,
       confirmText: 'Disable MFA',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -760,6 +764,7 @@ export default function UserDetailPage() {
       title: 'Revoke Session',
       message: 'Revoke this session? The user will be signed out on that device.',
       confirmText: 'Revoke',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -781,6 +786,7 @@ export default function UserDetailPage() {
       title: 'Revoke All Sessions',
       message: 'Revoke all active sessions for this user? They will be signed out everywhere.',
       confirmText: 'Revoke all',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -808,6 +814,7 @@ export default function UserDetailPage() {
       title: 'Reset Password',
       message: `Reset password for ${user?.username || user?.email || 'this user'}?`,
       confirmText: 'Reset password',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -14,6 +14,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useConfirm } from '@/components/ui/confirm-dialog';
+import { usePrivilegedActionDialog } from '@/components/ui/privileged-action-dialog';
 import { useToast } from '@/components/ui/toast';
 import { ArrowLeft, Key, Save, Building2, Users, Shield, Monitor, RefreshCw, Trash2, Clock, ShieldCheck, Plus, X } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
@@ -330,6 +331,7 @@ export default function UserDetailPage() {
   const router = useRouter();
   const userId = Array.isArray(params.id) ? params.id[0] : params.id;
   const confirm = useConfirm();
+  const promptPrivilegedAction = usePrivilegedActionDialog();
   const { success: toastSuccess, error: showError } = useToast();
 
   const [user, setUser] = useState<User | null>(null);
@@ -664,11 +666,34 @@ export default function UserDetailPage() {
       setError('You are not authorized to update this user.');
       return;
     }
+    const requiresPrivilegedApproval = Boolean(
+      user && (
+        formData.role !== user.role
+        || formData.is_active !== user.is_active
+      )
+    );
     try {
       setSaving(true);
       setError('');
       setSuccess('');
-      await api.updateUser(userId, formData);
+      let payload: Record<string, unknown> = { ...formData };
+      if (requiresPrivilegedApproval) {
+        const approval = await promptPrivilegedAction({
+          title: 'Apply privileged user changes',
+          message: 'Changing role or activation state requires a reason and reauthentication.',
+          confirmText: 'Apply changes',
+        });
+        if (!approval) {
+          setSaving(false);
+          return;
+        }
+        payload = {
+          ...payload,
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        };
+      }
+      await api.updateUser(userId, payload);
       setSuccess('User updated successfully');
       void loadUser();
     } catch (err: unknown) {
@@ -691,17 +716,18 @@ export default function UserDetailPage() {
 
   const handleDisableMfa = async () => {
     if (!mfaStatus?.enabled) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Disable MFA',
       message: `Disable MFA for ${user?.username || user?.email || 'this user'}?`,
       confirmText: 'Disable MFA',
-      variant: 'danger',
-      icon: 'delete',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
-      await api.disableUserMfa(userId);
+      await api.disableUserMfa(userId, {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
       toastSuccess('MFA disabled', 'Multi-factor authentication has been turned off.');
       void loadSecurity();
     } catch (err: unknown) {
@@ -711,17 +737,18 @@ export default function UserDetailPage() {
   };
 
   const handleRevokeSession = async (session: UserSession) => {
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Revoke Session',
       message: 'Revoke this session? The user will be signed out on that device.',
       confirmText: 'Revoke',
-      variant: 'warning',
-      icon: 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
-      await api.revokeUserSession(userId, session.id.toString());
+      await api.revokeUserSession(userId, session.id.toString(), {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
       toastSuccess('Session revoked', 'The session has been revoked.');
       void loadSecurity();
     } catch (err: unknown) {
@@ -731,17 +758,18 @@ export default function UserDetailPage() {
   };
 
   const handleRevokeAllSessions = async () => {
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Revoke All Sessions',
       message: 'Revoke all active sessions for this user? They will be signed out everywhere.',
       confirmText: 'Revoke all',
-      variant: 'warning',
-      icon: 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
-      await api.revokeAllUserSessions(userId);
+      await api.revokeAllUserSessions(userId, {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
       toastSuccess('Sessions revoked', 'All sessions have been revoked.');
       void loadSecurity();
     } catch (err: unknown) {
@@ -751,19 +779,19 @@ export default function UserDetailPage() {
   };
 
   const handleResetPassword = async () => {
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Reset Password',
       message: `Reset password for ${user?.username || user?.email || 'this user'}?`,
       confirmText: 'Reset password',
-      variant: 'warning',
-      icon: 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setPasswordResetLoading(true);
       const result = await api.resetUserPassword(userId, {
         force_password_change: forcePasswordChangeOnNextLogin,
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
       }) as PasswordResetResponse;
       const tempPassword = typeof result.temporary_password === 'string'
         ? result.temporary_password

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -72,7 +72,7 @@ type UserRole = (typeof roleOptions)[number]['value'];
 type UserFormData = {
   username: string;
   email: string;
-  role: UserRole;
+  role: string;
   is_active: boolean;
   storage_quota_mb: number;
 };
@@ -402,7 +402,9 @@ export default function UserDetailPage() {
       setIsAuthorized(true);
       const data = await api.getUser(userId);
       const userValue = data as User & { rate_limits?: UserRateLimits; metadata?: Record<string, unknown> };
-      const roleValue = userValue.role && isValidRole(userValue.role) ? userValue.role : 'user';
+      const roleValue = typeof userValue.role === 'string' && userValue.role.trim()
+        ? userValue.role
+        : 'user';
       setUser(userValue);
       setFormData({
         username: userValue.username || '',
@@ -674,7 +676,26 @@ export default function UserDetailPage() {
       setSaving(true);
       setError('');
       setSuccess('');
-      let payload: Record<string, unknown> = { ...formData };
+      const payload: Record<string, unknown> = {};
+      const normalizedEmail = formData.email.trim();
+      const currentEmail = typeof user?.email === 'string' ? user.email.trim() : '';
+      if (normalizedEmail !== currentEmail) {
+        payload.email = normalizedEmail;
+      }
+      if (user && formData.role !== user.role && isValidRole(formData.role)) {
+        payload.role = formData.role;
+      }
+      if (user && formData.is_active !== user.is_active) {
+        payload.is_active = formData.is_active;
+      }
+      if (user && formData.storage_quota_mb !== user.storage_quota_mb) {
+        payload.storage_quota_mb = formData.storage_quota_mb;
+      }
+      if (Object.keys(payload).length === 0) {
+        setSuccess('No changes to save');
+        setSaving(false);
+        return;
+      }
       if (requiresPrivilegedApproval) {
         const approval = await promptPrivilegedAction({
           title: 'Apply privileged user changes',
@@ -685,11 +706,11 @@ export default function UserDetailPage() {
           setSaving(false);
           return;
         }
-        payload = {
+        Object.assign(payload, {
           ...payload,
           reason: approval.reason,
           admin_password: approval.adminPassword,
-        };
+        });
       }
       await api.updateUser(userId, payload);
       setSuccess('User updated successfully');
@@ -1107,12 +1128,22 @@ export default function UserDetailPage() {
                         }
                       }}
                     >
+                      {!isValidRole(formData.role) && formData.role ? (
+                        <option value={formData.role}>
+                          Unsupported ({formData.role})
+                        </option>
+                      ) : null}
                       {roleOptions.map((option) => (
                         <option key={option.value} value={option.value}>
                           {option.label}
                         </option>
                       ))}
                     </Select>
+                    {!isValidRole(formData.role) && formData.role ? (
+                      <p className="text-xs text-muted-foreground">
+                        This account uses an unsupported role value. It will be preserved unless you explicitly choose a supported replacement.
+                      </p>
+                    ) : null}
                   </div>
 
                   <div className="flex items-center gap-2">

--- a/admin-ui/app/users/__tests__/page.test.tsx
+++ b/admin-ui/app/users/__tests__/page.test.tsx
@@ -8,6 +8,7 @@ import { api } from '@/lib/api-client';
 import { formatAxeViolations, getCriticalAndSeriousAxeViolations } from '@/test-utils/axe';
 
 const confirmMock = vi.hoisted(() => vi.fn());
+const privilegedActionMock = vi.hoisted(() => vi.fn());
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
 
@@ -52,6 +53,10 @@ vi.mock('@/components/ResponsiveLayout', () => ({
 
 vi.mock('@/components/ui/confirm-dialog', () => ({
   useConfirm: () => confirmMock,
+}));
+
+vi.mock('@/components/ui/privileged-action-dialog', () => ({
+  usePrivilegedActionDialog: () => privilegedActionMock,
 }));
 
 vi.mock('@/components/ui/toast', () => ({
@@ -130,6 +135,10 @@ const makeUser = (overrides: Partial<Record<string, unknown>> = {}) => ({
 
 beforeEach(() => {
   confirmMock.mockResolvedValue(true);
+  privilegedActionMock.mockResolvedValue({
+    reason: 'Customer requested this change',
+    adminPassword: 'AdminPass123!',
+  });
   toastSuccessMock.mockClear();
   toastErrorMock.mockClear();
 
@@ -288,12 +297,16 @@ describe('UsersPage', () => {
     await user.click(screen.getByRole('button', { name: 'Assign Role' }));
 
     await waitFor(() => {
-      expect(confirmMock).toHaveBeenCalledWith(
+      expect(privilegedActionMock).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Assign role to selected users' })
       );
     });
     await waitFor(() => {
-      expect(apiMock.updateUser).toHaveBeenCalledWith('2', { role: 'admin' });
+      expect(apiMock.updateUser).toHaveBeenCalledWith('2', {
+        role: 'admin',
+        reason: 'Customer requested this change',
+        admin_password: 'AdminPass123!',
+      });
     });
   });
 
@@ -306,13 +319,15 @@ describe('UsersPage', () => {
     await user.click(screen.getByRole('button', { name: 'Reset Passwords' }));
 
     await waitFor(() => {
-      expect(confirmMock).toHaveBeenCalledWith(
+      expect(privilegedActionMock).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Reset selected user passwords' })
       );
     });
     await waitFor(() => {
       expect(apiMock.resetUserPassword).toHaveBeenCalledWith('2', {
         force_password_change: true,
+        reason: 'Customer requested this change',
+        admin_password: 'AdminPass123!',
       });
     });
   });
@@ -326,13 +341,15 @@ describe('UsersPage', () => {
     await user.click(screen.getByRole('button', { name: 'Require MFA' }));
 
     await waitFor(() => {
-      expect(confirmMock).toHaveBeenCalledWith(
+      expect(privilegedActionMock).toHaveBeenCalledWith(
         expect.objectContaining({ title: 'Require MFA for selected users' })
       );
     });
     await waitFor(() => {
       expect(apiMock.setUserMfaRequirement).toHaveBeenCalledWith('2', {
         require_mfa: true,
+        reason: 'Customer requested this change',
+        admin_password: 'AdminPass123!',
       });
     });
   });

--- a/admin-ui/app/users/__tests__/page.test.tsx
+++ b/admin-ui/app/users/__tests__/page.test.tsx
@@ -310,26 +310,14 @@ describe('UsersPage', () => {
     });
   });
 
-  it('supports bulk password reset for selected users', async () => {
+  it('does not offer bulk password reset from the list view', async () => {
     const user = userEvent.setup();
     render(<UsersPage />);
 
     await screen.findByText('Bob');
     await user.click(screen.getByRole('checkbox', { name: /select user bob/i }));
-    await user.click(screen.getByRole('button', { name: 'Reset Passwords' }));
 
-    await waitFor(() => {
-      expect(privilegedActionMock).toHaveBeenCalledWith(
-        expect.objectContaining({ title: 'Reset selected user passwords' })
-      );
-    });
-    await waitFor(() => {
-      expect(apiMock.resetUserPassword).toHaveBeenCalledWith('2', {
-        force_password_change: true,
-        reason: 'Customer requested this change',
-        admin_password: 'AdminPass123!',
-      });
-    });
+    expect(screen.queryByRole('button', { name: 'Reset Passwords' })).not.toBeInTheDocument();
   });
 
   it('supports bulk MFA requirement updates for selected users', async () => {

--- a/admin-ui/app/users/page.tsx
+++ b/admin-ui/app/users/page.tsx
@@ -41,6 +41,7 @@ import { exportUsers, ExportFormat } from '@/lib/export';
 import { Skeleton, TableSkeleton } from '@/components/ui/skeleton';
 import { useUrlState, useUrlPagination } from '@/lib/use-url-state';
 import { useConfirm } from '@/components/ui/confirm-dialog';
+import { usePrivilegedActionDialog } from '@/components/ui/privileged-action-dialog';
 import { useToast } from '@/components/ui/toast';
 import { useOrgContext } from '@/components/OrgContextSwitcher';
 import { useResourceState } from '@/lib/use-resource-state';
@@ -163,6 +164,7 @@ const invitationStatusBadgeVariant = (status: InvitationStatus): 'default' | 'se
 function UsersPageContent() {
   const router = useRouter();
   const confirm = useConfirm();
+  const promptPrivilegedAction = usePrivilegedActionDialog();
   const { success, error: showError } = useToast();
   const { selectedOrg } = useOrgContext();
   const { user: currentUser } = usePermissions();
@@ -579,19 +581,21 @@ function UsersPageContent() {
   const handleBulkToggleActive = async (nextState: boolean) => {
     const ids = Array.from(selectedUserIds);
     if (ids.length === 0) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: nextState ? 'Activate selected users' : 'Deactivate selected users',
-      message: `${nextState ? 'Activate' : 'Deactivate'} ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
+      message: `${nextState ? 'Activate' : 'Deactivate'} ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? Reauthentication is required.`,
       confirmText: nextState ? 'Activate' : 'Deactivate',
-      variant: nextState ? 'default' : 'warning',
-      icon: nextState ? 'check' : 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setBulkAction(nextState ? 'activate' : 'deactivate');
       const results = await Promise.allSettled(
-        ids.map((id) => api.updateUser(id.toString(), { is_active: nextState }))
+        ids.map((id) => api.updateUser(id.toString(), {
+          is_active: nextState,
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        }))
       );
       const failures = results.filter((result) => result.status === 'rejected').length;
       if (failures > 0) {
@@ -622,19 +626,20 @@ function UsersPageContent() {
       showError('Cannot delete yourself', 'Remove your account from the selection to continue.');
       return;
     }
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Delete selected users',
       message: `Delete ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? This cannot be undone.`,
       confirmText: 'Delete',
-      variant: 'danger',
-      icon: 'delete',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setBulkAction('delete');
       const results = await Promise.allSettled(
-        ids.map((id) => api.deleteUser(id.toString()))
+        ids.map((id) => api.deleteUser(id.toString(), {
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        }))
       );
       const failures = results.filter((result) => result.status === 'rejected').length;
       if (failures > 0) {
@@ -661,19 +666,21 @@ function UsersPageContent() {
   const handleBulkAssignRole = async () => {
     const ids = Array.from(selectedUserIds);
     if (ids.length === 0 || !bulkRole) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Assign role to selected users',
-      message: `Assign "${bulkRole}" role to ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
+      message: `Assign "${bulkRole}" role to ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? Reauthentication is required.`,
       confirmText: 'Assign role',
-      variant: 'default',
-      icon: 'check',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setBulkAction('assign-role');
       const results = await Promise.allSettled(
-        ids.map((id) => api.updateUser(id.toString(), { role: bulkRole }))
+        ids.map((id) => api.updateUser(id.toString(), {
+          role: bulkRole,
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        }))
       );
       const failures = results.filter((result) => result.status === 'rejected').length;
       if (failures > 0) {
@@ -700,19 +707,21 @@ function UsersPageContent() {
   const handleBulkResetPasswords = async () => {
     const ids = Array.from(selectedUserIds);
     if (ids.length === 0) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Reset selected user passwords',
       message: `Reset passwords for ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
       confirmText: 'Reset passwords',
-      variant: 'warning',
-      icon: 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setBulkAction('reset-password');
       const results = await Promise.allSettled(
-        ids.map((id) => api.resetUserPassword(id.toString(), { force_password_change: true }))
+        ids.map((id) => api.resetUserPassword(id.toString(), {
+          force_password_change: true,
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        }))
       );
       const failures = results.filter((result) => result.status === 'rejected').length;
       if (failures > 0) {
@@ -738,19 +747,21 @@ function UsersPageContent() {
   const handleBulkSetMfaRequirement = async (requireMfa: boolean) => {
     const ids = Array.from(selectedUserIds);
     if (ids.length === 0) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: requireMfa ? 'Require MFA for selected users' : 'Clear MFA requirement for selected users',
       message: `${requireMfa ? 'Require MFA for' : 'Clear MFA requirement for'} ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
       confirmText: requireMfa ? 'Require MFA' : 'Clear requirement',
-      variant: requireMfa ? 'default' : 'warning',
-      icon: requireMfa ? 'check' : 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setBulkAction(requireMfa ? 'mfa-require' : 'mfa-clear');
       const results = await Promise.allSettled(
-        ids.map((id) => api.setUserMfaRequirement(id.toString(), { require_mfa: requireMfa }))
+        ids.map((id) => api.setUserMfaRequirement(id.toString(), {
+          require_mfa: requireMfa,
+          reason: approval.reason,
+          admin_password: approval.adminPassword,
+        }))
       );
       const failures = results.filter((result) => result.status === 'rejected').length;
       const successIds: number[] = [];
@@ -887,17 +898,19 @@ function UsersPageContent() {
 
   const handleToggleActive = async (user: User) => {
     const nextState = !user.is_active;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: nextState ? 'Activate User' : 'Deactivate User',
-      message: `${nextState ? 'Activate' : 'Deactivate'} ${user.username || user.email}?`,
+      message: `${nextState ? 'Activate' : 'Deactivate'} ${user.username || user.email}? Reauthentication is required.`,
       confirmText: nextState ? 'Activate' : 'Deactivate',
-      variant: nextState ? 'default' : 'warning',
-      icon: nextState ? 'check' : 'warning',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
-      await api.updateUser(user.id.toString(), { is_active: nextState });
+      await api.updateUser(user.id.toString(), {
+        is_active: nextState,
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
       success('User updated', `${user.username || user.email} ${nextState ? 'activated' : 'deactivated'}.`);
       void loadUsers();
     } catch (err: unknown) {
@@ -913,14 +926,12 @@ function UsersPageContent() {
     }
     const userId = user.id;
     if (deletingUserIds.has(userId)) return;
-    const confirmed = await confirm({
+    const approval = await promptPrivilegedAction({
       title: 'Delete User',
       message: `Delete ${user.username || user.email}? This cannot be undone.`,
       confirmText: 'Delete',
-      variant: 'danger',
-      icon: 'delete',
     });
-    if (!confirmed) return;
+    if (!approval) return;
 
     try {
       setDeletingUserIds((prev) => {
@@ -928,7 +939,10 @@ function UsersPageContent() {
         next.add(userId);
         return next;
       });
-      await api.deleteUser(String(userId));
+      await api.deleteUser(String(userId), {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
       success('User deleted', `${user.username || user.email} removed.`);
       void loadUsers();
     } catch (err: unknown) {

--- a/admin-ui/app/users/page.tsx
+++ b/admin-ui/app/users/page.tsx
@@ -60,7 +60,6 @@ type BulkActionType =
   | 'deactivate'
   | 'delete'
   | 'assign-role'
-  | 'reset-password'
   | 'mfa-require'
   | 'mfa-clear'
   | null;
@@ -704,46 +703,6 @@ function UsersPageContent() {
     }
   };
 
-  const handleBulkResetPasswords = async () => {
-    const ids = Array.from(selectedUserIds);
-    if (ids.length === 0) return;
-    const approval = await promptPrivilegedAction({
-      title: 'Reset selected user passwords',
-      message: `Reset passwords for ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
-      confirmText: 'Reset passwords',
-    });
-    if (!approval) return;
-
-    try {
-      setBulkAction('reset-password');
-      const results = await Promise.allSettled(
-        ids.map((id) => api.resetUserPassword(id.toString(), {
-          force_password_change: true,
-          reason: approval.reason,
-          admin_password: approval.adminPassword,
-        }))
-      );
-      const failures = results.filter((result) => result.status === 'rejected').length;
-      if (failures > 0) {
-        showError(
-          'Bulk password reset incomplete',
-          `${ids.length - failures} reset, ${failures} failed.`
-        );
-      } else {
-        success(
-          'Passwords reset',
-          `${ids.length} user${ids.length !== 1 ? 's' : ''} now require a password change on next login.`
-        );
-      }
-      handleClearSelection();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to reset passwords';
-      showError('Bulk password reset failed', message);
-    } finally {
-      setBulkAction(null);
-    }
-  };
-
   const handleBulkSetMfaRequirement = async (requireMfa: boolean) => {
     const ids = Array.from(selectedUserIds);
     if (ids.length === 0) return;
@@ -1343,17 +1302,6 @@ function UsersPageContent() {
                       >
                         <UserX className="mr-2 h-4 w-4" />
                         Deactivate
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleBulkResetPasswords}
-                        loading={bulkAction === 'reset-password'}
-                        loadingText="Resetting..."
-                        disabled={bulkBusy && bulkAction !== 'reset-password'}
-                      >
-                        <Key className="mr-2 h-4 w-4" />
-                        Reset Passwords
                       </Button>
                       <Button
                         variant="outline"

--- a/admin-ui/app/users/page.tsx
+++ b/admin-ui/app/users/page.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api } from '@/lib/api-client';
+import { isSingleUserMode } from '@/lib/auth';
 import { Organization, User } from '@/types';
 import { ExportMenu } from '@/components/ui/export-menu';
 import { exportUsers, ExportFormat } from '@/lib/export';
@@ -167,6 +168,7 @@ function UsersPageContent() {
   const { success, error: showError } = useToast();
   const { selectedOrg } = useOrgContext();
   const { user: currentUser } = usePermissions();
+  const requirePasswordReauth = !isSingleUserMode();
   const currentUserId = currentUser?.id;
   const [bulkAction, setBulkAction] = useState<BulkActionType>(null);
   const [selectedUserIds, setSelectedUserIds] = useState<Set<number>>(new Set());
@@ -584,6 +586,7 @@ function UsersPageContent() {
       title: nextState ? 'Activate selected users' : 'Deactivate selected users',
       message: `${nextState ? 'Activate' : 'Deactivate'} ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? Reauthentication is required.`,
       confirmText: nextState ? 'Activate' : 'Deactivate',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -629,6 +632,7 @@ function UsersPageContent() {
       title: 'Delete selected users',
       message: `Delete ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? This cannot be undone.`,
       confirmText: 'Delete',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -669,6 +673,7 @@ function UsersPageContent() {
       title: 'Assign role to selected users',
       message: `Assign "${bulkRole}" role to ${ids.length} selected user${ids.length !== 1 ? 's' : ''}? Reauthentication is required.`,
       confirmText: 'Assign role',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -710,6 +715,7 @@ function UsersPageContent() {
       title: requireMfa ? 'Require MFA for selected users' : 'Clear MFA requirement for selected users',
       message: `${requireMfa ? 'Require MFA for' : 'Clear MFA requirement for'} ${ids.length} selected user${ids.length !== 1 ? 's' : ''}?`,
       confirmText: requireMfa ? 'Require MFA' : 'Clear requirement',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -861,6 +867,7 @@ function UsersPageContent() {
       title: nextState ? 'Activate User' : 'Deactivate User',
       message: `${nextState ? 'Activate' : 'Deactivate'} ${user.username || user.email}? Reauthentication is required.`,
       confirmText: nextState ? 'Activate' : 'Deactivate',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 
@@ -889,6 +896,7 @@ function UsersPageContent() {
       title: 'Delete User',
       message: `Delete ${user.username || user.email}? This cannot be undone.`,
       confirmText: 'Delete',
+      requirePassword: requirePasswordReauth,
     });
     if (!approval) return;
 

--- a/admin-ui/components/ui/privileged-action-dialog.test.tsx
+++ b/admin-ui/components/ui/privileged-action-dialog.test.tsx
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Button } from './button';
+import {
+  PrivilegedActionDialogProvider,
+  usePrivilegedActionDialog,
+} from './privileged-action-dialog';
+
+function PrivilegedActionHarness() {
+  const prompt = usePrivilegedActionDialog();
+  const [result, setResult] = useState('idle');
+
+  return (
+    <div>
+      <Button
+        onClick={async () => {
+          const approval = await prompt({
+            title: 'Deactivate user',
+            message: 'Support action',
+            confirmText: 'Continue',
+            requirePassword: false,
+          });
+          setResult(approval ? `${approval.reason}|${approval.adminPassword}` : 'cancelled');
+        }}
+      >
+        Open dialog
+      </Button>
+      <p data-testid="privileged-action-result">{result}</p>
+    </div>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('usePrivilegedActionDialog', () => {
+  it('allows single-user approval without entering a password when password reauth is disabled', async () => {
+    render(
+      <PrivilegedActionDialogProvider>
+        <PrivilegedActionHarness />
+      </PrivilegedActionDialogProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open dialog' }));
+    fireEvent.change(screen.getByLabelText('Reason'), {
+      target: { value: 'Customer requested account restore' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('privileged-action-result').textContent).toBe(
+        'Customer requested account restore|'
+      );
+    });
+  });
+});

--- a/admin-ui/components/ui/privileged-action-dialog.tsx
+++ b/admin-ui/components/ui/privileged-action-dialog.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface PrivilegedActionOptions {
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export interface PrivilegedActionResult {
+  reason: string;
+  adminPassword: string;
+}
+
+interface PrivilegedActionContextType {
+  prompt: (options: PrivilegedActionOptions) => Promise<PrivilegedActionResult | null>;
+}
+
+const PrivilegedActionContext = createContext<PrivilegedActionContextType | null>(null);
+
+export function usePrivilegedActionDialog() {
+  const context = useContext(PrivilegedActionContext);
+  if (!context) {
+    throw new Error('usePrivilegedActionDialog must be used within a PrivilegedActionDialogProvider');
+  }
+  return context.prompt;
+}
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export function PrivilegedActionDialogProvider({ children }: ProviderProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [options, setOptions] = useState<PrivilegedActionOptions | null>(null);
+  const [reason, setReason] = useState('');
+  const [adminPassword, setAdminPassword] = useState('');
+  const [resolveRef, setResolveRef] = useState<((value: PrivilegedActionResult | null) => void) | null>(null);
+
+  const closeDialog = useCallback((value: PrivilegedActionResult | null) => {
+    setIsOpen(false);
+    setReason('');
+    setAdminPassword('');
+    resolveRef?.(value);
+    setResolveRef(null);
+  }, [resolveRef]);
+
+  const prompt = useCallback((nextOptions: PrivilegedActionOptions) => {
+    setOptions(nextOptions);
+    setReason('');
+    setAdminPassword('');
+    setIsOpen(true);
+
+    return new Promise<PrivilegedActionResult | null>((resolve) => {
+      setResolveRef(() => resolve);
+    });
+  }, []);
+
+  const canSubmit = reason.trim().length >= 8 && adminPassword.trim().length >= 8;
+
+  return (
+    <PrivilegedActionContext.Provider value={{ prompt }}>
+      {children}
+
+      <Dialog open={isOpen} onOpenChange={(open) => !open && closeDialog(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{options?.title || 'Privileged action'}</DialogTitle>
+            <DialogDescription>{options?.message}</DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="privileged-action-reason">Reason</Label>
+              <textarea
+                id="privileged-action-reason"
+                className="min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={reason}
+                onChange={(event) => setReason(event.target.value)}
+                placeholder="Describe why this action is necessary"
+              />
+              <p className="text-xs text-muted-foreground">
+                Required for auditability. Use at least 8 characters.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="privileged-action-password">Current password</Label>
+              <Input
+                id="privileged-action-password"
+                type="password"
+                value={adminPassword}
+                onChange={(event) => setAdminPassword(event.target.value)}
+                placeholder="Re-enter your password"
+                autoComplete="current-password"
+              />
+              <p className="text-xs text-muted-foreground">
+                Required to reauthenticate before this high-risk action.
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={() => closeDialog(null)}>
+              {options?.cancelText || 'Cancel'}
+            </Button>
+            <Button
+              onClick={() => closeDialog({ reason: reason.trim(), adminPassword: adminPassword.trim() })}
+              disabled={!canSubmit}
+            >
+              {options?.confirmText || 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PrivilegedActionContext.Provider>
+  );
+}

--- a/admin-ui/components/ui/privileged-action-dialog.tsx
+++ b/admin-ui/components/ui/privileged-action-dialog.tsx
@@ -18,6 +18,7 @@ export interface PrivilegedActionOptions {
   message: string;
   confirmText?: string;
   cancelText?: string;
+  requirePassword?: boolean;
 }
 
 export interface PrivilegedActionResult {
@@ -69,7 +70,8 @@ export function PrivilegedActionDialogProvider({ children }: ProviderProps) {
     });
   }, []);
 
-  const canSubmit = reason.trim().length >= 8 && adminPassword.trim().length >= 8;
+  const requiresPassword = options?.requirePassword ?? true;
+  const canSubmit = reason.trim().length >= 8 && (!requiresPassword || adminPassword.trim().length >= 8);
 
   return (
     <PrivilegedActionContext.Provider value={{ prompt }}>
@@ -97,20 +99,26 @@ export function PrivilegedActionDialogProvider({ children }: ProviderProps) {
               </p>
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="privileged-action-password">Current password</Label>
-              <Input
-                id="privileged-action-password"
-                type="password"
-                value={adminPassword}
-                onChange={(event) => setAdminPassword(event.target.value)}
-                placeholder="Re-enter your password"
-                autoComplete="current-password"
-              />
+            {requiresPassword ? (
+              <div className="space-y-2">
+                <Label htmlFor="privileged-action-password">Current password</Label>
+                <Input
+                  id="privileged-action-password"
+                  type="password"
+                  value={adminPassword}
+                  onChange={(event) => setAdminPassword(event.target.value)}
+                  placeholder="Re-enter your password"
+                  autoComplete="current-password"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Required to reauthenticate before this high-risk action.
+                </p>
+              </div>
+            ) : (
               <p className="text-xs text-muted-foreground">
-                Required to reauthenticate before this high-risk action.
+                Single-user mode requires an audit reason but does not prompt for password reauthentication.
               </p>
-            </div>
+            )}
           </div>
 
           <DialogFooter className="gap-2 sm:gap-0">

--- a/admin-ui/lib/admin-events.test.ts
+++ b/admin-ui/lib/admin-events.test.ts
@@ -32,9 +32,7 @@ describe('subscribeToAdminEvents', () => {
     vi.unstubAllGlobals();
   });
 
-  it('does not include credentials in query params and sends auth as headers', async () => {
-    localStorage.setItem('access_token', 'jwt-token-value');
-
+  it('does not include credentials in query params and uses the same-origin proxy', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       makeEventStreamResponse([
         'event: connected\ndata: {"event":"connected","category":"system","data":{},"timestamp":"2026-02-27T00:00:00Z"}\n\n',
@@ -56,12 +54,13 @@ describe('subscribeToAdminEvents', () => {
     });
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain('/admin/events/stream?categories=system%2Csecurity');
+    expect(url).toBe('/api/proxy/admin/events/stream?categories=system%2Csecurity');
     expect(url).not.toContain('token=');
     expect(url).not.toContain('api_key=');
 
     const headers = new Headers(init.headers);
-    expect(headers.get('Authorization')).toBe('Bearer jwt-token-value');
+    expect(headers.get('Authorization')).toBeNull();
+    expect(headers.get('X-API-KEY')).toBeNull();
     expect(headers.get('Accept')).toBe('text/event-stream');
     expect(onConnect).toHaveBeenCalledTimes(1);
 

--- a/admin-ui/lib/admin-events.ts
+++ b/admin-ui/lib/admin-events.ts
@@ -119,7 +119,7 @@ export function subscribeToAdminEvents(
     const queryString = params.toString();
     const url = buildProxyUrl(`/admin/events/stream${queryString ? `?${queryString}` : ''}`);
 
-    const headers = new Headers(buildAuthHeaders('GET'));
+    const headers = new Headers(buildAuthHeaders());
     headers.set('Accept', 'text/event-stream');
 
     abortController = new AbortController();

--- a/admin-ui/lib/admin-events.ts
+++ b/admin-ui/lib/admin-events.ts
@@ -1,7 +1,6 @@
 'use client';
 
-import { buildApiUrl } from './api-config';
-import { buildAuthHeaders } from './http';
+import { buildAuthHeaders, buildProxyUrl } from './http';
 
 export type AdminEventCategory = 'acp' | 'monitoring' | 'security' | 'budget' | 'jobs' | 'system';
 
@@ -118,7 +117,7 @@ export function subscribeToAdminEvents(
       params.set('categories', categories.join(','));
     }
     const queryString = params.toString();
-    const url = buildApiUrl(`/admin/events/stream${queryString ? `?${queryString}` : ''}`);
+    const url = buildProxyUrl(`/admin/events/stream${queryString ? `?${queryString}` : ''}`);
 
     const headers = new Headers(buildAuthHeaders('GET'));
     headers.set('Accept', 'text/event-stream');

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -138,23 +138,23 @@ export const api = {
   getUserEffectivePermissions: (userId: string) =>
     requestJson(`/admin/users/${userId}/effective-permissions`),
   getUserSessions: (userId: string) => requestJson(`/admin/users/${userId}/sessions`),
-  revokeUserSession: (userId: string, sessionId: string, data: { reason: string; admin_password: string }) =>
+  revokeUserSession: (userId: string, sessionId: string, data: { reason: string; admin_password?: string | null }) =>
     requestJson(`/admin/users/${userId}/sessions/${sessionId}`, {
       method: 'DELETE',
       body: JSON.stringify(data),
     }),
-  revokeAllUserSessions: (userId: string, data: { reason: string; admin_password: string }) =>
+  revokeAllUserSessions: (userId: string, data: { reason: string; admin_password?: string | null }) =>
     requestJson(`/admin/users/${userId}/sessions/revoke-all`, {
       method: 'POST',
       body: JSON.stringify(data),
     }),
   getUserMfaStatus: (userId: string) => requestJson(`/admin/users/${userId}/mfa`),
-  disableUserMfa: (userId: string, data: { reason: string; admin_password: string }) =>
+  disableUserMfa: (userId: string, data: { reason: string; admin_password?: string | null }) =>
     requestJson(`/admin/users/${userId}/mfa/disable`, {
       method: 'POST',
       body: JSON.stringify(data),
     }),
-  setUserMfaRequirement: (userId: string, data: { require_mfa: boolean; reason: string; admin_password: string }) =>
+  setUserMfaRequirement: (userId: string, data: { require_mfa: boolean; reason: string; admin_password?: string | null }) =>
     requestJson(`/admin/users/${userId}/mfa/require`, {
       method: 'POST',
       body: JSON.stringify(data),
@@ -165,12 +165,12 @@ export const api = {
   }),
   resetUserPassword: (
     userId: string,
-    data: { temporary_password?: string; force_password_change?: boolean; reason: string; admin_password: string }
+    data: { temporary_password: string; force_password_change?: boolean; reason: string; admin_password?: string | null }
   ) => requestJson(`/admin/users/${userId}/reset-password`, {
     method: 'POST',
     body: JSON.stringify(data),
   }),
-  deleteUser: (userId: string, data: { reason: string; admin_password: string }) => requestJson(`/admin/users/${userId}`, {
+  deleteUser: (userId: string, data: { reason: string; admin_password?: string | null }) => requestJson(`/admin/users/${userId}`, {
     method: 'DELETE',
     body: JSON.stringify(data),
   }),

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -138,20 +138,23 @@ export const api = {
   getUserEffectivePermissions: (userId: string) =>
     requestJson(`/admin/users/${userId}/effective-permissions`),
   getUserSessions: (userId: string) => requestJson(`/admin/users/${userId}/sessions`),
-  revokeUserSession: (userId: string, sessionId: string) =>
+  revokeUserSession: (userId: string, sessionId: string, data: { reason: string; admin_password: string }) =>
     requestJson(`/admin/users/${userId}/sessions/${sessionId}`, {
       method: 'DELETE',
+      body: JSON.stringify(data),
     }),
-  revokeAllUserSessions: (userId: string) =>
+  revokeAllUserSessions: (userId: string, data: { reason: string; admin_password: string }) =>
     requestJson(`/admin/users/${userId}/sessions/revoke-all`, {
       method: 'POST',
+      body: JSON.stringify(data),
     }),
   getUserMfaStatus: (userId: string) => requestJson(`/admin/users/${userId}/mfa`),
-  disableUserMfa: (userId: string) =>
+  disableUserMfa: (userId: string, data: { reason: string; admin_password: string }) =>
     requestJson(`/admin/users/${userId}/mfa/disable`, {
       method: 'POST',
+      body: JSON.stringify(data),
     }),
-  setUserMfaRequirement: (userId: string, data: { require_mfa: boolean }) =>
+  setUserMfaRequirement: (userId: string, data: { require_mfa: boolean; reason: string; admin_password: string }) =>
     requestJson(`/admin/users/${userId}/mfa/require`, {
       method: 'POST',
       body: JSON.stringify(data),
@@ -162,13 +165,14 @@ export const api = {
   }),
   resetUserPassword: (
     userId: string,
-    data: { temporary_password?: string; force_password_change?: boolean } = {}
+    data: { temporary_password?: string; force_password_change?: boolean; reason: string; admin_password: string }
   ) => requestJson(`/admin/users/${userId}/reset-password`, {
     method: 'POST',
     body: JSON.stringify(data),
   }),
-  deleteUser: (userId: string) => requestJson(`/admin/users/${userId}`, {
+  deleteUser: (userId: string, data: { reason: string; admin_password: string }) => requestJson(`/admin/users/${userId}`, {
     method: 'DELETE',
+    body: JSON.stringify(data),
   }),
   getCurrentUser: () => requestJson('/users/me'),
 

--- a/admin-ui/lib/auth.test.ts
+++ b/admin-ui/lib/auth.test.ts
@@ -56,7 +56,11 @@ describe('auth API key storage', () => {
     auth.setApiKey('legacy-api-key');
     const result = await auth.loginWithPassword('admin', 'password');
 
-    expect(result?.access_token).toBe('jwt-token');
+    expect(result).toEqual({
+      status: 'authenticated',
+      accessToken: 'jwt-token',
+      tokenType: 'bearer',
+    });
     expect(auth.getApiKey()).toBeNull();
     expect(sessionStorage.getItem('x_api_key')).toBeNull();
     expect(localStorage.getItem('access_token')).toBe('jwt-token');
@@ -91,5 +95,30 @@ describe('auth API key storage', () => {
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(auth.getApiKey()).toBe('fresh-api-key');
     expect(sessionStorage.getItem('x_api_key')).toBeNull();
+  });
+
+  it('returns MFA challenge details without storing auth when login requires MFA', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(
+      JSON.stringify({
+        session_token: 'mfa-session-token',
+        mfa_required: true,
+        expires_in: 300,
+        message: 'MFA required. Submit your TOTP or backup code.',
+      }),
+      { status: 202, headers: { 'Content-Type': 'application/json' } }
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const auth = await import('./auth');
+    const result = await auth.loginWithPassword('admin', 'password');
+
+    expect(result).toEqual({
+      status: 'mfa_required',
+      sessionToken: 'mfa-session-token',
+      expiresIn: 300,
+      message: 'MFA required. Submit your TOTP or backup code.',
+    });
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
   });
 });

--- a/admin-ui/lib/auth.test.ts
+++ b/admin-ui/lib/auth.test.ts
@@ -132,6 +132,6 @@ describe('auth API key storage', () => {
     const auth = await import('./auth');
 
     expect(auth.getJWTToken()).toBeNull();
-    expect(auth.hasStoredAuth()).toBe(true);
+    expect(auth.hasStoredAuth()).toBe(false);
   });
 });

--- a/admin-ui/lib/auth.test.ts
+++ b/admin-ui/lib/auth.test.ts
@@ -31,7 +31,7 @@ describe('auth API key storage', () => {
   it('clears existing API key when password login succeeds', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(new Response(
-        JSON.stringify({ access_token: 'jwt-token', token_type: 'bearer' }),
+        JSON.stringify({ token_type: 'bearer' }),
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       ))
       .mockResolvedValueOnce(new Response(
@@ -58,28 +58,30 @@ describe('auth API key storage', () => {
 
     expect(result).toEqual({
       status: 'authenticated',
-      accessToken: 'jwt-token',
-      tokenType: 'bearer',
     });
     expect(auth.getApiKey()).toBeNull();
     expect(sessionStorage.getItem('x_api_key')).toBeNull();
-    expect(localStorage.getItem('access_token')).toBe('jwt-token');
+    expect(auth.getJWTToken()).toBeNull();
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(localStorage.getItem('user')).toContain('"username":"admin"');
   });
 
   it('clears existing JWT when API key login succeeds', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(
       JSON.stringify({
-        id: 2,
-        uuid: 'user-2',
-        username: 'ops',
-        email: 'ops@example.com',
-        role: 'admin',
-        is_active: true,
-        is_verified: true,
-        storage_quota_mb: 1024,
-        storage_used_mb: 10,
-        created_at: '2026-02-27T00:00:00Z',
-        updated_at: '2026-02-27T00:00:00Z',
+        user: {
+          id: 2,
+          uuid: 'user-2',
+          username: 'ops',
+          email: 'ops@example.com',
+          role: 'admin',
+          is_active: true,
+          is_verified: true,
+          storage_quota_mb: 1024,
+          storage_used_mb: 10,
+          created_at: '2026-02-27T00:00:00Z',
+          updated_at: '2026-02-27T00:00:00Z',
+        },
       }),
       { status: 200, headers: { 'Content-Type': 'application/json' } }
     ));
@@ -93,8 +95,9 @@ describe('auth API key storage', () => {
     expect(ok).toBe(true);
     expect(auth.getJWTToken()).toBeNull();
     expect(localStorage.getItem('access_token')).toBeNull();
-    expect(auth.getApiKey()).toBe('fresh-api-key');
+    expect(auth.getApiKey()).toBeNull();
     expect(sessionStorage.getItem('x_api_key')).toBeNull();
+    expect(localStorage.getItem('user')).toContain('"username":"ops"');
   });
 
   it('returns MFA challenge details without storing auth when login requires MFA', async () => {
@@ -120,5 +123,15 @@ describe('auth API key storage', () => {
     });
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(localStorage.getItem('user')).toBeNull();
+  });
+
+  it('does not treat a stored user profile alone as a durable authenticated session after reload', async () => {
+    localStorage.setItem('user', JSON.stringify({ id: 1, username: 'admin' }));
+
+    vi.resetModules();
+    const auth = await import('./auth');
+
+    expect(auth.getJWTToken()).toBeNull();
+    expect(auth.hasStoredAuth()).toBe(true);
   });
 });

--- a/admin-ui/lib/auth.test.ts
+++ b/admin-ui/lib/auth.test.ts
@@ -134,4 +134,15 @@ describe('auth API key storage', () => {
     expect(auth.getJWTToken()).toBeNull();
     expect(auth.hasStoredAuth()).toBe(false);
   });
+
+  it('treats the API-key auth mode cookie as single-user mode after reload', async () => {
+    document.cookie = 'admin_auth_mode=api_key; path=/';
+    document.cookie = 'admin_session=1; path=/';
+
+    vi.resetModules();
+    const auth = await import('./auth');
+
+    expect(auth.isSingleUserMode()).toBe(true);
+    expect(auth.hasStoredAuth()).toBe(true);
+  });
 });

--- a/admin-ui/lib/auth.test.ts
+++ b/admin-ui/lib/auth.test.ts
@@ -136,7 +136,7 @@ describe('auth API key storage', () => {
   });
 
   it('treats the API-key auth mode cookie as single-user mode after reload', async () => {
-    document.cookie = 'admin_auth_mode=api_key; path=/';
+    document.cookie = 'admin_auth_mode=single_user; path=/';
     document.cookie = 'admin_session=1; path=/';
 
     vi.resetModules();

--- a/admin-ui/lib/auth.ts
+++ b/admin-ui/lib/auth.ts
@@ -141,7 +141,7 @@ export function getJWTToken(): string | null {
 
 export function hasStoredAuth(): boolean {
   if (typeof window === 'undefined') return false;
-  return hasSessionMarker() || !!getApiKey() || !!localStorage.getItem('user');
+  return hasSessionMarker() || !!getApiKey();
 }
 
 /**

--- a/admin-ui/lib/auth.ts
+++ b/admin-ui/lib/auth.ts
@@ -47,6 +47,61 @@ export interface LoginResponse {
   token_type: string;
 }
 
+export interface AuthenticatedLoginResult {
+  status: 'authenticated';
+  accessToken: string;
+  tokenType: string;
+}
+
+export interface MfaRequiredLoginResult {
+  status: 'mfa_required';
+  sessionToken: string;
+  expiresIn: number;
+  message: string;
+}
+
+export type PasswordLoginResult = AuthenticatedLoginResult | MfaRequiredLoginResult;
+
+type LoginSuccessPayload = {
+  access_token?: string;
+  token_type?: string;
+  session_token?: string;
+  mfa_required?: boolean;
+  expires_in?: number;
+  message?: string;
+};
+
+const isMfaChallengePayload = (
+  value: LoginSuccessPayload
+): value is Required<Pick<LoginSuccessPayload, 'session_token' | 'expires_in' | 'message'>> & {
+  mfa_required: true;
+} =>
+  value.mfa_required === true
+  && typeof value.session_token === 'string'
+  && typeof value.expires_in === 'number'
+  && typeof value.message === 'string';
+
+const isTokenPayload = (
+  value: LoginSuccessPayload
+): value is Required<Pick<LoginSuccessPayload, 'access_token' | 'token_type'>> =>
+  typeof value.access_token === 'string'
+  && typeof value.token_type === 'string';
+
+const finalizePasswordLogin = async (
+  accessToken: string,
+  tokenType: string
+): Promise<AuthenticatedLoginResult> => {
+  clearApiKeyStorage();
+  localStorage.setItem('access_token', accessToken);
+  emitAuthChange();
+  await fetchAndStoreUser(accessToken);
+  return {
+    status: 'authenticated',
+    accessToken,
+    tokenType,
+  };
+};
+
 /**
  * Check if we're in single-user mode (X-API-KEY auth)
  */
@@ -94,7 +149,7 @@ export function hasStoredAuth(): boolean {
 export async function loginWithPassword(
   username: string,
   password: string
-): Promise<LoginResponse | null> {
+): Promise<PasswordLoginResult | null> {
   try {
     // tldw_server expects OAuth2 form-urlencoded body
     const formData = new URLSearchParams();
@@ -110,22 +165,55 @@ export async function loginWithPassword(
     });
 
     if (response.ok) {
-      const data: LoginResponse = await response.json();
-      // Auth mode exclusivity: password/JWT login clears single-user API key state.
-      clearApiKeyStorage();
-      // Store JWT token
-      localStorage.setItem('access_token', data.access_token);
-      emitAuthChange();
-
-      // Fetch user info
-      await fetchAndStoreUser(data.access_token);
-
-      return data;
+      const data = await response.json() as LoginSuccessPayload;
+      if (isMfaChallengePayload(data)) {
+        return {
+          status: 'mfa_required',
+          sessionToken: data.session_token,
+          expiresIn: data.expires_in,
+          message: data.message,
+        };
+      }
+      if (isTokenPayload(data)) {
+        return await finalizePasswordLogin(data.access_token, data.token_type);
+      }
     }
 
     return null;
   } catch (error) {
     console.error('Login failed:', error);
+    return null;
+  }
+}
+
+export async function completeMfaLogin(
+  sessionToken: string,
+  mfaToken: string
+): Promise<AuthenticatedLoginResult | null> {
+  try {
+    const response = await fetch(buildApiUrl('/auth/mfa/login'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        session_token: sessionToken,
+        mfa_token: mfaToken,
+      }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json() as LoginSuccessPayload;
+    if (!isTokenPayload(data)) {
+      return null;
+    }
+
+    return await finalizePasswordLogin(data.access_token, data.token_type);
+  } catch (error) {
+    console.error('MFA login failed:', error);
     return null;
   }
 }

--- a/admin-ui/lib/auth.ts
+++ b/admin-ui/lib/auth.ts
@@ -124,7 +124,7 @@ const isAuthenticatedLoginPayload = (value: LoginSuccessPayload): boolean =>
  */
 export function isSingleUserMode(): boolean {
   if (typeof window === 'undefined') return false;
-  return getCookieValue(AUTH_MODE_COOKIE) === 'api_key' || !!getApiKey();
+  return getCookieValue(AUTH_MODE_COOKIE) === 'single_user' || !!getApiKey();
 }
 
 /**

--- a/admin-ui/lib/auth.ts
+++ b/admin-ui/lib/auth.ts
@@ -2,6 +2,7 @@
 
 const AUTH_CHANGE_EVENT = 'tldw-admin-auth-change';
 const SESSION_MARKER_COOKIE = 'admin_session';
+const AUTH_MODE_COOKIE = 'admin_auth_mode';
 
 // In-memory storage for legacy single-user API key mode.
 let inMemoryApiKey: string | null = null;
@@ -21,6 +22,17 @@ const hasSessionMarker = (): boolean => {
   return document.cookie
     .split(';')
     .some((cookie) => cookie.trim().startsWith(`${SESSION_MARKER_COOKIE}=`));
+};
+
+const getCookieValue = (name: string): string | null => {
+  if (typeof document === 'undefined') return null;
+  const cookie = document.cookie
+    .split(';')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(`${name}=`));
+  if (!cookie) return null;
+  const [, rawValue] = cookie.split('=');
+  return rawValue ? decodeURIComponent(rawValue) : null;
 };
 
 const emitAuthChange = (): void => {
@@ -112,7 +124,7 @@ const isAuthenticatedLoginPayload = (value: LoginSuccessPayload): boolean =>
  */
 export function isSingleUserMode(): boolean {
   if (typeof window === 'undefined') return false;
-  return !!getApiKey();
+  return getCookieValue(AUTH_MODE_COOKIE) === 'api_key' || !!getApiKey();
 }
 
 /**

--- a/admin-ui/lib/auth.ts
+++ b/admin-ui/lib/auth.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import { buildApiUrl } from './api-config';
-
-// In-memory storage for single-user API key (not persisted to web storage).
-let inMemoryApiKey: string | null = null;
 const AUTH_CHANGE_EVENT = 'tldw-admin-auth-change';
+const SESSION_MARKER_COOKIE = 'admin_session';
+
+// In-memory storage for legacy single-user API key mode.
+let inMemoryApiKey: string | null = null;
 
 const clearApiKeyStorage = (): void => {
   inMemoryApiKey = null;
@@ -16,9 +16,36 @@ const clearJwtStorage = (): void => {
   }
 };
 
-const emitAuthChange = () => {
+const hasSessionMarker = (): boolean => {
+  if (typeof document === 'undefined') return false;
+  return document.cookie
+    .split(';')
+    .some((cookie) => cookie.trim().startsWith(`${SESSION_MARKER_COOKIE}=`));
+};
+
+const emitAuthChange = (): void => {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new Event(AUTH_CHANGE_EVENT));
+};
+
+const storeUser = (user: AdminUser): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem('user', JSON.stringify(user));
+};
+
+const clearStoredUser = (): void => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem('user');
+};
+
+const finalizeAuthenticatedLogin = async (): Promise<AuthenticatedLoginResult> => {
+  clearApiKeyStorage();
+  clearJwtStorage();
+  await fetchAndStoreUser();
+  emitAuthChange();
+  return {
+    status: 'authenticated',
+  };
 };
 
 export const subscribeAuthChange = (handler: () => void): (() => void) => {
@@ -42,15 +69,8 @@ export interface AdminUser {
   last_login?: string;
 }
 
-export interface LoginResponse {
-  access_token: string;
-  token_type: string;
-}
-
 export interface AuthenticatedLoginResult {
   status: 'authenticated';
-  accessToken: string;
-  tokenType: string;
 }
 
 export interface MfaRequiredLoginResult {
@@ -63,12 +83,15 @@ export interface MfaRequiredLoginResult {
 export type PasswordLoginResult = AuthenticatedLoginResult | MfaRequiredLoginResult;
 
 type LoginSuccessPayload = {
-  access_token?: string;
   token_type?: string;
   session_token?: string;
   mfa_required?: boolean;
   expires_in?: number;
   message?: string;
+};
+
+type ApiKeyLoginPayload = {
+  user?: AdminUser;
 };
 
 const isMfaChallengePayload = (
@@ -81,26 +104,8 @@ const isMfaChallengePayload = (
   && typeof value.expires_in === 'number'
   && typeof value.message === 'string';
 
-const isTokenPayload = (
-  value: LoginSuccessPayload
-): value is Required<Pick<LoginSuccessPayload, 'access_token' | 'token_type'>> =>
-  typeof value.access_token === 'string'
-  && typeof value.token_type === 'string';
-
-const finalizePasswordLogin = async (
-  accessToken: string,
-  tokenType: string
-): Promise<AuthenticatedLoginResult> => {
-  clearApiKeyStorage();
-  localStorage.setItem('access_token', accessToken);
-  emitAuthChange();
-  await fetchAndStoreUser(accessToken);
-  return {
-    status: 'authenticated',
-    accessToken,
-    tokenType,
-  };
-};
+const isAuthenticatedLoginPayload = (value: LoginSuccessPayload): boolean =>
+  value.mfa_required !== true && typeof value.token_type === 'string';
 
 /**
  * Check if we're in single-user mode (X-API-KEY auth)
@@ -115,68 +120,67 @@ export function isSingleUserMode(): boolean {
  */
 export function getApiKey(): string | null {
   if (typeof window === 'undefined') return null;
-  if (inMemoryApiKey) return inMemoryApiKey;
-  return null;
+  return inMemoryApiKey;
 }
 
 /**
  * Set X-API-KEY for single-user mode
  */
 export function setApiKey(key: string): void {
-  if (typeof window !== 'undefined') {
-    inMemoryApiKey = key;
-    emitAuthChange();
-  }
+  if (typeof window === 'undefined') return;
+  inMemoryApiKey = key;
+  emitAuthChange();
 }
 
 /**
- * Get JWT token from localStorage
+ * Admin bearer tokens are stored in httpOnly cookies and are never exposed to browser JS.
  */
 export function getJWTToken(): string | null {
-  if (typeof window === 'undefined') return null;
-  return localStorage.getItem('access_token');
+  return null;
 }
 
 export function hasStoredAuth(): boolean {
   if (typeof window === 'undefined') return false;
-  return !!getJWTToken() || !!getApiKey();
+  return hasSessionMarker() || !!getApiKey() || !!localStorage.getItem('user');
 }
 
 /**
  * Login with username/email and password (multi-user JWT mode)
- * tldw_server uses OAuth2 form-urlencoded login
  */
 export async function loginWithPassword(
   username: string,
   password: string
 ): Promise<PasswordLoginResult | null> {
   try {
-    // tldw_server expects OAuth2 form-urlencoded body
     const formData = new URLSearchParams();
     formData.append('username', username);
     formData.append('password', password);
 
-    const response = await fetch(buildApiUrl('/auth/login'), {
+    const response = await fetch('/api/auth/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: formData.toString(),
+      credentials: 'include',
     });
 
-    if (response.ok) {
-      const data = await response.json() as LoginSuccessPayload;
-      if (isMfaChallengePayload(data)) {
-        return {
-          status: 'mfa_required',
-          sessionToken: data.session_token,
-          expiresIn: data.expires_in,
-          message: data.message,
-        };
-      }
-      if (isTokenPayload(data)) {
-        return await finalizePasswordLogin(data.access_token, data.token_type);
-      }
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json() as LoginSuccessPayload;
+    if (isMfaChallengePayload(data)) {
+      return {
+        status: 'mfa_required',
+        sessionToken: data.session_token,
+        expiresIn: data.expires_in,
+        message: data.message,
+      };
+    }
+
+    if (isAuthenticatedLoginPayload(data)) {
+      return await finalizeAuthenticatedLogin();
     }
 
     return null;
@@ -191,7 +195,7 @@ export async function completeMfaLogin(
   mfaToken: string
 ): Promise<AuthenticatedLoginResult | null> {
   try {
-    const response = await fetch(buildApiUrl('/auth/mfa/login'), {
+    const response = await fetch('/api/auth/mfa/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -200,6 +204,7 @@ export async function completeMfaLogin(
         session_token: sessionToken,
         mfa_token: mfaToken,
       }),
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -207,11 +212,11 @@ export async function completeMfaLogin(
     }
 
     const data = await response.json() as LoginSuccessPayload;
-    if (!isTokenPayload(data)) {
+    if (!isAuthenticatedLoginPayload(data)) {
       return null;
     }
 
-    return await finalizePasswordLogin(data.access_token, data.token_type);
+    return await finalizeAuthenticatedLogin();
   } catch (error) {
     console.error('MFA login failed:', error);
     return null;
@@ -223,24 +228,29 @@ export async function completeMfaLogin(
  */
 export async function loginWithApiKey(apiKey: string): Promise<boolean> {
   try {
-    // Validate the API key by calling a protected endpoint
-    const response = await fetch(buildApiUrl('/users/me'), {
-      method: 'GET',
+    const response = await fetch('/api/auth/apikey', {
+      method: 'POST',
       headers: {
-        'X-API-KEY': apiKey,
+        'Content-Type': 'application/json',
       },
+      body: JSON.stringify({ apiKey }),
+      credentials: 'include',
     });
 
-    if (response.ok) {
-      const user = await response.json();
-      // Auth mode exclusivity: API key login clears JWT auth state.
-      clearJwtStorage();
-      setApiKey(apiKey);
-      localStorage.setItem('user', JSON.stringify(user));
-      return true;
+    if (!response.ok) {
+      return false;
     }
 
-    return false;
+    const payload = await response.json() as ApiKeyLoginPayload;
+    if (!payload.user) {
+      return false;
+    }
+
+    clearJwtStorage();
+    clearApiKeyStorage();
+    storeUser(payload.user);
+    emitAuthChange();
+    return true;
   } catch (error) {
     console.error('API key validation failed:', error);
     return false;
@@ -248,22 +258,21 @@ export async function loginWithApiKey(apiKey: string): Promise<boolean> {
 }
 
 /**
- * Fetch and store current user info
+ * Fetch and store current user info using the server-managed session.
  */
-async function fetchAndStoreUser(token: string): Promise<AdminUser | null> {
+async function fetchAndStoreUser(): Promise<AdminUser | null> {
   try {
-    const response = await fetch(buildApiUrl('/users/me'), {
-      headers: {
-        'Authorization': `Bearer ${token}`,
-      },
+    const response = await fetch('/api/proxy/users/me', {
+      credentials: 'include',
     });
 
-    if (response.ok) {
-      const user: AdminUser = await response.json();
-      localStorage.setItem('user', JSON.stringify(user));
-      return user;
+    if (!response.ok) {
+      return null;
     }
-    return null;
+
+    const user: AdminUser = await response.json();
+    storeUser(user);
+    return user;
   } catch (error) {
     console.error('Failed to fetch user:', error);
     return null;
@@ -275,21 +284,14 @@ async function fetchAndStoreUser(token: string): Promise<AdminUser | null> {
  */
 export async function logout(): Promise<void> {
   try {
-    const token = getJWTToken();
-    if (token) {
-      // Try to invalidate token on server (optional - tldw_server may not have this endpoint)
-      await fetch(buildApiUrl('/auth/logout'), {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-        },
-      }).catch(() => {
-        // Ignore errors - server might not have logout endpoint
-      });
-    }
+    await fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+    }).catch(() => {
+      // Ignore errors - local auth state must still be cleared.
+    });
   } finally {
-    // Always clear local storage
-    localStorage.removeItem('user');
+    clearStoredUser();
     clearJwtStorage();
     clearApiKeyStorage();
     emitAuthChange();

--- a/admin-ui/lib/export-download.test.ts
+++ b/admin-ui/lib/export-download.test.ts
@@ -2,14 +2,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { downloadExportFile, getFilenameFromDisposition } from './export-download';
 
-vi.mock('@/lib/api-config', () => ({
-  buildApiUrl: (endpoint: string) => `https://api.example.test${endpoint}`,
+const { buildProxyUrl, buildAuthHeaders } = vi.hoisted(() => ({
+  buildProxyUrl: vi.fn((endpoint: string) => `/api/proxy${endpoint}`),
+  buildAuthHeaders: vi.fn(() => ({
+    'X-API-KEY': 'test-key',
+  })),
 }));
 
 vi.mock('@/lib/http', () => ({
-  buildAuthHeaders: () => ({
-    Authorization: 'Bearer test-token',
-  }),
+  buildAuthHeaders,
+  buildProxyUrl,
 }));
 
 describe('export-download', () => {
@@ -56,11 +58,13 @@ describe('export-download', () => {
       fallbackFilename: 'fallback.csv',
     });
 
+    expect(buildProxyUrl).toHaveBeenCalledWith('/admin/usage/daily/export.csv?start=2026-02-01&end=2026-02-15');
+    expect(buildAuthHeaders).toHaveBeenCalledWith();
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.example.test/admin/usage/daily/export.csv?start=2026-02-01&end=2026-02-15',
+      '/api/proxy/admin/usage/daily/export.csv?start=2026-02-01&end=2026-02-15',
       expect.objectContaining({
         credentials: 'include',
-        headers: { Authorization: 'Bearer test-token' },
+        headers: { 'X-API-KEY': 'test-key' },
       }),
     );
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledTimes(1);

--- a/admin-ui/lib/export-download.ts
+++ b/admin-ui/lib/export-download.ts
@@ -1,5 +1,4 @@
-import { buildApiUrl } from '@/lib/api-config';
-import { buildAuthHeaders } from '@/lib/http';
+import { buildAuthHeaders, buildProxyUrl } from '@/lib/http';
 
 export type DownloadExportOptions = {
   endpoint: string;
@@ -100,10 +99,11 @@ export const downloadExportFile = async ({
     : undefined;
 
   const query = new URLSearchParams(params).toString();
+  const url = buildProxyUrl(`${endpoint}${query ? `?${query}` : ''}`);
 
   try {
-    const response = await fetch(buildApiUrl(`${endpoint}${query ? `?${query}` : ''}`), {
-      headers: buildAuthHeaders('GET'),
+    const response = await fetch(url, {
+      headers: buildAuthHeaders(),
       credentials: 'include',
       signal: controller?.signal,
     });

--- a/admin-ui/lib/http.test.ts
+++ b/admin-ui/lib/http.test.ts
@@ -1,0 +1,46 @@
+/* @vitest-environment jsdom */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./auth', () => ({
+  getApiKey: vi.fn(() => null),
+  getJWTToken: vi.fn(() => null),
+  logout: vi.fn(() => Promise.resolve()),
+}));
+
+describe('http auth transport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ ok: true }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )));
+  });
+
+  it('routes JSON requests through the same-origin proxy without browser bearer headers', async () => {
+    const { requestJson } = await import('./http');
+
+    await requestJson('/users/me');
+
+    expect(fetch).toHaveBeenCalledWith('/api/proxy/users/me', expect.objectContaining({
+      credentials: 'include',
+      headers: expect.any(Headers),
+    }));
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('Authorization')).toBeNull();
+    expect(headers.get('X-API-KEY')).toBeNull();
+  });
+
+  it('forwards in-memory API keys only to the same-origin proxy', async () => {
+    const auth = await import('./auth');
+    vi.mocked(auth.getApiKey).mockReturnValue('ephemeral-api-key');
+
+    const { requestJson } = await import('./http');
+    await requestJson('/users/me');
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const headers = new Headers(init?.headers);
+    expect(headers.get('X-API-KEY')).toBe('ephemeral-api-key');
+  });
+});

--- a/admin-ui/lib/http.ts
+++ b/admin-ui/lib/http.ts
@@ -1,5 +1,4 @@
-import { buildApiUrl } from './api-config';
-import { getApiKey, getJWTToken, logout } from './auth';
+import { getApiKey, logout } from './auth';
 
 export class ApiError extends Error {
   status: number;
@@ -15,34 +14,17 @@ export class ApiError extends Error {
 
 type ResponseType = 'json' | 'text' | 'blob';
 
-const getCsrfToken = (): string | null => {
-  if (typeof document === 'undefined') return null;
-  const match = document.cookie.match(
-    new RegExp('(?:^|; )csrf_token=([^;]*)')
-  );
-  return match ? decodeURIComponent(match[1]) : null;
+export const buildProxyUrl = (endpoint: string): string => {
+  if (!endpoint) return '/api/proxy';
+  return `/api/proxy${endpoint.startsWith('/') ? endpoint : `/${endpoint}`}`;
 };
 
-export const buildAuthHeaders = (method: string = 'GET'): Record<string, string> => {
+export const buildAuthHeaders = (): Record<string, string> => {
   const headers: Record<string, string> = {};
-
-  const token = getJWTToken();
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
 
   const apiKey = getApiKey();
   if (apiKey) {
     headers['X-API-KEY'] = apiKey;
-  }
-
-  const methodUpper = method.toUpperCase();
-  const needsCsrf = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(methodUpper) && !apiKey;
-  if (needsCsrf) {
-    const csrf = getCsrfToken();
-    if (csrf) {
-      headers['X-CSRF-Token'] = csrf;
-    }
   }
 
   return headers;
@@ -60,7 +42,7 @@ const toApiErrorMessage = (detail: unknown): string => {
 };
 
 const buildRequestHeaders = (method: string, overrides?: HeadersInit): Headers => {
-  const headers = new Headers(buildAuthHeaders(method));
+  const headers = new Headers(buildAuthHeaders());
   if (overrides) {
     const overrideHeaders = new Headers(overrides);
     overrideHeaders.forEach((value, key) => {
@@ -82,7 +64,7 @@ const requestRaw = async <T>(
     headers.set('Content-Type', 'application/json');
   }
 
-  const response = await fetch(buildApiUrl(endpoint), {
+  const response = await fetch(buildProxyUrl(endpoint), {
     ...options,
     headers,
     credentials: 'include',

--- a/admin-ui/lib/server-auth.ts
+++ b/admin-ui/lib/server-auth.ts
@@ -5,6 +5,7 @@ export const REFRESH_TOKEN_COOKIE = 'refresh_token';
 export const API_KEY_COOKIE = 'x_api_key';
 export const LEGACY_API_KEY_COOKIE = 'x-api-key';
 export const SESSION_MARKER_COOKIE = 'admin_session';
+export const AUTH_MODE_COOKIE = 'admin_auth_mode';
 
 const isSecureCookie = process.env.NODE_ENV === 'production';
 
@@ -62,6 +63,12 @@ export const clearAdminSessionCookies = (response: NextResponse): void => {
     ...buildMarkerCookieOptions(),
     ...expired,
   });
+  response.cookies.set({
+    name: AUTH_MODE_COOKIE,
+    value: '',
+    ...buildMarkerCookieOptions(),
+    ...expired,
+  });
 };
 
 export const setJwtSessionCookies = (
@@ -90,6 +97,11 @@ export const setJwtSessionCookies = (
     value: '1',
     ...buildMarkerCookieOptions(payload.expiresIn),
   });
+  response.cookies.set({
+    name: AUTH_MODE_COOKIE,
+    value: 'jwt',
+    ...buildMarkerCookieOptions(payload.expiresIn),
+  });
 };
 
 export const setApiKeySessionCookies = (
@@ -105,6 +117,11 @@ export const setApiKeySessionCookies = (
   response.cookies.set({
     name: SESSION_MARKER_COOKIE,
     value: '1',
+    ...buildMarkerCookieOptions(),
+  });
+  response.cookies.set({
+    name: AUTH_MODE_COOKIE,
+    value: 'api_key',
     ...buildMarkerCookieOptions(),
   });
 };

--- a/admin-ui/lib/server-auth.ts
+++ b/admin-ui/lib/server-auth.ts
@@ -121,7 +121,7 @@ export const setApiKeySessionCookies = (
   });
   response.cookies.set({
     name: AUTH_MODE_COOKIE,
-    value: 'api_key',
+    value: 'single_user',
     ...buildMarkerCookieOptions(),
   });
 };

--- a/admin-ui/lib/server-auth.ts
+++ b/admin-ui/lib/server-auth.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const ACCESS_TOKEN_COOKIE = 'access_token';
+export const REFRESH_TOKEN_COOKIE = 'refresh_token';
+export const API_KEY_COOKIE = 'x_api_key';
+export const LEGACY_API_KEY_COOKIE = 'x-api-key';
+export const SESSION_MARKER_COOKIE = 'admin_session';
+
+const isSecureCookie = process.env.NODE_ENV === 'production';
+
+const buildHttpOnlyCookieOptions = (maxAge?: number) => ({
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: isSecureCookie,
+  path: '/',
+  ...(typeof maxAge === 'number' ? { maxAge } : {}),
+});
+
+const buildMarkerCookieOptions = (maxAge?: number) => ({
+  httpOnly: false,
+  sameSite: 'lax' as const,
+  secure: isSecureCookie,
+  path: '/',
+  ...(typeof maxAge === 'number' ? { maxAge } : {}),
+});
+
+const parseCookieValue = (value: string | undefined): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+export const clearAdminSessionCookies = (response: NextResponse): void => {
+  const expired = { maxAge: 0 };
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: '',
+    ...buildHttpOnlyCookieOptions(),
+    ...expired,
+  });
+  response.cookies.set({
+    name: REFRESH_TOKEN_COOKIE,
+    value: '',
+    ...buildHttpOnlyCookieOptions(),
+    ...expired,
+  });
+  response.cookies.set({
+    name: API_KEY_COOKIE,
+    value: '',
+    ...buildHttpOnlyCookieOptions(),
+    ...expired,
+  });
+  response.cookies.set({
+    name: LEGACY_API_KEY_COOKIE,
+    value: '',
+    ...buildHttpOnlyCookieOptions(),
+    ...expired,
+  });
+  response.cookies.set({
+    name: SESSION_MARKER_COOKIE,
+    value: '',
+    ...buildMarkerCookieOptions(),
+    ...expired,
+  });
+};
+
+export const setJwtSessionCookies = (
+  response: NextResponse,
+  payload: {
+    accessToken: string;
+    refreshToken?: string;
+    expiresIn?: number;
+  }
+): void => {
+  clearAdminSessionCookies(response);
+  response.cookies.set({
+    name: ACCESS_TOKEN_COOKIE,
+    value: payload.accessToken,
+    ...buildHttpOnlyCookieOptions(payload.expiresIn),
+  });
+  if (payload.refreshToken) {
+    response.cookies.set({
+      name: REFRESH_TOKEN_COOKIE,
+      value: payload.refreshToken,
+      ...buildHttpOnlyCookieOptions(),
+    });
+  }
+  response.cookies.set({
+    name: SESSION_MARKER_COOKIE,
+    value: '1',
+    ...buildMarkerCookieOptions(payload.expiresIn),
+  });
+};
+
+export const setApiKeySessionCookies = (
+  response: NextResponse,
+  apiKey: string
+): void => {
+  clearAdminSessionCookies(response);
+  response.cookies.set({
+    name: API_KEY_COOKIE,
+    value: apiKey,
+    ...buildHttpOnlyCookieOptions(),
+  });
+  response.cookies.set({
+    name: SESSION_MARKER_COOKIE,
+    value: '1',
+    ...buildMarkerCookieOptions(),
+  });
+};
+
+export const appendProxyHeaders = (request: NextRequest, headers: Headers): void => {
+  const passthroughHeaders = [
+    'accept',
+    'content-type',
+    'if-none-match',
+    'if-modified-since',
+    'range',
+  ];
+
+  for (const name of passthroughHeaders) {
+    const value = request.headers.get(name);
+    if (value) {
+      headers.set(name, value);
+    }
+  }
+};
+
+export const getBackendAuthHeaders = (request: NextRequest): Headers => {
+  const headers = new Headers();
+  const accessToken = parseCookieValue(request.cookies.get(ACCESS_TOKEN_COOKIE)?.value);
+  const apiKeyCookie =
+    parseCookieValue(request.cookies.get(API_KEY_COOKIE)?.value)
+    ?? parseCookieValue(request.cookies.get(LEGACY_API_KEY_COOKIE)?.value);
+  const apiKeyHeader = parseCookieValue(request.headers.get('x-api-key') ?? undefined);
+
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
+    return headers;
+  }
+
+  if (apiKeyCookie) {
+    headers.set('X-API-KEY', apiKeyCookie);
+    return headers;
+  }
+
+  if (apiKeyHeader) {
+    headers.set('X-API-KEY', apiKeyHeader);
+  }
+
+  return headers;
+};
+
+export const getRequestBody = async (request: NextRequest): Promise<BodyInit | undefined> => {
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    return undefined;
+  }
+
+  const body = await request.arrayBuffer();
+  return body.byteLength > 0 ? body : undefined;
+};
+
+export const buildProxyResponse = async (response: Response): Promise<NextResponse> => {
+  const headers = new Headers();
+
+  response.headers.forEach((value, key) => {
+    const lowerKey = key.toLowerCase();
+    if (['content-length', 'content-encoding', 'transfer-encoding', 'set-cookie'].includes(lowerKey)) {
+      return;
+    }
+    headers.set(key, value);
+  });
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers,
+  });
+};

--- a/admin-ui/next-env.d.ts
+++ b/admin-ui/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/admin-ui/tsconfig.json
+++ b/admin-ui/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "baseUrl": ".",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_sessions_mfa.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_sessions_mfa.py
@@ -6,8 +6,11 @@ from fastapi import APIRouter, Depends
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_auth_principal,
+    get_db_transaction,
+    get_password_service_dep,
     get_session_manager_dep,
 )
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import AdminPrivilegedActionRequest
 from tldw_Server_API.app.api.v1.schemas.auth_schemas import MessageResponse, SessionResponse
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.services import admin_sessions_mfa_service
@@ -33,8 +36,11 @@ async def admin_list_user_sessions(
 async def admin_revoke_user_session(
     user_id: int,
     session_id: int,
+    request: AdminPrivilegedActionRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     session_manager=Depends(get_session_manager_dep),
+    db=Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> MessageResponse:
     """Revoke a specific session for a user (admin scope)."""
     return await admin_sessions_mfa_service.revoke_user_session(
@@ -42,20 +48,29 @@ async def admin_revoke_user_session(
         user_id,
         session_id,
         session_manager,
+        db,
+        password_service,
+        request,
     )
 
 
 @router.post("/users/{user_id}/sessions/revoke-all", response_model=MessageResponse)
 async def admin_revoke_all_user_sessions(
     user_id: int,
+    request: AdminPrivilegedActionRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     session_manager=Depends(get_session_manager_dep),
+    db=Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> MessageResponse:
     """Revoke all sessions for a user (admin scope)."""
     return await admin_sessions_mfa_service.revoke_all_user_sessions(
         principal,
         user_id,
         session_manager,
+        db,
+        password_service,
+        request,
     )
 
 
@@ -74,10 +89,16 @@ async def admin_get_user_mfa_status(
 @router.post("/users/{user_id}/mfa/disable", response_model=MessageResponse)
 async def admin_disable_user_mfa(
     user_id: int,
+    request: AdminPrivilegedActionRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
+    db=Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> MessageResponse:
     """Disable MFA for a user (admin scope)."""
     return await admin_sessions_mfa_service.disable_user_mfa(
         principal,
         user_id,
+        db,
+        password_service,
+        request,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_user.py
@@ -9,9 +9,11 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_auth_principal,
     get_db_transaction,
+    get_password_service_dep,
     get_registration_service_dep,
 )
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminPrivilegedActionRequest,
     AdminMfaRequirementRequest,
     AdminMfaRequirementResponse,
     AdminPasswordResetRequest,
@@ -188,12 +190,14 @@ async def update_user(
     request: UserUpdateRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     db: Any = Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> MessageResponse:
     return await admin_users_service.update_user(
         principal,
         user_id,
         request,
         db,
+        password_service,
         is_pg_fn=_get_is_pg_fn(),
     )
 
@@ -204,12 +208,14 @@ async def reset_user_password(
     request: AdminPasswordResetRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     db: Any = Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> AdminPasswordResetResponse:
     result = await admin_users_service.reset_user_password(
         principal,
         user_id,
         request,
         db,
+        password_service,
         is_pg_fn=_get_is_pg_fn(),
     )
     return AdminPasswordResetResponse(**result)
@@ -221,12 +227,14 @@ async def set_user_mfa_requirement(
     request: AdminMfaRequirementRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     db: Any = Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> AdminMfaRequirementResponse:
     result = await admin_users_service.set_user_mfa_requirement(
         principal,
         user_id,
         request,
         db,
+        password_service,
         is_pg_fn=_get_is_pg_fn(),
     )
     return AdminMfaRequirementResponse(**result)
@@ -235,12 +243,16 @@ async def set_user_mfa_requirement(
 @router.delete("/users/{user_id}", response_model=MessageResponse)
 async def delete_user(
     user_id: int,
+    request: AdminPrivilegedActionRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
     db: Any = Depends(get_db_transaction),
+    password_service=Depends(get_password_service_dep),
 ) -> MessageResponse:
     return await admin_users_service.delete_user(
         principal,
         user_id,
+        request,
         db,
+        password_service,
         is_pg_fn=_get_is_pg_fn(),
     )

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -477,6 +477,11 @@ def _is_pytest_context() -> bool:
     return False
 
 
+def _is_enterprise_admin_ui_mode() -> bool:
+    raw_value = os.getenv("ADMIN_UI_ENTERPRISE_MODE", "")
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _auth_request_client_ip(request: Request) -> str:
     try:
         settings = get_settings()
@@ -1200,6 +1205,11 @@ async def login(
 
         # Generate tokens based on auth mode
         if settings.AUTH_MODE == "single_user":
+            if _is_enterprise_admin_ui_mode():
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Enterprise Admin UI requires multi-user authentication; single-user login is disabled.",
+                )
             # For single-user mode, return the configured API key as the access token.
             single_user_key = (
                 settings.SINGLE_USER_API_KEY

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -11,6 +11,12 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, field_validator
 
+
+def _blank_string_to_none(value: Any) -> Any:
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
 #######################################################################################################################
 #
 # User Management Schemas
@@ -24,7 +30,12 @@ class UserUpdateRequest(BaseModel):
     is_locked: bool | None = None
     storage_quota_mb: int | None = Field(None, ge=100)
     reason: str | None = Field(default=None, min_length=8, max_length=500)
-    admin_password: str | None = Field(default=None, min_length=8, max_length=128)
+    admin_password: str | None = Field(default=None, max_length=128)
+
+    @field_validator("admin_password", mode="before")
+    @classmethod
+    def normalize_blank_admin_password(cls, value: Any) -> Any:
+        return _blank_string_to_none(value)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -33,7 +44,12 @@ class AdminPrivilegedActionRequest(BaseModel):
     """Request payload for privileged admin actions."""
 
     reason: str = Field(..., min_length=8, max_length=500)
-    admin_password: str = Field(..., min_length=8, max_length=128)
+    admin_password: str | None = Field(default=None, max_length=128)
+
+    @field_validator("admin_password", mode="before")
+    @classmethod
+    def normalize_blank_admin_password(cls, value: Any) -> Any:
+        return _blank_string_to_none(value)
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -41,7 +57,7 @@ class AdminPrivilegedActionRequest(BaseModel):
 class AdminPasswordResetRequest(AdminPrivilegedActionRequest):
     """Request payload for admin-initiated user password reset."""
 
-    temporary_password: str | None = Field(default=None, min_length=10, max_length=128)
+    temporary_password: str = Field(..., min_length=10, max_length=128)
     force_password_change: bool = True
 
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -49,7 +49,6 @@ class AdminPasswordResetResponse(BaseModel):
     """Response payload for admin-initiated user password reset."""
 
     user_id: int
-    temporary_password: str
     force_password_change: bool
     message: str
 

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -23,17 +23,26 @@ class UserUpdateRequest(BaseModel):
     is_verified: bool | None = None
     is_locked: bool | None = None
     storage_quota_mb: int | None = Field(None, ge=100)
+    reason: str | None = Field(default=None, min_length=8, max_length=500)
+    admin_password: str | None = Field(default=None, min_length=8, max_length=128)
 
     model_config = ConfigDict(from_attributes=True)
 
 
-class AdminPasswordResetRequest(BaseModel):
+class AdminPrivilegedActionRequest(BaseModel):
+    """Request payload for privileged admin actions."""
+
+    reason: str = Field(..., min_length=8, max_length=500)
+    admin_password: str = Field(..., min_length=8, max_length=128)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AdminPasswordResetRequest(AdminPrivilegedActionRequest):
     """Request payload for admin-initiated user password reset."""
 
     temporary_password: str | None = Field(default=None, min_length=10, max_length=128)
     force_password_change: bool = True
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class AdminPasswordResetResponse(BaseModel):
@@ -47,12 +56,10 @@ class AdminPasswordResetResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class AdminMfaRequirementRequest(BaseModel):
+class AdminMfaRequirementRequest(AdminPrivilegedActionRequest):
     """Request payload for admin-managed MFA requirement flag."""
 
     require_mfa: bool = True
-
-    model_config = ConfigDict(from_attributes=True)
 
 
 class AdminMfaRequirementResponse(BaseModel):

--- a/tldw_Server_API/app/services/admin_audit_service.py
+++ b/tldw_Server_API/app/services/admin_audit_service.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
+    get_or_create_audit_service_for_user_id_optional,
+)
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditContext,
+    AuditEventCategory,
+    AuditEventType,
+)
+
+
+async def emit_admin_account_audit_event(
+    *,
+    actor_id: int | None,
+    target_user_id: int,
+    event_type: AuditEventType,
+    category: AuditEventCategory,
+    resource_type: str,
+    resource_id: str,
+    action: str,
+    metadata: dict[str, Any] | None = None,
+) -> None:
+    """Persist a durable audit event for privileged admin account mutations."""
+    svc = await get_or_create_audit_service_for_user_id_optional(actor_id)
+    ctx = AuditContext(
+        user_id=str(actor_id) if actor_id is not None else None,
+        endpoint="/api/v1/admin/users",
+        method="INTERNAL",
+    )
+    await svc.log_event(
+        event_type=event_type,
+        category=category,
+        context=ctx,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        metadata={
+            "actor_id": actor_id,
+            "target_user_id": target_user_id,
+            "resource_type": resource_type,
+            "resource_id": resource_id,
+            "action": action,
+            **(metadata or {}),
+        },
+    )
+    await svc.flush(raise_on_failure=True)

--- a/tldw_Server_API/app/services/admin_audit_service.py
+++ b/tldw_Server_API/app/services/admin_audit_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from loguru import logger
+
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import (
     get_or_create_audit_service_for_user_id_optional,
 )
@@ -24,26 +26,29 @@ async def emit_admin_account_audit_event(
     metadata: dict[str, Any] | None = None,
 ) -> None:
     """Persist a durable audit event for privileged admin account mutations."""
-    svc = await get_or_create_audit_service_for_user_id_optional(actor_id)
-    ctx = AuditContext(
-        user_id=str(actor_id) if actor_id is not None else None,
-        endpoint="/api/v1/admin/users",
-        method="INTERNAL",
-    )
-    await svc.log_event(
-        event_type=event_type,
-        category=category,
-        context=ctx,
-        resource_type=resource_type,
-        resource_id=resource_id,
-        action=action,
-        metadata={
-            "actor_id": actor_id,
-            "target_user_id": target_user_id,
-            "resource_type": resource_type,
-            "resource_id": resource_id,
-            "action": action,
-            **(metadata or {}),
-        },
-    )
-    await svc.flush(raise_on_failure=True)
+    try:
+        svc = await get_or_create_audit_service_for_user_id_optional(actor_id)
+        ctx = AuditContext(
+            user_id=str(actor_id) if actor_id is not None else None,
+            endpoint="/api/v1/admin/users",
+            method="INTERNAL",
+        )
+        await svc.log_event(
+            event_type=event_type,
+            category=category,
+            context=ctx,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            metadata={
+                "actor_id": actor_id,
+                "target_user_id": target_user_id,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "action": action,
+                **(metadata or {}),
+            },
+        )
+        await svc.flush(raise_on_failure=False)
+    except Exception as exc:
+        logger.warning("Admin audit emission failed for action={}: {}", action, exc)

--- a/tldw_Server_API/app/services/admin_guardrails_service.py
+++ b/tldw_Server_API/app/services/admin_guardrails_service.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import os
+
 from fastapi import HTTPException, status
 
-from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.services.auth_service import fetch_active_user_by_id
+
+
+def _enterprise_admin_mode_enabled() -> bool:
+    raw_value = os.getenv("ADMIN_UI_ENTERPRISE_MODE", "")
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 async def verify_privileged_action(
@@ -17,7 +24,16 @@ async def verify_privileged_action(
     normalized_reason = str(reason or "").strip()
     normalized_password = str(admin_password or "").strip()
 
-    if len(normalized_reason) < 8 or len(normalized_password) < 8:
+    if len(normalized_reason) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Reason is required for this action",
+        )
+
+    if is_single_user_principal(principal) and not _enterprise_admin_mode_enabled():
+        return normalized_reason
+
+    if len(normalized_password) < 8:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Reason and current password are required for this action",

--- a/tldw_Server_API/app/services/admin_guardrails_service.py
+++ b/tldw_Server_API/app/services/admin_guardrails_service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from fastapi import HTTPException, status
 
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
+from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.services.auth_service import fetch_active_user_by_id
 
 
@@ -15,12 +17,24 @@ def _enterprise_admin_mode_enabled() -> bool:
 
 async def verify_privileged_action(
     principal: AuthPrincipal,
-    db,
-    password_service,
+    db: Any,
+    password_service: PasswordService,
     *,
     reason: str | None,
     admin_password: str | None,
 ) -> str:
+    """
+    Enforce step-up guardrails for high-risk admin actions.
+
+    Requires a human-readable reason for every privileged action. In enterprise
+    mode, or for any non-single-user principal, it also requires the acting
+    admin's current password and validates it against the active user record.
+
+    Raises:
+        HTTPException: When the reason is missing, the password reauth check
+            fails, or the acting principal cannot be resolved to an active admin
+            account.
+    """
     normalized_reason = str(reason or "").strip()
     normalized_password = str(admin_password or "").strip()
 

--- a/tldw_Server_API/app/services/admin_guardrails_service.py
+++ b/tldw_Server_API/app/services/admin_guardrails_service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services.auth_service import fetch_active_user_by_id
+
+
+async def verify_privileged_action(
+    principal: AuthPrincipal,
+    db,
+    password_service,
+    *,
+    reason: str | None,
+    admin_password: str | None,
+) -> str:
+    normalized_reason = str(reason or "").strip()
+    normalized_password = str(admin_password or "").strip()
+
+    if len(normalized_reason) < 8 or len(normalized_password) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Reason and current password are required for this action",
+        )
+
+    if principal.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Privileged action reauthentication requires an authenticated admin user",
+        )
+
+    actor = await fetch_active_user_by_id(db, int(principal.user_id))
+    password_hash = actor.get("password_hash") if actor else None
+    if not actor or not isinstance(password_hash, str) or not password_hash:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
+        )
+
+    verified, _needs_rehash = password_service.verify_password(normalized_password, password_hash)
+    if not verified:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
+        )
+
+    return normalized_reason

--- a/tldw_Server_API/app/services/admin_scope_service.py
+++ b/tldw_Server_API/app/services/admin_scope_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -17,6 +18,11 @@ REQUIRED_TEAM_ADMIN_RANK = ROLE_HIERARCHY.get("lead", 2)
 PLATFORM_ADMIN_ROLES = {"owner", "super_admin", "admin"}
 
 
+def _enterprise_admin_mode_enabled() -> bool:
+    raw_value = os.getenv("ADMIN_UI_ENTERPRISE_MODE", "")
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 def role_rank(role: str | None) -> int:
     if role is None:
         return 0
@@ -25,7 +31,7 @@ def role_rank(role: str | None) -> int:
 
 def is_platform_admin(principal: AuthPrincipal) -> bool:
     if is_single_user_principal(principal):
-        return True
+        return not _enterprise_admin_mode_enabled()
     roles = {str(role).strip().lower() for role in (principal.roles or [])}
     return bool(roles & PLATFORM_ADMIN_ROLES)
 
@@ -46,7 +52,7 @@ async def enforce_admin_user_scope(
     require_hierarchy: bool,
 ) -> None:
     """Enforce shared org/team membership and optional role hierarchy for admin actions."""
-    if is_single_user_principal(principal) or is_platform_admin(principal):
+    if is_platform_admin(principal):
         return
 
     if principal.user_id is None:
@@ -117,7 +123,7 @@ async def enforce_admin_user_scope(
 
 
 async def get_admin_org_ids(principal: AuthPrincipal) -> list[int] | None:
-    if is_single_user_principal(principal) or is_platform_admin(principal):
+    if is_platform_admin(principal):
         return None
     if principal.user_id is None:
         raise HTTPException(
@@ -134,7 +140,7 @@ async def enforce_admin_org_access(
     *,
     require_admin: bool = True,
 ) -> None:
-    if is_single_user_principal(principal) or is_platform_admin(principal):
+    if is_platform_admin(principal):
         return
     if principal.user_id is None:
         raise HTTPException(

--- a/tldw_Server_API/app/services/admin_sessions_mfa_service.py
+++ b/tldw_Server_API/app/services/admin_sessions_mfa_service.py
@@ -5,13 +5,16 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import AdminPrivilegedActionRequest
 from tldw_Server_API.app.api.v1.schemas.auth_schemas import MessageResponse, SessionResponse
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
     AuditEventType,
 )
 from tldw_Server_API.app.core.AuthNZ.mfa_service import get_mfa_service
+from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
 from tldw_Server_API.app.services import admin_scope_service
 from tldw_Server_API.app.services.admin_audit_service import (
     emit_admin_account_audit_event as _emit_admin_account_audit_event,
@@ -32,7 +35,7 @@ _ADMIN_SESSIONS_NONCRITICAL_EXCEPTIONS = (
 async def list_user_sessions(
     principal: AuthPrincipal,
     user_id: int,
-    session_manager,
+    session_manager: SessionManager,
 ) -> list[SessionResponse]:
     """List active sessions for a user (admin scope)."""
     try:
@@ -64,10 +67,10 @@ async def revoke_user_session(
     principal: AuthPrincipal,
     user_id: int,
     session_id: int,
-    session_manager,
-    db,
-    password_service,
-    request,
+    session_manager: SessionManager,
+    db: Any,
+    password_service: PasswordService,
+    request: AdminPrivilegedActionRequest,
 ) -> MessageResponse:
     """Revoke a specific session for a user (admin scope)."""
     try:
@@ -108,10 +111,10 @@ async def revoke_user_session(
 async def revoke_all_user_sessions(
     principal: AuthPrincipal,
     user_id: int,
-    session_manager,
-    db,
-    password_service,
-    request,
+    session_manager: SessionManager,
+    db: Any,
+    password_service: PasswordService,
+    request: AdminPrivilegedActionRequest,
 ) -> MessageResponse:
     """Revoke all sessions for a user (admin scope)."""
     try:
@@ -172,9 +175,9 @@ async def get_user_mfa_status(
 async def disable_user_mfa(
     principal: AuthPrincipal,
     user_id: int,
-    db,
-    password_service,
-    request,
+    db: Any,
+    password_service: PasswordService,
+    request: AdminPrivilegedActionRequest,
 ) -> MessageResponse:
     """Disable MFA for a user (admin scope)."""
     try:

--- a/tldw_Server_API/app/services/admin_sessions_mfa_service.py
+++ b/tldw_Server_API/app/services/admin_sessions_mfa_service.py
@@ -6,9 +6,16 @@ from fastapi import HTTPException
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.schemas.auth_schemas import MessageResponse, SessionResponse
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventCategory,
+    AuditEventType,
+)
 from tldw_Server_API.app.core.AuthNZ.mfa_service import get_mfa_service
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.services import admin_scope_service
+from tldw_Server_API.app.services.admin_audit_service import (
+    emit_admin_account_audit_event as _emit_admin_account_audit_event,
+)
 from tldw_Server_API.app.services.admin_guardrails_service import verify_privileged_action
 
 _ADMIN_SESSIONS_NONCRITICAL_EXCEPTIONS = (
@@ -69,7 +76,7 @@ async def revoke_user_session(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -77,6 +84,19 @@ async def revoke_user_session(
             admin_password=getattr(request, "admin_password", None),
         )
         await session_manager.revoke_session(session_id=session_id, revoked_by=principal.user_id)
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.AUTH_TOKEN_REVOKED,
+            category=AuditEventCategory.AUTHENTICATION,
+            resource_type="user_session",
+            resource_id=str(session_id),
+            action="admin.user.session.revoke",
+            metadata={
+                "reason": reason,
+                "session_id": session_id,
+            },
+        )
         return MessageResponse(message="Session revoked")
     except HTTPException:
         raise
@@ -100,7 +120,7 @@ async def revoke_all_user_sessions(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -108,6 +128,19 @@ async def revoke_all_user_sessions(
             admin_password=getattr(request, "admin_password", None),
         )
         await session_manager.revoke_all_user_sessions(user_id=user_id)
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.AUTH_TOKEN_REVOKED,
+            category=AuditEventCategory.AUTHENTICATION,
+            resource_type="user_session",
+            resource_id=str(user_id),
+            action="admin.user.sessions.revoke_all",
+            metadata={
+                "reason": reason,
+                "scope": "all",
+            },
+        )
         return MessageResponse(message="All sessions revoked")
     except HTTPException:
         raise
@@ -150,7 +183,7 @@ async def disable_user_mfa(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -161,6 +194,16 @@ async def disable_user_mfa(
         success = await mfa_service.disable_mfa(user_id)
         if not success:
             raise HTTPException(status_code=404, detail="MFA not enabled")
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.CONFIG_CHANGED,
+            category=AuditEventCategory.SECURITY,
+            resource_type="user_mfa",
+            resource_id=str(user_id),
+            action="admin.user.mfa.disable",
+            metadata={"reason": reason},
+        )
         return MessageResponse(message="MFA disabled")
     except HTTPException:
         raise

--- a/tldw_Server_API/app/services/admin_sessions_mfa_service.py
+++ b/tldw_Server_API/app/services/admin_sessions_mfa_service.py
@@ -9,6 +9,7 @@ from tldw_Server_API.app.api.v1.schemas.auth_schemas import MessageResponse, Ses
 from tldw_Server_API.app.core.AuthNZ.mfa_service import get_mfa_service
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.services import admin_scope_service
+from tldw_Server_API.app.services.admin_guardrails_service import verify_privileged_action
 
 _ADMIN_SESSIONS_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
@@ -57,6 +58,9 @@ async def revoke_user_session(
     user_id: int,
     session_id: int,
     session_manager,
+    db,
+    password_service,
+    request,
 ) -> MessageResponse:
     """Revoke a specific session for a user (admin scope)."""
     try:
@@ -64,6 +68,13 @@ async def revoke_user_session(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=getattr(request, "reason", None),
+            admin_password=getattr(request, "admin_password", None),
         )
         await session_manager.revoke_session(session_id=session_id, revoked_by=principal.user_id)
         return MessageResponse(message="Session revoked")
@@ -78,6 +89,9 @@ async def revoke_all_user_sessions(
     principal: AuthPrincipal,
     user_id: int,
     session_manager,
+    db,
+    password_service,
+    request,
 ) -> MessageResponse:
     """Revoke all sessions for a user (admin scope)."""
     try:
@@ -85,6 +99,13 @@ async def revoke_all_user_sessions(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=getattr(request, "reason", None),
+            admin_password=getattr(request, "admin_password", None),
         )
         await session_manager.revoke_all_user_sessions(user_id=user_id)
         return MessageResponse(message="All sessions revoked")
@@ -118,6 +139,9 @@ async def get_user_mfa_status(
 async def disable_user_mfa(
     principal: AuthPrincipal,
     user_id: int,
+    db,
+    password_service,
+    request,
 ) -> MessageResponse:
     """Disable MFA for a user (admin scope)."""
     try:
@@ -125,6 +149,13 @@ async def disable_user_mfa(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=getattr(request, "reason", None),
+            admin_password=getattr(request, "admin_password", None),
         )
         mfa_service = get_mfa_service()
         success = await mfa_service.disable_mfa(user_id)

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -28,12 +28,19 @@ from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.AuthNZ.settings import get_profile
 from tldw_Server_API.app.core.AuthNZ.password_service import hash_password
 from tldw_Server_API.app.services import admin_scope_service
+from tldw_Server_API.app.services.admin_audit_service import (
+    emit_admin_account_audit_event as _emit_admin_account_audit_event,
+)
 from tldw_Server_API.app.services.admin_guardrails_service import verify_privileged_action
 from tldw_Server_API.app.services.admin_data_ops_service import (
     build_users_csv as svc_build_users_csv,
 )
 from tldw_Server_API.app.services.admin_data_ops_service import (
     build_users_json as svc_build_users_json,
+)
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventCategory,
+    AuditEventType,
 )
 
 
@@ -236,8 +243,9 @@ async def update_user(
             user_id,
             require_hierarchy=True,
         )
+        reason: str | None = None
         if request.role is not None or request.is_active is not None:
-            await verify_privileged_action(
+            reason = await verify_privileged_action(
                 principal,
                 db,
                 password_service,
@@ -319,6 +327,23 @@ async def update_user(
                     raise UserNotFoundError(f"User {user_id}")
             await db.commit()
 
+        if reason is not None:
+            metadata: dict[str, Any] = {"reason": reason}
+            if request.role is not None:
+                metadata["role"] = request.role
+            if request.is_active is not None:
+                metadata["is_active"] = request.is_active
+            await _emit_admin_account_audit_event(
+                actor_id=principal.user_id,
+                target_user_id=user_id,
+                event_type=AuditEventType.USER_UPDATED,
+                category=AuditEventCategory.AUTHORIZATION,
+                resource_type="user_account",
+                resource_id=str(user_id),
+                action="admin.user.update",
+                metadata=metadata,
+            )
+
         logger.info(f"Admin updated user {user_id}")
 
         return {"message": f"User {user_id} updated successfully"}
@@ -353,7 +378,7 @@ async def reset_user_password(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -414,6 +439,21 @@ async def reset_user_password(
             )
             await db.commit()
 
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.USER_PASSWORD_RESET,
+            category=AuditEventCategory.AUTHENTICATION,
+            resource_type="user_account",
+            resource_id=str(user_id),
+            action="admin.user.password_reset",
+            metadata={
+                "reason": reason,
+                "force_password_change": force_password_change,
+                "temporary_password_provided": request.temporary_password is not None,
+            },
+        )
+
         logger.info("Admin reset password for user {}", user_id)
 
         return {
@@ -458,7 +498,7 @@ async def set_user_mfa_requirement(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -513,6 +553,20 @@ async def set_user_mfa_requirement(
             )
             await db.commit()
 
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.CONFIG_CHANGED,
+            category=AuditEventCategory.SECURITY,
+            resource_type="user_mfa",
+            resource_id=str(user_id),
+            action="admin.user.mfa_requirement.update",
+            metadata={
+                "reason": reason,
+                "require_mfa": require_mfa,
+            },
+        )
+
         logger.info("Admin updated MFA requirement for user {} to {}", user_id, require_mfa)
 
         return {
@@ -556,7 +610,7 @@ async def delete_user(
             user_id,
             require_hierarchy=True,
         )
-        await verify_privileged_action(
+        reason = await verify_privileged_action(
             principal,
             db,
             password_service,
@@ -576,6 +630,17 @@ async def delete_user(
                 (user_id,),
             )
             await db.commit()
+
+        await _emit_admin_account_audit_event(
+            actor_id=principal.user_id,
+            target_user_id=user_id,
+            event_type=AuditEventType.USER_DEACTIVATED,
+            category=AuditEventCategory.AUTHORIZATION,
+            resource_type="user_account",
+            resource_id=str(user_id),
+            action="admin.user.deactivate",
+            metadata={"reason": reason},
+        )
 
         logger.info(f"Admin soft-deleted user {user_id}")
 

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -28,6 +28,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.AuthNZ.settings import get_profile
 from tldw_Server_API.app.core.AuthNZ.password_service import hash_password
 from tldw_Server_API.app.services import admin_scope_service
+from tldw_Server_API.app.services.admin_guardrails_service import verify_privileged_action
 from tldw_Server_API.app.services.admin_data_ops_service import (
     build_users_csv as svc_build_users_csv,
 )
@@ -225,6 +226,7 @@ async def update_user(
     user_id: int,
     request: UserUpdateRequest,
     db,
+    password_service,
     *,
     is_pg_fn: Callable[[], Awaitable[bool]],
 ) -> dict[str, str]:
@@ -234,6 +236,14 @@ async def update_user(
             user_id,
             require_hierarchy=True,
         )
+        if request.role is not None or request.is_active is not None:
+            await verify_privileged_action(
+                principal,
+                db,
+                password_service,
+                reason=request.reason,
+                admin_password=request.admin_password,
+            )
 
         is_pg = await is_pg_fn()
         updates = []
@@ -333,6 +343,7 @@ async def reset_user_password(
     user_id: int,
     request: AdminPasswordResetRequest,
     db,
+    password_service,
     *,
     is_pg_fn: Callable[[], Awaitable[bool]],
 ) -> dict[str, Any]:
@@ -341,6 +352,13 @@ async def reset_user_password(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=request.reason,
+            admin_password=request.admin_password,
         )
 
         temporary_password = request.temporary_password or _generate_temporary_password()
@@ -430,6 +448,7 @@ async def set_user_mfa_requirement(
     user_id: int,
     request: AdminMfaRequirementRequest,
     db,
+    password_service,
     *,
     is_pg_fn: Callable[[], Awaitable[bool]],
 ) -> dict[str, Any]:
@@ -438,6 +457,13 @@ async def set_user_mfa_requirement(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=request.reason,
+            admin_password=request.admin_password,
         )
 
         require_mfa = bool(request.require_mfa)
@@ -513,7 +539,9 @@ async def set_user_mfa_requirement(
 async def delete_user(
     principal: AuthPrincipal,
     user_id: int,
+    request,
     db,
+    password_service,
     *,
     is_pg_fn: Callable[[], Awaitable[bool]],
 ) -> dict[str, str]:
@@ -527,6 +555,13 @@ async def delete_user(
             principal,
             user_id,
             require_hierarchy=True,
+        )
+        await verify_privileged_action(
+            principal,
+            db,
+            password_service,
+            reason=getattr(request, "reason", None),
+            admin_password=getattr(request, "admin_password", None),
         )
 
         is_pg = await is_pg_fn()

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -386,7 +386,7 @@ async def reset_user_password(
             admin_password=request.admin_password,
         )
 
-        temporary_password = request.temporary_password or _generate_temporary_password()
+        temporary_password = request.temporary_password
         password_hash = hash_password(temporary_password)
         force_password_change = bool(request.force_password_change)
 
@@ -450,7 +450,7 @@ async def reset_user_password(
             metadata={
                 "reason": reason,
                 "force_password_change": force_password_change,
-                "temporary_password_provided": request.temporary_password is not None,
+                "credential_provided_by_admin": True,
             },
         )
 

--- a/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
+++ b/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminMfaRequirementRequest,
+    AdminPasswordResetRequest,
+)
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditEventCategory,
+    AuditEventType,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services import admin_sessions_mfa_service, admin_users_service
+
+
+class _FakeCursor:
+    def __init__(self, row=None, *, rowcount: int = 1) -> None:
+        self._row = row
+        self.rowcount = rowcount
+
+    async def fetchone(self):
+        return self._row
+
+
+class _FakeUserDb:
+    def __init__(self, metadata: str = "{}") -> None:
+        self.metadata = metadata
+        self.committed = False
+        self.queries: list[tuple[str, object]] = []
+
+    async def execute(self, query: str, params=None):
+        self.queries.append((query, params))
+        if "SELECT metadata FROM users" in query:
+            return _FakeCursor((self.metadata,))
+        return _FakeCursor()
+
+    async def commit(self) -> None:
+        self.committed = True
+
+
+class _FakeSessionManager:
+    def __init__(self) -> None:
+        self.revoked_session_id: int | None = None
+        self.revoked_by: int | None = None
+        self.revoked_all_user_id: int | None = None
+
+    async def revoke_session(self, *, session_id: int, revoked_by: int | None) -> None:
+        self.revoked_session_id = session_id
+        self.revoked_by = revoked_by
+
+    async def revoke_all_user_sessions(self, *, user_id: int) -> None:
+        self.revoked_all_user_id = user_id
+
+
+class _FakeMfaService:
+    def __init__(self, *, disable_result: bool = True) -> None:
+        self.disable_result = disable_result
+        self.disabled_user_id: int | None = None
+
+    async def disable_mfa(self, user_id: int) -> bool:
+        self.disabled_user_id = user_id
+        return self.disable_result
+
+
+def _admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=7,
+        subject="user:7",
+        roles=["admin"],
+        is_admin=True,
+    )
+
+
+async def _allow_scope(*_args, **_kwargs) -> None:
+    return None
+
+
+async def _allow_reauth(*_args, **_kwargs) -> str:
+    return "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(admin_users_service, "_emit_admin_account_audit_event", _fake_emit, raising=False)
+    monkeypatch.setattr(admin_users_service, "hash_password", lambda value: f"hashed::{value}")
+
+    result = await admin_users_service.reset_user_password(
+        _admin_principal(),
+        42,
+        AdminPasswordResetRequest(
+            reason="Support case 123",
+            admin_password="AdminPass123!",
+            temporary_password="TempPass123!",
+            force_password_change=True,
+        ),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert result["message"] == "Password reset successfully"
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.USER_PASSWORD_RESET
+    assert emitted[0]["category"] == AuditEventCategory.AUTHENTICATION
+    assert emitted[0]["resource_type"] == "user_account"
+    assert emitted[0]["resource_id"] == "42"
+    assert emitted[0]["action"] == "admin.user.password_reset"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_delete_user_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(admin_users_service, "_emit_admin_account_audit_event", _fake_emit, raising=False)
+
+    result = await admin_users_service.delete_user(
+        _admin_principal(),
+        42,
+        SimpleNamespace(reason="Support case 123", admin_password="AdminPass123!"),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert result["message"] == "User 42 has been deactivated"
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.USER_DEACTIVATED
+    assert emitted[0]["category"] == AuditEventCategory.AUTHORIZATION
+    assert emitted[0]["resource_type"] == "user_account"
+    assert emitted[0]["resource_id"] == "42"
+    assert emitted[0]["action"] == "admin.user.deactivate"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_session_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    session_manager = _FakeSessionManager()
+    monkeypatch.setattr(
+        admin_sessions_mfa_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_sessions_mfa_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    result = await admin_sessions_mfa_service.revoke_user_session(
+        _admin_principal(),
+        42,
+        84,
+        session_manager,
+        db=object(),
+        password_service=object(),
+        request=SimpleNamespace(reason="Support case 123", admin_password="AdminPass123!"),
+    )
+
+    assert result.message == "Session revoked"
+    assert session_manager.revoked_session_id == 84
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.AUTH_TOKEN_REVOKED
+    assert emitted[0]["category"] == AuditEventCategory.AUTHENTICATION
+    assert emitted[0]["resource_type"] == "user_session"
+    assert emitted[0]["resource_id"] == "84"
+    assert emitted[0]["action"] == "admin.user.session.revoke"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_user_sessions_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    session_manager = _FakeSessionManager()
+    monkeypatch.setattr(
+        admin_sessions_mfa_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_sessions_mfa_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    result = await admin_sessions_mfa_service.revoke_all_user_sessions(
+        _admin_principal(),
+        42,
+        session_manager,
+        db=object(),
+        password_service=object(),
+        request=SimpleNamespace(reason="Support case 123", admin_password="AdminPass123!"),
+    )
+
+    assert result.message == "All sessions revoked"
+    assert session_manager.revoked_all_user_id == 42
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.AUTH_TOKEN_REVOKED
+    assert emitted[0]["category"] == AuditEventCategory.AUTHENTICATION
+    assert emitted[0]["resource_type"] == "user_session"
+    assert emitted[0]["resource_id"] == "42"
+    assert emitted[0]["action"] == "admin.user.sessions.revoke_all"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+    assert emitted[0]["metadata"]["scope"] == "all"
+
+
+@pytest.mark.asyncio
+async def test_disable_user_mfa_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    mfa_service = _FakeMfaService(disable_result=True)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_sessions_mfa_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(admin_sessions_mfa_service, "get_mfa_service", lambda: mfa_service)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    result = await admin_sessions_mfa_service.disable_user_mfa(
+        _admin_principal(),
+        42,
+        db=object(),
+        password_service=object(),
+        request=SimpleNamespace(reason="Support case 123", admin_password="AdminPass123!"),
+    )
+
+    assert result.message == "MFA disabled"
+    assert mfa_service.disabled_user_id == 42
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.CONFIG_CHANGED
+    assert emitted[0]["category"] == AuditEventCategory.SECURITY
+    assert emitted[0]["resource_type"] == "user_mfa"
+    assert emitted[0]["resource_id"] == "42"
+    assert emitted[0]["action"] == "admin.user.mfa.disable"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_set_user_mfa_requirement_emits_durable_audit_event(monkeypatch) -> None:
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(**kwargs) -> None:
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _allow_reauth)
+    monkeypatch.setattr(admin_users_service, "_emit_admin_account_audit_event", _fake_emit, raising=False)
+
+    result = await admin_users_service.set_user_mfa_requirement(
+        _admin_principal(),
+        42,
+        AdminMfaRequirementRequest(
+            require_mfa=False,
+            reason="Support case 123",
+            admin_password="AdminPass123!",
+        ),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert result["message"] == "MFA requirement updated successfully"
+    assert len(emitted) == 1
+    assert emitted[0]["actor_id"] == 7
+    assert emitted[0]["target_user_id"] == 42
+    assert emitted[0]["event_type"] == AuditEventType.CONFIG_CHANGED
+    assert emitted[0]["category"] == AuditEventCategory.SECURITY
+    assert emitted[0]["resource_type"] == "user_mfa"
+    assert emitted[0]["resource_id"] == "42"
+    assert emitted[0]["action"] == "admin.user.mfa_requirement.update"
+    assert emitted[0]["metadata"]["reason"] == "Support case 123"
+    assert emitted[0]["metadata"]["require_mfa"] is False
+
+
+async def _false_async() -> bool:
+    return False

--- a/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
+++ b/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
@@ -90,6 +90,7 @@ async def _allow_reauth(*_args, **_kwargs) -> str:
 @pytest.mark.asyncio
 async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> None:
     emitted: list[dict[str, object]] = []
+    hashed_passwords: list[str] = []
 
     async def _fake_emit(**kwargs) -> None:
         emitted.append(kwargs)
@@ -101,7 +102,7 @@ async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> Non
     )
     monkeypatch.setattr(admin_users_service, "verify_privileged_action", _allow_reauth)
     monkeypatch.setattr(admin_users_service, "_emit_admin_account_audit_event", _fake_emit, raising=False)
-    monkeypatch.setattr(admin_users_service, "hash_password", lambda value: f"hashed::{value}")
+    monkeypatch.setattr(admin_users_service, "hash_password", lambda value: hashed_passwords.append(value) or f"hashed::{value}")
 
     result = await admin_users_service.reset_user_password(
         _admin_principal(),
@@ -118,6 +119,7 @@ async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> Non
     )
 
     assert result["message"] == "Password reset successfully"
+    assert hashed_passwords == ["TempPass123!"]
     assert len(emitted) == 1
     assert emitted[0]["actor_id"] == 7
     assert emitted[0]["target_user_id"] == 42
@@ -127,6 +129,7 @@ async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> Non
     assert emitted[0]["resource_id"] == "42"
     assert emitted[0]["action"] == "admin.user.password_reset"
     assert emitted[0]["metadata"]["reason"] == "Support case 123"
+    assert emitted[0]["metadata"]["credential_provided_by_admin"] is True
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
+++ b/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
@@ -13,7 +13,11 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventType,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.services import admin_sessions_mfa_service, admin_users_service
+from tldw_Server_API.app.services import (
+    admin_audit_service,
+    admin_sessions_mfa_service,
+    admin_users_service,
+)
 
 
 class _FakeCursor:
@@ -331,6 +335,36 @@ async def test_set_user_mfa_requirement_emits_durable_audit_event(monkeypatch) -
     assert emitted[0]["action"] == "admin.user.mfa_requirement.update"
     assert emitted[0]["metadata"]["reason"] == "Support case 123"
     assert emitted[0]["metadata"]["require_mfa"] is False
+
+
+@pytest.mark.asyncio
+async def test_emit_admin_account_audit_event_does_not_raise_when_flush_fails(monkeypatch) -> None:
+    class _FailingAuditService:
+        async def log_event(self, **_kwargs) -> None:
+            return None
+
+        async def flush(self, *, raise_on_failure: bool) -> None:
+            raise RuntimeError("audit unavailable")
+
+    async def _fake_get_service(_actor_id):
+        return _FailingAuditService()
+
+    monkeypatch.setattr(
+        admin_audit_service,
+        "get_or_create_audit_service_for_user_id_optional",
+        _fake_get_service,
+    )
+
+    await admin_audit_service.emit_admin_account_audit_event(
+        actor_id=7,
+        target_user_id=42,
+        event_type=AuditEventType.USER_DEACTIVATED,
+        category=AuditEventCategory.AUTHORIZATION,
+        resource_type="user_account",
+        resource_id="42",
+        action="admin.user.deactivate",
+        metadata={"reason": "Support case 123"},
+    )
 
 
 async def _false_async() -> bool:

--- a/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services import admin_guardrails_service
+
+
+class _PasswordService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def verify_password(self, password: str, password_hash: str) -> tuple[bool, bool]:
+        self.calls.append((password, password_hash))
+        return True, False
+
+
+def _single_user_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        subject="single_user",
+        roles=["admin"],
+        is_admin=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_allows_non_enterprise_single_user_without_password(monkeypatch) -> None:
+    password_service = _PasswordService()
+
+    async def _unexpected_fetch(*_args, **_kwargs):
+        raise AssertionError("single-user fallback should not load password hashes")
+
+    monkeypatch.delenv("ADMIN_UI_ENTERPRISE_MODE", raising=False)
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _unexpected_fetch)
+
+    reason = await admin_guardrails_service.verify_privileged_action(
+        _single_user_principal(),
+        db=object(),
+        password_service=password_service,
+        reason="Customer requested restore",
+        admin_password=None,
+    )
+
+    assert reason == "Customer requested restore"
+    assert password_service.calls == []
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_rejects_single_user_without_password_in_enterprise_mode(monkeypatch) -> None:
+    monkeypatch.setenv("ADMIN_UI_ENTERPRISE_MODE", "true")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await admin_guardrails_service.verify_privileged_action(
+            _single_user_principal(),
+            db=object(),
+            password_service=_PasswordService(),
+            reason="Customer requested restore",
+            admin_password=None,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "Reason and current password are required for this action"
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_requires_password_for_multi_user_admin(monkeypatch) -> None:
+    monkeypatch.delenv("ADMIN_UI_ENTERPRISE_MODE", raising=False)
+
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 7,
+            "password_hash": "hashed-password",
+        }
+
+    password_service = _PasswordService()
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+
+    reason = await admin_guardrails_service.verify_privileged_action(
+        AuthPrincipal(
+            kind="user",
+            user_id=7,
+            subject="user:7",
+            roles=["admin"],
+            is_admin=True,
+        ),
+        db=object(),
+        password_service=password_service,
+        reason="Customer requested restore",
+        admin_password="AdminPass123!",
+    )
+
+    assert reason == "Customer requested restore"
+    assert password_service.calls == [("AdminPass123!", "hashed-password")]

--- a/tldw_Server_API/tests/Admin/test_admin_scope_service_enterprise_mode.py
+++ b/tldw_Server_API/tests/Admin/test_admin_scope_service_enterprise_mode.py
@@ -1,0 +1,30 @@
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services import admin_scope_service
+
+
+def test_single_user_principal_is_not_platform_admin_in_enterprise_mode(monkeypatch):
+    monkeypatch.setenv("ADMIN_UI_ENTERPRISE_MODE", "true")
+
+    principal = AuthPrincipal(
+        kind="user",
+        user_id=1,
+        subject="single_user",
+        roles=["admin"],
+        is_admin=True,
+    )
+
+    assert admin_scope_service.is_platform_admin(principal) is False
+
+
+def test_single_user_principal_remains_platform_admin_when_enterprise_mode_disabled(monkeypatch):
+    monkeypatch.delenv("ADMIN_UI_ENTERPRISE_MODE", raising=False)
+
+    principal = AuthPrincipal(
+        kind="user",
+        user_id=1,
+        subject="single_user",
+        roles=["admin"],
+        is_admin=True,
+    )
+
+    assert admin_scope_service.is_platform_admin(principal) is True

--- a/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
@@ -1,0 +1,35 @@
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminPasswordResetResponse,
+    UserUpdateRequest,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_user_update_request_accepts_backend_role_vocabulary() -> None:
+    payload = UserUpdateRequest(role="user")
+
+    assert payload.role == "user"
+
+
+def test_user_update_request_rejects_legacy_member_role() -> None:
+    with pytest.raises(ValidationError):
+        UserUpdateRequest(role="member")
+
+
+def test_admin_password_reset_response_omits_plaintext_password() -> None:
+    payload = AdminPasswordResetResponse(
+        user_id=42,
+        force_password_change=True,
+        message="Password reset successfully",
+    )
+
+    assert payload.model_dump() == {
+        "user_id": 42,
+        "force_password_change": True,
+        "message": "Password reset successfully",
+    }

--- a/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
@@ -2,6 +2,8 @@ import pytest
 from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminPasswordResetRequest,
+    AdminPrivilegedActionRequest,
     AdminPasswordResetResponse,
     UserUpdateRequest,
 )
@@ -33,3 +35,30 @@ def test_admin_password_reset_response_omits_plaintext_password() -> None:
         "force_password_change": True,
         "message": "Password reset successfully",
     }
+
+
+def test_admin_password_reset_request_requires_temporary_password() -> None:
+    with pytest.raises(ValidationError):
+        AdminPasswordResetRequest(
+            reason="Support case 123",
+            admin_password="AdminPass123!",
+        )
+
+
+def test_admin_privileged_action_request_allows_blank_admin_password_for_single_user_mode() -> None:
+    payload = AdminPrivilegedActionRequest(
+        reason="Support case 123",
+        admin_password="",
+    )
+
+    assert payload.admin_password is None
+
+
+def test_user_update_request_allows_blank_admin_password_for_single_user_mode() -> None:
+    payload = UserUpdateRequest(
+        is_active=False,
+        reason="Support case 123",
+        admin_password="",
+    )
+
+    assert payload.admin_password is None

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -1321,5 +1321,64 @@ async def test_refresh_single_user_respects_ip_allowlist(monkeypatch):
             session_manager=object(),
             db=None,
             settings=auth.get_settings(),
-        )
+    )
     assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_single_user_mode_for_enterprise_admin_ui(monkeypatch):
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "single-key")
+    monkeypatch.setenv("ADMIN_UI_ENTERPRISE_MODE", "true")
+    reset_settings()
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    async def _fake_get_auth_governor():
+        return SimpleNamespace()
+
+    async def _fake_fetch_user_by_login_identifier(_db, _identifier: str):
+        return {
+            "id": 42,
+            "username": "admin",
+            "email": "admin@example.com",
+            "role": "admin",
+            "is_active": True,
+            "password_hash": "hashed-password",
+        }
+
+    monkeypatch.setattr(auth, "get_auth_governor", _fake_get_auth_governor)
+    monkeypatch.setattr(auth, "fetch_user_by_login_identifier", _fake_fetch_user_by_login_identifier)
+
+    request = Request({
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/login",
+        "headers": [],
+        "client": ("203.0.113.10", 1234),
+        "scheme": "http",
+        "query_string": b"",
+        "server": ("testserver", 80),
+    })
+    response = Response()
+
+    password_service = SimpleNamespace(
+        verify_password=lambda _password, _hash: (True, False),
+    )
+    rate_limiter = SimpleNamespace(enabled=False)
+
+    with pytest.raises(auth.HTTPException) as exc:
+        await auth.login(
+            request=request,
+            response=response,
+            form_data=SimpleNamespace(username="admin", password="password123"),
+            db=None,
+            jwt_service=object(),
+            password_service=password_service,
+            session_manager=SimpleNamespace(),
+            rate_limiter=rate_limiter,
+            settings=auth.get_settings(),
+        )
+
+    assert exc.value.status_code == 403
+    assert "enterprise admin ui" in exc.value.detail.lower()


### PR DESCRIPTION
## Summary
- add the admin-ui enterprise hardening fixes from the review work onto a clean branch from dev
- support MFA challenge login, move privileged auth to server-managed sessions, and disable API-key admin login in enterprise mode
- add step-up guardrails, durable audit events, safer password-reset/role flows, and track the missing Next.js TS config files required for clean builds

## Verification
- bun run lint
- bun run test
- bun run build
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Admin/test_admin_account_audit_events.py tldw_Server_API/tests/Admin/test_admin_user_schemas.py tldw_Server_API/tests/Admin/test_admin_scope_service_enterprise_mode.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/admin_audit_service.py tldw_Server_API/app/services/admin_users_service.py tldw_Server_API/app/services/admin_sessions_mfa_service.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_admin_ui_fixes_pr.json