### PR TITLE
feat(tts): Compose & Compare redesign for Speech Playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Some kind of Versioning
 
+## [0.1.36] 2026-03-08
+
+### Added
+
+- **TTS "Compose & Compare" Redesign** — New A/B comparison workflow for the Speech Playground TTS tab:
+  - **`UnifiedAudioPlayer`** (`components/Common/UnifiedAudioPlayer.tsx`): Single audio player component for all providers — play/pause/seek slider, time display, waveform visualization (via `WaveformCanvas`), download button; accepts `audioUrl`, `audioBlob`, or streaming mode; replaces per-provider player inconsistency
+  - **`RenderStrip`** (`components/Option/Speech/RenderStrip.tsx`): Self-contained generation card with five states (`idle`, `generating`, `ready`, `playing`, `error`); config tags (provider, voice, format, speed) as clickable chips; embeds `UnifiedAudioPlayer` for playback and `TtsJobProgress` for long-running generations; undo notification on remove with 4-second restore window
+  - **`useMultiRenderState`** hook (`hooks/useMultiRenderState.ts`): Manages array of render strips with independent generation lifecycle; actions: `addRender`, `removeRender`, `generateRender`, `generateAll`, `clearAll`, `playAllSequentially`; play-one-at-a-time enforcement (starting one pauses others); object URL lifecycle management (create on generate, revoke on remove/unmount)
+  - **`VoicePickerModal`** (`components/Option/Speech/VoicePickerModal.tsx`): Unified voice selection across all 19 backend TTS providers; search input, recent voices row (last 5 from localStorage), provider-grouped catalog (Local Engines / Cloud Providers) with collapsible sections; inline `[Play]` preview per voice; capability badges (Stream, Clone); selecting a voice returns `{ provider, voice, model }` and auto-selects provider
+  - **Render strips zone** in `SpeechPlaygroundPage.tsx`: Between text editor and action bar — maps `useMultiRenderState` to `RenderStrip` components; "Add Render", "Pick Voice", "Generate All", "Play All", "Clear" controls; per-strip generate, edit (opens voice picker), retry, remove actions
+  - **Action bar extensions** in `TtsStickyActionBar.tsx`: "Add Render" button with separator, "Play All" button (shown when multiple ready strips exist)
+  - **Smart defaults**: Last-used voice config persisted to `localStorage` for render strip defaults; recent voices tracked in voice picker
+  - **Accessibility**: `role="region"` + `aria-label` on all strips and players; `role="option"` + keyboard Enter on voice picker items; `aria-label` on all interactive buttons
+  - 36 new tests: `UnifiedAudioPlayer.test.tsx` (8), `RenderStrip.test.tsx` (11), `useMultiRenderState.test.ts` (10), `VoicePickerModal.test.tsx` (7)
+
+### Fixed
+
+- Sandbox runs no longer remain stuck in `starting` when Docker, Firecracker, or Lima runner startup fails; runner exceptions now persist a terminal `failed` state.
+- `sandbox_runs_started_total` now increments only after a sandbox run scaffold is accepted, so rejected requests are no longer counted as started runs.
+- Sandbox runtime admission now uses shared runtime preflight results across service and policy layers instead of diverging ad hoc availability booleans.
+- Sandbox websocket log streams now stop emitting heartbeats after a run ends, preventing terminal `end` frames from being buried in multi-subscriber stress scenarios.
+- Sandbox snapshot creation now tolerates transient files disappearing during concurrent atomic workspace writes, avoiding archive failures on temporary rename targets.
+- `RunStreamHub` subscriber registration now works in synchronous Python 3.11 contexts where no default main-thread event loop exists.
+
 ## [0.1.35] 2026-03-08
 
 ### Added

--- a/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
+++ b/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
@@ -1,0 +1,209 @@
+# TTS "Compose & Compare" Full Redesign
+
+**Date**: 2026-03-07
+**Status**: Design
+**Builds on**: `2026-03-06-tts-listen-tab-ux-redesign.md` (two-zone layout, provider strip, inspector panel)
+**Scope**: Full TTS experience redesign — page structure, render strips, voice picker, unified player
+
+---
+
+## Problem Statement
+
+The Speech Playground TTS experience (`SpeechPlaygroundPage.tsx`, 2,839 lines) has several UX issues grounded in Nielsen's 10 usability heuristics:
+
+1. **Inconsistent playback** (H4: Consistency) — Browser TTS uses Web Speech API controls; server TTS uses HTML5 `<audio>`. Different UI for the same action.
+2. **Provider switching confusion** (H6: Recognition over recall) — Changing providers reveals/hides different controls unpredictably. Users must remember which fields belong to which provider.
+3. **No comparison capability** (H7: Flexibility & efficiency) — No way to A/B test voices, models, or providers. Users must generate, listen, change settings, regenerate, and try to remember the previous result.
+4. **19 adapters, 4 exposed** (H8: Minimalist design, inverted) — The backend supports Kokoro, Higgs, Chatterbox, VibeVoice, ElevenLabs, OpenAI, and 13 more, but the UI only exposes 4 provider buckets.
+5. **Unsurfaced backend features** — Voice upload, voice preview, TTS history, async jobs, word-level alignment metadata are all available via API but not in the UI.
+6. **Settings form overload** (H8: Aesthetic & minimalist design) — 1,000+ lines of settings compete for attention on the same page.
+
+## Target Users
+
+Design uses progressive disclosure to serve three personas:
+- **General users**: Type text, click play. Minimal cognitive load.
+- **Content creators**: Batch generation, export, quality comparison.
+- **Developers/tinkerers**: Full provider visibility, parameter tuning, A/B testing.
+
+## Design: Compose & Compare
+
+### Core Concept
+
+The text editor is the primary surface. Audio outputs appear as **Render Strips** below the editor — self-contained cards, each representing one generation with its own provider/voice/settings. Comparison is structural: having two strips *is* comparison. No special mode needed.
+
+### Page Structure
+
+Single `/speech` route with top-level tabs: **TTS | STT | Roundtrip**
+
+TTS tab layout:
+
+```
++----------------------------------------------+
+| Document Toolbar                              |
+| [Voice: kokoro/af_heart ▾] [Preset: Balanced]|
+| [+ Add Render]  [History]  [⚙ Settings]      |
++----------------------------------------------+
+|  Text Editor (hero element)                   |
+|  +------------------------------------------+|
+|  | [Auto-sizing textarea]                    ||
+|  | 142/8000 chars · ~9s estimated            ||
+|  +------------------------------------------+|
+|                                               |
+|  Render Strips                                |
+|  +------------------------------------------+|
+|  | A: [kokoro] [af_heart] [mp3] [1.0x]      ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:12/0:45    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|  | B: [higgs] [en_speaker_0] [wav] [0.9x]   ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:08/0:38    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|                                               |
+| [▶ Generate] [■ Stop] [▶▶ Play All]          |
++----------------------------------------------+
+```
+
+Drawers (right side, opened on demand):
+- **Settings Drawer** — reuses `TtsInspectorPanel` with Voice, Output, Advanced tabs
+- **History Drawer** — past generations with search, filter, favorites
+
+### Component: Render Strip
+
+Each strip is a self-contained card with five states:
+
+| State | Visual |
+|-------|--------|
+| `idle` | Config tags + "Click Generate to synthesize" |
+| `generating` | Progress bar (or job step indicator for long text) |
+| `ready` | Waveform + playback controls + download |
+| `playing` | Animated waveform, highlighted play button |
+| `error` | Error message + Retry button |
+
+**Interactions:**
+- Config tags are clickable — clicking `[kokoro]` opens the voice picker pre-filtered
+- `[Edit]` opens the settings drawer pre-filled with this strip's config
+- `[✕]` removes the strip with an undo toast (H3: User control & freedom)
+- Only one strip plays at a time — starting one pauses others
+- `[Play All]` plays strips sequentially with a 1-second pause between them
+
+### Component: Voice Picker Modal
+
+Replaces the current per-provider voice/model selection with a unified modal:
+
+```
++----------------------------------------------------------+
+|  Choose a Voice                              [✕ Close]   |
++----------------------------------------------------------+
+|  [🔍 Search voices...]                                   |
+|  Recent: [af_heart] [alloy] [en_speaker_0]               |
++----------------------------------------------------------+
+|  ▾ Local Engines                                         |
+|    ● Kokoro (12 voices)              [healthy]           |
+|      af_heart [▶]  |  af_bella [▶]  |  am_adam [▶]      |
+|    ● Higgs (8 voices)                [healthy]           |
+|      en_speaker_0 [▶]  |  en_speaker_1 [▶]              |
+|    ○ Chatterbox                       [offline]          |
+|  ▾ Cloud Providers                                       |
+|    ● OpenAI (6 voices)                                   |
+|      alloy [▶]  |  echo [▶]  |  nova [▶]                |
+|    ● ElevenLabs (50+ voices)                             |
+|  ▾ Custom Voices                                         |
+|    my_cloned_voice [▶]  |  [+ Upload New]               |
++----------------------------------------------------------+
+```
+
+**Key behaviors:**
+- `[▶]` preview buttons call `/api/v1/audio/voices/{voice_id}/preview` — audio plays inline within the picker
+- Health status per provider from circuit breaker state (green dot / dimmed "offline")
+- Search filters across all providers simultaneously
+- Recent voices (last 5 used) pinned at top
+- Selecting a voice auto-selects its provider — no two-step "pick provider, then pick voice"
+- Provider capability icons: streaming, cloning, emotion, SSML
+- Custom voices section has inline upload via existing `VoiceCloningManager`
+
+### Component: Unified Audio Player
+
+Eliminates the H4 (Consistency) violation of different playback UIs per provider:
+
+- Single player component used in all render strips
+- For server providers: wraps HTML5 audio with custom waveform (reuses `WaveformCanvas`) + controls
+- For browser TTS: synthesizes via Web Speech API, maps events to same progress/play/pause interface
+- Consistent controls: play/pause, seek via waveform click, time display, download
+- Graceful degradation: if waveform data unavailable, shows animated progress bar with same controls
+
+### Progressive Disclosure
+
+| Level | What's visible | How to reach it |
+|-------|---------------|-----------------|
+| 0 — Just play | Text editor + toolbar (default voice) + action bar | Default state |
+| 1 — Customize | Click toolbar chip → settings drawer opens | 1 click |
+| 2 — Compare | Click "+ Add Render" → voice picker → second strip | 2 clicks |
+| 3 — Advanced | Settings drawer → Advanced tab (SSML, emotion, normalization, voice roles, async jobs) | 3 clicks |
+| 4 — Voice mgmt | Voice picker → Custom Voices → upload/clone | On demand |
+
+### Backend Feature Surfacing
+
+| Backend Feature | Where it appears |
+|----------------|-----------------|
+| All 19 TTS adapters | Voice Picker modal, grouped by Local/Cloud |
+| Voice preview API | `[▶]` button on each voice in the picker |
+| Custom voice upload | "Custom Voices" section in picker + `VoiceCloningManager` |
+| Voice encode/clone | Advanced tab in settings drawer |
+| TTS history | History drawer (right side) |
+| Async TTS jobs | Strip progress indicator for text > 2000 chars |
+| Word-level alignment | Opt-in: toggle on strip header highlights words in editor during playback |
+| Provider health | Colored dot per provider in voice picker |
+| Streaming | Progressive waveform drawing as audio arrives |
+
+### Heuristic Coverage
+
+| # | Heuristic | How addressed |
+|---|-----------|---------------|
+| 1 | Visibility of system status | Strip states, provider health dots, char count, estimated duration, waveform progress |
+| 2 | Match system & real world | Voice names + preview (not IDs), "Local Engines"/"Cloud Providers" grouping |
+| 3 | User control & freedom | Undo on strip removal, history drawer, explicit generate, editable config |
+| 4 | Consistency & standards | Unified audio player for all providers, consistent strip cards |
+| 5 | Error prevention | Char limit warning at 2000, explicit generate for all text, dimmed offline providers |
+| 6 | Recognition over recall | Recent voices pinned, config shown as tags on strips, voice preview |
+| 7 | Flexibility & efficiency | Ctrl+Enter to generate, presets, "+ Add Render", clickable config tags |
+| 8 | Aesthetic & minimalist design | Only editor + toolbar visible by default; settings/history in drawers |
+| 9 | Help users recover | Error state on strips with retry, toast with undo on deletion, provider retry |
+| 10 | Help & documentation | Tooltips on capability icons, estimated duration, char count guidance |
+
+### Relationship to Prior Designs
+
+This design extends `2026-03-06-tts-listen-tab-ux-redesign.md`:
+- **Keeps**: Two-zone concept (workspace + inspector), provider strip, sticky action bar, inspector panel tabs
+- **Adds**: Render strips (multi-generation), voice picker modal, unified audio player, comparison flow
+- **Changes**: Action bar includes "Add Render" and "Play All"; workspace zone contains render strips instead of single waveform
+
+The STT tab follows `2026-03-06-stt-playground-comparison-first-redesign.md` unchanged.
+
+### Existing Components to Reuse
+
+| Component | File | Reuse plan |
+|-----------|------|------------|
+| `TtsProviderStrip` | `Speech/TtsProviderStrip.tsx` | Becomes document toolbar |
+| `TtsStickyActionBar` | `Speech/TtsStickyActionBar.tsx` | Becomes action bar with added "Add Render" / "Play All" |
+| `TtsInspectorPanel` | `Speech/TtsInspectorPanel.tsx` | Settings drawer shell (reuse as-is) |
+| `TtsVoiceTab` | `Speech/TtsVoiceTab.tsx` | Inspector voice tab (refactor to support per-strip config) |
+| `TtsOutputTab` | `Speech/TtsOutputTab.tsx` | Inspector output tab |
+| `TtsAdvancedTab` | `Speech/TtsAdvancedTab.tsx` | Inspector advanced tab |
+| `WaveformCanvas` | `Common/WaveformCanvas.tsx` | Waveform in each render strip |
+| `TtsJobProgress` | `Common/TtsJobProgress.tsx` | Progress indicator in generating strips |
+| `VoiceCloningManager` | `TTS/VoiceCloningManager.tsx` | Custom voices section in voice picker |
+| `CharacterProgressBar` | `Common/CharacterProgressBar.tsx` | Char count in text editor |
+| `LongformDraftEditor` | `Common/LongformDraftEditor.tsx` | Advanced text editing mode |
+| `useTtsPlayground` | `hooks/useTtsPlayground.tsx` | Evolve to multi-strip state management |
+| `useTtsProviderData` | `hooks/useTtsProviderData.ts` | Provider/voice data fetching |
+| `useStreamingAudioPlayer` | `hooks/useStreamingAudioPlayer.ts` | Streaming playback per strip |
+
+### New Components to Build
+
+1. **`RenderStrip`** — Self-contained card: config tags + unified player + waveform + download
+2. **`VoicePickerModal`** — Provider-grouped voice catalog with search, preview, recent, custom upload
+3. **`UnifiedAudioPlayer`** — Normalizes browser TTS and server TTS behind common play/pause/seek/progress interface
+4. **`useMultiRenderState`** — Hook managing array of render strip states with independent generation

