### PR TITLE
feat(acp): ACP production readiness — phases 0-7

### DIFF
--- a/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
+++ b/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
@@ -1,0 +1,209 @@
+# TTS "Compose & Compare" Full Redesign
+
+**Date**: 2026-03-07
+**Status**: Design
+**Builds on**: `2026-03-06-tts-listen-tab-ux-redesign.md` (two-zone layout, provider strip, inspector panel)
+**Scope**: Full TTS experience redesign — page structure, render strips, voice picker, unified player
+
+---
+
+## Problem Statement
+
+The Speech Playground TTS experience (`SpeechPlaygroundPage.tsx`, 2,839 lines) has several UX issues grounded in Nielsen's 10 usability heuristics:
+
+1. **Inconsistent playback** (H4: Consistency) — Browser TTS uses Web Speech API controls; server TTS uses HTML5 `<audio>`. Different UI for the same action.
+2. **Provider switching confusion** (H6: Recognition over recall) — Changing providers reveals/hides different controls unpredictably. Users must remember which fields belong to which provider.
+3. **No comparison capability** (H7: Flexibility & efficiency) — No way to A/B test voices, models, or providers. Users must generate, listen, change settings, regenerate, and try to remember the previous result.
+4. **19 adapters, 4 exposed** (H8: Minimalist design, inverted) — The backend supports Kokoro, Higgs, Chatterbox, VibeVoice, ElevenLabs, OpenAI, and 13 more, but the UI only exposes 4 provider buckets.
+5. **Unsurfaced backend features** — Voice upload, voice preview, TTS history, async jobs, word-level alignment metadata are all available via API but not in the UI.
+6. **Settings form overload** (H8: Aesthetic & minimalist design) — 1,000+ lines of settings compete for attention on the same page.
+
+## Target Users
+
+Design uses progressive disclosure to serve three personas:
+- **General users**: Type text, click play. Minimal cognitive load.
+- **Content creators**: Batch generation, export, quality comparison.
+- **Developers/tinkerers**: Full provider visibility, parameter tuning, A/B testing.
+
+## Design: Compose & Compare
+
+### Core Concept
+
+The text editor is the primary surface. Audio outputs appear as **Render Strips** below the editor — self-contained cards, each representing one generation with its own provider/voice/settings. Comparison is structural: having two strips *is* comparison. No special mode needed.
+
+### Page Structure
+
+Single `/speech` route with top-level tabs: **TTS | STT | Roundtrip**
+
+TTS tab layout:
+
+```
++----------------------------------------------+
+| Document Toolbar                              |
+| [Voice: kokoro/af_heart ▾] [Preset: Balanced]|
+| [+ Add Render]  [History]  [⚙ Settings]      |
++----------------------------------------------+
+|  Text Editor (hero element)                   |
+|  +------------------------------------------+|
+|  | [Auto-sizing textarea]                    ||
+|  | 142/8000 chars · ~9s estimated            ||
+|  +------------------------------------------+|
+|                                               |
+|  Render Strips                                |
+|  +------------------------------------------+|
+|  | A: [kokoro] [af_heart] [mp3] [1.0x]      ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:12/0:45    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|  | B: [higgs] [en_speaker_0] [wav] [0.9x]   ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:08/0:38    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|                                               |
+| [▶ Generate] [■ Stop] [▶▶ Play All]          |
++----------------------------------------------+
+```
+
+Drawers (right side, opened on demand):
+- **Settings Drawer** — reuses `TtsInspectorPanel` with Voice, Output, Advanced tabs
+- **History Drawer** — past generations with search, filter, favorites
+
+### Component: Render Strip
+
+Each strip is a self-contained card with five states:
+
+| State | Visual |
+|-------|--------|
+| `idle` | Config tags + "Click Generate to synthesize" |
+| `generating` | Progress bar (or job step indicator for long text) |
+| `ready` | Waveform + playback controls + download |
+| `playing` | Animated waveform, highlighted play button |
+| `error` | Error message + Retry button |
+
+**Interactions:**
+- Config tags are clickable — clicking `[kokoro]` opens the voice picker pre-filtered
+- `[Edit]` opens the settings drawer pre-filled with this strip's config
+- `[✕]` removes the strip with an undo toast (H3: User control & freedom)
+- Only one strip plays at a time — starting one pauses others
+- `[Play All]` plays strips sequentially with a 1-second pause between them
+
+### Component: Voice Picker Modal
+
+Replaces the current per-provider voice/model selection with a unified modal:
+
+```
++----------------------------------------------------------+
+|  Choose a Voice                              [✕ Close]   |
++----------------------------------------------------------+
+|  [🔍 Search voices...]                                   |
+|  Recent: [af_heart] [alloy] [en_speaker_0]               |
++----------------------------------------------------------+
+|  ▾ Local Engines                                         |
+|    ● Kokoro (12 voices)              [healthy]           |
+|      af_heart [▶]  |  af_bella [▶]  |  am_adam [▶]      |
+|    ● Higgs (8 voices)                [healthy]           |
+|      en_speaker_0 [▶]  |  en_speaker_1 [▶]              |
+|    ○ Chatterbox                       [offline]          |
+|  ▾ Cloud Providers                                       |
+|    ● OpenAI (6 voices)                                   |
+|      alloy [▶]  |  echo [▶]  |  nova [▶]                |
+|    ● ElevenLabs (50+ voices)                             |
+|  ▾ Custom Voices                                         |
+|    my_cloned_voice [▶]  |  [+ Upload New]               |
++----------------------------------------------------------+
+```
+
+**Key behaviors:**
+- `[▶]` preview buttons call `/api/v1/audio/voices/{voice_id}/preview` — audio plays inline within the picker
+- Health status per provider from circuit breaker state (green dot / dimmed "offline")
+- Search filters across all providers simultaneously
+- Recent voices (last 5 used) pinned at top
+- Selecting a voice auto-selects its provider — no two-step "pick provider, then pick voice"
+- Provider capability icons: streaming, cloning, emotion, SSML
+- Custom voices section has inline upload via existing `VoiceCloningManager`
+
+### Component: Unified Audio Player
+
+Eliminates the H4 (Consistency) violation of different playback UIs per provider:
+
+- Single player component used in all render strips
+- For server providers: wraps HTML5 audio with custom waveform (reuses `WaveformCanvas`) + controls
+- For browser TTS: synthesizes via Web Speech API, maps events to same progress/play/pause interface
+- Consistent controls: play/pause, seek via waveform click, time display, download
+- Graceful degradation: if waveform data unavailable, shows animated progress bar with same controls
+
+### Progressive Disclosure
+
+| Level | What's visible | How to reach it |
+|-------|---------------|-----------------|
+| 0 — Just play | Text editor + toolbar (default voice) + action bar | Default state |
+| 1 — Customize | Click toolbar chip → settings drawer opens | 1 click |
+| 2 — Compare | Click "+ Add Render" → voice picker → second strip | 2 clicks |
+| 3 — Advanced | Settings drawer → Advanced tab (SSML, emotion, normalization, voice roles, async jobs) | 3 clicks |
+| 4 — Voice mgmt | Voice picker → Custom Voices → upload/clone | On demand |
+
+### Backend Feature Surfacing
+
+| Backend Feature | Where it appears |
+|----------------|-----------------|
+| All 19 TTS adapters | Voice Picker modal, grouped by Local/Cloud |
+| Voice preview API | `[▶]` button on each voice in the picker |
+| Custom voice upload | "Custom Voices" section in picker + `VoiceCloningManager` |
+| Voice encode/clone | Advanced tab in settings drawer |
+| TTS history | History drawer (right side) |
+| Async TTS jobs | Strip progress indicator for text > 2000 chars |
+| Word-level alignment | Opt-in: toggle on strip header highlights words in editor during playback |
+| Provider health | Colored dot per provider in voice picker |
+| Streaming | Progressive waveform drawing as audio arrives |
+
+### Heuristic Coverage
+
+| # | Heuristic | How addressed |
+|---|-----------|---------------|
+| 1 | Visibility of system status | Strip states, provider health dots, char count, estimated duration, waveform progress |
+| 2 | Match system & real world | Voice names + preview (not IDs), "Local Engines"/"Cloud Providers" grouping |
+| 3 | User control & freedom | Undo on strip removal, history drawer, explicit generate, editable config |
+| 4 | Consistency & standards | Unified audio player for all providers, consistent strip cards |
+| 5 | Error prevention | Char limit warning at 2000, explicit generate for all text, dimmed offline providers |
+| 6 | Recognition over recall | Recent voices pinned, config shown as tags on strips, voice preview |
+| 7 | Flexibility & efficiency | Ctrl+Enter to generate, presets, "+ Add Render", clickable config tags |
+| 8 | Aesthetic & minimalist design | Only editor + toolbar visible by default; settings/history in drawers |
+| 9 | Help users recover | Error state on strips with retry, toast with undo on deletion, provider retry |
+| 10 | Help & documentation | Tooltips on capability icons, estimated duration, char count guidance |
+
+### Relationship to Prior Designs
+
+This design extends `2026-03-06-tts-listen-tab-ux-redesign.md`:
+- **Keeps**: Two-zone concept (workspace + inspector), provider strip, sticky action bar, inspector panel tabs
+- **Adds**: Render strips (multi-generation), voice picker modal, unified audio player, comparison flow
+- **Changes**: Action bar includes "Add Render" and "Play All"; workspace zone contains render strips instead of single waveform
+
+The STT tab follows `2026-03-06-stt-playground-comparison-first-redesign.md` unchanged.
+
+### Existing Components to Reuse
+
+| Component | File | Reuse plan |
+|-----------|------|------------|
+| `TtsProviderStrip` | `Speech/TtsProviderStrip.tsx` | Becomes document toolbar |
+| `TtsStickyActionBar` | `Speech/TtsStickyActionBar.tsx` | Becomes action bar with added "Add Render" / "Play All" |
+| `TtsInspectorPanel` | `Speech/TtsInspectorPanel.tsx` | Settings drawer shell (reuse as-is) |
+| `TtsVoiceTab` | `Speech/TtsVoiceTab.tsx` | Inspector voice tab (refactor to support per-strip config) |
+| `TtsOutputTab` | `Speech/TtsOutputTab.tsx` | Inspector output tab |
+| `TtsAdvancedTab` | `Speech/TtsAdvancedTab.tsx` | Inspector advanced tab |
+| `WaveformCanvas` | `Common/WaveformCanvas.tsx` | Waveform in each render strip |
+| `TtsJobProgress` | `Common/TtsJobProgress.tsx` | Progress indicator in generating strips |
+| `VoiceCloningManager` | `TTS/VoiceCloningManager.tsx` | Custom voices section in voice picker |
+| `CharacterProgressBar` | `Common/CharacterProgressBar.tsx` | Char count in text editor |
+| `LongformDraftEditor` | `Common/LongformDraftEditor.tsx` | Advanced text editing mode |
+| `useTtsPlayground` | `hooks/useTtsPlayground.tsx` | Evolve to multi-strip state management |
+| `useTtsProviderData` | `hooks/useTtsProviderData.ts` | Provider/voice data fetching |
+| `useStreamingAudioPlayer` | `hooks/useStreamingAudioPlayer.ts` | Streaming playback per strip |
+
+### New Components to Build
+
+1. **`RenderStrip`** — Self-contained card: config tags + unified player + waveform + download
+2. **`VoicePickerModal`** — Provider-grouped voice catalog with search, preview, recent, custom upload
+3. **`UnifiedAudioPlayer`** — Normalizes browser TTS and server TTS behind common play/pause/seek/progress interface
+4. **`useMultiRenderState`** — Hook managing array of render strip states with independent generation

--- a/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md
+++ b/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md
@@ -244,7 +244,7 @@ interface Plan {
 
 interface Subscription {
   id: string
-  org_id: string
+  org_id: number
   plan_id: string
   stripe_subscription_id: string
   status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'

--- a/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-implementation-plan.md
@@ -1,0 +1,2575 @@
+# Admin UI SaaS Billing & Feature Gating — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add billing, subscription management, feature gating, and onboarding to the admin UI so it can operate as a multi-tenant SaaS with an open-core self-hosted option.
+
+**Architecture:** Stripe-first billing integration. New pages for Plans, Subscriptions, Feature Registry, and Onboarding. A `PlanGuard` component gates SaaS-only UI. A `NEXT_PUBLIC_BILLING_ENABLED` env var toggles the entire billing surface. Backend API endpoints are assumed to exist at `/api/v1/admin/billing/*` — this plan covers the frontend only.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Radix UI, React Hook Form + Zod, Recharts, Vitest + React Testing Library
+
+**Design Doc:** `Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md`
+
+---
+
+## Task 1: Add Billing Types
+
+**Files:**
+- Modify: `admin-ui/types/index.ts`
+
+**Step 1: Add types to the end of types/index.ts**
+
+Append after the last existing export:
+
+```typescript
+// ============================================
+// Billing & Subscription Types
+// ============================================
+
+export type PlanTier = 'free' | 'pro' | 'enterprise';
+export type SubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete';
+
+export interface Plan {
+  id: string;
+  name: string;
+  tier: PlanTier;
+  stripe_product_id: string;
+  stripe_price_id: string;
+  monthly_price_cents: number;
+  included_token_credits: number;
+  overage_rate_per_1k_tokens_cents: number;
+  features: string[];
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Subscription {
+  id: string;
+  org_id: number;
+  plan_id: string;
+  plan?: Plan;
+  stripe_subscription_id: string;
+  status: SubscriptionStatus;
+  current_period_start: string;
+  current_period_end: string;
+  trial_end?: string;
+  cancel_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OrgUsageSummary {
+  org_id: number;
+  period_start: string;
+  period_end: string;
+  tokens_used: number;
+  tokens_included: number;
+  tokens_overage: number;
+  overage_cost_cents: number;
+  breakdown_by_provider: Record<string, number>;
+}
+
+export interface Invoice {
+  id: string;
+  stripe_invoice_id: string;
+  amount_cents: number;
+  currency: string;
+  status: 'paid' | 'open' | 'void' | 'draft' | 'uncollectible';
+  invoice_pdf?: string;
+  period_start: string;
+  period_end: string;
+  created_at: string;
+}
+
+export interface FeatureRegistryEntry {
+  feature_key: string;
+  display_name: string;
+  description: string;
+  plans: string[];
+  category: string;
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No new errors from these types (pre-existing errors may exist)
+
+**Step 3: Commit**
+
+```bash
+git add admin-ui/types/index.ts
+git commit -m "feat(admin-ui): add billing, subscription, and feature registry types"
+```
+
+---
+
+## Task 2: Add Billing API Client Methods
+
+**Files:**
+- Modify: `admin-ui/lib/api-client.ts`
+
+**Step 1: Add import for new types**
+
+At the top of `api-client.ts`, update the import from `@/types` to include:
+
+```typescript
+import type {
+  AuditLog,
+  BackupsResponse,
+  FeatureRegistryEntry,
+  IncidentsResponse,
+  Invoice,
+  OrgUsageSummary,
+  Plan,
+  RegistrationCode,
+  RetentionPoliciesResponse,
+  Subscription,
+  UserWithKeyCount,
+} from '@/types';
+```
+
+**Step 2: Add billing API methods before the closing `};` of the api object (before `export default api;`)**
+
+```typescript
+  // ============================================
+  // Plans & Billing
+  // ============================================
+  getPlans: (params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Plan[]>(`/billing/plans${qs}`);
+  },
+  getPlan: (planId: string) =>
+    requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`),
+  createPlan: (data: Partial<Plan>) =>
+    requestJson<Plan>('/billing/plans', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  updatePlan: (planId: string, data: Partial<Plan>) =>
+    requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  deletePlan: (planId: string) =>
+    requestJson(`/billing/plans/${encodeURIComponent(planId)}`, {
+      method: 'DELETE',
+    }),
+
+  // Subscriptions
+  getSubscriptions: (params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Subscription[]>(`/billing/subscriptions${qs}`);
+  },
+  getOrgSubscription: (orgId: number) =>
+    requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`),
+  createSubscription: (orgId: number, data: { plan_id: string; trial_days?: number }) =>
+    requestJson<{ checkout_url?: string; subscription?: Subscription }>(
+      `/billing/orgs/${orgId}/subscription`,
+      { method: 'POST', body: JSON.stringify(data) },
+    ),
+  updateSubscription: (orgId: number, data: { plan_id: string }) =>
+    requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  cancelSubscription: (orgId: number) =>
+    requestJson(`/billing/orgs/${orgId}/subscription`, { method: 'DELETE' }),
+
+  // Usage & Invoices
+  getOrgUsageSummary: (orgId: number, params?: { period?: string }) => {
+    const qs = buildQueryString(params as Record<string, QueryParamValue>);
+    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs}`);
+  },
+  getOrgInvoices: (orgId: number, params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs}`);
+  },
+
+  // Feature Registry
+  getFeatureRegistry: () =>
+    requestJson<FeatureRegistryEntry[]>('/billing/feature-registry'),
+  updateFeatureRegistry: (data: FeatureRegistryEntry[]) =>
+    requestJson<FeatureRegistryEntry[]>('/billing/feature-registry', {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  // Onboarding
+  createOnboardingSession: (data: { org_name: string; org_slug: string; plan_id: string; owner_email?: string }) =>
+    requestJson<{ checkout_url?: string; org_id?: number }>(
+      '/billing/onboarding',
+      { method: 'POST', body: JSON.stringify(data) },
+    ),
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No new errors
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/lib/api-client.ts
+git commit -m "feat(admin-ui): add billing, subscription, and feature registry API methods"
+```
+
+---
+
+## Task 3: Add `billingEnabled` Helper and Navigation Items
+
+**Files:**
+- Create: `admin-ui/lib/billing.ts`
+- Modify: `admin-ui/lib/navigation.ts`
+
+**Step 1: Create billing helper**
+
+Create `admin-ui/lib/billing.ts`:
+
+```typescript
+'use client';
+
+/**
+ * Returns true when the SaaS billing surface is enabled.
+ * Self-hosted deployments set NEXT_PUBLIC_BILLING_ENABLED=false (or omit it).
+ */
+export function isBillingEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true';
+}
+```
+
+**Step 2: Add navigation items**
+
+In `admin-ui/lib/navigation.ts`, add imports at the top:
+
+```typescript
+import { CreditCard, Receipt, Grid3X3 } from 'lucide-react';
+```
+
+Add three new items to the `navigationItems` object (before the `} satisfies` closing):
+
+```typescript
+  plans: { name: 'Plans', href: '/plans', icon: CreditCard, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'pricing', 'subscription', 'tiers'] },
+  subscriptions: { name: 'Subscriptions', href: '/subscriptions', icon: Receipt, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'payments', 'invoices'] },
+  featureRegistry: { name: 'Feature Registry', href: '/feature-registry', icon: Grid3X3, role: ['admin', 'super_admin', 'owner'], keywords: ['gating', 'entitlements', 'open core'] },
+```
+
+Add these to the Governance section in `navigationSections`, after `navigationItems.usage`:
+
+```typescript
+      navigationItems.plans,
+      navigationItems.subscriptions,
+      navigationItems.featureRegistry,
+```
+
+Add breadcrumb support in `resolveDynamicPathLabel`:
+
+```typescript
+  if (root === 'plans' && segments.length === 2) {
+    return `Plan ${decodeURIComponent(idOrSlug)}`;
+  }
+  if (root === 'subscriptions' && segments.length === 2) {
+    return `Subscription ${decodeURIComponent(idOrSlug)}`;
+  }
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/lib/billing.ts admin-ui/lib/navigation.ts
+git commit -m "feat(admin-ui): add billing nav items and billingEnabled helper"
+```
+
+---
+
+## Task 4: PlanBadge Component
+
+**Files:**
+- Create: `admin-ui/components/PlanBadge.tsx`
+- Create: `admin-ui/components/__tests__/PlanBadge.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/PlanBadge.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanBadge } from '../PlanBadge';
+
+describe('PlanBadge', () => {
+  it('renders the plan tier label', () => {
+    render(<PlanBadge tier="pro" />);
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+
+  it('renders free tier with secondary variant styling', () => {
+    const { container } = render(<PlanBadge tier="free" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.textContent).toBe('Free');
+  });
+
+  it('renders enterprise tier', () => {
+    render(<PlanBadge tier="enterprise" />);
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+  });
+
+  it('applies additional className', () => {
+    const { container } = render(<PlanBadge tier="pro" className="ml-2" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('ml-2');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanBadge.test.tsx 2>&1 | tail -10`
+Expected: FAIL — module not found
+
+**Step 3: Implement PlanBadge**
+
+Create `admin-ui/components/PlanBadge.tsx`:
+
+```typescript
+import { Badge } from '@/components/ui/badge';
+import type { PlanTier } from '@/types';
+import { cn } from '@/lib/utils';
+
+const tierConfig: Record<PlanTier, { label: string; className: string }> = {
+  free: { label: 'Free', className: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300' },
+  pro: { label: 'Pro', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' },
+  enterprise: { label: 'Enterprise', className: 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300' },
+};
+
+interface PlanBadgeProps {
+  tier: PlanTier;
+  className?: string;
+}
+
+export function PlanBadge({ tier, className }: PlanBadgeProps) {
+  const config = tierConfig[tier] ?? tierConfig.free;
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanBadge.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/PlanBadge.tsx admin-ui/components/__tests__/PlanBadge.test.tsx
+git commit -m "feat(admin-ui): add PlanBadge component with tests"
+```
+
+---
+
+## Task 5: UsageMeter Component
+
+**Files:**
+- Create: `admin-ui/components/UsageMeter.tsx`
+- Create: `admin-ui/components/__tests__/UsageMeter.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/UsageMeter.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { UsageMeter } from '../UsageMeter';
+
+describe('UsageMeter', () => {
+  it('renders used and included token counts', () => {
+    render(<UsageMeter used={500_000} included={1_000_000} overageCostCents={0} />);
+    expect(screen.getByText(/500,000/)).toBeInTheDocument();
+    expect(screen.getByText(/1,000,000/)).toBeInTheDocument();
+  });
+
+  it('shows green bar when under 80% usage', () => {
+    const { container } = render(<UsageMeter used={400_000} included={1_000_000} overageCostCents={0} />);
+    const bar = container.querySelector('[data-testid="usage-bar"]');
+    expect(bar?.className).toContain('bg-green');
+  });
+
+  it('shows yellow bar when between 80-100% usage', () => {
+    const { container } = render(<UsageMeter used={850_000} included={1_000_000} overageCostCents={0} />);
+    const bar = container.querySelector('[data-testid="usage-bar"]');
+    expect(bar?.className).toContain('bg-yellow');
+  });
+
+  it('shows red bar and overage cost when over 100%', () => {
+    render(<UsageMeter used={1_200_000} included={1_000_000} overageCostCents={2400} />);
+    const bar = screen.getByTestId('usage-bar');
+    expect(bar.className).toContain('bg-red');
+    expect(screen.getByText(/\$24\.00/)).toBeInTheDocument();
+  });
+
+  it('handles zero included gracefully', () => {
+    render(<UsageMeter used={100} included={0} overageCostCents={0} />);
+    expect(screen.getByText(/100/)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UsageMeter.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement UsageMeter**
+
+Create `admin-ui/components/UsageMeter.tsx`:
+
+```typescript
+import { cn } from '@/lib/utils';
+
+interface UsageMeterProps {
+  used: number;
+  included: number;
+  overageCostCents: number;
+  className?: string;
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function UsageMeter({ used, included, overageCostCents, className }: UsageMeterProps) {
+  const pct = included > 0 ? (used / included) * 100 : (used > 0 ? 100 : 0);
+  const clampedPct = Math.min(pct, 100);
+
+  const barColor =
+    pct > 100 ? 'bg-red-500' :
+    pct >= 80 ? 'bg-yellow-500' :
+    'bg-green-500';
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      <div className="flex justify-between text-sm">
+        <span>{formatTokens(used)} / {formatTokens(included)} tokens</span>
+        {overageCostCents > 0 && (
+          <span className="text-red-600 dark:text-red-400 font-medium">
+            Overage: {formatCents(overageCostCents)}
+          </span>
+        )}
+      </div>
+      <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          data-testid="usage-bar"
+          className={cn('h-2 rounded-full transition-all', barColor)}
+          style={{ width: `${clampedPct}%` }}
+        />
+      </div>
+      <div className="text-xs text-muted-foreground text-right">
+        {pct.toFixed(1)}% used
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UsageMeter.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/UsageMeter.tsx admin-ui/components/__tests__/UsageMeter.test.tsx
+git commit -m "feat(admin-ui): add UsageMeter component with color zones and overage display"
+```
+
+---
+
+## Task 6: UpgradePrompt Component
+
+**Files:**
+- Create: `admin-ui/components/UpgradePrompt.tsx`
+- Create: `admin-ui/components/__tests__/UpgradePrompt.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/UpgradePrompt.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UpgradePrompt } from '../UpgradePrompt';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('UpgradePrompt', () => {
+  it('displays required plan name', () => {
+    render(<UpgradePrompt requiredPlan="pro" featureName="Advanced Analytics" />);
+    expect(screen.getByText(/Pro/)).toBeInTheDocument();
+    expect(screen.getByText(/Advanced Analytics/)).toBeInTheDocument();
+  });
+
+  it('shows upgrade link when showUpgradeLink is true', () => {
+    render(<UpgradePrompt requiredPlan="enterprise" featureName="SSO" showUpgradeLink />);
+    expect(screen.getByRole('link', { name: /upgrade/i })).toBeInTheDocument();
+  });
+
+  it('hides upgrade link by default', () => {
+    render(<UpgradePrompt requiredPlan="pro" featureName="Feature X" />);
+    expect(screen.queryByRole('link', { name: /upgrade/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UpgradePrompt.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement UpgradePrompt**
+
+Create `admin-ui/components/UpgradePrompt.tsx`:
+
+```typescript
+import Link from 'next/link';
+import { ArrowUpCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+interface UpgradePromptProps {
+  requiredPlan: string;
+  featureName: string;
+  showUpgradeLink?: boolean;
+}
+
+export function UpgradePrompt({ requiredPlan, featureName, showUpgradeLink }: UpgradePromptProps) {
+  const planLabel = requiredPlan.charAt(0).toUpperCase() + requiredPlan.slice(1);
+
+  return (
+    <Alert>
+      <ArrowUpCircle className="h-4 w-4" />
+      <AlertDescription className="flex items-center justify-between">
+        <span>
+          <strong>{featureName}</strong> requires the <strong>{planLabel}</strong> plan.
+          {!showUpgradeLink && ' Contact your administrator to upgrade.'}
+        </span>
+        {showUpgradeLink && (
+          <Button asChild size="sm" variant="outline" className="ml-4">
+            <Link href="/plans">Upgrade Plan</Link>
+          </Button>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UpgradePrompt.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/UpgradePrompt.tsx admin-ui/components/__tests__/UpgradePrompt.test.tsx
+git commit -m "feat(admin-ui): add UpgradePrompt component for plan-gated features"
+```
+
+---
+
+## Task 7: PlanGuard Component
+
+**Files:**
+- Create: `admin-ui/components/PlanGuard.tsx`
+- Create: `admin-ui/components/__tests__/PlanGuard.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/PlanGuard.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PlanGuard } from '../PlanGuard';
+
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
+const mockGetOrgSubscription = vi.hoisted(() => vi.fn());
+const mockUseOrgContext = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: mockIsBillingEnabled,
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  api: { getOrgSubscription: mockGetOrgSubscription },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/components/OrgContextSwitcher', () => ({
+  useOrgContext: mockUseOrgContext,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('PlanGuard', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders children when billing is disabled (self-hosted)', () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: null, loading: false });
+    render(<PlanGuard requiredPlan="pro"><div>Protected Content</div></PlanGuard>);
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('renders children when org has required plan', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'pro' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan="pro"><div>Protected Content</div></PlanGuard>);
+    expect(await screen.findByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('renders upgrade prompt when org lacks required plan', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'free' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan="pro" featureName="Analytics"><div>Hidden</div></PlanGuard>);
+    expect(await screen.findByText(/Pro/)).toBeInTheDocument();
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  it('accepts array of plans', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'enterprise' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan={['pro', 'enterprise']}><div>Visible</div></PlanGuard>);
+    expect(await screen.findByText('Visible')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanGuard.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement PlanGuard**
+
+Create `admin-ui/components/PlanGuard.tsx`:
+
+```typescript
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useOrgContext } from '@/components/OrgContextSwitcher';
+import { UpgradePrompt } from '@/components/UpgradePrompt';
+import type { PlanTier } from '@/types';
+
+const TIER_RANK: Record<PlanTier, number> = { free: 0, pro: 1, enterprise: 2 };
+
+interface PlanGuardProps {
+  requiredPlan: PlanTier | PlanTier[];
+  featureName?: string;
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+export function PlanGuard({ requiredPlan, featureName, fallback, children }: PlanGuardProps) {
+  const { selectedOrg, loading: orgLoading } = useOrgContext();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isBillingEnabled()) {
+      setAllowed(true);
+      return;
+    }
+    if (orgLoading || !selectedOrg) return;
+
+    let cancelled = false;
+    api.getOrgSubscription(selectedOrg.id)
+      .then((sub) => {
+        if (cancelled) return;
+        const tier = (sub?.plan?.tier ?? 'free') as PlanTier;
+        const plans = Array.isArray(requiredPlan) ? requiredPlan : [requiredPlan];
+        const meetsRequirement = plans.some((p) => TIER_RANK[tier] >= TIER_RANK[p]);
+        setAllowed(meetsRequirement);
+      })
+      .catch(() => {
+        if (!cancelled) setAllowed(true); // fail open — backend enforces
+      });
+    return () => { cancelled = true; };
+  }, [selectedOrg, orgLoading, requiredPlan]);
+
+  if (allowed === null) return null; // loading
+  if (allowed) return <>{children}</>;
+
+  if (fallback) return <>{fallback}</>;
+
+  const displayPlan = Array.isArray(requiredPlan) ? requiredPlan[0] : requiredPlan;
+  return (
+    <UpgradePrompt
+      requiredPlan={displayPlan}
+      featureName={featureName ?? 'This feature'}
+      showUpgradeLink
+    />
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanGuard.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/PlanGuard.tsx admin-ui/components/__tests__/PlanGuard.test.tsx
+git commit -m "feat(admin-ui): add PlanGuard component for plan-based UI gating"
+```
+
+---
+
+## Task 8: InvoiceTable Component
+
+**Files:**
+- Create: `admin-ui/components/InvoiceTable.tsx`
+- Create: `admin-ui/components/__tests__/InvoiceTable.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/InvoiceTable.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InvoiceTable } from '../InvoiceTable';
+import type { Invoice } from '@/types';
+
+const invoices: Invoice[] = [
+  {
+    id: '1',
+    stripe_invoice_id: 'inv_abc',
+    amount_cents: 4900,
+    currency: 'usd',
+    status: 'paid',
+    invoice_pdf: 'https://stripe.com/invoice.pdf',
+    period_start: '2026-02-01T00:00:00Z',
+    period_end: '2026-03-01T00:00:00Z',
+    created_at: '2026-03-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    stripe_invoice_id: 'inv_def',
+    amount_cents: 7500,
+    currency: 'usd',
+    status: 'open',
+    period_start: '2026-03-01T00:00:00Z',
+    period_end: '2026-04-01T00:00:00Z',
+    created_at: '2026-04-01T00:00:00Z',
+  },
+];
+
+describe('InvoiceTable', () => {
+  it('renders invoice rows', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    expect(screen.getByText('$49.00')).toBeInTheDocument();
+    expect(screen.getByText('$75.00')).toBeInTheDocument();
+  });
+
+  it('renders status badges', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    expect(screen.getByText('paid')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+  });
+
+  it('renders PDF download link when available', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    const links = screen.getAllByRole('link');
+    expect(links.some((link) => link.getAttribute('href') === 'https://stripe.com/invoice.pdf')).toBe(true);
+  });
+
+  it('renders empty state when no invoices', () => {
+    render(<InvoiceTable invoices={[]} />);
+    expect(screen.getByText(/no invoices/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/InvoiceTable.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement InvoiceTable**
+
+Create `admin-ui/components/InvoiceTable.tsx`:
+
+```typescript
+import { Download } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { Invoice } from '@/types';
+
+interface InvoiceTableProps {
+  invoices: Invoice[];
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  paid: 'default',
+  open: 'outline',
+  void: 'secondary',
+  draft: 'secondary',
+  uncollectible: 'destructive',
+};
+
+export function InvoiceTable({ invoices }: InvoiceTableProps) {
+  if (invoices.length === 0) {
+    return <p className="text-sm text-muted-foreground py-4 text-center">No invoices yet.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="py-2 pr-4">Date</th>
+            <th className="py-2 pr-4">Period</th>
+            <th className="py-2 pr-4">Amount</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {invoices.map((inv) => (
+            <tr key={inv.id} className="border-b">
+              <td className="py-2 pr-4">{formatDate(inv.created_at)}</td>
+              <td className="py-2 pr-4">
+                {formatDate(inv.period_start)} — {formatDate(inv.period_end)}
+              </td>
+              <td className="py-2 pr-4 font-medium">{formatCents(inv.amount_cents)}</td>
+              <td className="py-2 pr-4">
+                <Badge variant={statusVariant[inv.status] ?? 'outline'}>{inv.status}</Badge>
+              </td>
+              <td className="py-2">
+                {inv.invoice_pdf && (
+                  <a
+                    href={inv.invoice_pdf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <Download className="h-3 w-3" /> PDF
+                  </a>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/InvoiceTable.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/InvoiceTable.tsx admin-ui/components/__tests__/InvoiceTable.test.tsx
+git commit -m "feat(admin-ui): add InvoiceTable component for Stripe invoice display"
+```
+
+---
+
+## Task 9: Plans Management Page
+
+**Files:**
+- Create: `admin-ui/app/plans/page.tsx`
+- Create: `admin-ui/app/plans/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/plans/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetPlans = vi.hoisted(() => vi.fn());
+const mockCreatePlan = vi.hoisted(() => vi.fn());
+const mockDeletePlan = vi.hoisted(() => vi.fn());
+const confirmMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getPlans: mockGetPlans,
+    createPlan: mockCreatePlan,
+    deletePlan: mockDeletePlan,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useConfirm', () => ({
+  useConfirm: () => confirmMock,
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: toastSuccessMock, error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const samplePlans = [
+  {
+    id: 'plan_free',
+    name: 'Free',
+    tier: 'free' as const,
+    stripe_product_id: 'prod_free',
+    stripe_price_id: 'price_free',
+    monthly_price_cents: 0,
+    included_token_credits: 10_000,
+    overage_rate_per_1k_tokens_cents: 0,
+    features: ['basic_chat'],
+    is_default: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'plan_pro',
+    name: 'Pro',
+    tier: 'pro' as const,
+    stripe_product_id: 'prod_pro',
+    stripe_price_id: 'price_pro',
+    monthly_price_cents: 4900,
+    included_token_credits: 1_000_000,
+    overage_rate_per_1k_tokens_cents: 5,
+    features: ['basic_chat', 'advanced_analytics', 'priority_support'],
+    is_default: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+describe('PlansPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue(samplePlans);
+    confirmMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders plan list', async () => {
+    const PlansPage = (await import('../page')).default;
+    render(<PlansPage />);
+    expect(await screen.findByText('Free')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.getByText('$49.00/mo')).toBeInTheDocument();
+  });
+
+  it('shows create plan dialog', async () => {
+    const PlansPage = (await import('../page')).default;
+    const user = userEvent.setup();
+    render(<PlansPage />);
+    await screen.findByText('Free');
+    const createButton = screen.getByRole('button', { name: /create plan/i });
+    await user.click(createButton);
+    expect(screen.getByLabelText(/plan name/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/plans/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Plans page**
+
+Create `admin-ui/app/plans/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Plus, Trash2, Edit2 } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Plan, PlanTier } from '@/types';
+
+const planSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  tier: z.enum(['free', 'pro', 'enterprise']),
+  monthly_price_cents: z.coerce.number().min(0),
+  included_token_credits: z.coerce.number().min(0),
+  overage_rate_per_1k_tokens_cents: z.coerce.number().min(0),
+  stripe_product_id: z.string().optional(),
+  stripe_price_id: z.string().optional(),
+});
+
+type PlanFormData = z.infer<typeof planSchema>;
+
+export default function PlansPage() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingPlan, setEditingPlan] = useState<Plan | null>(null);
+  const confirm = useConfirm();
+  const toast = useToast();
+
+  const form = useForm<PlanFormData>({
+    resolver: zodResolver(planSchema),
+    defaultValues: {
+      name: '',
+      tier: 'free',
+      monthly_price_cents: 0,
+      included_token_credits: 0,
+      overage_rate_per_1k_tokens_cents: 0,
+    },
+  });
+
+  const loadPlans = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await api.getPlans();
+      setPlans(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Failed to load plans');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) loadPlans();
+    else setLoading(false);
+  }, [loadPlans]);
+
+  const handleCreate = async (data: PlanFormData) => {
+    try {
+      await api.createPlan(data as Partial<Plan>);
+      toast.success('Plan created');
+      setShowCreate(false);
+      form.reset();
+      loadPlans();
+    } catch {
+      toast.error('Failed to create plan');
+    }
+  };
+
+  const handleDelete = async (plan: Plan) => {
+    const ok = await confirm(`Delete plan "${plan.name}"? Orgs on this plan will need to be migrated.`);
+    if (!ok) return;
+    try {
+      await api.deletePlan(plan.id);
+      toast.success('Plan deleted');
+      loadPlans();
+    } catch {
+      toast.error('Failed to delete plan');
+    }
+  };
+
+  const handleEdit = async (data: PlanFormData) => {
+    if (!editingPlan) return;
+    try {
+      await api.updatePlan(editingPlan.id, data as Partial<Plan>);
+      toast.success('Plan updated');
+      setEditingPlan(null);
+      form.reset();
+      loadPlans();
+    } catch {
+      toast.error('Failed to update plan');
+    }
+  };
+
+  const openEdit = (plan: Plan) => {
+    form.reset({
+      name: plan.name,
+      tier: plan.tier,
+      monthly_price_cents: plan.monthly_price_cents,
+      included_token_credits: plan.included_token_credits,
+      overage_rate_per_1k_tokens_cents: plan.overage_rate_per_1k_tokens_cents,
+      stripe_product_id: plan.stripe_product_id,
+      stripe_price_id: plan.stripe_price_id,
+    });
+    setEditingPlan(plan);
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled. Set <code>NEXT_PUBLIC_BILLING_ENABLED=true</code> to manage plans.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const formatPrice = (cents: number) => cents === 0 ? 'Free' : `$${(cents / 100).toFixed(2)}/mo`;
+
+  const planFormDialog = (
+    open: boolean,
+    onOpenChange: (v: boolean) => void,
+    title: string,
+    onSubmit: (data: PlanFormData) => void,
+  ) => (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <Label htmlFor="name">Plan Name</Label>
+            <Input id="name" {...form.register('name')} />
+            {form.formState.errors.name && (
+              <p className="text-sm text-red-500 mt-1">{form.formState.errors.name.message}</p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="tier">Tier</Label>
+            <Select
+              value={form.watch('tier')}
+              onValueChange={(v) => form.setValue('tier', v as PlanTier)}
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">Free</SelectItem>
+                <SelectItem value="pro">Pro</SelectItem>
+                <SelectItem value="enterprise">Enterprise</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="monthly_price_cents">Monthly Price (cents)</Label>
+            <Input id="monthly_price_cents" type="number" {...form.register('monthly_price_cents')} />
+          </div>
+          <div>
+            <Label htmlFor="included_token_credits">Included Token Credits</Label>
+            <Input id="included_token_credits" type="number" {...form.register('included_token_credits')} />
+          </div>
+          <div>
+            <Label htmlFor="overage_rate_per_1k_tokens_cents">Overage Rate / 1K Tokens (cents)</Label>
+            <Input id="overage_rate_per_1k_tokens_cents" type="number" {...form.register('overage_rate_per_1k_tokens_cents')} />
+          </div>
+          <div>
+            <Label htmlFor="stripe_product_id">Stripe Product ID</Label>
+            <Input id="stripe_product_id" {...form.register('stripe_product_id')} placeholder="prod_..." />
+          </div>
+          <div>
+            <Label htmlFor="stripe_price_id">Stripe Price ID</Label>
+            <Input id="stripe_price_id" {...form.register('stripe_price_id')} placeholder="price_..." />
+          </div>
+          <DialogFooter>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Subscription Plans</h1>
+              <p className="text-muted-foreground">Manage pricing tiers and included features</p>
+            </div>
+            <Button onClick={() => { form.reset(); setShowCreate(true); }}>
+              <Plus className="h-4 w-4 mr-2" /> Create Plan
+            </Button>
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading plans...</p>
+          ) : plans.length === 0 ? (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground">
+                No plans configured. Create your first plan to get started.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {plans.map((plan) => (
+                <Card key={plan.id}>
+                  <CardHeader className="flex flex-row items-center justify-between pb-2">
+                    <div className="flex items-center gap-2">
+                      <CardTitle className="text-lg">{plan.name}</CardTitle>
+                      <PlanBadge tier={plan.tier} />
+                      {plan.is_default && (
+                        <span className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">Default</span>
+                      )}
+                    </div>
+                    <div className="flex gap-1">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(plan)}>
+                        <Edit2 className="h-3 w-3" />
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => handleDelete(plan)}>
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-bold">{formatPrice(plan.monthly_price_cents)}</p>
+                    <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+                      <p>{plan.included_token_credits.toLocaleString()} tokens included</p>
+                      {plan.overage_rate_per_1k_tokens_cents > 0 && (
+                        <p>${(plan.overage_rate_per_1k_tokens_cents / 100).toFixed(2)} per 1K overage tokens</p>
+                      )}
+                      <p>{plan.features.length} features enabled</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {planFormDialog(showCreate, setShowCreate, 'Create Plan', handleCreate)}
+        {planFormDialog(!!editingPlan, (v) => !v && setEditingPlan(null), 'Edit Plan', handleEdit)}
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/plans/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/plans/
+git commit -m "feat(admin-ui): add Plans management page with CRUD and Stripe IDs"
+```
+
+---
+
+## Task 10: Subscriptions List Page
+
+**Files:**
+- Create: `admin-ui/app/subscriptions/page.tsx`
+- Create: `admin-ui/app/subscriptions/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/subscriptions/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSubscriptions = vi.hoisted(() => vi.fn());
+const mockGetPlans = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getSubscriptions: mockGetSubscriptions,
+    getPlans: mockGetPlans,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/OrgContextSwitcher', () => ({
+  useOrgContext: () => ({ selectedOrg: null, loading: false, organizations: [] }),
+}));
+
+describe('SubscriptionsPage', () => {
+  beforeEach(() => {
+    mockGetSubscriptions.mockResolvedValue([
+      {
+        id: 'sub_1',
+        org_id: 1,
+        plan_id: 'plan_pro',
+        plan: { id: 'plan_pro', name: 'Pro', tier: 'pro' },
+        stripe_subscription_id: 'sub_stripe_1',
+        status: 'active',
+        current_period_start: '2026-03-01T00:00:00Z',
+        current_period_end: '2026-04-01T00:00:00Z',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-03-01T00:00:00Z',
+      },
+    ]);
+    mockGetPlans.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders subscription list', async () => {
+    const SubscriptionsPage = (await import('../page')).default;
+    render(<SubscriptionsPage />);
+    expect(await screen.findByText('active')).toBeInTheDocument();
+    expect(screen.getByText(/Pro/)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/subscriptions/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Subscriptions page**
+
+Create `admin-ui/app/subscriptions/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Subscription, SubscriptionStatus } from '@/types';
+
+const statusVariant: Record<SubscriptionStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  trialing: 'outline',
+  past_due: 'destructive',
+  canceled: 'secondary',
+  incomplete: 'secondary',
+};
+
+export default function SubscriptionsPage() {
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const toast = useToast();
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params: Record<string, string> = {};
+      if (statusFilter !== 'all') params.status = statusFilter;
+      const data = await api.getSubscriptions(params);
+      setSubscriptions(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Failed to load subscriptions');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) load();
+    else setLoading(false);
+  }, [load]);
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Subscriptions</h1>
+              <p className="text-muted-foreground">All active and past subscriptions across organizations</p>
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="trialing">Trialing</SelectItem>
+                <SelectItem value="past_due">Past Due</SelectItem>
+                <SelectItem value="canceled">Canceled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading...</p>
+          ) : subscriptions.length === 0 ? (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground">
+                No subscriptions found.
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="p-3">Organization</th>
+                        <th className="p-3">Plan</th>
+                        <th className="p-3">Status</th>
+                        <th className="p-3">Current Period</th>
+                        <th className="p-3">Created</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {subscriptions.map((sub) => (
+                        <tr key={sub.id} className="border-b hover:bg-muted/50">
+                          <td className="p-3">
+                            <Link href={`/organizations/${sub.org_id}`} className="text-blue-600 hover:underline">
+                              Org #{sub.org_id}
+                            </Link>
+                          </td>
+                          <td className="p-3">
+                            {sub.plan ? <PlanBadge tier={sub.plan.tier} /> : sub.plan_id}
+                          </td>
+                          <td className="p-3">
+                            <Badge variant={statusVariant[sub.status] ?? 'outline'}>{sub.status}</Badge>
+                          </td>
+                          <td className="p-3">
+                            {formatDate(sub.current_period_start)} — {formatDate(sub.current_period_end)}
+                          </td>
+                          <td className="p-3">{formatDate(sub.created_at)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/subscriptions/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/subscriptions/
+git commit -m "feat(admin-ui): add Subscriptions list page with status filtering"
+```
+
+---
+
+## Task 11: Feature Registry Page
+
+**Files:**
+- Create: `admin-ui/app/feature-registry/page.tsx`
+- Create: `admin-ui/app/feature-registry/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/feature-registry/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetFeatureRegistry = vi.hoisted(() => vi.fn());
+const mockGetPlans = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getFeatureRegistry: mockGetFeatureRegistry,
+    getPlans: mockGetPlans,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+describe('FeatureRegistryPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue([
+      { id: 'plan_free', name: 'Free', tier: 'free' },
+      { id: 'plan_pro', name: 'Pro', tier: 'pro' },
+    ]);
+    mockGetFeatureRegistry.mockResolvedValue([
+      {
+        feature_key: 'advanced_analytics',
+        display_name: 'Advanced Analytics',
+        description: 'Deep usage analytics',
+        plans: ['plan_pro'],
+        category: 'Analytics',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders feature matrix with plan columns', async () => {
+    const FeatureRegistryPage = (await import('../page')).default;
+    render(<FeatureRegistryPage />);
+    expect(await screen.findByText('Advanced Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/feature-registry/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Feature Registry page**
+
+Create `admin-ui/app/feature-registry/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Check, X } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { Plan, FeatureRegistryEntry } from '@/types';
+
+export default function FeatureRegistryPage() {
+  const [features, setFeatures] = useState<FeatureRegistryEntry[]>([]);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dirty, setDirty] = useState(false);
+  const toast = useToast();
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [featData, planData] = await Promise.all([
+        api.getFeatureRegistry(),
+        api.getPlans(),
+      ]);
+      setFeatures(Array.isArray(featData) ? featData : []);
+      setPlans(Array.isArray(planData) ? planData : []);
+    } catch {
+      toast.error('Failed to load feature registry');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) load();
+    else setLoading(false);
+  }, [load]);
+
+  const toggleFeature = (featureKey: string, planId: string) => {
+    setFeatures((prev) =>
+      prev.map((f) => {
+        if (f.feature_key !== featureKey) return f;
+        const has = f.plans.includes(planId);
+        return { ...f, plans: has ? f.plans.filter((p) => p !== planId) : [...f.plans, planId] };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      await api.updateFeatureRegistry(features);
+      toast.success('Feature registry saved');
+      setDirty(false);
+    } catch {
+      toast.error('Failed to save');
+    }
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const categories = Array.from(new Set(features.map((f) => f.category))).sort();
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Feature Registry</h1>
+              <p className="text-muted-foreground">Map features to plan tiers for open-core gating</p>
+            </div>
+            {dirty && <Button onClick={handleSave}>Save Changes</Button>}
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading...</p>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="p-3">Feature</th>
+                        {plans.map((plan) => (
+                          <th key={plan.id} className="p-3 text-center">{plan.name}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {categories.map((cat) => (
+                        <>
+                          <tr key={`cat-${cat}`}>
+                            <td colSpan={plans.length + 1} className="p-3 font-semibold bg-muted/50">
+                              {cat}
+                            </td>
+                          </tr>
+                          {features
+                            .filter((f) => f.category === cat)
+                            .map((feat) => (
+                              <tr key={feat.feature_key} className="border-b hover:bg-muted/30">
+                                <td className="p-3">
+                                  <div>{feat.display_name}</div>
+                                  <div className="text-xs text-muted-foreground">{feat.description}</div>
+                                </td>
+                                {plans.map((plan) => {
+                                  const included = feat.plans.includes(plan.id);
+                                  return (
+                                    <td key={plan.id} className="p-3 text-center">
+                                      <button
+                                        onClick={() => toggleFeature(feat.feature_key, plan.id)}
+                                        className="inline-flex items-center justify-center"
+                                      >
+                                        {included ? (
+                                          <Check className="h-4 w-4 text-green-600" />
+                                        ) : (
+                                          <X className="h-4 w-4 text-gray-300" />
+                                        )}
+                                      </button>
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            ))}
+                        </>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/feature-registry/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/feature-registry/
+git commit -m "feat(admin-ui): add Feature Registry page with plan-to-feature matrix"
+```
+
+---
+
+## Task 12: Onboarding Wizard Page
+
+**Files:**
+- Create: `admin-ui/app/onboarding/page.tsx`
+- Create: `admin-ui/app/onboarding/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/onboarding/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetPlans = vi.hoisted(() => vi.fn());
+const mockCreateOnboardingSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getPlans: mockGetPlans,
+    createOnboardingSession: mockCreateOnboardingSession,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+const plans = [
+  { id: 'plan_free', name: 'Free', tier: 'free', monthly_price_cents: 0, included_token_credits: 10000 },
+  { id: 'plan_pro', name: 'Pro', tier: 'pro', monthly_price_cents: 4900, included_token_credits: 1000000 },
+];
+
+describe('OnboardingPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue(plans);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders step 1 with org name input', async () => {
+    const OnboardingPage = (await import('../page')).default;
+    render(<OnboardingPage />);
+    expect(await screen.findByLabelText(/organization name/i)).toBeInTheDocument();
+  });
+
+  it('advances to step 2 on next', async () => {
+    const OnboardingPage = (await import('../page')).default;
+    const user = userEvent.setup();
+    render(<OnboardingPage />);
+
+    const nameInput = await screen.findByLabelText(/organization name/i);
+    await user.type(nameInput, 'Acme Corp');
+
+    const slugInput = screen.getByLabelText(/slug/i);
+    await user.type(slugInput, 'acme-corp');
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    await user.click(nextButton);
+
+    expect(await screen.findByText(/select a plan/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/onboarding/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Onboarding page**
+
+Create `admin-ui/app/onboarding/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Check, ChevronRight } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import type { Plan } from '@/types';
+
+const orgSchema = z.object({
+  org_name: z.string().min(1, 'Required'),
+  org_slug: z.string().min(1, 'Required').regex(/^[a-z0-9-]+$/, 'Lowercase letters, numbers, hyphens only'),
+  owner_email: z.string().email().optional().or(z.literal('')),
+});
+
+type OrgFormData = z.infer<typeof orgSchema>;
+
+const STEPS = ['Organization', 'Select Plan', 'Confirm'] as const;
+
+export default function OnboardingPage() {
+  const [step, setStep] = useState(0);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const toast = useToast();
+
+  const form = useForm<OrgFormData>({
+    resolver: zodResolver(orgSchema),
+    defaultValues: { org_name: '', org_slug: '', owner_email: '' },
+  });
+
+  const loadPlans = useCallback(async () => {
+    try {
+      const data = await api.getPlans();
+      const list = Array.isArray(data) ? data : [];
+      setPlans(list);
+      const defaultPlan = list.find((p) => p.is_default);
+      if (defaultPlan) setSelectedPlanId(defaultPlan.id);
+    } catch {
+      toast.error('Failed to load plans');
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) loadPlans();
+  }, [loadPlans]);
+
+  const handleNext = async () => {
+    if (step === 0) {
+      const valid = await form.trigger();
+      if (!valid) return;
+      setStep(1);
+    } else if (step === 1) {
+      if (!selectedPlanId) {
+        toast.error('Please select a plan');
+        return;
+      }
+      setStep(2);
+    }
+  };
+
+  const handleBack = () => {
+    if (step > 0) setStep(step - 1);
+  };
+
+  const handleSubmit = async () => {
+    const data = form.getValues();
+    setSubmitting(true);
+    try {
+      const result = await api.createOnboardingSession({
+        org_name: data.org_name,
+        org_slug: data.org_slug,
+        plan_id: selectedPlanId!,
+        owner_email: data.owner_email || undefined,
+      });
+      if (result.checkout_url) {
+        window.location.href = result.checkout_url;
+      } else {
+        toast.success('Organization created successfully');
+        setStep(0);
+        form.reset();
+      }
+    } catch {
+      toast.error('Onboarding failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const selectedPlan = plans.find((p) => p.id === selectedPlanId);
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="max-w-2xl mx-auto space-y-6">
+          <h1 className="text-2xl font-bold">Onboard New Organization</h1>
+
+          {/* Step indicator */}
+          <div className="flex items-center gap-2">
+            {STEPS.map((label, i) => (
+              <div key={label} className="flex items-center gap-2">
+                <div className={cn(
+                  'flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium',
+                  i < step ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' :
+                  i === step ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
+                  'bg-gray-100 text-gray-500 dark:bg-gray-800',
+                )}>
+                  {i < step ? <Check className="h-4 w-4" /> : i + 1}
+                </div>
+                <span className={cn('text-sm', i === step ? 'font-medium' : 'text-muted-foreground')}>
+                  {label}
+                </span>
+                {i < STEPS.length - 1 && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+              </div>
+            ))}
+          </div>
+
+          {/* Step 1: Organization Details */}
+          {step === 0 && (
+            <Card>
+              <CardHeader><CardTitle>Organization Details</CardTitle></CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <Label htmlFor="org_name">Organization Name</Label>
+                  <Input id="org_name" {...form.register('org_name')} />
+                  {form.formState.errors.org_name && (
+                    <p className="text-sm text-red-500 mt-1">{form.formState.errors.org_name.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="org_slug">Slug</Label>
+                  <Input id="org_slug" {...form.register('org_slug')} placeholder="acme-corp" />
+                  {form.formState.errors.org_slug && (
+                    <p className="text-sm text-red-500 mt-1">{form.formState.errors.org_slug.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="owner_email">Owner Email (optional)</Label>
+                  <Input id="owner_email" type="email" {...form.register('owner_email')} />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Step 2: Plan Selection */}
+          {step === 1 && (
+            <div className="space-y-3">
+              <p className="text-muted-foreground">Select a plan for this organization:</p>
+              {plans.map((plan) => (
+                <Card
+                  key={plan.id}
+                  className={cn(
+                    'cursor-pointer transition-colors',
+                    selectedPlanId === plan.id ? 'ring-2 ring-blue-500' : 'hover:bg-muted/50',
+                  )}
+                  onClick={() => setSelectedPlanId(plan.id)}
+                >
+                  <CardContent className="p-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <PlanBadge tier={plan.tier} />
+                      <div>
+                        <p className="font-medium">{plan.name}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {plan.included_token_credits.toLocaleString()} tokens included
+                        </p>
+                      </div>
+                    </div>
+                    <p className="font-bold">
+                      {plan.monthly_price_cents === 0 ? 'Free' : `$${(plan.monthly_price_cents / 100).toFixed(2)}/mo`}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {/* Step 3: Confirm */}
+          {step === 2 && (
+            <Card>
+              <CardHeader><CardTitle>Confirm</CardTitle></CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <p><strong>Organization:</strong> {form.getValues('org_name')} ({form.getValues('org_slug')})</p>
+                {form.getValues('owner_email') && <p><strong>Owner:</strong> {form.getValues('owner_email')}</p>}
+                <p><strong>Plan:</strong> {selectedPlan?.name ?? 'Unknown'}</p>
+                {selectedPlan && selectedPlan.monthly_price_cents > 0 && (
+                  <p className="text-muted-foreground">
+                    A Stripe Checkout session will be created for payment.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Navigation */}
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={handleBack} disabled={step === 0}>
+              Back
+            </Button>
+            {step < 2 ? (
+              <Button onClick={handleNext}>
+                Next <ChevronRight className="h-4 w-4 ml-1" />
+              </Button>
+            ) : (
+              <Button onClick={handleSubmit} disabled={submitting}>
+                {submitting ? 'Creating...' : selectedPlan && selectedPlan.monthly_price_cents > 0 ? 'Create & Pay' : 'Create Organization'}
+              </Button>
+            )}
+          </div>
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/onboarding/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/onboarding/
+git commit -m "feat(admin-ui): add Onboarding wizard with org creation and plan selection"
+```
+
+---
+
+## Task 13: Org Detail — Subscription Tab
+
+**Files:**
+- Modify: `admin-ui/app/organizations/[id]/page.tsx`
+
+**Step 1: Read the existing org detail page to understand current structure**
+
+Run: Read the file to find where to add the subscription section.
+
+**Step 2: Add imports for billing components**
+
+Add to the imports section of `admin-ui/app/organizations/[id]/page.tsx`:
+
+```typescript
+import { PlanBadge } from '@/components/PlanBadge';
+import { UsageMeter } from '@/components/UsageMeter';
+import { InvoiceTable } from '@/components/InvoiceTable';
+import { isBillingEnabled } from '@/lib/billing';
+import type { Subscription, OrgUsageSummary, Invoice } from '@/types';
+```
+
+**Step 3: Add subscription state alongside existing state**
+
+Add state variables:
+
+```typescript
+const [subscription, setSubscription] = useState<Subscription | null>(null);
+const [usageSummary, setUsageSummary] = useState<OrgUsageSummary | null>(null);
+const [invoices, setInvoices] = useState<Invoice[]>([]);
+```
+
+**Step 4: Add billing data fetch in the existing loadData function**
+
+Inside the existing `Promise.allSettled()` or after the main data loads, add:
+
+```typescript
+if (isBillingEnabled()) {
+  const [subResult, usageResult, invoiceResult] = await Promise.allSettled([
+    api.getOrgSubscription(Number(id)),
+    api.getOrgUsageSummary(Number(id)),
+    api.getOrgInvoices(Number(id)),
+  ]);
+  if (subResult.status === 'fulfilled') setSubscription(subResult.value);
+  if (usageResult.status === 'fulfilled') setUsageSummary(usageResult.value);
+  if (invoiceResult.status === 'fulfilled') setInvoices(Array.isArray(invoiceResult.value) ? invoiceResult.value : []);
+}
+```
+
+**Step 5: Add Subscription card section after the existing BYOK section**
+
+```tsx
+{/* Subscription & Billing (SaaS only) */}
+{isBillingEnabled() && (
+  <Card>
+    <CardHeader>
+      <CardTitle className="flex items-center gap-2">
+        Subscription
+        {subscription?.plan && <PlanBadge tier={subscription.plan.tier} />}
+      </CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      {subscription ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="text-muted-foreground">Status</p>
+              <p className="font-medium capitalize">{subscription.status}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Current Period</p>
+              <p className="font-medium">
+                {new Date(subscription.current_period_start).toLocaleDateString()} —{' '}
+                {new Date(subscription.current_period_end).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+
+          {usageSummary && (
+            <div>
+              <p className="text-sm font-medium mb-2">Token Usage</p>
+              <UsageMeter
+                used={usageSummary.tokens_used}
+                included={usageSummary.tokens_included}
+                overageCostCents={usageSummary.overage_cost_cents}
+              />
+            </div>
+          )}
+
+          {invoices.length > 0 && (
+            <div>
+              <p className="text-sm font-medium mb-2">Invoices</p>
+              <InvoiceTable invoices={invoices} />
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="text-muted-foreground">No active subscription.</p>
+      )}
+    </CardContent>
+  </Card>
+)}
+```
+
+**Step 6: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 7: Commit**
+
+```bash
+git add admin-ui/app/organizations/\[id\]/page.tsx
+git commit -m "feat(admin-ui): add Subscription section to org detail page"
+```
+
+---
+
+## Task 14: Modify Organizations List — Plan Column
+
+**Files:**
+- Modify: `admin-ui/app/organizations/page.tsx`
+
+**Step 1: Read the existing organizations page**
+
+Understand the table structure before modifying.
+
+**Step 2: Add PlanBadge import and subscription state**
+
+At the top:
+```typescript
+import { PlanBadge } from '@/components/PlanBadge';
+import { isBillingEnabled } from '@/lib/billing';
+```
+
+**Step 3: Extend org list to fetch subscriptions**
+
+After orgs are loaded, fetch subscriptions for visible orgs:
+
+```typescript
+// After loadData sets organizations, fetch their subscriptions if billing enabled
+const [orgPlans, setOrgPlans] = useState<Record<number, { tier: PlanTier; status: string }>>({});
+
+// In loadData, after org list is fetched:
+if (isBillingEnabled() && orgs.length > 0) {
+  const subs = await api.getSubscriptions({ org_ids: orgs.map((o: { id: number }) => o.id).join(',') });
+  const planMap: Record<number, { tier: PlanTier; status: string }> = {};
+  if (Array.isArray(subs)) {
+    subs.forEach((sub: Subscription) => {
+      planMap[sub.org_id] = { tier: sub.plan?.tier ?? 'free', status: sub.status };
+    });
+  }
+  setOrgPlans(planMap);
+}
+```
+
+**Step 4: Add Plan column to the table**
+
+In the table header, add after the existing columns:
+```tsx
+{isBillingEnabled() && <th className="p-3">Plan</th>}
+{isBillingEnabled() && <th className="p-3">Status</th>}
+```
+
+In the table body rows:
+```tsx
+{isBillingEnabled() && (
+  <td className="p-3">
+    <PlanBadge tier={orgPlans[org.id]?.tier ?? 'free'} />
+  </td>
+)}
+{isBillingEnabled() && (
+  <td className="p-3 capitalize text-sm">
+    {orgPlans[org.id]?.status ?? '—'}
+  </td>
+)}
+```
+
+**Step 5: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/app/organizations/page.tsx
+git commit -m "feat(admin-ui): add Plan and Status columns to organizations list"
+```
+
+---
+
+## Task 15: Dashboard — Revenue KPI and Plan Distribution
+
+**Files:**
+- Modify: `admin-ui/app/page.tsx` (dashboard)
+
+**Step 1: Read the existing dashboard page**
+
+Understand the KPI card structure.
+
+**Step 2: Add billing imports**
+
+```typescript
+import { isBillingEnabled } from '@/lib/billing';
+```
+
+**Step 3: Add billing KPIs**
+
+In the dashboard's data loading section, add:
+
+```typescript
+const [billingStats, setBillingStats] = useState<{
+  mrr_cents: number;
+  active_subscriptions: number;
+  past_due_count: number;
+  plan_distribution: Record<string, number>;
+} | null>(null);
+
+// In loadData:
+if (isBillingEnabled()) {
+  try {
+    const subs = await api.getSubscriptions();
+    if (Array.isArray(subs)) {
+      const active = subs.filter((s: Subscription) => s.status === 'active');
+      const pastDue = subs.filter((s: Subscription) => s.status === 'past_due');
+      const distribution: Record<string, number> = {};
+      subs.forEach((s: Subscription) => {
+        const tier = s.plan?.tier ?? 'free';
+        distribution[tier] = (distribution[tier] ?? 0) + 1;
+      });
+      setBillingStats({
+        mrr_cents: 0, // Would come from a dedicated endpoint
+        active_subscriptions: active.length,
+        past_due_count: pastDue.length,
+        plan_distribution: distribution,
+      });
+    }
+  } catch {
+    // Non-critical — dashboard still works without billing stats
+  }
+}
+```
+
+**Step 4: Add KPI cards in the dashboard grid (conditionally)**
+
+```tsx
+{isBillingEnabled() && billingStats && (
+  <>
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm text-muted-foreground">Active Subscriptions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-bold">{billingStats.active_subscriptions}</p>
+      </CardContent>
+    </Card>
+    {billingStats.past_due_count > 0 && (
+      <Card className="border-red-200 dark:border-red-800">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm text-red-600">Past Due</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold text-red-600">{billingStats.past_due_count}</p>
+        </CardContent>
+      </Card>
+    )}
+  </>
+)}
+```
+
+**Step 5: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/app/page.tsx
+git commit -m "feat(admin-ui): add billing KPIs to dashboard when billing enabled"
+```
+
+---
+
+## Task 16: Filter Billing Nav Items by `BILLING_ENABLED`
+
+**Files:**
+- Modify: `admin-ui/lib/navigation.ts`
+
+**Step 1: Add conditional filtering**
+
+The navigation items for plans, subscriptions, and featureRegistry should only appear when billing is enabled. Since `navigation.ts` is imported at module level (not in a component), we need a runtime filter.
+
+Update the `navigationSections` export to be a function or add a `billingOnly` flag:
+
+Add a `billingOnly?: boolean` field to the `NavigationItem` type:
+
+```typescript
+export type NavigationItem = {
+  name: string;
+  href: string;
+  icon: LucideIcon;
+  permission?: string;
+  role?: string[];
+  keywords?: string[];
+  billingOnly?: boolean;
+};
+```
+
+Mark the three billing items with `billingOnly: true`:
+
+```typescript
+  plans: { name: 'Plans', href: '/plans', icon: CreditCard, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'pricing'], billingOnly: true },
+  subscriptions: { name: 'Subscriptions', href: '/subscriptions', icon: Receipt, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'payments'], billingOnly: true },
+  featureRegistry: { name: 'Feature Registry', href: '/feature-registry', icon: Grid3X3, role: ['admin', 'super_admin', 'owner'], keywords: ['gating', 'entitlements'], billingOnly: true },
+```
+
+Then in the sidebar component (wherever `navigationSections` is consumed), filter out `billingOnly` items when `!isBillingEnabled()`. This keeps navigation.ts pure and moves the runtime check to the rendering layer.
+
+**Step 2: Verify build**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 3: Commit**
+
+```bash
+git add admin-ui/lib/navigation.ts
+git commit -m "feat(admin-ui): mark billing nav items with billingOnly flag for conditional display"
+```
+
+---
+
+## Task 17: Final Integration Test
+
+**Files:**
+- Create: `admin-ui/app/__tests__/billing-integration.test.tsx`
+
+**Step 1: Write integration test**
+
+Create `admin-ui/app/__tests__/billing-integration.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { isBillingEnabled } from '@/lib/billing';
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: vi.fn(),
+}));
+
+describe('Billing integration', () => {
+  it('isBillingEnabled returns false when env is not set', () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(false);
+    expect(isBillingEnabled()).toBe(false);
+  });
+
+  it('isBillingEnabled returns true when env is true', () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    expect(isBillingEnabled()).toBe(true);
+  });
+});
+
+describe('Billing types are importable', () => {
+  it('imports Plan type without error', async () => {
+    const types = await import('@/types');
+    expect(types).toBeDefined();
+  });
+});
+```
+
+**Step 2: Run all billing-related tests**
+
+Run: `cd admin-ui && npx vitest run --reporter=verbose 2>&1 | grep -E '(PASS|FAIL|billing|Plan|Usage|Invoice|Upgrade|Onboarding|Subscription|feature-registry)' | head -30`
+Expected: All PASS
+
+**Step 3: Run full test suite to check for regressions**
+
+Run: `cd admin-ui && npx vitest run 2>&1 | tail -20`
+Expected: No new failures
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/app/__tests__/billing-integration.test.tsx
+git commit -m "test(admin-ui): add billing integration smoke tests"
+```
+
+---
+
+## Summary
+
+| Task | Description | New Files | Modified Files |
+|------|------------|-----------|----------------|
+| 1 | Billing types | — | `types/index.ts` |
+| 2 | API client methods | — | `lib/api-client.ts` |
+| 3 | Billing helper + nav items | `lib/billing.ts` | `lib/navigation.ts` |
+| 4 | PlanBadge component | `components/PlanBadge.tsx` + test | — |
+| 5 | UsageMeter component | `components/UsageMeter.tsx` + test | — |
+| 6 | UpgradePrompt component | `components/UpgradePrompt.tsx` + test | — |
+| 7 | PlanGuard component | `components/PlanGuard.tsx` + test | — |
+| 8 | InvoiceTable component | `components/InvoiceTable.tsx` + test | — |
+| 9 | Plans page | `app/plans/` + test | — |
+| 10 | Subscriptions page | `app/subscriptions/` + test | — |
+| 11 | Feature Registry page | `app/feature-registry/` + test | — |
+| 12 | Onboarding page | `app/onboarding/` + test | — |
+| 13 | Org detail subscription tab | — | `app/organizations/[id]/page.tsx` |
+| 14 | Org list plan column | — | `app/organizations/page.tsx` |
+| 15 | Dashboard billing KPIs | — | `app/page.tsx` |
+| 16 | Nav billing filtering | — | `lib/navigation.ts` |
+| 17 | Integration test | `app/__tests__/billing-integration.test.tsx` | — |
+
+**Total: 17 tasks, ~17 commits, 12 new files, 6 modified files**

--- a/Docs/Plans/2026-03-08-ingestion-source-sync-design.md
+++ b/Docs/Plans/2026-03-08-ingestion-source-sync-design.md
@@ -1,0 +1,531 @@
+# Ingestion Source Sync Design
+
+## Date
+2026-03-08
+
+## Owner
+Generic document/file ingestion sync for local directories and archive snapshots
+
+## Goal
+Design a reusable sync/import system for document and file ingestion that supports local directories and uploaded archive refreshes, with selectable destination sinks for Media/Documents or Notes.
+
+## Scope
+
+In scope:
+- Generic syncable ingestion sources for:
+  - local directories on disk
+  - uploaded archive snapshots (`.zip`, later `.tar`/`.tar.gz` if supported by the same safety model)
+- Manual sync plus optional scheduled rescans for local-directory sources
+- UI and API refresh of archive-backed sources by replacing the payload for the same logical source
+- Selectable sink per source:
+  - `media`
+  - `notes`
+- Per-source lifecycle policy:
+  - `canonical`
+  - `import_only`
+- Source-scoped job execution, status, history, and conflict/degraded reporting
+
+Out of scope for v1:
+- Continuous filesystem watching
+- Git repository sync
+- Cloud provider/OAuth connectors
+- Three-way merge for synced note conflicts
+- Changing `sink_type` or source identity after the first successful sync
+- Full note revision-history storage
+- Generic binary ingestion into Notes
+
+## Problem Statement
+
+Current ingestion supports upload/import, but not durable source tracking and resynchronization. Users who keep notes or document collections in a folder or exported archive must re-upload everything when files change. Existing Notes import handles JSON/Markdown batches, and existing External Sources sync handles cloud providers for Media, but there is no reusable local/archive sync system that:
+
+- remembers a source over time
+- detects per-file adds/changes/deletes
+- updates existing destination content instead of blindly duplicating
+- supports both Media and Notes as destinations
+
+## Current Verified Constraints
+
+### Notes import/export exists, but not sync
+
+`POST /api/v1/notes/import` already supports JSON and Markdown batch import with duplicate strategies in:
+
+- `tldw_Server_API/app/api/v1/endpoints/notes.py`
+- `tldw_Server_API/app/api/v1/schemas/notes_schemas.py`
+
+This is import-only behavior. It does not persist source identity, track source items, or diff later refreshes.
+
+### Notes do not have recoverable content history today
+
+`CharactersRAGDB.update_note()` updates the current row in place and increments the optimistic-lock version:
+
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+That is not the same as preserving historical note bodies. Therefore the Notes sink in v1 must be defined as latest-state sync, not durable note revision history.
+
+### A stronger sync model already exists for cloud file sources
+
+The repo already has good patterns for source sync state, reconciliation, job fencing, and scheduled enqueue in:
+
+- `tldw_Server_API/app/core/External_Sources/README.md`
+- `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+- `tldw_Server_API/app/services/connectors_worker.py`
+
+That system is currently provider-centric and Media-centric. It should inform the design, but local folders and uploaded archives should not be modeled as fake OAuth providers.
+
+### Safe local path handling and allowed-root validation already matter in this repo
+
+Relevant existing patterns:
+
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/path_utils.py`
+- `tldw_Server_API/app/core/Setup/setup_manager.py`
+
+These confirm that local-path sync must be explicitly constrained to allowed roots and revalidated at runtime.
+
+### Existing ingestion coverage is broader for Media than for Notes
+
+The document/media ingestion pipeline already handles text-first documents and richer document formats:
+
+- `tldw_Server_API/app/api/v1/endpoints/media/process_documents.py`
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/Plaintext/Plaintext_Files.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py`
+
+Notes should therefore have a narrower v1 sink scope than Media.
+
+## Selected Architecture
+
+Create a new generic `ingestion_sources` subsystem for syncable inputs. Reuse the successful ideas from the existing External Sources and Jobs architecture, but keep this system independent from OAuth accounts and remote-provider assumptions.
+
+### Core flow
+
+1. User creates an ingestion source.
+2. A source adapter scans the source and emits a normalized snapshot of items.
+3. A diff/reconciliation layer compares the candidate snapshot to the last successful snapshot.
+4. A sink adapter applies creates/updates/deletes according to the source policy.
+5. Jobs own execution; APIs only create/update sources and enqueue work.
+6. Scheduled rescans use APScheduler to enqueue Jobs, not to process content inline.
+
+### Why this approach
+
+- Matches the repo’s existing preference for Jobs for user-visible work
+- Reuses proven sync-state and fencing concepts
+- Avoids building another one-shot import endpoint that cannot evolve
+- Leaves room for future source types such as git repos or more connectors
+
+## Data Model
+
+### Core tables
+
+`ingestion_sources`
+- one logical source per user
+- fields:
+  - `id`
+  - `user_id`
+  - `source_type` (`local_directory`, `archive_snapshot`)
+  - `sink_type` (`media`, `notes`)
+  - `policy` (`canonical`, `import_only`)
+  - `enabled`
+  - `schedule_enabled`
+  - `schedule_interval_sec` or equivalent schedule config
+  - source config payload
+  - created/updated timestamps
+
+`ingestion_source_state`
+- mutable runtime state per source
+- fields:
+  - `source_id`
+  - `active_job_id`
+  - `last_successful_snapshot_id`
+  - `last_sync_started_at`
+  - `last_sync_completed_at`
+  - `last_sync_status`
+  - `last_error`
+  - counts/summary fields
+
+`ingestion_source_snapshots`
+- one row per scan or archive refresh attempt
+- fields:
+  - `id`
+  - `source_id`
+  - `snapshot_kind` (`scan`, `archive_refresh`)
+  - `status` (`candidate`, `active`, `failed`, `superseded`)
+  - snapshot metadata and summary
+  - created timestamps
+
+`ingestion_source_items`
+- canonical per-item binding for the latest known source state
+- canonical identity in v1:
+  - `source_id + normalized_relative_path`
+- fields:
+  - source item path identity
+  - content fingerprint/hash
+  - file size / modified time metadata
+  - current sync status
+  - bound destination id and destination metadata
+  - item-level error/degraded/conflict state
+
+`ingestion_item_events`
+- append-only audit trail for item-level create/update/delete/archive/conflict events
+
+`ingestion_source_artifacts`
+- staged archive file metadata and extracted snapshot metadata
+- supports retention and cleanup of old uploaded payloads and extracted candidate trees
+
+## Source Semantics
+
+### `local_directory`
+
+- Stores a validated absolute source path under configured allowed roots
+- Supports:
+  - manual sync
+  - optional scheduled rescans
+- Does not support:
+  - filesystem watch in v1
+- Operational constraint:
+  - only safe in deployments where the worker that runs sync can access the same path later
+  - should be treated as self-hosted/admin-controlled unless shared storage guarantees exist
+
+### `archive_snapshot`
+
+- Represents one logical source whose payload is replaced over time by new uploaded archives
+- Refresh paths:
+  - UI re-upload to the same source
+  - API archive replacement for the same source
+- Every refresh creates a candidate snapshot
+- Candidate snapshot becomes authoritative only after successful extraction, normalization, diffing, and sink application
+- If refresh fails, the previous successful snapshot remains current
+
+## Normalization Rules
+
+For both source types, adapters emit normalized items with:
+
+- normalized relative path
+- display path
+- content fingerprint
+- size
+- modified time when available
+- parseable media/document hint
+
+### Archive normalization
+
+If an uploaded archive contains a single common top-level directory, strip that root during normalization so timestamped export wrappers do not cause a full delete/create churn every refresh.
+
+### Rename semantics
+
+In v1, rename is explicitly modeled as:
+
+- old path deleted
+- new path created
+
+No rename continuity is attempted in v1.
+
+## Reconciliation Contract
+
+Candidate snapshot vs last successful snapshot yields:
+
+- `created`
+- `changed`
+- `unchanged`
+- `deleted`
+
+Fingerprinting rule:
+- content hash is authoritative
+- file size and modified time may be used as scan shortcuts, but not as the final truth when content is available
+
+This is especially important for archive refreshes, where filename reuse is common.
+
+## Lifecycle Policies
+
+### `canonical`
+
+- one destination object per source item
+- content changes update that same bound destination object
+- removed source items archive or soft-delete the destination object
+
+### `import_only`
+
+- one destination object per source item
+- content changes update that same bound destination object
+- removed source items do not trigger automatic archival/deletion
+
+### Deferred from v1
+
+`append_only`
+- every change creates a new destination object
+- excluded from v1 to keep binding semantics simple
+
+## Sink Semantics
+
+### `media` sink
+
+- Broadest v1 sink
+- Reuses the document/media ingestion pipeline
+- Appropriate for mixed source collections containing text documents, PDFs, DOCX, EPUB, HTML, Markdown, plain text, and other supported document types
+- On change:
+  - update the same logical bound item where supported
+  - create a new document/media version instead of duplicating when the existing Media model allows it
+- On failed revision ingest:
+  - preserve the last good active version
+  - mark item degraded instead of destroying continuity
+
+### `notes` sink
+
+- Narrower by design in v1
+- Supported input classes for direct Notes sync:
+  - `.md`
+  - `.markdown`
+  - `.txt`
+  - `.html`
+  - `.htm`
+  - `.xml`
+  - `.json`
+  - `.docx`
+  - `.rtf`
+- Not supported for direct Notes sync in v1:
+  - PDFs
+  - ebooks
+  - generic binaries
+
+Reason:
+- Notes are text-first
+- existing note import behavior is oriented around structured text
+- Media already owns the richer document extraction path
+
+### Notes sink content contract
+
+- V1 Notes sync is latest-state sync only
+- It does not promise durable historical note body preservation
+- Title/body derivation:
+  - front matter title when available
+  - Markdown heading fallback
+  - filename fallback
+- Keywords/tags may be mapped where the parsed content exposes them cleanly
+
+## Synced Notes Conflict Policy
+
+This is required to avoid silent user-data loss.
+
+### Recommended v1 rule
+
+- Synced notes are marked `sync_managed`
+- User edits are allowed
+- Once a sync-managed note is manually edited locally, it becomes `detached`
+- Detached note behavior:
+  - future source syncs do not overwrite that note
+  - the source item is marked `conflict_detached`
+  - source status surfaces that conflict for user resolution
+
+### Why this rule
+
+- Safer than overwriting user edits
+- Simpler than read-only synced notes
+- Much simpler than three-way merge
+
+### Deferred from v1
+
+- automatic merge
+- inline conflict editing UI
+- true bidirectional sync
+
+## API Shape
+
+### Endpoints
+
+`POST /api/v1/ingestion-sources`
+- create a source
+
+`GET /api/v1/ingestion-sources`
+- list sources with current status
+
+`GET /api/v1/ingestion-sources/{id}`
+- source detail, last run summary, last error, counts
+
+`PATCH /api/v1/ingestion-sources/{id}`
+- mutable fields only:
+  - enabled flag
+  - schedule
+  - lifecycle policy
+  - parser/filter options
+
+Immutable after first successful sync:
+- `source_type`
+- source identity
+- `sink_type`
+
+`POST /api/v1/ingestion-sources/{id}/sync`
+- enqueue a manual sync
+
+`POST /api/v1/ingestion-sources/{id}/archive`
+- replace payload for an archive-backed source
+- create a candidate snapshot
+- enqueue a sync for that candidate snapshot
+
+`GET /api/v1/ingestion-sources/{id}/items`
+- inspect bound items and sync states
+
+Optional useful follow-up, but not required for first backend checkpoint:
+- `POST /api/v1/ingestion-sources/{id}/items/{item_id}/reattach`
+
+## Jobs and Scheduling
+
+Use Jobs for execution because this is user-visible work with status and admin visibility requirements.
+
+Use APScheduler only to enqueue recurring sync jobs, consistent with repo guidance and existing patterns such as:
+
+- `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+
+Execution requirements:
+- source-scoped active job fencing
+- lease renewal for long syncs
+- no inline processing in request handlers
+
+## Error Handling
+
+### Source validation failures
+
+- invalid local path
+- path escape
+- path outside allowed roots
+- unsupported source configuration
+
+Result:
+- reject creation/update or fail the queued job with actionable error text
+
+### Archive failures
+
+- invalid archive
+- encrypted archive
+- unsafe member path
+- unsupported archive member handling
+
+Result:
+- reject candidate snapshot
+- preserve last successful snapshot as current
+
+### Item-level processing failures
+
+- parse/extract failure on one file
+- sink write failure on one file
+
+Result:
+- keep partial progress for other items
+- mark item failed or degraded
+- retain the previous good bound state where applicable
+
+### Notes conflicts
+
+- detached synced note
+
+Result:
+- do not overwrite
+- mark `conflict_detached`
+
+### Sink mutation attempts
+
+- changing `sink_type` or source identity after first success
+
+Result:
+- reject with 400/409
+- never migrate implicitly
+
+## Security and Deployment Constraints
+
+### Local directory roots
+
+Add a dedicated allowlist such as:
+
+- `INGESTION_SOURCE_ALLOWED_ROOTS`
+
+Behavior:
+- create/update validates configured path against the allowlist
+- runtime scan revalidates actual resolved path containment before reading
+- symlink and traversal escapes must be treated as unsafe
+
+### Archive safety
+
+Follow the same archive-member safety posture already used in other parts of the repo:
+
+- reject zip-slip and unsafe member names
+- reject unsupported encrypted archives
+- never extract blindly into uncontrolled paths
+
+## Retention and Cleanup
+
+Staged uploads and extracted candidate snapshots need explicit cleanup rules.
+
+Defaults:
+- keep current successful snapshot
+- keep a bounded number of previous successful snapshots
+- keep failed candidate snapshots only briefly for debugging
+- remove expired staged artifacts with a cleanup job/service
+
+This prevents archive-backed sync sources from becoming unbounded storage leaks.
+
+## Testing Strategy
+
+### Unit tests
+
+- path normalization and allowed-root enforcement
+- archive root stripping
+- snapshot diffing
+- lifecycle policy behavior
+- sink selection and routing
+- detached-note conflict handling
+
+### Integration tests
+
+- local directory initial sync
+- local directory rescan with add/change/delete
+- archive source initial upload
+- archive source successful re-upload diff
+- archive source failed re-upload rollback
+- media sink version update behavior
+- notes sink latest-state update behavior
+- detached note not overwritten on later sync
+- scheduled enqueue without inline processing
+
+### Security tests
+
+- path traversal via local path input
+- unsafe archive member names
+- symlink/path escape attempts
+
+### Verification
+
+- targeted pytest scope for new backend paths
+- Bandit on touched Python scope before completion
+
+## Recommended Implementation Sequence
+
+1. Add generic source tables and source-state invariants
+2. Add snapshot builder and diff engine
+3. Add local-directory source adapter
+4. Add archive candidate snapshot flow
+5. Add media sink adapter
+6. Add notes sink adapter with `sync_managed` / `detached` semantics
+7. Add Jobs worker and scheduled enqueue
+8. Add source CRUD/status APIs
+9. Add UI after backend behavior is stable
+
+## Final Decisions Captured
+
+- The solution is a general sync/import system for document/file ingestion, not a Notes-only feature
+- v1 source types:
+  - local directory
+  - uploaded archive snapshot
+- local-directory refresh:
+  - manual sync
+  - optional scheduled rescans
+- archive refresh:
+  - UI/manual re-upload
+  - API refresh for the same source
+- destination model:
+  - selectable sink per source (`media` or `notes`)
+- lifecycle:
+  - per-source policy
+- Notes sink:
+  - latest-state sync only
+  - detached conflict semantics
+- sink/source identity:
+  - immutable after first successful sync

--- a/Docs/Plans/2026-03-08-persona-garden-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-persona-garden-implementation-plan.md
@@ -1,0 +1,539 @@
+# Persona Garden Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `Persona Garden` as the branded advanced persona workspace for WebUI and extension, keep `My Chat Identity` separate from persona, and add a character-to-persona creation flow where personas become independent after creation.
+
+**Architecture:** Keep the existing shared `/persona` route and websocket workflow intact, but reorganize it into a clearer `Persona Garden` workspace with explicit sections. Treat persona creation as a fork from a character snapshot: persist provenance metadata for audit/display, but do not keep live inheritance from the source character. Keep normal chat semantics unchanged in this pass.
+
+**Tech Stack:** React, TypeScript, shared route components in `apps/packages/ui`, Next.js page shims in `apps/tldw-frontend`, WXT extension routes, FastAPI, Pydantic, ChaChaNotes SQLite/PostgreSQL DB layer, Vitest, Playwright, pytest, Bandit.
+
+---
+
+### Task 1: Rebrand `/persona` as Persona Garden Without Breaking Live Session Behavior
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx`
+- Modify: `apps/packages/ui/src/data/settings-index.ts`
+- Test: `apps/packages/ui/src/data/__tests__/settings-index.test.ts`
+
+**Step 1: Write the failing test**
+
+Add assertions that the persona route renders `Persona Garden` framing while keeping the existing live session controls (`Connect`, memory toggle, session select) visible. Cover the online route plus the offline/unsupported empty-state branches so no hard-coded `Persona` header is missed. In settings/search tests, assert that `Persona Garden` is added as its own entry instead of renaming `Characters`.
+
+```tsx
+it("renders Persona Garden while preserving live session controls", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByText("Persona Garden")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-memory-toggle")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-resume-session-select")).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/data/__tests__/settings-index.test.ts
+```
+
+Expected:
+
+- FAIL because the route/header/empty-state labels still say `Persona` instead of `Persona Garden`, and settings/search does not yet expose a separate `Persona Garden` destination
+
+**Step 3: Write minimal implementation**
+
+Update the shared route/header copy across all route branches without removing the current live-session controls. Add a new settings/search entry for `Persona Garden`; do not rename the existing `Characters` entry.
+
+```tsx
+<SidepanelHeaderSimple activeTitle={t("sidepanel:persona.title", "Persona Garden")} />
+```
+
+```ts
+{
+  id: "setting-persona-garden",
+  labelKey: "settings:personaGardenNav",
+  defaultLabel: "Persona Garden",
+  defaultDescription: "Configure advanced personas and live persona sessions",
+  route: "/persona",
+  section: "Knowledge",
+  keywords: ["persona", "garden", "memory", "state", "assistant"],
+  controlType: "button",
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/data/__tests__/settings-index.test.ts
+```
+
+Expected:
+
+- PASS with route label updates and no regressions in the current live persona flow
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx apps/packages/ui/src/data/settings-index.ts apps/packages/ui/src/data/__tests__/settings-index.test.ts
+git commit -m "feat: rebrand persona route as Persona Garden"
+```
+
+### Task 2: Extract `My Chat Identity` From Persona And Make It Explicit In Chat UI
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/MyChatIdentityMenu.tsx`
+- Create: `apps/packages/ui/src/components/Common/__tests__/MyChatIdentityMenu.test.tsx`
+- Modify: `apps/packages/ui/src/components/Common/CharacterSelect.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx`
+
+**Step 1: Write the failing test**
+
+Write a component test that verifies the quick surface exposes user identity controls separately from characters and persona navigation.
+
+```tsx
+it("keeps user identity controls separate from persona navigation", async () => {
+  render(<MyChatIdentityMenu />)
+
+  expect(screen.getByText("My Chat Identity")).toBeInTheDocument()
+  expect(screen.getByText("Set your name")).toBeInTheDocument()
+  expect(screen.getByText("Upload your image")).toBeInTheDocument()
+  expect(screen.getByText("Prompt style templates")).toBeInTheDocument()
+  expect(screen.queryByText("Scope rules")).not.toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Common/__tests__/MyChatIdentityMenu.test.tsx
+```
+
+Expected:
+
+- FAIL because `MyChatIdentityMenu` does not exist yet
+
+**Step 3: Write minimal implementation**
+
+Create a dedicated quick-surface component that owns only user display name, user avatar, and user-side prompt templates. Remove persona framing from the existing user controls in `CharacterSelect`.
+
+```tsx
+export const MyChatIdentityMenu = () => (
+  <section aria-label="My Chat Identity">
+    <button type="button">Set your name</button>
+    <button type="button">Upload your image</button>
+    <button type="button">Prompt style templates</button>
+  </section>
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Common/__tests__/MyChatIdentityMenu.test.tsx
+```
+
+Expected:
+
+- PASS with explicit user-identity separation
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Common/MyChatIdentityMenu.tsx apps/packages/ui/src/components/Common/__tests__/MyChatIdentityMenu.test.tsx apps/packages/ui/src/components/Common/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx
+git commit -m "feat: separate My Chat Identity from persona controls"
+```
+
+### Task 3: Refactor Persona Garden Into Explicit Sections While Preserving The Existing Route Contract
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/PersonaGardenTabs.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/StateDocsPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add route tests that require explicit sections while still preserving the current live controls and plan-approval area.
+
+```tsx
+it("shows Persona Garden sections and keeps live controls", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByRole("tab", { name: "Live Session" })).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: "Profiles" })).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: "State Docs" })).toBeInTheDocument()
+  expect(screen.getByTestId("persona-memory-toggle")).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- FAIL because the route is still a single flat layout
+
+**Step 3: Write minimal implementation**
+
+Decompose the large route into focused panels, but keep route-owned state and effects in `sidepanel-persona.tsx`. Websocket lifecycle, session bootstrap/resume, unsaved-state blockers, per-message memory flags, and profile-default PATCH behavior must stay in the route and be passed into presentational panels as props/callbacks. Do not move API calls or websocket effects into the panel components in this task.
+
+```tsx
+<Tabs
+  items={[
+    { key: "live", label: "Live Session", children: <LiveSessionPanel {...props} /> },
+    { key: "profiles", label: "Profiles", children: <ProfilePanel {...props} /> },
+    { key: "state", label: "State Docs", children: <StateDocsPanel {...props} /> },
+    { key: "scopes", label: "Scopes", children: <ScopesPanel {...props} /> },
+    { key: "policies", label: "Policies", children: <PoliciesPanel {...props} /> }
+  ]}
+/>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- PASS with the new IA and no loss of current live behavior
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/PersonaGardenTabs.tsx apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx apps/packages/ui/src/components/PersonaGarden/StateDocsPanel.tsx apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: split Persona Garden into live and configuration sections"
+```
+
+### Task 4: Add Character-To-Persona Provenance And Independent Persona Creation On The Backend
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`
+- Test: `tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py`
+
+**Step 1: Write the failing test**
+
+Add backend tests proving that creating a persona from a character stores provenance snapshots but does not require live character inheritance afterward.
+
+```python
+def test_create_persona_from_character_snapshots_origin_without_live_dependency(client, character_id):
+    response = client.post(
+        "/api/v1/persona/profiles",
+        json={"name": "Garden Helper", "character_card_id": character_id},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["character_card_id"] == character_id
+    assert payload["origin_character_name"] == "Source Character"
+```
+
+```python
+def test_persona_remains_valid_when_origin_character_missing(db, persona_id):
+    source_character = db.get_character_card_by_name("Source Character")
+    assert source_character is not None
+    assert db.soft_delete_character_card(source_character["id"], expected_version=source_character["version"])
+    persona = db.get_persona_profile(persona_id, user_id="1", include_deleted=False)
+    assert persona is not None
+    assert persona["origin_character_name"] == "Source Character"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+```
+
+Expected:
+
+- FAIL because origin snapshot fields and independence semantics are not implemented yet
+
+**Step 3: Write minimal implementation**
+
+Add a schema migration from v28 to v29 for persona provenance snapshot fields. Keep `character_card_id` as an optional current-source link for compatibility, but do not treat it as the sole provenance field because the FK can be nulled on source deletion. Persist separate origin snapshot fields so the persona remains self-describing after source changes or deletion.
+
+```python
+class PersonaProfileResponse(BaseModel):
+    id: str
+    name: str
+    character_card_id: int | None = None
+    origin_character_id: int | None = None
+    origin_character_name: str | None = None
+    origin_character_snapshot_at: str | None = None
+```
+
+```python
+if character_card_id is not None:
+    source_character = self.get_character_card(character_card_id, user_id=user_id)
+    origin_character_id = source_character.get("id")
+    origin_character_name = source_character.get("name")
+    origin_character_snapshot_at = datetime.utcnow().isoformat()
+```
+
+```sql
+ALTER TABLE persona_profiles ADD COLUMN origin_character_id INTEGER;
+ALTER TABLE persona_profiles ADD COLUMN origin_character_name TEXT;
+ALTER TABLE persona_profiles ADD COLUMN origin_character_snapshot_at DATETIME;
+UPDATE db_schema_version SET version = 29 WHERE schema_name = 'rag_char_chat_schema' AND version < 29;
+```
+
+Do not add automatic re-sync from character to persona in this pass. If a source character is later deleted and `character_card_id` becomes `NULL`, the `origin_*` fields must still be returned.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+```
+
+Expected:
+
+- PASS with stable provenance metadata and independent persona persistence
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py
+git commit -m "feat: snapshot persona origin when creating from character"
+```
+
+### Task 5: Add `Create Persona From Character` And `Open In Persona Garden` Flows
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Characters/CharactersWorkspace.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Characters/Manager.tsx`
+- Modify: `apps/packages/ui/src/routes/option-characters.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+- Create: `apps/packages/ui/src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx`
+- Test: `tldw_Server_API/tests/Persona/test_persona_catalog.py`
+
+**Step 1: Write the failing test**
+
+Add frontend tests proving the Characters workspace exposes persona creation/open actions and that Persona Garden shows provenance text instead of implying live inheritance.
+
+```tsx
+it("offers Create Persona from Character from the Characters workspace", async () => {
+  render(<CharactersWorkspace />)
+
+  expect(await screen.findByText("Create Persona from Character")).toBeInTheDocument()
+})
+```
+
+```tsx
+it("shows origin text in Persona Garden instead of live linkage copy", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByText(/Origin: created from/i)).toBeInTheDocument()
+  expect(screen.queryByText(/currently based on/i)).not.toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- FAIL because the actions and provenance text do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Add explicit character actions that create/open personas and update Persona Garden to display source provenance text using the new backend fields. If the open action uses `/persona?persona_id=...`, add route bootstrap logic in `sidepanel-persona.tsx` that reads the requested persona from `location.search` before falling back to catalog/default selection.
+
+```tsx
+<Button onClick={() => onCreatePersonaFromCharacter(record)}>
+  Create Persona from Character
+</Button>
+<Button onClick={() => navigate(`/persona?persona_id=${personaId}`)}>
+  Open in Persona Garden
+</Button>
+```
+
+```tsx
+const location = useLocation()
+const requestedPersonaId = React.useMemo(
+  () => new URLSearchParams(location.search).get("persona_id")?.trim() || "",
+  [location.search]
+)
+```
+
+```tsx
+<p className="text-xs text-text-muted">
+  {originCharacterName ? `Origin: created from ${originCharacterName}` : "Standalone persona"}
+</p>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_catalog.py -v
+```
+
+Expected:
+
+- PASS with the new action flow and correct provenance copy
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Characters/CharactersWorkspace.tsx apps/packages/ui/src/components/Option/Characters/Manager.tsx apps/packages/ui/src/routes/option-characters.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx apps/packages/ui/src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx tldw_Server_API/tests/Persona/test_persona_catalog.py
+git commit -m "feat: add create-persona flow from Characters"
+```
+
+### Task 6: Cross-Surface Verification And Security Scan
+
+**Files:**
+- Create: `apps/tldw-frontend/e2e/workflows/persona-garden.spec.ts`
+- Modify: `apps/tldw-frontend/__tests__/extension/route-registry.persona.test.ts`
+
+**Step 1: Write the failing test**
+
+Add an end-to-end route/parity test proving WebUI and extension both expose Persona Garden without mutating normal chat identity.
+
+```ts
+test("Persona Garden is reachable in web and extension without changing My Chat Identity", async ({ authedPage }) => {
+  await authedPage.goto("/persona")
+  await expect(authedPage.getByText("Persona Garden")).toBeVisible()
+  await expect(authedPage.getByText("My Chat Identity")).not.toBeVisible()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/route-registry.persona.test.ts
+```
+
+Expected:
+
+- FAIL until route labels/e2e expectations are updated
+
+**Step 3: Write minimal implementation**
+
+Keep the route-registry parity test focused on route registration only, and cover `Persona Garden` branding through rendered route tests or E2E. Do not edit the approved design doc in this task unless implementation forces a semantic product change.
+
+```ts
+expect(routeRegistrySource).toMatch(/path:\s*"\/persona"/)
+expect(routeRegistrySource).toMatch(/element:\s*<SidepanelPersona\s*\/>/)
+```
+
+**Step 4: Run verification commands**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/components/Common/__tests__/MyChatIdentityMenu.test.tsx src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx
+```
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend
+bunx vitest run __tests__/extension/route-registry.persona.test.ts
+```
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_profiles_api.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_catalog.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/persona.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_persona_garden.json
+```
+
+Expected:
+
+- All targeted tests PASS
+- Bandit reports no new findings in touched backend scope
+
+**Step 5: Commit**
+
+```bash
+git add apps/tldw-frontend/e2e/workflows/persona-garden.spec.ts apps/tldw-frontend/__tests__/extension/route-registry.persona.test.ts
+git commit -m "test: add Persona Garden cross-surface coverage"
+```
+
+## Notes For The Implementer
+
+- Do not change normal chat to consume persona profiles in this plan.
+- Do not make persona part of `My Chat Identity`.
+- Do not make persona creation a live linked dependency on a character after creation.
+- Keep the current websocket/live-session route functional throughout the refactor.
+- Prefer additive schema changes and compatibility-preserving endpoint behavior.
+- Treat `character_card_id` as a convenience link only; `origin_*` fields are the durable provenance contract.
+
+## Suggested Execution Order
+
+1. Task 1
+2. Task 2
+3. Task 3
+4. Task 4
+5. Task 5
+6. Task 6
+
+## Manual QA Checklist
+
+- Open `/persona` in WebUI and confirm the page title reads `Persona Garden`.
+- Confirm live persona session connect/resume still works.
+- Confirm `My Chat Identity` editing still updates user display name/avatar in normal chat only.
+- Confirm Characters shows `Create Persona from Character`.
+- Confirm `Open in Persona Garden` preselects the requested persona when navigating from Characters.
+- Confirm a created persona shows origin/provenance text but does not imply live character inheritance.
+- Confirm deleting or changing the source character does not break the persona record.

--- a/Docs/Plans/2026-03-08-sandbox-subsystem-review-findings.md
+++ b/Docs/Plans/2026-03-08-sandbox-subsystem-review-findings.md
@@ -1,0 +1,64 @@
+# Sandbox Subsystem Review Findings
+
+Date: 2026-03-08
+Base commit reviewed: `0c13998e9`
+Scope: `tldw_Server_API/app/core/Sandbox/` and `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+
+## Findings
+
+### [P1] Docker runner exceptions after admission leave runs stuck in `starting`
+
+- Type: Bug
+- Evidence:
+  - `tldw_Server_API/app/core/Sandbox/service.py:933-976`
+  - `tldw_Server_API/app/core/Sandbox/service.py:993-1023`
+  - `tldw_Server_API/app/core/Sandbox/service.py:1238-1250`
+- Why it matters:
+  - Both Docker execution branches admit the run into `starting` before invoking `DockerRunner.start_run()`.
+  - If `start_run()` raises, the background branch only logs `Background docker execution failed` and returns without forcing a terminal state.
+  - The foreground branch logs `Docker execution failed; keeping enqueue status`, but the status object is already `starting`, so the final persistence path writes that non-terminal state back to the store unchanged.
+  - A stranded `starting` run can consume active-run quota, block accurate status reporting, and require manual cancelation to recover.
+- Reproduction:
+  - Foreground: patched `DockerRunner.start_run` to raise `RuntimeError("boom")` with `SANDBOX_ENABLE_EXECUTION=1` and `SANDBOX_BACKGROUND_EXECUTION=0`; the returned and stored run both stayed in `starting` with no `finished_at` or failure message.
+  - Background: same patch with `SANDBOX_BACKGROUND_EXECUTION=1` and synchronous `_submit_background_worker`; the returned and stored run again stayed in `starting`.
+
+### [P2] `sandbox_runs_started_total` counts rejected requests as started runs
+
+- Type: Bug
+- Evidence:
+  - `tldw_Server_API/app/api/v1/endpoints/sandbox.py:1086-1093`
+- Why it matters:
+  - The route increments `sandbox_runs_started_total` before `_service.start_run_scaffold(...)` performs runtime selection, policy validation, queue admission, and idempotency checks.
+  - Requests that are rejected with `runtime_unavailable`, `policy_unsupported`, `queue_full`, `invalid_spec_version`, or `idempotency_conflict` are still counted as started runs.
+  - This distorts operational dashboards and any failure-rate math that relies on `started_total` as the denominator.
+
+### [P3] The generic runtime capability contract is only partially wired into the subsystem
+
+- Type: Incomplete Item
+- Evidence:
+  - `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py:9-30`
+  - `tldw_Server_API/app/core/Sandbox/policy.py:151-169`
+- Why it matters:
+  - The repository defines `RuntimeCapabilities` and `RuntimePreflightResult`, but in the reviewed path only Lima preflight meaningfully uses the shared contract object.
+  - Runtime selection in `SandboxPolicy.select_runtime()` still relies on ad hoc availability booleans instead of a provider-neutral capability interface.
+  - This increases the chance that Docker, Firecracker, and Lima drift apart on admission and error semantics as the subsystem evolves.
+
+## Targeted Test Runs
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape`
+  - Result: PASS
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_run_claim_fencing.py tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py tldw_Server_API/tests/sandbox/test_queue_full_429.py`
+  - Result: 14 passed
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_runtime_unavailable.py tldw_Server_API/tests/sandbox/test_lima_no_fallback.py tldw_Server_API/tests/sandbox/test_lima_strict_admission.py`
+  - Result: 9 passed
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_run_ownership.py tldw_Server_API/tests/sandbox/test_admin_rbac.py tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py tldw_Server_API/tests/sandbox/test_artifact_range.py tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py`
+  - Result: 9 passed, 1 skipped
+
+## Validation Gaps
+
+- No existing targeted regression test in the reviewed slice covers the “runner raises after admission” path for Docker foreground or background execution. That gap allowed the stuck-`starting` bug above to persist despite the broader queueing and lifecycle suite passing.
+
+- `tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py::test_artifact_traversal_rejected_under_uvicorn` skipped locally, so the live-server variant of raw-path traversal rejection was not revalidated in this run.

--- a/Docs/Plans/2026-03-08-sandbox-subsystem-review-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-sandbox-subsystem-review-implementation-plan.md
@@ -1,0 +1,231 @@
+# Sandbox Subsystem Review Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Execute a focused, evidence-driven review of the sandbox subsystem and sandbox API endpoints, producing findings for bugs, risky incomplete items, and residual risks.
+
+**Architecture:** Review the internal control plane before the API layer so endpoint behavior is evaluated against the actual queueing, ownership, policy, store, and artifact invariants. Use a targeted pytest slice to confirm or falsify the highest-risk assumptions instead of relying on static inspection alone.
+
+**Tech Stack:** Python 3.11, FastAPI, pytest, loguru, in-memory/SQLite/Postgres sandbox stores, Docker/Firecracker/Lima sandbox runners.
+
+---
+
+### Task 1: Establish the Sandbox Review Harness
+
+**Files:**
+- Inspect: `tldw_Server_API/tests/sandbox/conftest.py`
+- Inspect: `tldw_Server_API/tests/sandbox/test_sandbox_api.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+
+**Step 1: Confirm the sandbox test harness assumptions**
+
+Read:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/sandbox/conftest.py
+sed -n '1,220p' tldw_Server_API/tests/sandbox/test_sandbox_api.py
+```
+Expected: clear understanding of auth defaults, fake execution defaults, stream-hub resets, and TestClient patching used by sandbox tests.
+
+**Step 2: Run a baseline sandbox API smoke test**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape
+```
+Expected: PASS. If this fails, stop and document the environment or harness problem before deeper review.
+
+**Step 3: Record baseline review constraints**
+
+Capture in working notes:
+- whether fake Docker execution is enabled
+- whether WS signed URLs are disabled
+- whether auth is operating in sandbox single-user test mode
+
+### Task 2: Audit Run Lifecycle, Queueing, and Claim Semantics
+
+**Files:**
+- Inspect: `tldw_Server_API/app/core/Sandbox/service.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/orchestrator.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_claim_fencing.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py`
+- Test: `tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py`
+- Test: `tldw_Server_API/tests/sandbox/test_queue_full_429.py`
+
+**Step 1: Read the core run-start and cancelation paths**
+
+Inspect these functions:
+- `SandboxService.start_run_scaffold`
+- `SandboxService._run_with_claim_lease`
+- `SandboxService.cancel_run`
+- `SandboxOrchestrator.enqueue_run`
+- `SandboxOrchestrator.try_claim_run`
+- `SandboxOrchestrator.renew_run_claim`
+- `SandboxOrchestrator.try_admit_run_start`
+- `SandboxOrchestrator._prune_queue_ttl`
+
+Expected: a written list of invariants for enqueue, claim, execution admission, lease renewal, and cancellation.
+
+**Step 2: Run queueing and claim tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_run_claim_fencing.py \
+  tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py \
+  tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py \
+  tldw_Server_API/tests/sandbox/test_queue_full_429.py
+```
+Expected: PASS. Any failure becomes a first-class review finding or a blocking regression if it prevents further trust in lifecycle behavior.
+
+**Step 3: Cross-check the implementation against the tests**
+
+For any surprising branch or swallowed exception, trace supporting references:
+```bash
+rg -n "try_claim_run|renew_run_claim|release_run_claim|try_admit_run_start|cancel_run" \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/core/Sandbox/orchestrator.py
+```
+Expected: evidence for whether the code matches the tested contract or leaves an uncovered path.
+
+### Task 3: Audit Store, Policy, and Runtime Fail-Closed Behavior
+
+**Files:**
+- Inspect: `tldw_Server_API/app/core/Sandbox/store.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/policy.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/docker_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/lima_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py`
+- Test: `tldw_Server_API/tests/sandbox/test_runtime_unavailable.py`
+- Test: `tldw_Server_API/tests/sandbox/test_lima_no_fallback.py`
+- Test: `tldw_Server_API/tests/sandbox/test_lima_strict_admission.py`
+
+**Step 1: Compare store semantics across backends**
+
+Inspect the concrete implementations of:
+- `check_idempotency`
+- `store_idempotency`
+- `put_run` / `update_run`
+- `try_claim_run` / `renew_run_claim` / `release_run_claim`
+- `try_admit_run_start`
+- `get_run_owner` / `get_session_owner`
+
+Expected: note any semantic drift between `InMemoryStore`, `SQLiteStore`, and `PostgresStore`, especially around ownership, timestamps, and lease handling.
+
+**Step 2: Inspect runtime selection and strict-policy enforcement**
+
+Review the policy and runner paths for:
+- default runtime parsing
+- `runtime_unavailable` vs `policy_unsupported` behavior
+- no-fallback guarantees
+- Lima strict admission and enforcement readiness
+
+Expected: a short matrix of documented versus actual fail-closed behavior by runtime.
+
+**Step 3: Run runtime and policy tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_runtime_unavailable.py \
+  tldw_Server_API/tests/sandbox/test_lima_no_fallback.py \
+  tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+```
+Expected: PASS. Any mismatch between policy code and tests should be captured as either a bug or a risky incomplete path.
+
+### Task 4: Audit Endpoint Ownership, Artifact Safety, and Stream Lifecycle
+
+**Files:**
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_ownership.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_rbac.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_range.py`
+- Test: `tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py`
+- Test: `tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py`
+- Test: `tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py`
+
+**Step 1: Read the route guards and ownership checks**
+
+Inspect:
+- `SandboxArtifactGuardRoute`
+- `_require_run_owner`
+- `_require_session_owner`
+- `_resolve_sandbox_ws_user_id`
+- `download_artifact`
+- `stream_run_logs`
+- admin list/detail endpoints
+
+Expected: a map of which routes trust raw path inspection, stored ownership, admin status, or websocket token binding.
+
+**Step 2: Run endpoint and stream tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_run_ownership.py \
+  tldw_Server_API/tests/sandbox/test_admin_rbac.py \
+  tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py \
+  tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py \
+  tldw_Server_API/tests/sandbox/test_artifact_range.py \
+  tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py \
+  tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py \
+  tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py
+```
+Expected: PASS. If a test fails, trace whether the issue is route logic, shared core state, or harness assumptions.
+
+**Step 3: Trace any uncovered endpoint branches**
+
+Use targeted search for error-prone branches:
+```bash
+rg -n "PermissionError|HTTPException|invalid_path|range|quota|resume|heartbeat|cancel" \
+  tldw_Server_API/app/api/v1/endpoints/sandbox.py
+```
+Expected: identify branches that are reachable but not clearly covered by the selected tests.
+
+### Task 5: Synthesize Findings and Deliver the Review
+
+**Files:**
+- Create: `docs/plans/2026-03-08-sandbox-subsystem-review-findings.md`
+- Reference: `docs/plans/2026-03-08-sandbox-subsystem-review-design.md`
+
+**Step 1: Draft the findings report**
+
+Write the report with these sections:
+```markdown
+# Sandbox Subsystem Review Findings
+
+## Findings
+- [Severity] Title
+  - Type: Bug | Incomplete Item | Residual Risk
+  - Evidence: file path + line
+  - Why it matters
+
+## Targeted Test Runs
+- command
+- result
+
+## Validation Gaps
+- gap
+```
+
+**Step 2: Validate every finding against evidence**
+
+Before delivering the review, ensure each finding has:
+- one specific file reference
+- one concrete behavioral claim
+- a classification that matches the design doc rules
+
+Expected: no vague findings, no “might be bad” commentary without evidence, and no mixing of intentional scaffolding with confirmed defects.
+
+**Step 3: Deliver the user-facing review**
+
+Respond in findings-first order:
+- highest-severity findings first
+- then open questions or assumptions
+- then a short summary of tests run and any remaining gaps
+
+Expected: a concise review that behaves like a code review, not a changelog or architecture essay.

--- a/Docs/Plans/2026-03-08-sandbox-ws-stress-debug-plan.md
+++ b/Docs/Plans/2026-03-08-sandbox-ws-stress-debug-plan.md
@@ -1,0 +1,17 @@
+## Stage 1: Reproduce And Bound The Failure
+**Goal**: Reproduce the grouped websocket stress failure deterministically and identify whether the missing `end` frame is caused by queue loss, subscription timing, or test harness behavior.
+**Success Criteria**: One grouped pytest command reproduces the issue and the likely failure mode is documented from code/test evidence.
+**Tests**: `python -m pytest -vv tldw_Server_API/tests/sandbox/test_store_sqlite_migrations.py tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py tldw_Server_API/tests/sandbox/test_streams_hub_resume_and_ordering.py tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py tldw_Server_API/tests/sandbox/test_ws_heartbeat_seq.py tldw_Server_API/tests/sandbox/test_ws_multi_subscribers.py tldw_Server_API/tests/sandbox/test_ws_multi_subscribers_stress.py tldw_Server_API/tests/sandbox/test_ws_queue_overflow_drops.py tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py tldw_Server_API/tests/sandbox/test_ws_resume_from_seq.py tldw_Server_API/tests/sandbox/test_ws_resume_url_exposure.py tldw_Server_API/tests/sandbox/test_ws_seq.py`
+**Status**: In Progress
+
+## Stage 2: Restore A Clean Regression Surface
+**Goal**: Remove unsuccessful experimental edits and replace them with a focused regression that captures the actual websocket failure mode.
+**Success Criteria**: Only intentional test coverage remains and the failing behavior is asserted directly.
+**Tests**: Focused websocket stress test(s)
+**Status**: Not Started
+
+## Stage 3: Implement And Verify The Minimal Fix
+**Goal**: Fix the websocket failure without regressing the original sandbox bug fixes.
+**Success Criteria**: Grouped websocket subset passes, original sandbox regression slice passes, and Bandit reports no findings in touched files.
+**Tests**: Grouped websocket subset, original focused sandbox regression slice, Bandit on touched paths
+**Status**: Not Started

--- a/Helper_Scripts/setup_acp.sh
+++ b/Helper_Scripts/setup_acp.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# setup_acp.sh — Download and install the tldw-agent-acp binary for the current platform.
+#
+# Usage:
+#   ./Helper_Scripts/setup_acp.sh [--version VERSION] [--install-dir DIR]
+#
+# Environment overrides:
+#   TLDW_AGENT_VERSION   — Version tag (default: latest)
+#   TLDW_AGENT_INSTALL   — Install directory (default: ./bin)
+#   GITHUB_TOKEN         — Optional token for private repos / rate limits
+
+set -euo pipefail
+
+BINARY_NAME="tldw-agent-acp"
+GITHUB_OWNER="user"          # TODO: replace with actual org/owner when repo is published
+GITHUB_REPO="tldw-agent"
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+VERSION="${TLDW_AGENT_VERSION:-latest}"
+INSTALL_DIR="${TLDW_AGENT_INSTALL:-./bin}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: $0 [--version VERSION] [--install-dir DIR]"
+            echo ""
+            echo "Downloads the tldw-agent-acp binary for the current platform."
+            echo ""
+            echo "Options:"
+            echo "  --version VERSION   Release tag (default: latest)"
+            echo "  --install-dir DIR   Installation directory (default: ./bin)"
+            echo ""
+            echo "Environment variables:"
+            echo "  TLDW_AGENT_VERSION  Same as --version"
+            echo "  TLDW_AGENT_INSTALL  Same as --install-dir"
+            echo "  GITHUB_TOKEN        GitHub token for API requests"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Detect platform
+# ---------------------------------------------------------------------------
+detect_platform() {
+    local os arch
+
+    case "$(uname -s)" in
+        Linux*)  os="linux" ;;
+        Darwin*) os="darwin" ;;
+        *)       echo "ERROR: Unsupported OS: $(uname -s)"; exit 1 ;;
+    esac
+
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="amd64" ;;
+        aarch64|arm64) arch="arm64" ;;
+        *)             echo "ERROR: Unsupported architecture: $(uname -m)"; exit 1 ;;
+    esac
+
+    echo "${os}_${arch}"
+}
+
+PLATFORM="$(detect_platform)"
+echo "==> Detected platform: ${PLATFORM}"
+
+# ---------------------------------------------------------------------------
+# Resolve version
+# ---------------------------------------------------------------------------
+auth_header() {
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        echo "Authorization: token ${GITHUB_TOKEN}"
+    else
+        echo "X-No-Auth: true"
+    fi
+}
+
+if [[ "$VERSION" == "latest" ]]; then
+    echo "==> Resolving latest release..."
+    RELEASE_URL="https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest"
+    VERSION=$(curl -fsSL -H "$(auth_header)" "$RELEASE_URL" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+    if [[ -z "$VERSION" ]]; then
+        echo "ERROR: Could not determine latest release version."
+        echo ""
+        echo "This may mean:"
+        echo "  1. The tldw-agent repo has no published releases yet"
+        echo "  2. GitHub API rate limit reached (set GITHUB_TOKEN to increase)"
+        echo "  3. The repo URL is incorrect"
+        echo ""
+        echo "Alternative: Build from source:"
+        echo "  cd ../tldw-agent && go build -o ../tldw_server2/bin/tldw-agent-acp ./cmd/tldw-agent-acp"
+        exit 1
+    fi
+    echo "==> Latest version: ${VERSION}"
+fi
+
+# ---------------------------------------------------------------------------
+# Download binary
+# ---------------------------------------------------------------------------
+ASSET_NAME="${BINARY_NAME}_${PLATFORM}"
+DOWNLOAD_URL="https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases/download/${VERSION}/${ASSET_NAME}"
+CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+
+mkdir -p "${INSTALL_DIR}"
+TARGET="${INSTALL_DIR}/${BINARY_NAME}"
+
+echo "==> Downloading ${ASSET_NAME} (${VERSION})..."
+
+HTTP_CODE=$(curl -fsSL -w "%{http_code}" -H "$(auth_header)" -o "${TARGET}.tmp" "$DOWNLOAD_URL" 2>/dev/null || true)
+
+if [[ ! -f "${TARGET}.tmp" ]] || [[ "${HTTP_CODE:-0}" != "200" ]]; then
+    rm -f "${TARGET}.tmp"
+    echo "ERROR: Download failed (HTTP ${HTTP_CODE:-???})."
+    echo ""
+    echo "The binary may not be published yet. Build from source instead:"
+    echo "  1. Install Go 1.22+: https://go.dev/dl/"
+    echo "  2. Clone the tldw-agent repo:"
+    echo "     git clone https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git ../tldw-agent"
+    echo "  3. Build:"
+    echo "     cd ../tldw-agent && go build -o ${INSTALL_DIR}/${BINARY_NAME} ./cmd/tldw-agent-acp"
+    echo ""
+    echo "Then configure in config.txt:"
+    echo "  [ACP]"
+    echo "  runner_binary_path = ${INSTALL_DIR}/${BINARY_NAME}"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Verify checksum (if available)
+# ---------------------------------------------------------------------------
+echo "==> Verifying checksum..."
+EXPECTED_SUM=$(curl -fsSL -H "$(auth_header)" "$CHECKSUM_URL" 2>/dev/null | awk '{print $1}' || true)
+
+if [[ -n "$EXPECTED_SUM" ]]; then
+    if command -v sha256sum &>/dev/null; then
+        ACTUAL_SUM=$(sha256sum "${TARGET}.tmp" | awk '{print $1}')
+    elif command -v shasum &>/dev/null; then
+        ACTUAL_SUM=$(shasum -a 256 "${TARGET}.tmp" | awk '{print $1}')
+    else
+        echo "WARN: No sha256sum or shasum found — skipping checksum verification"
+        ACTUAL_SUM="$EXPECTED_SUM"
+    fi
+
+    if [[ "$ACTUAL_SUM" != "$EXPECTED_SUM" ]]; then
+        rm -f "${TARGET}.tmp"
+        echo "ERROR: Checksum mismatch!"
+        echo "  Expected: ${EXPECTED_SUM}"
+        echo "  Got:      ${ACTUAL_SUM}"
+        exit 1
+    fi
+    echo "==> Checksum verified"
+else
+    echo "WARN: No checksum file available — skipping verification"
+fi
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
+mv "${TARGET}.tmp" "${TARGET}"
+chmod +x "${TARGET}"
+
+echo "==> Installed: ${TARGET}"
+echo ""
+echo "Configure tldw_server to use this binary:"
+echo ""
+echo "  Option 1 — config.txt:"
+echo "    [ACP]"
+echo "    runner_binary_path = ${TARGET}"
+echo ""
+echo "  Option 2 — environment variable:"
+echo "    export ACP_RUNNER_BINARY_PATH=${TARGET}"
+echo ""
+
+# Quick validation
+if "${TARGET}" --version &>/dev/null 2>&1; then
+    echo "==> Binary validated: $(${TARGET} --version 2>&1 || echo 'ok')"
+else
+    echo "==> Binary installed (could not verify --version flag, but file is executable)"
+fi
+
+echo "==> ACP setup complete!"

--- a/admin-ui/app/onboarding/page.tsx
+++ b/admin-ui/app/onboarding/page.tsx
@@ -70,6 +70,7 @@ function StepIndicator({ currentStep }: { currentStep: number }) {
 
 function OnboardingPageContent() {
   const { success, error: showError } = useToast();
+  const billingEnabled = isBillingEnabled();
   const [currentStep, setCurrentStep] = useState(1);
   const [plans, setPlans] = useState<Plan[]>([]);
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
@@ -100,10 +101,12 @@ function OnboardingPageContent() {
   }, [showError]);
 
   useEffect(() => {
-    fetchPlans();
-  }, [fetchPlans]);
+    if (billingEnabled) {
+      fetchPlans();
+    }
+  }, [billingEnabled, fetchPlans]);
 
-  if (!isBillingEnabled()) {
+  if (!billingEnabled) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Alert>
@@ -143,10 +146,12 @@ function OnboardingPageContent() {
         plan_id: selectedPlanId!,
         owner_email: values.owner_email || undefined,
       });
-      if (result.checkout_url) {
+      if (result.checkout_url && result.checkout_url.startsWith('https://')) {
         window.location.href = result.checkout_url;
-      } else {
+      } else if (!result.checkout_url) {
         success('Organization created successfully');
+        setSelectedPlanId(null);
+        setCurrentStep(1);
       }
     } catch {
       showError('Failed to create organization');
@@ -319,7 +324,7 @@ function OnboardingPageContent() {
 
 export default function OnboardingPage() {
   return (
-    <PermissionGuard>
+    <PermissionGuard role={['admin', 'super_admin', 'owner']}>
       <OnboardingPageContent />
     </PermissionGuard>
   );

--- a/admin-ui/app/organizations/page.tsx
+++ b/admin-ui/app/organizations/page.tsx
@@ -148,8 +148,8 @@ function OrganizationsPageContent() {
             });
           }
           setOrgPlans(planMap);
-        } catch {
-          // Non-critical — org list still works without plan info
+        } catch (err) {
+          console.warn('Failed to load subscription data for organizations:', err);
         }
       }
     } catch (error: unknown) {

--- a/admin-ui/app/subscriptions/page.tsx
+++ b/admin-ui/app/subscriptions/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from '@/components/ui/toast';
 import { api } from '@/lib/api-client';
 import { isBillingEnabled } from '@/lib/billing';
 import Link from 'next/link';
+import { formatDate } from '@/lib/formatters';
 import type { Subscription, SubscriptionStatus } from '@/types';
 
 const STATUS_VARIANTS: Record<SubscriptionStatus, 'default' | 'outline' | 'destructive' | 'secondary'> = {
@@ -32,10 +33,6 @@ const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: 'past_due', label: 'Past Due' },
   { value: 'canceled', label: 'Canceled' },
 ];
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
-}
 
 function SubscriptionsPageContent() {
   const { error: showError } = useToast();

--- a/admin-ui/components/InvoiceTable.tsx
+++ b/admin-ui/components/InvoiceTable.tsx
@@ -1,17 +1,10 @@
 import { Download } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { formatCents, formatDate } from '@/lib/formatters';
 import type { Invoice } from '@/types';
 
 interface InvoiceTableProps {
   invoices: Invoice[];
-}
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
@@ -51,7 +44,7 @@ export function InvoiceTable({ invoices }: InvoiceTableProps) {
                 <Badge variant={statusVariant[inv.status] ?? 'outline'}>{inv.status}</Badge>
               </td>
               <td className="py-2">
-                {inv.invoice_pdf && (
+                {inv.invoice_pdf && inv.invoice_pdf.startsWith('https://') && (
                   <a
                     href={inv.invoice_pdf}
                     target="_blank"

--- a/admin-ui/components/PlanGuard.tsx
+++ b/admin-ui/components/PlanGuard.tsx
@@ -37,7 +37,7 @@ export function PlanGuard({ requiredPlan, featureName, fallback, children }: Pla
         setAllowed(meetsRequirement);
       })
       .catch(() => {
-        if (!cancelled) setAllowed(true); // fail open — backend enforces
+        if (!cancelled) setAllowed(false);
       });
     return () => { cancelled = true; };
   }, [selectedOrg, orgLoading, requiredPlan]);

--- a/admin-ui/components/UsageMeter.tsx
+++ b/admin-ui/components/UsageMeter.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { formatCents } from '@/lib/formatters';
 
 interface UsageMeterProps {
   used: number;
@@ -9,10 +10,6 @@ interface UsageMeterProps {
 
 function formatTokens(n: number): string {
   return n.toLocaleString();
-}
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
 }
 
 export function UsageMeter({ used, included, overageCostCents, className }: UsageMeterProps) {

--- a/admin-ui/components/__tests__/PlanGuard.test.tsx
+++ b/admin-ui/components/__tests__/PlanGuard.test.tsx
@@ -87,11 +87,12 @@ describe('PlanGuard', () => {
     expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
   });
 
-  it('fails open on API error', async () => {
+  it('fails closed on API error', async () => {
     mockIsBillingEnabled.mockReturnValue(true);
     mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
     mockGetOrgSubscription.mockRejectedValue(new Error('Network error'));
-    render(<PlanGuard requiredPlan="pro"><div>Still Visible</div></PlanGuard>);
-    expect(await screen.findByText('Still Visible')).toBeInTheDocument();
+    render(<PlanGuard requiredPlan="pro" featureName="Analytics"><div>Hidden</div></PlanGuard>);
+    expect(await screen.findByText('Upgrade Plan')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
   });
 });

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -20,6 +20,20 @@ export { ApiError };
 type QueryParamPrimitive = string | number | boolean;
 type QueryParamValue = QueryParamPrimitive | QueryParamPrimitive[] | null | undefined;
 
+type CreatePlanInput = {
+  name: string;
+  tier: string;
+  monthly_price_cents: number;
+  included_token_credits: number;
+  overage_rate_per_1k_tokens_cents: number;
+  stripe_product_id?: string;
+  stripe_price_id?: string;
+  features?: string[];
+  is_default?: boolean;
+};
+
+type UpdatePlanInput = Partial<CreatePlanInput>;
+
 type AddTeamMemberInput =
   | { email: string; role?: string }
   | { userId: string | number; role?: string }
@@ -1070,13 +1084,13 @@ export const api = {
   // ============================================
   getPlans: (params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Plan[]>(`/billing/plans${qs}`);
+    return requestJson<Plan[]>(`/billing/plans${qs ? `?${qs}` : ''}`);
   },
   getPlan: (planId: string) =>
     requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`),
-  createPlan: (data: Partial<Plan>) =>
+  createPlan: (data: CreatePlanInput) =>
     requestJson<Plan>('/billing/plans', { method: 'POST', body: JSON.stringify(data) }),
-  updatePlan: (planId: string, data: Partial<Plan>) =>
+  updatePlan: (planId: string, data: UpdatePlanInput) =>
     requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`, { method: 'PUT', body: JSON.stringify(data) }),
   deletePlan: (planId: string) =>
     requestJson(`/billing/plans/${encodeURIComponent(planId)}`, { method: 'DELETE' }),
@@ -1084,7 +1098,7 @@ export const api = {
   // Subscriptions
   getSubscriptions: (params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Subscription[]>(`/billing/subscriptions${qs}`);
+    return requestJson<Subscription[]>(`/billing/subscriptions${qs ? `?${qs}` : ''}`);
   },
   getOrgSubscription: (orgId: number) =>
     requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`),
@@ -1098,12 +1112,12 @@ export const api = {
 
   // Usage & Invoices
   getOrgUsageSummary: (orgId: number, params?: { period?: string }) => {
-    const qs = buildQueryString(params as Record<string, QueryParamValue>);
-    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs}`);
+    const qs = buildQueryString(params);
+    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs ? `?${qs}` : ''}`);
   },
   getOrgInvoices: (orgId: number, params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs}`);
+    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs ? `?${qs}` : ''}`);
   },
 
   // Feature Registry

--- a/admin-ui/lib/formatters.ts
+++ b/admin-ui/lib/formatters.ts
@@ -1,0 +1,17 @@
+/**
+ * Format cents to a dollar string like "$49.00"
+ */
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
+ * Format ISO date string to localized display format
+ */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentRegistry/index.tsx
@@ -1,0 +1,300 @@
+import React, { useEffect, useState, useCallback, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { useStorage } from "@plasmohq/storage/hook"
+import { Alert, Button, Card, Spin, Tag, Tooltip, Empty, Badge } from "antd"
+import {
+  Bot,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  RefreshCw,
+  Play,
+  Settings,
+  Heart,
+} from "lucide-react"
+import { ACPRestClient } from "@/services/acp/client"
+
+type AgentEntry = {
+  type: string
+  name: string
+  description: string
+  status: "available" | "unavailable" | "requires_setup"
+  reason?: string
+  is_default?: boolean
+}
+
+type HealthStatus = {
+  runner: string
+  agent: string
+  api_keys: string
+  details?: string
+}
+
+export const AgentRegistryPage: React.FC = () => {
+  const { t } = useTranslation(["option", "common"])
+
+  const [serverUrl] = useStorage("serverUrl", "http://localhost:8000")
+  const [authMode] = useStorage("authMode", "single-user")
+  const [apiKey] = useStorage("apiKey", "")
+  const [accessToken] = useStorage("accessToken", "")
+
+  const [agents, setAgents] = useState<AgentEntry[]>([])
+  const [health, setHealth] = useState<HealthStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [healthLoading, setHealthLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const restClient = useMemo(
+    () =>
+      new ACPRestClient({
+        serverUrl,
+        getAuthHeaders: async () => {
+          const headers: Record<string, string> = {}
+          if (authMode === "single-user" && apiKey) {
+            headers["X-API-KEY"] = apiKey
+          } else if (authMode === "multi-user" && accessToken) {
+            headers.Authorization = `Bearer ${accessToken}`
+          }
+          return headers
+        },
+        getAuthParams: async () => ({
+          token: authMode === "multi-user" && accessToken ? accessToken : undefined,
+          api_key: authMode === "single-user" && apiKey ? apiKey : undefined,
+        }),
+      }),
+    [serverUrl, authMode, apiKey, accessToken]
+  )
+
+  const fetchAgents = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await restClient.getAvailableAgents()
+      setAgents(response.agents ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load agents")
+    } finally {
+      setLoading(false)
+    }
+  }, [restClient])
+
+  const fetchHealth = useCallback(async () => {
+    setHealthLoading(true)
+    try {
+      const url = `${serverUrl}/api/v1/acp/health`
+      const headers: Record<string, string> = { "Content-Type": "application/json" }
+      if (authMode === "single-user" && apiKey) {
+        headers["X-API-KEY"] = apiKey
+      } else if (authMode === "multi-user" && accessToken) {
+        headers.Authorization = `Bearer ${accessToken}`
+      }
+      const res = await fetch(url, { headers })
+      if (res.ok) {
+        setHealth(await res.json())
+      }
+    } catch {
+      // Health check failure is not critical
+    } finally {
+      setHealthLoading(false)
+    }
+  }, [serverUrl, authMode, apiKey, accessToken])
+
+  useEffect(() => {
+    void fetchAgents()
+    void fetchHealth()
+  }, [fetchAgents, fetchHealth])
+
+  const statusIcon = (status: string) => {
+    switch (status) {
+      case "available":
+      case "ok":
+        return <CheckCircle className="h-4 w-4 text-green-500" />
+      case "unavailable":
+      case "missing":
+      case "error":
+        return <XCircle className="h-4 w-4 text-red-500" />
+      default:
+        return <AlertTriangle className="h-4 w-4 text-yellow-500" />
+    }
+  }
+
+  const statusColor = (status: string): "success" | "error" | "warning" => {
+    switch (status) {
+      case "available":
+      case "ok":
+        return "success"
+      case "unavailable":
+      case "missing":
+      case "error":
+        return "error"
+      default:
+        return "warning"
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Health Status */}
+      <Card
+        title={
+          <span className="flex items-center gap-2">
+            <Heart className="h-4 w-4" />
+            ACP System Health
+          </span>
+        }
+        extra={
+          <Button
+            size="small"
+            icon={<RefreshCw className="h-3.5 w-3.5" />}
+            onClick={() => {
+              void fetchHealth()
+              void fetchAgents()
+            }}
+          >
+            Refresh
+          </Button>
+        }
+      >
+        {healthLoading ? (
+          <div className="flex justify-center py-4">
+            <Spin size="small" />
+          </div>
+        ) : health ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="flex items-center gap-2 rounded-lg border border-border p-3">
+              {statusIcon(health.runner)}
+              <div>
+                <div className="text-xs text-muted-foreground">Runner Binary</div>
+                <Tag color={statusColor(health.runner)}>{health.runner}</Tag>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 rounded-lg border border-border p-3">
+              {statusIcon(health.agent)}
+              <div>
+                <div className="text-xs text-muted-foreground">Agent Status</div>
+                <Tag color={statusColor(health.agent)}>{health.agent}</Tag>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 rounded-lg border border-border p-3">
+              {statusIcon(health.api_keys)}
+              <div>
+                <div className="text-xs text-muted-foreground">API Keys</div>
+                <Tag color={statusColor(health.api_keys)}>{health.api_keys}</Tag>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <Alert
+            type="warning"
+            message="Health check unavailable"
+            description="Could not reach the ACP health endpoint. Ensure the server is running."
+            showIcon
+          />
+        )}
+        {health?.details && (
+          <div className="mt-2 text-xs text-muted-foreground">{health.details}</div>
+        )}
+      </Card>
+
+      {/* Error */}
+      {error && (
+        <Alert type="error" message={error} closable onClose={() => setError(null)} />
+      )}
+
+      {/* Agent List */}
+      <Card
+        title={
+          <span className="flex items-center gap-2">
+            <Bot className="h-4 w-4" />
+            Registered Agents
+            {!loading && (
+              <Badge
+                count={agents.length}
+                style={{ backgroundColor: "var(--primary)" }}
+              />
+            )}
+          </span>
+        }
+      >
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <Spin />
+          </div>
+        ) : agents.length === 0 ? (
+          <Empty description="No agents registered" />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {agents.map((agent) => (
+              <AgentCard key={agent.type} agent={agent} />
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}
+
+const AgentCard: React.FC<{ agent: AgentEntry }> = ({ agent }) => {
+  const statusColor =
+    agent.status === "available"
+      ? "success"
+      : agent.status === "requires_setup"
+        ? "warning"
+        : "error"
+
+  const statusLabel =
+    agent.status === "available"
+      ? "Ready"
+      : agent.status === "requires_setup"
+        ? "Setup Required"
+        : "Unavailable"
+
+  return (
+    <div className="rounded-lg border border-border p-4 transition-shadow hover:shadow-md">
+      <div className="mb-2 flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <Bot className="h-5 w-5 text-primary" />
+          <h3 className="font-medium">{agent.name}</h3>
+        </div>
+        <div className="flex items-center gap-1">
+          {agent.is_default && (
+            <Tag color="blue" className="text-xs">
+              Default
+            </Tag>
+          )}
+          <Tag color={statusColor}>{statusLabel}</Tag>
+        </div>
+      </div>
+
+      <p className="mb-3 text-sm text-muted-foreground">
+        {agent.description || `Agent type: ${agent.type}`}
+      </p>
+
+      {agent.reason && (
+        <div className="mb-3 rounded bg-yellow-50 p-2 text-xs text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400">
+          {agent.reason}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Tooltip title={agent.status === "available" ? "Launch session" : statusLabel}>
+          <Button
+            size="small"
+            type="primary"
+            icon={<Play className="h-3 w-3" />}
+            disabled={agent.status !== "available"}
+            onClick={() => {
+              // Navigate to ACP playground with this agent pre-selected
+              window.location.hash = `/acp-playground?agent=${agent.type}`
+            }}
+          >
+            Launch
+          </Button>
+        </Tooltip>
+        <span className="text-xs text-muted-foreground">{agent.type}</span>
+      </div>
+    </div>
+  )
+}
+
+export default AgentRegistryPage

--- a/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
+++ b/apps/packages/ui/src/components/Option/AgentTasks/index.tsx
@@ -1,0 +1,588 @@
+import React, { useEffect, useState, useCallback, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { useStorage } from "@plasmohq/storage/hook"
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Input,
+  Modal,
+  Select,
+  Spin,
+  Tag,
+  Tooltip,
+  Badge,
+  Form,
+  Collapse,
+} from "antd"
+import {
+  FolderPlus,
+  ListTodo,
+  Play,
+  CheckCircle,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  RefreshCw,
+  Plus,
+  Trash2,
+  ChevronRight,
+} from "lucide-react"
+
+// Types matching the backend orchestration API
+type ProjectSummary = {
+  id: number
+  name: string
+  description?: string
+  user_id: number
+  created_at: string
+  task_summary?: {
+    total_tasks: number
+    status_counts: Record<string, number>
+  }
+}
+
+type TaskItem = {
+  id: number
+  project_id: number
+  title: string
+  description?: string
+  status: string
+  agent_type?: string
+  dependency_id?: number | null
+  review_count: number
+  max_review_attempts: number
+  created_at: string
+  updated_at: string
+  runs?: RunItem[]
+}
+
+type RunItem = {
+  id: number
+  task_id: number
+  session_id?: string
+  agent_type?: string
+  status: string
+  result_summary?: string
+  error?: string
+  started_at: string
+  completed_at?: string
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  todo: "default",
+  inprogress: "processing",
+  review: "warning",
+  complete: "success",
+  triage: "error",
+}
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  todo: <Clock className="h-3.5 w-3.5" />,
+  inprogress: <Play className="h-3.5 w-3.5" />,
+  review: <AlertTriangle className="h-3.5 w-3.5" />,
+  complete: <CheckCircle className="h-3.5 w-3.5" />,
+  triage: <XCircle className="h-3.5 w-3.5" />,
+}
+
+export const AgentTasksPage: React.FC = () => {
+  const { t } = useTranslation(["option", "common"])
+
+  const [serverUrl] = useStorage("serverUrl", "http://localhost:8000")
+  const [authMode] = useStorage("authMode", "single-user")
+  const [apiKey] = useStorage("apiKey", "")
+  const [accessToken] = useStorage("accessToken", "")
+
+  const [projects, setProjects] = useState<ProjectSummary[]>([])
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null)
+  const [tasks, setTasks] = useState<TaskItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [tasksLoading, setTasksLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Modal states
+  const [showProjectModal, setShowProjectModal] = useState(false)
+  const [showTaskModal, setShowTaskModal] = useState(false)
+  const [projectForm] = Form.useForm()
+  const [taskForm] = Form.useForm()
+
+  const getHeaders = useCallback(async () => {
+    const headers: Record<string, string> = { "Content-Type": "application/json" }
+    if (authMode === "single-user" && apiKey) {
+      headers["X-API-KEY"] = apiKey
+    } else if (authMode === "multi-user" && accessToken) {
+      headers.Authorization = `Bearer ${accessToken}`
+    }
+    return headers
+  }, [authMode, apiKey, accessToken])
+
+  const apiBase = `${serverUrl}/api/v1/agent-orchestration`
+
+  const fetchProjects = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const headers = await getHeaders()
+      const res = await fetch(`${apiBase}/projects`, { headers })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setProjects(data.projects ?? [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load projects")
+    } finally {
+      setLoading(false)
+    }
+  }, [apiBase, getHeaders])
+
+  const fetchTasks = useCallback(
+    async (projectId: number) => {
+      setTasksLoading(true)
+      try {
+        const headers = await getHeaders()
+        const res = await fetch(`${apiBase}/projects/${projectId}/tasks`, { headers })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+        setTasks(data.tasks ?? [])
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load tasks")
+      } finally {
+        setTasksLoading(false)
+      }
+    },
+    [apiBase, getHeaders]
+  )
+
+  useEffect(() => {
+    void fetchProjects()
+  }, [fetchProjects])
+
+  useEffect(() => {
+    if (selectedProjectId !== null) {
+      void fetchTasks(selectedProjectId)
+    } else {
+      setTasks([])
+    }
+  }, [selectedProjectId, fetchTasks])
+
+  const handleCreateProject = async (values: { name: string; description?: string }) => {
+    try {
+      const headers = await getHeaders()
+      const res = await fetch(`${apiBase}/projects`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(values),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setShowProjectModal(false)
+      projectForm.resetFields()
+      void fetchProjects()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create project")
+    }
+  }
+
+  const handleCreateTask = async (values: {
+    title: string
+    description?: string
+    agent_type?: string
+    dependency_id?: number
+    max_review_attempts?: number
+  }) => {
+    if (selectedProjectId === null) return
+    try {
+      const headers = await getHeaders()
+      const body = {
+        ...values,
+        dependency_id: values.dependency_id || undefined,
+        max_review_attempts: values.max_review_attempts || 3,
+      }
+      const res = await fetch(`${apiBase}/projects/${selectedProjectId}/tasks`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setShowTaskModal(false)
+      taskForm.resetFields()
+      void fetchTasks(selectedProjectId)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create task")
+    }
+  }
+
+  const handleDispatchRun = async (taskId: number) => {
+    try {
+      const headers = await getHeaders()
+      const res = await fetch(`${apiBase}/tasks/${taskId}/run`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({}),
+      })
+      if (!res.ok) {
+        const errData = await res.json().catch(() => ({}))
+        throw new Error(errData.detail || `HTTP ${res.status}`)
+      }
+      if (selectedProjectId !== null) {
+        void fetchTasks(selectedProjectId)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to dispatch run")
+    }
+  }
+
+  const handleSubmitReview = async (taskId: number, approved: boolean) => {
+    try {
+      const headers = await getHeaders()
+      const res = await fetch(`${apiBase}/tasks/${taskId}/review`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ approved }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      if (selectedProjectId !== null) {
+        void fetchTasks(selectedProjectId)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit review")
+    }
+  }
+
+  const handleDeleteProject = async (projectId: number) => {
+    try {
+      const headers = await getHeaders()
+      const res = await fetch(`${apiBase}/projects/${projectId}`, {
+        method: "DELETE",
+        headers,
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      if (selectedProjectId === projectId) {
+        setSelectedProjectId(null)
+      }
+      void fetchProjects()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete project")
+    }
+  }
+
+  const selectedProject = projects.find((p) => p.id === selectedProjectId)
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <Alert type="error" message={error} closable onClose={() => setError(null)} />
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Projects Panel */}
+        <Card
+          title={
+            <span className="flex items-center gap-2">
+              <FolderPlus className="h-4 w-4" />
+              Projects
+            </span>
+          }
+          extra={
+            <div className="flex gap-1">
+              <Button
+                size="small"
+                icon={<RefreshCw className="h-3.5 w-3.5" />}
+                onClick={() => void fetchProjects()}
+              />
+              <Button
+                size="small"
+                type="primary"
+                icon={<Plus className="h-3.5 w-3.5" />}
+                onClick={() => setShowProjectModal(true)}
+              >
+                New
+              </Button>
+            </div>
+          }
+          className="lg:col-span-1"
+          styles={{ body: { padding: 0 } }}
+        >
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Spin />
+            </div>
+          ) : projects.length === 0 ? (
+            <Empty
+              description="No projects yet"
+              className="py-8"
+            >
+              <Button type="primary" onClick={() => setShowProjectModal(true)}>
+                Create Project
+              </Button>
+            </Empty>
+          ) : (
+            <div className="divide-y divide-border">
+              {projects.map((project) => (
+                <div
+                  key={project.id}
+                  className={`flex cursor-pointer items-center gap-2 px-4 py-3 transition-colors hover:bg-surface-hover ${
+                    selectedProjectId === project.id ? "bg-surface-hover" : ""
+                  }`}
+                  onClick={() => setSelectedProjectId(project.id)}
+                >
+                  <ChevronRight
+                    className={`h-4 w-4 shrink-0 transition-transform ${
+                      selectedProjectId === project.id ? "rotate-90" : ""
+                    }`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium truncate">{project.name}</div>
+                    {project.task_summary && (
+                      <div className="flex gap-1 text-xs text-muted-foreground mt-0.5">
+                        <span>{project.task_summary.total_tasks} tasks</span>
+                        {project.task_summary.status_counts?.complete > 0 && (
+                          <span className="text-green-600">
+                            {project.task_summary.status_counts.complete} done
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <Tooltip title="Delete project">
+                    <Button
+                      size="small"
+                      type="text"
+                      danger
+                      icon={<Trash2 className="h-3.5 w-3.5" />}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        void handleDeleteProject(project.id)
+                      }}
+                    />
+                  </Tooltip>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        {/* Tasks Panel */}
+        <Card
+          title={
+            <span className="flex items-center gap-2">
+              <ListTodo className="h-4 w-4" />
+              Tasks
+              {selectedProject && (
+                <span className="text-sm font-normal text-muted-foreground">
+                  — {selectedProject.name}
+                </span>
+              )}
+            </span>
+          }
+          extra={
+            selectedProjectId !== null && (
+              <div className="flex gap-1">
+                <Button
+                  size="small"
+                  icon={<RefreshCw className="h-3.5 w-3.5" />}
+                  onClick={() => void fetchTasks(selectedProjectId)}
+                />
+                <Button
+                  size="small"
+                  type="primary"
+                  icon={<Plus className="h-3.5 w-3.5" />}
+                  onClick={() => setShowTaskModal(true)}
+                >
+                  New Task
+                </Button>
+              </div>
+            )
+          }
+          className="lg:col-span-2"
+        >
+          {selectedProjectId === null ? (
+            <Empty description="Select a project to view tasks" className="py-8" />
+          ) : tasksLoading ? (
+            <div className="flex justify-center py-8">
+              <Spin />
+            </div>
+          ) : tasks.length === 0 ? (
+            <Empty description="No tasks yet" className="py-8">
+              <Button type="primary" onClick={() => setShowTaskModal(true)}>
+                Create Task
+              </Button>
+            </Empty>
+          ) : (
+            <div className="space-y-3">
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  allTasks={tasks}
+                  onDispatchRun={handleDispatchRun}
+                  onReview={handleSubmitReview}
+                />
+              ))}
+            </div>
+          )}
+        </Card>
+      </div>
+
+      {/* Create Project Modal */}
+      <Modal
+        title="Create Project"
+        open={showProjectModal}
+        onCancel={() => setShowProjectModal(false)}
+        onOk={() => projectForm.submit()}
+        okText="Create"
+      >
+        <Form form={projectForm} layout="vertical" onFinish={handleCreateProject}>
+          <Form.Item
+            name="name"
+            label="Project Name"
+            rules={[{ required: true, message: "Project name is required" }]}
+          >
+            <Input placeholder="My Agent Project" />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea placeholder="Optional description..." rows={3} />
+          </Form.Item>
+        </Form>
+      </Modal>
+
+      {/* Create Task Modal */}
+      <Modal
+        title="Create Task"
+        open={showTaskModal}
+        onCancel={() => setShowTaskModal(false)}
+        onOk={() => taskForm.submit()}
+        okText="Create"
+      >
+        <Form form={taskForm} layout="vertical" onFinish={handleCreateTask}>
+          <Form.Item
+            name="title"
+            label="Task Title"
+            rules={[{ required: true, message: "Task title is required" }]}
+          >
+            <Input placeholder="Implement feature X" />
+          </Form.Item>
+          <Form.Item name="description" label="Description">
+            <Input.TextArea placeholder="Detailed task description..." rows={3} />
+          </Form.Item>
+          <Form.Item name="agent_type" label="Agent Type">
+            <Select
+              placeholder="Default agent"
+              allowClear
+              options={[
+                { value: "claude_code", label: "Claude Code" },
+                { value: "codex", label: "Codex CLI" },
+                { value: "opencode", label: "OpenCode" },
+              ]}
+            />
+          </Form.Item>
+          <Form.Item name="dependency_id" label="Depends On">
+            <Select
+              placeholder="No dependency"
+              allowClear
+              options={tasks.map((t) => ({
+                value: t.id,
+                label: `#${t.id}: ${t.title}`,
+              }))}
+            />
+          </Form.Item>
+          <Form.Item name="max_review_attempts" label="Max Review Attempts">
+            <Select
+              defaultValue={3}
+              options={[
+                { value: 1, label: "1" },
+                { value: 2, label: "2" },
+                { value: 3, label: "3" },
+                { value: 5, label: "5" },
+              ]}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  )
+}
+
+const TaskCard: React.FC<{
+  task: TaskItem
+  allTasks: TaskItem[]
+  onDispatchRun: (taskId: number) => Promise<void>
+  onReview: (taskId: number, approved: boolean) => Promise<void>
+}> = ({ task, allTasks, onDispatchRun, onReview }) => {
+  const depTask = task.dependency_id
+    ? allTasks.find((t) => t.id === task.dependency_id)
+    : null
+
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="mb-2 flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          {STATUS_ICONS[task.status] ?? <Clock className="h-3.5 w-3.5" />}
+          <h4 className="font-medium">{task.title}</h4>
+          <Tag color={STATUS_COLORS[task.status] ?? "default"}>
+            {task.status}
+          </Tag>
+        </div>
+        <span className="text-xs text-muted-foreground">#{task.id}</span>
+      </div>
+
+      {task.description && (
+        <p className="mb-2 text-sm text-muted-foreground">{task.description}</p>
+      )}
+
+      <div className="mb-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        {task.agent_type && <Tag>{task.agent_type}</Tag>}
+        {depTask && (
+          <Tag color="blue">
+            Depends on: #{depTask.id} ({depTask.status})
+          </Tag>
+        )}
+        {task.review_count > 0 && (
+          <Tag>
+            Reviews: {task.review_count}/{task.max_review_attempts}
+          </Tag>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {task.status === "todo" && (
+          <Button
+            size="small"
+            type="primary"
+            icon={<Play className="h-3 w-3" />}
+            onClick={() => void onDispatchRun(task.id)}
+          >
+            Run
+          </Button>
+        )}
+        {task.status === "review" && (
+          <>
+            <Button
+              size="small"
+              type="primary"
+              icon={<CheckCircle className="h-3 w-3" />}
+              onClick={() => void onReview(task.id, true)}
+            >
+              Approve
+            </Button>
+            <Button
+              size="small"
+              danger
+              icon={<XCircle className="h-3 w-3" />}
+              onClick={() => void onReview(task.id, false)}
+            >
+              Reject
+            </Button>
+          </>
+        )}
+        {task.status === "inprogress" && (
+          <Tag color="processing">Running...</Tag>
+        )}
+        {task.status === "triage" && (
+          <Tag color="error">Needs human attention</Tag>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AgentTasksPage

--- a/apps/packages/ui/src/routes/option-agent-tasks.tsx
+++ b/apps/packages/ui/src/routes/option-agent-tasks.tsx
@@ -1,0 +1,15 @@
+import OptionLayout from "~/components/Layouts/Layout"
+import { PageShell } from "@/components/Common/PageShell"
+import { AgentTasksPage } from "@/components/Option/AgentTasks"
+
+const OptionAgentTasks = () => {
+  return (
+    <OptionLayout>
+      <PageShell className="py-6" maxWidthClassName="max-w-7xl">
+        <AgentTasksPage />
+      </PageShell>
+    </OptionLayout>
+  )
+}
+
+export default OptionAgentTasks

--- a/apps/packages/ui/src/routes/option-agents.tsx
+++ b/apps/packages/ui/src/routes/option-agents.tsx
@@ -1,0 +1,15 @@
+import OptionLayout from "~/components/Layouts/Layout"
+import { PageShell } from "@/components/Common/PageShell"
+import { AgentRegistryPage } from "@/components/Option/AgentRegistry"
+
+const OptionAgents = () => {
+  return (
+    <OptionLayout>
+      <PageShell className="py-6">
+        <AgentRegistryPage />
+      </PageShell>
+    </OptionLayout>
+  )
+}
+
+export default OptionAgents

--- a/apps/packages/ui/src/routes/route-registry.tsx
+++ b/apps/packages/ui/src/routes/route-registry.tsx
@@ -34,7 +34,8 @@ import {
   SlidersHorizontal,
   FileText,
   Zap,
-  Sparkles
+  Sparkles,
+  ListTodo,
 } from "lucide-react"
 import { ALL_TARGETS, type PlatformTarget } from "@/config/platform"
 import { createSettingsRoute } from "./settings-route"
@@ -196,6 +197,8 @@ const OptionAudiobookStudio = lazy(() => import("./option-audiobook-studio"))
 const OptionChatWorkflows = lazy(() => import("./option-chat-workflows"))
 const OptionWorkflowEditor = lazy(() => import("./option-workflow-editor"))
 const OptionACPPlayground = lazy(() => import("./option-acp-playground"))
+const OptionAgents = lazy(() => import("./option-agents"))
+const OptionAgentTasks = lazy(() => import("./option-agent-tasks"))
 const OptionMcpHub = lazy(() => import("./option-mcp-hub"))
 const OptionSkills = lazy(() => import("./option-skills"))
 const OptionRepo2Txt = lazy(() => import("./option-repo2txt"))
@@ -672,6 +675,30 @@ export const ROUTE_DEFINITIONS: RouteDefinition[] = [
       order: 12,
       beta: true
     }
+  },
+  {
+    kind: "options",
+    path: "/agents",
+    element: <OptionAgents />,
+    nav: {
+      group: "workspace",
+      labelToken: "option:header.agents",
+      icon: Bot,
+      order: 12.2,
+      beta: true,
+    },
+  },
+  {
+    kind: "options",
+    path: "/agent-tasks",
+    element: <OptionAgentTasks />,
+    nav: {
+      group: "workspace",
+      labelToken: "option:header.agentTasks",
+      icon: ListTodo,
+      order: 12.4,
+      beta: true,
+    },
   },
   {
     kind: "options",

--- a/apps/packages/ui/src/services/acp/types.ts
+++ b/apps/packages/ui/src/services/acp/types.ts
@@ -186,6 +186,18 @@ export interface ACPSessionPromptResponse {
   usage?: ACPTokenUsage | null
 }
 
+export interface ACPSessionCancelRequest {
+  session_id: string
+}
+
+export interface ACPSessionCloseRequest {
+  session_id: string
+}
+
+export interface ACPSessionUpdatesResponse {
+  updates: Array<Record<string, unknown>>
+}
+
 // -----------------------------------------------------------------------------
 // Session and Update Types
 // -----------------------------------------------------------------------------
@@ -225,6 +237,7 @@ export interface ACPSessionListResponse {
 export interface ACPSessionDetailResponse extends ACPSessionListItem {
   messages: Array<Record<string, unknown>>
   cwd?: string | null
+  fork_lineage: string[]
 }
 
 export interface ACPSessionUsageResponse {
@@ -333,6 +346,71 @@ export interface ACPStructuredError {
   message: string
   suggestions: ACPErrorSuggestion[]
   data?: Record<string, unknown>
+}
+
+// -----------------------------------------------------------------------------
+// ACP Health & Agent Registry
+// -----------------------------------------------------------------------------
+
+export interface ACPHealthResponse {
+  runner: "ok" | "missing" | "error"
+  agent: "ok" | "missing" | "error"
+  api_keys: "ok" | "missing"
+  details?: string
+}
+
+export interface ACPAgentRegistryEntry {
+  type: string
+  name: string
+  description: string
+  status: "available" | "unavailable" | "requires_setup"
+  reason?: string
+  is_default?: boolean
+}
+
+// -----------------------------------------------------------------------------
+// Orchestration Types
+// -----------------------------------------------------------------------------
+
+export type OrchestrationTaskStatus = "todo" | "inprogress" | "review" | "complete" | "triage"
+export type OrchestrationRunStatus = "running" | "completed" | "failed"
+
+export interface OrchestrationProject {
+  id: number
+  name: string
+  description?: string
+  user_id: number
+  created_at: string
+  task_summary?: {
+    total_tasks: number
+    status_counts: Record<string, number>
+  }
+}
+
+export interface OrchestrationTask {
+  id: number
+  project_id: number
+  title: string
+  description?: string
+  status: OrchestrationTaskStatus
+  agent_type?: string
+  dependency_id?: number | null
+  review_count: number
+  max_review_attempts: number
+  created_at: string
+  updated_at: string
+}
+
+export interface OrchestrationRun {
+  id: number
+  task_id: number
+  session_id?: string
+  agent_type?: string
+  status: OrchestrationRunStatus
+  result_summary?: string
+  error?: string
+  started_at: string
+  completed_at?: string
 }
 
 // -----------------------------------------------------------------------------

--- a/apps/tldw-frontend/pages/agent-tasks.tsx
+++ b/apps/tldw-frontend/pages/agent-tasks.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-agent-tasks"), { ssr: false })

--- a/apps/tldw-frontend/pages/agents.tsx
+++ b/apps/tldw-frontend/pages/agents.tsx
@@ -1,0 +1,3 @@
+import dynamic from "next/dynamic"
+
+export default dynamic(() => import("@/routes/option-agents"), { ssr: false })

--- a/tldw_Server_API/Config_Files/agents.yaml
+++ b/tldw_Server_API/Config_Files/agents.yaml
@@ -1,0 +1,50 @@
+# ACP Agent Registry
+# Defines available agents for the Agent Client Protocol.
+# Each entry describes how to launch and configure an agent.
+#
+# Fields:
+#   type: Unique identifier (used in API requests)
+#   name: Human-readable display name
+#   description: Short description of the agent's capabilities
+#   command: Binary or command to execute
+#   args: Command-line arguments (list)
+#   env: Environment variables to pass (dict)
+#   requires_api_key: Env var that must be set (null if none required)
+#   default: Whether this is the default agent (only one should be true)
+
+agents:
+  - type: claude_code
+    name: Claude Code
+    description: "Anthropic's Claude Code agent for software development tasks"
+    command: claude
+    args: []
+    env: {}
+    requires_api_key: ANTHROPIC_API_KEY
+    default: true
+
+  - type: codex
+    name: OpenAI Codex CLI
+    description: "OpenAI's Codex agent for code generation and analysis"
+    command: codex
+    args: []
+    env: {}
+    requires_api_key: OPENAI_API_KEY
+    default: false
+
+  - type: opencode
+    name: OpenCode
+    description: "Open-source coding agent (github.com/sst/opencode)"
+    command: opencode
+    args: []
+    env: {}
+    requires_api_key: null
+    default: false
+
+  - type: custom
+    name: Custom Agent
+    description: "Configure a custom agent with your own settings"
+    command: ""
+    args: []
+    env: {}
+    requires_api_key: null
+    default: false

--- a/tldw_Server_API/Config_Files/privilege_catalog.yaml
+++ b/tldw_Server_API/Config_Files/privilege_catalog.yaml
@@ -100,6 +100,36 @@ scopes:
     ownership_predicates:
       - same_org
     doc_url: https://docs.example.com/privileges/acp-agents-list
+  - id: acp.health
+    description: Check ACP dependency chain health (runner binary, agents, API keys).
+    resource_tags:
+      - acp
+      - health
+    sensitivity_tier: moderate
+    rate_limit_class: standard
+    default_roles:
+      - admin
+      - analyst
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-health
+  - id: acp.setup_guide
+    description: Get ACP setup instructions for runner and agent configuration.
+    resource_tags:
+      - acp
+      - setup
+    sensitivity_tier: moderate
+    rate_limit_class: standard
+    default_roles:
+      - admin
+      - analyst
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/acp-setup-guide
   - id: acp.sessions.read
     description: View ACP session metadata, history, diagnostics, and audit artifacts.
     resource_tags:
@@ -131,6 +161,66 @@ scopes:
     ownership_predicates:
       - same_org
     doc_url: https://docs.example.com/privileges/acp-sessions-manage
+  - id: agent_orchestration.projects.read
+    description: View agent orchestration projects and summaries.
+    resource_tags:
+      - orchestration
+      - projects
+      - read
+    sensitivity_tier: moderate
+    rate_limit_class: standard
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/agent-orchestration-projects-read
+  - id: agent_orchestration.projects.manage
+    description: Create, update, and delete agent orchestration projects.
+    resource_tags:
+      - orchestration
+      - projects
+      - control
+    sensitivity_tier: high
+    rate_limit_class: elevated
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/agent-orchestration-projects-manage
+  - id: agent_orchestration.tasks.read
+    description: View agent orchestration tasks and run history.
+    resource_tags:
+      - orchestration
+      - tasks
+      - read
+    sensitivity_tier: moderate
+    rate_limit_class: standard
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/agent-orchestration-tasks-read
+  - id: agent_orchestration.tasks.manage
+    description: Create tasks, dispatch runs, and submit reviews.
+    resource_tags:
+      - orchestration
+      - tasks
+      - control
+    sensitivity_tier: restricted
+    rate_limit_class: admin
+    default_roles:
+      - admin
+      - developer
+    feature_flag_id: null
+    ownership_predicates:
+      - same_org
+    doc_url: https://docs.example.com/privileges/agent-orchestration-tasks-manage
   - id: chat.completions
     description: Invoke chat completion style LLM endpoints.
     resource_tags:

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -167,6 +167,18 @@ def _acp_record_audit_event(
     }
     with _ACP_AUDIT_LOCK:
         _ACP_AUDIT_EVENTS.append(event)
+    # Persist to SQLite audit DB (best-effort)
+    try:
+        from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import get_acp_audit_db
+        audit_db = get_acp_audit_db()
+        audit_db.record_event(
+            action=action,
+            user_id=user_id,
+            session_id=session_id,
+            metadata=metadata,
+        )
+    except Exception:
+        pass  # Audit persistence failure should not block operations
     logger.info(
         "ACP audit event action={} user_id={} session_id={}",
         event["action"],
@@ -1104,6 +1116,262 @@ async def _handle_client_message(
         })
 
 
+# ---------------------------------------------------------------------------
+# Health check & setup-guide helpers
+# ---------------------------------------------------------------------------
+
+_AGENT_SETUP_GUIDES: dict[str, dict[str, Any]] = {
+    "claude_code": {
+        "name": "Claude Code",
+        "binary": "claude",
+        "install_instructions": [
+            "Install Claude Code CLI: npm install -g @anthropic-ai/claude-code",
+            "Or via pip: pip install claude-code",
+        ],
+        "required_env_vars": ["ANTHROPIC_API_KEY"],
+        "docs_url": "https://docs.anthropic.com/en/docs/claude-code",
+    },
+    "codex": {
+        "name": "OpenAI Codex CLI",
+        "binary": "codex",
+        "install_instructions": [
+            "Install Codex CLI: npm install -g @openai/codex",
+        ],
+        "required_env_vars": ["OPENAI_API_KEY"],
+        "docs_url": "https://github.com/openai/codex",
+    },
+    "opencode": {
+        "name": "OpenCode",
+        "binary": "opencode",
+        "install_instructions": [
+            "Install OpenCode: go install github.com/sst/opencode@latest",
+            "Or download from: https://github.com/sst/opencode/releases",
+        ],
+        "required_env_vars": [],
+        "docs_url": "https://github.com/sst/opencode",
+    },
+}
+
+
+def _check_runner_binary() -> dict[str, Any]:
+    """Check if the ACP runner binary is available."""
+    import shutil
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_runner_config
+
+    try:
+        cfg = load_acp_runner_config()
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+        return {"status": "error", "detail": f"Config load failed: {exc}"}
+
+    # Check binary_path shortcut first
+    if cfg.binary_path:
+        path = os.path.expanduser(cfg.binary_path)
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return {"status": "ok", "path": path, "source": "binary_path"}
+        return {
+            "status": "missing",
+            "detail": f"Binary not found at configured path: {cfg.binary_path}",
+            "configured_path": cfg.binary_path,
+        }
+
+    # Check command-based config
+    if not cfg.command:
+        return {
+            "status": "missing",
+            "detail": "No runner_command or runner_binary_path configured in [ACP] section",
+        }
+
+    # If command is an absolute/relative path, check it directly
+    if os.sep in cfg.command or cfg.command.startswith("."):
+        resolved = cfg.command
+        if cfg.cwd:
+            resolved = os.path.join(cfg.cwd, cfg.command)
+        if os.path.isfile(resolved) and os.access(resolved, os.X_OK):
+            return {"status": "ok", "path": resolved, "source": "runner_command"}
+        return {
+            "status": "missing",
+            "detail": f"Runner command not found: {cfg.command}",
+            "configured_command": cfg.command,
+            "configured_cwd": cfg.cwd,
+        }
+
+    # Check if command is on PATH (e.g., "go", "node", or a binary name)
+    which_result = shutil.which(cfg.command)
+    if which_result:
+        return {"status": "ok", "path": which_result, "source": "PATH"}
+
+    return {
+        "status": "missing",
+        "detail": f"Runner command '{cfg.command}' not found on PATH",
+        "configured_command": cfg.command,
+    }
+
+
+def _check_agent_availability(agent_type: str) -> dict[str, Any]:
+    """Check if a downstream agent binary and API keys are available."""
+    import shutil
+
+    guide = _AGENT_SETUP_GUIDES.get(agent_type)
+    if not guide:
+        return {"status": "unknown", "detail": f"No setup guide for agent type: {agent_type}"}
+
+    result: dict[str, Any] = {"agent_type": agent_type, "name": guide["name"]}
+
+    # Check binary
+    binary_name = guide.get("binary", "")
+    if binary_name:
+        which_result = shutil.which(binary_name)
+        result["binary_status"] = "ok" if which_result else "missing"
+        if which_result:
+            result["binary_path"] = which_result
+    else:
+        result["binary_status"] = "not_applicable"
+
+    # Check env vars
+    missing_keys = []
+    for var in guide.get("required_env_vars", []):
+        if not os.getenv(var):
+            missing_keys.append(var)
+    result["api_keys_status"] = "ok" if not missing_keys else "missing"
+    if missing_keys:
+        result["missing_api_keys"] = missing_keys
+
+    # Overall status
+    if result.get("binary_status") == "missing":
+        result["status"] = "unavailable"
+    elif missing_keys:
+        result["status"] = "requires_setup"
+    else:
+        result["status"] = "available"
+
+    return result
+
+
+@router.get(
+    "/health",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.health"))],
+)
+async def acp_health(
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """
+    ACP dependency chain health check.
+
+    Validates the full stack: runner binary → downstream agent availability → API keys.
+    Returns structured diagnostics for debugging ACP setup issues.
+    """
+    result: dict[str, Any] = {"timestamp": _now_iso()}
+
+    # 1. Check runner binary
+    runner_status = _check_runner_binary()
+    result["runner"] = runner_status
+
+    # 2. Check downstream agents
+    agents_status: list[dict[str, Any]] = []
+    for agent_type in _AGENT_SETUP_GUIDES:
+        agents_status.append(_check_agent_availability(agent_type))
+    result["agents"] = agents_status
+
+    # 3. Try to probe the runner (if binary is available)
+    runner_probe: dict[str, Any] = {"status": "skipped"}
+    if runner_status.get("status") == "ok":
+        try:
+            client = await get_runner_client()
+            if hasattr(client, "is_running") and client.is_running:
+                runner_probe = {"status": "ok", "detail": "Runner process is alive"}
+                caps = getattr(client, "agent_capabilities", None)
+                if caps:
+                    runner_probe["agent_capabilities"] = caps
+            else:
+                runner_probe = {"status": "not_running", "detail": "Runner process is not started"}
+        except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+            runner_probe = {"status": "error", "detail": str(exc)}
+    result["runner_probe"] = runner_probe
+
+    # 4. Overall status
+    any_agent_available = any(a.get("status") == "available" for a in agents_status)
+    runner_ok = runner_status.get("status") == "ok"
+
+    if runner_ok and any_agent_available:
+        result["overall"] = "ok"
+    elif runner_ok and not any_agent_available:
+        result["overall"] = "degraded"
+        result["message"] = "Runner binary found but no agents are fully configured"
+    elif not runner_ok:
+        result["overall"] = "unavailable"
+        result["message"] = "ACP runner binary not found or not configured"
+    else:
+        result["overall"] = "degraded"
+
+    return result
+
+
+@router.get(
+    "/setup-guide",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.setup_guide"))],
+)
+async def acp_setup_guide(
+    agent_type: str | None = Query(default=None, description="Filter to a specific agent type"),
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """
+    Return agent-specific setup instructions.
+
+    Checks current system state and returns actionable steps to get ACP working.
+    """
+    result: dict[str, Any] = {"timestamp": _now_iso(), "guides": []}
+
+    # Runner setup
+    runner_status = _check_runner_binary()
+    runner_guide: dict[str, Any] = {
+        "component": "runner",
+        "status": runner_status.get("status", "unknown"),
+        "steps": [],
+    }
+    if runner_status.get("status") != "ok":
+        runner_guide["steps"] = [
+            "Download the ACP runner binary: run Helper_Scripts/setup_acp.sh",
+            "Or build from source: cd ../tldw-agent && go build -o bin/tldw-agent-acp ./cmd/tldw-agent-acp",
+            "Set runner_binary_path in config.txt [ACP] section, or set ACP_RUNNER_BINARY_PATH env var",
+        ]
+    else:
+        runner_guide["steps"] = ["Runner binary is available - no action needed"]
+    result["runner"] = runner_guide
+
+    # Agent guides
+    guides: list[dict[str, Any]] = []
+    target_agents = [agent_type] if agent_type and agent_type in _AGENT_SETUP_GUIDES else list(_AGENT_SETUP_GUIDES)
+
+    for at in target_agents:
+        agent_status = _check_agent_availability(at)
+        guide_info = _AGENT_SETUP_GUIDES.get(at, {})
+        entry: dict[str, Any] = {
+            "agent_type": at,
+            "name": guide_info.get("name", at),
+            "status": agent_status.get("status", "unknown"),
+            "steps": [],
+        }
+
+        if agent_status.get("binary_status") == "missing":
+            entry["steps"].extend(guide_info.get("install_instructions", []))
+
+        if agent_status.get("api_keys_status") == "missing":
+            for key in agent_status.get("missing_api_keys", []):
+                entry["steps"].append(f"Set {key} environment variable or add to .env file")
+
+        if not entry["steps"]:
+            entry["steps"] = [f"{guide_info.get('name', at)} is fully configured"]
+
+        if guide_info.get("docs_url"):
+            entry["docs_url"] = guide_info["docs_url"]
+
+        guides.append(entry)
+
+    result["guides"] = guides
+    return result
+
+
 def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
     """Fallback list of built-in agents when runner registry is unavailable."""
     import os
@@ -1155,8 +1423,38 @@ def _get_static_agents() -> tuple[list[ACPAgentInfo], str]:
     return agents, "claude_code"
 
 
+def _get_registry_agents() -> tuple[list[ACPAgentInfo], str] | None:
+    """Try to get agents from YAML registry. Returns None if registry is unavailable."""
+    try:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import get_agent_registry
+        registry = get_agent_registry()
+        available = registry.get_available_agents()
+        if not available:
+            return None
+        agents: list[ACPAgentInfo] = []
+        for item in available:
+            agents.append(
+                ACPAgentInfo(
+                    type=str(item["type"]),
+                    name=str(item["name"]),
+                    description=str(item.get("description", "")),
+                    is_configured=bool(item.get("is_configured", False)),
+                    requires_api_key=item.get("missing_api_key"),
+                )
+            )
+        return agents, registry.default_type
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
+        return None
+
+
 async def _get_available_agents() -> tuple[list[ACPAgentInfo], str]:
-    """Get list of available agents and their configuration status."""
+    """Get list of available agents: registry → runner → static fallback."""
+    # 1. Try YAML registry first
+    registry_result = _get_registry_agents()
+    if registry_result:
+        return registry_result
+
+    # 2. Try runner's agent/list RPC
     try:
         client = await get_runner_client()
         raw = await client.list_agents()
@@ -1245,6 +1543,20 @@ async def acp_session_new(
 
     Optionally specify a session name, agent type, tags, and MCP server configs.
     """
+    # Quota check: max concurrent sessions per user
+    try:
+        store = await get_acp_session_store()
+        quota_error = await store.check_session_quota(user.id)
+        if quota_error:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=quota_error,
+            )
+    except HTTPException:
+        raise
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
+        pass  # Quota check failure shouldn't block session creation
+
     # Generate session name if not provided
     session_name = payload.name or _generate_session_name(payload.cwd)
 
@@ -1363,6 +1675,19 @@ async def acp_session_prompt(
     user: User = Depends(get_request_user),
 ) -> ACPSessionPromptResponse:
     _acp_enforce_control_rate_limit(user_id=int(user.id), action="prompt")
+    # Token quota check
+    try:
+        store = await get_acp_session_store()
+        token_error = await store.check_token_quota(payload.session_id)
+        if token_error:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=token_error,
+            )
+    except HTTPException:
+        raise
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
+        pass
     try:
         client = await get_runner_client()
         result, turn_usage = await _execute_acp_prompt(
@@ -1679,8 +2004,10 @@ async def acp_session_detail(
     rec = await store.get_session(session_id)
     if not rec:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session_not_found")
+    fork_lineage = await store.get_fork_lineage(session_id)
     return ACPSessionDetailResponse(**rec.to_detail_dict(
         has_websocket=client.has_websocket_connections(session_id),
+        fork_lineage=fork_lineage,
     ))
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -178,7 +178,8 @@ def _acp_record_audit_event(
             session_id=session_id,
             metadata=metadata,
         )
-        audit_db.flush()
+        # Flush when buffer reaches threshold to balance durability vs performance
+        audit_db.flush_if_needed(threshold=10)
     except Exception as exc:
         logger.warning("ACP audit persistence failed: {}", exc)
     logger.info(
@@ -1549,7 +1550,7 @@ async def acp_session_new(
     # Quota check: max concurrent sessions per user
     try:
         store = await get_acp_session_store()
-        quota_error = await store.check_session_quota(user.id)
+        quota_error = await store.check_session_quota(int(user.id))
         if quota_error:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import SlidingWindow
 from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
     ACPAgentInfo,
     ACPAgentListResponse,
+    ACPHealthResponse,
     ACPSessionCancelRequest,
     ACPSessionCloseRequest,
     ACPSessionDetailResponse,
@@ -177,8 +178,9 @@ def _acp_record_audit_event(
             session_id=session_id,
             metadata=metadata,
         )
-    except Exception:
-        pass  # Audit persistence failure should not block operations
+        audit_db.flush()
+    except Exception as exc:
+        logger.warning("ACP audit persistence failed: {}", exc)
     logger.info(
         "ACP audit event action={} user_id={} session_id={}",
         event["action"],
@@ -1250,6 +1252,7 @@ def _check_agent_availability(agent_type: str) -> dict[str, Any]:
 
 @router.get(
     "/health",
+    response_model=ACPHealthResponse,
     dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="acp.health"))],
 )
 async def acp_health(
@@ -1554,8 +1557,8 @@ async def acp_session_new(
             )
     except HTTPException:
         raise
-    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
-        pass  # Quota check failure shouldn't block session creation
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning("Session quota check failed (non-blocking): {}", exc)
 
     # Generate session name if not provided
     session_name = payload.name or _generate_session_name(payload.cwd)
@@ -1686,8 +1689,8 @@ async def acp_session_prompt(
             )
     except HTTPException:
         raise
-    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
-        pass
+    except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning("Token quota check failed (non-blocking): {}", exc)
     try:
         client = await get_runner_client()
         result, turn_usage = await _execute_acp_prompt(

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -305,7 +305,7 @@ async def dispatch_run(
 
         # Quota check
         store = await get_acp_session_store()
-        quota_error = await store.check_session_quota(user.id)
+        quota_error = await store.check_session_quota(int(user.id))
         if quota_error:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
@@ -382,11 +382,13 @@ async def dispatch_run(
             detail=f"ACP prompt failed: {exc}",
         ) from exc
 
+    # Refetch task to get post-transition status
+    updated_task = await svc.get_task(task_id)
     return {
         "task_id": task_id,
         "run_id": run.id,
         "session_id": session_id,
-        "status": task.status.value,
+        "status": updated_task.status.value if updated_task else "unknown",
     }
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -1,0 +1,394 @@
+"""Agent Orchestration API endpoints.
+
+Provides project/task management, run dispatch, and reviewer gate.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_token_scope
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.Agent_Orchestration.models import (
+    TaskStatus,
+    RunStatus,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
+    CycleDependencyError,
+    get_orchestration_service,
+)
+
+router = APIRouter(prefix="/agent-orchestration", tags=["agent-orchestration"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class ProjectCreateRequest(BaseModel):
+    name: str = Field(..., description="Project name")
+    description: str = Field(default="", description="Project description")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectResponse(BaseModel):
+    id: int
+    name: str
+    description: str = ""
+    user_id: int = 0
+    created_at: str = ""
+    updated_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    task_summary: dict[str, Any] | None = None
+
+
+class TaskCreateRequest(BaseModel):
+    title: str = Field(..., description="Task title")
+    description: str = Field(default="", description="Task description")
+    agent_type: str | None = Field(default=None, description="Agent type to use for this task")
+    dependency_id: int | None = Field(default=None, description="Task ID this depends on")
+    reviewer_agent_type: str | None = Field(default=None, description="Agent type for review gate")
+    max_review_attempts: int = Field(default=3, ge=1, le=10, description="Max review attempts before triage")
+    success_criteria: str = Field(default="", description="Success criteria for the task")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class TaskResponse(BaseModel):
+    id: int
+    project_id: int
+    title: str
+    description: str = ""
+    status: str = "todo"
+    agent_type: str | None = None
+    dependency_id: int | None = None
+    reviewer_agent_type: str | None = None
+    max_review_attempts: int = 3
+    review_count: int = 0
+    success_criteria: str = ""
+    user_id: int = 0
+    created_at: str = ""
+    updated_at: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    runs: list[dict[str, Any]] | None = None
+
+
+class RunDispatchRequest(BaseModel):
+    agent_type: str | None = Field(default=None, description="Override agent type for this run")
+    cwd: str = Field(default=".", description="Working directory for the ACP session")
+
+
+class ReviewRequest(BaseModel):
+    approved: bool = Field(..., description="Whether the review is approved")
+    feedback: str = Field(default="", description="Review feedback")
+
+
+# ---------------------------------------------------------------------------
+# Project endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/projects",
+    response_model=ProjectResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+)
+async def create_project(
+    payload: ProjectCreateRequest,
+    user: User = Depends(get_request_user),
+) -> ProjectResponse:
+    """Create a new agent project."""
+    svc = await get_orchestration_service()
+    project = await svc.create_project(
+        name=payload.name,
+        description=payload.description,
+        user_id=user.id,
+        metadata=payload.metadata,
+    )
+    return ProjectResponse(**project.to_dict())
+
+
+@router.get(
+    "/projects",
+    response_model=list[ProjectResponse],
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+)
+async def list_projects(
+    user: User = Depends(get_request_user),
+) -> list[ProjectResponse]:
+    """List all projects for the current user."""
+    svc = await get_orchestration_service()
+    projects = await svc.list_projects(user_id=user.id)
+    results = []
+    for p in projects:
+        summary = await svc.get_project_summary(p.id)
+        d = p.to_dict()
+        d["task_summary"] = summary
+        results.append(ProjectResponse(**d))
+    return results
+
+
+@router.get(
+    "/projects/{project_id}",
+    response_model=ProjectResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.read"))],
+)
+async def get_project(
+    project_id: int,
+    user: User = Depends(get_request_user),
+) -> ProjectResponse:
+    """Get a project by ID."""
+    svc = await get_orchestration_service()
+    project = await svc.get_project(project_id)
+    if not project or project.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    summary = await svc.get_project_summary(project_id)
+    d = project.to_dict()
+    d["task_summary"] = summary
+    return ProjectResponse(**d)
+
+
+@router.delete(
+    "/projects/{project_id}",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.projects.manage"))],
+)
+async def delete_project(
+    project_id: int,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Delete a project and all associated tasks/runs."""
+    svc = await get_orchestration_service()
+    project = await svc.get_project(project_id)
+    if not project or project.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    await svc.delete_project(project_id)
+    return {"deleted": True, "project_id": project_id}
+
+
+# ---------------------------------------------------------------------------
+# Task endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/projects/{project_id}/tasks",
+    response_model=TaskResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+)
+async def create_task(
+    project_id: int,
+    payload: TaskCreateRequest,
+    user: User = Depends(get_request_user),
+) -> TaskResponse:
+    """Create a new task in a project."""
+    svc = await get_orchestration_service()
+    project = await svc.get_project(project_id)
+    if not project or project.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    try:
+        task = await svc.create_task(
+            project_id=project_id,
+            title=payload.title,
+            description=payload.description,
+            agent_type=payload.agent_type,
+            dependency_id=payload.dependency_id,
+            reviewer_agent_type=payload.reviewer_agent_type,
+            max_review_attempts=payload.max_review_attempts,
+            success_criteria=payload.success_criteria,
+            user_id=user.id,
+            metadata=payload.metadata,
+        )
+    except CycleDependencyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return TaskResponse(**task.to_dict())
+
+
+@router.get(
+    "/projects/{project_id}/tasks",
+    response_model=list[TaskResponse],
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+)
+async def list_tasks(
+    project_id: int,
+    status_filter: str | None = Query(default=None, alias="status"),
+    user: User = Depends(get_request_user),
+) -> list[TaskResponse]:
+    """List tasks in a project with optional status filter."""
+    svc = await get_orchestration_service()
+    project = await svc.get_project(project_id)
+    if not project or project.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Project not found")
+    task_status = None
+    if status_filter:
+        try:
+            task_status = TaskStatus(status_filter)
+        except ValueError:
+            raise HTTPException(status_code=400, detail=f"Invalid status: {status_filter}")
+    tasks = await svc.list_tasks(project_id, status=task_status)
+    return [TaskResponse(**t.to_dict()) for t in tasks]
+
+
+@router.get(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.read"))],
+)
+async def get_task(
+    task_id: int,
+    user: User = Depends(get_request_user),
+) -> TaskResponse:
+    """Get task detail including run history."""
+    svc = await get_orchestration_service()
+    task = await svc.get_task(task_id)
+    if not task or task.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    runs = await svc.list_runs(task_id)
+    d = task.to_dict()
+    d["runs"] = [r.to_dict() for r in runs]
+    return TaskResponse(**d)
+
+
+# ---------------------------------------------------------------------------
+# Run dispatch
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/tasks/{task_id}/run",
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+)
+async def dispatch_run(
+    task_id: int,
+    payload: RunDispatchRequest,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    """Dispatch a task run to an ACP agent.
+
+    Creates an ACP session, sends the task description as the initial prompt,
+    and tracks the run.
+    """
+    svc = await get_orchestration_service()
+    task = await svc.get_task(task_id)
+    if not task or task.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    # Check dependency
+    dep_ready = await svc.check_dependency_ready(task_id)
+    if not dep_ready:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Task dependency {task.dependency_id} is not complete",
+        )
+
+    # Transition to in_progress
+    try:
+        await svc.transition_task(task_id, TaskStatus.IN_PROGRESS)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Create ACP session
+    session_id: str | None = None
+    try:
+        from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import get_runner_client
+        client = await get_runner_client()
+        agent_type = payload.agent_type or task.agent_type
+        session_id = await client.create_session(
+            payload.cwd,
+            agent_type=agent_type,
+            user_id=user.id,
+        )
+    except Exception as exc:
+        logger.error("Failed to create ACP session for task {}: {}", task_id, exc)
+        # Create a failed run record
+        run = await svc.create_run(task_id, agent_type=payload.agent_type or task.agent_type)
+        await svc.fail_run(run.id, error=str(exc))
+        await svc.transition_task(task_id, TaskStatus.TRIAGE)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Failed to create ACP session: {exc}",
+        ) from exc
+
+    # Create run record
+    run = await svc.create_run(
+        task_id,
+        agent_type=payload.agent_type or task.agent_type,
+        session_id=session_id,
+    )
+
+    # Send initial prompt with task description
+    prompt_text = f"Task: {task.title}\n\n{task.description}"
+    if task.success_criteria:
+        prompt_text += f"\n\nSuccess Criteria: {task.success_criteria}"
+
+    try:
+        result = await client.prompt(
+            session_id,
+            [{"role": "user", "content": prompt_text}],
+        )
+        stop_reason = result.get("stopReason", "")
+        await svc.complete_run(
+            run.id,
+            result_summary=stop_reason,
+            token_usage=result.get("usage", {}),
+        )
+        # Transition to review if reviewer is configured
+        if task.reviewer_agent_type:
+            await svc.transition_task(task_id, TaskStatus.REVIEW)
+        else:
+            await svc.transition_task(task_id, TaskStatus.REVIEW)
+
+    except Exception as exc:
+        logger.error("ACP prompt failed for task {}: {}", task_id, exc)
+        await svc.fail_run(run.id, error=str(exc))
+        await svc.transition_task(task_id, TaskStatus.TRIAGE)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"ACP prompt failed: {exc}",
+        ) from exc
+
+    return {
+        "task_id": task_id,
+        "run_id": run.id,
+        "session_id": session_id,
+        "status": task.status.value,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Review gate
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/tasks/{task_id}/review",
+    response_model=TaskResponse,
+    dependencies=[Depends(require_token_scope("any", require_if_present=True, endpoint_id="agent_orchestration.tasks.manage"))],
+)
+async def submit_review(
+    task_id: int,
+    payload: ReviewRequest,
+    user: User = Depends(get_request_user),
+) -> TaskResponse:
+    """Submit a review result for a task.
+
+    Approved → complete. Rejected → back to in_progress or triage (after max attempts).
+    """
+    svc = await get_orchestration_service()
+    task = await svc.get_task(task_id)
+    if not task or task.user_id != user.id:
+        raise HTTPException(status_code=404, detail="Task not found")
+    try:
+        updated = await svc.submit_review(task_id, payload.approved, payload.feedback)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return TaskResponse(**updated.to_dict())

--- a/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_orchestration.py
@@ -296,21 +296,47 @@ async def dispatch_run(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # Create ACP session
+    # Create ACP session with quota check, session-store registration, and audit
     session_id: str | None = None
+    agent_type = payload.agent_type or task.agent_type
     try:
         from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import get_runner_client
+        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
+
+        # Quota check
+        store = await get_acp_session_store()
+        quota_error = await store.check_session_quota(user.id)
+        if quota_error:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=quota_error,
+            )
+
         client = await get_runner_client()
-        agent_type = payload.agent_type or task.agent_type
         session_id = await client.create_session(
             payload.cwd,
             agent_type=agent_type,
             user_id=user.id,
         )
+
+        # Register in session store
+        try:
+            await store.register_session(
+                session_id=session_id,
+                user_id=int(user.id),
+                agent_type=agent_type or "custom",
+                name=f"orchestration-task-{task_id}",
+                cwd=payload.cwd,
+            )
+        except Exception as reg_exc:
+            logger.warning("Failed to register orchestration ACP session {}: {}", session_id, reg_exc)
+
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.error("Failed to create ACP session for task {}: {}", task_id, exc)
         # Create a failed run record
-        run = await svc.create_run(task_id, agent_type=payload.agent_type or task.agent_type)
+        run = await svc.create_run(task_id, agent_type=agent_type)
         await svc.fail_run(run.id, error=str(exc))
         await svc.transition_task(task_id, TaskStatus.TRIAGE)
         raise HTTPException(
@@ -341,11 +367,11 @@ async def dispatch_run(
             result_summary=stop_reason,
             token_usage=result.get("usage", {}),
         )
-        # Transition to review if reviewer is configured
+        # Transition to review if reviewer is configured, else complete
         if task.reviewer_agent_type:
             await svc.transition_task(task_id, TaskStatus.REVIEW)
         else:
-            await svc.transition_task(task_id, TaskStatus.REVIEW)
+            await svc.transition_task(task_id, TaskStatus.COMPLETE)
 
     except Exception as exc:
         logger.error("ACP prompt failed for task {}: {}", task_id, exc)

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -155,6 +155,18 @@ router = APIRouter(prefix="/sandbox", tags=["sandbox"], route_class=SandboxArtif
 
 _service = SandboxService(enable_background_tasks=False)
 
+try:
+    import fcntl  # type: ignore
+    _SANDBOX_HAS_FCNTL = True
+except Exception:
+    _SANDBOX_HAS_FCNTL = False
+
+try:
+    import msvcrt  # type: ignore
+    _SANDBOX_HAS_MSVCRT = True
+except Exception:
+    _SANDBOX_HAS_MSVCRT = False
+
 
 @router.on_event("startup")
 async def _sandbox_startup() -> None:
@@ -173,6 +185,71 @@ _SANDBOX_WS_ACTIVE_BY_USER: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_PERSONA: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_SESSION: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_RUN: dict[str, int] = {}
+_SANDBOX_UPLOAD_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
+_SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD = threading.Lock()
+
+
+def _sandbox_upload_lock_path(workspace_root: str) -> str:
+    return os.path.join(workspace_root, ".sandbox-upload.lock")
+
+
+def _get_sandbox_upload_thread_lock(lock_path: str) -> threading.Lock:
+    key = str(os.path.abspath(lock_path))
+    with _SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD:
+        lock = _SANDBOX_UPLOAD_FALLBACK_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SANDBOX_UPLOAD_FALLBACK_LOCKS[key] = lock
+    return lock
+
+
+@contextlib.asynccontextmanager
+async def _sandbox_session_upload_lock(workspace_root: str):
+    os.makedirs(workspace_root, exist_ok=True)
+    lock_path = _sandbox_upload_lock_path(workspace_root)
+
+    if _SANDBOX_HAS_FCNTL:
+        def _open_and_lock():
+            handle = open(lock_path, "a", encoding="utf-8")
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            return handle
+
+        handle = await asyncio.to_thread(_open_and_lock)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(fcntl.flock, handle.fileno(), fcntl.LOCK_UN)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.close)
+        return
+
+    if _SANDBOX_HAS_MSVCRT:
+        def _open_and_lock():
+            handle = open(lock_path, "a+b")
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            return handle
+
+        handle = await asyncio.to_thread(_open_and_lock)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.seek, 0)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(msvcrt.locking, handle.fileno(), msvcrt.LK_UNLCK, 1)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.close)
+        return
+
+    lock = _get_sandbox_upload_thread_lock(lock_path)
+    await asyncio.to_thread(lock.acquire)
+    try:
+        yield
+    finally:
+        lock.release()
 
 
 def _sandbox_ws_limit(env_key: str, settings_attr: str, default: int) -> int:
@@ -910,183 +987,184 @@ async def upload_files(
     if not ws_root:
         raise HTTPException(status_code=404, detail="session_not_found")
 
-    try:
-        cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
-    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-        cap_mb = 256
-    cap_bytes = cap_mb * 1024 * 1024
-    chunk_size = 64 * 1024
-    written = 0
-    count = 0
-
-    import tarfile
-    import zipfile
-    def _workspace_usage_bytes(root: str) -> int:
-        total = 0
-        for dirpath, _dirnames, filenames in os.walk(root):
-            for filename in filenames:
-                full_path = os.path.join(dirpath, filename)
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    if os.path.isfile(full_path):
-                        total += int(os.path.getsize(full_path))
-        return total
-
-    def _existing_file_size(target: str) -> int:
+    async with _sandbox_session_upload_lock(ws_root):
         try:
-            if os.path.isfile(target):
-                return int(os.path.getsize(target))
+            cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
         except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            cap_mb = 256
+        cap_bytes = cap_mb * 1024 * 1024
+        chunk_size = 64 * 1024
+        written = 0
+        count = 0
+
+        import tarfile
+        import zipfile
+        def _workspace_usage_bytes(root: str) -> int:
+            total = 0
+            for dirpath, _dirnames, filenames in os.walk(root):
+                for filename in filenames:
+                    full_path = os.path.join(dirpath, filename)
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        if os.path.isfile(full_path):
+                            total += int(os.path.getsize(full_path))
+            return total
+
+        def _existing_file_size(target: str) -> int:
+            try:
+                if os.path.isfile(target):
+                    return int(os.path.getsize(target))
+            except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                return 0
             return 0
-        return 0
 
-    def _stream_reader_to_target(
-        target: str,
-        read_chunk,
-        *,
-        workspace_used: int,
-    ) -> tuple[int, int]:
-        parent = os.path.dirname(target)
-        os.makedirs(parent, exist_ok=True)
-        existing_size = _existing_file_size(target)
-        fd, temp_path = tempfile.mkstemp(
-            dir=parent,
-            prefix=f".{os.path.basename(target)}.",
-            suffix=".upload",
-        )
-        os.close(fd)
-        file_bytes = 0
-        try:
-            with open(temp_path, "wb") as out:
-                while True:
-                    chunk = read_chunk(chunk_size)
-                    if not chunk:
-                        break
-                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                    if next_total > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    out.write(chunk)
-                    file_bytes += len(chunk)
-            os.replace(temp_path, target)
-            return file_bytes, workspace_used - existing_size + file_bytes
-        except Exception:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                os.unlink(temp_path)
-            raise
-
-    async def _stream_upload_to_target(
-        upload: UploadFile,
-        target: str,
-        *,
-        workspace_used: int,
-    ) -> tuple[int, int]:
-        parent = os.path.dirname(target)
-        os.makedirs(parent, exist_ok=True)
-        existing_size = _existing_file_size(target)
-        fd, temp_path = tempfile.mkstemp(
-            dir=parent,
-            prefix=f".{os.path.basename(target)}.",
-            suffix=".upload",
-        )
-        os.close(fd)
-        file_bytes = 0
-        try:
-            with open(temp_path, "wb") as out:
-                while True:
-                    chunk = await upload.read(chunk_size)
-                    if not chunk:
-                        break
-                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                    if next_total > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    out.write(chunk)
-                    file_bytes += len(chunk)
-            os.replace(temp_path, target)
-            return file_bytes, workspace_used - existing_size + file_bytes
-        except Exception:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                os.unlink(temp_path)
-            raise
-
-    workspace_used = _workspace_usage_bytes(ws_root)
-
-    for up in files:
-        lower = (up.filename or "").lower()
-        if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+        def _stream_reader_to_target(
+            target: str,
+            read_chunk,
+            *,
+            workspace_used: int,
+        ) -> tuple[int, int]:
+            parent = os.path.dirname(target)
+            os.makedirs(parent, exist_ok=True)
+            existing_size = _existing_file_size(target)
+            fd, temp_path = tempfile.mkstemp(
+                dir=parent,
+                prefix=f".{os.path.basename(target)}.",
+                suffix=".upload",
+            )
+            os.close(fd)
+            file_bytes = 0
             try:
+                with open(temp_path, "wb") as out:
+                    while True:
+                        chunk = read_chunk(chunk_size)
+                        if not chunk:
+                            break
+                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                        if next_total > cap_bytes:
+                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                        out.write(chunk)
+                        file_bytes += len(chunk)
+                os.replace(temp_path, target)
+                return file_bytes, workspace_used - existing_size + file_bytes
+            except Exception:
                 with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                with tarfile.open(fileobj=up.file, mode="r:*") as tf:
-                    for member in tf.getmembers():
-                        if member.isdev() or member.issym() or member.islnk():
-                            continue
-                        target = safe_join(ws_root, member.name)
-                        if target is None:
-                            continue
-                        if member.isdir():
-                            os.makedirs(target, exist_ok=True)
-                            continue
-                        fileobj = tf.extractfile(member)
-                        if fileobj is None:
-                            continue
-                        try:
-                            file_bytes, workspace_used = _stream_reader_to_target(
-                                target,
-                                fileobj.read,
-                                workspace_used=workspace_used,
-                            )
-                        finally:
-                            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                                fileobj.close()
-                        written += file_bytes
-                        count += 1
-            except HTTPException:
+                    os.unlink(temp_path)
                 raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to extract tar: {e}")
-        elif lower.endswith(".zip"):
+
+        async def _stream_upload_to_target(
+            upload: UploadFile,
+            target: str,
+            *,
+            workspace_used: int,
+        ) -> tuple[int, int]:
+            parent = os.path.dirname(target)
+            os.makedirs(parent, exist_ok=True)
+            existing_size = _existing_file_size(target)
+            fd, temp_path = tempfile.mkstemp(
+                dir=parent,
+                prefix=f".{os.path.basename(target)}.",
+                suffix=".upload",
+            )
+            os.close(fd)
+            file_bytes = 0
             try:
+                with open(temp_path, "wb") as out:
+                    while True:
+                        chunk = await upload.read(chunk_size)
+                        if not chunk:
+                            break
+                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                        if next_total > cap_bytes:
+                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                        out.write(chunk)
+                        file_bytes += len(chunk)
+                os.replace(temp_path, target)
+                return file_bytes, workspace_used - existing_size + file_bytes
+            except Exception:
                 with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                with zipfile.ZipFile(up.file) as zf:
-                    for member in zf.infolist():
-                        if member.is_dir():
-                            continue
-                        if (member.external_attr >> 16) & 0xF000 == 0xA000:
-                            continue
-                        target = safe_join(ws_root, member.filename)
-                        if target is None:
-                            continue
-                        with zf.open(member) as fileobj:
-                            file_bytes, workspace_used = _stream_reader_to_target(
-                                target,
-                                fileobj.read,
-                                workspace_used=workspace_used,
-                            )
-                        written += file_bytes
-                        count += 1
-            except HTTPException:
+                    os.unlink(temp_path)
                 raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to extract zip: {e}")
-        else:
-            target = safe_join(ws_root, up.filename or f"file_{count}")
-            if target is None:
-                continue
-            try:
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                file_bytes, workspace_used = await _stream_upload_to_target(
-                    up,
-                    target,
-                    workspace_used=workspace_used,
-                )
-            except HTTPException:
-                raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed reading upload file {up.filename}: {e}")
-                continue
-            written += file_bytes
-            count += 1
+
+        workspace_used = _workspace_usage_bytes(ws_root)
+
+        for up in files:
+            lower = (up.filename or "").lower()
+            if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    with tarfile.open(fileobj=up.file, mode="r:*") as tf:
+                        for member in tf.getmembers():
+                            if member.isdev() or member.issym() or member.islnk():
+                                continue
+                            target = safe_join(ws_root, member.name)
+                            if target is None:
+                                continue
+                            if member.isdir():
+                                os.makedirs(target, exist_ok=True)
+                                continue
+                            fileobj = tf.extractfile(member)
+                            if fileobj is None:
+                                continue
+                            try:
+                                file_bytes, workspace_used = _stream_reader_to_target(
+                                    target,
+                                    fileobj.read,
+                                    workspace_used=workspace_used,
+                                )
+                            finally:
+                                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                                    fileobj.close()
+                            written += file_bytes
+                            count += 1
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed to extract tar: {e}")
+            elif lower.endswith(".zip"):
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    with zipfile.ZipFile(up.file) as zf:
+                        for member in zf.infolist():
+                            if member.is_dir():
+                                continue
+                            if (member.external_attr >> 16) & 0xF000 == 0xA000:
+                                continue
+                            target = safe_join(ws_root, member.filename)
+                            if target is None:
+                                continue
+                            with zf.open(member) as fileobj:
+                                file_bytes, workspace_used = _stream_reader_to_target(
+                                    target,
+                                    fileobj.read,
+                                    workspace_used=workspace_used,
+                                )
+                            written += file_bytes
+                            count += 1
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed to extract zip: {e}")
+            else:
+                target = safe_join(ws_root, up.filename or f"file_{count}")
+                if target is None:
+                    continue
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    file_bytes, workspace_used = await _stream_upload_to_target(
+                        up,
+                        target,
+                        workspace_used=workspace_used,
+                    )
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed reading upload file {up.filename}: {e}")
+                    continue
+                written += file_bytes
+                count += 1
 
     # Metrics
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import mimetypes
 import os
+import tempfile
 import threading
 import time
 
@@ -24,7 +25,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 
@@ -296,6 +297,15 @@ def _require_session_owner(session_id: str, current_user: User) -> str:
     if not _is_admin_user(current_user) and str(owner) != str(current_user.id):
         raise HTTPException(status_code=404, detail="session_not_found")
     return str(owner)
+
+
+def _model_field_names(model: object | None) -> set[str]:
+    if model is None:
+        return set()
+    fields = getattr(model, "model_fields_set", None)
+    if fields is None:
+        fields = getattr(model, "__fields_set__", set())
+    return {str(field) for field in (fields or set())}
 
 
 def _looks_like_jwt(token: str | None) -> bool:
@@ -720,6 +730,13 @@ async def create_session(
         id=session.id,
         runtime=session.runtime.value,
         base_image=session.base_image,
+        cpu_limit=session.cpu_limit,
+        memory_mb=session.memory_mb,
+        timeout_sec=session.timeout_sec,
+        network_policy=session.network_policy,
+        env=dict(session.env or {}),
+        labels=dict(session.labels or {}),
+        trust_level=(session.trust_level.value if session.trust_level else None),
         expires_at=session.expires_at,
         policy_hash=ph,
         persona_id=session.persona_id,
@@ -898,86 +915,177 @@ async def upload_files(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
         cap_mb = 256
     cap_bytes = cap_mb * 1024 * 1024
+    chunk_size = 64 * 1024
     written = 0
     count = 0
 
-    import io
     import tarfile
     import zipfile
-    for up in files:
+    def _workspace_usage_bytes(root: str) -> int:
+        total = 0
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for filename in filenames:
+                full_path = os.path.join(dirpath, filename)
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    if os.path.isfile(full_path):
+                        total += int(os.path.getsize(full_path))
+        return total
+
+    def _existing_file_size(target: str) -> int:
         try:
-            content = await up.read()
-        except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-            logger.warning(f"Failed reading upload file {up.filename}: {e}")
-            continue
-        if written + len(content) > cap_bytes:
-            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+            if os.path.isfile(target):
+                return int(os.path.getsize(target))
+        except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            return 0
+        return 0
+
+    def _stream_reader_to_target(
+        target: str,
+        read_chunk,
+        *,
+        workspace_used: int,
+    ) -> tuple[int, int]:
+        parent = os.path.dirname(target)
+        os.makedirs(parent, exist_ok=True)
+        existing_size = _existing_file_size(target)
+        fd, temp_path = tempfile.mkstemp(
+            dir=parent,
+            prefix=f".{os.path.basename(target)}.",
+            suffix=".upload",
+        )
+        os.close(fd)
+        file_bytes = 0
+        try:
+            with open(temp_path, "wb") as out:
+                while True:
+                    chunk = read_chunk(chunk_size)
+                    if not chunk:
+                        break
+                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                    if next_total > cap_bytes:
+                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                    out.write(chunk)
+                    file_bytes += len(chunk)
+            os.replace(temp_path, target)
+            return file_bytes, workspace_used - existing_size + file_bytes
+        except Exception:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                os.unlink(temp_path)
+            raise
+
+    async def _stream_upload_to_target(
+        upload: UploadFile,
+        target: str,
+        *,
+        workspace_used: int,
+    ) -> tuple[int, int]:
+        parent = os.path.dirname(target)
+        os.makedirs(parent, exist_ok=True)
+        existing_size = _existing_file_size(target)
+        fd, temp_path = tempfile.mkstemp(
+            dir=parent,
+            prefix=f".{os.path.basename(target)}.",
+            suffix=".upload",
+        )
+        os.close(fd)
+        file_bytes = 0
+        try:
+            with open(temp_path, "wb") as out:
+                while True:
+                    chunk = await upload.read(chunk_size)
+                    if not chunk:
+                        break
+                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                    if next_total > cap_bytes:
+                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                    out.write(chunk)
+                    file_bytes += len(chunk)
+            os.replace(temp_path, target)
+            return file_bytes, workspace_used - existing_size + file_bytes
+        except Exception:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                os.unlink(temp_path)
+            raise
+
+    workspace_used = _workspace_usage_bytes(ws_root)
+
+    for up in files:
         lower = (up.filename or "").lower()
         if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
             try:
-                mode = "r:*"
-                tf = tarfile.open(fileobj=io.BytesIO(content), mode=mode)
-                for m in tf.getmembers():
-                    # Skip device files, symlinks, and hard links
-                    if m.isdev() or m.issym() or m.islnk():
-                        continue
-                    # Use secure path join to prevent traversal
-                    target = safe_join(ws_root, m.name)
-                    if target is None:
-                        # Path traversal attempt detected, skip this entry
-                        continue
-                    if m.isdir():
-                        os.makedirs(target, exist_ok=True)
-                        continue
-                    os.makedirs(os.path.dirname(target), exist_ok=True)
-                    f = tf.extractfile(m)
-                    if f is None:
-                        continue
-                    data = f.read()
-                    if written + len(data) > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    with open(target, "wb") as out:
-                        out.write(data)
-                    written += len(data)
-                    count += 1
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                with tarfile.open(fileobj=up.file, mode="r:*") as tf:
+                    for member in tf.getmembers():
+                        if member.isdev() or member.issym() or member.islnk():
+                            continue
+                        target = safe_join(ws_root, member.name)
+                        if target is None:
+                            continue
+                        if member.isdir():
+                            os.makedirs(target, exist_ok=True)
+                            continue
+                        fileobj = tf.extractfile(member)
+                        if fileobj is None:
+                            continue
+                        try:
+                            file_bytes, workspace_used = _stream_reader_to_target(
+                                target,
+                                fileobj.read,
+                                workspace_used=workspace_used,
+                            )
+                        finally:
+                            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                                fileobj.close()
+                        written += file_bytes
+                        count += 1
+            except HTTPException:
+                raise
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Failed to extract tar: {e}")
         elif lower.endswith(".zip"):
             try:
-                zf = zipfile.ZipFile(io.BytesIO(content))
-                for m in zf.infolist():
-                    if m.is_dir():
-                        continue
-                    # Check for symlinks in zip files (external_attr >> 28 == 0xA indicates symlink)
-                    # Unix symlink mode is 0o120000 (0xA000), stored in high 16 bits of external_attr
-                    if (m.external_attr >> 16) & 0xF000 == 0xA000:
-                        continue
-                    name = m.filename
-                    # Use secure path join to prevent traversal
-                    target = safe_join(ws_root, name)
-                    if target is None:
-                        # Path traversal attempt detected, skip this entry
-                        continue
-                    data = zf.read(m)
-                    if written + len(data) > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    os.makedirs(os.path.dirname(target), exist_ok=True)
-                    with open(target, "wb") as out:
-                        out.write(data)
-                    written += len(data)
-                    count += 1
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                with zipfile.ZipFile(up.file) as zf:
+                    for member in zf.infolist():
+                        if member.is_dir():
+                            continue
+                        if (member.external_attr >> 16) & 0xF000 == 0xA000:
+                            continue
+                        target = safe_join(ws_root, member.filename)
+                        if target is None:
+                            continue
+                        with zf.open(member) as fileobj:
+                            file_bytes, workspace_used = _stream_reader_to_target(
+                                target,
+                                fileobj.read,
+                                workspace_used=workspace_used,
+                            )
+                        written += file_bytes
+                        count += 1
+            except HTTPException:
+                raise
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Failed to extract zip: {e}")
         else:
-            # Use secure path join for regular file uploads
             target = safe_join(ws_root, up.filename or f"file_{count}")
             if target is None:
-                # Path traversal attempt detected, skip this file
                 continue
-            os.makedirs(os.path.dirname(target), exist_ok=True)
-            with open(target, "wb") as out:
-                out.write(content)
-            written += len(content)
+            try:
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                file_bytes, workspace_used = await _stream_upload_to_target(
+                    up,
+                    target,
+                    workspace_used=workspace_used,
+                )
+            except HTTPException:
+                raise
+            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                logger.warning(f"Failed reading upload file {up.filename}: {e}")
+                continue
+            written += file_bytes
             count += 1
 
     # Metrics
@@ -1044,9 +1152,24 @@ async def start_run(
         HTTPException: 409 with code "idempotency_conflict" when an idempotent request conflicts.
         HTTPException: 400 with code "invalid_spec_version" when the provided spec_version is unsupported.
     """
+    session = None
     if payload.session_id:
         _require_session_owner(payload.session_id, current_user)
-    files_inline = _service.parse_inline_files([f.dict() for f in (payload.files or [])])
+        session = _service.get_session(payload.session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="session_not_found")
+    try:
+        files_inline = _service.parse_inline_files([(f.model_dump() if hasattr(f, "model_dump") else f.dict()) for f in (payload.files or [])])
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": {
+                    "code": "invalid_inline_file",
+                    "message": str(e),
+                }
+            },
+        ) from e
     try:
         default_exec_to = int(getattr(app_settings, "SANDBOX_DEFAULT_EXEC_TIMEOUT_SEC", 300))
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
@@ -1057,17 +1180,71 @@ async def start_run(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
         default_startup_to = 20
 
+    payload_fields = _model_field_names(payload)
+    resource_fields = _model_field_names(payload.resources)
+
+    runtime = (CoreRuntimeType(payload.runtime) if payload.runtime else None) if "runtime" in payload_fields else None
+    if runtime is None and session is not None and session.runtime is not None:
+        runtime = session.runtime
+
+    base_image = payload.base_image if "base_image" in payload_fields else None
+    if base_image is None and session is not None and session.base_image:
+        base_image = session.base_image
+    if payload.session_id and not base_image:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": {
+                    "code": "session_base_image_required",
+                    "message": "Session-backed runs require a base_image",
+                }
+            },
+        )
+
+    env = dict(payload.env or {}) if "env" in payload_fields else (
+        dict(session.env or {}) if session is not None else {}
+    )
+    timeout_sec = int(payload.timeout_sec) if "timeout_sec" in payload_fields else (
+        int(session.timeout_sec) if session is not None and session.timeout_sec is not None else default_exec_to
+    )
+    cpu = (payload.resources.cpu if payload.resources else None) if "cpu" in resource_fields else (
+        session.cpu_limit if session is not None else None
+    )
+    memory_mb = (payload.resources.memory_mb if payload.resources else None) if "memory_mb" in resource_fields else (
+        session.memory_mb if session is not None else None
+    )
+    network_policy = payload.network_policy if "network_policy" in payload_fields else (
+        session.network_policy if session is not None else None
+    )
+    trust_level = (
+        CoreTrustLevel(payload.trust_level) if payload.trust_level else None
+    ) if "trust_level" in payload_fields else (
+        session.trust_level if session is not None else None
+    )
+    persona_id = payload.persona_id if "persona_id" in payload_fields else (
+        session.persona_id if session is not None else None
+    )
+    workspace_id = payload.workspace_id if "workspace_id" in payload_fields else (
+        session.workspace_id if session is not None else None
+    )
+    workspace_group_id = payload.workspace_group_id if "workspace_group_id" in payload_fields else (
+        session.workspace_group_id if session is not None else None
+    )
+    scope_snapshot_id = payload.scope_snapshot_id if "scope_snapshot_id" in payload_fields else (
+        session.scope_snapshot_id if session is not None else None
+    )
+
     spec = RunSpec(
         session_id=payload.session_id,
-        runtime=(CoreRuntimeType(payload.runtime) if payload.runtime else None),
-        base_image=payload.base_image,
+        runtime=runtime,
+        base_image=base_image,
         command=list(payload.command),
-        env=payload.env or {},
+        env=env,
         startup_timeout_sec=payload.startup_timeout_sec or default_startup_to,
-        timeout_sec=payload.timeout_sec or default_exec_to,
-        cpu=(payload.resources.cpu if payload.resources else None) if hasattr(payload, "resources") and payload.resources else None,
-        memory_mb=(payload.resources.memory_mb if payload.resources else None) if hasattr(payload, "resources") and payload.resources else None,
-        network_policy=payload.network_policy,
+        timeout_sec=timeout_sec,
+        cpu=cpu,
+        memory_mb=memory_mb,
+        network_policy=network_policy,
         files_inline=files_inline,
         capture_patterns=payload.capture_patterns or [],
         interactive=(bool(payload.interactive) if hasattr(payload, "interactive") and payload.interactive is not None else None),
@@ -1075,11 +1252,11 @@ async def start_run(
         stdin_max_frame_bytes=(int(payload.stdin_max_frame_bytes) if hasattr(payload, "stdin_max_frame_bytes") and payload.stdin_max_frame_bytes is not None else None),
         stdin_bps=(int(payload.stdin_bps) if hasattr(payload, "stdin_bps") and payload.stdin_bps is not None else None),
         stdin_idle_timeout_sec=(int(payload.stdin_idle_timeout_sec) if hasattr(payload, "stdin_idle_timeout_sec") and payload.stdin_idle_timeout_sec is not None else None),
-        trust_level=(CoreTrustLevel(payload.trust_level) if hasattr(payload, "trust_level") and payload.trust_level else None),
-        persona_id=payload.persona_id,
-        workspace_id=payload.workspace_id,
-        workspace_group_id=payload.workspace_group_id,
-        scope_snapshot_id=payload.scope_snapshot_id,
+        trust_level=trust_level,
+        persona_id=persona_id,
+        workspace_id=workspace_id,
+        workspace_group_id=workspace_group_id,
+        scope_snapshot_id=scope_snapshot_id,
     )
     # Scaffold: return immediate completed status without real execution
     try:
@@ -1532,10 +1709,19 @@ async def download_artifact(
         or ".." in raw
     ):
         raise HTTPException(status_code=400, detail="invalid_path")
-    data = _service._orch.get_artifact(run_id, path)  # type: ignore[attr-defined]
-    if data is None:
-        raise HTTPException(status_code=404, detail="artifact_not_found")
-    size = len(data)
+
+    artifact_path = _service._orch.get_artifact_path(run_id, path)  # type: ignore[attr-defined]
+    data = None
+    if artifact_path is not None:
+        try:
+            size = int(artifact_path.stat().st_size)
+        except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            raise HTTPException(status_code=404, detail="artifact_not_found") from None
+    else:
+        data = _service._orch.get_artifact(run_id, path)  # type: ignore[attr-defined]
+        if data is None:
+            raise HTTPException(status_code=404, detail="artifact_not_found")
+        size = len(data)
     ctype, _ = mimetypes.guess_type(path)
     ctype = ctype or "application/octet-stream"
 
@@ -1566,6 +1752,19 @@ async def download_artifact(
         except _SANDBOX_NONCRITICAL_EXCEPTIONS:
             return None
 
+    def _iter_artifact_file(file_path: str, start: int, end: int):
+        if end < start:
+            return
+        remaining = end - start + 1
+        with open(file_path, "rb") as handle:
+            handle.seek(start)
+            while remaining > 0:
+                chunk = handle.read(min(64 * 1024, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+                yield chunk
+
     headers = {"Accept-Ranges": "bytes"}
     if range_header:
         rng = _parse_range(range_header)
@@ -1573,14 +1772,27 @@ async def download_artifact(
             # Invalid or unsupported range
             return Response(status_code=416, headers={"Content-Range": f"bytes */{size}"})
         start, end = rng
-        chunk = data[start:end + 1]
+        chunk_len = end - start + 1
         headers.update({
             "Content-Range": f"bytes {start}-{end}/{size}",
-            "Content-Length": str(len(chunk)),
+            "Content-Length": str(chunk_len),
         })
-        return Response(content=chunk, media_type=ctype, headers=headers, status_code=206)
-    # Default: return full content
+        if artifact_path is not None:
+            return StreamingResponse(
+                _iter_artifact_file(str(artifact_path), start, end),
+                media_type=ctype,
+                headers=headers,
+                status_code=206,
+            )
+        return Response(content=data[start:end + 1], media_type=ctype, headers=headers, status_code=206)
+
     headers["Content-Length"] = str(size)
+    if artifact_path is not None:
+        return StreamingResponse(
+            _iter_artifact_file(str(artifact_path), 0, size - 1),
+            media_type=ctype,
+            headers=headers,
+        )
     return Response(content=data, media_type=ctype, headers=headers)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -309,6 +309,7 @@ class ACPSessionDetailResponse(ACPSessionInfo):
     """Detailed information about an ACP session, including message history."""
     messages: list[dict[str, Any]] = Field(default_factory=list, description="Message history (if available)")
     cwd: str | None = Field(default=None, description="Working directory for this session")
+    fork_lineage: list[str] = Field(default_factory=list, description="Ancestor session IDs from oldest to most recent parent")
 
 
 class ACPSessionForkRequest(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -417,21 +417,6 @@ class ACPPermissionPolicyListResponse(BaseModel):
 # -----------------------------------------------------------------------------
 
 
-class ACPHealthAgentStatus(BaseModel):
-    """Status of a single downstream agent."""
-    agent_type: str = Field(..., description="Agent type identifier")
-    status: str = Field(..., description="available | unavailable | requires_setup")
-    reason: str | None = Field(default=None, description="Explanation when not available")
-    missing_keys: list[str] = Field(default_factory=list, description="Missing environment variables")
-
-
-class ACPHealthRunnerProbe(BaseModel):
-    """Result of probing the runner process."""
-    status: str = Field(..., description="ok | not_running | skipped | error")
-    detail: str | None = Field(default=None)
-    agent_capabilities: dict[str, Any] | None = Field(default=None)
-
-
 class ACPHealthResponse(BaseModel):
     """ACP dependency chain health check response."""
     timestamp: str = Field(..., description="ISO 8601 timestamp")

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -413,6 +413,36 @@ class ACPPermissionPolicyListResponse(BaseModel):
 
 
 # -----------------------------------------------------------------------------
+# Health Check Response
+# -----------------------------------------------------------------------------
+
+
+class ACPHealthAgentStatus(BaseModel):
+    """Status of a single downstream agent."""
+    agent_type: str = Field(..., description="Agent type identifier")
+    status: str = Field(..., description="available | unavailable | requires_setup")
+    reason: str | None = Field(default=None, description="Explanation when not available")
+    missing_keys: list[str] = Field(default_factory=list, description="Missing environment variables")
+
+
+class ACPHealthRunnerProbe(BaseModel):
+    """Result of probing the runner process."""
+    status: str = Field(..., description="ok | not_running | skipped | error")
+    detail: str | None = Field(default=None)
+    agent_capabilities: dict[str, Any] | None = Field(default=None)
+
+
+class ACPHealthResponse(BaseModel):
+    """ACP dependency chain health check response."""
+    timestamp: str = Field(..., description="ISO 8601 timestamp")
+    runner: dict[str, Any] = Field(default_factory=dict, description="Runner binary status")
+    agents: list[dict[str, Any]] = Field(default_factory=list, description="Downstream agent statuses")
+    runner_probe: dict[str, Any] = Field(default_factory=dict, description="Runner process probe result")
+    overall: str = Field(default="unknown", description="ok | degraded | unavailable")
+    message: str | None = Field(default=None, description="Human-readable status message")
+
+
+# -----------------------------------------------------------------------------
 # Structured Error Responses
 # -----------------------------------------------------------------------------
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -4,6 +4,10 @@ from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+try:
+    from pydantic import model_validator
+except ImportError:  # pragma: no cover - pydantic v1 fallback
+    from pydantic import root_validator as model_validator  # type: ignore
 
 RuntimeType = Literal["docker", "firecracker", "lima"]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
@@ -60,6 +64,13 @@ class SandboxSession(BaseModel):
     id: str
     runtime: RuntimeType
     base_image: str | None = None
+    cpu_limit: float | None = None
+    memory_mb: int | None = None
+    timeout_sec: int | None = None
+    network_policy: Literal["deny_all", "allowlist"] | None = None
+    env: dict[str, str] | None = None
+    labels: dict[str, str] | None = None
+    trust_level: TrustLevelType | None = None
     expires_at: datetime | None = None
     policy_hash: str | None = None
     persona_id: str | None = None
@@ -114,6 +125,14 @@ class SandboxRunCreateRequest(BaseModel):
     workspace_id: str | None = Field(default=None, description="Optional workspace identifier bound to this run")
     workspace_group_id: str | None = Field(default=None, description="Optional workspace-group identifier bound to this run")
     scope_snapshot_id: str | None = Field(default=None, description="Optional scope snapshot identifier bound to this run")
+
+    @model_validator(mode="after")
+    def validate_session_or_base_image(self):
+        has_session = isinstance(self.session_id, str) and bool(self.session_id.strip())
+        has_image = isinstance(self.base_image, str) and bool(self.base_image.strip())
+        if has_session == has_image:
+            raise ValueError("Provide exactly one of session_id or base_image")
+        return self
 
 
 class SandboxRun(BaseModel):

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/__init__.py
@@ -1,4 +1,5 @@
 from .config import ACPRunnerConfig, ACPSandboxConfig, load_acp_runner_config, load_acp_sandbox_config
+
 from .runner_client import ACPRunnerClient, get_runner_client
 
 __all__ = [

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -1,0 +1,191 @@
+"""YAML-based global agent registry for ACP.
+
+Loads agent definitions from Config_Files/agents.yaml and provides
+runtime availability detection (binary on PATH, API keys set).
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+
+@dataclass
+class AgentRegistryEntry:
+    """A single agent entry from the registry."""
+    type: str
+    name: str
+    description: str = ""
+    command: str = ""
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
+    requires_api_key: str | None = None
+    default: bool = False
+
+    def check_availability(self) -> dict[str, Any]:
+        """Check runtime availability of this agent."""
+        result: dict[str, Any] = {
+            "type": self.type,
+            "name": self.name,
+            "description": self.description,
+        }
+
+        # Check binary
+        if self.command:
+            which_result = shutil.which(self.command)
+            result["binary_found"] = which_result is not None
+            if which_result:
+                result["binary_path"] = which_result
+        else:
+            result["binary_found"] = True  # No binary required (e.g., "custom")
+
+        # Check API key
+        if self.requires_api_key:
+            result["api_key_set"] = bool(os.getenv(self.requires_api_key))
+            if not result["api_key_set"]:
+                result["missing_api_key"] = self.requires_api_key
+        else:
+            result["api_key_set"] = True
+
+        # Overall status
+        if not result.get("binary_found"):
+            result["status"] = "unavailable"
+        elif not result.get("api_key_set"):
+            result["status"] = "requires_setup"
+        else:
+            result["status"] = "available"
+
+        result["is_configured"] = result["status"] == "available"
+        return result
+
+
+class AgentRegistry:
+    """Loads and caches agent entries from agents.yaml."""
+
+    def __init__(self, yaml_path: str | None = None) -> None:
+        if yaml_path is None:
+            yaml_path = os.path.join(
+                os.path.dirname(__file__),
+                "..", "..", "..", "Config_Files", "agents.yaml",
+            )
+        self._yaml_path = os.path.abspath(yaml_path)
+        self._entries: list[AgentRegistryEntry] = []
+        self._default_type: str = "custom"
+        self._last_load_time: float = 0
+        self._last_mtime: float = 0
+        self._reload_interval: float = 30.0  # seconds
+
+    def load(self) -> None:
+        """Load or reload the registry from YAML."""
+        if yaml is None:
+            logger.warning("PyYAML not installed — agent registry unavailable")
+            self._entries = []
+            return
+
+        if not os.path.isfile(self._yaml_path):
+            logger.warning("Agent registry file not found: {}", self._yaml_path)
+            self._entries = []
+            return
+
+        try:
+            with open(self._yaml_path, "r") as f:
+                data = yaml.safe_load(f)
+        except Exception as exc:
+            logger.error("Failed to load agent registry: {}", exc)
+            return
+
+        if not isinstance(data, dict):
+            logger.error("Agent registry is not a valid YAML mapping")
+            return
+
+        entries: list[AgentRegistryEntry] = []
+        default_type = "custom"
+
+        for item in data.get("agents", []):
+            if not isinstance(item, dict):
+                continue
+            agent_type = item.get("type")
+            name = item.get("name")
+            if not agent_type or not name:
+                continue
+            entry = AgentRegistryEntry(
+                type=str(agent_type),
+                name=str(name),
+                description=str(item.get("description", "")),
+                command=str(item.get("command", "")),
+                args=list(item.get("args", [])),
+                env=dict(item.get("env", {})),
+                requires_api_key=item.get("requires_api_key"),
+                default=bool(item.get("default", False)),
+            )
+            entries.append(entry)
+            if entry.default:
+                default_type = entry.type
+
+        self._entries = entries
+        self._default_type = default_type
+        self._last_load_time = time.time()
+        try:
+            self._last_mtime = os.path.getmtime(self._yaml_path)
+        except OSError:
+            pass
+        logger.debug("Loaded {} agents from registry", len(entries))
+
+    def _maybe_reload(self) -> None:
+        """Reload if the file has changed."""
+        now = time.time()
+        if now - self._last_load_time < self._reload_interval:
+            return
+        try:
+            current_mtime = os.path.getmtime(self._yaml_path)
+        except OSError:
+            return
+        if current_mtime != self._last_mtime:
+            logger.info("Agent registry file changed, reloading")
+            self.load()
+
+    @property
+    def entries(self) -> list[AgentRegistryEntry]:
+        """Get all registry entries, reloading if needed."""
+        if not self._entries:
+            self.load()
+        else:
+            self._maybe_reload()
+        return list(self._entries)
+
+    @property
+    def default_type(self) -> str:
+        if not self._entries:
+            self.load()
+        return self._default_type
+
+    def get_entry(self, agent_type: str) -> AgentRegistryEntry | None:
+        """Look up an entry by type."""
+        for entry in self.entries:
+            if entry.type == agent_type:
+                return entry
+        return None
+
+    def get_available_agents(self) -> list[dict[str, Any]]:
+        """Get all agents with runtime availability info."""
+        return [entry.check_availability() for entry in self.entries]
+
+
+# Module-level singleton
+_registry: AgentRegistry | None = None
+
+
+def get_agent_registry() -> AgentRegistry:
+    global _registry
+    if _registry is None:
+        _registry = AgentRegistry()
+    return _registry

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/config.py
@@ -17,6 +17,7 @@ class ACPRunnerConfig:
     env: dict[str, str] = field(default_factory=dict)
     cwd: str | None = None
     startup_timeout_sec: float = 10.0
+    binary_path: str | None = None
 
 
 @dataclass
@@ -25,6 +26,7 @@ class ACPSandboxConfig:
     runtime: str = "docker"
     base_image: str = "tldw/acp-agent:latest"
     network_policy: str = "deny_all"
+    allowed_egress_hosts: list[str] = field(default_factory=list)
     run_as_root: bool = False
     read_only_root: bool = True
     ssh_enabled: bool = True
@@ -36,6 +38,13 @@ class ACPSandboxConfig:
     agent_command: str = ""
     agent_args: list[str] = field(default_factory=list)
     agent_env: dict[str, str] = field(default_factory=dict)
+
+    # Session TTL and quotas
+    session_ttl_seconds: int = 86400  # 24h default
+    max_concurrent_sessions_per_user: int = 5
+    max_tokens_per_session: int = 1_000_000
+    max_session_duration_seconds: int = 14400  # 4h default
+    audit_retention_days: int = 30
 
 
 def _parse_args(raw: str | None) -> list[str]:
@@ -84,10 +93,17 @@ def _parse_env(raw: str | None) -> dict[str, str]:
 
 def load_acp_runner_config() -> ACPRunnerConfig:
     section = get_config_section("ACP")
+    binary_path = os.getenv("ACP_RUNNER_BINARY_PATH") or section.get("runner_binary_path")
     command = os.getenv("ACP_RUNNER_COMMAND") or section.get("runner_command", "")
     args_raw = os.getenv("ACP_RUNNER_ARGS") or section.get("runner_args", "")
     env_raw = os.getenv("ACP_RUNNER_ENV") or section.get("runner_env", "")
     cwd = os.getenv("ACP_RUNNER_CWD") or section.get("runner_cwd")
+
+    # If binary_path is set, use it as the command directly (shortcut)
+    if binary_path and not command:
+        command = str(binary_path)
+        args_raw = args_raw or ""
+        cwd = cwd or None
 
     timeout_raw = os.getenv("ACP_RUNNER_STARTUP_TIMEOUT_MS") or section.get(
         "startup_timeout_ms"
@@ -103,6 +119,7 @@ def load_acp_runner_config() -> ACPRunnerConfig:
         env=_parse_env(env_raw),
         cwd=str(cwd) if cwd else None,
         startup_timeout_sec=timeout_sec,
+        binary_path=str(binary_path) if binary_path else None,
     )
 
 
@@ -121,12 +138,31 @@ def _parse_int(raw: str | None, default: int) -> int:
         return default
 
 
+def _parse_string_list(raw: str | None) -> list[str]:
+    """Parse a comma-separated or JSON array string into a list of strings."""
+    if not raw:
+        return []
+    text = raw.strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            return [s.strip() for s in text.split(",") if s.strip()]
+        if isinstance(data, list):
+            return [str(item) for item in data]
+        return []
+    return [s.strip() for s in text.split(",") if s.strip()]
+
+
 def load_acp_sandbox_config() -> ACPSandboxConfig:
     section = get_config_section("ACP-SANDBOX")
     enabled = _parse_bool(os.getenv("ACP_SANDBOX_ENABLED") or section.get("enabled"), False)
     runtime = os.getenv("ACP_SANDBOX_RUNTIME") or section.get("runtime", "docker")
     base_image = os.getenv("ACP_SANDBOX_BASE_IMAGE") or section.get("base_image", "tldw/acp-agent:latest")
     network_policy = os.getenv("ACP_SANDBOX_NETWORK_POLICY") or section.get("network_policy", "deny_all")
+    allowed_egress_raw = os.getenv("ACP_SANDBOX_ALLOWED_EGRESS_HOSTS") or section.get("allowed_egress_hosts", "")
     run_as_root = _parse_bool(os.getenv("ACP_SANDBOX_RUN_AS_ROOT") or section.get("run_as_root"), False)
     read_only_root = _parse_bool(os.getenv("ACP_SANDBOX_READ_ONLY_ROOT") or section.get("read_only_root"), True)
     ssh_enabled = _parse_bool(os.getenv("ACP_SSH_ENABLED") or section.get("ssh_enabled"), True)
@@ -142,11 +178,29 @@ def load_acp_sandbox_config() -> ACPSandboxConfig:
     agent_args_raw = os.getenv("ACP_SANDBOX_AGENT_ARGS") or section.get("agent_args", "")
     agent_env_raw = os.getenv("ACP_SANDBOX_AGENT_ENV") or section.get("agent_env", "")
 
+    # Session management config
+    session_ttl = _parse_int(
+        os.getenv("ACP_SESSION_TTL_SECONDS") or section.get("session_ttl_seconds"), 86400
+    )
+    max_concurrent = _parse_int(
+        os.getenv("ACP_MAX_CONCURRENT_SESSIONS_PER_USER") or section.get("max_concurrent_sessions_per_user"), 5
+    )
+    max_tokens = _parse_int(
+        os.getenv("ACP_MAX_TOKENS_PER_SESSION") or section.get("max_tokens_per_session"), 1_000_000
+    )
+    max_duration = _parse_int(
+        os.getenv("ACP_MAX_SESSION_DURATION_SECONDS") or section.get("max_session_duration_seconds"), 14400
+    )
+    audit_retention = _parse_int(
+        os.getenv("ACP_AUDIT_RETENTION_DAYS") or section.get("audit_retention_days"), 30
+    )
+
     return ACPSandboxConfig(
         enabled=bool(enabled),
         runtime=str(runtime or "docker"),
         base_image=str(base_image or "tldw/acp-agent:latest"),
         network_policy=str(network_policy or "deny_all"),
+        allowed_egress_hosts=_parse_string_list(allowed_egress_raw),
         run_as_root=bool(run_as_root),
         read_only_root=bool(read_only_root),
         ssh_enabled=bool(ssh_enabled),
@@ -158,4 +212,9 @@ def load_acp_sandbox_config() -> ACPSandboxConfig:
         agent_command=str(agent_command or ""),
         agent_args=_parse_args(agent_args_raw),
         agent_env=_parse_env(agent_env_raw),
+        session_ttl_seconds=session_ttl,
+        max_concurrent_sessions_per_user=max_concurrent,
+        max_tokens_per_session=max_tokens,
+        max_session_duration_seconds=max_duration,
+        audit_retention_days=audit_retention,
     )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/metrics.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/metrics.py
@@ -1,0 +1,178 @@
+"""ACP observability metrics.
+
+Registers ACP-specific counters and gauges with the unified MetricsRegistry
+so they appear on the ``/metrics`` Prometheus endpoint.
+"""
+from __future__ import annotations
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Metrics import (
+    MetricDefinition,
+    MetricType,
+    get_metrics_registry,
+    increment_counter,
+    set_gauge,
+    observe_histogram,
+)
+
+
+_ACP_METRICS_REGISTERED = False
+
+
+def _ensure_registered() -> None:
+    """Lazily register ACP metrics on first use."""
+    global _ACP_METRICS_REGISTERED
+    if _ACP_METRICS_REGISTERED:
+        return
+
+    registry = get_metrics_registry()
+
+    defs = [
+        MetricDefinition(
+            name="acp_active_sessions",
+            type=MetricType.GAUGE,
+            description="Number of currently active ACP sessions",
+            labels=["agent_type"],
+        ),
+        MetricDefinition(
+            name="acp_sessions_created_total",
+            type=MetricType.COUNTER,
+            description="Total number of ACP sessions created",
+            labels=["agent_type"],
+        ),
+        MetricDefinition(
+            name="acp_sessions_closed_total",
+            type=MetricType.COUNTER,
+            description="Total number of ACP sessions closed",
+            labels=["reason"],
+        ),
+        MetricDefinition(
+            name="acp_prompts_total",
+            type=MetricType.COUNTER,
+            description="Total prompts sent to ACP agents",
+            labels=["agent_type"],
+        ),
+        MetricDefinition(
+            name="acp_prompt_latency_seconds",
+            type=MetricType.HISTOGRAM,
+            description="ACP prompt response latency in seconds",
+            labels=["agent_type"],
+        ),
+        MetricDefinition(
+            name="acp_token_usage_total",
+            type=MetricType.COUNTER,
+            description="Total tokens consumed by ACP sessions",
+            labels=["agent_type", "direction"],
+        ),
+        MetricDefinition(
+            name="acp_governance_blocks_total",
+            type=MetricType.COUNTER,
+            description="Total governance policy blocks",
+            labels=["policy", "agent_type"],
+        ),
+        MetricDefinition(
+            name="acp_errors_total",
+            type=MetricType.COUNTER,
+            description="Total ACP errors",
+            labels=["error_type"],
+        ),
+        MetricDefinition(
+            name="acp_quota_rejections_total",
+            type=MetricType.COUNTER,
+            description="Total quota-based rejections (429s)",
+            labels=["quota_type"],
+        ),
+        MetricDefinition(
+            name="acp_orchestration_tasks_total",
+            type=MetricType.COUNTER,
+            description="Total orchestration tasks created",
+            labels=["status"],
+        ),
+        MetricDefinition(
+            name="acp_orchestration_runs_total",
+            type=MetricType.COUNTER,
+            description="Total orchestration runs dispatched",
+            labels=["status"],
+        ),
+    ]
+
+    for d in defs:
+        try:
+            registry.register_metric(d)
+        except Exception:
+            pass  # Already registered
+
+    _ACP_METRICS_REGISTERED = True
+    logger.debug("ACP metrics registered with MetricsRegistry")
+
+
+# ---- Convenience wrappers ----
+
+
+def record_session_created(agent_type: str = "unknown") -> None:
+    _ensure_registered()
+    increment_counter("acp_sessions_created_total", labels={"agent_type": agent_type})
+
+
+def record_session_closed(reason: str = "normal") -> None:
+    _ensure_registered()
+    increment_counter("acp_sessions_closed_total", labels={"reason": reason})
+
+
+def set_active_sessions(count: int, agent_type: str = "all") -> None:
+    _ensure_registered()
+    set_gauge("acp_active_sessions", count, labels={"agent_type": agent_type})
+
+
+def record_prompt(agent_type: str = "unknown") -> None:
+    _ensure_registered()
+    increment_counter("acp_prompts_total", labels={"agent_type": agent_type})
+
+
+def record_prompt_latency(seconds: float, agent_type: str = "unknown") -> None:
+    _ensure_registered()
+    observe_histogram(
+        "acp_prompt_latency_seconds", seconds, labels={"agent_type": agent_type}
+    )
+
+
+def record_token_usage(
+    tokens: int, agent_type: str = "unknown", direction: str = "total"
+) -> None:
+    _ensure_registered()
+    increment_counter(
+        "acp_token_usage_total",
+        value=tokens,
+        labels={"agent_type": agent_type, "direction": direction},
+    )
+
+
+def record_governance_block(policy: str, agent_type: str = "unknown") -> None:
+    _ensure_registered()
+    increment_counter(
+        "acp_governance_blocks_total",
+        labels={"policy": policy, "agent_type": agent_type},
+    )
+
+
+def record_error(error_type: str = "unknown") -> None:
+    _ensure_registered()
+    increment_counter("acp_errors_total", labels={"error_type": error_type})
+
+
+def record_quota_rejection(quota_type: str = "concurrent_sessions") -> None:
+    _ensure_registered()
+    increment_counter(
+        "acp_quota_rejections_total", labels={"quota_type": quota_type}
+    )
+
+
+def record_orchestration_task(status: str = "created") -> None:
+    _ensure_registered()
+    increment_counter("acp_orchestration_tasks_total", labels={"status": status})
+
+
+def record_orchestration_run(status: str = "dispatched") -> None:
+    _ensure_registered()
+    increment_counter("acp_orchestration_runs_total", labels={"status": status})

--- a/tldw_Server_API/app/core/Agent_Orchestration/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/__init__.py
@@ -1,0 +1,1 @@
+"""Agent Orchestration — project/task management for ACP agents."""

--- a/tldw_Server_API/app/core/Agent_Orchestration/models.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/models.py
@@ -1,0 +1,138 @@
+"""Data models and state machine for Agent Orchestration.
+
+State machine:
+    todo → inprogress → review → complete
+                  ↘                  ↗
+                    → triage --------→
+
+Tasks have optional dependencies: a task with dependency_id can't
+start until the dependency is 'complete'.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class TaskStatus(str, Enum):
+    TODO = "todo"
+    IN_PROGRESS = "inprogress"
+    REVIEW = "review"
+    COMPLETE = "complete"
+    TRIAGE = "triage"
+
+
+# Valid transitions in the state machine
+_VALID_TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
+    TaskStatus.TODO: {TaskStatus.IN_PROGRESS},
+    TaskStatus.IN_PROGRESS: {TaskStatus.REVIEW, TaskStatus.TRIAGE},
+    TaskStatus.REVIEW: {TaskStatus.COMPLETE, TaskStatus.TRIAGE, TaskStatus.IN_PROGRESS},
+    TaskStatus.TRIAGE: {TaskStatus.TODO, TaskStatus.IN_PROGRESS},
+    TaskStatus.COMPLETE: set(),  # Terminal state
+}
+
+
+def is_valid_transition(from_status: TaskStatus, to_status: TaskStatus) -> bool:
+    """Check if a status transition is allowed."""
+    return to_status in _VALID_TRANSITIONS.get(from_status, set())
+
+
+class RunStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class AgentProject:
+    """A project grouping related tasks."""
+    id: int
+    name: str
+    description: str = ""
+    user_id: int = 0
+    created_at: str = ""
+    updated_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "user_id": self.user_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class AgentTask:
+    """A single task within a project."""
+    id: int
+    project_id: int
+    title: str
+    description: str = ""
+    status: TaskStatus = TaskStatus.TODO
+    agent_type: str | None = None
+    dependency_id: int | None = None
+    reviewer_agent_type: str | None = None
+    max_review_attempts: int = 3
+    review_count: int = 0
+    success_criteria: str = ""
+    user_id: int = 0
+    created_at: str = ""
+    updated_at: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "title": self.title,
+            "description": self.description,
+            "status": self.status.value,
+            "agent_type": self.agent_type,
+            "dependency_id": self.dependency_id,
+            "reviewer_agent_type": self.reviewer_agent_type,
+            "max_review_attempts": self.max_review_attempts,
+            "review_count": self.review_count,
+            "success_criteria": self.success_criteria,
+            "user_id": self.user_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class AgentRun:
+    """A single execution run of a task."""
+    id: int
+    task_id: int
+    session_id: str | None = None
+    status: RunStatus = RunStatus.PENDING
+    agent_type: str | None = None
+    started_at: str | None = None
+    completed_at: str | None = None
+    result_summary: str = ""
+    error: str | None = None
+    token_usage: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "task_id": self.task_id,
+            "session_id": self.session_id,
+            "status": self.status.value,
+            "agent_type": self.agent_type,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "result_summary": self.result_summary,
+            "error": self.error,
+            "token_usage": dict(self.token_usage),
+        }

--- a/tldw_Server_API/app/core/Agent_Orchestration/orchestration_service.py
+++ b/tldw_Server_API/app/core/Agent_Orchestration/orchestration_service.py
@@ -1,0 +1,295 @@
+"""In-memory orchestration service for agent projects, tasks, and runs.
+
+Provides CRUD operations, dependency gating, cycle detection,
+and reviewer gate logic. A future iteration can persist to SQLite.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from .models import (
+    AgentProject,
+    AgentRun,
+    AgentTask,
+    RunStatus,
+    TaskStatus,
+    is_valid_transition,
+)
+
+
+class CycleDependencyError(ValueError):
+    """Raised when a task dependency would create a cycle."""
+
+
+class OrchestrationService:
+    """In-memory orchestration service."""
+
+    def __init__(self) -> None:
+        self._projects: dict[int, AgentProject] = {}
+        self._tasks: dict[int, AgentTask] = {}
+        self._runs: dict[int, AgentRun] = {}
+        self._project_seq = 0
+        self._task_seq = 0
+        self._run_seq = 0
+        self._lock = asyncio.Lock()
+
+    # -- Projects --
+
+    async def create_project(
+        self, name: str, description: str = "", user_id: int = 0, metadata: dict[str, Any] | None = None,
+    ) -> AgentProject:
+        async with self._lock:
+            self._project_seq += 1
+            now = datetime.now(timezone.utc).isoformat()
+            project = AgentProject(
+                id=self._project_seq,
+                name=name,
+                description=description,
+                user_id=user_id,
+                created_at=now,
+                metadata=metadata or {},
+            )
+            self._projects[project.id] = project
+        return project
+
+    async def get_project(self, project_id: int) -> AgentProject | None:
+        return self._projects.get(project_id)
+
+    async def list_projects(self, user_id: int | None = None) -> list[AgentProject]:
+        results = list(self._projects.values())
+        if user_id is not None:
+            results = [p for p in results if p.user_id == user_id]
+        results.sort(key=lambda p: p.created_at, reverse=True)
+        return results
+
+    async def delete_project(self, project_id: int) -> bool:
+        async with self._lock:
+            if project_id not in self._projects:
+                return False
+            # Delete associated tasks and runs
+            task_ids = [t.id for t in self._tasks.values() if t.project_id == project_id]
+            for tid in task_ids:
+                run_ids = [r.id for r in self._runs.values() if r.task_id == tid]
+                for rid in run_ids:
+                    del self._runs[rid]
+                del self._tasks[tid]
+            del self._projects[project_id]
+        return True
+
+    # -- Tasks --
+
+    def _detect_cycle(self, task_id: int, dependency_id: int) -> bool:
+        """Check if adding dependency_id as a dependency of task_id would create a cycle."""
+        visited: set[int] = set()
+        current = dependency_id
+        while current is not None:
+            if current == task_id:
+                return True
+            if current in visited:
+                return False  # Hit a non-cyclic loop
+            visited.add(current)
+            dep_task = self._tasks.get(current)
+            if dep_task is None:
+                return False
+            current = dep_task.dependency_id
+        return False
+
+    async def create_task(
+        self,
+        project_id: int,
+        title: str,
+        description: str = "",
+        agent_type: str | None = None,
+        dependency_id: int | None = None,
+        reviewer_agent_type: str | None = None,
+        max_review_attempts: int = 3,
+        success_criteria: str = "",
+        user_id: int = 0,
+        metadata: dict[str, Any] | None = None,
+    ) -> AgentTask:
+        async with self._lock:
+            if project_id not in self._projects:
+                raise ValueError(f"Project {project_id} not found")
+            if dependency_id is not None:
+                if dependency_id not in self._tasks:
+                    raise ValueError(f"Dependency task {dependency_id} not found")
+                # Cycle detection (use temp task_id = next seq)
+                temp_id = self._task_seq + 1
+                if self._detect_cycle(temp_id, dependency_id):
+                    raise CycleDependencyError(
+                        f"Adding dependency {dependency_id} would create a cycle"
+                    )
+            self._task_seq += 1
+            now = datetime.now(timezone.utc).isoformat()
+            task = AgentTask(
+                id=self._task_seq,
+                project_id=project_id,
+                title=title,
+                description=description,
+                agent_type=agent_type,
+                dependency_id=dependency_id,
+                reviewer_agent_type=reviewer_agent_type,
+                max_review_attempts=max_review_attempts,
+                success_criteria=success_criteria,
+                user_id=user_id,
+                created_at=now,
+                metadata=metadata or {},
+            )
+            self._tasks[task.id] = task
+        return task
+
+    async def get_task(self, task_id: int) -> AgentTask | None:
+        return self._tasks.get(task_id)
+
+    async def list_tasks(
+        self, project_id: int, status: TaskStatus | None = None,
+    ) -> list[AgentTask]:
+        results = [t for t in self._tasks.values() if t.project_id == project_id]
+        if status is not None:
+            results = [t for t in results if t.status == status]
+        results.sort(key=lambda t: t.created_at)
+        return results
+
+    async def transition_task(self, task_id: int, new_status: TaskStatus) -> AgentTask:
+        """Transition a task to a new status, enforcing the state machine."""
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise ValueError(f"Task {task_id} not found")
+            if not is_valid_transition(task.status, new_status):
+                raise ValueError(
+                    f"Invalid transition: {task.status.value} → {new_status.value}"
+                )
+            task.status = new_status
+            task.updated_at = datetime.now(timezone.utc).isoformat()
+        return task
+
+    async def check_dependency_ready(self, task_id: int) -> bool:
+        """Check if a task's dependency is complete (or has no dependency)."""
+        task = self._tasks.get(task_id)
+        if task is None:
+            return False
+        if task.dependency_id is None:
+            return True
+        dep = self._tasks.get(task.dependency_id)
+        if dep is None:
+            return False
+        return dep.status == TaskStatus.COMPLETE
+
+    # -- Runs --
+
+    async def create_run(
+        self, task_id: int, agent_type: str | None = None, session_id: str | None = None,
+    ) -> AgentRun:
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise ValueError(f"Task {task_id} not found")
+            self._run_seq += 1
+            now = datetime.now(timezone.utc).isoformat()
+            run = AgentRun(
+                id=self._run_seq,
+                task_id=task_id,
+                session_id=session_id,
+                agent_type=agent_type or task.agent_type,
+                started_at=now,
+                status=RunStatus.RUNNING,
+            )
+            self._runs[run.id] = run
+        return run
+
+    async def complete_run(
+        self, run_id: int, result_summary: str = "", token_usage: dict[str, int] | None = None,
+    ) -> AgentRun:
+        async with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                raise ValueError(f"Run {run_id} not found")
+            run.status = RunStatus.COMPLETED
+            run.completed_at = datetime.now(timezone.utc).isoformat()
+            run.result_summary = result_summary
+            if token_usage:
+                run.token_usage = token_usage
+        return run
+
+    async def fail_run(self, run_id: int, error: str = "") -> AgentRun:
+        async with self._lock:
+            run = self._runs.get(run_id)
+            if run is None:
+                raise ValueError(f"Run {run_id} not found")
+            run.status = RunStatus.FAILED
+            run.completed_at = datetime.now(timezone.utc).isoformat()
+            run.error = error
+        return run
+
+    async def list_runs(self, task_id: int) -> list[AgentRun]:
+        results = [r for r in self._runs.values() if r.task_id == task_id]
+        results.sort(key=lambda r: r.started_at or "", reverse=True)
+        return results
+
+    # -- Reviewer Gate --
+
+    async def submit_review(
+        self, task_id: int, approved: bool, feedback: str = "",
+    ) -> AgentTask:
+        """Submit a review result. Approved → complete, rejected → back to inprogress or triage."""
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise ValueError(f"Task {task_id} not found")
+            if task.status != TaskStatus.REVIEW:
+                raise ValueError(f"Task {task_id} is not in review status")
+
+            task.review_count += 1
+            now = datetime.now(timezone.utc).isoformat()
+            task.updated_at = now
+
+            if approved:
+                task.status = TaskStatus.COMPLETE
+                logger.info("Task {} approved after {} review(s)", task_id, task.review_count)
+            else:
+                if task.review_count >= task.max_review_attempts:
+                    task.status = TaskStatus.TRIAGE
+                    logger.warning(
+                        "Task {} sent to triage after {} failed review(s)",
+                        task_id, task.review_count,
+                    )
+                else:
+                    task.status = TaskStatus.IN_PROGRESS
+                    logger.info(
+                        "Task {} rejected (review {}/{}), returning to in_progress",
+                        task_id, task.review_count, task.max_review_attempts,
+                    )
+        return task
+
+    # -- Summary --
+
+    async def get_project_summary(self, project_id: int) -> dict[str, Any]:
+        """Get task counts by status for a project."""
+        tasks = await self.list_tasks(project_id)
+        counts: dict[str, int] = {}
+        for task in tasks:
+            counts[task.status.value] = counts.get(task.status.value, 0) + 1
+        return {
+            "project_id": project_id,
+            "total_tasks": len(tasks),
+            "status_counts": counts,
+        }
+
+
+# Module-level singleton
+_service: OrchestrationService | None = None
+_service_lock = asyncio.Lock()
+
+
+async def get_orchestration_service() -> OrchestrationService:
+    global _service
+    if _service is None:
+        async with _service_lock:
+            if _service is None:
+                _service = OrchestrationService()
+    return _service

--- a/tldw_Server_API/app/core/DB_Management/ACP_Audit_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Audit_DB.py
@@ -99,6 +99,13 @@ class ACPAuditDB:
             self._write_buffer.append(event)
         return event
 
+    def flush_if_needed(self, threshold: int = 10) -> int:
+        """Flush if buffer has reached threshold. Returns count written or 0."""
+        with self._buffer_lock:
+            if len(self._write_buffer) < threshold:
+                return 0
+        return self.flush()
+
     def flush(self) -> int:
         """Flush buffered events to SQLite. Returns count written."""
         with self._buffer_lock:

--- a/tldw_Server_API/app/core/DB_Management/ACP_Audit_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Audit_DB.py
@@ -1,0 +1,236 @@
+"""SQLite-backed ACP audit event persistence.
+
+Provides durable audit logging for ACP sessions with configurable retention.
+Uses a simple single-table schema optimized for append-heavy workloads.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS acp_audit_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    user_id INTEGER NOT NULL,
+    payload_json TEXT DEFAULT '{}',
+    created_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_acp_audit_session ON acp_audit_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_acp_audit_user ON acp_audit_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_acp_audit_ts ON acp_audit_events(created_at);
+"""
+
+
+class ACPAuditDB:
+    """SQLite-backed audit event store with in-memory hot cache."""
+
+    def __init__(
+        self,
+        db_path: str | None = None,
+        hot_cache_size: int = 5000,
+        retention_days: int = 30,
+    ) -> None:
+        if db_path is None:
+            db_path = os.path.join(
+                os.path.dirname(__file__),
+                "..", "..", "..", "Databases", "acp_audit.db",
+            )
+        self._db_path = os.path.abspath(db_path)
+        self._retention_days = retention_days
+        self._hot_cache: deque[dict[str, Any]] = deque(maxlen=hot_cache_size)
+        self._write_buffer: list[dict[str, Any]] = []
+        self._buffer_lock = threading.Lock()
+        self._conn_local = threading.local()
+        self._initialized = False
+        self._init_lock = threading.Lock()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Get a thread-local SQLite connection."""
+        conn = getattr(self._conn_local, "conn", None)
+        if conn is None:
+            os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
+            conn = sqlite3.connect(self._db_path, timeout=10)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA synchronous=NORMAL")
+            self._conn_local.conn = conn
+        return conn
+
+    def _ensure_schema(self) -> None:
+        """Create tables if needed (idempotent)."""
+        if self._initialized:
+            return
+        with self._init_lock:
+            if self._initialized:
+                return
+            conn = self._get_conn()
+            conn.executescript(_SCHEMA_SQL)
+            conn.commit()
+            self._initialized = True
+
+    def record_event(
+        self,
+        *,
+        action: str,
+        user_id: int,
+        session_id: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Record an audit event. Adds to hot cache and write buffer."""
+        event = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "action": str(action),
+            "user_id": int(user_id),
+            "session_id": str(session_id),
+            "metadata": dict(metadata or {}),
+        }
+        self._hot_cache.append(event)
+        with self._buffer_lock:
+            self._write_buffer.append(event)
+        return event
+
+    def flush(self) -> int:
+        """Flush buffered events to SQLite. Returns count written."""
+        with self._buffer_lock:
+            if not self._write_buffer:
+                return 0
+            batch = list(self._write_buffer)
+            self._write_buffer.clear()
+
+        self._ensure_schema()
+        conn = self._get_conn()
+        try:
+            conn.executemany(
+                "INSERT INTO acp_audit_events (timestamp, event_type, session_id, user_id, payload_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (
+                        e["timestamp"],
+                        e["action"],
+                        e["session_id"],
+                        e["user_id"],
+                        json.dumps(e.get("metadata", {})),
+                    )
+                    for e in batch
+                ],
+            )
+            conn.commit()
+            return len(batch)
+        except sqlite3.Error as exc:
+            logger.error("ACP audit flush failed: {}", exc)
+            # Re-buffer failed events
+            with self._buffer_lock:
+                self._write_buffer = batch + self._write_buffer
+            return 0
+
+    def query_events(
+        self,
+        *,
+        session_id: str | None = None,
+        user_id: int | None = None,
+        action: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Query persisted events from SQLite."""
+        self._ensure_schema()
+        conn = self._get_conn()
+        conditions: list[str] = []
+        params: list[Any] = []
+        if session_id:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+        if user_id is not None:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+        if action:
+            conditions.append("event_type = ?")
+            params.append(action)
+
+        where = " AND ".join(conditions) if conditions else "1=1"
+        sql = f"SELECT timestamp, event_type, session_id, user_id, payload_json FROM acp_audit_events WHERE {where} ORDER BY id DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+
+        cursor = conn.execute(sql, params)
+        results = []
+        for row in cursor.fetchall():
+            try:
+                payload = json.loads(row[4]) if row[4] else {}
+            except (json.JSONDecodeError, TypeError):
+                payload = {}
+            results.append({
+                "timestamp": row[0],
+                "action": row[1],
+                "session_id": row[2],
+                "user_id": row[3],
+                "metadata": payload,
+            })
+        return results
+
+    def get_hot_cache(self, *, session_id: str | None = None) -> list[dict[str, Any]]:
+        """Get events from in-memory hot cache."""
+        if session_id:
+            return [
+                dict(e) for e in self._hot_cache
+                if str(e.get("session_id")) == str(session_id)
+            ]
+        return [dict(e) for e in self._hot_cache]
+
+    def purge_old_events(self) -> int:
+        """Remove events older than retention_days. Returns count deleted."""
+        self._ensure_schema()
+        conn = self._get_conn()
+        cutoff = time.time() - (self._retention_days * 86400)
+        cursor = conn.execute(
+            "DELETE FROM acp_audit_events WHERE created_at < ?",
+            (cutoff,),
+        )
+        conn.commit()
+        deleted = cursor.rowcount
+        if deleted:
+            logger.info("Purged {} old ACP audit events (retention={}d)", deleted, self._retention_days)
+        return deleted
+
+    def close(self) -> None:
+        """Close the thread-local connection."""
+        conn = getattr(self._conn_local, "conn", None)
+        if conn:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+            self._conn_local.conn = None
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_audit_db: ACPAuditDB | None = None
+_audit_db_lock = threading.Lock()
+
+
+def get_acp_audit_db(
+    db_path: str | None = None,
+    retention_days: int = 30,
+) -> ACPAuditDB:
+    """Get or create the module-level ACPAuditDB singleton."""
+    global _audit_db
+    if _audit_db is None:
+        with _audit_db_lock:
+            if _audit_db is None:
+                _audit_db = ACPAuditDB(
+                    db_path=db_path,
+                    retention_days=retention_days,
+                )
+    return _audit_db

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -21,6 +21,7 @@ from loguru import logger
 
 from ....Sandbox.models import RunSpec
 from ....Sandbox.models import RuntimeType as SbxRuntimeType
+from ....Sandbox.models import TrustLevel
 from ....Sandbox.service import SandboxService
 from ..base import BaseModule
 
@@ -64,12 +65,17 @@ class SandboxModule(BaseModule):
                             }
                         },
                         "timeout_sec": {"type": "integer", "minimum": 1},
+                        "cpu": {"type": "number", "minimum": 0},
+                        "memory_mb": {"type": "integer", "minimum": 64},
+                        "network_policy": {"type": "string", "enum": ["deny_all", "allowlist"]},
                         "env": {"type": "object"},
+                        "trust_level": {"type": "string", "enum": ["trusted", "standard", "untrusted"]},
                         "persona_id": {"type": "string"},
                         "workspace_id": {"type": "string"},
                         "workspace_group_id": {"type": "string"},
                         "scope_snapshot_id": {"type": "string"},
-                        "spec_version": {"type": "string"}
+                        "spec_version": {"type": "string"},
+                        "idempotency_key": {"type": "string"},
                     },
                     "oneOf": [
                         {"required": ["session_id", "command"]},
@@ -89,61 +95,97 @@ class SandboxModule(BaseModule):
         # Validate strictly (write-capable tool)
         self.validate_tool_arguments(tool_name, args)
 
-        # Prepare RunSpec
-        runtime_raw = (args.get("runtime") or "").strip().lower()
-        runtime: SbxRuntimeType | None = None
-        if runtime_raw in ("docker", "firecracker", "lima"):
-            runtime = SbxRuntimeType(runtime_raw)
-        # files (inline)
-        files_inline: list[tuple[str, bytes]] = []
-        for f in (args.get("files") or []):
-            try:
-                p = str(f.get("path", ""))
-                b64 = str(f.get("content_b64", ""))
-                data = base64.b64decode(b64)
-                files_inline.append((p, data))
-            except (TypeError, ValueError, binascii.Error, AttributeError) as exc:
-                logger.debug("sandbox.run: skipping invalid inline file payload: {}", exc)
-                continue
-        command = [str(x) for x in (args.get("command") or [])]
+        # Require authenticated principal binding; no synthetic fallback identity.
+        user_id = getattr(context, "user_id", None) if context is not None else None
+        if user_id is None or not str(user_id).strip():
+            raise PermissionError("sandbox.run requires an authenticated user context")
+        user_id = str(user_id)
+
+        runtime = self._coerce_runtime(args.get("runtime"))
+        base_image = (str(args.get("base_image")).strip() if args.get("base_image") is not None else None) or None
         env = args.get("env") or {}
         if not isinstance(env, dict):
             env = {}
         timeout = int(args.get("timeout_sec") or 300)
+        cpu = float(args.get("cpu")) if args.get("cpu") is not None else None
+        memory_mb = int(args.get("memory_mb")) if args.get("memory_mb") is not None else None
+        network_policy = (str(args.get("network_policy")).strip() if args.get("network_policy") is not None else None) or None
+        trust_level = self._coerce_trust_level(args.get("trust_level"))
+        persona_id = (str(args.get("persona_id")) if args.get("persona_id") is not None else None)
+        workspace_id = (str(args.get("workspace_id")) if args.get("workspace_id") is not None else None)
+        workspace_group_id = (str(args.get("workspace_group_id")) if args.get("workspace_group_id") is not None else None)
+        scope_snapshot_id = (str(args.get("scope_snapshot_id")) if args.get("scope_snapshot_id") is not None else None)
+
+        session_id = args.get("session_id")
+        if session_id is not None:
+            session_id = str(session_id).strip() or None
+        if session_id:
+            owner = self._svc.get_session_owner(session_id)
+            if owner is None:
+                raise ValueError("session_not_found")
+            if not self._is_admin(context) and str(owner) != user_id:
+                raise PermissionError("sandbox.run session not found")
+            session = self._svc.get_session(session_id)
+            if session is None:
+                raise ValueError("session_not_found")
+            if "runtime" not in args and session.runtime is not None:
+                runtime = session.runtime
+            if "base_image" not in args and session.base_image:
+                base_image = session.base_image
+            if "env" not in args:
+                env = dict(session.env or {})
+            if "timeout_sec" not in args and session.timeout_sec is not None:
+                timeout = int(session.timeout_sec)
+            if "cpu" not in args and session.cpu_limit is not None:
+                cpu = float(session.cpu_limit)
+            if "memory_mb" not in args and session.memory_mb is not None:
+                memory_mb = int(session.memory_mb)
+            if "network_policy" not in args and session.network_policy:
+                network_policy = str(session.network_policy)
+            if "trust_level" not in args and session.trust_level is not None:
+                trust_level = session.trust_level
+            if "persona_id" not in args and session.persona_id is not None:
+                persona_id = str(session.persona_id)
+            if "workspace_id" not in args and session.workspace_id is not None:
+                workspace_id = str(session.workspace_id)
+            if "workspace_group_id" not in args and session.workspace_group_id is not None:
+                workspace_group_id = str(session.workspace_group_id)
+            if "scope_snapshot_id" not in args and session.scope_snapshot_id is not None:
+                scope_snapshot_id = str(session.scope_snapshot_id)
+            if not base_image:
+                raise ValueError("session-backed runs require a base_image")
+
+        files_inline = self._decode_inline_files(args.get("files") or [])
+        command = [str(x) for x in (args.get("command") or [])]
         spec = RunSpec(
-            session_id=args.get("session_id"),
+            session_id=session_id,
             runtime=runtime,
-            base_image=args.get("base_image"),
+            base_image=base_image,
             command=command,
             env={str(k): str(v) for k, v in env.items()},
             timeout_sec=timeout,
-            cpu=None,
-            memory_mb=None,
-            network_policy=None,
+            cpu=cpu,
+            memory_mb=memory_mb,
+            network_policy=network_policy,
             files_inline=files_inline,
             capture_patterns=[],
-            persona_id=(str(args.get("persona_id")) if args.get("persona_id") is not None else None),
-            workspace_id=(str(args.get("workspace_id")) if args.get("workspace_id") is not None else None),
-            workspace_group_id=(str(args.get("workspace_group_id")) if args.get("workspace_group_id") is not None else None),
-            scope_snapshot_id=(str(args.get("scope_snapshot_id")) if args.get("scope_snapshot_id") is not None else None),
+            trust_level=trust_level,
+            persona_id=persona_id,
+            workspace_id=workspace_id,
+            workspace_group_id=workspace_group_id,
+            scope_snapshot_id=scope_snapshot_id,
         )
 
-        # Spec version
         spec_version = str(args.get("spec_version") or "1.0")
-        # Idempotency optional
         idem_key = None
         try:
             idem_key = str(args.get("idempotency_key") or args.get("idempotencyKey") or "") or None
         except Exception:
             idem_key = None
 
-        # Require authenticated principal binding; no synthetic fallback identity.
-        user_id = getattr(context, "user_id", None) if context is not None else None
-        if user_id is None or not str(user_id).strip():
-            raise PermissionError("sandbox.run requires an authenticated user context")
         try:
             status = self._svc.start_run_scaffold(
-                user_id=str(user_id),
+                user_id=user_id,
                 spec=spec,
                 spec_version=spec_version,
                 idem_key=idem_key,
@@ -176,6 +218,41 @@ class SandboxModule(BaseModule):
             "workspace_group_id": status.workspace_group_id,
             "scope_snapshot_id": status.scope_snapshot_id,
         }
+
+    def _is_admin(self, context: Any | None) -> bool:
+        try:
+            if bool(getattr(context, "is_admin", False)):
+                return True
+            roles = (getattr(context, "metadata", {}) or {}).get("roles")
+            if isinstance(roles, str):
+                roles = [roles]
+            return isinstance(roles, list) and any(str(r).lower() == "admin" for r in roles)
+        except Exception:
+            return False
+
+    def _coerce_runtime(self, value: Any) -> SbxRuntimeType | None:
+        runtime_raw = (str(value).strip().lower() if value is not None else "")
+        if runtime_raw in ("docker", "firecracker", "lima"):
+            return SbxRuntimeType(runtime_raw)
+        return None
+
+    def _coerce_trust_level(self, value: Any) -> TrustLevel | None:
+        trust_raw = (str(value).strip().lower() if value is not None else "")
+        if trust_raw in ("trusted", "standard", "untrusted"):
+            return TrustLevel(trust_raw)
+        return None
+
+    def _decode_inline_files(self, files: list[dict[str, Any]]) -> list[tuple[str, bytes]]:
+        decoded: list[tuple[str, bytes]] = []
+        for index, file_entry in enumerate(files):
+            try:
+                path = str(file_entry.get("path", ""))
+                content_b64 = str(file_entry.get("content_b64", ""))
+                data = base64.b64decode(content_b64, validate=True)
+            except (TypeError, ValueError, binascii.Error, AttributeError) as exc:
+                raise ValueError(f"invalid inline file at index {index}") from exc
+            decoded.append((path, data))
+        return decoded
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """
@@ -227,3 +304,25 @@ class SandboxModule(BaseModule):
             for i, f in enumerate(files):
                 if not isinstance(f, dict) or not f.get("path") or not f.get("content_b64"):
                     raise ValueError(f"files[{i}] must include path and content_b64")
+                try:
+                    base64.b64decode(str(f.get("content_b64", "")), validate=True)
+                except (TypeError, ValueError, binascii.Error):
+                    raise ValueError(f"files[{i}].content_b64 must be valid base64") from None
+        if arguments.get("cpu") is not None:
+            try:
+                cpu = float(arguments.get("cpu"))
+                if cpu < 0:
+                    raise ValueError
+            except Exception:
+                raise ValueError("cpu must be a non-negative number") from None
+        if arguments.get("memory_mb") is not None:
+            try:
+                memory_mb = int(arguments.get("memory_mb"))
+                if memory_mb < 64:
+                    raise ValueError
+            except Exception:
+                raise ValueError("memory_mb must be an integer >= 64") from None
+        if arguments.get("network_policy") is not None and str(arguments.get("network_policy")) not in {"deny_all", "allowlist"}:
+            raise ValueError("network_policy must be deny_all|allowlist when provided")
+        if arguments.get("trust_level") is not None and str(arguments.get("trust_level")).lower() not in {"trusted", "standard", "untrusted"}:
+            raise ValueError("trust_level must be trusted|standard|untrusted when provided")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -223,10 +223,20 @@ class SandboxModule(BaseModule):
         try:
             if bool(getattr(context, "is_admin", False)):
                 return True
-            roles = (getattr(context, "metadata", {}) or {}).get("roles")
+            metadata = getattr(context, "metadata", {}) or {}
+            roles = metadata.get("roles")
             if isinstance(roles, str):
                 roles = [roles]
-            return isinstance(roles, list) and any(str(r).lower() == "admin" for r in roles)
+            if isinstance(roles, list) and any(str(r).strip().lower() == "admin" for r in roles):
+                return True
+            permissions = metadata.get("permissions")
+            if isinstance(permissions, str):
+                permissions = [permissions]
+            if isinstance(permissions, list):
+                normalized = {str(permission).strip().lower() for permission in permissions if str(permission).strip()}
+                if "*" in normalized or "system.configure" in normalized:
+                    return True
+            return False
         except Exception:
             return False
 

--- a/tldw_Server_API/app/core/Sandbox/models.py
+++ b/tldw_Server_API/app/core/Sandbox/models.py
@@ -46,6 +46,13 @@ class Session:
     runtime: RuntimeType
     base_image: str | None
     expires_at: datetime | None
+    cpu_limit: float | None = None
+    memory_mb: int | None = None
+    timeout_sec: int = 300
+    network_policy: str = "deny_all"
+    env: dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
+    trust_level: TrustLevel | None = None
     persona_id: str | None = None
     workspace_id: str | None = None
     workspace_group_id: str | None = None

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -1194,12 +1194,6 @@ class SandboxOrchestrator:
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
             cap_user = 128 * 1024 * 1024
 
-        # Determine remaining budget
-        try:
-            current_user_bytes = int(self._store.get_user_artifact_bytes(owner))
-        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
-            current_user_bytes = 0
-
         selected: dict[str, bytes] = {}
         total_run = 0
         # Deterministic order
@@ -1208,16 +1202,20 @@ class SandboxOrchestrator:
             sz = len(data)
             if total_run + sz > cap_run:
                 break
-            if current_user_bytes + sz > cap_user:
+            try:
+                admitted = bool(self._store.try_reserve_user_artifact_bytes(owner, sz, cap_user))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                admitted = False
+            if not admitted:
                 break
             selected[path] = data
             total_run += sz
-            current_user_bytes += sz
 
         # Persist selected to FS and memory map for backward compatibility
         art_dir = self._artifact_dir(owner, run_id)
         with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
             art_dir.mkdir(parents=True, exist_ok=True)
+        persisted: dict[str, bytes] = {}
         for path, data in selected.items():
             rel = self._safe_rel(path)
             full = art_dir / rel
@@ -1227,11 +1225,13 @@ class SandboxOrchestrator:
                     f.write(data)
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"Failed to persist artifact {rel}: {e}")
+                with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
+                    self._store.increment_user_artifact_bytes(owner, -len(data))
+                continue
+            persisted[path] = data
 
         with self._lock:
-            self._artifacts[run_id] = selected
-        with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
-            self._store.increment_user_artifact_bytes(owner, int(total_run))
+            self._artifacts[run_id] = persisted
 
     def list_artifacts(self, run_id: str) -> dict[str, int]:
         self._maybe_prune_expired_artifacts()

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -18,7 +18,7 @@ from loguru import logger
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
-from .models import RunPhase, RunSpec, RunStatus, RuntimeType, Session, SessionSpec
+from .models import RunPhase, RunSpec, RunStatus, RuntimeType, Session, SessionSpec, TrustLevel
 from .policy import SandboxPolicy, SandboxPolicyConfig
 from .store import IdempotencyConflict as StoreIdemConflict
 from .store import get_store
@@ -211,11 +211,51 @@ class SandboxOrchestrator:
                 expires_at = datetime.fromisoformat(str(expires_raw))
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
                 expires_at = None
+        cpu_limit = None
+        if record.get("cpu_limit") is not None:
+            try:
+                cpu_limit = float(record.get("cpu_limit"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                cpu_limit = None
+        memory_mb = None
+        if record.get("memory_mb") is not None:
+            try:
+                memory_mb = int(record.get("memory_mb"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                memory_mb = None
+        timeout_sec = 300
+        if record.get("timeout_sec") is not None:
+            try:
+                timeout_sec = int(record.get("timeout_sec"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                timeout_sec = 300
+        trust_level = None
+        trust_raw = record.get("trust_level")
+        if trust_raw:
+            try:
+                trust_level = TrustLevel(str(trust_raw))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                trust_level = None
         return Session(
             id=sid,
             runtime=runtime,
             base_image=(str(record.get("base_image")) if record.get("base_image") is not None else None),
             expires_at=expires_at,
+            cpu_limit=cpu_limit,
+            memory_mb=memory_mb,
+            timeout_sec=timeout_sec,
+            network_policy=(str(record.get("network_policy") or "deny_all")),
+            env=(
+                {str(k): str(v) for k, v in (record.get("env") or {}).items()}
+                if isinstance(record.get("env"), dict)
+                else {}
+            ),
+            labels=(
+                {str(k): str(v) for k, v in (record.get("labels") or {}).items()}
+                if isinstance(record.get("labels"), dict)
+                else {}
+            ),
+            trust_level=trust_level,
             persona_id=(str(record.get("persona_id")) if record.get("persona_id") is not None else None),
             workspace_id=(str(record.get("workspace_id")) if record.get("workspace_id") is not None else None),
             workspace_group_id=(str(record.get("workspace_group_id")) if record.get("workspace_group_id") is not None else None),
@@ -301,6 +341,41 @@ class SandboxOrchestrator:
                 runtime=runtime,
                 base_image=(stored.get("base_image") if stored.get("base_image") is not None else spec.base_image),
                 expires_at=expires_at,
+                cpu_limit=(
+                    float(stored.get("cpu_limit"))
+                    if stored.get("cpu_limit") is not None
+                    else spec.cpu_limit
+                ),
+                memory_mb=(
+                    int(stored.get("memory_mb"))
+                    if stored.get("memory_mb") is not None
+                    else spec.memory_mb
+                ),
+                timeout_sec=(
+                    int(stored.get("timeout_sec"))
+                    if stored.get("timeout_sec") is not None
+                    else spec.timeout_sec
+                ),
+                network_policy=(
+                    str(stored.get("network_policy"))
+                    if stored.get("network_policy") is not None
+                    else spec.network_policy
+                ),
+                env=(
+                    {str(k): str(v) for k, v in (stored.get("env") or {}).items()}
+                    if isinstance(stored.get("env"), dict)
+                    else dict(spec.env or {})
+                ),
+                labels=(
+                    {str(k): str(v) for k, v in (stored.get("labels") or {}).items()}
+                    if isinstance(stored.get("labels"), dict)
+                    else dict(spec.labels or {})
+                ),
+                trust_level=(
+                    TrustLevel(str(stored.get("trust_level")))
+                    if stored.get("trust_level") is not None
+                    else spec.trust_level
+                ),
                 persona_id=(
                     str(stored.get("persona_id"))
                     if stored.get("persona_id") is not None
@@ -332,6 +407,13 @@ class SandboxOrchestrator:
                     session_id=sid_str,
                     runtime=sess.runtime.value if sess.runtime else None,
                     base_image=sess.base_image,
+                    cpu_limit=sess.cpu_limit,
+                    memory_mb=sess.memory_mb,
+                    timeout_sec=sess.timeout_sec,
+                    network_policy=sess.network_policy,
+                    env=sess.env,
+                    labels=sess.labels,
+                    trust_level=(sess.trust_level.value if sess.trust_level else None),
                     expires_at_iso=(sess.expires_at.isoformat() if sess.expires_at else None),
                     workspace_path=ws_path,
                     persona_id=sess.persona_id,
@@ -357,6 +439,13 @@ class SandboxOrchestrator:
             runtime=spec.runtime or self.policy.cfg.default_runtime,
             base_image=spec.base_image,
             expires_at=expires_at,
+            cpu_limit=spec.cpu_limit,
+            memory_mb=spec.memory_mb,
+            timeout_sec=spec.timeout_sec,
+            network_policy=spec.network_policy,
+            env=dict(spec.env or {}),
+            labels=dict(spec.labels or {}),
+            trust_level=spec.trust_level,
             persona_id=spec.persona_id,
             workspace_id=spec.workspace_id,
             workspace_group_id=spec.workspace_group_id,
@@ -372,6 +461,13 @@ class SandboxOrchestrator:
                 session_id=sid,
                 runtime=sess.runtime.value if sess.runtime else None,
                 base_image=sess.base_image,
+                cpu_limit=sess.cpu_limit,
+                memory_mb=sess.memory_mb,
+                timeout_sec=sess.timeout_sec,
+                network_policy=sess.network_policy,
+                env=sess.env,
+                labels=sess.labels,
+                trust_level=(sess.trust_level.value if sess.trust_level else None),
                 expires_at_iso=(sess.expires_at.isoformat() if sess.expires_at else None),
                 workspace_path=ws_path,
                 persona_id=sess.persona_id,
@@ -386,6 +482,13 @@ class SandboxOrchestrator:
             "id": sid,
             "runtime": sess.runtime.value,
             "base_image": sess.base_image,
+            "cpu_limit": sess.cpu_limit,
+            "memory_mb": sess.memory_mb,
+            "timeout_sec": sess.timeout_sec,
+            "network_policy": sess.network_policy,
+            "env": dict(sess.env or {}),
+            "labels": dict(sess.labels or {}),
+            "trust_level": (sess.trust_level.value if sess.trust_level else None),
             "expires_at": (sess.expires_at.isoformat() if sess.expires_at else None),
             "persona_id": sess.persona_id,
             "workspace_id": sess.workspace_id,
@@ -1175,6 +1278,23 @@ class SandboxOrchestrator:
         with self._lock:
             mapping = self._artifacts.get(run_id) or {}
             return mapping.get(path)
+
+    def get_artifact_path(self, run_id: str, path: str) -> Path | None:
+        self._maybe_prune_expired_artifacts()
+        owner = None
+        try:
+            owner = self._store.get_run_owner(run_id)
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            owner = None
+        art_dir = self._artifact_dir((owner or "unknown"), run_id)
+        rel = self._safe_rel(path)
+        full = art_dir / rel
+        try:
+            if full.exists() and full.is_file():
+                return full
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+        return None
 
     # -----------------
     # Workspaces

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import contextlib
 import os
 import threading
@@ -824,6 +825,12 @@ class SandboxService:
         sess = self._orch.create_session(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
         return sess
 
+    def get_session(self, session_id: str) -> Session | None:
+        return self._orch.get_session(session_id)
+
+    def get_session_owner(self, session_id: str) -> str | None:
+        return self._orch.get_session_owner(session_id)
+
     def destroy_session(self, session_id: str) -> bool:
         try:
             destroyed = bool(self._orch.destroy_session(session_id))
@@ -898,14 +905,14 @@ class SandboxService:
         results: list[tuple[str, bytes]] = []
         if not files:
             return results
-        for f in files:
+        for index, f in enumerate(files):
             try:
                 p = str(f.get("path", ""))
                 b64 = str(f.get("content_b64", ""))
-                data = base64.b64decode(b64)
+                data = base64.b64decode(b64, validate=True)
                 results.append((p, data))
-            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to parse inline file: {e}")
+            except (binascii.Error, ValueError, TypeError, AttributeError) as e:
+                raise ValueError(f"invalid inline file at index {index}") from e
         return results
 
     def start_run_scaffold(self, user_id: str | int, spec: RunSpec, spec_version: str, idem_key: str | None, raw_body: dict) -> RunStatus:
@@ -1456,6 +1463,13 @@ class SandboxService:
             spec = SessionSpec(
                 runtime=source_sess.runtime,
                 base_image=source_sess.base_image,
+                cpu_limit=source_sess.cpu_limit,
+                memory_mb=source_sess.memory_mb,
+                timeout_sec=source_sess.timeout_sec,
+                network_policy=source_sess.network_policy,
+                env=dict(source_sess.env or {}),
+                labels=dict(source_sess.labels or {}),
+                trust_level=source_sess.trust_level,
                 persona_id=source_sess.persona_id,
                 workspace_id=source_sess.workspace_id,
                 workspace_group_id=source_sess.workspace_group_id,

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -201,6 +201,16 @@ class SandboxStore:
     def get_user_artifact_bytes(self, user_id: str) -> int:
         return 0
 
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        if int(delta or 0) <= 0:
+            self.increment_user_artifact_bytes(user_id, int(delta or 0))
+            return True
+        current = int(self.get_user_artifact_bytes(user_id))
+        if current + int(delta) > int(cap_bytes):
+            return False
+        self.increment_user_artifact_bytes(user_id, int(delta))
+        return True
+
     def increment_user_artifact_bytes(self, user_id: str, delta: int) -> None:
         pass
 
@@ -638,6 +648,18 @@ class InMemoryStore(SandboxStore):
         with self._lock:
             cur = int(self._user_bytes.get(user_id, 0))
             self._user_bytes[user_id] = max(0, cur + int(delta))
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock:
+            cur = int(self._user_bytes.get(user_id, 0))
+            if cur + d > int(cap_bytes):
+                return False
+            self._user_bytes[user_id] = cur + d
+            return True
 
     def list_runs(
         self,
@@ -1676,6 +1698,25 @@ class SQLiteStore(SandboxStore):
                 "REPLACE INTO sandbox_usage(user_id, artifact_bytes) VALUES (?,?)",
                 (user_id, new_val),
             )
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock, self._conn() as con:
+            con.execute("BEGIN IMMEDIATE")
+            cur = con.execute("SELECT artifact_bytes FROM sandbox_usage WHERE user_id=?", (user_id,))
+            row = cur.fetchone()
+            cur_val = int(row["artifact_bytes"]) if row and row["artifact_bytes"] is not None else 0
+            if cur_val + d > int(cap_bytes):
+                con.rollback()
+                return False
+            con.execute(
+                "REPLACE INTO sandbox_usage(user_id, artifact_bytes) VALUES (?,?)",
+                (user_id, cur_val + d),
+            )
+            return True
 
     def list_runs(
         self,
@@ -2793,6 +2834,29 @@ class PostgresStore(SandboxStore):
                     """,
                     (user_id, d),
                 )
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        if not user_id:
+            return False
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock, self._conn() as con:
+            with con.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO sandbox_usage(user_id, artifact_bytes)
+                    SELECT %s, %s
+                    WHERE %s <= %s
+                    ON CONFLICT (user_id) DO UPDATE
+                    SET artifact_bytes = COALESCE(sandbox_usage.artifact_bytes, 0) + EXCLUDED.artifact_bytes
+                    WHERE COALESCE(sandbox_usage.artifact_bytes, 0) + EXCLUDED.artifact_bytes <= %s
+                    RETURNING artifact_bytes
+                    """,
+                    (user_id, d, d, int(cap_bytes), int(cap_bytes)),
+                )
+                return cur.fetchone() is not None
 
     def list_runs(
         self,

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -64,6 +64,23 @@ def _parse_optional_iso_datetime(value: Any) -> datetime | None:
         return None
 
 
+def _normalize_string_dict(value: Any) -> dict[str, str]:
+    if isinstance(value, dict):
+        return {str(k): str(v) for k, v in value.items()}
+    if value is None:
+        return {}
+    text = str(value).strip()
+    if not text:
+        return {}
+    try:
+        loaded = json.loads(text)
+    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(k): str(v) for k, v in loaded.items()}
+
+
 class IdempotencyConflict(Exception):
     def __init__(self, original_id: str, key: str | None = None, created_at: float | None = None, message: str = "Idempotency conflict") -> None:
         super().__init__(message)
@@ -131,6 +148,13 @@ class SandboxStore:
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -508,6 +532,13 @@ class InMemoryStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -521,6 +552,13 @@ class InMemoryStore(SandboxStore):
                 "user_id": self._user_key(user_id),
                 "runtime": runtime,
                 "base_image": base_image,
+                "cpu_limit": (float(cpu_limit) if cpu_limit is not None else None),
+                "memory_mb": (int(memory_mb) if memory_mb is not None else None),
+                "timeout_sec": (int(timeout_sec) if timeout_sec is not None else None),
+                "network_policy": (str(network_policy) if network_policy is not None else None),
+                "env": _normalize_string_dict(env),
+                "labels": _normalize_string_dict(labels),
+                "trust_level": (str(trust_level) if trust_level is not None else None),
                 "expires_at": expires_at_iso,
                 "workspace_path": workspace_path,
                 "persona_id": (str(persona_id) if persona_id is not None else None),
@@ -891,6 +929,13 @@ class SQLiteStore(SandboxStore):
                     user_id TEXT,
                     runtime TEXT,
                     base_image TEXT,
+                    cpu_limit REAL,
+                    memory_mb INTEGER,
+                    timeout_sec INTEGER,
+                    network_policy TEXT,
+                    env TEXT,
+                    labels TEXT,
+                    trust_level TEXT,
                     persona_id TEXT,
                     workspace_id TEXT,
                     workspace_group_id TEXT,
@@ -951,6 +996,13 @@ class SQLiteStore(SandboxStore):
             _ensure_sqlite_column("sandbox_runs", "scope_snapshot_id", "TEXT")
             _ensure_sqlite_column("sandbox_runs", "claim_owner", "TEXT")
             _ensure_sqlite_column("sandbox_runs", "claim_expires_at", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "cpu_limit", "REAL")
+            _ensure_sqlite_column("sandbox_sessions", "memory_mb", "INTEGER")
+            _ensure_sqlite_column("sandbox_sessions", "timeout_sec", "INTEGER")
+            _ensure_sqlite_column("sandbox_sessions", "network_policy", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "env", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "labels", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "trust_level", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "persona_id", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "workspace_id", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "workspace_group_id", "TEXT")
@@ -1413,6 +1465,13 @@ class SQLiteStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -1425,13 +1484,20 @@ class SQLiteStore(SandboxStore):
             con.execute(
                 (
                     "INSERT INTO sandbox_sessions("
-                    "id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
-                    "expires_at,workspace_path,created_at,updated_at"
-                    ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?) "
+                    "id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,expires_at,workspace_path,created_at,updated_at"
+                    ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
                     "ON CONFLICT(id) DO UPDATE SET "
                     "user_id=excluded.user_id,"
                     "runtime=excluded.runtime,"
                     "base_image=excluded.base_image,"
+                    "cpu_limit=excluded.cpu_limit,"
+                    "memory_mb=excluded.memory_mb,"
+                    "timeout_sec=excluded.timeout_sec,"
+                    "network_policy=excluded.network_policy,"
+                    "env=excluded.env,"
+                    "labels=excluded.labels,"
+                    "trust_level=excluded.trust_level,"
                     "persona_id=excluded.persona_id,"
                     "workspace_id=excluded.workspace_id,"
                     "workspace_group_id=excluded.workspace_group_id,"
@@ -1445,6 +1511,13 @@ class SQLiteStore(SandboxStore):
                     self._user_key(user_id),
                     (str(runtime) if runtime is not None else None),
                     (str(base_image) if base_image is not None else None),
+                    (float(cpu_limit) if cpu_limit is not None else None),
+                    (int(memory_mb) if memory_mb is not None else None),
+                    (int(timeout_sec) if timeout_sec is not None else None),
+                    (str(network_policy) if network_policy is not None else None),
+                    (json.dumps(_normalize_string_dict(env)) if env is not None else None),
+                    (json.dumps(_normalize_string_dict(labels)) if labels is not None else None),
+                    (str(trust_level) if trust_level is not None else None),
                     (str(persona_id) if persona_id is not None else None),
                     (str(workspace_id) if workspace_id is not None else None),
                     (str(workspace_group_id) if workspace_group_id is not None else None),
@@ -1460,7 +1533,8 @@ class SQLiteStore(SandboxStore):
         with self._lock, self._conn() as con:
             cur = con.execute(
                 (
-                    "SELECT id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
+                    "SELECT id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
                     "expires_at,workspace_path,created_at,updated_at "
                     "FROM sandbox_sessions WHERE id=?"
                 ),
@@ -1475,6 +1549,13 @@ class SQLiteStore(SandboxStore):
                 "user_id": row_dict.get("user_id"),
                 "runtime": row_dict.get("runtime"),
                 "base_image": row_dict.get("base_image"),
+                "cpu_limit": row_dict.get("cpu_limit"),
+                "memory_mb": row_dict.get("memory_mb"),
+                "timeout_sec": row_dict.get("timeout_sec"),
+                "network_policy": row_dict.get("network_policy"),
+                "env": _normalize_string_dict(row_dict.get("env")),
+                "labels": _normalize_string_dict(row_dict.get("labels")),
+                "trust_level": row_dict.get("trust_level"),
                 "persona_id": row_dict.get("persona_id"),
                 "workspace_id": row_dict.get("workspace_id"),
                 "workspace_group_id": row_dict.get("workspace_group_id"),
@@ -1955,6 +2036,13 @@ class PostgresStore(SandboxStore):
                         user_id TEXT,
                         runtime TEXT,
                         base_image TEXT,
+                        cpu_limit DOUBLE PRECISION,
+                        memory_mb INTEGER,
+                        timeout_sec INTEGER,
+                        network_policy TEXT,
+                        env TEXT,
+                        labels TEXT,
+                        trust_level TEXT,
                         persona_id TEXT,
                         workspace_id TEXT,
                         workspace_group_id TEXT,
@@ -2011,6 +2099,13 @@ class PostgresStore(SandboxStore):
             _ensure_column("sandbox_runs", "scope_snapshot_id", "TEXT")
             _ensure_column("sandbox_runs", "claim_owner", "TEXT")
             _ensure_column("sandbox_runs", "claim_expires_at", "TEXT")
+            _ensure_column("sandbox_sessions", "cpu_limit", "DOUBLE PRECISION")
+            _ensure_column("sandbox_sessions", "memory_mb", "INTEGER")
+            _ensure_column("sandbox_sessions", "timeout_sec", "INTEGER")
+            _ensure_column("sandbox_sessions", "network_policy", "TEXT")
+            _ensure_column("sandbox_sessions", "env", "TEXT")
+            _ensure_column("sandbox_sessions", "labels", "TEXT")
+            _ensure_column("sandbox_sessions", "trust_level", "TEXT")
             _ensure_column("sandbox_sessions", "persona_id", "TEXT")
             _ensure_column("sandbox_sessions", "workspace_id", "TEXT")
             _ensure_column("sandbox_sessions", "workspace_group_id", "TEXT")
@@ -2492,6 +2587,13 @@ class PostgresStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -2505,14 +2607,21 @@ class PostgresStore(SandboxStore):
                 cur.execute(
                     """
                     INSERT INTO sandbox_sessions(
-                        id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,
-                        expires_at,workspace_path,created_at,updated_at
+                        id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,
+                        persona_id,workspace_id,workspace_group_id,scope_snapshot_id,expires_at,workspace_path,created_at,updated_at
                     )
-                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
                     ON CONFLICT (id) DO UPDATE SET
                         user_id=EXCLUDED.user_id,
                         runtime=EXCLUDED.runtime,
                         base_image=EXCLUDED.base_image,
+                        cpu_limit=EXCLUDED.cpu_limit,
+                        memory_mb=EXCLUDED.memory_mb,
+                        timeout_sec=EXCLUDED.timeout_sec,
+                        network_policy=EXCLUDED.network_policy,
+                        env=EXCLUDED.env,
+                        labels=EXCLUDED.labels,
+                        trust_level=EXCLUDED.trust_level,
                         persona_id=EXCLUDED.persona_id,
                         workspace_id=EXCLUDED.workspace_id,
                         workspace_group_id=EXCLUDED.workspace_group_id,
@@ -2526,6 +2635,13 @@ class PostgresStore(SandboxStore):
                         self._user_key(user_id),
                         (str(runtime) if runtime is not None else None),
                         (str(base_image) if base_image is not None else None),
+                        (float(cpu_limit) if cpu_limit is not None else None),
+                        (int(memory_mb) if memory_mb is not None else None),
+                        (int(timeout_sec) if timeout_sec is not None else None),
+                        (str(network_policy) if network_policy is not None else None),
+                        (json.dumps(_normalize_string_dict(env)) if env is not None else None),
+                        (json.dumps(_normalize_string_dict(labels)) if labels is not None else None),
+                        (str(trust_level) if trust_level is not None else None),
                         (str(persona_id) if persona_id is not None else None),
                         (str(workspace_id) if workspace_id is not None else None),
                         (str(workspace_group_id) if workspace_group_id is not None else None),
@@ -2541,14 +2657,20 @@ class PostgresStore(SandboxStore):
         with self._lock, self._conn() as con, con.cursor() as cur:
             cur.execute(
                 (
-                    "SELECT id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
+                    "SELECT id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
                     "expires_at,workspace_path,created_at,updated_at "
                     "FROM sandbox_sessions WHERE id=%s"
                 ),
                 (str(session_id),),
             )
             row = cur.fetchone()
-            return dict(row) if isinstance(row, dict) else None
+            if not isinstance(row, dict):
+                return None
+            result = dict(row)
+            result["env"] = _normalize_string_dict(result.get("env"))
+            result["labels"] = _normalize_string_dict(result.get("labels"))
+            return result
 
     def get_session_owner(self, session_id: str) -> str | None:
         row = self.get_session(str(session_id))

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -5772,6 +5772,13 @@ elif _MINIMAL_TEST_APP:
         app.include_router(acp_router, prefix=f"{API_V1_PREFIX}", tags=["acp"])
     except _IMPORT_EXCEPTIONS as _acp_min_err:
         logger.debug(f"Skipping ACP router in minimal test app: {_acp_min_err}")
+    # Agent Orchestration endpoints
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.agent_orchestration import router as orch_router
+
+        app.include_router(orch_router, prefix=f"{API_V1_PREFIX}", tags=["agent-orchestration"])
+    except _IMPORT_EXCEPTIONS as _orch_min_err:
+        logger.debug(f"Skipping orchestration router in minimal test app: {_orch_min_err}")
     # Include admin router in minimal mode if available (ensure not gated by MCP import)
     try:
         if "admin_router" not in locals():

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -89,10 +89,16 @@ class SessionRecord:
             "forked_from": self.forked_from,
         }
 
-    def to_detail_dict(self, *, has_websocket: bool = False) -> dict[str, Any]:
+    def to_detail_dict(
+        self,
+        *,
+        has_websocket: bool = False,
+        fork_lineage: list[str] | None = None,
+    ) -> dict[str, Any]:
         d = self.to_info_dict(has_websocket=has_websocket)
         d["messages"] = list(self.messages)
         d["cwd"] = self.cwd
+        d["fork_lineage"] = fork_lineage or []
         return d
 
 
@@ -251,6 +257,131 @@ class ACPSessionStore:
         # Permission policies — keyed by id
         self._permission_policies: dict[int, PermissionPolicy] = {}
         self._permission_policy_seq = 0
+        # Session TTL cleanup task
+        self._cleanup_task: asyncio.Task | None = None
+        # Quotas (loaded from config on first use)
+        self._session_ttl_seconds: int = 86400
+        self._max_concurrent_per_user: int = 5
+        self._max_tokens_per_session: int = 1_000_000
+        self._max_session_duration_seconds: int = 14400
+
+    def configure_quotas(
+        self,
+        session_ttl_seconds: int = 86400,
+        max_concurrent_per_user: int = 5,
+        max_tokens_per_session: int = 1_000_000,
+        max_session_duration_seconds: int = 14400,
+    ) -> None:
+        """Set quota limits from config."""
+        self._session_ttl_seconds = session_ttl_seconds
+        self._max_concurrent_per_user = max_concurrent_per_user
+        self._max_tokens_per_session = max_tokens_per_session
+        self._max_session_duration_seconds = max_session_duration_seconds
+
+    def start_cleanup_task(self) -> None:
+        """Start background task to evict expired sessions."""
+        if self._cleanup_task is None or self._cleanup_task.done():
+            self._cleanup_task = asyncio.ensure_future(self._cleanup_loop())
+
+    def stop_cleanup_task(self) -> None:
+        """Cancel the cleanup background task."""
+        if self._cleanup_task and not self._cleanup_task.done():
+            self._cleanup_task.cancel()
+            self._cleanup_task = None
+
+    async def _cleanup_loop(self) -> None:
+        """Periodically evict expired sessions."""
+        while True:
+            try:
+                await asyncio.sleep(300)  # Check every 5 minutes
+                await self._evict_expired_sessions()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.error("ACP session cleanup error: {}", exc)
+                await asyncio.sleep(60)
+
+    async def _evict_expired_sessions(self) -> int:
+        """Evict sessions past TTL or max duration. Returns count evicted."""
+        now = time.time()
+        evicted = 0
+        async with self._lock:
+            to_evict: list[str] = []
+            for sid, rec in self._sessions.items():
+                if rec.status != "active":
+                    continue
+                try:
+                    created = datetime.fromisoformat(rec.created_at).timestamp()
+                except (ValueError, TypeError):
+                    continue
+                age = now - created
+                if age > self._session_ttl_seconds:
+                    to_evict.append(sid)
+                    continue
+                if age > self._max_session_duration_seconds:
+                    to_evict.append(sid)
+            for sid in to_evict:
+                rec = self._sessions.get(sid)
+                if rec:
+                    rec.status = "closed"
+                    rec.last_activity_at = datetime.now(timezone.utc).isoformat()
+                    evicted += 1
+                    logger.info("ACP session {} evicted (TTL/duration expired)", sid)
+        return evicted
+
+    async def check_session_quota(self, user_id: int) -> dict[str, Any] | None:
+        """Check if user can create a new session. Returns None if ok, or error dict."""
+        active_count = 0
+        async with self._lock:
+            for rec in self._sessions.values():
+                if rec.user_id == user_id and rec.status == "active":
+                    active_count += 1
+        if active_count >= self._max_concurrent_per_user:
+            return {
+                "code": "quota_exceeded",
+                "message": f"Max concurrent sessions ({self._max_concurrent_per_user}) exceeded",
+                "current": active_count,
+                "limit": self._max_concurrent_per_user,
+            }
+        return None
+
+    async def check_token_quota(self, session_id: str) -> dict[str, Any] | None:
+        """Check if a session has exceeded its token quota. Returns None if ok."""
+        rec = self._sessions.get(session_id)
+        if not rec:
+            return None
+        if rec.usage.total_tokens >= self._max_tokens_per_session:
+            return {
+                "code": "token_quota_exceeded",
+                "message": f"Session token limit ({self._max_tokens_per_session}) exceeded",
+                "current": rec.usage.total_tokens,
+                "limit": self._max_tokens_per_session,
+            }
+        return None
+
+    async def get_quota_status(self, user_id: int, session_id: str | None = None) -> dict[str, Any]:
+        """Get current quota usage for a user/session."""
+        active_count = 0
+        async with self._lock:
+            for rec in self._sessions.values():
+                if rec.user_id == user_id and rec.status == "active":
+                    active_count += 1
+        result: dict[str, Any] = {
+            "concurrent_sessions": {
+                "current": active_count,
+                "limit": self._max_concurrent_per_user,
+            },
+            "session_ttl_seconds": self._session_ttl_seconds,
+            "max_session_duration_seconds": self._max_session_duration_seconds,
+        }
+        if session_id:
+            rec = self._sessions.get(session_id)
+            if rec:
+                result["session_tokens"] = {
+                    "current": rec.usage.total_tokens,
+                    "limit": self._max_tokens_per_session,
+                }
+        return result
 
     # -- Session CRUD -------------------------------------------------------
 
@@ -328,6 +459,24 @@ class ACPSessionStore:
 
     async def get_session(self, session_id: str) -> SessionRecord | None:
         return self._sessions.get(session_id)
+
+    async def get_fork_lineage(self, session_id: str, *, max_depth: int = 50) -> list[str]:
+        """Walk the forked_from chain and return ancestor session IDs (oldest first)."""
+        lineage: list[str] = []
+        current_id = session_id
+        seen: set[str] = {current_id}
+        for _ in range(max_depth):
+            rec = self._sessions.get(current_id)
+            if not rec or not rec.forked_from:
+                break
+            parent_id = rec.forked_from
+            if parent_id in seen:
+                break  # cycle guard
+            seen.add(parent_id)
+            lineage.append(parent_id)
+            current_id = parent_id
+        lineage.reverse()  # oldest ancestor first
+        return lineage
 
     async def build_bootstrap_prompt(
         self,

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -722,5 +722,19 @@ async def get_acp_session_store() -> ACPSessionStore:
     if _store is None:
         async with _store_lock:
             if _store is None:
-                _store = ACPSessionStore()
+                store = ACPSessionStore()
+                # Initialize quotas from ACP config
+                try:
+                    from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_sandbox_config
+                    cfg = load_acp_sandbox_config()
+                    store.configure_quotas(
+                        session_ttl_seconds=cfg.session_ttl_seconds,
+                        max_concurrent_per_user=cfg.max_concurrent_sessions_per_user,
+                        max_tokens_per_session=cfg.max_tokens_per_session,
+                        max_session_duration_seconds=cfg.max_session_duration_seconds,
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to load ACP quota config, using defaults: {}", exc)
+                store.start_cleanup_task()
+                _store = store
     return _store

--- a/tldw_Server_API/tests/Agent_Client_Protocol/conftest.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for ACP tests.
+
+Provides a ``stub_agent_process`` fixture that spawns the stub agent
+via the real ``ACPStdioClient``, enabling integration-level tests of the
+full STDIO JSON-RPC protocol without needing the Go runner binary.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPStdioClient
+
+
+STUB_AGENT_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "Helper_Scripts",
+    "acp_stub_agent.py",
+)
+
+
+@pytest.fixture
+async def stub_stdio_client() -> ACPStdioClient:
+    """Spawn the stub agent via ACPStdioClient for integration tests.
+
+    Yields a started client; shuts it down after the test.
+    """
+    client = ACPStdioClient(
+        command=sys.executable,
+        args=[os.path.abspath(STUB_AGENT_PATH)],
+    )
+    await client.start()
+    yield client
+    await client.close()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
@@ -1,0 +1,188 @@
+"""Tests for ACP agent registry (Phase 2)."""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+SAMPLE_REGISTRY = """
+agents:
+  - type: claude_code
+    name: Claude Code
+    description: Test agent
+    command: nonexistent_binary_xyz
+    args: []
+    env: {}
+    requires_api_key: ANTHROPIC_API_KEY
+    default: true
+
+  - type: test_agent
+    name: Test Agent
+    description: A test agent
+    command: python3
+    args: ["-c", "pass"]
+    env: {}
+    requires_api_key: null
+    default: false
+"""
+
+
+@pytest.fixture
+def registry_file():
+    """Create a temporary registry YAML file."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(SAMPLE_REGISTRY)
+        path = f.name
+    yield path
+    os.unlink(path)
+
+
+def test_registry_loads_from_yaml(registry_file):
+    """Registry loads agent entries from YAML file."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    assert len(reg.entries) == 2
+    assert reg.default_type == "claude_code"
+
+
+def test_registry_entry_fields(registry_file):
+    """Registry entries have correct field values."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    entry = reg.get_entry("claude_code")
+    assert entry is not None
+    assert entry.name == "Claude Code"
+    assert entry.requires_api_key == "ANTHROPIC_API_KEY"
+    assert entry.default is True
+
+
+def test_registry_get_entry_none(registry_file):
+    """get_entry returns None for unknown type."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    assert reg.get_entry("nonexistent") is None
+
+
+def test_registry_check_availability(registry_file, monkeypatch):
+    """check_availability detects missing binary and API key."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    # claude_code has nonexistent binary and (likely) no API key
+    entry = reg.get_entry("claude_code")
+    avail = entry.check_availability()
+    assert avail["binary_found"] is False
+    assert avail["status"] == "unavailable"
+
+    # test_agent uses python3 (should be on PATH) and no API key required
+    entry = reg.get_entry("test_agent")
+    avail = entry.check_availability()
+    assert avail["binary_found"] is True
+    assert avail["api_key_set"] is True
+    assert avail["status"] == "available"
+
+
+def test_registry_get_available_agents(registry_file):
+    """get_available_agents returns all entries with availability info."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg.load()
+
+    available = reg.get_available_agents()
+    assert len(available) == 2
+    for agent in available:
+        assert "type" in agent
+        assert "name" in agent
+        assert "status" in agent
+        assert agent["status"] in ("available", "unavailable", "requires_setup")
+
+
+def test_registry_missing_file():
+    """Registry handles missing YAML file gracefully."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path="/nonexistent/agents.yaml")
+    reg.load()
+    assert reg.entries == []
+    assert reg.default_type == "custom"
+
+
+def test_registry_invalid_yaml():
+    """Registry handles invalid YAML content gracefully."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write("not: [valid: yaml: content")
+        path = f.name
+
+    try:
+        reg = AgentRegistry(yaml_path=path)
+        reg.load()
+        # Should not crash, just produce empty entries
+    finally:
+        os.unlink(path)
+
+
+def test_registry_hot_reload(registry_file):
+    """Registry detects file changes and reloads."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    reg = AgentRegistry(yaml_path=registry_file)
+    reg._reload_interval = 0  # Disable throttling
+    reg.load()
+    assert len(reg.entries) == 2
+
+    # Modify the file
+    with open(registry_file, "w") as f:
+        f.write("""
+agents:
+  - type: new_agent
+    name: New Agent
+    description: Added dynamically
+    command: python3
+    args: []
+    env: {}
+    requires_api_key: null
+    default: true
+""")
+
+    # Touch file to update mtime
+    import time
+    os.utime(registry_file, (time.time() + 1, time.time() + 1))
+
+    # Access entries to trigger reload
+    entries = reg.entries
+    assert len(entries) == 1
+    assert entries[0].type == "new_agent"
+
+
+def test_default_agents_yaml_exists():
+    """The shipped agents.yaml file exists and is valid."""
+    config_path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "Config_Files", "agents.yaml",
+    )
+    assert os.path.isfile(config_path), f"agents.yaml not found at {config_path}"
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+    reg = AgentRegistry(yaml_path=config_path)
+    reg.load()
+    assert len(reg.entries) >= 3  # claude_code, codex, opencode, custom

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_e2e_smoke.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_e2e_smoke.py
@@ -1,0 +1,127 @@
+"""End-to-end smoke test for ACP with stub agent.
+
+Exercises the full lifecycle: spawn runner → initialize → create session →
+send prompt → receive response → close session.
+
+Requires the stub agent script at Helper_Scripts/acp_stub_agent.py.
+Skips if stub agent is missing.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+STUB_AGENT_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "Helper_Scripts",
+    "acp_stub_agent.py",
+)
+
+
+@pytest.fixture
+def stub_agent_available():
+    if not os.path.isfile(STUB_AGENT_PATH):
+        pytest.skip("Stub agent script not found")
+
+
+async def test_full_lifecycle_smoke(stub_agent_available):
+    """Full ACP lifecycle with stub agent."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+        ACPStdioClient,
+    )
+
+    client = ACPStdioClient(
+        command=sys.executable,
+        args=[os.path.abspath(STUB_AGENT_PATH)],
+    )
+
+    try:
+        # 1. Start
+        await client.start()
+        assert client.is_running
+
+        # 2. Initialize
+        init_result = await client.call("initialize", {})
+        assert init_result.result is not None
+        agent_info = init_result.result.get("agentInfo", {})
+        assert agent_info.get("name") == "tldw-acp-stub"
+
+        # 3. Create session
+        new_result = await client.call("session/new", {})
+        session_id = new_result.result["sessionId"]
+        assert session_id
+
+        # 4. Send prompt
+        prompt_result = await client.call(
+            "session/prompt",
+            {"sessionId": session_id, "prompt": "What is 2+2?"},
+        )
+        assert prompt_result.result["stopReason"] == "end"
+
+        # 5. Cancel (should succeed)
+        cancel_result = await client.call("session/cancel", {})
+        assert cancel_result.result is None
+
+    finally:
+        await client.close()
+
+    assert not client.is_running
+
+
+async def test_protocol_version_check(stub_agent_available):
+    """Verify initialize returns expected protocol version."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+        ACPStdioClient,
+    )
+
+    client = ACPStdioClient(
+        command=sys.executable,
+        args=[os.path.abspath(STUB_AGENT_PATH)],
+    )
+
+    try:
+        await client.start()
+        result = await client.call("initialize", {})
+        assert result.result["protocolVersion"] == 1
+        assert "agentCapabilities" in result.result
+        caps = result.result["agentCapabilities"]
+        assert caps["loadSession"] is False
+        assert "promptCapabilities" in caps
+    finally:
+        await client.close()
+
+
+async def test_multiple_prompts_same_session(stub_agent_available):
+    """Verify multiple prompts can be sent to the same session."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+        ACPStdioClient,
+    )
+
+    client = ACPStdioClient(
+        command=sys.executable,
+        args=[os.path.abspath(STUB_AGENT_PATH)],
+    )
+
+    try:
+        await client.start()
+        await client.call("initialize", {})
+        new_result = await client.call("session/new", {})
+        session_id = new_result.result["sessionId"]
+
+        for i in range(3):
+            result = await client.call(
+                "session/prompt",
+                {"sessionId": session_id, "prompt": f"Prompt {i}"},
+            )
+            assert result.result["stopReason"] == "end"
+
+    finally:
+        await client.close()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_fork_lineage.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_fork_lineage.py
@@ -1,0 +1,121 @@
+"""Tests for ACP fork lineage tracking (Phase 7.2)."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.services.admin_acp_sessions_service import (
+    ACPSessionStore,
+    SessionRecord,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def store():
+    return ACPSessionStore()
+
+
+async def _create_session(store, session_id, forked_from=None):
+    """Helper to create a session record directly."""
+    rec = SessionRecord(
+        session_id=session_id,
+        user_id=1,
+        agent_type="claude_code",
+        name=f"Session {session_id}",
+        forked_from=forked_from,
+    )
+    store._sessions[session_id] = rec
+    return rec
+
+
+# ---- Basic lineage ----
+
+
+async def test_no_fork_empty_lineage(store):
+    """Session with no fork parent has empty lineage."""
+    await _create_session(store, "s1")
+    lineage = await store.get_fork_lineage("s1")
+    assert lineage == []
+
+
+async def test_single_fork_lineage(store):
+    """Session forked from one parent returns single-element lineage."""
+    await _create_session(store, "parent")
+    await _create_session(store, "child", forked_from="parent")
+    lineage = await store.get_fork_lineage("child")
+    assert lineage == ["parent"]
+
+
+async def test_chain_of_three(store):
+    """Three-level fork chain: grandparent → parent → child."""
+    await _create_session(store, "gp")
+    await _create_session(store, "p", forked_from="gp")
+    await _create_session(store, "c", forked_from="p")
+
+    lineage = await store.get_fork_lineage("c")
+    assert lineage == ["gp", "p"]  # Oldest first
+
+
+async def test_chain_of_five(store):
+    """Five-level fork chain."""
+    await _create_session(store, "s1")
+    await _create_session(store, "s2", forked_from="s1")
+    await _create_session(store, "s3", forked_from="s2")
+    await _create_session(store, "s4", forked_from="s3")
+    await _create_session(store, "s5", forked_from="s4")
+
+    lineage = await store.get_fork_lineage("s5")
+    assert lineage == ["s1", "s2", "s3", "s4"]
+
+
+# ---- Edge cases ----
+
+
+async def test_missing_parent_stops_chain(store):
+    """If a parent session is missing from store, lineage includes the reference but stops."""
+    await _create_session(store, "child", forked_from="missing_parent")
+    lineage = await store.get_fork_lineage("child")
+    assert lineage == ["missing_parent"]  # Reference preserved even if parent gone
+
+
+async def test_nonexistent_session(store):
+    """Getting lineage for nonexistent session returns empty."""
+    lineage = await store.get_fork_lineage("nonexistent")
+    assert lineage == []
+
+
+async def test_cycle_guard(store):
+    """Cycle in fork chain is handled gracefully."""
+    await _create_session(store, "a", forked_from="b")
+    await _create_session(store, "b", forked_from="a")
+    lineage = await store.get_fork_lineage("a")
+    # Should not infinite loop — stops at cycle
+    assert len(lineage) <= 2
+
+
+async def test_max_depth_limit(store):
+    """Lineage respects max_depth parameter."""
+    await _create_session(store, "s0")
+    for i in range(1, 10):
+        await _create_session(store, f"s{i}", forked_from=f"s{i-1}")
+
+    lineage = await store.get_fork_lineage("s9", max_depth=3)
+    assert len(lineage) == 3
+
+
+# ---- Integration with to_detail_dict ----
+
+
+async def test_detail_dict_includes_lineage(store):
+    """to_detail_dict includes fork_lineage when provided."""
+    rec = await _create_session(store, "s1")
+    d = rec.to_detail_dict(fork_lineage=["ancestor1", "ancestor2"])
+    assert d["fork_lineage"] == ["ancestor1", "ancestor2"]
+
+
+async def test_detail_dict_default_empty_lineage(store):
+    """to_detail_dict defaults to empty lineage."""
+    rec = await _create_session(store, "s1")
+    d = rec.to_detail_dict()
+    assert d["fork_lineage"] == []

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_health.py
@@ -1,0 +1,262 @@
+"""Tests for ACP health check and setup-guide endpoints (Phase 0)."""
+import importlib.machinery
+import os
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# Stub heavyweight audio deps before app import in shared fixtures.
+if "torch" not in sys.modules:
+    _fake_torch = types.ModuleType("torch")
+    _fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    _fake_torch.Tensor = object
+    _fake_torch.nn = types.SimpleNamespace(Module=object)
+    sys.modules["torch"] = _fake_torch
+
+if "faster_whisper" not in sys.modules:
+    _fake_fw = types.ModuleType("faster_whisper")
+    _fake_fw.__spec__ = importlib.machinery.ModuleSpec("faster_whisper", loader=None)
+
+    class _StubWhisperModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    _fake_fw.WhisperModel = _StubWhisperModel
+    _fake_fw.BatchedInferencePipeline = _StubWhisperModel
+    sys.modules["faster_whisper"] = _fake_fw
+
+if "transformers" not in sys.modules:
+    _fake_tf = types.ModuleType("transformers")
+    _fake_tf.__spec__ = importlib.machinery.ModuleSpec("transformers", loader=None)
+
+    class _StubProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    class _StubModel:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    _fake_tf.AutoProcessor = _StubProcessor
+    _fake_tf.Qwen2AudioForConditionalGeneration = _StubModel
+    sys.modules["transformers"] = _fake_tf
+
+
+class StubRunnerClient:
+    def __init__(self) -> None:
+        self.agent_capabilities = {"promptCapabilities": {"image": False}}
+        self.is_running = True
+
+    async def create_session(self, cwd, mcp_servers=None, agent_type=None, user_id=None, **kwargs):
+        return "session-123"
+
+    async def prompt(self, session_id, prompt):
+        return {"stopReason": "end"}
+
+    async def cancel(self, session_id):
+        pass
+
+    async def close_session(self, session_id):
+        pass
+
+    def pop_updates(self, session_id, limit=100):
+        return []
+
+
+@pytest.fixture()
+def stub_runner_client(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+
+    stub = StubRunnerClient()
+
+    async def _get_runner_client():
+        return stub
+
+    monkeypatch.setattr(acp_endpoints, "get_runner_client", _get_runner_client)
+    return stub
+
+
+# ---- Config tests ----
+
+def test_config_binary_path_loaded(monkeypatch):
+    """runner_binary_path config option is loaded from env."""
+    monkeypatch.setenv("ACP_RUNNER_BINARY_PATH", "/usr/local/bin/tldw-agent-acp")
+    monkeypatch.setenv("ACP_RUNNER_COMMAND", "")  # Clear command
+
+    import tldw_Server_API.app.core.Agent_Client_Protocol.config as acp_config
+    # Mock get_config_section to return empty dict so config.txt doesn't interfere
+    monkeypatch.setattr(acp_config, "get_config_section", lambda _: {})
+
+    cfg = acp_config.load_acp_runner_config()
+    assert cfg.binary_path == "/usr/local/bin/tldw-agent-acp"
+    # When binary_path is set and command is empty, command becomes the binary_path
+    assert cfg.command == "/usr/local/bin/tldw-agent-acp"
+
+
+def test_config_binary_path_does_not_override_command(monkeypatch):
+    """When both binary_path and command are set, command takes precedence."""
+    monkeypatch.setenv("ACP_RUNNER_BINARY_PATH", "/usr/local/bin/tldw-agent-acp")
+    monkeypatch.setenv("ACP_RUNNER_COMMAND", "go")
+    monkeypatch.setenv("ACP_RUNNER_ARGS", '["run", "./cmd"]')
+
+    import tldw_Server_API.app.core.Agent_Client_Protocol.config as acp_config
+    monkeypatch.setattr(acp_config, "get_config_section", lambda _: {})
+
+    cfg = acp_config.load_acp_runner_config()
+    assert cfg.binary_path == "/usr/local/bin/tldw-agent-acp"
+    assert cfg.command == "go"  # command takes precedence
+
+
+def test_sandbox_config_new_fields(monkeypatch):
+    """New sandbox config fields have correct defaults."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_sandbox_config
+    cfg = load_acp_sandbox_config()
+    assert cfg.session_ttl_seconds == 86400
+    assert cfg.max_concurrent_sessions_per_user == 5
+    assert cfg.max_tokens_per_session == 1_000_000
+    assert cfg.max_session_duration_seconds == 14400
+    assert cfg.audit_retention_days == 30
+    assert cfg.allowed_egress_hosts == []
+
+
+def test_sandbox_config_custom_values(monkeypatch):
+    """New sandbox config fields can be customized via env vars."""
+    monkeypatch.setenv("ACP_SESSION_TTL_SECONDS", "3600")
+    monkeypatch.setenv("ACP_MAX_CONCURRENT_SESSIONS_PER_USER", "10")
+    monkeypatch.setenv("ACP_SANDBOX_ALLOWED_EGRESS_HOSTS", "api.anthropic.com,api.openai.com")
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_sandbox_config
+    cfg = load_acp_sandbox_config()
+    assert cfg.session_ttl_seconds == 3600
+    assert cfg.max_concurrent_sessions_per_user == 10
+    assert cfg.allowed_egress_hosts == ["api.anthropic.com", "api.openai.com"]
+
+
+def test_sandbox_config_allowed_egress_json(monkeypatch):
+    """allowed_egress_hosts accepts JSON array format."""
+    monkeypatch.setenv("ACP_SANDBOX_ALLOWED_EGRESS_HOSTS", '["api.anthropic.com", "api.openai.com"]')
+
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import load_acp_sandbox_config
+    cfg = load_acp_sandbox_config()
+    assert cfg.allowed_egress_hosts == ["api.anthropic.com", "api.openai.com"]
+
+
+# ---- Health endpoint tests ----
+
+def test_acp_health_returns_structured_response(client_user_only, stub_runner_client, monkeypatch):
+    """Health endpoint returns structured diagnostics."""
+    # Ensure no real binaries interfere
+    monkeypatch.setenv("ACP_RUNNER_COMMAND", "nonexistent-binary-12345")
+    monkeypatch.delenv("ACP_RUNNER_BINARY_PATH", raising=False)
+
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "timestamp" in data
+    assert "runner" in data
+    assert "agents" in data
+    assert "runner_probe" in data
+    assert "overall" in data
+    assert data["runner"]["status"] in ("ok", "missing", "error")
+
+
+def test_acp_health_runner_missing(client_user_only, stub_runner_client, monkeypatch):
+    """Health endpoint reports missing runner."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_mod
+    from tldw_Server_API.app.core.Agent_Client_Protocol.config import ACPRunnerConfig
+
+    def _check_missing():
+        return {"status": "missing", "detail": "No runner configured"}
+
+    monkeypatch.setattr(acp_mod, "_check_runner_binary", _check_missing)
+
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["runner"]["status"] == "missing"
+
+
+def test_acp_health_agents_detection(client_user_only, stub_runner_client):
+    """Health endpoint lists agent availability."""
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    agents = data["agents"]
+    assert len(agents) >= 3  # claude_code, codex, opencode
+    agent_types = [a["agent_type"] for a in agents]
+    assert "claude_code" in agent_types
+    assert "codex" in agent_types
+    assert "opencode" in agent_types
+    for agent in agents:
+        assert "status" in agent
+        assert agent["status"] in ("available", "unavailable", "requires_setup", "unknown")
+
+
+def test_acp_health_runner_probe_with_running_client(client_user_only, stub_runner_client):
+    """Health endpoint probes running runner client."""
+    # stub_runner_client has is_running = True
+    resp = client_user_only.get("/api/v1/acp/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Runner probe should try to check the client
+    assert "runner_probe" in data
+
+
+# ---- Setup guide endpoint tests ----
+
+def test_acp_setup_guide_returns_guides(client_user_only, stub_runner_client):
+    """Setup guide endpoint returns actionable guides."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "runner" in data
+    assert "guides" in data
+    assert len(data["guides"]) >= 3
+    for guide in data["guides"]:
+        assert "agent_type" in guide
+        assert "name" in guide
+        assert "status" in guide
+        assert "steps" in guide
+        assert len(guide["steps"]) > 0
+
+
+def test_acp_setup_guide_filter_agent(client_user_only, stub_runner_client):
+    """Setup guide endpoint can filter to a specific agent type."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=claude_code")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["guides"]) == 1
+    assert data["guides"][0]["agent_type"] == "claude_code"
+
+
+def test_acp_setup_guide_unknown_agent(client_user_only, stub_runner_client):
+    """Setup guide endpoint returns all agents for unknown agent_type."""
+    resp = client_user_only.get("/api/v1/acp/setup-guide?agent_type=unknown_agent_xyz")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Falls back to listing all agents
+    assert len(data["guides"]) >= 3
+
+
+def test_acp_setup_guide_runner_steps(client_user_only, stub_runner_client, monkeypatch):
+    """Setup guide includes runner setup steps when runner is missing."""
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_mod
+
+    def _check_missing():
+        return {"status": "missing", "detail": "No runner configured"}
+
+    monkeypatch.setattr(acp_mod, "_check_runner_binary", _check_missing)
+
+    resp = client_user_only.get("/api/v1/acp/setup-guide")
+    assert resp.status_code == 200
+    data = resp.json()
+    runner = data["runner"]
+    assert runner["status"] == "missing"
+    assert len(runner["steps"]) > 1  # Should have setup instructions
+    assert any("setup_acp.sh" in step for step in runner["steps"])

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
@@ -1,0 +1,121 @@
+"""Integration tests using the stub agent via real STDIO transport.
+
+These tests exercise the full JSON-RPC protocol path through
+ACPStdioClient → acp_stub_agent.py without needing the Go binary.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+    ACPStdioClient,
+    ACPResponseError,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+STUB_AGENT_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "Helper_Scripts",
+    "acp_stub_agent.py",
+)
+
+
+@pytest.fixture
+async def client():
+    """Spawn stub agent for each test."""
+    c = ACPStdioClient(
+        command=sys.executable,
+        args=[os.path.abspath(STUB_AGENT_PATH)],
+    )
+    await c.start()
+    yield c
+    await c.close()
+
+
+# ---- Session lifecycle ----
+
+async def test_initialize(client):
+    """Verify initialize handshake returns agent info."""
+    result = await client.call("initialize", {})
+    assert result.result is not None
+    assert result.result["agentInfo"]["name"] == "tldw-acp-stub"
+    assert result.result["protocolVersion"] == 1
+
+
+async def test_session_new(client):
+    """Verify session/new returns a session ID."""
+    await client.call("initialize", {})
+    result = await client.call("session/new", {})
+    assert "sessionId" in result.result
+    assert result.result["sessionId"].startswith("stub-")
+
+
+async def test_session_prompt(client):
+    """Verify session/prompt returns stop reason and emits update."""
+    await client.call("initialize", {})
+    new_result = await client.call("session/new", {})
+    session_id = new_result.result["sessionId"]
+
+    # Collect notifications
+    notifications = []
+
+    async def handler(msg):
+        notifications.append(msg)
+
+    client.set_notification_handler(handler)
+
+    result = await client.call(
+        "session/prompt",
+        {"sessionId": session_id, "prompt": "Hello"},
+    )
+    assert result.result["stopReason"] == "end"
+
+
+async def test_session_cancel(client):
+    """Verify session/cancel returns successfully."""
+    await client.call("initialize", {})
+    result = await client.call("session/cancel", {})
+    assert result.result is None
+
+
+async def test_unknown_method_returns_error(client):
+    """Verify unknown methods raise ACPResponseError."""
+    with pytest.raises(ACPResponseError, match="method not found"):
+        await client.call("nonexistent/method", {})
+
+
+# ---- Concurrent sessions ----
+
+async def test_concurrent_sessions(client):
+    """Verify multiple sessions can be created sequentially."""
+    await client.call("initialize", {})
+
+    session_ids = []
+    for _ in range(3):
+        result = await client.call("session/new", {})
+        session_ids.append(result.result["sessionId"])
+
+    assert len(set(session_ids)) == 3  # All unique
+
+
+# ---- Error handling ----
+
+async def test_client_close_is_idempotent(client):
+    """Closing an already-closed client should not raise."""
+    await client.close()
+    await client.close()  # Should not raise
+
+
+async def test_client_is_running(client):
+    """Verify is_running reflects process state."""
+    assert client.is_running
+    await client.close()
+    assert not client.is_running

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_metrics.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_metrics.py
@@ -1,0 +1,127 @@
+"""Tests for ACP metrics module."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_metrics_registration():
+    """Verify ACP metrics register without error."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        _ensure_registered,
+    )
+
+    _ensure_registered()  # Should not raise
+
+
+def test_record_session_created():
+    """Verify session creation metric increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_session_created,
+    )
+
+    record_session_created("claude_code")  # Should not raise
+
+
+def test_record_session_closed():
+    """Verify session close metric increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_session_closed,
+    )
+
+    record_session_closed("normal")
+    record_session_closed("timeout")
+
+
+def test_set_active_sessions():
+    """Verify active sessions gauge can be set."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        set_active_sessions,
+    )
+
+    set_active_sessions(5, "claude_code")
+    set_active_sessions(0)
+
+
+def test_record_prompt():
+    """Verify prompt counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import record_prompt
+
+    record_prompt("codex")
+
+
+def test_record_prompt_latency():
+    """Verify latency histogram records."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_prompt_latency,
+    )
+
+    record_prompt_latency(1.5, "claude_code")
+
+
+def test_record_token_usage():
+    """Verify token usage counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_token_usage,
+    )
+
+    record_token_usage(500, "claude_code", "input")
+    record_token_usage(200, "claude_code", "output")
+
+
+def test_record_governance_block():
+    """Verify governance block counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_governance_block,
+    )
+
+    record_governance_block("rate_limit", "claude_code")
+
+
+def test_record_error():
+    """Verify error counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import record_error
+
+    record_error("timeout")
+    record_error("connection_refused")
+
+
+def test_record_quota_rejection():
+    """Verify quota rejection counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_quota_rejection,
+    )
+
+    record_quota_rejection("concurrent_sessions")
+    record_quota_rejection("token_limit")
+
+
+def test_record_orchestration_task():
+    """Verify orchestration task counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_orchestration_task,
+    )
+
+    record_orchestration_task("created")
+    record_orchestration_task("completed")
+
+
+def test_record_orchestration_run():
+    """Verify orchestration run counter increments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        record_orchestration_run,
+    )
+
+    record_orchestration_run("dispatched")
+    record_orchestration_run("completed")
+
+
+def test_idempotent_registration():
+    """Verify metrics can be registered multiple times without error."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.metrics import (
+        _ensure_registered,
+    )
+
+    _ensure_registered()
+    _ensure_registered()  # Should not raise

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
@@ -1,0 +1,267 @@
+"""Tests for ACP session TTL, quotas, and audit persistence (Phase 1)."""
+from __future__ import annotations
+
+import asyncio
+import importlib.machinery
+import os
+import sys
+import tempfile
+import types
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Stub heavyweight audio deps before app import.
+if "torch" not in sys.modules:
+    _fake_torch = types.ModuleType("torch")
+    _fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    _fake_torch.Tensor = object
+    _fake_torch.nn = types.SimpleNamespace(Module=object)
+    sys.modules["torch"] = _fake_torch
+
+if "faster_whisper" not in sys.modules:
+    _fake_fw = types.ModuleType("faster_whisper")
+    _fake_fw.__spec__ = importlib.machinery.ModuleSpec("faster_whisper", loader=None)
+
+    class _StubWhisperModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    _fake_fw.WhisperModel = _StubWhisperModel
+    _fake_fw.BatchedInferencePipeline = _StubWhisperModel
+    sys.modules["faster_whisper"] = _fake_fw
+
+if "transformers" not in sys.modules:
+    _fake_tf = types.ModuleType("transformers")
+    _fake_tf.__spec__ = importlib.machinery.ModuleSpec("transformers", loader=None)
+
+    class _StubProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    class _StubModel:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    _fake_tf.AutoProcessor = _StubProcessor
+    _fake_tf.Qwen2AudioForConditionalGeneration = _StubModel
+    sys.modules["transformers"] = _fake_tf
+
+
+# ---- Session Store quota/TTL tests ----
+
+@pytest.fixture
+def session_store():
+    from tldw_Server_API.app.services.admin_acp_sessions_service import ACPSessionStore
+    return ACPSessionStore()
+
+
+@pytest.mark.asyncio
+async def test_session_quota_enforcement(session_store):
+    """Max concurrent sessions quota is enforced."""
+    session_store.configure_quotas(max_concurrent_per_user=2)
+
+    # Create 2 sessions — should be fine
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+    await session_store.register_session("s2", user_id=1, name="Session 2")
+
+    # Third session should hit quota
+    error = await session_store.check_session_quota(user_id=1)
+    assert error is not None
+    assert error["code"] == "quota_exceeded"
+    assert error["current"] == 2
+    assert error["limit"] == 2
+
+
+@pytest.mark.asyncio
+async def test_session_quota_allows_after_close(session_store):
+    """Closing a session frees up quota."""
+    session_store.configure_quotas(max_concurrent_per_user=1)
+
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+    error = await session_store.check_session_quota(user_id=1)
+    assert error is not None
+
+    await session_store.close_session("s1")
+    error = await session_store.check_session_quota(user_id=1)
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_session_quota_per_user(session_store):
+    """Quota is per-user, not global."""
+    session_store.configure_quotas(max_concurrent_per_user=1)
+
+    await session_store.register_session("s1", user_id=1, name="User 1 Session")
+
+    # User 2 should not be blocked by user 1's sessions
+    error = await session_store.check_session_quota(user_id=2)
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_token_quota_enforcement(session_store):
+    """Token quota is enforced per session."""
+    session_store.configure_quotas(max_tokens_per_session=100)
+
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+
+    # Record a prompt that pushes tokens over limit
+    await session_store.record_prompt(
+        "s1",
+        [{"role": "user", "content": "hi"}],
+        {"stopReason": "end", "usage": {"prompt_tokens": 50, "completion_tokens": 60}},
+    )
+
+    error = await session_store.check_token_quota("s1")
+    assert error is not None
+    assert error["code"] == "token_quota_exceeded"
+    assert error["current"] == 110
+
+
+@pytest.mark.asyncio
+async def test_token_quota_ok_under_limit(session_store):
+    """Token quota check passes when under limit."""
+    session_store.configure_quotas(max_tokens_per_session=1000)
+
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+    await session_store.record_prompt(
+        "s1",
+        [{"role": "user", "content": "hi"}],
+        {"stopReason": "end", "usage": {"prompt_tokens": 10, "completion_tokens": 20}},
+    )
+
+    error = await session_store.check_token_quota("s1")
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_session_eviction(session_store):
+    """Expired sessions are evicted by cleanup."""
+    session_store.configure_quotas(session_ttl_seconds=0)  # Immediate expiry
+
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+    rec = await session_store.get_session("s1")
+    assert rec is not None
+    assert rec.status == "active"
+
+    # Run eviction
+    evicted = await session_store._evict_expired_sessions()
+    assert evicted == 1
+
+    rec = await session_store.get_session("s1")
+    assert rec.status == "closed"
+
+
+@pytest.mark.asyncio
+async def test_quota_status(session_store):
+    """Quota status returns current usage."""
+    session_store.configure_quotas(max_concurrent_per_user=5, max_tokens_per_session=1000)
+
+    await session_store.register_session("s1", user_id=1, name="Session 1")
+    status = await session_store.get_quota_status(user_id=1, session_id="s1")
+    assert status["concurrent_sessions"]["current"] == 1
+    assert status["concurrent_sessions"]["limit"] == 5
+    assert status["session_tokens"]["current"] == 0
+    assert status["session_tokens"]["limit"] == 1000
+
+
+# ---- Audit DB tests ----
+
+def test_audit_db_record_and_flush():
+    """Audit events are recorded and flushed to SQLite."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import ACPAuditDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = ACPAuditDB(db_path=os.path.join(tmpdir, "audit.db"))
+        db.record_event(action="session_new", user_id=1, session_id="s1", metadata={"test": True})
+        db.record_event(action="prompt", user_id=1, session_id="s1")
+
+        # Hot cache should have 2 events
+        cache = db.get_hot_cache()
+        assert len(cache) == 2
+
+        # Flush to disk
+        flushed = db.flush()
+        assert flushed == 2
+
+        # Query from SQLite
+        events = db.query_events(session_id="s1")
+        assert len(events) == 2
+        assert events[0]["action"] == "prompt"  # DESC order
+        assert events[1]["action"] == "session_new"
+
+        db.close()
+
+
+def test_audit_db_query_filters():
+    """Audit events can be filtered by user_id and action."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import ACPAuditDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = ACPAuditDB(db_path=os.path.join(tmpdir, "audit.db"))
+        db.record_event(action="session_new", user_id=1, session_id="s1")
+        db.record_event(action="prompt", user_id=2, session_id="s2")
+        db.record_event(action="session_close", user_id=1, session_id="s1")
+        db.flush()
+
+        # Filter by user_id
+        events = db.query_events(user_id=1)
+        assert len(events) == 2
+
+        # Filter by action
+        events = db.query_events(action="prompt")
+        assert len(events) == 1
+        assert events[0]["user_id"] == 2
+
+        db.close()
+
+
+def test_audit_db_hot_cache_filter():
+    """Hot cache can be filtered by session_id."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import ACPAuditDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = ACPAuditDB(db_path=os.path.join(tmpdir, "audit.db"))
+        db.record_event(action="a", user_id=1, session_id="s1")
+        db.record_event(action="b", user_id=1, session_id="s2")
+
+        filtered = db.get_hot_cache(session_id="s1")
+        assert len(filtered) == 1
+        assert filtered[0]["session_id"] == "s1"
+
+        db.close()
+
+
+def test_audit_db_purge():
+    """Old events are purged by retention policy."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import ACPAuditDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = ACPAuditDB(db_path=os.path.join(tmpdir, "audit.db"), retention_days=0)
+        db.record_event(action="old", user_id=1, session_id="s1")
+        db.flush()
+
+        # Purge with 0-day retention should delete everything
+        deleted = db.purge_old_events()
+        assert deleted >= 1
+
+        events = db.query_events()
+        assert len(events) == 0
+
+        db.close()
+
+
+def test_audit_db_double_flush_is_idempotent():
+    """Flushing with no new events returns 0."""
+    from tldw_Server_API.app.core.DB_Management.ACP_Audit_DB import ACPAuditDB
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db = ACPAuditDB(db_path=os.path.join(tmpdir, "audit.db"))
+        db.record_event(action="test", user_id=1, session_id="s1")
+        assert db.flush() == 1
+        assert db.flush() == 0  # No new events
+        db.close()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
@@ -112,10 +112,11 @@ class _StubSessionRecord:
             "forked_from": self.forked_from,
         }
 
-    def to_detail_dict(self, *, has_websocket: bool = False) -> dict:
+    def to_detail_dict(self, *, has_websocket: bool = False, fork_lineage: list[str] | None = None) -> dict:
         payload = self.to_info_dict(has_websocket=has_websocket)
         payload["messages"] = list(self.messages)
         payload["cwd"] = self.cwd
+        payload["fork_lineage"] = fork_lineage or []
         return payload
 
 
@@ -140,6 +141,9 @@ class _StubSessionStore:
         if session_id != self.record.session_id:
             return None
         return self.record
+
+    async def get_fork_lineage(self, session_id: str, *, max_depth: int = 50):
+        return []
 
 
 class _StubRunnerClient:

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_api.py
@@ -1,0 +1,194 @@
+"""Tests for Agent Orchestration API endpoints (Phase 4.2)."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
+    OrchestrationService,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def svc():
+    return OrchestrationService()
+
+
+# ---- Project API scenarios ----
+
+
+async def test_create_and_list_projects(svc):
+    """Create multiple projects and verify listing."""
+    await svc.create_project(name="Alpha", user_id=1)
+    await svc.create_project(name="Beta", user_id=1)
+    await svc.create_project(name="Gamma", user_id=2)
+
+    user1_projects = await svc.list_projects(user_id=1)
+    assert len(user1_projects) == 2
+    names = {p.name for p in user1_projects}
+    assert names == {"Alpha", "Beta"}
+
+
+async def test_get_project_not_found(svc):
+    """Getting a nonexistent project returns None."""
+    assert await svc.get_project(999) is None
+
+
+async def test_delete_nonexistent_project(svc):
+    """Deleting a nonexistent project returns False."""
+    assert await svc.delete_project(999) is False
+
+
+# ---- Task API scenarios ----
+
+
+async def test_create_task_with_all_fields(svc):
+    """Create a task with all optional fields."""
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(
+        project.id,
+        title="Full Task",
+        description="A comprehensive task",
+        agent_type="codex",
+        max_review_attempts=5,
+        user_id=1,
+    )
+    assert task.description == "A comprehensive task"
+    assert task.agent_type == "codex"
+    assert task.max_review_attempts == 5
+
+
+async def test_list_tasks_all_statuses(svc):
+    """List tasks returns all statuses when no filter."""
+    project = await svc.create_project(name="P1", user_id=1)
+    await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", user_id=1)
+    await svc.transition_task(t2.id, TaskStatus.IN_PROGRESS)
+    t3 = await svc.create_task(project.id, title="T3", user_id=1)
+    await svc.transition_task(t3.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t3.id, TaskStatus.REVIEW)
+
+    all_tasks = await svc.list_tasks(project.id)
+    assert len(all_tasks) == 3
+
+
+# ---- Run dispatch scenarios ----
+
+
+async def test_run_inherits_agent_type(svc):
+    """Run should inherit agent_type from its parent task."""
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(
+        project.id, title="T1", agent_type="codex", user_id=1
+    )
+    run = await svc.create_run(task.id, session_id="sess-1")
+    assert run.agent_type == "codex"
+
+
+async def test_multiple_runs_per_task(svc):
+    """Multiple runs can be created for the same task."""
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    r1 = await svc.create_run(task.id, session_id="s1")
+    r2 = await svc.create_run(task.id, session_id="s2")
+    r3 = await svc.create_run(task.id, session_id="s3")
+
+    runs = await svc.list_runs(task.id)
+    assert len(runs) == 3
+    assert {r.session_id for r in runs} == {"s1", "s2", "s3"}
+
+
+# ---- Review gate edge cases ----
+
+
+async def test_review_approval_after_rejection(svc):
+    """Approve should work after a previous rejection."""
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(
+        project.id, title="T1", max_review_attempts=5, user_id=1
+    )
+
+    # First cycle: reject
+    await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+    await svc.submit_review(task.id, approved=False)
+    assert (await svc.get_task(task.id)).status == TaskStatus.IN_PROGRESS
+
+    # Second cycle: approve
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+    result = await svc.submit_review(task.id, approved=True)
+    assert result.status == TaskStatus.COMPLETE
+    assert result.review_count == 2
+
+
+# ---- Dependency chain ----
+
+
+async def test_three_level_dependency_chain(svc):
+    """Three-level dependency chain: T3 → T2 → T1."""
+    project = await svc.create_project(name="P1", user_id=1)
+    t1 = await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(
+        project.id, title="T2", dependency_id=t1.id, user_id=1
+    )
+    t3 = await svc.create_task(
+        project.id, title="T3", dependency_id=t2.id, user_id=1
+    )
+
+    # T3 not ready because T2 not complete
+    assert await svc.check_dependency_ready(t3.id) is False
+
+    # Complete T1
+    await svc.transition_task(t1.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t1.id, TaskStatus.REVIEW)
+    await svc.transition_task(t1.id, TaskStatus.COMPLETE)
+
+    # T2 is ready, T3 still not (T2 not complete)
+    assert await svc.check_dependency_ready(t2.id) is True
+    assert await svc.check_dependency_ready(t3.id) is False
+
+    # Complete T2
+    await svc.transition_task(t2.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t2.id, TaskStatus.REVIEW)
+    await svc.transition_task(t2.id, TaskStatus.COMPLETE)
+
+    # Now T3 is ready
+    assert await svc.check_dependency_ready(t3.id) is True
+
+
+# ---- Summary ----
+
+
+async def test_project_summary_includes_all_statuses(svc):
+    """Project summary should include all task status categories."""
+    project = await svc.create_project(name="P1", user_id=1)
+    t1 = await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", user_id=1)
+    t3 = await svc.create_task(project.id, title="T3", user_id=1)
+
+    await svc.transition_task(t1.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t2.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t2.id, TaskStatus.REVIEW)
+    await svc.transition_task(t3.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t3.id, TaskStatus.TRIAGE)
+
+    summary = await svc.get_project_summary(project.id)
+    assert summary["total_tasks"] == 3
+    counts = summary["status_counts"]
+    assert counts.get("inprogress", 0) == 1
+    assert counts.get("review", 0) == 1
+    assert counts.get("triage", 0) == 1
+
+
+async def test_get_task_not_found(svc):
+    """Getting a nonexistent task returns None."""
+    assert await svc.get_task(999) is None
+
+
+async def test_transition_nonexistent_task_raises(svc):
+    """Transitioning a nonexistent task raises ValueError."""
+    with pytest.raises(ValueError, match="Task 999 not found"):
+        await svc.transition_task(999, TaskStatus.IN_PROGRESS)

--- a/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
+++ b/tldw_Server_API/tests/Agent_Orchestration/test_orchestration_service.py
@@ -1,0 +1,275 @@
+"""Tests for Agent Orchestration service (Phase 4)."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Orchestration.models import (
+    TaskStatus,
+    RunStatus,
+    is_valid_transition,
+)
+from tldw_Server_API.app.core.Agent_Orchestration.orchestration_service import (
+    CycleDependencyError,
+    OrchestrationService,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def svc():
+    return OrchestrationService()
+
+
+# ---- State machine tests ----
+
+def test_valid_transitions():
+    assert is_valid_transition(TaskStatus.TODO, TaskStatus.IN_PROGRESS)
+    assert is_valid_transition(TaskStatus.IN_PROGRESS, TaskStatus.REVIEW)
+    assert is_valid_transition(TaskStatus.IN_PROGRESS, TaskStatus.TRIAGE)
+    assert is_valid_transition(TaskStatus.REVIEW, TaskStatus.COMPLETE)
+    assert is_valid_transition(TaskStatus.REVIEW, TaskStatus.TRIAGE)
+    assert is_valid_transition(TaskStatus.REVIEW, TaskStatus.IN_PROGRESS)
+    assert is_valid_transition(TaskStatus.TRIAGE, TaskStatus.TODO)
+    assert is_valid_transition(TaskStatus.TRIAGE, TaskStatus.IN_PROGRESS)
+
+
+def test_invalid_transitions():
+    assert not is_valid_transition(TaskStatus.TODO, TaskStatus.COMPLETE)
+    assert not is_valid_transition(TaskStatus.TODO, TaskStatus.REVIEW)
+    assert not is_valid_transition(TaskStatus.COMPLETE, TaskStatus.TODO)
+    assert not is_valid_transition(TaskStatus.COMPLETE, TaskStatus.IN_PROGRESS)
+    assert not is_valid_transition(TaskStatus.IN_PROGRESS, TaskStatus.TODO)
+
+
+# ---- Project CRUD tests ----
+
+@pytest.mark.asyncio
+async def test_create_project(svc):
+    project = await svc.create_project(name="Test Project", user_id=1)
+    assert project.id == 1
+    assert project.name == "Test Project"
+    assert project.user_id == 1
+
+
+@pytest.mark.asyncio
+async def test_list_projects_filters_by_user(svc):
+    await svc.create_project(name="P1", user_id=1)
+    await svc.create_project(name="P2", user_id=2)
+
+    projects = await svc.list_projects(user_id=1)
+    assert len(projects) == 1
+    assert projects[0].name == "P1"
+
+
+@pytest.mark.asyncio
+async def test_delete_project_cascades(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+    run = await svc.create_run(task.id)
+
+    assert await svc.delete_project(project.id) is True
+    assert await svc.get_project(project.id) is None
+    assert await svc.get_task(task.id) is None
+
+
+# ---- Task CRUD tests ----
+
+@pytest.mark.asyncio
+async def test_create_task(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(
+        project.id, title="Task 1",
+        description="Do something", agent_type="claude_code",
+        user_id=1,
+    )
+    assert task.id == 1
+    assert task.title == "Task 1"
+    assert task.status == TaskStatus.TODO
+    assert task.agent_type == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_create_task_nonexistent_project(svc):
+    with pytest.raises(ValueError, match="Project 999 not found"):
+        await svc.create_task(999, title="T1", user_id=1)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_with_status_filter(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", user_id=1)
+    await svc.transition_task(t2.id, TaskStatus.IN_PROGRESS)
+
+    todo_tasks = await svc.list_tasks(project.id, status=TaskStatus.TODO)
+    assert len(todo_tasks) == 1
+
+    ip_tasks = await svc.list_tasks(project.id, status=TaskStatus.IN_PROGRESS)
+    assert len(ip_tasks) == 1
+
+
+# ---- Dependency tests ----
+
+@pytest.mark.asyncio
+async def test_dependency_gating(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    t1 = await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", dependency_id=t1.id, user_id=1)
+
+    # T2 depends on T1, which is TODO → not ready
+    assert await svc.check_dependency_ready(t2.id) is False
+
+    # Complete T1
+    await svc.transition_task(t1.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(t1.id, TaskStatus.REVIEW)
+    await svc.transition_task(t1.id, TaskStatus.COMPLETE)
+
+    # Now T2 should be ready
+    assert await svc.check_dependency_ready(t2.id) is True
+
+
+@pytest.mark.asyncio
+async def test_cycle_detection(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    t1 = await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", dependency_id=t1.id, user_id=1)
+
+    # T3 depending on T2 depending on T1 → no cycle
+    t3 = await svc.create_task(project.id, title="T3", dependency_id=t2.id, user_id=1)
+    assert t3.dependency_id == t2.id
+
+
+@pytest.mark.asyncio
+async def test_no_dependency_always_ready(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    t1 = await svc.create_task(project.id, title="T1", user_id=1)
+
+    assert await svc.check_dependency_ready(t1.id) is True
+
+
+# ---- State transition tests ----
+
+@pytest.mark.asyncio
+async def test_transition_todo_to_inprogress(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    updated = await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    assert updated.status == TaskStatus.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_invalid_transition_raises(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    with pytest.raises(ValueError, match="Invalid transition"):
+        await svc.transition_task(task.id, TaskStatus.COMPLETE)
+
+
+# ---- Run tests ----
+
+@pytest.mark.asyncio
+async def test_create_and_complete_run(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", agent_type="claude_code", user_id=1)
+
+    run = await svc.create_run(task.id, session_id="acp-session-1")
+    assert run.status == RunStatus.RUNNING
+    assert run.session_id == "acp-session-1"
+    assert run.agent_type == "claude_code"
+
+    completed = await svc.complete_run(run.id, result_summary="Done")
+    assert completed.status == RunStatus.COMPLETED
+    assert completed.result_summary == "Done"
+
+
+@pytest.mark.asyncio
+async def test_fail_run(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    run = await svc.create_run(task.id)
+    failed = await svc.fail_run(run.id, error="Timeout")
+    assert failed.status == RunStatus.FAILED
+    assert failed.error == "Timeout"
+
+
+@pytest.mark.asyncio
+async def test_list_runs(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    await svc.create_run(task.id, session_id="s1")
+    await svc.create_run(task.id, session_id="s2")
+
+    runs = await svc.list_runs(task.id)
+    assert len(runs) == 2
+
+
+# ---- Reviewer gate tests ----
+
+@pytest.mark.asyncio
+async def test_review_approved(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+    await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+
+    result = await svc.submit_review(task.id, approved=True)
+    assert result.status == TaskStatus.COMPLETE
+    assert result.review_count == 1
+
+
+@pytest.mark.asyncio
+async def test_review_rejected_returns_to_inprogress(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", max_review_attempts=3, user_id=1)
+    await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+
+    result = await svc.submit_review(task.id, approved=False)
+    assert result.status == TaskStatus.IN_PROGRESS
+    assert result.review_count == 1
+
+
+@pytest.mark.asyncio
+async def test_review_max_attempts_triggers_triage(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", max_review_attempts=2, user_id=1)
+
+    # First review cycle
+    await svc.transition_task(task.id, TaskStatus.IN_PROGRESS)
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+    await svc.submit_review(task.id, approved=False)  # review_count=1, back to inprogress
+
+    # Second review cycle
+    await svc.transition_task(task.id, TaskStatus.REVIEW)
+    result = await svc.submit_review(task.id, approved=False)  # review_count=2 >= max(2) → triage
+    assert result.status == TaskStatus.TRIAGE
+    assert result.review_count == 2
+
+
+@pytest.mark.asyncio
+async def test_review_on_non_review_task_raises(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    task = await svc.create_task(project.id, title="T1", user_id=1)
+
+    with pytest.raises(ValueError, match="not in review status"):
+        await svc.submit_review(task.id, approved=True)
+
+
+# ---- Summary test ----
+
+@pytest.mark.asyncio
+async def test_project_summary(svc):
+    project = await svc.create_project(name="P1", user_id=1)
+    await svc.create_task(project.id, title="T1", user_id=1)
+    t2 = await svc.create_task(project.id, title="T2", user_id=1)
+    await svc.transition_task(t2.id, TaskStatus.IN_PROGRESS)
+
+    summary = await svc.get_project_summary(project.id)
+    assert summary["total_tasks"] == 2
+    assert summary["status_counts"]["todo"] == 1
+    assert summary["status_counts"]["inprogress"] == 1

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
@@ -7,12 +7,15 @@ import pytest
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module import SandboxModule
 from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, Session, TrustLevel
 
 
 class _FakeSandboxService:
     def __init__(self) -> None:
         self.user_ids: list[str] = []
+        self.specs: list[object] = []
+        self.sessions: dict[str, Session] = {}
+        self.session_owners: dict[str, str] = {}
 
     def start_run_scaffold(
         self,
@@ -24,6 +27,7 @@ class _FakeSandboxService:
         raw_body,  # noqa: ANN001 - minimal test stub
     ) -> RunStatus:
         self.user_ids.append(str(user_id))
+        self.specs.append(spec)
         return RunStatus(
             id="run-test-1",
             phase=RunPhase.queued,
@@ -32,6 +36,12 @@ class _FakeSandboxService:
             base_image=spec.base_image,
             started_at=datetime.now(timezone.utc),
         )
+
+    def get_session(self, session_id: str) -> Session | None:
+        return self.sessions.get(str(session_id))
+
+    def get_session_owner(self, session_id: str) -> str | None:
+        return self.session_owners.get(str(session_id))
 
 
 @pytest.mark.asyncio
@@ -75,3 +85,82 @@ async def test_sandbox_run_binds_authenticated_context_user_id() -> None:
 
     assert module._svc.user_ids == ["77"]
     assert result["id"] == "run-test-1"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_rejects_unowned_session_id() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-1"] = Session(
+        id="sess-1",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+    )
+    module._svc.session_owners["sess-1"] = "88"
+    ctx = RequestContext(
+        request_id="req-2",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    with pytest.raises(PermissionError):
+        await module.execute_tool(
+            "sandbox.run",
+            {
+                "session_id": "sess-1",
+                "command": ["python", "-c", "print('ok')"],
+            },
+            context=ctx,
+        )
+
+    assert module._svc.user_ids == []
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_inherits_owned_session_defaults() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-2"] = Session(
+        id="sess-2",
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        expires_at=None,
+        cpu_limit=1.5,
+        memory_mb=768,
+        timeout_sec=77,
+        network_policy="deny_all",
+        env={"SESSION_TOKEN": "present"},
+        labels={"team": "sandbox"},
+        trust_level=TrustLevel.untrusted,
+    )
+    module._svc.session_owners["sess-2"] = "77"
+    ctx = RequestContext(
+        request_id="req-3",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {
+            "session_id": "sess-2",
+            "command": ["python", "-c", "print('ok')"],
+        },
+        context=ctx,
+    )
+
+    assert result["base_image"] == "python:3.12-slim"
+    spec = module._svc.specs[-1]
+    assert spec.runtime == RuntimeType.docker
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.cpu == 1.5
+    assert spec.memory_mb == 768
+    assert spec.timeout_sec == 77
+    assert spec.network_policy == "deny_all"
+    assert spec.env == {"SESSION_TOKEN": "present"}
+    assert spec.trust_level == TrustLevel.untrusted

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
@@ -164,3 +164,35 @@ async def test_sandbox_run_inherits_owned_session_defaults() -> None:
     assert spec.network_policy == "deny_all"
     assert spec.env == {"SESSION_TOKEN": "present"}
     assert spec.trust_level == TrustLevel.untrusted
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_allows_permission_based_admin_override() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-admin"] = Session(
+        id="sess-admin",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+    )
+    module._svc.session_owners["sess-admin"] = "88"
+    ctx = RequestContext(
+        request_id="req-admin-1",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={"permissions": ["system.configure"]},
+    )
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {
+            "session_id": "sess-admin",
+            "command": ["python", "-c", "print('ok')"],
+        },
+        context=ctx,
+    )
+
+    assert result["id"] == "run-test-1"
+    assert module._svc.user_ids == ["77"]

--- a/tldw_Server_API/tests/sandbox/test_artifact_range.py
+++ b/tldw_Server_API/tests/sandbox/test_artifact_range.py
@@ -55,3 +55,33 @@ def test_artifact_download_range_support(monkeypatch) -> None:
         assert r3.headers.get("Content-Range") == "bytes 7-9/10"
         assert r3.headers.get("Content-Length") == "3"
         assert r3.content == b"789"
+
+
+def test_artifact_download_range_avoids_full_artifact_read(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body: Dict[str, Any] = {
+            "spec_version": "1.0",
+            "runtime": "docker",
+            "base_image": "python:3.11-slim",
+            "command": ["bash", "-lc", "echo done"],
+            "timeout_sec": 5,
+            "capture_patterns": ["out.txt"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 200
+        run_id = r.json()["id"]
+
+        from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+        payload = b"0123456789"
+        sb._service._orch.store_artifacts(run_id, {"out.txt": payload})  # type: ignore[attr-defined]
+
+        def _fail_get_artifact(*args, **kwargs):
+            raise AssertionError("download path should stream from disk instead of loading full artifact")
+
+        monkeypatch.setattr(sb._service._orch, "get_artifact", _fail_get_artifact)
+
+        r2 = client.get(f"/api/v1/sandbox/runs/{run_id}/artifacts/out.txt", headers={"Range": "bytes=0-4"})
+        assert r2.status_code == 206
+        assert r2.headers.get("Content-Range") == "bytes 0-4/10"
+        assert r2.content == b"01234"

--- a/tldw_Server_API/tests/sandbox/test_artifact_usage_accounting.py
+++ b/tldw_Server_API/tests/sandbox/test_artifact_usage_accounting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import threading
 
 import pytest
 
@@ -35,3 +36,61 @@ def test_artifact_usage_bytes_incremented(monkeypatch: pytest.MonkeyPatch, tmp_p
     orch.store_artifacts(run_id, {"out.txt": b"hello"})
     used = orch._store.get_user_artifact_bytes("user-1")
     assert used == 5
+
+
+def test_artifact_usage_cap_holds_under_concurrent_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+    monkeypatch.setenv("SANDBOX_MAX_ARTIFACT_BYTES_PER_USER_MB", "1")
+
+    orch = SandboxOrchestrator()
+    run_a = "run-art-concurrent-a"
+    run_b = "run-art-concurrent-b"
+    orch._store.put_run("user-1", RunStatus(id=run_a, phase=RunPhase.completed))
+    orch._store.put_run("user-1", RunStatus(id=run_b, phase=RunPhase.completed))
+
+    original_get = orch._store.get_user_artifact_bytes
+    barrier = threading.Barrier(2)
+
+    def _synchronized_get(user_id: str) -> int:
+        value = original_get(user_id)
+        try:
+            barrier.wait(timeout=1.0)
+        except threading.BrokenBarrierError:
+            pass
+        return value
+
+    monkeypatch.setattr(orch._store, "get_user_artifact_bytes", _synchronized_get)
+
+    errors: list[BaseException] = []
+
+    def _worker(run_id: str, payload: bytes) -> None:
+        try:
+            orch.store_artifacts(run_id, {"out.txt": payload})
+        except BaseException as exc:  # pragma: no cover - assertion capture path
+            errors.append(exc)
+
+    payload = b"x" * (700 * 1024)
+    thread_a = threading.Thread(target=_worker, args=(run_a, payload))
+    thread_b = threading.Thread(target=_worker, args=(run_b, payload))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=2.0)
+    thread_b.join(timeout=2.0)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert errors == []
+
+    cap_bytes = 1 * 1024 * 1024
+    used = original_get("user-1")
+    total_persisted = sum(
+        orch.list_artifacts(run_id).get("out.txt", 0)
+        for run_id in (run_a, run_b)
+    )
+
+    assert used <= cap_bytes
+    assert total_persisted <= cap_bytes
+    assert any(
+        orch.list_artifacts(run_id).get("out.txt", 0) == 0
+        for run_id in (run_a, run_b)
+    )

--- a/tldw_Server_API/tests/sandbox/test_docker_runner_integration.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_runner_integration.py
@@ -90,13 +90,12 @@ def test_full_lifecycle(sandbox_client):
         "session_id": session_id,
         "spec_version": "1.0",
         "runtime": "docker",
-        "base_image": "python:3.11-slim",
         "command": ["python", "/workspace/hello.py"],
-        "files_inline": [
-            [
-                "hello.py",
-                "aW1wb3J0IHN5cwpwcmludCgiSGVsbG8gZnJvbSBzYW5kYm94ISIpCnN5cy5leGl0KDAp",
-            ]
+        "files": [
+            {
+                "path": "hello.py",
+                "content_b64": "aW1wb3J0IHN5cwpwcmludCgiSGVsbG8gZnJvbSBzYW5kYm94ISIpCnN5cy5leGl0KDAp",
+            }
         ],
         "capture_patterns": ["*.py"],
         "timeout_sec": 30,

--- a/tldw_Server_API/tests/sandbox/test_run_started_metric_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_run_started_metric_contract.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "false")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "false")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "1")
+
+    from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router
+
+    app = FastAPI()
+    app.include_router(sandbox_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_started_metric_not_emitted_for_runtime_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    import tldw_Server_API.app.api.v1.endpoints.sandbox as sandbox_endpoint
+
+    def _inc(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(sandbox_endpoint, "increment_counter", _inc, raising=True)
+    monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_AVAILABLE", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "runtime": "firecracker",
+                "base_image": "python:3.11-slim",
+                "command": ["bash", "-lc", "echo"],
+                "timeout_sec": 5,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "runtime_unavailable"
+    assert not any(args and args[0] == "sandbox_runs_started_total" for args, _kwargs in calls)
+
+
+@pytest.mark.unit
+def test_started_metric_emitted_for_accepted_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    import tldw_Server_API.app.api.v1.endpoints.sandbox as sandbox_endpoint
+
+    def _inc(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(sandbox_endpoint, "increment_counter", _inc, raising=True)
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.11-slim",
+                "command": ["bash", "-lc", "echo ok"],
+                "timeout_sec": 5,
+            },
+        )
+
+    assert response.status_code == 200
+    assert any(args and args[0] == "sandbox_runs_started_total" for args, _kwargs in calls)

--- a/tldw_Server_API/tests/sandbox/test_runner_failure_state_recovery.py
+++ b/tldw_Server_API/tests/sandbox/test_runner_failure_state_recovery.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def _spec() -> RunSpec:
+    return RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print(1)"],
+        env={},
+        timeout_sec=5,
+    )
+
+
+@pytest.mark.unit
+def test_foreground_docker_runner_exception_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+
+    svc = SandboxService()
+
+    with patch(
+        "tldw_Server_API.app.core.Sandbox.runners.docker_runner.DockerRunner.start_run",
+        side_effect=RuntimeError("boom"),
+    ):
+        status = svc.start_run_scaffold(
+            user_id="1",
+            spec=_spec(),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+
+    stored = svc.get_run(status.id)
+    assert status.phase.value == "failed"
+    assert status.message == "docker_failed"
+    assert status.finished_at is not None
+    assert stored is not None
+    assert stored.phase.value == "failed"
+    assert stored.message == "docker_failed"
+    assert stored.finished_at is not None
+
+
+@pytest.mark.unit
+def test_background_docker_runner_exception_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+
+    svc = SandboxService()
+
+    with patch(
+        "tldw_Server_API.app.core.Sandbox.runners.docker_runner.DockerRunner.start_run",
+        side_effect=RuntimeError("boom"),
+    ):
+        with patch.object(SandboxService, "_submit_background_worker", lambda self, fn: fn()):
+            status = svc.start_run_scaffold(
+                user_id="1",
+                spec=_spec(),
+                spec_version="1.0",
+                idem_key=None,
+                raw_body={},
+            )
+
+    stored = svc.get_run(status.id)
+    assert status.phase.value == "failed"
+    assert status.message == "docker_failed"
+    assert status.finished_at is not None
+    assert stored is not None
+    assert stored.phase.value == "failed"
+    assert stored.message == "docker_failed"
+    assert stored.finished_at is not None

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 from typing import Any, Dict
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, TrustLevel
 
 
 def _client(monkeypatch) -> TestClient:
@@ -65,6 +67,33 @@ def test_create_session_scaffold(monkeypatch) -> None:
         assert r3.status_code == 409
 
 
+def test_create_session_returns_execution_defaults(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body: Dict[str, Any] = {
+            "spec_version": "1.0",
+            "runtime": "docker",
+            "base_image": "python:3.12-slim",
+            "cpu_limit": 1.5,
+            "memory_mb": 768,
+            "timeout_sec": 77,
+            "network_policy": "deny_all",
+            "env": {"SESSION_TOKEN": "present"},
+            "labels": {"team": "sandbox"},
+            "trust_level": "trusted",
+        }
+        r = client.post("/api/v1/sandbox/sessions", json=body)
+        assert r.status_code == 200
+        j = r.json()
+        assert j["base_image"] == "python:3.12-slim"
+        assert j["cpu_limit"] == 1.5
+        assert j["memory_mb"] == 768
+        assert j["timeout_sec"] == 77
+        assert j["network_policy"] == "deny_all"
+        assert j["env"] == {"SESSION_TOKEN": "present"}
+        assert j["labels"] == {"team": "sandbox"}
+        assert j["trust_level"] == "trusted"
+
+
 def test_start_run_scaffold_returns_completed_with_metadata(monkeypatch) -> None:
 
 
@@ -96,6 +125,104 @@ def test_start_run_scaffold_returns_completed_with_metadata(monkeypatch) -> None
         assert r3.status_code == 409
 
 
+def test_start_run_rejects_missing_session_and_base_image(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        r = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert r.status_code == 422
+
+
+def test_start_run_rejects_both_session_and_base_image(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        session_resp = client.post(
+            "/api/v1/sandbox/sessions",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.11-slim",
+            },
+        )
+        assert session_resp.status_code == 200
+        session_id = str(session_resp.json()["id"])
+
+        r = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": session_id,
+                "base_image": "python:3.11-slim",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert r.status_code == 422
+
+
+def test_session_backed_run_inherits_session_defaults(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    captured: dict[str, Any] = {}
+
+    def _fake_start_run_scaffold(*, user_id, spec, spec_version, idem_key, raw_body):
+        captured["user_id"] = user_id
+        captured["spec"] = spec
+        return RunStatus(
+            id="run-session-defaults",
+            phase=RunPhase.queued,
+            spec_version=spec_version,
+            runtime=spec.runtime or RuntimeType.docker,
+            base_image=spec.base_image,
+            session_id=spec.session_id,
+            started_at=datetime.now(timezone.utc),
+        )
+
+    monkeypatch.setattr(sb._service, "start_run_scaffold", _fake_start_run_scaffold)
+
+    with _client(monkeypatch) as client:
+        session_resp = client.post(
+            "/api/v1/sandbox/sessions",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.12-slim",
+                "cpu_limit": 1.5,
+                "memory_mb": 768,
+                "timeout_sec": 77,
+                "network_policy": "deny_all",
+                "env": {"SESSION_TOKEN": "present"},
+                "trust_level": "trusted",
+            },
+        )
+        assert session_resp.status_code == 200
+        session_id = str(session_resp.json()["id"])
+
+        run_resp = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": session_id,
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert run_resp.status_code == 200
+        assert run_resp.json()["base_image"] == "python:3.12-slim"
+
+    spec = captured["spec"]
+    assert spec.session_id == session_id
+    assert spec.runtime == RuntimeType.docker
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.cpu == 1.5
+    assert spec.memory_mb == 768
+    assert spec.timeout_sec == 77
+    assert spec.network_policy == "deny_all"
+    assert spec.env == {"SESSION_TOKEN": "present"}
+    assert spec.trust_level == TrustLevel.trusted
+
+
 def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
     monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
 
@@ -116,7 +243,6 @@ def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
             json={
                 "spec_version": "1.0",
                 "runtime": "docker",
-                "base_image": "python:3.11-slim",
                 "session_id": session_id,
                 "command": ["python", "-c", "print('queued')"],
                 "timeout_sec": 15,

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -102,7 +102,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
         network_policy="deny_all",
         env={"SESSION_TOKEN": "present"},
         labels={"team": "sandbox"},
-        trust_level=TrustLevel.untrusted,
+        trust_level=TrustLevel.trusted,
         persona_id="persona-77",
         workspace_id="workspace-77",
         workspace_group_id="wg-77",
@@ -126,7 +126,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
     assert restored.network_policy == "deny_all"
     assert restored.env == {"SESSION_TOKEN": "present"}
     assert restored.labels == {"team": "sandbox"}
-    assert restored.trust_level == TrustLevel.untrusted
+    assert restored.trust_level == TrustLevel.trusted
 
     cloned = restarted_service.clone_session(source.id)
     assert cloned.base_image == "python:3.12-slim"
@@ -136,7 +136,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
     assert cloned.network_policy == "deny_all"
     assert cloned.env == {"SESSION_TOKEN": "present"}
     assert cloned.labels == {"team": "sandbox"}
-    assert cloned.trust_level == TrustLevel.untrusted
+    assert cloned.trust_level == TrustLevel.trusted
 
 
 def test_cross_node_delete_invalidates_cached_session_state(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tldw_Server_API.app.core.config import clear_config_cache, settings as app_settings
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType, RunSpec, SessionSpec
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType, RunSpec, SessionSpec, TrustLevel
 from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 from tldw_Server_API.app.core.Sandbox.store import get_store
@@ -87,6 +87,56 @@ def test_clone_session_works_after_service_restart(monkeypatch, tmp_path: Path) 
     assert cloned_ws is not None
     assert restarted_service._orch.get_session_owner(cloned.id) == "user-7"
     assert (Path(str(cloned_ws)) / "notes.txt").read_text(encoding="utf-8") == "stateful data"
+
+
+def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    source_service = SandboxService()
+    spec = SessionSpec(
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        cpu_limit=1.5,
+        memory_mb=768,
+        timeout_sec=77,
+        network_policy="deny_all",
+        env={"SESSION_TOKEN": "present"},
+        labels={"team": "sandbox"},
+        trust_level=TrustLevel.untrusted,
+        persona_id="persona-77",
+        workspace_id="workspace-77",
+        workspace_group_id="wg-77",
+        scope_snapshot_id="scope-77",
+    )
+    source = source_service.create_session(
+        user_id="user-7",
+        spec=spec,
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+
+    restarted_service = SandboxService()
+    restored = restarted_service._orch.get_session(source.id)
+    assert restored is not None
+    assert restored.base_image == "python:3.12-slim"
+    assert restored.cpu_limit == 1.5
+    assert restored.memory_mb == 768
+    assert restored.timeout_sec == 77
+    assert restored.network_policy == "deny_all"
+    assert restored.env == {"SESSION_TOKEN": "present"}
+    assert restored.labels == {"team": "sandbox"}
+    assert restored.trust_level == TrustLevel.untrusted
+
+    cloned = restarted_service.clone_session(source.id)
+    assert cloned.base_image == "python:3.12-slim"
+    assert cloned.cpu_limit == 1.5
+    assert cloned.memory_mb == 768
+    assert cloned.timeout_sec == 77
+    assert cloned.network_policy == "deny_all"
+    assert cloned.env == {"SESSION_TOKEN": "present"}
+    assert cloned.labels == {"team": "sandbox"}
+    assert cloned.trust_level == TrustLevel.untrusted
 
 
 def test_cross_node_delete_invalidates_cached_session_state(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -6,6 +6,7 @@ import tarfile
 import zipfile
 import tempfile
 
+from fastapi import HTTPException, UploadFile
 from fastapi.testclient import TestClient
 import pytest
 
@@ -56,6 +57,150 @@ def test_session_upload_creates_workspace(monkeypatch) -> None:
         assert payload.get("file_count") == 1
     finally:
         app.dependency_overrides.pop(get_request_user, None)
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_plain_upload_without_unbounded_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    upload = UploadFile(filename="hello.txt", file=io.BytesIO(b"hello world"))
+    original_read = upload.read
+
+    async def _guarded_read(size: int = -1):
+        if size in (-1, None):
+            raise AssertionError("plain upload should be read in bounded chunks")
+        return await original_read(size)
+
+    upload.read = _guarded_read  # type: ignore[assignment]
+
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-plain",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.bytes_received == 11
+    assert response.file_count == 1
+    assert (tmp_path / "hello.txt").read_bytes() == b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_tar_members_without_full_member_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="safe.txt")
+        data = b"streamed tar content"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    tar_buffer.seek(0)
+
+    original_extractfile = tarfile.TarFile.extractfile
+
+    class _GuardedReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def read(self, size: int = -1):
+            if size in (-1, None):
+                raise AssertionError("tar members should be copied in bounded chunks")
+            return self._wrapped.read(size)
+
+        def close(self):
+            return self._wrapped.close()
+
+    def _guarded_extractfile(self, member, *args, **kwargs):
+        reader = original_extractfile(self, member, *args, **kwargs)
+        if reader is None:
+            return None
+        return _GuardedReader(reader)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractfile", _guarded_extractfile)
+
+    upload = UploadFile(filename="archive.tar.gz", file=tar_buffer)
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-tar",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.file_count == 1
+    assert (tmp_path / "safe.txt").read_bytes() == b"streamed tar content"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_zip_members_without_zipfile_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zf:
+        zf.writestr("safe.txt", "streamed zip content")
+    zip_buffer.seek(0)
+
+    def _forbidden_read(self, name, pwd=None):
+        raise AssertionError("zip uploads should stream via ZipFile.open, not ZipFile.read")
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", _forbidden_read)
+
+    upload = UploadFile(filename="archive.zip", file=zip_buffer)
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-zip",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.file_count == 1
+    assert (tmp_path / "safe.txt").read_text(encoding="utf-8") == "streamed zip content"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_enforces_cap_against_existing_workspace_bytes(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
+
+    first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
+    second = UploadFile(filename="second.bin", file=io.BytesIO(b"b" * (700 * 1024)))
+
+    first_response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-cap",
+        files=[first],
+        current_user=_user(1),
+        audit_service=None,
+    )
+    assert first_response.file_count == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-cap",
+            files=[second],
+            current_user=_user(1),
+            audit_service=None,
+        )
+
+    assert exc_info.value.status_code == 413
+    assert (tmp_path / "first.bin").exists()
+    assert not (tmp_path / "second.bin").exists()
 
 
 # =============================================================================

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 import tarfile
@@ -199,6 +200,74 @@ async def test_upload_files_enforces_cap_against_existing_workspace_bytes(monkey
         )
 
     assert exc_info.value.status_code == 413
+    assert (tmp_path / "first.bin").exists()
+    assert not (tmp_path / "second.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_uploads_are_serialized_per_session(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
+
+    first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
+    second = UploadFile(filename="second.bin", file=io.BytesIO(b"b" * (700 * 1024)))
+
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    original_first_read = first.read
+    original_second_read = second.read
+
+    async def _first_read(size: int = -1):
+        if not first_entered.is_set():
+            first_entered.set()
+            await release_first.wait()
+        return await original_first_read(size)
+
+    async def _second_read(size: int = -1):
+        second_entered.set()
+        return await original_second_read(size)
+
+    first.read = _first_read  # type: ignore[assignment]
+    second.read = _second_read  # type: ignore[assignment]
+
+    first_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-concurrent",
+            files=[first],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+    await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+
+    second_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-concurrent",
+            files=[second],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    assert not second_entered.is_set(), "second upload should wait for the session lock"
+
+    release_first.set()
+    first_response = await asyncio.wait_for(first_task, timeout=2.0)
+    assert first_response.file_count == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        await asyncio.wait_for(second_task, timeout=2.0)
+
+    assert exc_info.value.status_code == 413
+    assert second_entered.is_set()
     assert (tmp_path / "first.bin").exists()
     assert not (tmp_path / "second.bin").exists()
 


### PR DESCRIPTION
## Summary

- **Phase 0**: Binary acquisition script, health check endpoint (`GET /api/v1/acp/health`), setup guide endpoint with per-agent instructions
- **Phase 1**: Session TTL with background cleanup, SQLite-backed audit log (`ACP_Audit_DB`), resource quotas (concurrent sessions, token limits) with 429 enforcement
- **Phase 2**: YAML-based agent registry (`agents.yaml`) with hot-reload, agent discovery endpoint, privilege catalog scopes
- **Phase 4**: Task orchestration with state machine (`todo→inprogress→review→complete|triage`), full CRUD API for projects/tasks/runs, dependency gating with cycle detection, reviewer gate with max attempts → triage
- **Phase 5**: `/agents` page (health panel, agent cards, launch buttons), `/agent-tasks` page (project list, task board, run dispatch, review controls)
- **Phase 6**: Integration test fixture with stub agent, e2e smoke tests, 179 total tests passing
- **Phase 7**: ACP metrics (11 definitions) in unified MetricsRegistry, fork lineage API in session detail, TypeScript schema sync

## Test plan

- [x] All 179 ACP + orchestration unit tests pass (`pytest tldw_Server_API/tests/Agent_Client_Protocol/ tldw_Server_API/tests/Agent_Orchestration/`)
- [x] Integration tests with real STDIO transport via stub agent pass
- [x] E2E smoke tests (full lifecycle: spawn → initialize → session → prompt → close) pass
- [x] Fork lineage tests (chains, cycles, max depth, missing parents) pass
- [x] Metrics registration and recording tests pass
- [ ] Verify `/agents` page renders agent registry with health panel
- [ ] Verify `/agent-tasks` page shows project/task CRUD and run dispatch
- [ ] Verify `GET /api/v1/acp/health` returns structured diagnostics
- [ ] Verify `GET /api/v1/agent-orchestration/projects` CRUD operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)