### PR TITLE
fix(quick-ingest): wire wizard session runtime

### DIFF
--- a/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx
@@ -1,0 +1,319 @@
+import React from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  startQuickIngestSession: vi.fn(),
+  submitQuickIngestBatch: vi.fn(),
+  cancelQuickIngestSession: vi.fn(),
+  runtimeListeners: [] as Array<(message: any) => void>,
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+            [k: string]: unknown
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      return defaultValueOrOptions?.defaultValue || key
+    },
+  }),
+}))
+
+vi.mock("antd", () => ({
+  Modal: Object.assign(
+    ({ children, open, onCancel, className, title }: any) =>
+      open ? (
+        <div role="dialog" className={className}>
+          <div className="ant-modal-content">
+            <h2>{title}</h2>
+            <button onClick={onCancel}>Close</button>
+            {children}
+          </div>
+        </div>
+      ) : null,
+    {
+      confirm: vi.fn(),
+      destroyAll: vi.fn(),
+    }
+  ),
+  Button: ({ children, onClick, disabled, ...props }: any) => (
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {children}
+    </button>
+  ),
+  Switch: ({ checked, onChange, ...props }: any) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onChange?.(event.target.checked)}
+      {...props}
+    />
+  ),
+  Select: ({ value, onChange, options, ...props }: any) => (
+    <select value={value} onChange={(event) => onChange?.(event.target.value)} {...props}>
+      {(options || []).map((option: any) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+  Radio: Object.assign(
+    ({ children, value, checked, onChange, ...props }: any) => (
+      <label>
+        <input
+          type="radio"
+          value={value}
+          checked={checked}
+          onChange={onChange}
+          {...props}
+        />
+        {children}
+      </label>
+    ),
+    {
+      Group: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+    }
+  ),
+  Collapse: ({ items }: any) => (
+    <div>{items?.map((item: any) => <div key={item.key}>{item.children}</div>)}</div>
+  ),
+}))
+
+vi.mock("lucide-react", () => {
+  const icon = (name: string) => (props: any) => (
+    <span data-icon={name} aria-hidden={props?.["aria-hidden"]} />
+  )
+  return {
+    ArrowLeft: icon("ArrowLeft"),
+    ArrowRight: icon("ArrowRight"),
+    ChevronDown: icon("ChevronDown"),
+    Minimize2: icon("Minimize2"),
+    XCircle: icon("XCircle"),
+    Info: icon("Info"),
+  }
+})
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    runtime: {
+      onMessage: {
+        addListener: (listener: (message: any) => void) => {
+          mocks.runtimeListeners.push(listener)
+        },
+        removeListener: (listener: (message: any) => void) => {
+          const index = mocks.runtimeListeners.indexOf(listener)
+          if (index >= 0) {
+            mocks.runtimeListeners.splice(index, 1)
+          }
+        },
+      },
+    },
+  },
+}))
+
+vi.mock("@/services/tldw/quick-ingest-batch", () => ({
+  startQuickIngestSession: (...args: unknown[]) => mocks.startQuickIngestSession(...args),
+  submitQuickIngestBatch: (...args: unknown[]) => mocks.submitQuickIngestBatch(...args),
+  cancelQuickIngestSession: (...args: unknown[]) => mocks.cancelQuickIngestSession(...args),
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    initialize: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+vi.mock("@/components/Common/QuickIngest/IngestWizardStepper", () => ({
+  IngestWizardStepper: () => <div data-testid="wizard-stepper" />,
+}))
+
+vi.mock("@/components/Common/QuickIngest/AddContentStep", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/Common/QuickIngest/IngestWizardContext")
+  >("@/components/Common/QuickIngest/IngestWizardContext")
+  return {
+    AddContentStep: ({ onQuickProcess }: { onQuickProcess?: () => void }) => {
+      const { setQueueItems } = actual.useIngestWizard()
+      return (
+        <button
+          onClick={() => {
+            setQueueItems([
+              {
+                id: "queued-url-1",
+                url: "https://example.com/article",
+                detectedType: "web",
+                icon: "Globe",
+                fileSize: 0,
+                validation: { valid: true },
+              },
+            ])
+            onQuickProcess?.()
+          }}
+        >
+          Queue And Process
+        </button>
+      )
+    },
+  }
+})
+
+vi.mock("@/components/Common/QuickIngest/ReviewStep", () => ({
+  ReviewStep: () => <div data-testid="wizard-review" />,
+}))
+
+vi.mock("@/components/Common/QuickIngest/ProcessingStep", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/Common/QuickIngest/IngestWizardContext")
+  >("@/components/Common/QuickIngest/IngestWizardContext")
+  return {
+    ProcessingStep: () => {
+      const { state } = actual.useIngestWizard()
+      return (
+        <div data-testid="wizard-processing">
+          {state.processingState.status}:{state.processingState.perItemProgress.length}
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock("@/components/Common/QuickIngest/WizardResultsStep", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/Common/QuickIngest/IngestWizardContext")
+  >("@/components/Common/QuickIngest/IngestWizardContext")
+  return {
+    WizardResultsStep: () => {
+      const { state } = actual.useIngestWizard()
+      return (
+        <div data-testid="wizard-results">
+          {state.processingState.status}:{state.results.length}
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock("@/components/Common/QuickIngest/FloatingProgressWidget", () => ({
+  FloatingProgressWidget: () => null,
+}))
+
+import { QuickIngestWizardModal } from "@/components/Common/QuickIngestWizardModal"
+
+const emitRuntimeMessage = (message: any) => {
+  for (const listener of [...mocks.runtimeListeners]) {
+    listener(message)
+  }
+}
+
+describe("QuickIngestWizardModal session runtime", () => {
+  beforeEach(() => {
+    mocks.runtimeListeners.splice(0, mocks.runtimeListeners.length)
+    mocks.startQuickIngestSession.mockReset()
+    mocks.submitQuickIngestBatch.mockReset()
+    mocks.cancelQuickIngestSession.mockReset()
+    mocks.cancelQuickIngestSession.mockResolvedValue({ ok: true })
+  })
+
+  it("submits the queued wizard batch through the authenticated quick-ingest transport", async () => {
+    const user = userEvent.setup()
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-direct-test",
+    })
+    mocks.submitQuickIngestBatch.mockResolvedValue({
+      ok: true,
+      results: [
+        {
+          id: "queued-url-1",
+          status: "ok",
+          url: "https://example.com/article",
+          type: "html",
+        },
+      ],
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    expect(screen.getByRole("dialog")).toHaveClass(
+      "quick-ingest-modal",
+      "quick-ingest-wizard-modal"
+    )
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+
+    await waitFor(() => {
+      expect(mocks.startQuickIngestSession).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(mocks.submitQuickIngestBatch).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mocks.submitQuickIngestBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        __quickIngestSessionId: "qi-direct-test",
+        entries: [
+          expect.objectContaining({
+            id: "queued-url-1",
+            url: "https://example.com/article",
+            type: "html",
+          }),
+        ],
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
+    })
+  })
+
+  it("uses runtime completion events for extension-backed sessions instead of calling the broken SSE path", async () => {
+    const user = userEvent.setup()
+    mocks.startQuickIngestSession.mockResolvedValue({
+      ok: true,
+      sessionId: "qi-runtime-test",
+    })
+
+    render(<QuickIngestWizardModal open onClose={vi.fn()} />)
+
+    expect(screen.getByRole("dialog")).toHaveClass(
+      "quick-ingest-modal",
+      "quick-ingest-wizard-modal"
+    )
+
+    await user.click(screen.getByRole("button", { name: "Queue And Process" }))
+
+    await waitFor(() => {
+      expect(mocks.startQuickIngestSession).toHaveBeenCalledTimes(1)
+    })
+
+    expect(mocks.submitQuickIngestBatch).not.toHaveBeenCalled()
+
+    emitRuntimeMessage({
+      type: "tldw:quick-ingest/completed",
+      payload: {
+        sessionId: "qi-runtime-test",
+        results: [
+          {
+            id: "queued-url-1",
+            status: "ok",
+            url: "https://example.com/article",
+            type: "html",
+          },
+        ],
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard-results")).toHaveTextContent("complete:1")
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
+++ b/apps/packages/ui/src/components/Common/QuickIngestWizardModal.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef } from "react"
 import { Modal, Button, Switch, Select, Radio, Collapse } from "antd"
+import type { RadioChangeEvent } from "antd"
 import { useTranslation } from "react-i18next"
 import {
   ArrowLeft,
@@ -9,6 +10,7 @@ import {
   XCircle,
   Info,
 } from "lucide-react"
+import { browser } from "wxt/browser"
 import { IngestWizardProvider, useIngestWizard } from "./QuickIngest/IngestWizardContext"
 import { IngestWizardStepper } from "./QuickIngest/IngestWizardStepper"
 import { AddContentStep } from "./QuickIngest/AddContentStep"
@@ -17,8 +19,20 @@ import { ReviewStep } from "./QuickIngest/ReviewStep"
 import { ProcessingStep } from "./QuickIngest/ProcessingStep"
 import { WizardResultsStep } from "./QuickIngest/WizardResultsStep"
 import { FloatingProgressWidget } from "./QuickIngest/FloatingProgressWidget"
-import { useIngestSSE } from "./QuickIngest/useIngestSSE"
-import type { DetectedMediaType, WizardStep } from "./QuickIngest/types"
+import {
+  cancelQuickIngestSession,
+  startQuickIngestSession,
+  submitQuickIngestBatch,
+} from "@/services/tldw/quick-ingest-batch"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import type {
+  DetectedMediaType,
+  ItemProgress,
+  ItemProgressStatus,
+  TypeDefaults,
+  WizardQueueItem,
+  WizardResultItem,
+} from "./QuickIngest/types"
 
 // ---------------------------------------------------------------------------
 // Props
@@ -115,7 +129,7 @@ const ConfigureStep: React.FC = () => {
   )
 
   const handleStorageChange = useCallback(
-    (e: any) => {
+    (e: RadioChangeEvent) => {
       setCustomOptions({ storeRemote: e.target.value })
     },
     [setCustomOptions],
@@ -285,6 +299,233 @@ const ConfigureStep: React.FC = () => {
   )
 }
 
+type QuickIngestEntryType = "auto" | "html" | "pdf" | "document" | "audio" | "video"
+
+type QuickIngestRequestPayload = {
+  entries: Array<{
+    id: string
+    url: string
+    type: QuickIngestEntryType
+    defaults?: TypeDefaults
+  }>
+  files: Array<{
+    id: string
+    name: string
+    type?: string
+    data: number[]
+    defaults?: TypeDefaults
+  }>
+  storeRemote: boolean
+  processOnly: boolean
+  common: {
+    perform_analysis: boolean
+    perform_chunking: boolean
+    overwrite_existing: boolean
+  }
+  advancedValues: Record<string, unknown>
+  fileDefaults: TypeDefaults
+  __quickIngestSessionId?: string
+}
+
+type QuickIngestRuntimeMessage = {
+  type: string
+  payload?: {
+    sessionId?: string
+    result?: Partial<WizardResultItem>
+    results?: Array<Partial<WizardResultItem>>
+    error?: string
+    reason?: string
+  }
+}
+
+const RESULT_SUCCESS_STATUS_TOKENS = [
+  "ok",
+  "success",
+  "completed",
+  "complete",
+  "done",
+  "ingested",
+  "processed",
+  "ready",
+]
+
+const RESULT_CANCELLED_STATUS_TOKENS = ["cancelled", "canceled"]
+
+const mapDetectedTypeToEntryType = (
+  detectedType: DetectedMediaType
+): QuickIngestEntryType => {
+  switch (detectedType) {
+    case "audio":
+    case "video":
+    case "pdf":
+    case "document":
+      return detectedType
+    case "web":
+      return "html"
+    default:
+      return "auto"
+  }
+}
+
+const buildDefaultsForQueueItem = (
+  item: WizardQueueItem,
+  typeDefaults: TypeDefaults
+): TypeDefaults | undefined => {
+  switch (item.detectedType) {
+    case "audio":
+      return typeDefaults.audio ? { audio: typeDefaults.audio } : undefined
+    case "video":
+      return {
+        ...(typeDefaults.audio ? { audio: typeDefaults.audio } : {}),
+        ...(typeDefaults.video ? { video: typeDefaults.video } : {}),
+      }
+    case "document":
+    case "pdf":
+    case "ebook":
+    case "image":
+      return typeDefaults.document ? { document: typeDefaults.document } : undefined
+    default:
+      return undefined
+  }
+}
+
+const normalizeResultStatus = (status: unknown): "ok" | "error" => {
+  const normalized = String(status || "").trim().toLowerCase()
+  if (RESULT_SUCCESS_STATUS_TOKENS.includes(normalized)) return "ok"
+  return "error"
+}
+
+const isCancelledError = (value: unknown) =>
+  RESULT_CANCELLED_STATUS_TOKENS.some((token) =>
+    String(value || "").trim().toLowerCase().includes(token)
+  )
+
+const normalizeWizardResult = (
+  item: Partial<WizardResultItem> | null | undefined
+): WizardResultItem | null => {
+  if (!item?.id) return null
+  const id = String(item.id).trim()
+  if (!id) return null
+  const status = normalizeResultStatus(item.status)
+  const error = typeof item.error === "string" ? item.error : undefined
+  return {
+    id,
+    status,
+    outcome:
+      status === "ok"
+        ? item.outcome || "processed"
+        : isCancelledError(error)
+          ? "cancelled"
+          : item.outcome || "failed",
+    url: item.url,
+    fileName: item.fileName,
+    type: String(item.type || "item"),
+    data: item.data,
+    error,
+    title: item.title,
+    durationMs: item.durationMs,
+    mediaId: item.mediaId,
+  }
+}
+
+const mergeWizardResults = (
+  existing: WizardResultItem[],
+  incoming: WizardResultItem[]
+): WizardResultItem[] => {
+  const merged = new Map<string, WizardResultItem>()
+  for (const item of existing) {
+    merged.set(item.id, item)
+  }
+  for (const item of incoming) {
+    const previous = merged.get(item.id)
+    merged.set(item.id, previous ? { ...previous, ...item } : item)
+  }
+  return Array.from(merged.values())
+}
+
+const buildTerminalProgress = (
+  previous: ItemProgress,
+  result: WizardResultItem
+): ItemProgress => {
+  const cancelled = result.outcome === "cancelled" || isCancelledError(result.error)
+  const nextStatus: ItemProgressStatus =
+    result.status === "ok" ? "complete" : cancelled ? "cancelled" : "failed"
+  return {
+    ...previous,
+    status: nextStatus,
+    progressPercent: 100,
+    currentStage:
+      nextStatus === "complete"
+        ? "Complete"
+        : nextStatus === "cancelled"
+          ? "Cancelled"
+          : result.error || "Failed",
+    estimatedRemaining: 0,
+    error: nextStatus === "failed" ? result.error : undefined,
+  }
+}
+
+const buildFailureResults = (
+  items: WizardQueueItem[],
+  message: string,
+  outcome: "failed" | "cancelled"
+): WizardResultItem[] =>
+  items.map((item) => ({
+    id: item.id,
+    status: "error",
+    outcome,
+    url: item.url,
+    fileName: item.fileName,
+    type: mapDetectedTypeToEntryType(item.detectedType),
+    error: message,
+  }))
+
+const buildQuickIngestPayload = async (
+  items: WizardQueueItem[],
+  options: QuickIngestRequestPayload["common"] & {
+    storeRemote: boolean
+    reviewBeforeStorage: boolean
+    advancedValues?: Record<string, unknown>
+    typeDefaults: TypeDefaults
+  }
+): Promise<QuickIngestRequestPayload> => {
+  const validItems = items.filter((item) => item.validation.valid)
+  const entries = validItems
+    .filter((item): item is WizardQueueItem & { url: string } => Boolean(item.url))
+    .map((item) => ({
+      id: item.id,
+      url: item.url,
+      type: mapDetectedTypeToEntryType(item.detectedType),
+      defaults: buildDefaultsForQueueItem(item, options.typeDefaults),
+    }))
+
+  const files = await Promise.all(
+    validItems
+      .filter((item): item is WizardQueueItem & { file: File } => Boolean(item.file))
+      .map(async (item) => ({
+        id: item.id,
+        name: item.file.name,
+        type: item.file.type || undefined,
+        data: Array.from(new Uint8Array(await item.file.arrayBuffer())),
+        defaults: buildDefaultsForQueueItem(item, options.typeDefaults),
+      }))
+  )
+
+  return {
+    entries,
+    files,
+    storeRemote: options.storeRemote,
+    processOnly: options.reviewBeforeStorage || !options.storeRemote,
+    common: {
+      perform_analysis: options.perform_analysis,
+      perform_chunking: options.perform_chunking,
+      overwrite_existing: options.overwrite_existing,
+    },
+    advancedValues: options.advancedValues ?? {},
+    fileDefaults: options.typeDefaults,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Inner modal content (must be inside IngestWizardProvider)
 // ---------------------------------------------------------------------------
@@ -299,23 +540,30 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
   autoProcessQueued = false,
 }) => {
   const { t } = useTranslation(["option"])
-  const { state, minimize, cancelProcessing, skipToProcessing } = useIngestWizard()
-  const { currentStep, queueItems, processingState } = state
+  const {
+    state,
+    minimize,
+    cancelProcessing,
+    skipToProcessing,
+    updateItemProgress,
+    updateProcessingState,
+    setResults,
+    goNext,
+  } = useIngestWizard()
+  const { currentStep, queueItems, processingState, presetConfig, results } = state
+  const activeSessionIdRef = useRef<string | null>(null)
+  const resultsRef = useRef(results)
+  const hasStartedRunRef = useRef(false)
+  const runStartedAtRef = useRef<number | null>(null)
+  const cancelledSessionIdsRef = useRef<Set<string>>(new Set())
+  const validQueueItems = useMemo(
+    () => queueItems.filter((item) => item.validation.valid),
+    [queueItems]
+  )
 
-  // Track the batch ID for SSE subscription (set when processing starts)
-  const [sseJobMap] = useState(() => new Map<number, string>())
-  const [sseBatchId, setSseBatchId] = useState<string | undefined>()
-
-  // SSE connection: active during processing step
-  const sseEnabled =
-    currentStep === 4 &&
-    (processingState.status === "running" || processingState.status === "idle")
-
-  useIngestSSE({
-    batchId: sseBatchId,
-    jobIdToQueueId: sseJobMap,
-    enabled: sseEnabled,
-  })
+  useEffect(() => {
+    resultsRef.current = results
+  }, [results])
 
   // Auto-process on mount if autoProcessQueued is set and there are queued items
   const autoProcessedRef = useRef(false)
@@ -336,6 +584,260 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
 
   // Whether processing is actively running
   const isProcessingActive = processingState.status === "running"
+
+  const syncElapsed = useCallback(() => {
+    const startedAt = runStartedAtRef.current
+    if (!startedAt) return
+    updateProcessingState({
+      elapsed: Math.max(0, Math.floor((Date.now() - startedAt) / 1000)),
+    })
+  }, [updateProcessingState])
+
+  useEffect(() => {
+    if (processingState.status !== "running") return
+    syncElapsed()
+    const timer = window.setInterval(syncElapsed, 1000)
+    return () => window.clearInterval(timer)
+  }, [processingState.status, syncElapsed])
+
+  const applyResults = useCallback(
+    (incoming: WizardResultItem[]) => {
+      const next = mergeWizardResults(resultsRef.current, incoming)
+      resultsRef.current = next
+      setResults(next)
+      const progressMap = new Map(
+        processingState.perItemProgress.map((item) => [item.id, item])
+      )
+      for (const result of incoming) {
+        const previous = progressMap.get(result.id)
+        if (!previous) continue
+        updateItemProgress(buildTerminalProgress(previous, result))
+      }
+      return next
+    },
+    [processingState.perItemProgress, setResults, updateItemProgress]
+  )
+
+  const finalizeRun = useCallback(
+    (
+      nextStatus: "complete" | "cancelled" | "error",
+      incomingResults: WizardResultItem[]
+    ) => {
+      syncElapsed()
+      applyResults(incomingResults)
+      updateProcessingState({
+        status: nextStatus,
+        estimatedRemaining: 0,
+      })
+      hasStartedRunRef.current = false
+      activeSessionIdRef.current = null
+      goNext()
+    },
+    [applyResults, goNext, syncElapsed, updateProcessingState]
+  )
+
+  const finalizeFailure = useCallback(
+    (message: string, outcome: "failed" | "cancelled") => {
+      const fallbackResults = buildFailureResults(validQueueItems, message, outcome)
+      finalizeRun(outcome === "cancelled" ? "cancelled" : "error", fallbackResults)
+    },
+    [finalizeRun, validQueueItems]
+  )
+
+  const markRunActive = useCallback(() => {
+    runStartedAtRef.current = Date.now()
+    for (const item of validQueueItems) {
+      const initialStatus: ItemProgressStatus = item.file ? "uploading" : "processing"
+      updateItemProgress({
+        id: item.id,
+        status: initialStatus,
+        progressPercent: 10,
+        currentStage: initialStatus === "uploading" ? "Uploading" : "Processing",
+        estimatedRemaining: 0,
+      })
+    }
+  }, [updateItemProgress, validQueueItems])
+
+  const handleRuntimeMessage = useCallback(
+    (message: QuickIngestRuntimeMessage) => {
+      if (!message || typeof message.type !== "string") return
+      const sessionId = String(message.payload?.sessionId || "").trim()
+      if (!sessionId || sessionId !== String(activeSessionIdRef.current || "").trim()) {
+        return
+      }
+      if (
+        cancelledSessionIdsRef.current.has(sessionId) &&
+        message.type !== "tldw:quick-ingest/progress"
+      ) {
+        return
+      }
+
+      if (message.type === "tldw:quick-ingest/progress") {
+        const result = normalizeWizardResult(message.payload?.result)
+        if (result) {
+          applyResults([result])
+        }
+        return
+      }
+
+      if (message.type === "tldw:quick-ingest/completed") {
+        const normalizedResults = (message.payload?.results || [])
+          .map((item) => normalizeWizardResult(item))
+          .filter((item): item is WizardResultItem => Boolean(item))
+        if (normalizedResults.length === 0) {
+          finalizeFailure("Ingest request finished without item results.", "failed")
+          return
+        }
+        finalizeRun("complete", normalizedResults)
+        return
+      }
+
+      if (message.type === "tldw:quick-ingest/failed") {
+        finalizeFailure(
+          String(message.payload?.error || "Quick ingest failed."),
+          "failed"
+        )
+        return
+      }
+
+      if (message.type === "tldw:quick-ingest/cancelled") {
+        finalizeFailure(
+          String(message.payload?.reason || "Cancelled by user."),
+          "cancelled"
+        )
+      }
+    },
+    [applyResults, finalizeFailure, finalizeRun]
+  )
+
+  useEffect(() => {
+    const listener = (message: QuickIngestRuntimeMessage) => {
+      handleRuntimeMessage(message)
+    }
+    try {
+      if (browser?.runtime?.onMessage?.addListener) {
+        browser.runtime.onMessage.addListener(listener)
+      }
+    } catch {
+      return
+    }
+
+    return () => {
+      try {
+        if (browser?.runtime?.onMessage?.removeListener) {
+          browser.runtime.onMessage.removeListener(listener)
+        }
+      } catch {
+        // Ignore cleanup failures in non-extension runtimes.
+      }
+    }
+  }, [handleRuntimeMessage])
+
+  const startRun = useCallback(async () => {
+    if (hasStartedRunRef.current || validQueueItems.length === 0) return
+    hasStartedRunRef.current = true
+    markRunActive()
+
+    try {
+      try {
+        await tldwClient.initialize()
+      } catch {
+        // Best effort; background proxy handles auth for direct runtimes.
+      }
+
+      const requestPayload = await buildQuickIngestPayload(validQueueItems, {
+        ...presetConfig.common,
+        storeRemote: presetConfig.storeRemote,
+        reviewBeforeStorage: presetConfig.reviewBeforeStorage,
+        advancedValues: presetConfig.advancedValues,
+        typeDefaults: presetConfig.typeDefaults,
+      })
+
+      const startAck = await startQuickIngestSession(requestPayload)
+      if (!startAck?.ok || !startAck?.sessionId) {
+        finalizeFailure(
+          startAck?.error ||
+            "Quick ingest failed to start. Check tldw server settings and try again.",
+          "failed"
+        )
+        return
+      }
+
+      const sessionId = String(startAck.sessionId).trim()
+      activeSessionIdRef.current = sessionId
+      cancelledSessionIdsRef.current.delete(sessionId)
+
+      if (!sessionId.startsWith("qi-direct-")) {
+        return
+      }
+
+      const response = await submitQuickIngestBatch({
+        ...requestPayload,
+        __quickIngestSessionId: sessionId,
+      })
+
+      if (
+        cancelledSessionIdsRef.current.has(sessionId) ||
+        sessionId !== String(activeSessionIdRef.current || "").trim()
+      ) {
+        return
+      }
+
+      if (!response?.ok) {
+        finalizeFailure(
+          response?.error ||
+            "Quick ingest failed. Check tldw server settings and try again.",
+          "failed"
+        )
+        return
+      }
+
+      const normalizedResults = (response.results || [])
+        .map((item) => normalizeWizardResult(item))
+        .filter((item): item is WizardResultItem => Boolean(item))
+
+      if (normalizedResults.length === 0) {
+        finalizeFailure("Ingest request finished without item results.", "failed")
+        return
+      }
+
+      finalizeRun("complete", normalizedResults)
+    } catch (error) {
+      finalizeFailure(
+        error instanceof Error ? error.message : "Quick ingest failed.",
+        "failed"
+      )
+    }
+  }, [
+    finalizeFailure,
+    finalizeRun,
+    markRunActive,
+    presetConfig.advancedValues,
+    presetConfig.common,
+    presetConfig.reviewBeforeStorage,
+    presetConfig.storeRemote,
+    presetConfig.typeDefaults,
+    validQueueItems,
+  ])
+
+  useEffect(() => {
+    if (currentStep !== 4 || processingState.status !== "running") return
+    void startRun()
+  }, [currentStep, processingState.status, startRun])
+
+  useEffect(() => {
+    if (processingState.status !== "cancelled") return
+    const sessionId = String(activeSessionIdRef.current || "").trim()
+    if (!sessionId || cancelledSessionIdsRef.current.has(sessionId)) return
+    cancelledSessionIdsRef.current.add(sessionId)
+    void cancelQuickIngestSession({
+      sessionId,
+      reason: "user_cancelled",
+    }).catch(() => {
+      // best effort cancellation
+    })
+    finalizeFailure("Cancelled by user.", "cancelled")
+  }, [finalizeFailure, processingState.status])
 
   // Modal title with item count
   const modalTitle = useMemo(() => {
@@ -422,7 +924,7 @@ const WizardModalContent: React.FC<WizardModalContentProps> = ({
         footer={null}
         width={800}
         destroyOnHidden
-        className="quick-ingest-wizard-modal"
+        className="quick-ingest-modal quick-ingest-wizard-modal"
         styles={{
           body: { padding: "0 16px 16px" },
         }}


### PR DESCRIPTION
## Summary
- rewrite the stale merge PR onto current `dev`
- wire `QuickIngestWizardModal` to the authenticated quick-ingest session runtime
- support direct `qi-direct-*` completion, runtime-backed completion events, and session cancellation inside the wizard
- preserve hidden-tab compatibility by keeping the legacy `quick-ingest-modal` class on the wizard modal

## Why
- current `dev` already routes active quick-ingest entry points to `QuickIngestWizardModal`
- the wizard processing step was still subscribing to an unset SSE `batchId` and never started a quick-ingest session
- this PR now contains only the still-needed follow-up from the old merge branch

## Test Plan
- `cd apps/tldw-frontend && bunx vitest run ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.session.test.tsx ../packages/ui/src/components/Common/QuickIngest/__tests__/QuickIngestWizardModal.integration.test.tsx ../packages/ui/src/entries/shared/__tests__/app-shell.splash.test.tsx`
- no Python files changed; Bandit not applicable for this PR rewrite