--- a/apps/packages/ui/src/components/Common/UnifiedAudioPlayer.tsx
+++ b/apps/packages/ui/src/components/Common/UnifiedAudioPlayer.tsx
@@ -1,0 +1,236 @@
+import React from "react"
+import { Button, Slider, Tooltip, Typography } from "antd"
+import { Download, Pause, Play } from "lucide-react"
+import WaveformCanvas from "@/components/Common/WaveformCanvas"
+
+const { Text } = Typography
+
+export type UnifiedAudioPlayerProps = {
+  /** Object URL or data URL for the audio */
+  audioUrl?: string
+  /** Raw blob for download */
+  audioBlob?: Blob
+  /** Whether audio is currently streaming in */
+  isStreaming?: boolean
+  /** Label for accessibility */
+  label?: string
+  /** Compact mode reduces height */
+  compact?: boolean
+  /** Called when playback starts */
+  onPlay?: () => void
+  /** Called when playback pauses */
+  onPause?: () => void
+  /** Called when playback ends naturally */
+  onEnd?: () => void
+  /** Called on seek */
+  onSeek?: (time: number) => void
+  /** Filename for download (without extension) */
+  downloadFilename?: string
+  /** Audio format for download extension */
+  format?: string
+  /** Whether to show the waveform visualization */
+  showWaveform?: boolean
+  /** External control: force pause */
+  forcePaused?: boolean
+}
+
+const formatTime = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds < 0) return "0:00"
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}:${secs.toString().padStart(2, "0")}`
+}
+
+export const UnifiedAudioPlayer: React.FC<UnifiedAudioPlayerProps> = ({
+  audioUrl,
+  audioBlob,
+  isStreaming = false,
+  label = "Audio player",
+  compact = false,
+  onPlay,
+  onPause,
+  onEnd,
+  onSeek,
+  downloadFilename,
+  format = "mp3",
+  showWaveform = true,
+  forcePaused
+}) => {
+  const audioRef = React.useRef<HTMLAudioElement>(null)
+  const [playing, setPlaying] = React.useState(false)
+  const [currentTime, setCurrentTime] = React.useState(0)
+  const [duration, setDuration] = React.useState(0)
+
+  // Load audio source
+  React.useEffect(() => {
+    const el = audioRef.current
+    if (!el) return
+    if (audioUrl) {
+      el.src = audioUrl
+      el.load()
+    } else {
+      el.removeAttribute("src")
+    }
+    setPlaying(false)
+    setCurrentTime(0)
+    setDuration(0)
+  }, [audioUrl])
+
+  // Force pause from parent
+  React.useEffect(() => {
+    if (forcePaused && playing) {
+      audioRef.current?.pause()
+      setPlaying(false)
+    }
+  }, [forcePaused, playing])
+
+  const handlePlayPause = () => {
+    const el = audioRef.current
+    if (!el || !audioUrl) return
+    if (playing) {
+      el.pause()
+      setPlaying(false)
+      onPause?.()
+    } else {
+      el.play().catch(() => {})
+      setPlaying(true)
+      onPlay?.()
+    }
+  }
+
+  const handleTimeUpdate = () => {
+    const el = audioRef.current
+    if (!el) return
+    setCurrentTime(el.currentTime)
+    setDuration(el.duration || 0)
+  }
+
+  const handleEnded = () => {
+    setPlaying(false)
+    setCurrentTime(0)
+    onEnd?.()
+  }
+
+  const handleSeek = (value: number) => {
+    const el = audioRef.current
+    if (!el || !Number.isFinite(value)) return
+    el.currentTime = value
+    setCurrentTime(value)
+    onSeek?.(value)
+  }
+
+  const handleDownload = () => {
+    const blob = audioBlob
+    const url = audioUrl
+    if (!blob && !url) return
+
+    const extension = format || "mp3"
+    const name = downloadFilename || `audio-${Date.now()}`
+    const filename = `${name}.${extension}`
+
+    if (blob) {
+      const blobUrl = URL.createObjectURL(blob)
+      const link = document.createElement("a")
+      link.href = blobUrl
+      link.download = filename
+      link.click()
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 1000)
+    } else if (url) {
+      const link = document.createElement("a")
+      link.href = url
+      link.download = filename
+      link.click()
+    }
+  }
+
+  const hasAudio = Boolean(audioUrl)
+  const sliderMax = duration > 0 ? duration : 1
+  const waveformHeight = compact ? 40 : 56
+
+  return (
+    <div
+      role="region"
+      aria-label={label}
+      className="flex flex-col gap-1.5 rounded-md border border-border bg-surface/60 px-3 py-2"
+    >
+      {/* Hidden native audio element */}
+      <audio
+        ref={audioRef}
+        onTimeUpdate={handleTimeUpdate}
+        onLoadedMetadata={handleTimeUpdate}
+        onEnded={handleEnded}
+        preload="metadata"
+      />
+
+      {/* Controls row */}
+      <div className="flex items-center gap-2">
+        <Button
+          type="text"
+          size="small"
+          icon={
+            playing ? (
+              <Pause className="h-4 w-4" />
+            ) : (
+              <Play className="h-4 w-4" />
+            )
+          }
+          disabled={!hasAudio && !isStreaming}
+          onClick={handlePlayPause}
+          aria-label={playing ? "Pause" : "Play"}
+        />
+
+        {/* Time display */}
+        <Text className="min-w-[80px] text-xs tabular-nums text-text-muted">
+          {formatTime(currentTime)} / {formatTime(duration)}
+        </Text>
+
+        {/* Seek slider */}
+        <div className="flex-1">
+          <Slider
+            min={0}
+            max={sliderMax}
+            step={0.1}
+            value={currentTime}
+            onChange={handleSeek}
+            disabled={!hasAudio || duration <= 0}
+            tooltip={{ formatter: (v) => formatTime(v ?? 0) }}
+            styles={{ track: { height: 3 }, rail: { height: 3 } }}
+          />
+        </div>
+
+        {/* Download */}
+        {(audioBlob || audioUrl) && (
+          <Tooltip title="Download">
+            <Button
+              type="text"
+              size="small"
+              icon={<Download className="h-3.5 w-3.5" />}
+              onClick={handleDownload}
+              aria-label="Download audio"
+            />
+          </Tooltip>
+        )}
+      </div>
+
+      {/* Waveform visualization */}
+      {showWaveform && hasAudio && (
+        <WaveformCanvas
+          audioRef={audioRef as React.RefObject<HTMLAudioElement>}
+          active={playing}
+          label={`${label} waveform`}
+          height={waveformHeight}
+        />
+      )}
+
+      {/* Streaming indicator */}
+      {isStreaming && (
+        <div className="flex items-center gap-1.5">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-green-500" />
+          <Text className="text-xs text-text-muted">Streaming...</Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default UnifiedAudioPlayer

--- a/apps/packages/ui/src/components/Common/__tests__/UnifiedAudioPlayer.test.tsx
+++ b/apps/packages/ui/src/components/Common/__tests__/UnifiedAudioPlayer.test.tsx
@@ -1,0 +1,79 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { UnifiedAudioPlayer } from "../UnifiedAudioPlayer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/components/Common/WaveformCanvas", () => ({
+  __esModule: true,
+  default: ({ label }: { label?: string }) => (
+    <div data-testid="waveform" aria-label={label} />
+  )
+}))
+
+// Mock HTMLAudioElement
+const mockAudio = {
+  play: vi.fn().mockResolvedValue(undefined),
+  pause: vi.fn(),
+  load: vi.fn(),
+  removeAttribute: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  currentTime: 0,
+  duration: 120,
+  src: "",
+  preload: ""
+}
+
+describe("UnifiedAudioPlayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders with idle state when no audioUrl", () => {
+    render(<UnifiedAudioPlayer />)
+    const playButton = screen.getByRole("button", { name: "Play" })
+    expect(playButton).toBeDisabled()
+  })
+
+  it("renders play button when audioUrl is provided", () => {
+    render(<UnifiedAudioPlayer audioUrl="blob:test" />)
+    const playButton = screen.getByRole("button", { name: "Play" })
+    expect(playButton).not.toBeDisabled()
+  })
+
+  it("renders region with correct aria-label", () => {
+    render(<UnifiedAudioPlayer label="Test player" />)
+    expect(screen.getByRole("region", { name: "Test player" })).toBeInTheDocument()
+  })
+
+  it("shows streaming indicator when isStreaming is true", () => {
+    render(<UnifiedAudioPlayer isStreaming />)
+    expect(screen.getByText("Streaming...")).toBeInTheDocument()
+  })
+
+  it("does not show streaming indicator by default", () => {
+    render(<UnifiedAudioPlayer />)
+    expect(screen.queryByText("Streaming...")).not.toBeInTheDocument()
+  })
+
+  it("renders time display", () => {
+    render(<UnifiedAudioPlayer audioUrl="blob:test" />)
+    expect(screen.getByText("0:00 / 0:00")).toBeInTheDocument()
+  })
+
+  it("shows download button when audioUrl is provided", () => {
+    render(<UnifiedAudioPlayer audioUrl="blob:test" />)
+    expect(screen.getByRole("button", { name: "Download audio" })).toBeInTheDocument()
+  })
+
+  it("does not show download button when no audio", () => {
+    render(<UnifiedAudioPlayer />)
+    expect(screen.queryByRole("button", { name: "Download audio" })).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
@@ -1,0 +1,258 @@
+import React from "react"
+import { Button, Tag, Tooltip, notification } from "antd"
+import { Edit3, Play, RefreshCw, Trash2, X } from "lucide-react"
+import { UnifiedAudioPlayer } from "@/components/Common/UnifiedAudioPlayer"
+import { TtsJobProgress, type TtsJobProgressStep } from "@/components/Common/TtsJobProgress"
+
+export type RenderStripState = "idle" | "generating" | "ready" | "playing" | "error"
+
+export type RenderStripConfig = {
+  provider: string
+  voice: string
+  model?: string
+  format?: string
+  speed?: number
+}
+
+export type RenderStripProps = {
+  id: string
+  state: RenderStripState
+  config: RenderStripConfig
+  audioUrl?: string
+  audioBlob?: Blob
+  errorMessage?: string
+  /** Progress 0-100 for long-running generations */
+  progress?: number
+  /** Whether this strip's audio is currently playing */
+  isPlaying?: boolean
+  /** Force pause (when another strip starts playing) */
+  forcePaused?: boolean
+  /** Generation progress steps for long-running jobs */
+  jobSteps?: TtsJobProgressStep[]
+  jobCurrentStep?: number
+  jobMessage?: string
+  jobEta?: number
+  onGenerate?: (id: string) => void
+  onRemove?: (id: string) => void
+  onEdit?: (id: string) => void
+  onPlay?: (id: string) => void
+  onPause?: (id: string) => void
+  onRetry?: (id: string) => void
+  onConfigTagClick?: (id: string, field: string) => void
+}
+
+const DEFAULT_JOB_STEPS: TtsJobProgressStep[] = [
+  { key: "queued", label: "Queued" },
+  { key: "synthesizing", label: "Synthesizing" },
+  { key: "complete", label: "Complete" }
+]
+
+export const RenderStrip: React.FC<RenderStripProps> = ({
+  id,
+  state,
+  config,
+  audioUrl,
+  audioBlob,
+  errorMessage,
+  progress,
+  isPlaying,
+  forcePaused,
+  jobSteps,
+  jobCurrentStep,
+  jobMessage,
+  jobEta,
+  onGenerate,
+  onRemove,
+  onEdit,
+  onPlay,
+  onPause,
+  onRetry,
+  onConfigTagClick
+}) => {
+  const [undoPending, setUndoPending] = React.useState(false)
+  const undoTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleRemove = () => {
+    setUndoPending(true)
+    undoTimerRef.current = setTimeout(() => {
+      setUndoPending(false)
+      onRemove?.(id)
+    }, 4000)
+    notification.info({
+      key: `undo-${id}`,
+      message: "Render strip removed",
+      description: "Click Undo to restore it.",
+      btn: (
+        <Button
+          size="small"
+          onClick={() => {
+            if (undoTimerRef.current) {
+              clearTimeout(undoTimerRef.current)
+              undoTimerRef.current = null
+            }
+            setUndoPending(false)
+            notification.destroy(`undo-${id}`)
+          }}
+        >
+          Undo
+        </Button>
+      ),
+      duration: 4
+    })
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current)
+    }
+  }, [])
+
+  if (undoPending) return null
+
+  const providerLabel = config.provider === "tldw"
+    ? (config.model || "tldw")
+    : config.provider
+
+  const isGenerating = state === "generating"
+  const isReady = state === "ready" || state === "playing"
+  const isError = state === "error"
+  const isIdle = state === "idle"
+
+  return (
+    <div
+      role="region"
+      aria-label={`Render strip: ${providerLabel} ${config.voice}`}
+      className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-border-hover"
+      data-strip-id={id}
+      data-strip-state={state}
+    >
+      {/* Config tags row */}
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        <Tooltip title={`Provider: ${config.provider}`}>
+          <Tag
+            className="cursor-pointer"
+            onClick={() => onConfigTagClick?.(id, "provider")}
+          >
+            {providerLabel}
+          </Tag>
+        </Tooltip>
+
+        <Tooltip title={`Voice: ${config.voice}`}>
+          <Tag
+            className="cursor-pointer"
+            onClick={() => onConfigTagClick?.(id, "voice")}
+          >
+            {config.voice}
+          </Tag>
+        </Tooltip>
+
+        {config.format && (
+          <Tooltip title={`Format: ${config.format}`}>
+            <Tag
+              className="cursor-pointer"
+              onClick={() => onConfigTagClick?.(id, "format")}
+            >
+              {config.format.toUpperCase()}
+            </Tag>
+          </Tooltip>
+        )}
+
+        {config.speed && config.speed !== 1 && (
+          <Tooltip title={`Speed: ${config.speed}x`}>
+            <Tag
+              className="cursor-pointer"
+              onClick={() => onConfigTagClick?.(id, "speed")}
+            >
+              {config.speed}x
+            </Tag>
+          </Tooltip>
+        )}
+
+        <div className="flex-1" />
+
+        {/* Action buttons */}
+        {isIdle && (
+          <Tooltip title="Generate">
+            <Button
+              type="primary"
+              size="small"
+              icon={<Play className="h-3.5 w-3.5" />}
+              onClick={() => onGenerate?.(id)}
+              aria-label="Generate audio"
+            >
+              Generate
+            </Button>
+          </Tooltip>
+        )}
+
+        <Tooltip title="Edit config">
+          <Button
+            type="text"
+            size="small"
+            icon={<Edit3 className="h-3.5 w-3.5" />}
+            onClick={() => onEdit?.(id)}
+            aria-label="Edit configuration"
+          />
+        </Tooltip>
+
+        <Tooltip title="Remove">
+          <Button
+            type="text"
+            size="small"
+            danger
+            icon={<Trash2 className="h-3.5 w-3.5" />}
+            onClick={handleRemove}
+            aria-label="Remove render strip"
+          />
+        </Tooltip>
+      </div>
+
+      {/* Generating state */}
+      {isGenerating && (
+        <TtsJobProgress
+          title="Generating audio..."
+          steps={jobSteps || DEFAULT_JOB_STEPS}
+          currentStep={jobCurrentStep ?? 0}
+          percent={progress}
+          message={jobMessage}
+          status="running"
+          etaSeconds={jobEta}
+        />
+      )}
+
+      {/* Ready/Playing state — unified audio player */}
+      {isReady && audioUrl && (
+        <UnifiedAudioPlayer
+          audioUrl={audioUrl}
+          audioBlob={audioBlob}
+          label={`${providerLabel} ${config.voice} audio`}
+          compact
+          format={config.format}
+          downloadFilename={`tts-${config.provider}-${config.voice}-${Date.now()}`}
+          forcePaused={forcePaused}
+          onPlay={() => onPlay?.(id)}
+          onPause={() => onPause?.(id)}
+        />
+      )}
+
+      {/* Error state */}
+      {isError && (
+        <div className="flex items-center gap-2 rounded border border-red-200 bg-red-50 px-3 py-2 dark:border-red-900 dark:bg-red-950/30">
+          <X className="h-4 w-4 shrink-0 text-red-500" />
+          <span className="flex-1 text-sm text-red-700 dark:text-red-400">
+            {errorMessage || "Generation failed"}
+          </span>
+          <Button
+            size="small"
+            icon={<RefreshCw className="h-3.5 w-3.5" />}
+            onClick={() => onRetry?.(id)}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RenderStrip

--- a/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/RenderStrip.tsx
@@ -37,6 +37,8 @@ export type RenderStripProps = {
   onEdit?: (id: string) => void
   onPlay?: (id: string) => void
   onPause?: (id: string) => void
+  /** Called when audio playback ends naturally */
+  onEnd?: (id: string) => void
   onRetry?: (id: string) => void
   onConfigTagClick?: (id: string, field: string) => void
 }
@@ -66,6 +68,7 @@ export const RenderStrip: React.FC<RenderStripProps> = ({
   onEdit,
   onPlay,
   onPause,
+  onEnd,
   onRetry,
   onConfigTagClick
 }) => {
@@ -232,6 +235,7 @@ export const RenderStrip: React.FC<RenderStripProps> = ({
           forcePaused={forcePaused}
           onPlay={() => onPlay?.(id)}
           onPause={() => onPause?.(id)}
+          onEnd={() => onEnd?.(id)}
         />
       )}
 

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -726,7 +726,11 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
             ...existing.config,
             provider: selection.provider,
             voice: selection.voice,
-            model: selection.model || existing.config.model
+            // Only preserve old model if the provider didn't change; otherwise use selection.model
+            // (which is undefined for openai/elevenlabs/browser — that's intentional)
+            model: selection.provider === existing.config.provider
+              ? (selection.model ?? existing.config.model)
+              : selection.model
           })
         }
         setVoicePickerTargetStripId(null)
@@ -763,8 +767,8 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
     [multiRender]
   )
 
-  const handlePlayAllRenders = React.useCallback(async () => {
-    await multiRender.playAllSequentially()
+  const handlePlayAllRenders = React.useCallback(() => {
+    multiRender.playAllSequentially()
   }, [multiRender])
 
   React.useEffect(() => {
@@ -2454,6 +2458,7 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                             }}
                             onPlay={multiRender.startPlaying}
                             onPause={multiRender.stopPlaying}
+                            onEnd={multiRender.handleStripEnded}
                             onRetry={(id) => {
                               const effectiveText = useDraftEditor ? transcriptDraft : ttsText
                               void multiRender.generateRender(id, effectiveText)

--- a/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx
@@ -17,7 +17,7 @@ import {
   notification
 } from "antd"
 import type { DefaultOptionType } from "antd/es/select"
-import { ArrowRight, Copy, Lock, Mic, Pause, Play, Save, Star, Trash2, Unlock } from "lucide-react"
+import { ArrowRight, Copy, Lock, Mic, Pause, Play, Plus, Save, Star, Trash2, Unlock } from "lucide-react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { PageShell } from "@/components/Common/PageShell"
 import WaveformCanvas from "@/components/Common/WaveformCanvas"
@@ -62,6 +62,9 @@ import { TtsVoiceTab } from "@/components/Option/Speech/TtsVoiceTab"
 import { TtsOutputTab } from "@/components/Option/Speech/TtsOutputTab"
 import { TtsAdvancedTab } from "@/components/Option/Speech/TtsAdvancedTab"
 import { VoiceCloningManager } from "@/components/Option/TTS/VoiceCloningManager"
+import { RenderStrip } from "@/components/Option/Speech/RenderStrip"
+import { VoicePickerModal, type VoiceSelection } from "@/components/Option/Speech/VoicePickerModal"
+import { useMultiRenderState } from "@/hooks/useMultiRenderState"
 
 const { Text, Title, Paragraph } = Typography
 
@@ -684,6 +687,85 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
   const [voicePreviewUrl, setVoicePreviewUrl] = React.useState<string | null>(null)
   const [voicePreviewCardId, setVoicePreviewCardId] = React.useState<string | null>(null)
   const [voicePreviewingId, setVoicePreviewingId] = React.useState<string | null>(null)
+
+  // Compose & Compare: Multi-render strips + voice picker
+  const [voicePickerOpen, setVoicePickerOpen] = React.useState(false)
+  const [voicePickerTargetStripId, setVoicePickerTargetStripId] = React.useState<string | null>(null)
+  const multiRender = useMultiRenderState()
+
+  const handleAddRenderStrip = React.useCallback(() => {
+    // Try to use last-used voice config from localStorage
+    let lastVoice: { provider?: string; voice?: string; model?: string } | null = null
+    try {
+      const stored = localStorage.getItem("tts-last-render-config")
+      if (stored) lastVoice = JSON.parse(stored)
+    } catch {}
+
+    const defaultConfig = {
+      provider: lastVoice?.provider || (provider === "browser" ? "tldw" : provider),
+      voice: lastVoice?.voice || tldwVoice || ttsSettings?.tldwTtsVoice || "af_heart",
+      model: lastVoice?.model || tldwModel || ttsSettings?.tldwTtsModel || "kokoro",
+      format: tldwFormat || ttsSettings?.tldwTtsResponseFormat || "mp3",
+      speed: ttsSettings?.tldwTtsSpeed ?? 1
+    }
+    multiRender.addRender(defaultConfig)
+  }, [provider, tldwVoice, tldwModel, tldwFormat, ttsSettings, multiRender])
+
+  const handleVoicePickerSelect = React.useCallback(
+    (selection: VoiceSelection) => {
+      // Persist last-used voice config
+      try {
+        localStorage.setItem("tts-last-render-config", JSON.stringify(selection))
+      } catch {}
+
+      if (voicePickerTargetStripId) {
+        // Update existing strip config
+        const existing = multiRender.renders.find((r) => r.id === voicePickerTargetStripId)
+        if (existing) {
+          multiRender.updateConfig(voicePickerTargetStripId, {
+            ...existing.config,
+            provider: selection.provider,
+            voice: selection.voice,
+            model: selection.model || existing.config.model
+          })
+        }
+        setVoicePickerTargetStripId(null)
+      } else {
+        // Add new render strip with the selected voice
+        multiRender.addRender({
+          provider: selection.provider,
+          voice: selection.voice,
+          model: selection.model,
+          format: tldwFormat || ttsSettings?.tldwTtsResponseFormat || "mp3",
+          speed: ttsSettings?.tldwTtsSpeed ?? 1
+        })
+      }
+    },
+    [voicePickerTargetStripId, multiRender, tldwFormat, ttsSettings]
+  )
+
+  const handleRenderStripConfigTagClick = React.useCallback(
+    (stripId: string, field: string) => {
+      if (field === "voice" || field === "provider") {
+        setVoicePickerTargetStripId(stripId)
+        setVoicePickerOpen(true)
+      }
+      // format/speed tag clicks are handled after openInspectorAt is defined
+    },
+    []
+  )
+
+  const handleGenerateAllRenders = React.useCallback(
+    async (text: string) => {
+      if (!text.trim()) return
+      await multiRender.generateAll(text)
+    },
+    [multiRender]
+  )
+
+  const handlePlayAllRenders = React.useCallback(async () => {
+    await multiRender.playAllSequentially()
+  }, [multiRender])
 
   React.useEffect(() => {
     return () => {
@@ -2309,6 +2391,99 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                       {previewWordCount} words · {previewSegments.length} segments ({responseSplitting}) · Est. ~{formatDuration(estimatedDurationSeconds)}
                     </div>
 
+                    {/* Compose & Compare: Render Strips Zone */}
+                    {multiRender.renders.length > 0 && (
+                      <div className="space-y-2" role="region" aria-label="Render strips for A/B comparison">
+                        <div className="flex items-center justify-between">
+                          <Text strong className="text-sm">
+                            {t("playground:tts.renderStrips", "Render Strips")}
+                          </Text>
+                          <div className="flex items-center gap-1.5">
+                            {multiRender.hasReady && (
+                              <Button
+                                size="small"
+                                onClick={() => void handlePlayAllRenders()}
+                                icon={<Play className="h-3 w-3" />}
+                              >
+                                {t("playground:tts.playAll", "Play All")}
+                              </Button>
+                            )}
+                            {multiRender.hasIdle && (
+                              <Button
+                                size="small"
+                                type="primary"
+                                onClick={() => {
+                                  const effectiveText = useDraftEditor ? transcriptDraft : ttsText
+                                  void handleGenerateAllRenders(effectiveText)
+                                }}
+                                disabled={!(useDraftEditor ? transcriptDraft : ttsText).trim()}
+                              >
+                                {t("playground:tts.generateAll", "Generate All")}
+                              </Button>
+                            )}
+                            <Button
+                              size="small"
+                              type="text"
+                              danger
+                              onClick={multiRender.clearAll}
+                            >
+                              {t("playground:tts.clearStrips", "Clear")}
+                            </Button>
+                          </div>
+                        </div>
+                        {multiRender.renders.map((render) => (
+                          <RenderStrip
+                            key={render.id}
+                            id={render.id}
+                            state={render.state}
+                            config={render.config}
+                            audioUrl={render.audioUrl}
+                            audioBlob={render.audioBlob}
+                            errorMessage={render.errorMessage}
+                            progress={render.progress}
+                            isPlaying={multiRender.playingId === render.id}
+                            forcePaused={multiRender.playingId !== null && multiRender.playingId !== render.id}
+                            onGenerate={(id) => {
+                              const effectiveText = useDraftEditor ? transcriptDraft : ttsText
+                              void multiRender.generateRender(id, effectiveText)
+                            }}
+                            onRemove={multiRender.removeRender}
+                            onEdit={(id) => {
+                              setVoicePickerTargetStripId(id)
+                              setVoicePickerOpen(true)
+                            }}
+                            onPlay={multiRender.startPlaying}
+                            onPause={multiRender.stopPlaying}
+                            onRetry={(id) => {
+                              const effectiveText = useDraftEditor ? transcriptDraft : ttsText
+                              void multiRender.generateRender(id, effectiveText)
+                            }}
+                            onConfigTagClick={handleRenderStripConfigTagClick}
+                          />
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Add Render button */}
+                    <div className="flex items-center gap-2">
+                      <Button
+                        size="small"
+                        icon={<Plus className="h-3.5 w-3.5" />}
+                        onClick={handleAddRenderStrip}
+                      >
+                        {t("playground:tts.addRender", "Add Render")}
+                      </Button>
+                      <Button
+                        size="small"
+                        onClick={() => {
+                          setVoicePickerTargetStripId(null)
+                          setVoicePickerOpen(true)
+                        }}
+                      >
+                        {t("playground:tts.pickVoice", "Pick Voice")}
+                      </Button>
+                    </div>
+
                     {/* Streaming / Job status — when active */}
                     {canStream && streamStatus !== "idle" && (
                       <div className="flex flex-wrap items-center gap-2 text-xs" aria-live="polite">
@@ -2462,6 +2637,10 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
                     inspectorBadge={inspectorBadge}
                     segmentCount={segments.length}
                     provider={provider}
+                    onAddRender={handleAddRenderStrip}
+                    onPlayAllRenders={() => void handlePlayAllRenders()}
+                    renderStripCount={multiRender.renders.length}
+                    hasReadyRenders={multiRender.hasReady}
                   />
                 </div>
 
@@ -2832,6 +3011,16 @@ export const SpeechPlaygroundPage: React.FC<SpeechPlaygroundPageProps> = ({
           )}
         </Card>
       </div>
+      {/* Voice Picker Modal */}
+      <VoicePickerModal
+        open={voicePickerOpen}
+        onClose={() => {
+          setVoicePickerOpen(false)
+          setVoicePickerTargetStripId(null)
+        }}
+        onSelect={handleVoicePickerSelect}
+        providersInfo={providersInfo}
+      />
     </PageShell>
   )
 }

--- a/apps/packages/ui/src/components/Option/Speech/TtsStickyActionBar.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/TtsStickyActionBar.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { Button, Dropdown } from "antd"
 import type { MenuProps } from "antd"
-import { Play, Square, Download, Settings } from "lucide-react"
+import { Play, Plus, Square, Download, Settings } from "lucide-react"
 import { cn } from "@/libs/utils"
 
 export type StreamStatus = "idle" | "connecting" | "streaming" | "complete" | "error"
@@ -25,6 +25,11 @@ export interface TtsStickyActionBarProps {
   inspectorBadge: BadgeType
   segmentCount: number
   provider: string
+  /** Compose & Compare: render strip controls */
+  onAddRender?: () => void
+  onPlayAllRenders?: () => void
+  renderStripCount?: number
+  hasReadyRenders?: boolean
 }
 
 const STATUS_DOT_COLORS: Record<StreamStatus, string> = {
@@ -67,6 +72,10 @@ export function TtsStickyActionBar({
   segmentCount,
   provider,
   onToggleInspector,
+  onAddRender,
+  onPlayAllRenders,
+  renderStripCount = 0,
+  hasReadyRenders = false,
 }: TtsStickyActionBarProps) {
   const { t } = useTranslation("playground")
 
@@ -128,6 +137,31 @@ export function TtsStickyActionBar({
             {t("tts.download", "Download")}
           </Button>
         </Dropdown>
+
+        {/* Compose & Compare controls */}
+        {onAddRender && (
+          <>
+            <div className="mx-1 h-5 w-px bg-border" aria-hidden="true" />
+            <Button
+              size="small"
+              icon={<Plus className="h-3.5 w-3.5" />}
+              onClick={onAddRender}
+              aria-label={t("tts.addRender", "Add Render")}
+            >
+              {t("tts.addRender", "Add Render")}
+            </Button>
+          </>
+        )}
+        {onPlayAllRenders && hasReadyRenders && renderStripCount > 1 && (
+          <Button
+            size="small"
+            icon={<Play className="h-3.5 w-3.5" />}
+            onClick={onPlayAllRenders}
+            aria-label={t("tts.playAll", "Play All")}
+          >
+            {t("tts.playAll", "Play All")}
+          </Button>
+        )}
 
         {/* Flex spacer */}
         <div className="flex-1" />

--- a/apps/packages/ui/src/components/Option/Speech/VoicePickerModal.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/VoicePickerModal.tsx
@@ -80,6 +80,7 @@ export const VoicePickerModal: React.FC<VoicePickerModalProps> = ({
   const [searchQuery, setSearchQuery] = React.useState("")
   const [previewingVoice, setPreviewingVoice] = React.useState<string | null>(null)
   const previewAudioRef = React.useRef<HTMLAudioElement | null>(null)
+  const previewBlobUrlRef = React.useRef<string | null>(null)
 
   // Fetch providers if not passed externally
   const { data: fetchedProvidersInfo, isLoading } = useQuery<TldwTtsProvidersInfo | null>({
@@ -221,15 +222,19 @@ export const VoicePickerModal: React.FC<VoicePickerModalProps> = ({
       )
       const blob = new Blob([buffer], { type: "audio/mpeg" })
       const url = URL.createObjectURL(blob)
+      // Track blob URL so cleanup effect can revoke it if modal closes during playback
+      previewBlobUrlRef.current = url
       const audio = new Audio(url)
       previewAudioRef.current = audio
       audio.onended = () => {
         setPreviewingVoice(null)
         URL.revokeObjectURL(url)
+        previewBlobUrlRef.current = null
       }
       audio.onerror = () => {
         setPreviewingVoice(null)
         URL.revokeObjectURL(url)
+        previewBlobUrlRef.current = null
       }
       await audio.play()
     } catch {
@@ -243,6 +248,11 @@ export const VoicePickerModal: React.FC<VoicePickerModalProps> = ({
       previewAudioRef.current?.pause()
       setPreviewingVoice(null)
       setSearchQuery("")
+      // Revoke any outstanding preview blob URL to prevent memory leak
+      if (previewBlobUrlRef.current) {
+        URL.revokeObjectURL(previewBlobUrlRef.current)
+        previewBlobUrlRef.current = null
+      }
     }
   }, [open])
 

--- a/apps/packages/ui/src/components/Option/Speech/VoicePickerModal.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/VoicePickerModal.tsx
@@ -1,0 +1,410 @@
+import React from "react"
+import { Button, Input, Modal, Tag, Tooltip, Typography, Collapse, Empty, Spin } from "antd"
+import { Play, Search, Volume2 } from "lucide-react"
+import { useQuery } from "@tanstack/react-query"
+import {
+  fetchTtsProviders,
+  type TldwTtsProvidersInfo,
+  type TldwTtsVoiceInfo,
+  type TldwTtsProviderCapabilities
+} from "@/services/tldw/audio-providers"
+import { PROVIDER_REGISTRY, type ProviderCapability } from "@/utils/provider-registry"
+import { OPENAI_TTS_VOICES } from "@/hooks/useTtsProviderData"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { normalizeTtsProviderKey } from "@/services/tldw/tts-provider-keys"
+
+const { Text, Title } = Typography
+
+export type VoiceSelection = {
+  provider: string
+  voice: string
+  model?: string
+}
+
+type VoicePickerModalProps = {
+  open: boolean
+  onClose: () => void
+  onSelect: (selection: VoiceSelection) => void
+  /** Current server provider info (passed to avoid duplicate queries) */
+  providersInfo?: TldwTtsProvidersInfo | null
+}
+
+const RECENT_VOICES_KEY = "tts-recent-voices"
+const MAX_RECENT = 5
+
+const getRecentVoices = (): VoiceSelection[] => {
+  try {
+    const stored = localStorage.getItem(RECENT_VOICES_KEY)
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
+}
+
+const saveRecentVoice = (selection: VoiceSelection) => {
+  try {
+    const existing = getRecentVoices()
+    const filtered = existing.filter(
+      (v) => !(v.provider === selection.provider && v.voice === selection.voice)
+    )
+    const next = [selection, ...filtered].slice(0, MAX_RECENT)
+    localStorage.setItem(RECENT_VOICES_KEY, JSON.stringify(next))
+  } catch {}
+}
+
+type ProviderGroup = {
+  key: string
+  label: string
+  category: "local" | "cloud"
+  caps?: TldwTtsProviderCapabilities
+  voices: TldwTtsVoiceInfo[]
+}
+
+const categorizeProvider = (key: string): "local" | "cloud" => {
+  const cloudProviders = new Set(["elevenlabs", "openai"])
+  if (cloudProviders.has(key)) return "cloud"
+  return "local"
+}
+
+const getProviderLabel = (key: string): string => {
+  const meta = PROVIDER_REGISTRY[key]
+  return meta?.ttsLabel || meta?.label || key
+}
+
+export const VoicePickerModal: React.FC<VoicePickerModalProps> = ({
+  open,
+  onClose,
+  onSelect,
+  providersInfo: externalProvidersInfo
+}) => {
+  const [searchQuery, setSearchQuery] = React.useState("")
+  const [previewingVoice, setPreviewingVoice] = React.useState<string | null>(null)
+  const previewAudioRef = React.useRef<HTMLAudioElement | null>(null)
+
+  // Fetch providers if not passed externally
+  const { data: fetchedProvidersInfo, isLoading } = useQuery<TldwTtsProvidersInfo | null>({
+    queryKey: ["tldw-tts-providers-picker"],
+    queryFn: () => fetchTtsProviders(),
+    enabled: open && !externalProvidersInfo
+  })
+
+  const providersInfo = externalProvidersInfo || fetchedProvidersInfo
+
+  const recentVoices = React.useMemo(() => getRecentVoices(), [open])
+
+  // Build provider groups
+  const providerGroups = React.useMemo((): ProviderGroup[] => {
+    const groups: ProviderGroup[] = []
+
+    // Add browser TTS
+    groups.push({
+      key: "browser",
+      label: "Browser TTS",
+      category: "local",
+      voices: [{ id: "default", name: "System Default" }]
+    })
+
+    // Add OpenAI voices
+    const allOpenAiVoices = new Set<string>()
+    Object.values(OPENAI_TTS_VOICES).forEach((list) =>
+      list.forEach((v) => allOpenAiVoices.add(v.value))
+    )
+    groups.push({
+      key: "openai",
+      label: "OpenAI",
+      category: "cloud",
+      voices: Array.from(allOpenAiVoices).map((v) => ({
+        id: v,
+        name: v
+      }))
+    })
+
+    // Add server providers
+    if (providersInfo) {
+      const { providers, voices } = providersInfo
+      for (const [provKey, caps] of Object.entries(providers)) {
+        const normalizedKey = normalizeTtsProviderKey(provKey)
+        // Skip if already handled
+        if (normalizedKey === "browser" || normalizedKey === "openai") continue
+
+        const provVoices = voices[provKey] || voices[normalizedKey] || []
+        groups.push({
+          key: normalizedKey,
+          label: getProviderLabel(normalizedKey) || caps.provider_name || provKey,
+          category: categorizeProvider(normalizedKey),
+          caps,
+          voices: provVoices
+        })
+      }
+    }
+
+    return groups
+  }, [providersInfo])
+
+  // Filter groups by search
+  const filteredGroups = React.useMemo(() => {
+    if (!searchQuery.trim()) return providerGroups
+    const q = searchQuery.toLowerCase()
+    return providerGroups
+      .map((group) => ({
+        ...group,
+        voices: group.voices.filter(
+          (v) =>
+            (v.name || "").toLowerCase().includes(q) ||
+            (v.id || "").toLowerCase().includes(q) ||
+            group.label.toLowerCase().includes(q) ||
+            (v.language || "").toLowerCase().includes(q)
+        )
+      }))
+      .filter((group) => group.voices.length > 0)
+  }, [providerGroups, searchQuery])
+
+  const localGroups = filteredGroups.filter((g) => g.category === "local")
+  const cloudGroups = filteredGroups.filter((g) => g.category === "cloud")
+
+  const handleSelect = (providerKey: string, voice: TldwTtsVoiceInfo) => {
+    const voiceId = voice.id || voice.name || ""
+    const selection: VoiceSelection = {
+      provider: providerKey === "browser" || providerKey === "openai" || providerKey === "elevenlabs"
+        ? providerKey
+        : "tldw",
+      voice: voiceId,
+      model: providerKey !== "browser" && providerKey !== "openai" && providerKey !== "elevenlabs"
+        ? providerKey
+        : undefined
+    }
+    saveRecentVoice(selection)
+    onSelect(selection)
+    onClose()
+  }
+
+  const handlePreview = async (providerKey: string, voice: TldwTtsVoiceInfo) => {
+    const voiceId = voice.id || voice.name || ""
+    if (previewingVoice === voiceId) {
+      // Stop preview
+      previewAudioRef.current?.pause()
+      setPreviewingVoice(null)
+      return
+    }
+
+    setPreviewingVoice(voiceId)
+    try {
+      // Use preview_url if available
+      if (voice.preview_url) {
+        const audio = new Audio(voice.preview_url)
+        previewAudioRef.current = audio
+        audio.onended = () => setPreviewingVoice(null)
+        audio.onerror = () => setPreviewingVoice(null)
+        await audio.play()
+        return
+      }
+
+      // Generate a quick preview via the server
+      const model = providerKey !== "browser" && providerKey !== "openai" && providerKey !== "elevenlabs"
+        ? providerKey
+        : undefined
+      const provider = providerKey === "browser" || providerKey === "openai" || providerKey === "elevenlabs"
+        ? providerKey
+        : "tldw"
+
+      if (provider === "browser") {
+        // Use browser speech synthesis
+        const utterance = new SpeechSynthesisUtterance("Hello, this is a voice preview.")
+        speechSynthesis.speak(utterance)
+        utterance.onend = () => setPreviewingVoice(null)
+        return
+      }
+
+      const buffer = await tldwClient.synthesizeSpeech(
+        "Hello, this is a voice preview.",
+        { model: model || "tts-1", voice: voiceId, responseFormat: "mp3" }
+      )
+      const blob = new Blob([buffer], { type: "audio/mpeg" })
+      const url = URL.createObjectURL(blob)
+      const audio = new Audio(url)
+      previewAudioRef.current = audio
+      audio.onended = () => {
+        setPreviewingVoice(null)
+        URL.revokeObjectURL(url)
+      }
+      audio.onerror = () => {
+        setPreviewingVoice(null)
+        URL.revokeObjectURL(url)
+      }
+      await audio.play()
+    } catch {
+      setPreviewingVoice(null)
+    }
+  }
+
+  // Cleanup preview audio on close
+  React.useEffect(() => {
+    if (!open) {
+      previewAudioRef.current?.pause()
+      setPreviewingVoice(null)
+      setSearchQuery("")
+    }
+  }, [open])
+
+  const renderVoiceList = (group: ProviderGroup) => (
+    <div className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+      {group.voices.map((voice, idx) => {
+        const voiceId = voice.id || voice.name || `voice-${idx}`
+        const isActive = previewingVoice === voiceId
+        return (
+          <div
+            key={voiceId}
+            className="flex items-center gap-2 rounded-md border border-border px-3 py-2 transition-colors hover:bg-surface-hover cursor-pointer"
+            onClick={() => handleSelect(group.key, voice)}
+            role="option"
+            aria-selected={false}
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSelect(group.key, voice)
+            }}
+          >
+            <Volume2 className="h-3.5 w-3.5 shrink-0 text-text-muted" />
+            <div className="flex-1 min-w-0">
+              <Text className="block truncate text-sm">
+                {voice.name || voice.id || `Voice ${idx + 1}`}
+              </Text>
+              {voice.language && (
+                <Text className="text-xs text-text-muted">{voice.language}</Text>
+              )}
+            </div>
+            {/* Capability badges */}
+            {group.caps?.supports_streaming && (
+              <Tag className="text-[10px]" variant="filled">
+                Stream
+              </Tag>
+            )}
+            {group.caps?.supports_voice_cloning && (
+              <Tag className="text-[10px]" variant="filled">
+                Clone
+              </Tag>
+            )}
+            {/* Preview button */}
+            <Tooltip title={isActive ? "Stop preview" : "Preview voice"}>
+              <Button
+                type="text"
+                size="small"
+                loading={isActive}
+                icon={<Play className="h-3 w-3" />}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handlePreview(group.key, voice)
+                }}
+                aria-label={`Preview ${voice.name || voice.id}`}
+              />
+            </Tooltip>
+          </div>
+        )
+      })}
+    </div>
+  )
+
+  const renderGroupSection = (title: string, groups: ProviderGroup[]) => {
+    if (groups.length === 0) return null
+    return (
+      <div className="space-y-2">
+        <Text strong className="text-xs uppercase tracking-wide text-text-muted">
+          {title}
+        </Text>
+        <Collapse
+          ghost
+          defaultActiveKey={groups.map((g) => g.key)}
+          items={groups.map((group) => ({
+            key: group.key,
+            label: (
+              <div className="flex items-center gap-2">
+                <span>{group.label}</span>
+                <Tag className="text-[10px]" variant="filled">
+                  {group.voices.length}
+                </Tag>
+                {group.caps && (
+                  <span
+                    className={`h-2 w-2 rounded-full ${
+                      group.caps.provider_name ? "bg-green-500" : "bg-gray-400"
+                    }`}
+                    title={group.caps.provider_name ? "Available" : "Unknown status"}
+                  />
+                )}
+              </div>
+            ),
+            children: renderVoiceList(group)
+          }))}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <Modal
+      title={
+        <div className="flex items-center gap-2">
+          <Volume2 className="h-5 w-5" />
+          <span>Choose a Voice</span>
+        </div>
+      }
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width={640}
+      styles={{ body: { maxHeight: "70vh", overflowY: "auto" } }}
+    >
+      {/* Search */}
+      <Input
+        prefix={<Search className="h-4 w-4 text-text-muted" />}
+        placeholder="Search voices, providers..."
+        value={searchQuery}
+        onChange={(e) => setSearchQuery(e.target.value)}
+        allowClear
+        className="mb-4"
+        aria-label="Search voices"
+        autoFocus
+      />
+
+      {/* Recent voices */}
+      {!searchQuery.trim() && recentVoices.length > 0 && (
+        <div className="mb-4">
+          <Text strong className="mb-1.5 block text-xs uppercase tracking-wide text-text-muted">
+            Recent
+          </Text>
+          <div className="flex flex-wrap gap-1.5">
+            {recentVoices.map((rv, i) => (
+              <Tag
+                key={`recent-${i}`}
+                className="cursor-pointer"
+                onClick={() => {
+                  onSelect(rv)
+                  onClose()
+                }}
+              >
+                {rv.model ? `${rv.model}/${rv.voice}` : `${rv.provider}/${rv.voice}`}
+              </Tag>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <Spin tip="Loading voices..." />
+        </div>
+      )}
+
+      {!isLoading && filteredGroups.length === 0 && (
+        <Empty description="No voices found" />
+      )}
+
+      {!isLoading && (
+        <div className="space-y-4">
+          {renderGroupSection("Local Engines", localGroups)}
+          {renderGroupSection("Cloud Providers", cloudGroups)}
+        </div>
+      )}
+    </Modal>
+  )
+}
+
+export default VoicePickerModal

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx
@@ -1,0 +1,133 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { RenderStrip, type RenderStripConfig } from "../RenderStrip"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/components/Common/UnifiedAudioPlayer", () => ({
+  UnifiedAudioPlayer: ({ label }: { label?: string }) => (
+    <div data-testid="unified-audio-player" aria-label={label} />
+  )
+}))
+
+vi.mock("@/components/Common/TtsJobProgress", () => ({
+  TtsJobProgress: ({ title }: { title?: string }) => (
+    <div data-testid="tts-job-progress">{title}</div>
+  )
+}))
+
+const baseConfig: RenderStripConfig = {
+  provider: "tldw",
+  voice: "af_heart",
+  model: "kokoro",
+  format: "mp3",
+  speed: 1
+}
+
+describe("RenderStrip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders config tags for provider, voice, format", () => {
+    render(<RenderStrip id="r1" state="idle" config={baseConfig} />)
+    expect(screen.getByText("kokoro")).toBeInTheDocument()
+    expect(screen.getByText("af_heart")).toBeInTheDocument()
+    expect(screen.getByText("MP3")).toBeInTheDocument()
+  })
+
+  it("shows Generate button in idle state", () => {
+    render(<RenderStrip id="r1" state="idle" config={baseConfig} />)
+    expect(screen.getByRole("button", { name: "Generate audio" })).toBeInTheDocument()
+  })
+
+  it("does not show Generate button in ready state", () => {
+    render(
+      <RenderStrip
+        id="r1"
+        state="ready"
+        config={baseConfig}
+        audioUrl="blob:test"
+      />
+    )
+    expect(screen.queryByRole("button", { name: "Generate audio" })).not.toBeInTheDocument()
+  })
+
+  it("calls onGenerate when Generate is clicked", () => {
+    const onGenerate = vi.fn()
+    render(
+      <RenderStrip id="r1" state="idle" config={baseConfig} onGenerate={onGenerate} />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Generate audio" }))
+    expect(onGenerate).toHaveBeenCalledWith("r1")
+  })
+
+  it("shows TtsJobProgress in generating state", () => {
+    render(<RenderStrip id="r1" state="generating" config={baseConfig} />)
+    expect(screen.getByTestId("tts-job-progress")).toBeInTheDocument()
+  })
+
+  it("shows UnifiedAudioPlayer in ready state", () => {
+    render(
+      <RenderStrip
+        id="r1"
+        state="ready"
+        config={baseConfig}
+        audioUrl="blob:test"
+      />
+    )
+    expect(screen.getByTestId("unified-audio-player")).toBeInTheDocument()
+  })
+
+  it("shows error message and retry button in error state", () => {
+    const onRetry = vi.fn()
+    render(
+      <RenderStrip
+        id="r1"
+        state="error"
+        config={baseConfig}
+        errorMessage="Connection failed"
+        onRetry={onRetry}
+      />
+    )
+    expect(screen.getByText("Connection failed")).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Retry"))
+    expect(onRetry).toHaveBeenCalledWith("r1")
+  })
+
+  it("does not show speed tag when speed is 1", () => {
+    render(<RenderStrip id="r1" state="idle" config={{ ...baseConfig, speed: 1 }} />)
+    expect(screen.queryByText("1x")).not.toBeInTheDocument()
+  })
+
+  it("shows speed tag when speed is not 1", () => {
+    render(<RenderStrip id="r1" state="idle" config={{ ...baseConfig, speed: 1.5 }} />)
+    expect(screen.getByText("1.5x")).toBeInTheDocument()
+  })
+
+  it("calls onConfigTagClick when voice tag is clicked", () => {
+    const onConfigTagClick = vi.fn()
+    render(
+      <RenderStrip
+        id="r1"
+        state="idle"
+        config={baseConfig}
+        onConfigTagClick={onConfigTagClick}
+      />
+    )
+    fireEvent.click(screen.getByText("af_heart"))
+    expect(onConfigTagClick).toHaveBeenCalledWith("r1", "voice")
+  })
+
+  it("has correct aria-label", () => {
+    render(<RenderStrip id="r1" state="idle" config={baseConfig} />)
+    expect(
+      screen.getByRole("region", { name: "Render strip: kokoro af_heart" })
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/Speech/__tests__/VoicePickerModal.test.tsx
+++ b/apps/packages/ui/src/components/Option/Speech/__tests__/VoicePickerModal.test.tsx
@@ -1,0 +1,167 @@
+import React from "react"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { VoicePickerModal, type VoiceSelection } from "../VoicePickerModal"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/services/tldw/audio-providers", () => ({
+  fetchTtsProviders: vi.fn().mockResolvedValue(null)
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    synthesizeSpeech: vi.fn().mockResolvedValue(new ArrayBuffer(100))
+  }
+}))
+
+vi.mock("@/services/tldw/tts-provider-keys", () => ({
+  normalizeTtsProviderKey: (k: string) => k.toLowerCase()
+}))
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } }
+})
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+const mockProvidersInfo = {
+  providers: {
+    kokoro: {
+      provider_name: "Kokoro",
+      formats: ["mp3", "wav"],
+      supports_streaming: true
+    }
+  },
+  voices: {
+    kokoro: [
+      { id: "af_heart", name: "Heart", language: "en" },
+      { id: "am_adam", name: "Adam", language: "en" }
+    ]
+  }
+}
+
+describe("VoicePickerModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  it("renders modal with search input when open", () => {
+    render(
+      <VoicePickerModal
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("Choose a Voice")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("Search voices, providers...")).toBeInTheDocument()
+  })
+
+  it("does not render content when closed", () => {
+    render(
+      <VoicePickerModal
+        open={false}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    expect(screen.queryByText("Choose a Voice")).not.toBeInTheDocument()
+  })
+
+  it("displays server provider voices", () => {
+    render(
+      <VoicePickerModal
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("Heart")).toBeInTheDocument()
+    expect(screen.getByText("Adam")).toBeInTheDocument()
+  })
+
+  it("displays OpenAI voices", () => {
+    render(
+      <VoicePickerModal
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("alloy")).toBeInTheDocument()
+  })
+
+  it("filters voices by search query", () => {
+    render(
+      <VoicePickerModal
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    const searchInput = screen.getByPlaceholderText("Search voices, providers...")
+    fireEvent.change(searchInput, { target: { value: "Heart" } })
+    expect(screen.getByText("Heart")).toBeInTheDocument()
+    expect(screen.queryByText("alloy")).not.toBeInTheDocument()
+  })
+
+  it("calls onSelect and onClose when a voice is clicked", () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <VoicePickerModal
+        open
+        onClose={onClose}
+        onSelect={onSelect}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    fireEvent.click(screen.getByText("Heart"))
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "tldw",
+        voice: "af_heart"
+      })
+    )
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it("saves and displays recent voices", () => {
+    const storedVoices: VoiceSelection[] = [
+      { provider: "tldw", voice: "af_heart", model: "kokoro" }
+    ]
+    localStorage.setItem("tts-recent-voices", JSON.stringify(storedVoices))
+
+    render(
+      <VoicePickerModal
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+        providersInfo={mockProvidersInfo}
+      />,
+      { wrapper }
+    )
+    expect(screen.getByText("Recent")).toBeInTheDocument()
+    expect(screen.getByText("kokoro/af_heart")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/hooks/__tests__/useMultiRenderState.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useMultiRenderState.test.ts
@@ -142,6 +142,45 @@ describe("useMultiRenderState", () => {
     expect(result.current.hasReady).toBe(false)
   })
 
+  it("handleStripEnded clears playingId when no queue", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    const id = result.current.renders[0].id
+    act(() => {
+      result.current.startPlaying(id)
+    })
+    expect(result.current.playingId).toBe(id)
+    act(() => {
+      result.current.handleStripEnded(id)
+    })
+    expect(result.current.playingId).toBeNull()
+  })
+
+  it("playAllSequentially sets first strip as playing", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "v1" })
+      result.current.addRender({ provider: "tldw", voice: "v2" })
+    })
+    // Manually set both strips to ready state with audioUrl
+    act(() => {
+      result.current.updateRender(result.current.renders[0].id, {
+        state: "ready",
+        audioUrl: "blob:url1"
+      })
+      result.current.updateRender(result.current.renders[1].id, {
+        state: "ready",
+        audioUrl: "blob:url2"
+      })
+    })
+    act(() => {
+      result.current.playAllSequentially()
+    })
+    expect(result.current.playingId).toBe(result.current.renders[0].id)
+  })
+
   it("generateRender transitions to generating then ready", async () => {
     const { result } = renderHook(() => useMultiRenderState())
     act(() => {

--- a/apps/packages/ui/src/hooks/__tests__/useMultiRenderState.test.ts
+++ b/apps/packages/ui/src/hooks/__tests__/useMultiRenderState.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useMultiRenderState } from "../useMultiRenderState"
+
+vi.mock("@/services/tts-provider", () => ({
+  resolveTtsProviderContext: vi.fn().mockResolvedValue({
+    provider: "tldw",
+    utterance: "test text",
+    playbackSpeed: 1,
+    supported: true,
+    synthesize: vi.fn().mockResolvedValue({
+      buffer: new ArrayBuffer(100),
+      format: "mp3",
+      mimeType: "audio/mpeg"
+    })
+  })
+}))
+
+// Mock URL.createObjectURL and revokeObjectURL
+const mockCreateObjectURL = vi.fn().mockReturnValue("blob:mock-url")
+const mockRevokeObjectURL = vi.fn()
+Object.defineProperty(globalThis, "URL", {
+  value: {
+    createObjectURL: mockCreateObjectURL,
+    revokeObjectURL: mockRevokeObjectURL
+  },
+  writable: true
+})
+
+describe("useMultiRenderState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("starts with empty renders", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    expect(result.current.renders).toEqual([])
+    expect(result.current.playingId).toBeNull()
+  })
+
+  it("addRender creates a new entry with idle state", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    let id: string
+    act(() => {
+      id = result.current.addRender({
+        provider: "tldw",
+        voice: "af_heart",
+        model: "kokoro",
+        format: "mp3"
+      })
+    })
+    expect(result.current.renders).toHaveLength(1)
+    expect(result.current.renders[0].state).toBe("idle")
+    expect(result.current.renders[0].config.voice).toBe("af_heart")
+  })
+
+  it("removeRender removes the entry", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    let id: string
+    act(() => {
+      id = result.current.addRender({
+        provider: "tldw",
+        voice: "af_heart"
+      })
+    })
+    act(() => {
+      result.current.removeRender(result.current.renders[0].id)
+    })
+    expect(result.current.renders).toHaveLength(0)
+  })
+
+  it("updateConfig changes the config of a render", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    const id = result.current.renders[0].id
+    act(() => {
+      result.current.updateConfig(id, {
+        provider: "tldw",
+        voice: "am_adam",
+        model: "kokoro"
+      })
+    })
+    expect(result.current.renders[0].config.voice).toBe("am_adam")
+  })
+
+  it("clearAll removes all renders", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "v1" })
+      result.current.addRender({ provider: "tldw", voice: "v2" })
+      result.current.addRender({ provider: "tldw", voice: "v3" })
+    })
+    expect(result.current.renders).toHaveLength(3)
+    act(() => {
+      result.current.clearAll()
+    })
+    expect(result.current.renders).toHaveLength(0)
+  })
+
+  it("startPlaying sets playingId", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    const id = result.current.renders[0].id
+    act(() => {
+      result.current.startPlaying(id)
+    })
+    expect(result.current.playingId).toBe(id)
+  })
+
+  it("stopPlaying clears playingId for that strip", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    const id = result.current.renders[0].id
+    act(() => {
+      result.current.startPlaying(id)
+    })
+    act(() => {
+      result.current.stopPlaying(id)
+    })
+    expect(result.current.playingId).toBeNull()
+  })
+
+  it("hasIdle is true when idle renders exist", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    expect(result.current.hasIdle).toBe(true)
+  })
+
+  it("hasReady is false when no audio generated", () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({ provider: "tldw", voice: "af_heart" })
+    })
+    expect(result.current.hasReady).toBe(false)
+  })
+
+  it("generateRender transitions to generating then ready", async () => {
+    const { result } = renderHook(() => useMultiRenderState())
+    act(() => {
+      result.current.addRender({
+        provider: "tldw",
+        voice: "af_heart",
+        model: "kokoro"
+      })
+    })
+    const id = result.current.renders[0].id
+    await act(async () => {
+      await result.current.generateRender(id, "Hello world")
+    })
+    expect(result.current.renders[0].state).toBe("ready")
+    expect(result.current.renders[0].audioUrl).toBe("blob:mock-url")
+  })
+})

--- a/apps/packages/ui/src/hooks/useMultiRenderState.ts
+++ b/apps/packages/ui/src/hooks/useMultiRenderState.ts
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  resolveTtsProviderContext,
+  type TtsProviderOverrides
+} from "@/services/tts-provider"
+import type { RenderStripConfig, RenderStripState } from "@/components/Option/Speech/RenderStrip"
+
+export type RenderEntry = {
+  id: string
+  config: RenderStripConfig
+  state: RenderStripState
+  audioUrl?: string
+  audioBlob?: Blob
+  errorMessage?: string
+  progress?: number
+}
+
+let nextId = 1
+const genId = () => `render-${Date.now()}-${nextId++}`
+
+const configToOverrides = (config: RenderStripConfig): TtsProviderOverrides => {
+  const overrides: TtsProviderOverrides = { provider: config.provider }
+  if (config.provider === "tldw") {
+    overrides.tldwModel = config.model
+    overrides.tldwVoice = config.voice
+    overrides.tldwResponseFormat = config.format
+    overrides.tldwSpeed = config.speed
+  } else if (config.provider === "openai") {
+    overrides.openAiModel = config.model
+    overrides.openAiVoice = config.voice
+    overrides.openAiSpeed = config.speed
+  } else if (config.provider === "elevenlabs") {
+    overrides.elevenLabsModel = config.model
+    overrides.elevenLabsVoiceId = config.voice
+    overrides.elevenLabsSpeed = config.speed
+  }
+  return overrides
+}
+
+export const useMultiRenderState = () => {
+  const [renders, setRenders] = useState<RenderEntry[]>([])
+  const [playingId, setPlayingId] = useState<string | null>(null)
+  const objectUrlsRef = useRef<Map<string, string>>(new Map())
+  const abortControllersRef = useRef<Map<string, AbortController>>(new Map())
+
+  // Cleanup object URLs on unmount
+  useEffect(() => {
+    return () => {
+      for (const url of objectUrlsRef.current.values()) {
+        try { URL.revokeObjectURL(url) } catch {}
+      }
+      objectUrlsRef.current.clear()
+      for (const ctrl of abortControllersRef.current.values()) {
+        try { ctrl.abort() } catch {}
+      }
+      abortControllersRef.current.clear()
+    }
+  }, [])
+
+  const addRender = useCallback((config: RenderStripConfig): string => {
+    const id = genId()
+    setRenders((prev) => [
+      ...prev,
+      { id, config, state: "idle" }
+    ])
+    return id
+  }, [])
+
+  const removeRender = useCallback((id: string) => {
+    // Revoke object URL
+    const url = objectUrlsRef.current.get(id)
+    if (url) {
+      try { URL.revokeObjectURL(url) } catch {}
+      objectUrlsRef.current.delete(id)
+    }
+    // Abort any in-progress generation
+    const ctrl = abortControllersRef.current.get(id)
+    if (ctrl) {
+      try { ctrl.abort() } catch {}
+      abortControllersRef.current.delete(id)
+    }
+    setRenders((prev) => prev.filter((r) => r.id !== id))
+    setPlayingId((prev) => (prev === id ? null : prev))
+  }, [])
+
+  const updateRender = useCallback(
+    (id: string, updates: Partial<RenderEntry>) => {
+      setRenders((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, ...updates } : r))
+      )
+    },
+    []
+  )
+
+  const updateConfig = useCallback(
+    (id: string, config: RenderStripConfig) => {
+      setRenders((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, config } : r))
+      )
+    },
+    []
+  )
+
+  const generateRender = useCallback(
+    async (id: string, text: string) => {
+      if (!text.trim()) return
+
+      updateRender(id, { state: "generating", progress: 0, errorMessage: undefined })
+
+      const entry = renders.find((r) => r.id === id)
+      if (!entry) return
+
+      const controller = new AbortController()
+      abortControllersRef.current.set(id, controller)
+
+      try {
+        const overrides = configToOverrides(entry.config)
+        const context = await resolveTtsProviderContext(text, overrides)
+
+        if (!context.supported || !context.synthesize) {
+          updateRender(id, {
+            state: "error",
+            errorMessage: `Provider "${entry.config.provider}" is not supported`
+          })
+          return
+        }
+
+        if (controller.signal.aborted) return
+
+        const audio = await context.synthesize(context.utterance)
+
+        if (controller.signal.aborted) return
+
+        const blob = new Blob([audio.buffer], { type: audio.mimeType })
+        const url = URL.createObjectURL(blob)
+
+        // Revoke old URL if any
+        const oldUrl = objectUrlsRef.current.get(id)
+        if (oldUrl) {
+          try { URL.revokeObjectURL(oldUrl) } catch {}
+        }
+        objectUrlsRef.current.set(id, url)
+
+        updateRender(id, {
+          state: "ready",
+          audioUrl: url,
+          audioBlob: blob,
+          progress: 100
+        })
+      } catch (error) {
+        if (controller.signal.aborted) return
+        updateRender(id, {
+          state: "error",
+          errorMessage:
+            error instanceof Error ? error.message : "Generation failed"
+        })
+      } finally {
+        abortControllersRef.current.delete(id)
+      }
+    },
+    [renders, updateRender]
+  )
+
+  const generateAll = useCallback(
+    async (text: string) => {
+      const pending = renders.filter(
+        (r) => r.state === "idle" || r.state === "error"
+      )
+      await Promise.allSettled(
+        pending.map((r) => generateRender(r.id, text))
+      )
+    },
+    [renders, generateRender]
+  )
+
+  const clearAll = useCallback(() => {
+    for (const url of objectUrlsRef.current.values()) {
+      try { URL.revokeObjectURL(url) } catch {}
+    }
+    objectUrlsRef.current.clear()
+    for (const ctrl of abortControllersRef.current.values()) {
+      try { ctrl.abort() } catch {}
+    }
+    abortControllersRef.current.clear()
+    setRenders([])
+    setPlayingId(null)
+  }, [])
+
+  // Play-one-at-a-time: setting playingId pauses all others
+  const startPlaying = useCallback((id: string) => {
+    setPlayingId(id)
+  }, [])
+
+  const stopPlaying = useCallback((id: string) => {
+    setPlayingId((prev) => (prev === id ? null : prev))
+  }, [])
+
+  const playAllSequentially = useCallback(
+    async (onStripPlay?: (id: string) => void) => {
+      const readyStrips = renders.filter(
+        (r) => r.state === "ready" && r.audioUrl
+      )
+      for (const strip of readyStrips) {
+        setPlayingId(strip.id)
+        onStripPlay?.(strip.id)
+        // Wait for audio to finish by creating a temporary audio element
+        await new Promise<void>((resolve) => {
+          if (!strip.audioUrl) {
+            resolve()
+            return
+          }
+          const audio = new Audio(strip.audioUrl)
+          audio.onended = () => resolve()
+          audio.onerror = () => resolve()
+          audio.play().catch(() => resolve())
+        })
+        // 1-second pause between strips
+        await new Promise<void>((resolve) => setTimeout(resolve, 1000))
+      }
+      setPlayingId(null)
+    },
+    [renders]
+  )
+
+  const hasIdle = renders.some((r) => r.state === "idle" || r.state === "error")
+  const hasReady = renders.some((r) => r.state === "ready")
+  const isAnyGenerating = renders.some((r) => r.state === "generating")
+
+  return {
+    renders,
+    playingId,
+    addRender,
+    removeRender,
+    updateRender,
+    updateConfig,
+    generateRender,
+    generateAll,
+    clearAll,
+    startPlaying,
+    stopPlaying,
+    playAllSequentially,
+    hasIdle,
+    hasReady,
+    isAnyGenerating
+  }
+}

--- a/apps/packages/ui/src/hooks/useMultiRenderState.ts
+++ b/apps/packages/ui/src/hooks/useMultiRenderState.ts
@@ -195,31 +195,44 @@ export const useMultiRenderState = () => {
     setPlayingId((prev) => (prev === id ? null : prev))
   }, [])
 
-  const playAllSequentially = useCallback(
-    async (onStripPlay?: (id: string) => void) => {
-      const readyStrips = renders.filter(
-        (r) => r.state === "ready" && r.audioUrl
-      )
-      for (const strip of readyStrips) {
-        setPlayingId(strip.id)
-        onStripPlay?.(strip.id)
-        // Wait for audio to finish by creating a temporary audio element
-        await new Promise<void>((resolve) => {
-          if (!strip.audioUrl) {
-            resolve()
-            return
-          }
-          const audio = new Audio(strip.audioUrl)
-          audio.onended = () => resolve()
-          audio.onerror = () => resolve()
-          audio.play().catch(() => resolve())
-        })
-        // 1-second pause between strips
-        await new Promise<void>((resolve) => setTimeout(resolve, 1000))
-      }
+  // Sequential play queue: stores IDs to play in order.
+  // When the current strip ends (via onEnd callback from UnifiedAudioPlayer),
+  // the next strip in the queue is activated by setting playingId.
+  const playQueueRef = useRef<string[]>([])
+
+  const advancePlayQueue = useCallback(() => {
+    const next = playQueueRef.current.shift()
+    if (next) {
+      // 1-second pause between strips
+      setTimeout(() => setPlayingId(next), 1000)
+    } else {
       setPlayingId(null)
+    }
+  }, [])
+
+  const playAllSequentially = useCallback(() => {
+    const readyStrips = renders.filter(
+      (r) => r.state === "ready" && r.audioUrl
+    )
+    if (readyStrips.length === 0) return
+
+    // Queue all but the first; start the first immediately
+    playQueueRef.current = readyStrips.slice(1).map((r) => r.id)
+    setPlayingId(readyStrips[0].id)
+  }, [renders])
+
+  // Called by RenderStrip when its UnifiedAudioPlayer emits onEnd
+  const handleStripEnded = useCallback(
+    (id: string) => {
+      // If this strip was playing as part of a sequential queue, advance
+      if (playQueueRef.current.length > 0) {
+        advancePlayQueue()
+      } else {
+        // Single strip ended naturally — clear playingId
+        setPlayingId((prev) => (prev === id ? null : prev))
+      }
     },
-    [renders]
+    [advancePlayQueue]
   )
 
   const hasIdle = renders.some((r) => r.state === "idle" || r.state === "error")
@@ -239,6 +252,7 @@ export const useMultiRenderState = () => {
     startPlaying,
     stopPlaying,
     playAllSequentially,
+    handleStripEnded,
     hasIdle,
     hasReady,
     isAnyGenerating


### PR DESCRIPTION
## Summary

- **UnifiedAudioPlayer**: Single audio player component replacing per-provider player inconsistency — play/pause/seek, waveform visualization, time display, download
- **RenderStrip**: Self-contained TTS generation card with 5 states (idle/generating/ready/playing/error), config tags as clickable chips, undo-on-remove toast
- **useMultiRenderState**: Hook managing array of render strips with independent generation lifecycle, play-one-at-a-time enforcement, object URL cleanup
- **VoicePickerModal**: Unified voice selection across all 19 backend TTS providers with search, recent voices, provider-grouped catalog, inline preview
- **SpeechPlaygroundPage integration**: Render strips zone between text editor and action bar, "Add Render" / "Pick Voice" / "Generate All" / "Play All" controls
- **TtsStickyActionBar**: Extended with "Add Render" and "Play All" buttons

## Test plan

- [x] 36 new unit tests across 4 test files (UnifiedAudioPlayer, RenderStrip, useMultiRenderState, VoicePickerModal)
- [x] All 52 Speech/TTS tests passing (existing + new)
- [x] Full test suite: no regressions from changes (24 pre-existing failures unrelated)
- [ ] Manual: Navigate to `/speech`, type text, click "Add Render" → strip appears
- [ ] Manual: Click "Pick Voice" → modal shows providers, search, preview
- [ ] Manual: Add 2 renders with different voices, "Generate All" → both generate
- [ ] Manual: "Play All" → sequential playback with 1s pause between strips
- [ ] Manual: Click config tags on strip → voice picker or inspector opens
- [ ] Manual: Remove strip → undo toast with 4s restore window
- [ ] Mobile viewport: strips stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)