### PR TITLE
fix: harden sandbox workspace locking

### DIFF
--- a/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
+++ b/Docs/Plans/2026-03-07-tts-compose-compare-redesign.md
@@ -1,0 +1,209 @@
+# TTS "Compose & Compare" Full Redesign
+
+**Date**: 2026-03-07
+**Status**: Design
+**Builds on**: `2026-03-06-tts-listen-tab-ux-redesign.md` (two-zone layout, provider strip, inspector panel)
+**Scope**: Full TTS experience redesign — page structure, render strips, voice picker, unified player
+
+---
+
+## Problem Statement
+
+The Speech Playground TTS experience (`SpeechPlaygroundPage.tsx`, 2,839 lines) has several UX issues grounded in Nielsen's 10 usability heuristics:
+
+1. **Inconsistent playback** (H4: Consistency) — Browser TTS uses Web Speech API controls; server TTS uses HTML5 `<audio>`. Different UI for the same action.
+2. **Provider switching confusion** (H6: Recognition over recall) — Changing providers reveals/hides different controls unpredictably. Users must remember which fields belong to which provider.
+3. **No comparison capability** (H7: Flexibility & efficiency) — No way to A/B test voices, models, or providers. Users must generate, listen, change settings, regenerate, and try to remember the previous result.
+4. **19 adapters, 4 exposed** (H8: Minimalist design, inverted) — The backend supports Kokoro, Higgs, Chatterbox, VibeVoice, ElevenLabs, OpenAI, and 13 more, but the UI only exposes 4 provider buckets.
+5. **Unsurfaced backend features** — Voice upload, voice preview, TTS history, async jobs, word-level alignment metadata are all available via API but not in the UI.
+6. **Settings form overload** (H8: Aesthetic & minimalist design) — 1,000+ lines of settings compete for attention on the same page.
+
+## Target Users
+
+Design uses progressive disclosure to serve three personas:
+- **General users**: Type text, click play. Minimal cognitive load.
+- **Content creators**: Batch generation, export, quality comparison.
+- **Developers/tinkerers**: Full provider visibility, parameter tuning, A/B testing.
+
+## Design: Compose & Compare
+
+### Core Concept
+
+The text editor is the primary surface. Audio outputs appear as **Render Strips** below the editor — self-contained cards, each representing one generation with its own provider/voice/settings. Comparison is structural: having two strips *is* comparison. No special mode needed.
+
+### Page Structure
+
+Single `/speech` route with top-level tabs: **TTS | STT | Roundtrip**
+
+TTS tab layout:
+
+```
++----------------------------------------------+
+| Document Toolbar                              |
+| [Voice: kokoro/af_heart ▾] [Preset: Balanced]|
+| [+ Add Render]  [History]  [⚙ Settings]      |
++----------------------------------------------+
+|  Text Editor (hero element)                   |
+|  +------------------------------------------+|
+|  | [Auto-sizing textarea]                    ||
+|  | 142/8000 chars · ~9s estimated            ||
+|  +------------------------------------------+|
+|                                               |
+|  Render Strips                                |
+|  +------------------------------------------+|
+|  | A: [kokoro] [af_heart] [mp3] [1.0x]      ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:12/0:45    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|  | B: [higgs] [en_speaker_0] [wav] [0.9x]   ||
+|  |    [Edit] [✕]                             ||
+|  |    [========waveform=======] 0:08/0:38    ||
+|  |    [⏮][▶ Play][⏭] ───●───── [⬇ Download]||
+|  +------------------------------------------+|
+|                                               |
+| [▶ Generate] [■ Stop] [▶▶ Play All]          |
++----------------------------------------------+
+```
+
+Drawers (right side, opened on demand):
+- **Settings Drawer** — reuses `TtsInspectorPanel` with Voice, Output, Advanced tabs
+- **History Drawer** — past generations with search, filter, favorites
+
+### Component: Render Strip
+
+Each strip is a self-contained card with five states:
+
+| State | Visual |
+|-------|--------|
+| `idle` | Config tags + "Click Generate to synthesize" |
+| `generating` | Progress bar (or job step indicator for long text) |
+| `ready` | Waveform + playback controls + download |
+| `playing` | Animated waveform, highlighted play button |
+| `error` | Error message + Retry button |
+
+**Interactions:**
+- Config tags are clickable — clicking `[kokoro]` opens the voice picker pre-filtered
+- `[Edit]` opens the settings drawer pre-filled with this strip's config
+- `[✕]` removes the strip with an undo toast (H3: User control & freedom)
+- Only one strip plays at a time — starting one pauses others
+- `[Play All]` plays strips sequentially with a 1-second pause between them
+
+### Component: Voice Picker Modal
+
+Replaces the current per-provider voice/model selection with a unified modal:
+
+```
++----------------------------------------------------------+
+|  Choose a Voice                              [✕ Close]   |
++----------------------------------------------------------+
+|  [🔍 Search voices...]                                   |
+|  Recent: [af_heart] [alloy] [en_speaker_0]               |
++----------------------------------------------------------+
+|  ▾ Local Engines                                         |
+|    ● Kokoro (12 voices)              [healthy]           |
+|      af_heart [▶]  |  af_bella [▶]  |  am_adam [▶]      |
+|    ● Higgs (8 voices)                [healthy]           |
+|      en_speaker_0 [▶]  |  en_speaker_1 [▶]              |
+|    ○ Chatterbox                       [offline]          |
+|  ▾ Cloud Providers                                       |
+|    ● OpenAI (6 voices)                                   |
+|      alloy [▶]  |  echo [▶]  |  nova [▶]                |
+|    ● ElevenLabs (50+ voices)                             |
+|  ▾ Custom Voices                                         |
+|    my_cloned_voice [▶]  |  [+ Upload New]               |
++----------------------------------------------------------+
+```
+
+**Key behaviors:**
+- `[▶]` preview buttons call `/api/v1/audio/voices/{voice_id}/preview` — audio plays inline within the picker
+- Health status per provider from circuit breaker state (green dot / dimmed "offline")
+- Search filters across all providers simultaneously
+- Recent voices (last 5 used) pinned at top
+- Selecting a voice auto-selects its provider — no two-step "pick provider, then pick voice"
+- Provider capability icons: streaming, cloning, emotion, SSML
+- Custom voices section has inline upload via existing `VoiceCloningManager`
+
+### Component: Unified Audio Player
+
+Eliminates the H4 (Consistency) violation of different playback UIs per provider:
+
+- Single player component used in all render strips
+- For server providers: wraps HTML5 audio with custom waveform (reuses `WaveformCanvas`) + controls
+- For browser TTS: synthesizes via Web Speech API, maps events to same progress/play/pause interface
+- Consistent controls: play/pause, seek via waveform click, time display, download
+- Graceful degradation: if waveform data unavailable, shows animated progress bar with same controls
+
+### Progressive Disclosure
+
+| Level | What's visible | How to reach it |
+|-------|---------------|-----------------|
+| 0 — Just play | Text editor + toolbar (default voice) + action bar | Default state |
+| 1 — Customize | Click toolbar chip → settings drawer opens | 1 click |
+| 2 — Compare | Click "+ Add Render" → voice picker → second strip | 2 clicks |
+| 3 — Advanced | Settings drawer → Advanced tab (SSML, emotion, normalization, voice roles, async jobs) | 3 clicks |
+| 4 — Voice mgmt | Voice picker → Custom Voices → upload/clone | On demand |
+
+### Backend Feature Surfacing
+
+| Backend Feature | Where it appears |
+|----------------|-----------------|
+| All 19 TTS adapters | Voice Picker modal, grouped by Local/Cloud |
+| Voice preview API | `[▶]` button on each voice in the picker |
+| Custom voice upload | "Custom Voices" section in picker + `VoiceCloningManager` |
+| Voice encode/clone | Advanced tab in settings drawer |
+| TTS history | History drawer (right side) |
+| Async TTS jobs | Strip progress indicator for text > 2000 chars |
+| Word-level alignment | Opt-in: toggle on strip header highlights words in editor during playback |
+| Provider health | Colored dot per provider in voice picker |
+| Streaming | Progressive waveform drawing as audio arrives |
+
+### Heuristic Coverage
+
+| # | Heuristic | How addressed |
+|---|-----------|---------------|
+| 1 | Visibility of system status | Strip states, provider health dots, char count, estimated duration, waveform progress |
+| 2 | Match system & real world | Voice names + preview (not IDs), "Local Engines"/"Cloud Providers" grouping |
+| 3 | User control & freedom | Undo on strip removal, history drawer, explicit generate, editable config |
+| 4 | Consistency & standards | Unified audio player for all providers, consistent strip cards |
+| 5 | Error prevention | Char limit warning at 2000, explicit generate for all text, dimmed offline providers |
+| 6 | Recognition over recall | Recent voices pinned, config shown as tags on strips, voice preview |
+| 7 | Flexibility & efficiency | Ctrl+Enter to generate, presets, "+ Add Render", clickable config tags |
+| 8 | Aesthetic & minimalist design | Only editor + toolbar visible by default; settings/history in drawers |
+| 9 | Help users recover | Error state on strips with retry, toast with undo on deletion, provider retry |
+| 10 | Help & documentation | Tooltips on capability icons, estimated duration, char count guidance |
+
+### Relationship to Prior Designs
+
+This design extends `2026-03-06-tts-listen-tab-ux-redesign.md`:
+- **Keeps**: Two-zone concept (workspace + inspector), provider strip, sticky action bar, inspector panel tabs
+- **Adds**: Render strips (multi-generation), voice picker modal, unified audio player, comparison flow
+- **Changes**: Action bar includes "Add Render" and "Play All"; workspace zone contains render strips instead of single waveform
+
+The STT tab follows `2026-03-06-stt-playground-comparison-first-redesign.md` unchanged.
+
+### Existing Components to Reuse
+
+| Component | File | Reuse plan |
+|-----------|------|------------|
+| `TtsProviderStrip` | `Speech/TtsProviderStrip.tsx` | Becomes document toolbar |
+| `TtsStickyActionBar` | `Speech/TtsStickyActionBar.tsx` | Becomes action bar with added "Add Render" / "Play All" |
+| `TtsInspectorPanel` | `Speech/TtsInspectorPanel.tsx` | Settings drawer shell (reuse as-is) |
+| `TtsVoiceTab` | `Speech/TtsVoiceTab.tsx` | Inspector voice tab (refactor to support per-strip config) |
+| `TtsOutputTab` | `Speech/TtsOutputTab.tsx` | Inspector output tab |
+| `TtsAdvancedTab` | `Speech/TtsAdvancedTab.tsx` | Inspector advanced tab |
+| `WaveformCanvas` | `Common/WaveformCanvas.tsx` | Waveform in each render strip |
+| `TtsJobProgress` | `Common/TtsJobProgress.tsx` | Progress indicator in generating strips |
+| `VoiceCloningManager` | `TTS/VoiceCloningManager.tsx` | Custom voices section in voice picker |
+| `CharacterProgressBar` | `Common/CharacterProgressBar.tsx` | Char count in text editor |
+| `LongformDraftEditor` | `Common/LongformDraftEditor.tsx` | Advanced text editing mode |
+| `useTtsPlayground` | `hooks/useTtsPlayground.tsx` | Evolve to multi-strip state management |
+| `useTtsProviderData` | `hooks/useTtsProviderData.ts` | Provider/voice data fetching |
+| `useStreamingAudioPlayer` | `hooks/useStreamingAudioPlayer.ts` | Streaming playback per strip |
+
+### New Components to Build
+
+1. **`RenderStrip`** — Self-contained card: config tags + unified player + waveform + download
+2. **`VoicePickerModal`** — Provider-grouped voice catalog with search, preview, recent, custom upload
+3. **`UnifiedAudioPlayer`** — Normalizes browser TTS and server TTS behind common play/pause/seek/progress interface
+4. **`useMultiRenderState`** — Hook managing array of render strip states with independent generation

--- a/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md
+++ b/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md
@@ -244,7 +244,7 @@ interface Plan {
 
 interface Subscription {
   id: string
-  org_id: string
+  org_id: number
   plan_id: string
   stripe_subscription_id: string
   status: 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete'

--- a/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-implementation-plan.md
@@ -1,0 +1,2575 @@
+# Admin UI SaaS Billing & Feature Gating — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add billing, subscription management, feature gating, and onboarding to the admin UI so it can operate as a multi-tenant SaaS with an open-core self-hosted option.
+
+**Architecture:** Stripe-first billing integration. New pages for Plans, Subscriptions, Feature Registry, and Onboarding. A `PlanGuard` component gates SaaS-only UI. A `NEXT_PUBLIC_BILLING_ENABLED` env var toggles the entire billing surface. Backend API endpoints are assumed to exist at `/api/v1/admin/billing/*` — this plan covers the frontend only.
+
+**Tech Stack:** Next.js 15 (App Router), React 19, TypeScript, Tailwind CSS, Radix UI, React Hook Form + Zod, Recharts, Vitest + React Testing Library
+
+**Design Doc:** `Docs/Plans/2026-03-08-admin-ui-saas-billing-gaps-design.md`
+
+---
+
+## Task 1: Add Billing Types
+
+**Files:**
+- Modify: `admin-ui/types/index.ts`
+
+**Step 1: Add types to the end of types/index.ts**
+
+Append after the last existing export:
+
+```typescript
+// ============================================
+// Billing & Subscription Types
+// ============================================
+
+export type PlanTier = 'free' | 'pro' | 'enterprise';
+export type SubscriptionStatus = 'active' | 'past_due' | 'canceled' | 'trialing' | 'incomplete';
+
+export interface Plan {
+  id: string;
+  name: string;
+  tier: PlanTier;
+  stripe_product_id: string;
+  stripe_price_id: string;
+  monthly_price_cents: number;
+  included_token_credits: number;
+  overage_rate_per_1k_tokens_cents: number;
+  features: string[];
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Subscription {
+  id: string;
+  org_id: number;
+  plan_id: string;
+  plan?: Plan;
+  stripe_subscription_id: string;
+  status: SubscriptionStatus;
+  current_period_start: string;
+  current_period_end: string;
+  trial_end?: string;
+  cancel_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OrgUsageSummary {
+  org_id: number;
+  period_start: string;
+  period_end: string;
+  tokens_used: number;
+  tokens_included: number;
+  tokens_overage: number;
+  overage_cost_cents: number;
+  breakdown_by_provider: Record<string, number>;
+}
+
+export interface Invoice {
+  id: string;
+  stripe_invoice_id: string;
+  amount_cents: number;
+  currency: string;
+  status: 'paid' | 'open' | 'void' | 'draft' | 'uncollectible';
+  invoice_pdf?: string;
+  period_start: string;
+  period_end: string;
+  created_at: string;
+}
+
+export interface FeatureRegistryEntry {
+  feature_key: string;
+  display_name: string;
+  description: string;
+  plans: string[];
+  category: string;
+}
+```
+
+**Step 2: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No new errors from these types (pre-existing errors may exist)
+
+**Step 3: Commit**
+
+```bash
+git add admin-ui/types/index.ts
+git commit -m "feat(admin-ui): add billing, subscription, and feature registry types"
+```
+
+---
+
+## Task 2: Add Billing API Client Methods
+
+**Files:**
+- Modify: `admin-ui/lib/api-client.ts`
+
+**Step 1: Add import for new types**
+
+At the top of `api-client.ts`, update the import from `@/types` to include:
+
+```typescript
+import type {
+  AuditLog,
+  BackupsResponse,
+  FeatureRegistryEntry,
+  IncidentsResponse,
+  Invoice,
+  OrgUsageSummary,
+  Plan,
+  RegistrationCode,
+  RetentionPoliciesResponse,
+  Subscription,
+  UserWithKeyCount,
+} from '@/types';
+```
+
+**Step 2: Add billing API methods before the closing `};` of the api object (before `export default api;`)**
+
+```typescript
+  // ============================================
+  // Plans & Billing
+  // ============================================
+  getPlans: (params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Plan[]>(`/billing/plans${qs}`);
+  },
+  getPlan: (planId: string) =>
+    requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`),
+  createPlan: (data: Partial<Plan>) =>
+    requestJson<Plan>('/billing/plans', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  updatePlan: (planId: string, data: Partial<Plan>) =>
+    requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  deletePlan: (planId: string) =>
+    requestJson(`/billing/plans/${encodeURIComponent(planId)}`, {
+      method: 'DELETE',
+    }),
+
+  // Subscriptions
+  getSubscriptions: (params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Subscription[]>(`/billing/subscriptions${qs}`);
+  },
+  getOrgSubscription: (orgId: number) =>
+    requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`),
+  createSubscription: (orgId: number, data: { plan_id: string; trial_days?: number }) =>
+    requestJson<{ checkout_url?: string; subscription?: Subscription }>(
+      `/billing/orgs/${orgId}/subscription`,
+      { method: 'POST', body: JSON.stringify(data) },
+    ),
+  updateSubscription: (orgId: number, data: { plan_id: string }) =>
+    requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+  cancelSubscription: (orgId: number) =>
+    requestJson(`/billing/orgs/${orgId}/subscription`, { method: 'DELETE' }),
+
+  // Usage & Invoices
+  getOrgUsageSummary: (orgId: number, params?: { period?: string }) => {
+    const qs = buildQueryString(params as Record<string, QueryParamValue>);
+    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs}`);
+  },
+  getOrgInvoices: (orgId: number, params?: Record<string, QueryParamValue>) => {
+    const qs = buildQueryString(params);
+    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs}`);
+  },
+
+  // Feature Registry
+  getFeatureRegistry: () =>
+    requestJson<FeatureRegistryEntry[]>('/billing/feature-registry'),
+  updateFeatureRegistry: (data: FeatureRegistryEntry[]) =>
+    requestJson<FeatureRegistryEntry[]>('/billing/feature-registry', {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  // Onboarding
+  createOnboardingSession: (data: { org_name: string; org_slug: string; plan_id: string; owner_email?: string }) =>
+    requestJson<{ checkout_url?: string; org_id?: number }>(
+      '/billing/onboarding',
+      { method: 'POST', body: JSON.stringify(data) },
+    ),
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+Expected: No new errors
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/lib/api-client.ts
+git commit -m "feat(admin-ui): add billing, subscription, and feature registry API methods"
+```
+
+---
+
+## Task 3: Add `billingEnabled` Helper and Navigation Items
+
+**Files:**
+- Create: `admin-ui/lib/billing.ts`
+- Modify: `admin-ui/lib/navigation.ts`
+
+**Step 1: Create billing helper**
+
+Create `admin-ui/lib/billing.ts`:
+
+```typescript
+'use client';
+
+/**
+ * Returns true when the SaaS billing surface is enabled.
+ * Self-hosted deployments set NEXT_PUBLIC_BILLING_ENABLED=false (or omit it).
+ */
+export function isBillingEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true';
+}
+```
+
+**Step 2: Add navigation items**
+
+In `admin-ui/lib/navigation.ts`, add imports at the top:
+
+```typescript
+import { CreditCard, Receipt, Grid3X3 } from 'lucide-react';
+```
+
+Add three new items to the `navigationItems` object (before the `} satisfies` closing):
+
+```typescript
+  plans: { name: 'Plans', href: '/plans', icon: CreditCard, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'pricing', 'subscription', 'tiers'] },
+  subscriptions: { name: 'Subscriptions', href: '/subscriptions', icon: Receipt, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'payments', 'invoices'] },
+  featureRegistry: { name: 'Feature Registry', href: '/feature-registry', icon: Grid3X3, role: ['admin', 'super_admin', 'owner'], keywords: ['gating', 'entitlements', 'open core'] },
+```
+
+Add these to the Governance section in `navigationSections`, after `navigationItems.usage`:
+
+```typescript
+      navigationItems.plans,
+      navigationItems.subscriptions,
+      navigationItems.featureRegistry,
+```
+
+Add breadcrumb support in `resolveDynamicPathLabel`:
+
+```typescript
+  if (root === 'plans' && segments.length === 2) {
+    return `Plan ${decodeURIComponent(idOrSlug)}`;
+  }
+  if (root === 'subscriptions' && segments.length === 2) {
+    return `Subscription ${decodeURIComponent(idOrSlug)}`;
+  }
+```
+
+**Step 3: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/lib/billing.ts admin-ui/lib/navigation.ts
+git commit -m "feat(admin-ui): add billing nav items and billingEnabled helper"
+```
+
+---
+
+## Task 4: PlanBadge Component
+
+**Files:**
+- Create: `admin-ui/components/PlanBadge.tsx`
+- Create: `admin-ui/components/__tests__/PlanBadge.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/PlanBadge.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { PlanBadge } from '../PlanBadge';
+
+describe('PlanBadge', () => {
+  it('renders the plan tier label', () => {
+    render(<PlanBadge tier="pro" />);
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+
+  it('renders free tier with secondary variant styling', () => {
+    const { container } = render(<PlanBadge tier="free" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.textContent).toBe('Free');
+  });
+
+  it('renders enterprise tier', () => {
+    render(<PlanBadge tier="enterprise" />);
+    expect(screen.getByText('Enterprise')).toBeInTheDocument();
+  });
+
+  it('applies additional className', () => {
+    const { container } = render(<PlanBadge tier="pro" className="ml-2" />);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge.className).toContain('ml-2');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanBadge.test.tsx 2>&1 | tail -10`
+Expected: FAIL — module not found
+
+**Step 3: Implement PlanBadge**
+
+Create `admin-ui/components/PlanBadge.tsx`:
+
+```typescript
+import { Badge } from '@/components/ui/badge';
+import type { PlanTier } from '@/types';
+import { cn } from '@/lib/utils';
+
+const tierConfig: Record<PlanTier, { label: string; className: string }> = {
+  free: { label: 'Free', className: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300' },
+  pro: { label: 'Pro', className: 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' },
+  enterprise: { label: 'Enterprise', className: 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300' },
+};
+
+interface PlanBadgeProps {
+  tier: PlanTier;
+  className?: string;
+}
+
+export function PlanBadge({ tier, className }: PlanBadgeProps) {
+  const config = tierConfig[tier] ?? tierConfig.free;
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {config.label}
+    </Badge>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanBadge.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/PlanBadge.tsx admin-ui/components/__tests__/PlanBadge.test.tsx
+git commit -m "feat(admin-ui): add PlanBadge component with tests"
+```
+
+---
+
+## Task 5: UsageMeter Component
+
+**Files:**
+- Create: `admin-ui/components/UsageMeter.tsx`
+- Create: `admin-ui/components/__tests__/UsageMeter.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/UsageMeter.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { UsageMeter } from '../UsageMeter';
+
+describe('UsageMeter', () => {
+  it('renders used and included token counts', () => {
+    render(<UsageMeter used={500_000} included={1_000_000} overageCostCents={0} />);
+    expect(screen.getByText(/500,000/)).toBeInTheDocument();
+    expect(screen.getByText(/1,000,000/)).toBeInTheDocument();
+  });
+
+  it('shows green bar when under 80% usage', () => {
+    const { container } = render(<UsageMeter used={400_000} included={1_000_000} overageCostCents={0} />);
+    const bar = container.querySelector('[data-testid="usage-bar"]');
+    expect(bar?.className).toContain('bg-green');
+  });
+
+  it('shows yellow bar when between 80-100% usage', () => {
+    const { container } = render(<UsageMeter used={850_000} included={1_000_000} overageCostCents={0} />);
+    const bar = container.querySelector('[data-testid="usage-bar"]');
+    expect(bar?.className).toContain('bg-yellow');
+  });
+
+  it('shows red bar and overage cost when over 100%', () => {
+    render(<UsageMeter used={1_200_000} included={1_000_000} overageCostCents={2400} />);
+    const bar = screen.getByTestId('usage-bar');
+    expect(bar.className).toContain('bg-red');
+    expect(screen.getByText(/\$24\.00/)).toBeInTheDocument();
+  });
+
+  it('handles zero included gracefully', () => {
+    render(<UsageMeter used={100} included={0} overageCostCents={0} />);
+    expect(screen.getByText(/100/)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UsageMeter.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement UsageMeter**
+
+Create `admin-ui/components/UsageMeter.tsx`:
+
+```typescript
+import { cn } from '@/lib/utils';
+
+interface UsageMeterProps {
+  used: number;
+  included: number;
+  overageCostCents: number;
+  className?: string;
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function UsageMeter({ used, included, overageCostCents, className }: UsageMeterProps) {
+  const pct = included > 0 ? (used / included) * 100 : (used > 0 ? 100 : 0);
+  const clampedPct = Math.min(pct, 100);
+
+  const barColor =
+    pct > 100 ? 'bg-red-500' :
+    pct >= 80 ? 'bg-yellow-500' :
+    'bg-green-500';
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      <div className="flex justify-between text-sm">
+        <span>{formatTokens(used)} / {formatTokens(included)} tokens</span>
+        {overageCostCents > 0 && (
+          <span className="text-red-600 dark:text-red-400 font-medium">
+            Overage: {formatCents(overageCostCents)}
+          </span>
+        )}
+      </div>
+      <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700">
+        <div
+          data-testid="usage-bar"
+          className={cn('h-2 rounded-full transition-all', barColor)}
+          style={{ width: `${clampedPct}%` }}
+        />
+      </div>
+      <div className="text-xs text-muted-foreground text-right">
+        {pct.toFixed(1)}% used
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UsageMeter.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/UsageMeter.tsx admin-ui/components/__tests__/UsageMeter.test.tsx
+git commit -m "feat(admin-ui): add UsageMeter component with color zones and overage display"
+```
+
+---
+
+## Task 6: UpgradePrompt Component
+
+**Files:**
+- Create: `admin-ui/components/UpgradePrompt.tsx`
+- Create: `admin-ui/components/__tests__/UpgradePrompt.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/UpgradePrompt.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { UpgradePrompt } from '../UpgradePrompt';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('UpgradePrompt', () => {
+  it('displays required plan name', () => {
+    render(<UpgradePrompt requiredPlan="pro" featureName="Advanced Analytics" />);
+    expect(screen.getByText(/Pro/)).toBeInTheDocument();
+    expect(screen.getByText(/Advanced Analytics/)).toBeInTheDocument();
+  });
+
+  it('shows upgrade link when showUpgradeLink is true', () => {
+    render(<UpgradePrompt requiredPlan="enterprise" featureName="SSO" showUpgradeLink />);
+    expect(screen.getByRole('link', { name: /upgrade/i })).toBeInTheDocument();
+  });
+
+  it('hides upgrade link by default', () => {
+    render(<UpgradePrompt requiredPlan="pro" featureName="Feature X" />);
+    expect(screen.queryByRole('link', { name: /upgrade/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UpgradePrompt.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement UpgradePrompt**
+
+Create `admin-ui/components/UpgradePrompt.tsx`:
+
+```typescript
+import Link from 'next/link';
+import { ArrowUpCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+interface UpgradePromptProps {
+  requiredPlan: string;
+  featureName: string;
+  showUpgradeLink?: boolean;
+}
+
+export function UpgradePrompt({ requiredPlan, featureName, showUpgradeLink }: UpgradePromptProps) {
+  const planLabel = requiredPlan.charAt(0).toUpperCase() + requiredPlan.slice(1);
+
+  return (
+    <Alert>
+      <ArrowUpCircle className="h-4 w-4" />
+      <AlertDescription className="flex items-center justify-between">
+        <span>
+          <strong>{featureName}</strong> requires the <strong>{planLabel}</strong> plan.
+          {!showUpgradeLink && ' Contact your administrator to upgrade.'}
+        </span>
+        {showUpgradeLink && (
+          <Button asChild size="sm" variant="outline" className="ml-4">
+            <Link href="/plans">Upgrade Plan</Link>
+          </Button>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/UpgradePrompt.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/UpgradePrompt.tsx admin-ui/components/__tests__/UpgradePrompt.test.tsx
+git commit -m "feat(admin-ui): add UpgradePrompt component for plan-gated features"
+```
+
+---
+
+## Task 7: PlanGuard Component
+
+**Files:**
+- Create: `admin-ui/components/PlanGuard.tsx`
+- Create: `admin-ui/components/__tests__/PlanGuard.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/PlanGuard.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PlanGuard } from '../PlanGuard';
+
+const mockIsBillingEnabled = vi.hoisted(() => vi.fn());
+const mockGetOrgSubscription = vi.hoisted(() => vi.fn());
+const mockUseOrgContext = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: mockIsBillingEnabled,
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  api: { getOrgSubscription: mockGetOrgSubscription },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/components/OrgContextSwitcher', () => ({
+  useOrgContext: mockUseOrgContext,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+describe('PlanGuard', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders children when billing is disabled (self-hosted)', () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: null, loading: false });
+    render(<PlanGuard requiredPlan="pro"><div>Protected Content</div></PlanGuard>);
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('renders children when org has required plan', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'pro' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan="pro"><div>Protected Content</div></PlanGuard>);
+    expect(await screen.findByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('renders upgrade prompt when org lacks required plan', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'free' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan="pro" featureName="Analytics"><div>Hidden</div></PlanGuard>);
+    expect(await screen.findByText(/Pro/)).toBeInTheDocument();
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
+  });
+
+  it('accepts array of plans', async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
+    mockGetOrgSubscription.mockResolvedValue({
+      plan: { tier: 'enterprise' },
+      status: 'active',
+    });
+    render(<PlanGuard requiredPlan={['pro', 'enterprise']}><div>Visible</div></PlanGuard>);
+    expect(await screen.findByText('Visible')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanGuard.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement PlanGuard**
+
+Create `admin-ui/components/PlanGuard.tsx`:
+
+```typescript
+'use client';
+
+import { ReactNode, useEffect, useState } from 'react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useOrgContext } from '@/components/OrgContextSwitcher';
+import { UpgradePrompt } from '@/components/UpgradePrompt';
+import type { PlanTier } from '@/types';
+
+const TIER_RANK: Record<PlanTier, number> = { free: 0, pro: 1, enterprise: 2 };
+
+interface PlanGuardProps {
+  requiredPlan: PlanTier | PlanTier[];
+  featureName?: string;
+  fallback?: ReactNode;
+  children: ReactNode;
+}
+
+export function PlanGuard({ requiredPlan, featureName, fallback, children }: PlanGuardProps) {
+  const { selectedOrg, loading: orgLoading } = useOrgContext();
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isBillingEnabled()) {
+      setAllowed(true);
+      return;
+    }
+    if (orgLoading || !selectedOrg) return;
+
+    let cancelled = false;
+    api.getOrgSubscription(selectedOrg.id)
+      .then((sub) => {
+        if (cancelled) return;
+        const tier = (sub?.plan?.tier ?? 'free') as PlanTier;
+        const plans = Array.isArray(requiredPlan) ? requiredPlan : [requiredPlan];
+        const meetsRequirement = plans.some((p) => TIER_RANK[tier] >= TIER_RANK[p]);
+        setAllowed(meetsRequirement);
+      })
+      .catch(() => {
+        if (!cancelled) setAllowed(true); // fail open — backend enforces
+      });
+    return () => { cancelled = true; };
+  }, [selectedOrg, orgLoading, requiredPlan]);
+
+  if (allowed === null) return null; // loading
+  if (allowed) return <>{children}</>;
+
+  if (fallback) return <>{fallback}</>;
+
+  const displayPlan = Array.isArray(requiredPlan) ? requiredPlan[0] : requiredPlan;
+  return (
+    <UpgradePrompt
+      requiredPlan={displayPlan}
+      featureName={featureName ?? 'This feature'}
+      showUpgradeLink
+    />
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/PlanGuard.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/PlanGuard.tsx admin-ui/components/__tests__/PlanGuard.test.tsx
+git commit -m "feat(admin-ui): add PlanGuard component for plan-based UI gating"
+```
+
+---
+
+## Task 8: InvoiceTable Component
+
+**Files:**
+- Create: `admin-ui/components/InvoiceTable.tsx`
+- Create: `admin-ui/components/__tests__/InvoiceTable.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/components/__tests__/InvoiceTable.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InvoiceTable } from '../InvoiceTable';
+import type { Invoice } from '@/types';
+
+const invoices: Invoice[] = [
+  {
+    id: '1',
+    stripe_invoice_id: 'inv_abc',
+    amount_cents: 4900,
+    currency: 'usd',
+    status: 'paid',
+    invoice_pdf: 'https://stripe.com/invoice.pdf',
+    period_start: '2026-02-01T00:00:00Z',
+    period_end: '2026-03-01T00:00:00Z',
+    created_at: '2026-03-01T00:00:00Z',
+  },
+  {
+    id: '2',
+    stripe_invoice_id: 'inv_def',
+    amount_cents: 7500,
+    currency: 'usd',
+    status: 'open',
+    period_start: '2026-03-01T00:00:00Z',
+    period_end: '2026-04-01T00:00:00Z',
+    created_at: '2026-04-01T00:00:00Z',
+  },
+];
+
+describe('InvoiceTable', () => {
+  it('renders invoice rows', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    expect(screen.getByText('$49.00')).toBeInTheDocument();
+    expect(screen.getByText('$75.00')).toBeInTheDocument();
+  });
+
+  it('renders status badges', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    expect(screen.getByText('paid')).toBeInTheDocument();
+    expect(screen.getByText('open')).toBeInTheDocument();
+  });
+
+  it('renders PDF download link when available', () => {
+    render(<InvoiceTable invoices={invoices} />);
+    const links = screen.getAllByRole('link');
+    expect(links.some((link) => link.getAttribute('href') === 'https://stripe.com/invoice.pdf')).toBe(true);
+  });
+
+  it('renders empty state when no invoices', () => {
+    render(<InvoiceTable invoices={[]} />);
+    expect(screen.getByText(/no invoices/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/InvoiceTable.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement InvoiceTable**
+
+Create `admin-ui/components/InvoiceTable.tsx`:
+
+```typescript
+import { Download } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import type { Invoice } from '@/types';
+
+interface InvoiceTableProps {
+  invoices: Invoice[];
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  paid: 'default',
+  open: 'outline',
+  void: 'secondary',
+  draft: 'secondary',
+  uncollectible: 'destructive',
+};
+
+export function InvoiceTable({ invoices }: InvoiceTableProps) {
+  if (invoices.length === 0) {
+    return <p className="text-sm text-muted-foreground py-4 text-center">No invoices yet.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="py-2 pr-4">Date</th>
+            <th className="py-2 pr-4">Period</th>
+            <th className="py-2 pr-4">Amount</th>
+            <th className="py-2 pr-4">Status</th>
+            <th className="py-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {invoices.map((inv) => (
+            <tr key={inv.id} className="border-b">
+              <td className="py-2 pr-4">{formatDate(inv.created_at)}</td>
+              <td className="py-2 pr-4">
+                {formatDate(inv.period_start)} — {formatDate(inv.period_end)}
+              </td>
+              <td className="py-2 pr-4 font-medium">{formatCents(inv.amount_cents)}</td>
+              <td className="py-2 pr-4">
+                <Badge variant={statusVariant[inv.status] ?? 'outline'}>{inv.status}</Badge>
+              </td>
+              <td className="py-2">
+                {inv.invoice_pdf && (
+                  <a
+                    href={inv.invoice_pdf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                  >
+                    <Download className="h-3 w-3" /> PDF
+                  </a>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run components/__tests__/InvoiceTable.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/InvoiceTable.tsx admin-ui/components/__tests__/InvoiceTable.test.tsx
+git commit -m "feat(admin-ui): add InvoiceTable component for Stripe invoice display"
+```
+
+---
+
+## Task 9: Plans Management Page
+
+**Files:**
+- Create: `admin-ui/app/plans/page.tsx`
+- Create: `admin-ui/app/plans/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/plans/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetPlans = vi.hoisted(() => vi.fn());
+const mockCreatePlan = vi.hoisted(() => vi.fn());
+const mockDeletePlan = vi.hoisted(() => vi.fn());
+const confirmMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getPlans: mockGetPlans,
+    createPlan: mockCreatePlan,
+    deletePlan: mockDeletePlan,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useConfirm', () => ({
+  useConfirm: () => confirmMock,
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: toastSuccessMock, error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const samplePlans = [
+  {
+    id: 'plan_free',
+    name: 'Free',
+    tier: 'free' as const,
+    stripe_product_id: 'prod_free',
+    stripe_price_id: 'price_free',
+    monthly_price_cents: 0,
+    included_token_credits: 10_000,
+    overage_rate_per_1k_tokens_cents: 0,
+    features: ['basic_chat'],
+    is_default: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'plan_pro',
+    name: 'Pro',
+    tier: 'pro' as const,
+    stripe_product_id: 'prod_pro',
+    stripe_price_id: 'price_pro',
+    monthly_price_cents: 4900,
+    included_token_credits: 1_000_000,
+    overage_rate_per_1k_tokens_cents: 5,
+    features: ['basic_chat', 'advanced_analytics', 'priority_support'],
+    is_default: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+describe('PlansPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue(samplePlans);
+    confirmMock.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders plan list', async () => {
+    const PlansPage = (await import('../page')).default;
+    render(<PlansPage />);
+    expect(await screen.findByText('Free')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.getByText('$49.00/mo')).toBeInTheDocument();
+  });
+
+  it('shows create plan dialog', async () => {
+    const PlansPage = (await import('../page')).default;
+    const user = userEvent.setup();
+    render(<PlansPage />);
+    await screen.findByText('Free');
+    const createButton = screen.getByRole('button', { name: /create plan/i });
+    await user.click(createButton);
+    expect(screen.getByLabelText(/plan name/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/plans/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Plans page**
+
+Create `admin-ui/app/plans/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Plus, Trash2, Edit2 } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Plan, PlanTier } from '@/types';
+
+const planSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  tier: z.enum(['free', 'pro', 'enterprise']),
+  monthly_price_cents: z.coerce.number().min(0),
+  included_token_credits: z.coerce.number().min(0),
+  overage_rate_per_1k_tokens_cents: z.coerce.number().min(0),
+  stripe_product_id: z.string().optional(),
+  stripe_price_id: z.string().optional(),
+});
+
+type PlanFormData = z.infer<typeof planSchema>;
+
+export default function PlansPage() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingPlan, setEditingPlan] = useState<Plan | null>(null);
+  const confirm = useConfirm();
+  const toast = useToast();
+
+  const form = useForm<PlanFormData>({
+    resolver: zodResolver(planSchema),
+    defaultValues: {
+      name: '',
+      tier: 'free',
+      monthly_price_cents: 0,
+      included_token_credits: 0,
+      overage_rate_per_1k_tokens_cents: 0,
+    },
+  });
+
+  const loadPlans = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await api.getPlans();
+      setPlans(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Failed to load plans');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) loadPlans();
+    else setLoading(false);
+  }, [loadPlans]);
+
+  const handleCreate = async (data: PlanFormData) => {
+    try {
+      await api.createPlan(data as Partial<Plan>);
+      toast.success('Plan created');
+      setShowCreate(false);
+      form.reset();
+      loadPlans();
+    } catch {
+      toast.error('Failed to create plan');
+    }
+  };
+
+  const handleDelete = async (plan: Plan) => {
+    const ok = await confirm(`Delete plan "${plan.name}"? Orgs on this plan will need to be migrated.`);
+    if (!ok) return;
+    try {
+      await api.deletePlan(plan.id);
+      toast.success('Plan deleted');
+      loadPlans();
+    } catch {
+      toast.error('Failed to delete plan');
+    }
+  };
+
+  const handleEdit = async (data: PlanFormData) => {
+    if (!editingPlan) return;
+    try {
+      await api.updatePlan(editingPlan.id, data as Partial<Plan>);
+      toast.success('Plan updated');
+      setEditingPlan(null);
+      form.reset();
+      loadPlans();
+    } catch {
+      toast.error('Failed to update plan');
+    }
+  };
+
+  const openEdit = (plan: Plan) => {
+    form.reset({
+      name: plan.name,
+      tier: plan.tier,
+      monthly_price_cents: plan.monthly_price_cents,
+      included_token_credits: plan.included_token_credits,
+      overage_rate_per_1k_tokens_cents: plan.overage_rate_per_1k_tokens_cents,
+      stripe_product_id: plan.stripe_product_id,
+      stripe_price_id: plan.stripe_price_id,
+    });
+    setEditingPlan(plan);
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled. Set <code>NEXT_PUBLIC_BILLING_ENABLED=true</code> to manage plans.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const formatPrice = (cents: number) => cents === 0 ? 'Free' : `$${(cents / 100).toFixed(2)}/mo`;
+
+  const planFormDialog = (
+    open: boolean,
+    onOpenChange: (v: boolean) => void,
+    title: string,
+    onSubmit: (data: PlanFormData) => void,
+  ) => (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <Label htmlFor="name">Plan Name</Label>
+            <Input id="name" {...form.register('name')} />
+            {form.formState.errors.name && (
+              <p className="text-sm text-red-500 mt-1">{form.formState.errors.name.message}</p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="tier">Tier</Label>
+            <Select
+              value={form.watch('tier')}
+              onValueChange={(v) => form.setValue('tier', v as PlanTier)}
+            >
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">Free</SelectItem>
+                <SelectItem value="pro">Pro</SelectItem>
+                <SelectItem value="enterprise">Enterprise</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="monthly_price_cents">Monthly Price (cents)</Label>
+            <Input id="monthly_price_cents" type="number" {...form.register('monthly_price_cents')} />
+          </div>
+          <div>
+            <Label htmlFor="included_token_credits">Included Token Credits</Label>
+            <Input id="included_token_credits" type="number" {...form.register('included_token_credits')} />
+          </div>
+          <div>
+            <Label htmlFor="overage_rate_per_1k_tokens_cents">Overage Rate / 1K Tokens (cents)</Label>
+            <Input id="overage_rate_per_1k_tokens_cents" type="number" {...form.register('overage_rate_per_1k_tokens_cents')} />
+          </div>
+          <div>
+            <Label htmlFor="stripe_product_id">Stripe Product ID</Label>
+            <Input id="stripe_product_id" {...form.register('stripe_product_id')} placeholder="prod_..." />
+          </div>
+          <div>
+            <Label htmlFor="stripe_price_id">Stripe Price ID</Label>
+            <Input id="stripe_price_id" {...form.register('stripe_price_id')} placeholder="price_..." />
+          </div>
+          <DialogFooter>
+            <Button type="submit">Save</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Subscription Plans</h1>
+              <p className="text-muted-foreground">Manage pricing tiers and included features</p>
+            </div>
+            <Button onClick={() => { form.reset(); setShowCreate(true); }}>
+              <Plus className="h-4 w-4 mr-2" /> Create Plan
+            </Button>
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading plans...</p>
+          ) : plans.length === 0 ? (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground">
+                No plans configured. Create your first plan to get started.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {plans.map((plan) => (
+                <Card key={plan.id}>
+                  <CardHeader className="flex flex-row items-center justify-between pb-2">
+                    <div className="flex items-center gap-2">
+                      <CardTitle className="text-lg">{plan.name}</CardTitle>
+                      <PlanBadge tier={plan.tier} />
+                      {plan.is_default && (
+                        <span className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded">Default</span>
+                      )}
+                    </div>
+                    <div className="flex gap-1">
+                      <Button variant="ghost" size="sm" onClick={() => openEdit(plan)}>
+                        <Edit2 className="h-3 w-3" />
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => handleDelete(plan)}>
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-2xl font-bold">{formatPrice(plan.monthly_price_cents)}</p>
+                    <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+                      <p>{plan.included_token_credits.toLocaleString()} tokens included</p>
+                      {plan.overage_rate_per_1k_tokens_cents > 0 && (
+                        <p>${(plan.overage_rate_per_1k_tokens_cents / 100).toFixed(2)} per 1K overage tokens</p>
+                      )}
+                      <p>{plan.features.length} features enabled</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {planFormDialog(showCreate, setShowCreate, 'Create Plan', handleCreate)}
+        {planFormDialog(!!editingPlan, (v) => !v && setEditingPlan(null), 'Edit Plan', handleEdit)}
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/plans/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/plans/
+git commit -m "feat(admin-ui): add Plans management page with CRUD and Stripe IDs"
+```
+
+---
+
+## Task 10: Subscriptions List Page
+
+**Files:**
+- Create: `admin-ui/app/subscriptions/page.tsx`
+- Create: `admin-ui/app/subscriptions/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/subscriptions/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetSubscriptions = vi.hoisted(() => vi.fn());
+const mockGetPlans = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getSubscriptions: mockGetSubscriptions,
+    getPlans: mockGetPlans,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/OrgContextSwitcher', () => ({
+  useOrgContext: () => ({ selectedOrg: null, loading: false, organizations: [] }),
+}));
+
+describe('SubscriptionsPage', () => {
+  beforeEach(() => {
+    mockGetSubscriptions.mockResolvedValue([
+      {
+        id: 'sub_1',
+        org_id: 1,
+        plan_id: 'plan_pro',
+        plan: { id: 'plan_pro', name: 'Pro', tier: 'pro' },
+        stripe_subscription_id: 'sub_stripe_1',
+        status: 'active',
+        current_period_start: '2026-03-01T00:00:00Z',
+        current_period_end: '2026-04-01T00:00:00Z',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-03-01T00:00:00Z',
+      },
+    ]);
+    mockGetPlans.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders subscription list', async () => {
+    const SubscriptionsPage = (await import('../page')).default;
+    render(<SubscriptionsPage />);
+    expect(await screen.findByText('active')).toBeInTheDocument();
+    expect(screen.getByText(/Pro/)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/subscriptions/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Subscriptions page**
+
+Create `admin-ui/app/subscriptions/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Subscription, SubscriptionStatus } from '@/types';
+
+const statusVariant: Record<SubscriptionStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  active: 'default',
+  trialing: 'outline',
+  past_due: 'destructive',
+  canceled: 'secondary',
+  incomplete: 'secondary',
+};
+
+export default function SubscriptionsPage() {
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const toast = useToast();
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const params: Record<string, string> = {};
+      if (statusFilter !== 'all') params.status = statusFilter;
+      const data = await api.getSubscriptions(params);
+      setSubscriptions(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Failed to load subscriptions');
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) load();
+    else setLoading(false);
+  }, [load]);
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Subscriptions</h1>
+              <p className="text-muted-foreground">All active and past subscriptions across organizations</p>
+            </div>
+            <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="trialing">Trialing</SelectItem>
+                <SelectItem value="past_due">Past Due</SelectItem>
+                <SelectItem value="canceled">Canceled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading...</p>
+          ) : subscriptions.length === 0 ? (
+            <Card>
+              <CardContent className="py-8 text-center text-muted-foreground">
+                No subscriptions found.
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="p-3">Organization</th>
+                        <th className="p-3">Plan</th>
+                        <th className="p-3">Status</th>
+                        <th className="p-3">Current Period</th>
+                        <th className="p-3">Created</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {subscriptions.map((sub) => (
+                        <tr key={sub.id} className="border-b hover:bg-muted/50">
+                          <td className="p-3">
+                            <Link href={`/organizations/${sub.org_id}`} className="text-blue-600 hover:underline">
+                              Org #{sub.org_id}
+                            </Link>
+                          </td>
+                          <td className="p-3">
+                            {sub.plan ? <PlanBadge tier={sub.plan.tier} /> : sub.plan_id}
+                          </td>
+                          <td className="p-3">
+                            <Badge variant={statusVariant[sub.status] ?? 'outline'}>{sub.status}</Badge>
+                          </td>
+                          <td className="p-3">
+                            {formatDate(sub.current_period_start)} — {formatDate(sub.current_period_end)}
+                          </td>
+                          <td className="p-3">{formatDate(sub.created_at)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/subscriptions/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/subscriptions/
+git commit -m "feat(admin-ui): add Subscriptions list page with status filtering"
+```
+
+---
+
+## Task 11: Feature Registry Page
+
+**Files:**
+- Create: `admin-ui/app/feature-registry/page.tsx`
+- Create: `admin-ui/app/feature-registry/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/feature-registry/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetFeatureRegistry = vi.hoisted(() => vi.fn());
+const mockGetPlans = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getFeatureRegistry: mockGetFeatureRegistry,
+    getPlans: mockGetPlans,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+describe('FeatureRegistryPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue([
+      { id: 'plan_free', name: 'Free', tier: 'free' },
+      { id: 'plan_pro', name: 'Pro', tier: 'pro' },
+    ]);
+    mockGetFeatureRegistry.mockResolvedValue([
+      {
+        feature_key: 'advanced_analytics',
+        display_name: 'Advanced Analytics',
+        description: 'Deep usage analytics',
+        plans: ['plan_pro'],
+        category: 'Analytics',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders feature matrix with plan columns', async () => {
+    const FeatureRegistryPage = (await import('../page')).default;
+    render(<FeatureRegistryPage />);
+    expect(await screen.findByText('Advanced Analytics')).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/feature-registry/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Feature Registry page**
+
+Create `admin-ui/app/feature-registry/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Check, X } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import type { Plan, FeatureRegistryEntry } from '@/types';
+
+export default function FeatureRegistryPage() {
+  const [features, setFeatures] = useState<FeatureRegistryEntry[]>([]);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dirty, setDirty] = useState(false);
+  const toast = useToast();
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [featData, planData] = await Promise.all([
+        api.getFeatureRegistry(),
+        api.getPlans(),
+      ]);
+      setFeatures(Array.isArray(featData) ? featData : []);
+      setPlans(Array.isArray(planData) ? planData : []);
+    } catch {
+      toast.error('Failed to load feature registry');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) load();
+    else setLoading(false);
+  }, [load]);
+
+  const toggleFeature = (featureKey: string, planId: string) => {
+    setFeatures((prev) =>
+      prev.map((f) => {
+        if (f.feature_key !== featureKey) return f;
+        const has = f.plans.includes(planId);
+        return { ...f, plans: has ? f.plans.filter((p) => p !== planId) : [...f.plans, planId] };
+      }),
+    );
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    try {
+      await api.updateFeatureRegistry(features);
+      toast.success('Feature registry saved');
+      setDirty(false);
+    } catch {
+      toast.error('Failed to save');
+    }
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const categories = Array.from(new Set(features.map((f) => f.category))).sort();
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="space-y-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold">Feature Registry</h1>
+              <p className="text-muted-foreground">Map features to plan tiers for open-core gating</p>
+            </div>
+            {dirty && <Button onClick={handleSave}>Save Changes</Button>}
+          </div>
+
+          {loading ? (
+            <p className="text-muted-foreground">Loading...</p>
+          ) : (
+            <Card>
+              <CardContent className="p-0">
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b text-left text-muted-foreground">
+                        <th className="p-3">Feature</th>
+                        {plans.map((plan) => (
+                          <th key={plan.id} className="p-3 text-center">{plan.name}</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {categories.map((cat) => (
+                        <>
+                          <tr key={`cat-${cat}`}>
+                            <td colSpan={plans.length + 1} className="p-3 font-semibold bg-muted/50">
+                              {cat}
+                            </td>
+                          </tr>
+                          {features
+                            .filter((f) => f.category === cat)
+                            .map((feat) => (
+                              <tr key={feat.feature_key} className="border-b hover:bg-muted/30">
+                                <td className="p-3">
+                                  <div>{feat.display_name}</div>
+                                  <div className="text-xs text-muted-foreground">{feat.description}</div>
+                                </td>
+                                {plans.map((plan) => {
+                                  const included = feat.plans.includes(plan.id);
+                                  return (
+                                    <td key={plan.id} className="p-3 text-center">
+                                      <button
+                                        onClick={() => toggleFeature(feat.feature_key, plan.id)}
+                                        className="inline-flex items-center justify-center"
+                                      >
+                                        {included ? (
+                                          <Check className="h-4 w-4 text-green-600" />
+                                        ) : (
+                                          <X className="h-4 w-4 text-gray-300" />
+                                        )}
+                                      </button>
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            ))}
+                        </>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/feature-registry/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/feature-registry/
+git commit -m "feat(admin-ui): add Feature Registry page with plan-to-feature matrix"
+```
+
+---
+
+## Task 12: Onboarding Wizard Page
+
+**Files:**
+- Create: `admin-ui/app/onboarding/page.tsx`
+- Create: `admin-ui/app/onboarding/__tests__/page.test.tsx`
+
+**Step 1: Write the test**
+
+Create `admin-ui/app/onboarding/__tests__/page.test.tsx`:
+
+```typescript
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetPlans = vi.hoisted(() => vi.fn());
+const mockCreateOnboardingSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    getPlans: mockGetPlans,
+    createOnboardingSession: mockCreateOnboardingSession,
+  },
+  ApiError: class extends Error {},
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('@/components/PermissionGuard', () => ({
+  usePermissions: () => ({ user: { id: 1, role: 'admin' }, loading: false, hasRole: () => true }),
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: () => true,
+}));
+
+const plans = [
+  { id: 'plan_free', name: 'Free', tier: 'free', monthly_price_cents: 0, included_token_credits: 10000 },
+  { id: 'plan_pro', name: 'Pro', tier: 'pro', monthly_price_cents: 4900, included_token_credits: 1000000 },
+];
+
+describe('OnboardingPage', () => {
+  beforeEach(() => {
+    mockGetPlans.mockResolvedValue(plans);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it('renders step 1 with org name input', async () => {
+    const OnboardingPage = (await import('../page')).default;
+    render(<OnboardingPage />);
+    expect(await screen.findByLabelText(/organization name/i)).toBeInTheDocument();
+  });
+
+  it('advances to step 2 on next', async () => {
+    const OnboardingPage = (await import('../page')).default;
+    const user = userEvent.setup();
+    render(<OnboardingPage />);
+
+    const nameInput = await screen.findByLabelText(/organization name/i);
+    await user.type(nameInput, 'Acme Corp');
+
+    const slugInput = screen.getByLabelText(/slug/i);
+    await user.type(slugInput, 'acme-corp');
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    await user.click(nextButton);
+
+    expect(await screen.findByText(/select a plan/i)).toBeInTheDocument();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd admin-ui && npx vitest run app/onboarding/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: FAIL
+
+**Step 3: Implement Onboarding page**
+
+Create `admin-ui/app/onboarding/page.tsx`:
+
+```typescript
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Check, ChevronRight } from 'lucide-react';
+import { api } from '@/lib/api-client';
+import { isBillingEnabled } from '@/lib/billing';
+import { useToast } from '@/hooks/useToast';
+import PermissionGuard from '@/components/PermissionGuard';
+import { PlanBadge } from '@/components/PlanBadge';
+import { ResponsiveLayout } from '@/components/ResponsiveLayout';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+import type { Plan } from '@/types';
+
+const orgSchema = z.object({
+  org_name: z.string().min(1, 'Required'),
+  org_slug: z.string().min(1, 'Required').regex(/^[a-z0-9-]+$/, 'Lowercase letters, numbers, hyphens only'),
+  owner_email: z.string().email().optional().or(z.literal('')),
+});
+
+type OrgFormData = z.infer<typeof orgSchema>;
+
+const STEPS = ['Organization', 'Select Plan', 'Confirm'] as const;
+
+export default function OnboardingPage() {
+  const [step, setStep] = useState(0);
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const toast = useToast();
+
+  const form = useForm<OrgFormData>({
+    resolver: zodResolver(orgSchema),
+    defaultValues: { org_name: '', org_slug: '', owner_email: '' },
+  });
+
+  const loadPlans = useCallback(async () => {
+    try {
+      const data = await api.getPlans();
+      const list = Array.isArray(data) ? data : [];
+      setPlans(list);
+      const defaultPlan = list.find((p) => p.is_default);
+      if (defaultPlan) setSelectedPlanId(defaultPlan.id);
+    } catch {
+      toast.error('Failed to load plans');
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (isBillingEnabled()) loadPlans();
+  }, [loadPlans]);
+
+  const handleNext = async () => {
+    if (step === 0) {
+      const valid = await form.trigger();
+      if (!valid) return;
+      setStep(1);
+    } else if (step === 1) {
+      if (!selectedPlanId) {
+        toast.error('Please select a plan');
+        return;
+      }
+      setStep(2);
+    }
+  };
+
+  const handleBack = () => {
+    if (step > 0) setStep(step - 1);
+  };
+
+  const handleSubmit = async () => {
+    const data = form.getValues();
+    setSubmitting(true);
+    try {
+      const result = await api.createOnboardingSession({
+        org_name: data.org_name,
+        org_slug: data.org_slug,
+        plan_id: selectedPlanId!,
+        owner_email: data.owner_email || undefined,
+      });
+      if (result.checkout_url) {
+        window.location.href = result.checkout_url;
+      } else {
+        toast.success('Organization created successfully');
+        setStep(0);
+        form.reset();
+      }
+    } catch {
+      toast.error('Onboarding failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isBillingEnabled()) {
+    return (
+      <ResponsiveLayout>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Billing is not enabled.
+          </CardContent>
+        </Card>
+      </ResponsiveLayout>
+    );
+  }
+
+  const selectedPlan = plans.find((p) => p.id === selectedPlanId);
+
+  return (
+    <ResponsiveLayout>
+      <PermissionGuard role={['admin', 'super_admin', 'owner']}>
+        <div className="max-w-2xl mx-auto space-y-6">
+          <h1 className="text-2xl font-bold">Onboard New Organization</h1>
+
+          {/* Step indicator */}
+          <div className="flex items-center gap-2">
+            {STEPS.map((label, i) => (
+              <div key={label} className="flex items-center gap-2">
+                <div className={cn(
+                  'flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium',
+                  i < step ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300' :
+                  i === step ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
+                  'bg-gray-100 text-gray-500 dark:bg-gray-800',
+                )}>
+                  {i < step ? <Check className="h-4 w-4" /> : i + 1}
+                </div>
+                <span className={cn('text-sm', i === step ? 'font-medium' : 'text-muted-foreground')}>
+                  {label}
+                </span>
+                {i < STEPS.length - 1 && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+              </div>
+            ))}
+          </div>
+
+          {/* Step 1: Organization Details */}
+          {step === 0 && (
+            <Card>
+              <CardHeader><CardTitle>Organization Details</CardTitle></CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <Label htmlFor="org_name">Organization Name</Label>
+                  <Input id="org_name" {...form.register('org_name')} />
+                  {form.formState.errors.org_name && (
+                    <p className="text-sm text-red-500 mt-1">{form.formState.errors.org_name.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="org_slug">Slug</Label>
+                  <Input id="org_slug" {...form.register('org_slug')} placeholder="acme-corp" />
+                  {form.formState.errors.org_slug && (
+                    <p className="text-sm text-red-500 mt-1">{form.formState.errors.org_slug.message}</p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor="owner_email">Owner Email (optional)</Label>
+                  <Input id="owner_email" type="email" {...form.register('owner_email')} />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Step 2: Plan Selection */}
+          {step === 1 && (
+            <div className="space-y-3">
+              <p className="text-muted-foreground">Select a plan for this organization:</p>
+              {plans.map((plan) => (
+                <Card
+                  key={plan.id}
+                  className={cn(
+                    'cursor-pointer transition-colors',
+                    selectedPlanId === plan.id ? 'ring-2 ring-blue-500' : 'hover:bg-muted/50',
+                  )}
+                  onClick={() => setSelectedPlanId(plan.id)}
+                >
+                  <CardContent className="p-4 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <PlanBadge tier={plan.tier} />
+                      <div>
+                        <p className="font-medium">{plan.name}</p>
+                        <p className="text-sm text-muted-foreground">
+                          {plan.included_token_credits.toLocaleString()} tokens included
+                        </p>
+                      </div>
+                    </div>
+                    <p className="font-bold">
+                      {plan.monthly_price_cents === 0 ? 'Free' : `$${(plan.monthly_price_cents / 100).toFixed(2)}/mo`}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {/* Step 3: Confirm */}
+          {step === 2 && (
+            <Card>
+              <CardHeader><CardTitle>Confirm</CardTitle></CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <p><strong>Organization:</strong> {form.getValues('org_name')} ({form.getValues('org_slug')})</p>
+                {form.getValues('owner_email') && <p><strong>Owner:</strong> {form.getValues('owner_email')}</p>}
+                <p><strong>Plan:</strong> {selectedPlan?.name ?? 'Unknown'}</p>
+                {selectedPlan && selectedPlan.monthly_price_cents > 0 && (
+                  <p className="text-muted-foreground">
+                    A Stripe Checkout session will be created for payment.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Navigation */}
+          <div className="flex justify-between">
+            <Button variant="outline" onClick={handleBack} disabled={step === 0}>
+              Back
+            </Button>
+            {step < 2 ? (
+              <Button onClick={handleNext}>
+                Next <ChevronRight className="h-4 w-4 ml-1" />
+              </Button>
+            ) : (
+              <Button onClick={handleSubmit} disabled={submitting}>
+                {submitting ? 'Creating...' : selectedPlan && selectedPlan.monthly_price_cents > 0 ? 'Create & Pay' : 'Create Organization'}
+              </Button>
+            )}
+          </div>
+        </div>
+      </PermissionGuard>
+    </ResponsiveLayout>
+  );
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd admin-ui && npx vitest run app/onboarding/__tests__/page.test.tsx 2>&1 | tail -10`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/onboarding/
+git commit -m "feat(admin-ui): add Onboarding wizard with org creation and plan selection"
+```
+
+---
+
+## Task 13: Org Detail — Subscription Tab
+
+**Files:**
+- Modify: `admin-ui/app/organizations/[id]/page.tsx`
+
+**Step 1: Read the existing org detail page to understand current structure**
+
+Run: Read the file to find where to add the subscription section.
+
+**Step 2: Add imports for billing components**
+
+Add to the imports section of `admin-ui/app/organizations/[id]/page.tsx`:
+
+```typescript
+import { PlanBadge } from '@/components/PlanBadge';
+import { UsageMeter } from '@/components/UsageMeter';
+import { InvoiceTable } from '@/components/InvoiceTable';
+import { isBillingEnabled } from '@/lib/billing';
+import type { Subscription, OrgUsageSummary, Invoice } from '@/types';
+```
+
+**Step 3: Add subscription state alongside existing state**
+
+Add state variables:
+
+```typescript
+const [subscription, setSubscription] = useState<Subscription | null>(null);
+const [usageSummary, setUsageSummary] = useState<OrgUsageSummary | null>(null);
+const [invoices, setInvoices] = useState<Invoice[]>([]);
+```
+
+**Step 4: Add billing data fetch in the existing loadData function**
+
+Inside the existing `Promise.allSettled()` or after the main data loads, add:
+
+```typescript
+if (isBillingEnabled()) {
+  const [subResult, usageResult, invoiceResult] = await Promise.allSettled([
+    api.getOrgSubscription(Number(id)),
+    api.getOrgUsageSummary(Number(id)),
+    api.getOrgInvoices(Number(id)),
+  ]);
+  if (subResult.status === 'fulfilled') setSubscription(subResult.value);
+  if (usageResult.status === 'fulfilled') setUsageSummary(usageResult.value);
+  if (invoiceResult.status === 'fulfilled') setInvoices(Array.isArray(invoiceResult.value) ? invoiceResult.value : []);
+}
+```
+
+**Step 5: Add Subscription card section after the existing BYOK section**
+
+```tsx
+{/* Subscription & Billing (SaaS only) */}
+{isBillingEnabled() && (
+  <Card>
+    <CardHeader>
+      <CardTitle className="flex items-center gap-2">
+        Subscription
+        {subscription?.plan && <PlanBadge tier={subscription.plan.tier} />}
+      </CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      {subscription ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="text-muted-foreground">Status</p>
+              <p className="font-medium capitalize">{subscription.status}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Current Period</p>
+              <p className="font-medium">
+                {new Date(subscription.current_period_start).toLocaleDateString()} —{' '}
+                {new Date(subscription.current_period_end).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+
+          {usageSummary && (
+            <div>
+              <p className="text-sm font-medium mb-2">Token Usage</p>
+              <UsageMeter
+                used={usageSummary.tokens_used}
+                included={usageSummary.tokens_included}
+                overageCostCents={usageSummary.overage_cost_cents}
+              />
+            </div>
+          )}
+
+          {invoices.length > 0 && (
+            <div>
+              <p className="text-sm font-medium mb-2">Invoices</p>
+              <InvoiceTable invoices={invoices} />
+            </div>
+          )}
+        </>
+      ) : (
+        <p className="text-muted-foreground">No active subscription.</p>
+      )}
+    </CardContent>
+  </Card>
+)}
+```
+
+**Step 6: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 7: Commit**
+
+```bash
+git add admin-ui/app/organizations/\[id\]/page.tsx
+git commit -m "feat(admin-ui): add Subscription section to org detail page"
+```
+
+---
+
+## Task 14: Modify Organizations List — Plan Column
+
+**Files:**
+- Modify: `admin-ui/app/organizations/page.tsx`
+
+**Step 1: Read the existing organizations page**
+
+Understand the table structure before modifying.
+
+**Step 2: Add PlanBadge import and subscription state**
+
+At the top:
+```typescript
+import { PlanBadge } from '@/components/PlanBadge';
+import { isBillingEnabled } from '@/lib/billing';
+```
+
+**Step 3: Extend org list to fetch subscriptions**
+
+After orgs are loaded, fetch subscriptions for visible orgs:
+
+```typescript
+// After loadData sets organizations, fetch their subscriptions if billing enabled
+const [orgPlans, setOrgPlans] = useState<Record<number, { tier: PlanTier; status: string }>>({});
+
+// In loadData, after org list is fetched:
+if (isBillingEnabled() && orgs.length > 0) {
+  const subs = await api.getSubscriptions({ org_ids: orgs.map((o: { id: number }) => o.id).join(',') });
+  const planMap: Record<number, { tier: PlanTier; status: string }> = {};
+  if (Array.isArray(subs)) {
+    subs.forEach((sub: Subscription) => {
+      planMap[sub.org_id] = { tier: sub.plan?.tier ?? 'free', status: sub.status };
+    });
+  }
+  setOrgPlans(planMap);
+}
+```
+
+**Step 4: Add Plan column to the table**
+
+In the table header, add after the existing columns:
+```tsx
+{isBillingEnabled() && <th className="p-3">Plan</th>}
+{isBillingEnabled() && <th className="p-3">Status</th>}
+```
+
+In the table body rows:
+```tsx
+{isBillingEnabled() && (
+  <td className="p-3">
+    <PlanBadge tier={orgPlans[org.id]?.tier ?? 'free'} />
+  </td>
+)}
+{isBillingEnabled() && (
+  <td className="p-3 capitalize text-sm">
+    {orgPlans[org.id]?.status ?? '—'}
+  </td>
+)}
+```
+
+**Step 5: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/app/organizations/page.tsx
+git commit -m "feat(admin-ui): add Plan and Status columns to organizations list"
+```
+
+---
+
+## Task 15: Dashboard — Revenue KPI and Plan Distribution
+
+**Files:**
+- Modify: `admin-ui/app/page.tsx` (dashboard)
+
+**Step 1: Read the existing dashboard page**
+
+Understand the KPI card structure.
+
+**Step 2: Add billing imports**
+
+```typescript
+import { isBillingEnabled } from '@/lib/billing';
+```
+
+**Step 3: Add billing KPIs**
+
+In the dashboard's data loading section, add:
+
+```typescript
+const [billingStats, setBillingStats] = useState<{
+  mrr_cents: number;
+  active_subscriptions: number;
+  past_due_count: number;
+  plan_distribution: Record<string, number>;
+} | null>(null);
+
+// In loadData:
+if (isBillingEnabled()) {
+  try {
+    const subs = await api.getSubscriptions();
+    if (Array.isArray(subs)) {
+      const active = subs.filter((s: Subscription) => s.status === 'active');
+      const pastDue = subs.filter((s: Subscription) => s.status === 'past_due');
+      const distribution: Record<string, number> = {};
+      subs.forEach((s: Subscription) => {
+        const tier = s.plan?.tier ?? 'free';
+        distribution[tier] = (distribution[tier] ?? 0) + 1;
+      });
+      setBillingStats({
+        mrr_cents: 0, // Would come from a dedicated endpoint
+        active_subscriptions: active.length,
+        past_due_count: pastDue.length,
+        plan_distribution: distribution,
+      });
+    }
+  } catch {
+    // Non-critical — dashboard still works without billing stats
+  }
+}
+```
+
+**Step 4: Add KPI cards in the dashboard grid (conditionally)**
+
+```tsx
+{isBillingEnabled() && billingStats && (
+  <>
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm text-muted-foreground">Active Subscriptions</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-2xl font-bold">{billingStats.active_subscriptions}</p>
+      </CardContent>
+    </Card>
+    {billingStats.past_due_count > 0 && (
+      <Card className="border-red-200 dark:border-red-800">
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm text-red-600">Past Due</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-2xl font-bold text-red-600">{billingStats.past_due_count}</p>
+        </CardContent>
+      </Card>
+    )}
+  </>
+)}
+```
+
+**Step 5: Verify TypeScript compiles**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/app/page.tsx
+git commit -m "feat(admin-ui): add billing KPIs to dashboard when billing enabled"
+```
+
+---
+
+## Task 16: Filter Billing Nav Items by `BILLING_ENABLED`
+
+**Files:**
+- Modify: `admin-ui/lib/navigation.ts`
+
+**Step 1: Add conditional filtering**
+
+The navigation items for plans, subscriptions, and featureRegistry should only appear when billing is enabled. Since `navigation.ts` is imported at module level (not in a component), we need a runtime filter.
+
+Update the `navigationSections` export to be a function or add a `billingOnly` flag:
+
+Add a `billingOnly?: boolean` field to the `NavigationItem` type:
+
+```typescript
+export type NavigationItem = {
+  name: string;
+  href: string;
+  icon: LucideIcon;
+  permission?: string;
+  role?: string[];
+  keywords?: string[];
+  billingOnly?: boolean;
+};
+```
+
+Mark the three billing items with `billingOnly: true`:
+
+```typescript
+  plans: { name: 'Plans', href: '/plans', icon: CreditCard, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'pricing'], billingOnly: true },
+  subscriptions: { name: 'Subscriptions', href: '/subscriptions', icon: Receipt, role: ['admin', 'super_admin', 'owner'], keywords: ['billing', 'payments'], billingOnly: true },
+  featureRegistry: { name: 'Feature Registry', href: '/feature-registry', icon: Grid3X3, role: ['admin', 'super_admin', 'owner'], keywords: ['gating', 'entitlements'], billingOnly: true },
+```
+
+Then in the sidebar component (wherever `navigationSections` is consumed), filter out `billingOnly` items when `!isBillingEnabled()`. This keeps navigation.ts pure and moves the runtime check to the rendering layer.
+
+**Step 2: Verify build**
+
+Run: `cd admin-ui && npx tsc --noEmit --pretty 2>&1 | head -20`
+
+**Step 3: Commit**
+
+```bash
+git add admin-ui/lib/navigation.ts
+git commit -m "feat(admin-ui): mark billing nav items with billingOnly flag for conditional display"
+```
+
+---
+
+## Task 17: Final Integration Test
+
+**Files:**
+- Create: `admin-ui/app/__tests__/billing-integration.test.tsx`
+
+**Step 1: Write integration test**
+
+Create `admin-ui/app/__tests__/billing-integration.test.tsx`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { isBillingEnabled } from '@/lib/billing';
+
+vi.mock('@/lib/billing', () => ({
+  isBillingEnabled: vi.fn(),
+}));
+
+describe('Billing integration', () => {
+  it('isBillingEnabled returns false when env is not set', () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(false);
+    expect(isBillingEnabled()).toBe(false);
+  });
+
+  it('isBillingEnabled returns true when env is true', () => {
+    vi.mocked(isBillingEnabled).mockReturnValue(true);
+    expect(isBillingEnabled()).toBe(true);
+  });
+});
+
+describe('Billing types are importable', () => {
+  it('imports Plan type without error', async () => {
+    const types = await import('@/types');
+    expect(types).toBeDefined();
+  });
+});
+```
+
+**Step 2: Run all billing-related tests**
+
+Run: `cd admin-ui && npx vitest run --reporter=verbose 2>&1 | grep -E '(PASS|FAIL|billing|Plan|Usage|Invoice|Upgrade|Onboarding|Subscription|feature-registry)' | head -30`
+Expected: All PASS
+
+**Step 3: Run full test suite to check for regressions**
+
+Run: `cd admin-ui && npx vitest run 2>&1 | tail -20`
+Expected: No new failures
+
+**Step 4: Commit**
+
+```bash
+git add admin-ui/app/__tests__/billing-integration.test.tsx
+git commit -m "test(admin-ui): add billing integration smoke tests"
+```
+
+---
+
+## Summary
+
+| Task | Description | New Files | Modified Files |
+|------|------------|-----------|----------------|
+| 1 | Billing types | — | `types/index.ts` |
+| 2 | API client methods | — | `lib/api-client.ts` |
+| 3 | Billing helper + nav items | `lib/billing.ts` | `lib/navigation.ts` |
+| 4 | PlanBadge component | `components/PlanBadge.tsx` + test | — |
+| 5 | UsageMeter component | `components/UsageMeter.tsx` + test | — |
+| 6 | UpgradePrompt component | `components/UpgradePrompt.tsx` + test | — |
+| 7 | PlanGuard component | `components/PlanGuard.tsx` + test | — |
+| 8 | InvoiceTable component | `components/InvoiceTable.tsx` + test | — |
+| 9 | Plans page | `app/plans/` + test | — |
+| 10 | Subscriptions page | `app/subscriptions/` + test | — |
+| 11 | Feature Registry page | `app/feature-registry/` + test | — |
+| 12 | Onboarding page | `app/onboarding/` + test | — |
+| 13 | Org detail subscription tab | — | `app/organizations/[id]/page.tsx` |
+| 14 | Org list plan column | — | `app/organizations/page.tsx` |
+| 15 | Dashboard billing KPIs | — | `app/page.tsx` |
+| 16 | Nav billing filtering | — | `lib/navigation.ts` |
+| 17 | Integration test | `app/__tests__/billing-integration.test.tsx` | — |
+
+**Total: 17 tasks, ~17 commits, 12 new files, 6 modified files**

--- a/Docs/Plans/2026-03-08-ingestion-source-sync-design.md
+++ b/Docs/Plans/2026-03-08-ingestion-source-sync-design.md
@@ -1,0 +1,531 @@
+# Ingestion Source Sync Design
+
+## Date
+2026-03-08
+
+## Owner
+Generic document/file ingestion sync for local directories and archive snapshots
+
+## Goal
+Design a reusable sync/import system for document and file ingestion that supports local directories and uploaded archive refreshes, with selectable destination sinks for Media/Documents or Notes.
+
+## Scope
+
+In scope:
+- Generic syncable ingestion sources for:
+  - local directories on disk
+  - uploaded archive snapshots (`.zip`, later `.tar`/`.tar.gz` if supported by the same safety model)
+- Manual sync plus optional scheduled rescans for local-directory sources
+- UI and API refresh of archive-backed sources by replacing the payload for the same logical source
+- Selectable sink per source:
+  - `media`
+  - `notes`
+- Per-source lifecycle policy:
+  - `canonical`
+  - `import_only`
+- Source-scoped job execution, status, history, and conflict/degraded reporting
+
+Out of scope for v1:
+- Continuous filesystem watching
+- Git repository sync
+- Cloud provider/OAuth connectors
+- Three-way merge for synced note conflicts
+- Changing `sink_type` or source identity after the first successful sync
+- Full note revision-history storage
+- Generic binary ingestion into Notes
+
+## Problem Statement
+
+Current ingestion supports upload/import, but not durable source tracking and resynchronization. Users who keep notes or document collections in a folder or exported archive must re-upload everything when files change. Existing Notes import handles JSON/Markdown batches, and existing External Sources sync handles cloud providers for Media, but there is no reusable local/archive sync system that:
+
+- remembers a source over time
+- detects per-file adds/changes/deletes
+- updates existing destination content instead of blindly duplicating
+- supports both Media and Notes as destinations
+
+## Current Verified Constraints
+
+### Notes import/export exists, but not sync
+
+`POST /api/v1/notes/import` already supports JSON and Markdown batch import with duplicate strategies in:
+
+- `tldw_Server_API/app/api/v1/endpoints/notes.py`
+- `tldw_Server_API/app/api/v1/schemas/notes_schemas.py`
+
+This is import-only behavior. It does not persist source identity, track source items, or diff later refreshes.
+
+### Notes do not have recoverable content history today
+
+`CharactersRAGDB.update_note()` updates the current row in place and increments the optimistic-lock version:
+
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+That is not the same as preserving historical note bodies. Therefore the Notes sink in v1 must be defined as latest-state sync, not durable note revision history.
+
+### A stronger sync model already exists for cloud file sources
+
+The repo already has good patterns for source sync state, reconciliation, job fencing, and scheduled enqueue in:
+
+- `tldw_Server_API/app/core/External_Sources/README.md`
+- `tldw_Server_API/app/core/External_Sources/connectors_service.py`
+- `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+- `tldw_Server_API/app/services/connectors_worker.py`
+
+That system is currently provider-centric and Media-centric. It should inform the design, but local folders and uploaded archives should not be modeled as fake OAuth providers.
+
+### Safe local path handling and allowed-root validation already matter in this repo
+
+Relevant existing patterns:
+
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/path_utils.py`
+- `tldw_Server_API/app/core/Setup/setup_manager.py`
+
+These confirm that local-path sync must be explicitly constrained to allowed roots and revalidated at runtime.
+
+### Existing ingestion coverage is broader for Media than for Notes
+
+The document/media ingestion pipeline already handles text-first documents and richer document formats:
+
+- `tldw_Server_API/app/api/v1/endpoints/media/process_documents.py`
+- `tldw_Server_API/app/core/Ingestion_Media_Processing/Plaintext/Plaintext_Files.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py`
+- `tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py`
+
+Notes should therefore have a narrower v1 sink scope than Media.
+
+## Selected Architecture
+
+Create a new generic `ingestion_sources` subsystem for syncable inputs. Reuse the successful ideas from the existing External Sources and Jobs architecture, but keep this system independent from OAuth accounts and remote-provider assumptions.
+
+### Core flow
+
+1. User creates an ingestion source.
+2. A source adapter scans the source and emits a normalized snapshot of items.
+3. A diff/reconciliation layer compares the candidate snapshot to the last successful snapshot.
+4. A sink adapter applies creates/updates/deletes according to the source policy.
+5. Jobs own execution; APIs only create/update sources and enqueue work.
+6. Scheduled rescans use APScheduler to enqueue Jobs, not to process content inline.
+
+### Why this approach
+
+- Matches the repo’s existing preference for Jobs for user-visible work
+- Reuses proven sync-state and fencing concepts
+- Avoids building another one-shot import endpoint that cannot evolve
+- Leaves room for future source types such as git repos or more connectors
+
+## Data Model
+
+### Core tables
+
+`ingestion_sources`
+- one logical source per user
+- fields:
+  - `id`
+  - `user_id`
+  - `source_type` (`local_directory`, `archive_snapshot`)
+  - `sink_type` (`media`, `notes`)
+  - `policy` (`canonical`, `import_only`)
+  - `enabled`
+  - `schedule_enabled`
+  - `schedule_interval_sec` or equivalent schedule config
+  - source config payload
+  - created/updated timestamps
+
+`ingestion_source_state`
+- mutable runtime state per source
+- fields:
+  - `source_id`
+  - `active_job_id`
+  - `last_successful_snapshot_id`
+  - `last_sync_started_at`
+  - `last_sync_completed_at`
+  - `last_sync_status`
+  - `last_error`
+  - counts/summary fields
+
+`ingestion_source_snapshots`
+- one row per scan or archive refresh attempt
+- fields:
+  - `id`
+  - `source_id`
+  - `snapshot_kind` (`scan`, `archive_refresh`)
+  - `status` (`candidate`, `active`, `failed`, `superseded`)
+  - snapshot metadata and summary
+  - created timestamps
+
+`ingestion_source_items`
+- canonical per-item binding for the latest known source state
+- canonical identity in v1:
+  - `source_id + normalized_relative_path`
+- fields:
+  - source item path identity
+  - content fingerprint/hash
+  - file size / modified time metadata
+  - current sync status
+  - bound destination id and destination metadata
+  - item-level error/degraded/conflict state
+
+`ingestion_item_events`
+- append-only audit trail for item-level create/update/delete/archive/conflict events
+
+`ingestion_source_artifacts`
+- staged archive file metadata and extracted snapshot metadata
+- supports retention and cleanup of old uploaded payloads and extracted candidate trees
+
+## Source Semantics
+
+### `local_directory`
+
+- Stores a validated absolute source path under configured allowed roots
+- Supports:
+  - manual sync
+  - optional scheduled rescans
+- Does not support:
+  - filesystem watch in v1
+- Operational constraint:
+  - only safe in deployments where the worker that runs sync can access the same path later
+  - should be treated as self-hosted/admin-controlled unless shared storage guarantees exist
+
+### `archive_snapshot`
+
+- Represents one logical source whose payload is replaced over time by new uploaded archives
+- Refresh paths:
+  - UI re-upload to the same source
+  - API archive replacement for the same source
+- Every refresh creates a candidate snapshot
+- Candidate snapshot becomes authoritative only after successful extraction, normalization, diffing, and sink application
+- If refresh fails, the previous successful snapshot remains current
+
+## Normalization Rules
+
+For both source types, adapters emit normalized items with:
+
+- normalized relative path
+- display path
+- content fingerprint
+- size
+- modified time when available
+- parseable media/document hint
+
+### Archive normalization
+
+If an uploaded archive contains a single common top-level directory, strip that root during normalization so timestamped export wrappers do not cause a full delete/create churn every refresh.
+
+### Rename semantics
+
+In v1, rename is explicitly modeled as:
+
+- old path deleted
+- new path created
+
+No rename continuity is attempted in v1.
+
+## Reconciliation Contract
+
+Candidate snapshot vs last successful snapshot yields:
+
+- `created`
+- `changed`
+- `unchanged`
+- `deleted`
+
+Fingerprinting rule:
+- content hash is authoritative
+- file size and modified time may be used as scan shortcuts, but not as the final truth when content is available
+
+This is especially important for archive refreshes, where filename reuse is common.
+
+## Lifecycle Policies
+
+### `canonical`
+
+- one destination object per source item
+- content changes update that same bound destination object
+- removed source items archive or soft-delete the destination object
+
+### `import_only`
+
+- one destination object per source item
+- content changes update that same bound destination object
+- removed source items do not trigger automatic archival/deletion
+
+### Deferred from v1
+
+`append_only`
+- every change creates a new destination object
+- excluded from v1 to keep binding semantics simple
+
+## Sink Semantics
+
+### `media` sink
+
+- Broadest v1 sink
+- Reuses the document/media ingestion pipeline
+- Appropriate for mixed source collections containing text documents, PDFs, DOCX, EPUB, HTML, Markdown, plain text, and other supported document types
+- On change:
+  - update the same logical bound item where supported
+  - create a new document/media version instead of duplicating when the existing Media model allows it
+- On failed revision ingest:
+  - preserve the last good active version
+  - mark item degraded instead of destroying continuity
+
+### `notes` sink
+
+- Narrower by design in v1
+- Supported input classes for direct Notes sync:
+  - `.md`
+  - `.markdown`
+  - `.txt`
+  - `.html`
+  - `.htm`
+  - `.xml`
+  - `.json`
+  - `.docx`
+  - `.rtf`
+- Not supported for direct Notes sync in v1:
+  - PDFs
+  - ebooks
+  - generic binaries
+
+Reason:
+- Notes are text-first
+- existing note import behavior is oriented around structured text
+- Media already owns the richer document extraction path
+
+### Notes sink content contract
+
+- V1 Notes sync is latest-state sync only
+- It does not promise durable historical note body preservation
+- Title/body derivation:
+  - front matter title when available
+  - Markdown heading fallback
+  - filename fallback
+- Keywords/tags may be mapped where the parsed content exposes them cleanly
+
+## Synced Notes Conflict Policy
+
+This is required to avoid silent user-data loss.
+
+### Recommended v1 rule
+
+- Synced notes are marked `sync_managed`
+- User edits are allowed
+- Once a sync-managed note is manually edited locally, it becomes `detached`
+- Detached note behavior:
+  - future source syncs do not overwrite that note
+  - the source item is marked `conflict_detached`
+  - source status surfaces that conflict for user resolution
+
+### Why this rule
+
+- Safer than overwriting user edits
+- Simpler than read-only synced notes
+- Much simpler than three-way merge
+
+### Deferred from v1
+
+- automatic merge
+- inline conflict editing UI
+- true bidirectional sync
+
+## API Shape
+
+### Endpoints
+
+`POST /api/v1/ingestion-sources`
+- create a source
+
+`GET /api/v1/ingestion-sources`
+- list sources with current status
+
+`GET /api/v1/ingestion-sources/{id}`
+- source detail, last run summary, last error, counts
+
+`PATCH /api/v1/ingestion-sources/{id}`
+- mutable fields only:
+  - enabled flag
+  - schedule
+  - lifecycle policy
+  - parser/filter options
+
+Immutable after first successful sync:
+- `source_type`
+- source identity
+- `sink_type`
+
+`POST /api/v1/ingestion-sources/{id}/sync`
+- enqueue a manual sync
+
+`POST /api/v1/ingestion-sources/{id}/archive`
+- replace payload for an archive-backed source
+- create a candidate snapshot
+- enqueue a sync for that candidate snapshot
+
+`GET /api/v1/ingestion-sources/{id}/items`
+- inspect bound items and sync states
+
+Optional useful follow-up, but not required for first backend checkpoint:
+- `POST /api/v1/ingestion-sources/{id}/items/{item_id}/reattach`
+
+## Jobs and Scheduling
+
+Use Jobs for execution because this is user-visible work with status and admin visibility requirements.
+
+Use APScheduler only to enqueue recurring sync jobs, consistent with repo guidance and existing patterns such as:
+
+- `tldw_Server_API/app/services/connectors_sync_scheduler.py`
+
+Execution requirements:
+- source-scoped active job fencing
+- lease renewal for long syncs
+- no inline processing in request handlers
+
+## Error Handling
+
+### Source validation failures
+
+- invalid local path
+- path escape
+- path outside allowed roots
+- unsupported source configuration
+
+Result:
+- reject creation/update or fail the queued job with actionable error text
+
+### Archive failures
+
+- invalid archive
+- encrypted archive
+- unsafe member path
+- unsupported archive member handling
+
+Result:
+- reject candidate snapshot
+- preserve last successful snapshot as current
+
+### Item-level processing failures
+
+- parse/extract failure on one file
+- sink write failure on one file
+
+Result:
+- keep partial progress for other items
+- mark item failed or degraded
+- retain the previous good bound state where applicable
+
+### Notes conflicts
+
+- detached synced note
+
+Result:
+- do not overwrite
+- mark `conflict_detached`
+
+### Sink mutation attempts
+
+- changing `sink_type` or source identity after first success
+
+Result:
+- reject with 400/409
+- never migrate implicitly
+
+## Security and Deployment Constraints
+
+### Local directory roots
+
+Add a dedicated allowlist such as:
+
+- `INGESTION_SOURCE_ALLOWED_ROOTS`
+
+Behavior:
+- create/update validates configured path against the allowlist
+- runtime scan revalidates actual resolved path containment before reading
+- symlink and traversal escapes must be treated as unsafe
+
+### Archive safety
+
+Follow the same archive-member safety posture already used in other parts of the repo:
+
+- reject zip-slip and unsafe member names
+- reject unsupported encrypted archives
+- never extract blindly into uncontrolled paths
+
+## Retention and Cleanup
+
+Staged uploads and extracted candidate snapshots need explicit cleanup rules.
+
+Defaults:
+- keep current successful snapshot
+- keep a bounded number of previous successful snapshots
+- keep failed candidate snapshots only briefly for debugging
+- remove expired staged artifacts with a cleanup job/service
+
+This prevents archive-backed sync sources from becoming unbounded storage leaks.
+
+## Testing Strategy
+
+### Unit tests
+
+- path normalization and allowed-root enforcement
+- archive root stripping
+- snapshot diffing
+- lifecycle policy behavior
+- sink selection and routing
+- detached-note conflict handling
+
+### Integration tests
+
+- local directory initial sync
+- local directory rescan with add/change/delete
+- archive source initial upload
+- archive source successful re-upload diff
+- archive source failed re-upload rollback
+- media sink version update behavior
+- notes sink latest-state update behavior
+- detached note not overwritten on later sync
+- scheduled enqueue without inline processing
+
+### Security tests
+
+- path traversal via local path input
+- unsafe archive member names
+- symlink/path escape attempts
+
+### Verification
+
+- targeted pytest scope for new backend paths
+- Bandit on touched Python scope before completion
+
+## Recommended Implementation Sequence
+
+1. Add generic source tables and source-state invariants
+2. Add snapshot builder and diff engine
+3. Add local-directory source adapter
+4. Add archive candidate snapshot flow
+5. Add media sink adapter
+6. Add notes sink adapter with `sync_managed` / `detached` semantics
+7. Add Jobs worker and scheduled enqueue
+8. Add source CRUD/status APIs
+9. Add UI after backend behavior is stable
+
+## Final Decisions Captured
+
+- The solution is a general sync/import system for document/file ingestion, not a Notes-only feature
+- v1 source types:
+  - local directory
+  - uploaded archive snapshot
+- local-directory refresh:
+  - manual sync
+  - optional scheduled rescans
+- archive refresh:
+  - UI/manual re-upload
+  - API refresh for the same source
+- destination model:
+  - selectable sink per source (`media` or `notes`)
+- lifecycle:
+  - per-source policy
+- Notes sink:
+  - latest-state sync only
+  - detached conflict semantics
+- sink/source identity:
+  - immutable after first successful sync

--- a/Docs/Plans/2026-03-08-persona-garden-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-persona-garden-implementation-plan.md
@@ -1,0 +1,539 @@
+# Persona Garden Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build `Persona Garden` as the branded advanced persona workspace for WebUI and extension, keep `My Chat Identity` separate from persona, and add a character-to-persona creation flow where personas become independent after creation.
+
+**Architecture:** Keep the existing shared `/persona` route and websocket workflow intact, but reorganize it into a clearer `Persona Garden` workspace with explicit sections. Treat persona creation as a fork from a character snapshot: persist provenance metadata for audit/display, but do not keep live inheritance from the source character. Keep normal chat semantics unchanged in this pass.
+
+**Tech Stack:** React, TypeScript, shared route components in `apps/packages/ui`, Next.js page shims in `apps/tldw-frontend`, WXT extension routes, FastAPI, Pydantic, ChaChaNotes SQLite/PostgreSQL DB layer, Vitest, Playwright, pytest, Bandit.
+
+---
+
+### Task 1: Rebrand `/persona` as Persona Garden Without Breaking Live Session Behavior
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx`
+- Modify: `apps/packages/ui/src/data/settings-index.ts`
+- Test: `apps/packages/ui/src/data/__tests__/settings-index.test.ts`
+
+**Step 1: Write the failing test**
+
+Add assertions that the persona route renders `Persona Garden` framing while keeping the existing live session controls (`Connect`, memory toggle, session select) visible. Cover the online route plus the offline/unsupported empty-state branches so no hard-coded `Persona` header is missed. In settings/search tests, assert that `Persona Garden` is added as its own entry instead of renaming `Characters`.
+
+```tsx
+it("renders Persona Garden while preserving live session controls", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByText("Persona Garden")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-memory-toggle")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-resume-session-select")).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/data/__tests__/settings-index.test.ts
+```
+
+Expected:
+
+- FAIL because the route/header/empty-state labels still say `Persona` instead of `Persona Garden`, and settings/search does not yet expose a separate `Persona Garden` destination
+
+**Step 3: Write minimal implementation**
+
+Update the shared route/header copy across all route branches without removing the current live-session controls. Add a new settings/search entry for `Persona Garden`; do not rename the existing `Characters` entry.
+
+```tsx
+<SidepanelHeaderSimple activeTitle={t("sidepanel:persona.title", "Persona Garden")} />
+```
+
+```ts
+{
+  id: "setting-persona-garden",
+  labelKey: "settings:personaGardenNav",
+  defaultLabel: "Persona Garden",
+  defaultDescription: "Configure advanced personas and live persona sessions",
+  route: "/persona",
+  section: "Knowledge",
+  keywords: ["persona", "garden", "memory", "state", "assistant"],
+  controlType: "button",
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/data/__tests__/settings-index.test.ts
+```
+
+Expected:
+
+- PASS with route label updates and no regressions in the current live persona flow
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx apps/packages/ui/src/data/settings-index.ts apps/packages/ui/src/data/__tests__/settings-index.test.ts
+git commit -m "feat: rebrand persona route as Persona Garden"
+```
+
+### Task 2: Extract `My Chat Identity` From Persona And Make It Explicit In Chat UI
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/MyChatIdentityMenu.tsx`
+- Create: `apps/packages/ui/src/components/Common/__tests__/MyChatIdentityMenu.test.tsx`
+- Modify: `apps/packages/ui/src/components/Common/CharacterSelect.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx`
+
+**Step 1: Write the failing test**
+
+Write a component test that verifies the quick surface exposes user identity controls separately from characters and persona navigation.
+
+```tsx
+it("keeps user identity controls separate from persona navigation", async () => {
+  render(<MyChatIdentityMenu />)
+
+  expect(screen.getByText("My Chat Identity")).toBeInTheDocument()
+  expect(screen.getByText("Set your name")).toBeInTheDocument()
+  expect(screen.getByText("Upload your image")).toBeInTheDocument()
+  expect(screen.getByText("Prompt style templates")).toBeInTheDocument()
+  expect(screen.queryByText("Scope rules")).not.toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Common/__tests__/MyChatIdentityMenu.test.tsx
+```
+
+Expected:
+
+- FAIL because `MyChatIdentityMenu` does not exist yet
+
+**Step 3: Write minimal implementation**
+
+Create a dedicated quick-surface component that owns only user display name, user avatar, and user-side prompt templates. Remove persona framing from the existing user controls in `CharacterSelect`.
+
+```tsx
+export const MyChatIdentityMenu = () => (
+  <section aria-label="My Chat Identity">
+    <button type="button">Set your name</button>
+    <button type="button">Upload your image</button>
+    <button type="button">Prompt style templates</button>
+  </section>
+)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Common/__tests__/MyChatIdentityMenu.test.tsx
+```
+
+Expected:
+
+- PASS with explicit user-identity separation
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Common/MyChatIdentityMenu.tsx apps/packages/ui/src/components/Common/__tests__/MyChatIdentityMenu.test.tsx apps/packages/ui/src/components/Common/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/CharacterSelect.tsx apps/packages/ui/src/components/Sidepanel/Chat/SidepanelHeaderSimple.tsx
+git commit -m "feat: separate My Chat Identity from persona controls"
+```
+
+### Task 3: Refactor Persona Garden Into Explicit Sections While Preserving The Existing Route Contract
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/PersonaGardenTabs.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/StateDocsPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add route tests that require explicit sections while still preserving the current live controls and plan-approval area.
+
+```tsx
+it("shows Persona Garden sections and keeps live controls", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByRole("tab", { name: "Live Session" })).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: "Profiles" })).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: "State Docs" })).toBeInTheDocument()
+  expect(screen.getByTestId("persona-memory-toggle")).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- FAIL because the route is still a single flat layout
+
+**Step 3: Write minimal implementation**
+
+Decompose the large route into focused panels, but keep route-owned state and effects in `sidepanel-persona.tsx`. Websocket lifecycle, session bootstrap/resume, unsaved-state blockers, per-message memory flags, and profile-default PATCH behavior must stay in the route and be passed into presentational panels as props/callbacks. Do not move API calls or websocket effects into the panel components in this task.
+
+```tsx
+<Tabs
+  items={[
+    { key: "live", label: "Live Session", children: <LiveSessionPanel {...props} /> },
+    { key: "profiles", label: "Profiles", children: <ProfilePanel {...props} /> },
+    { key: "state", label: "State Docs", children: <StateDocsPanel {...props} /> },
+    { key: "scopes", label: "Scopes", children: <ScopesPanel {...props} /> },
+    { key: "policies", label: "Policies", children: <PoliciesPanel {...props} /> }
+  ]}
+/>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- PASS with the new IA and no loss of current live behavior
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/PersonaGardenTabs.tsx apps/packages/ui/src/components/PersonaGarden/LiveSessionPanel.tsx apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx apps/packages/ui/src/components/PersonaGarden/StateDocsPanel.tsx apps/packages/ui/src/components/PersonaGarden/ScopesPanel.tsx apps/packages/ui/src/components/PersonaGarden/PoliciesPanel.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: split Persona Garden into live and configuration sections"
+```
+
+### Task 4: Add Character-To-Persona Provenance And Independent Persona Creation On The Backend
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`
+- Test: `tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py`
+
+**Step 1: Write the failing test**
+
+Add backend tests proving that creating a persona from a character stores provenance snapshots but does not require live character inheritance afterward.
+
+```python
+def test_create_persona_from_character_snapshots_origin_without_live_dependency(client, character_id):
+    response = client.post(
+        "/api/v1/persona/profiles",
+        json={"name": "Garden Helper", "character_card_id": character_id},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["character_card_id"] == character_id
+    assert payload["origin_character_name"] == "Source Character"
+```
+
+```python
+def test_persona_remains_valid_when_origin_character_missing(db, persona_id):
+    source_character = db.get_character_card_by_name("Source Character")
+    assert source_character is not None
+    assert db.soft_delete_character_card(source_character["id"], expected_version=source_character["version"])
+    persona = db.get_persona_profile(persona_id, user_id="1", include_deleted=False)
+    assert persona is not None
+    assert persona["origin_character_name"] == "Source Character"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+```
+
+Expected:
+
+- FAIL because origin snapshot fields and independence semantics are not implemented yet
+
+**Step 3: Write minimal implementation**
+
+Add a schema migration from v28 to v29 for persona provenance snapshot fields. Keep `character_card_id` as an optional current-source link for compatibility, but do not treat it as the sole provenance field because the FK can be nulled on source deletion. Persist separate origin snapshot fields so the persona remains self-describing after source changes or deletion.
+
+```python
+class PersonaProfileResponse(BaseModel):
+    id: str
+    name: str
+    character_card_id: int | None = None
+    origin_character_id: int | None = None
+    origin_character_name: str | None = None
+    origin_character_snapshot_at: str | None = None
+```
+
+```python
+if character_card_id is not None:
+    source_character = self.get_character_card(character_card_id, user_id=user_id)
+    origin_character_id = source_character.get("id")
+    origin_character_name = source_character.get("name")
+    origin_character_snapshot_at = datetime.utcnow().isoformat()
+```
+
+```sql
+ALTER TABLE persona_profiles ADD COLUMN origin_character_id INTEGER;
+ALTER TABLE persona_profiles ADD COLUMN origin_character_name TEXT;
+ALTER TABLE persona_profiles ADD COLUMN origin_character_snapshot_at DATETIME;
+UPDATE db_schema_version SET version = 29 WHERE schema_name = 'rag_char_chat_schema' AND version < 29;
+```
+
+Do not add automatic re-sync from character to persona in this pass. If a source character is later deleted and `character_card_id` becomes `NULL`, the `origin_*` fields must still be returned.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+```
+
+Expected:
+
+- PASS with stable provenance metadata and independent persona persistence
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py
+git commit -m "feat: snapshot persona origin when creating from character"
+```
+
+### Task 5: Add `Create Persona From Character` And `Open In Persona Garden` Flows
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Characters/CharactersWorkspace.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Characters/Manager.tsx`
+- Modify: `apps/packages/ui/src/routes/option-characters.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+- Create: `apps/packages/ui/src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx`
+- Test: `tldw_Server_API/tests/Persona/test_persona_catalog.py`
+
+**Step 1: Write the failing test**
+
+Add frontend tests proving the Characters workspace exposes persona creation/open actions and that Persona Garden shows provenance text instead of implying live inheritance.
+
+```tsx
+it("offers Create Persona from Character from the Characters workspace", async () => {
+  render(<CharactersWorkspace />)
+
+  expect(await screen.findByText("Create Persona from Character")).toBeInTheDocument()
+})
+```
+
+```tsx
+it("shows origin text in Persona Garden instead of live linkage copy", async () => {
+  render(<SidepanelPersona />)
+
+  expect(await screen.findByText(/Origin: created from/i)).toBeInTheDocument()
+  expect(screen.queryByText(/currently based on/i)).not.toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected:
+
+- FAIL because the actions and provenance text do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Add explicit character actions that create/open personas and update Persona Garden to display source provenance text using the new backend fields. If the open action uses `/persona?persona_id=...`, add route bootstrap logic in `sidepanel-persona.tsx` that reads the requested persona from `location.search` before falling back to catalog/default selection.
+
+```tsx
+<Button onClick={() => onCreatePersonaFromCharacter(record)}>
+  Create Persona from Character
+</Button>
+<Button onClick={() => navigate(`/persona?persona_id=${personaId}`)}>
+  Open in Persona Garden
+</Button>
+```
+
+```tsx
+const location = useLocation()
+const requestedPersonaId = React.useMemo(
+  () => new URLSearchParams(location.search).get("persona_id")?.trim() || "",
+  [location.search]
+)
+```
+
+```tsx
+<p className="text-xs text-text-muted">
+  {originCharacterName ? `Origin: created from ${originCharacterName}` : "Standalone persona"}
+</p>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_catalog.py -v
+```
+
+Expected:
+
+- PASS with the new action flow and correct provenance copy
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Characters/CharactersWorkspace.tsx apps/packages/ui/src/components/Option/Characters/Manager.tsx apps/packages/ui/src/routes/option-characters.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx apps/packages/ui/src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx tldw_Server_API/tests/Persona/test_persona_catalog.py
+git commit -m "feat: add create-persona flow from Characters"
+```
+
+### Task 6: Cross-Surface Verification And Security Scan
+
+**Files:**
+- Create: `apps/tldw-frontend/e2e/workflows/persona-garden.spec.ts`
+- Modify: `apps/tldw-frontend/__tests__/extension/route-registry.persona.test.ts`
+
+**Step 1: Write the failing test**
+
+Add an end-to-end route/parity test proving WebUI and extension both expose Persona Garden without mutating normal chat identity.
+
+```ts
+test("Persona Garden is reachable in web and extension without changing My Chat Identity", async ({ authedPage }) => {
+  await authedPage.goto("/persona")
+  await expect(authedPage.getByText("Persona Garden")).toBeVisible()
+  await expect(authedPage.getByText("My Chat Identity")).not.toBeVisible()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/tldw-frontend
+bunx vitest run __tests__/extension/route-registry.persona.test.ts
+```
+
+Expected:
+
+- FAIL until route labels/e2e expectations are updated
+
+**Step 3: Write minimal implementation**
+
+Keep the route-registry parity test focused on route registration only, and cover `Persona Garden` branding through rendered route tests or E2E. Do not edit the approved design doc in this task unless implementation forces a semantic product change.
+
+```ts
+expect(routeRegistrySource).toMatch(/path:\s*"\/persona"/)
+expect(routeRegistrySource).toMatch(/element:\s*<SidepanelPersona\s*\/>/)
+```
+
+**Step 4: Run verification commands**
+
+Run:
+
+```bash
+cd apps/packages/ui
+bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx src/components/Common/__tests__/MyChatIdentityMenu.test.tsx src/components/Option/Characters/__tests__/CharactersWorkspace.persona-garden.test.tsx
+```
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend
+bunx vitest run __tests__/extension/route-registry.persona.test.ts
+```
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_profiles_api.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/Persona/test_persona_catalog.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/tests/ChaChaNotesDB/test_persona_persistence_db.py -v
+python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/api/v1/endpoints/persona.py /Users/macbook-dev/Documents/GitHub/tldw_server2/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_persona_garden.json
+```
+
+Expected:
+
+- All targeted tests PASS
+- Bandit reports no new findings in touched backend scope
+
+**Step 5: Commit**
+
+```bash
+git add apps/tldw-frontend/e2e/workflows/persona-garden.spec.ts apps/tldw-frontend/__tests__/extension/route-registry.persona.test.ts
+git commit -m "test: add Persona Garden cross-surface coverage"
+```
+
+## Notes For The Implementer
+
+- Do not change normal chat to consume persona profiles in this plan.
+- Do not make persona part of `My Chat Identity`.
+- Do not make persona creation a live linked dependency on a character after creation.
+- Keep the current websocket/live-session route functional throughout the refactor.
+- Prefer additive schema changes and compatibility-preserving endpoint behavior.
+- Treat `character_card_id` as a convenience link only; `origin_*` fields are the durable provenance contract.
+
+## Suggested Execution Order
+
+1. Task 1
+2. Task 2
+3. Task 3
+4. Task 4
+5. Task 5
+6. Task 6
+
+## Manual QA Checklist
+
+- Open `/persona` in WebUI and confirm the page title reads `Persona Garden`.
+- Confirm live persona session connect/resume still works.
+- Confirm `My Chat Identity` editing still updates user display name/avatar in normal chat only.
+- Confirm Characters shows `Create Persona from Character`.
+- Confirm `Open in Persona Garden` preselects the requested persona when navigating from Characters.
+- Confirm a created persona shows origin/provenance text but does not imply live character inheritance.
+- Confirm deleting or changing the source character does not break the persona record.

--- a/Docs/Plans/2026-03-08-sandbox-subsystem-review-findings.md
+++ b/Docs/Plans/2026-03-08-sandbox-subsystem-review-findings.md
@@ -1,0 +1,64 @@
+# Sandbox Subsystem Review Findings
+
+Date: 2026-03-08
+Base commit reviewed: `0c13998e9`
+Scope: `tldw_Server_API/app/core/Sandbox/` and `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+
+## Findings
+
+### [P1] Docker runner exceptions after admission leave runs stuck in `starting`
+
+- Type: Bug
+- Evidence:
+  - `tldw_Server_API/app/core/Sandbox/service.py:933-976`
+  - `tldw_Server_API/app/core/Sandbox/service.py:993-1023`
+  - `tldw_Server_API/app/core/Sandbox/service.py:1238-1250`
+- Why it matters:
+  - Both Docker execution branches admit the run into `starting` before invoking `DockerRunner.start_run()`.
+  - If `start_run()` raises, the background branch only logs `Background docker execution failed` and returns without forcing a terminal state.
+  - The foreground branch logs `Docker execution failed; keeping enqueue status`, but the status object is already `starting`, so the final persistence path writes that non-terminal state back to the store unchanged.
+  - A stranded `starting` run can consume active-run quota, block accurate status reporting, and require manual cancelation to recover.
+- Reproduction:
+  - Foreground: patched `DockerRunner.start_run` to raise `RuntimeError("boom")` with `SANDBOX_ENABLE_EXECUTION=1` and `SANDBOX_BACKGROUND_EXECUTION=0`; the returned and stored run both stayed in `starting` with no `finished_at` or failure message.
+  - Background: same patch with `SANDBOX_BACKGROUND_EXECUTION=1` and synchronous `_submit_background_worker`; the returned and stored run again stayed in `starting`.
+
+### [P2] `sandbox_runs_started_total` counts rejected requests as started runs
+
+- Type: Bug
+- Evidence:
+  - `tldw_Server_API/app/api/v1/endpoints/sandbox.py:1086-1093`
+- Why it matters:
+  - The route increments `sandbox_runs_started_total` before `_service.start_run_scaffold(...)` performs runtime selection, policy validation, queue admission, and idempotency checks.
+  - Requests that are rejected with `runtime_unavailable`, `policy_unsupported`, `queue_full`, `invalid_spec_version`, or `idempotency_conflict` are still counted as started runs.
+  - This distorts operational dashboards and any failure-rate math that relies on `started_total` as the denominator.
+
+### [P3] The generic runtime capability contract is only partially wired into the subsystem
+
+- Type: Incomplete Item
+- Evidence:
+  - `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py:9-30`
+  - `tldw_Server_API/app/core/Sandbox/policy.py:151-169`
+- Why it matters:
+  - The repository defines `RuntimeCapabilities` and `RuntimePreflightResult`, but in the reviewed path only Lima preflight meaningfully uses the shared contract object.
+  - Runtime selection in `SandboxPolicy.select_runtime()` still relies on ad hoc availability booleans instead of a provider-neutral capability interface.
+  - This increases the chance that Docker, Firecracker, and Lima drift apart on admission and error semantics as the subsystem evolves.
+
+## Targeted Test Runs
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape`
+  - Result: PASS
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_run_claim_fencing.py tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py tldw_Server_API/tests/sandbox/test_queue_full_429.py`
+  - Result: 14 passed
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_runtime_unavailable.py tldw_Server_API/tests/sandbox/test_lima_no_fallback.py tldw_Server_API/tests/sandbox/test_lima_strict_admission.py`
+  - Result: 9 passed
+
+- `source .venv/bin/activate && python -m pytest -vv tldw_Server_API/tests/sandbox/test_run_ownership.py tldw_Server_API/tests/sandbox/test_admin_rbac.py tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py tldw_Server_API/tests/sandbox/test_artifact_range.py tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py`
+  - Result: 9 passed, 1 skipped
+
+## Validation Gaps
+
+- No existing targeted regression test in the reviewed slice covers the “runner raises after admission” path for Docker foreground or background execution. That gap allowed the stuck-`starting` bug above to persist despite the broader queueing and lifecycle suite passing.
+
+- `tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py::test_artifact_traversal_rejected_under_uvicorn` skipped locally, so the live-server variant of raw-path traversal rejection was not revalidated in this run.

--- a/Docs/Plans/2026-03-08-sandbox-subsystem-review-implementation-plan.md
+++ b/Docs/Plans/2026-03-08-sandbox-subsystem-review-implementation-plan.md
@@ -1,0 +1,231 @@
+# Sandbox Subsystem Review Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Execute a focused, evidence-driven review of the sandbox subsystem and sandbox API endpoints, producing findings for bugs, risky incomplete items, and residual risks.
+
+**Architecture:** Review the internal control plane before the API layer so endpoint behavior is evaluated against the actual queueing, ownership, policy, store, and artifact invariants. Use a targeted pytest slice to confirm or falsify the highest-risk assumptions instead of relying on static inspection alone.
+
+**Tech Stack:** Python 3.11, FastAPI, pytest, loguru, in-memory/SQLite/Postgres sandbox stores, Docker/Firecracker/Lima sandbox runners.
+
+---
+
+### Task 1: Establish the Sandbox Review Harness
+
+**Files:**
+- Inspect: `tldw_Server_API/tests/sandbox/conftest.py`
+- Inspect: `tldw_Server_API/tests/sandbox/test_sandbox_api.py`
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+
+**Step 1: Confirm the sandbox test harness assumptions**
+
+Read:
+```bash
+sed -n '1,240p' tldw_Server_API/tests/sandbox/conftest.py
+sed -n '1,220p' tldw_Server_API/tests/sandbox/test_sandbox_api.py
+```
+Expected: clear understanding of auth defaults, fake execution defaults, stream-hub resets, and TestClient patching used by sandbox tests.
+
+**Step 2: Run a baseline sandbox API smoke test**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_sandbox_api.py::test_runtimes_discovery_shape
+```
+Expected: PASS. If this fails, stop and document the environment or harness problem before deeper review.
+
+**Step 3: Record baseline review constraints**
+
+Capture in working notes:
+- whether fake Docker execution is enabled
+- whether WS signed URLs are disabled
+- whether auth is operating in sandbox single-user test mode
+
+### Task 2: Audit Run Lifecycle, Queueing, and Claim Semantics
+
+**Files:**
+- Inspect: `tldw_Server_API/app/core/Sandbox/service.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/orchestrator.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_claim_fencing.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py`
+- Test: `tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py`
+- Test: `tldw_Server_API/tests/sandbox/test_queue_full_429.py`
+
+**Step 1: Read the core run-start and cancelation paths**
+
+Inspect these functions:
+- `SandboxService.start_run_scaffold`
+- `SandboxService._run_with_claim_lease`
+- `SandboxService.cancel_run`
+- `SandboxOrchestrator.enqueue_run`
+- `SandboxOrchestrator.try_claim_run`
+- `SandboxOrchestrator.renew_run_claim`
+- `SandboxOrchestrator.try_admit_run_start`
+- `SandboxOrchestrator._prune_queue_ttl`
+
+Expected: a written list of invariants for enqueue, claim, execution admission, lease renewal, and cancellation.
+
+**Step 2: Run queueing and claim tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_run_claim_fencing.py \
+  tldw_Server_API/tests/sandbox/test_run_claim_heartbeat.py \
+  tldw_Server_API/tests/sandbox/test_execution_concurrency_cap.py \
+  tldw_Server_API/tests/sandbox/test_queue_full_429.py
+```
+Expected: PASS. Any failure becomes a first-class review finding or a blocking regression if it prevents further trust in lifecycle behavior.
+
+**Step 3: Cross-check the implementation against the tests**
+
+For any surprising branch or swallowed exception, trace supporting references:
+```bash
+rg -n "try_claim_run|renew_run_claim|release_run_claim|try_admit_run_start|cancel_run" \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/core/Sandbox/orchestrator.py
+```
+Expected: evidence for whether the code matches the tested contract or leaves an uncovered path.
+
+### Task 3: Audit Store, Policy, and Runtime Fail-Closed Behavior
+
+**Files:**
+- Inspect: `tldw_Server_API/app/core/Sandbox/store.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/policy.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/docker_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/firecracker_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/lima_runner.py`
+- Inspect: `tldw_Server_API/app/core/Sandbox/runners/lima_enforcer.py`
+- Test: `tldw_Server_API/tests/sandbox/test_runtime_unavailable.py`
+- Test: `tldw_Server_API/tests/sandbox/test_lima_no_fallback.py`
+- Test: `tldw_Server_API/tests/sandbox/test_lima_strict_admission.py`
+
+**Step 1: Compare store semantics across backends**
+
+Inspect the concrete implementations of:
+- `check_idempotency`
+- `store_idempotency`
+- `put_run` / `update_run`
+- `try_claim_run` / `renew_run_claim` / `release_run_claim`
+- `try_admit_run_start`
+- `get_run_owner` / `get_session_owner`
+
+Expected: note any semantic drift between `InMemoryStore`, `SQLiteStore`, and `PostgresStore`, especially around ownership, timestamps, and lease handling.
+
+**Step 2: Inspect runtime selection and strict-policy enforcement**
+
+Review the policy and runner paths for:
+- default runtime parsing
+- `runtime_unavailable` vs `policy_unsupported` behavior
+- no-fallback guarantees
+- Lima strict admission and enforcement readiness
+
+Expected: a short matrix of documented versus actual fail-closed behavior by runtime.
+
+**Step 3: Run runtime and policy tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_runtime_unavailable.py \
+  tldw_Server_API/tests/sandbox/test_lima_no_fallback.py \
+  tldw_Server_API/tests/sandbox/test_lima_strict_admission.py
+```
+Expected: PASS. Any mismatch between policy code and tests should be captured as either a bug or a risky incomplete path.
+
+### Task 4: Audit Endpoint Ownership, Artifact Safety, and Stream Lifecycle
+
+**Files:**
+- Inspect: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Test: `tldw_Server_API/tests/sandbox/test_run_ownership.py`
+- Test: `tldw_Server_API/tests/sandbox/test_admin_rbac.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py`
+- Test: `tldw_Server_API/tests/sandbox/test_artifact_range.py`
+- Test: `tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py`
+- Test: `tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py`
+- Test: `tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py`
+
+**Step 1: Read the route guards and ownership checks**
+
+Inspect:
+- `SandboxArtifactGuardRoute`
+- `_require_run_owner`
+- `_require_session_owner`
+- `_resolve_sandbox_ws_user_id`
+- `download_artifact`
+- `stream_run_logs`
+- admin list/detail endpoints
+
+Expected: a map of which routes trust raw path inspection, stored ownership, admin status, or websocket token binding.
+
+**Step 2: Run endpoint and stream tests**
+
+Run:
+```bash
+source .venv/bin/activate && python -m pytest -vv \
+  tldw_Server_API/tests/sandbox/test_run_ownership.py \
+  tldw_Server_API/tests/sandbox/test_admin_rbac.py \
+  tldw_Server_API/tests/sandbox/test_artifact_traversal_integration.py \
+  tldw_Server_API/tests/sandbox/test_artifact_content_type_and_path.py \
+  tldw_Server_API/tests/sandbox/test_artifact_range.py \
+  tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py \
+  tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py \
+  tldw_Server_API/tests/sandbox/test_cancel_endpoint_ws_and_status.py
+```
+Expected: PASS. If a test fails, trace whether the issue is route logic, shared core state, or harness assumptions.
+
+**Step 3: Trace any uncovered endpoint branches**
+
+Use targeted search for error-prone branches:
+```bash
+rg -n "PermissionError|HTTPException|invalid_path|range|quota|resume|heartbeat|cancel" \
+  tldw_Server_API/app/api/v1/endpoints/sandbox.py
+```
+Expected: identify branches that are reachable but not clearly covered by the selected tests.
+
+### Task 5: Synthesize Findings and Deliver the Review
+
+**Files:**
+- Create: `docs/plans/2026-03-08-sandbox-subsystem-review-findings.md`
+- Reference: `docs/plans/2026-03-08-sandbox-subsystem-review-design.md`
+
+**Step 1: Draft the findings report**
+
+Write the report with these sections:
+```markdown
+# Sandbox Subsystem Review Findings
+
+## Findings
+- [Severity] Title
+  - Type: Bug | Incomplete Item | Residual Risk
+  - Evidence: file path + line
+  - Why it matters
+
+## Targeted Test Runs
+- command
+- result
+
+## Validation Gaps
+- gap
+```
+
+**Step 2: Validate every finding against evidence**
+
+Before delivering the review, ensure each finding has:
+- one specific file reference
+- one concrete behavioral claim
+- a classification that matches the design doc rules
+
+Expected: no vague findings, no “might be bad” commentary without evidence, and no mixing of intentional scaffolding with confirmed defects.
+
+**Step 3: Deliver the user-facing review**
+
+Respond in findings-first order:
+- highest-severity findings first
+- then open questions or assumptions
+- then a short summary of tests run and any remaining gaps
+
+Expected: a concise review that behaves like a code review, not a changelog or architecture essay.

--- a/Docs/Plans/2026-03-08-sandbox-ws-stress-debug-plan.md
+++ b/Docs/Plans/2026-03-08-sandbox-ws-stress-debug-plan.md
@@ -1,0 +1,17 @@
+## Stage 1: Reproduce And Bound The Failure
+**Goal**: Reproduce the grouped websocket stress failure deterministically and identify whether the missing `end` frame is caused by queue loss, subscription timing, or test harness behavior.
+**Success Criteria**: One grouped pytest command reproduces the issue and the likely failure mode is documented from code/test evidence.
+**Tests**: `python -m pytest -vv tldw_Server_API/tests/sandbox/test_store_sqlite_migrations.py tldw_Server_API/tests/sandbox/test_streams_hub_lifecycle.py tldw_Server_API/tests/sandbox/test_streams_hub_resume_and_ordering.py tldw_Server_API/tests/sandbox/test_ws_connection_quotas.py tldw_Server_API/tests/sandbox/test_ws_heartbeat_seq.py tldw_Server_API/tests/sandbox/test_ws_multi_subscribers.py tldw_Server_API/tests/sandbox/test_ws_multi_subscribers_stress.py tldw_Server_API/tests/sandbox/test_ws_queue_overflow_drops.py tldw_Server_API/tests/sandbox/test_ws_resume_edge_cases.py tldw_Server_API/tests/sandbox/test_ws_resume_from_seq.py tldw_Server_API/tests/sandbox/test_ws_resume_url_exposure.py tldw_Server_API/tests/sandbox/test_ws_seq.py`
+**Status**: In Progress
+
+## Stage 2: Restore A Clean Regression Surface
+**Goal**: Remove unsuccessful experimental edits and replace them with a focused regression that captures the actual websocket failure mode.
+**Success Criteria**: Only intentional test coverage remains and the failing behavior is asserted directly.
+**Tests**: Focused websocket stress test(s)
+**Status**: Not Started
+
+## Stage 3: Implement And Verify The Minimal Fix
+**Goal**: Fix the websocket failure without regressing the original sandbox bug fixes.
+**Success Criteria**: Grouped websocket subset passes, original sandbox regression slice passes, and Bandit reports no findings in touched files.
+**Tests**: Grouped websocket subset, original focused sandbox regression slice, Bandit on touched paths
+**Status**: Not Started

--- a/Docs/Plans/2026-03-09-pr-839-stt-retry-implementation-plan.md
+++ b/Docs/Plans/2026-03-09-pr-839-stt-retry-implementation-plan.md
@@ -1,0 +1,78 @@
+# PR 839 STT Retry Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the `/stt` page surface a persistent inline model-load error with a Retry action so the PR #839 UX smoke gate passes.
+
+**Architecture:** Keep the change local to `SttPlaygroundPage` by adding explicit model-loading/error state and rendering an inline recovery alert instead of relying only on transient notifications. Validate the behavior with a focused component test that drives the initial failure and the retry path without broad UI changes.
+
+**Tech Stack:** React, Ant Design, Vitest, Testing Library, Bun
+
+---
+
+### Task 1: Add the failing STT recovery test
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx`
+- Reference: `apps/tldw-frontend/e2e/smoke/stage7-audio-regression.spec.ts`
+
+**Step 1: Write the failing test**
+
+Add a test that:
+- Mocks `tldwClient.getTranscriptionModels` to reject once and resolve on retry.
+- Renders `SttPlaygroundPage`.
+- Asserts the inline model-load warning appears with a `Retry` button.
+- Clicks `Retry`.
+- Waits for the warning to clear and confirms the fetch mock was called twice.
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx`
+
+Expected: FAIL because the current page only emits a notification and does not render inline retry UI.
+
+**Step 3: Commit**
+
+Do not commit yet. Continue to implementation once the failure proves the gap.
+
+### Task 2: Implement the minimal STT retry UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx`
+- Test: `apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx`
+
+**Step 1: Write minimal implementation**
+
+Update `SttPlaygroundPage` to:
+- Track `serverModelsLoading`, `serverModelsError`, and `modelsLoadAttempt`.
+- Re-fetch models when `modelsLoadAttempt` changes.
+- Render an inline Ant Design `Alert` with the current error copy and a `Retry` button.
+- Clear the inline error when a retry starts or succeeds.
+- Preserve existing successful model population behavior.
+
+**Step 2: Run the targeted test to verify it passes**
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx`
+
+Expected: PASS
+
+**Step 3: Run adjacent verification**
+
+Run:
+- `bunx vitest run apps/packages/ui/src/components/Option/STT/__tests__/ComparisonPanel.test.tsx`
+- `bunx vitest run apps/packages/ui/src/components/Option/Speech/__tests__/RenderStrip.test.tsx`
+
+Expected: PASS
+
+**Step 4: Run security validation on touched scope**
+
+Run: `source .venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/Option/STT -f json -o /tmp/bandit_pr839_stt_retry.json`
+
+Expected: PASS or no new findings in touched code
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Plans/2026-03-09-pr-839-stt-retry-implementation-plan.md apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+git commit -m "fix(stt): add inline model load retry recovery"
+```

--- a/admin-ui/app/onboarding/page.tsx
+++ b/admin-ui/app/onboarding/page.tsx
@@ -70,6 +70,7 @@ function StepIndicator({ currentStep }: { currentStep: number }) {
 
 function OnboardingPageContent() {
   const { success, error: showError } = useToast();
+  const billingEnabled = isBillingEnabled();
   const [currentStep, setCurrentStep] = useState(1);
   const [plans, setPlans] = useState<Plan[]>([]);
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
@@ -100,10 +101,12 @@ function OnboardingPageContent() {
   }, [showError]);
 
   useEffect(() => {
-    fetchPlans();
-  }, [fetchPlans]);
+    if (billingEnabled) {
+      fetchPlans();
+    }
+  }, [billingEnabled, fetchPlans]);
 
-  if (!isBillingEnabled()) {
+  if (!billingEnabled) {
     return (
       <div className="mx-auto max-w-2xl p-8">
         <Alert>
@@ -143,10 +146,12 @@ function OnboardingPageContent() {
         plan_id: selectedPlanId!,
         owner_email: values.owner_email || undefined,
       });
-      if (result.checkout_url) {
+      if (result.checkout_url && result.checkout_url.startsWith('https://')) {
         window.location.href = result.checkout_url;
-      } else {
+      } else if (!result.checkout_url) {
         success('Organization created successfully');
+        setSelectedPlanId(null);
+        setCurrentStep(1);
       }
     } catch {
       showError('Failed to create organization');
@@ -319,7 +324,7 @@ function OnboardingPageContent() {
 
 export default function OnboardingPage() {
   return (
-    <PermissionGuard>
+    <PermissionGuard role={['admin', 'super_admin', 'owner']}>
       <OnboardingPageContent />
     </PermissionGuard>
   );

--- a/admin-ui/app/organizations/page.tsx
+++ b/admin-ui/app/organizations/page.tsx
@@ -148,8 +148,8 @@ function OrganizationsPageContent() {
             });
           }
           setOrgPlans(planMap);
-        } catch {
-          // Non-critical — org list still works without plan info
+        } catch (err) {
+          console.warn('Failed to load subscription data for organizations:', err);
         }
       }
     } catch (error: unknown) {

--- a/admin-ui/app/subscriptions/page.tsx
+++ b/admin-ui/app/subscriptions/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from '@/components/ui/toast';
 import { api } from '@/lib/api-client';
 import { isBillingEnabled } from '@/lib/billing';
 import Link from 'next/link';
+import { formatDate } from '@/lib/formatters';
 import type { Subscription, SubscriptionStatus } from '@/types';
 
 const STATUS_VARIANTS: Record<SubscriptionStatus, 'default' | 'outline' | 'destructive' | 'secondary'> = {
@@ -32,10 +33,6 @@ const STATUS_OPTIONS: { value: string; label: string }[] = [
   { value: 'past_due', label: 'Past Due' },
   { value: 'canceled', label: 'Canceled' },
 ];
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString();
-}
 
 function SubscriptionsPageContent() {
   const { error: showError } = useToast();

--- a/admin-ui/components/InvoiceTable.tsx
+++ b/admin-ui/components/InvoiceTable.tsx
@@ -1,17 +1,10 @@
 import { Download } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
+import { formatCents, formatDate } from '@/lib/formatters';
 import type { Invoice } from '@/types';
 
 interface InvoiceTableProps {
   invoices: Invoice[];
-}
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 const statusVariant: Record<string, 'default' | 'secondary' | 'destructive' | 'outline'> = {
@@ -51,7 +44,7 @@ export function InvoiceTable({ invoices }: InvoiceTableProps) {
                 <Badge variant={statusVariant[inv.status] ?? 'outline'}>{inv.status}</Badge>
               </td>
               <td className="py-2">
-                {inv.invoice_pdf && (
+                {inv.invoice_pdf && inv.invoice_pdf.startsWith('https://') && (
                   <a
                     href={inv.invoice_pdf}
                     target="_blank"

--- a/admin-ui/components/PlanGuard.tsx
+++ b/admin-ui/components/PlanGuard.tsx
@@ -37,7 +37,7 @@ export function PlanGuard({ requiredPlan, featureName, fallback, children }: Pla
         setAllowed(meetsRequirement);
       })
       .catch(() => {
-        if (!cancelled) setAllowed(true); // fail open — backend enforces
+        if (!cancelled) setAllowed(false);
       });
     return () => { cancelled = true; };
   }, [selectedOrg, orgLoading, requiredPlan]);

--- a/admin-ui/components/UsageMeter.tsx
+++ b/admin-ui/components/UsageMeter.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { formatCents } from '@/lib/formatters';
 
 interface UsageMeterProps {
   used: number;
@@ -9,10 +10,6 @@ interface UsageMeterProps {
 
 function formatTokens(n: number): string {
   return n.toLocaleString();
-}
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
 }
 
 export function UsageMeter({ used, included, overageCostCents, className }: UsageMeterProps) {

--- a/admin-ui/components/__tests__/PlanGuard.test.tsx
+++ b/admin-ui/components/__tests__/PlanGuard.test.tsx
@@ -87,11 +87,12 @@ describe('PlanGuard', () => {
     expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
   });
 
-  it('fails open on API error', async () => {
+  it('fails closed on API error', async () => {
     mockIsBillingEnabled.mockReturnValue(true);
     mockUseOrgContext.mockReturnValue({ selectedOrg: { id: 1, name: 'Test' }, loading: false });
     mockGetOrgSubscription.mockRejectedValue(new Error('Network error'));
-    render(<PlanGuard requiredPlan="pro"><div>Still Visible</div></PlanGuard>);
-    expect(await screen.findByText('Still Visible')).toBeInTheDocument();
+    render(<PlanGuard requiredPlan="pro" featureName="Analytics"><div>Hidden</div></PlanGuard>);
+    expect(await screen.findByText('Upgrade Plan')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
   });
 });

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -20,6 +20,20 @@ export { ApiError };
 type QueryParamPrimitive = string | number | boolean;
 type QueryParamValue = QueryParamPrimitive | QueryParamPrimitive[] | null | undefined;
 
+type CreatePlanInput = {
+  name: string;
+  tier: string;
+  monthly_price_cents: number;
+  included_token_credits: number;
+  overage_rate_per_1k_tokens_cents: number;
+  stripe_product_id?: string;
+  stripe_price_id?: string;
+  features?: string[];
+  is_default?: boolean;
+};
+
+type UpdatePlanInput = Partial<CreatePlanInput>;
+
 type AddTeamMemberInput =
   | { email: string; role?: string }
   | { userId: string | number; role?: string }
@@ -1070,13 +1084,13 @@ export const api = {
   // ============================================
   getPlans: (params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Plan[]>(`/billing/plans${qs}`);
+    return requestJson<Plan[]>(`/billing/plans${qs ? `?${qs}` : ''}`);
   },
   getPlan: (planId: string) =>
     requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`),
-  createPlan: (data: Partial<Plan>) =>
+  createPlan: (data: CreatePlanInput) =>
     requestJson<Plan>('/billing/plans', { method: 'POST', body: JSON.stringify(data) }),
-  updatePlan: (planId: string, data: Partial<Plan>) =>
+  updatePlan: (planId: string, data: UpdatePlanInput) =>
     requestJson<Plan>(`/billing/plans/${encodeURIComponent(planId)}`, { method: 'PUT', body: JSON.stringify(data) }),
   deletePlan: (planId: string) =>
     requestJson(`/billing/plans/${encodeURIComponent(planId)}`, { method: 'DELETE' }),
@@ -1084,7 +1098,7 @@ export const api = {
   // Subscriptions
   getSubscriptions: (params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Subscription[]>(`/billing/subscriptions${qs}`);
+    return requestJson<Subscription[]>(`/billing/subscriptions${qs ? `?${qs}` : ''}`);
   },
   getOrgSubscription: (orgId: number) =>
     requestJson<Subscription>(`/billing/orgs/${orgId}/subscription`),
@@ -1098,12 +1112,12 @@ export const api = {
 
   // Usage & Invoices
   getOrgUsageSummary: (orgId: number, params?: { period?: string }) => {
-    const qs = buildQueryString(params as Record<string, QueryParamValue>);
-    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs}`);
+    const qs = buildQueryString(params);
+    return requestJson<OrgUsageSummary>(`/billing/orgs/${orgId}/usage${qs ? `?${qs}` : ''}`);
   },
   getOrgInvoices: (orgId: number, params?: Record<string, QueryParamValue>) => {
     const qs = buildQueryString(params);
-    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs}`);
+    return requestJson<Invoice[]>(`/billing/orgs/${orgId}/invoices${qs ? `?${qs}` : ''}`);
   },
 
   // Feature Registry

--- a/admin-ui/lib/formatters.ts
+++ b/admin-ui/lib/formatters.ts
@@ -1,0 +1,17 @@
+/**
+ * Format cents to a dollar string like "$49.00"
+ */
+export function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
+ * Format ISO date string to localized display format
+ */
+export function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}

--- a/apps/packages/ui/src/components/Common/Workflow/WorkflowIntegrationHost.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/WorkflowIntegrationHost.tsx
@@ -39,6 +39,10 @@ export const WorkflowIntegrationHost: React.FC<
 
   const shouldAutoShow = useMemo(() => {
     if (!autoShow) return false
+    // The home route already renders the dedicated LandingHub surface.
+    // Auto-opening the modal there duplicates the welcome UI and can block
+    // header controls behind the overlay.
+    if (location.pathname === "/") return false
     return autoShowPaths.includes(location.pathname)
   }, [autoShow, autoShowPaths, location.pathname])
 

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowIntegrationHost.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowIntegrationHost.test.tsx
@@ -1,0 +1,87 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { MemoryRouter } from "react-router-dom"
+
+let hasCompletedFirstRun = true
+let showLanding = false
+
+const loadLandingConfigMock = vi.fn().mockResolvedValue(undefined)
+const loadDismissedSuggestionsMock = vi.fn().mockResolvedValue(undefined)
+const markLandingSeenMock = vi.fn()
+const setShowLandingMock = vi.fn()
+
+vi.mock("@/hooks/useConnectionState", () => ({
+  useConnectionUxState: () => ({
+    hasCompletedFirstRun
+  })
+}))
+
+vi.mock("@/store/workflows", () => ({
+  useWorkflowsStore: (
+    selector: (state: {
+      loadLandingConfig: typeof loadLandingConfigMock
+      loadDismissedSuggestions: typeof loadDismissedSuggestionsMock
+      markLandingSeen: typeof markLandingSeenMock
+      showLanding: boolean
+      setShowLanding: typeof setShowLandingMock
+    }) => unknown
+  ) =>
+    selector({
+      loadLandingConfig: loadLandingConfigMock,
+      loadDismissedSuggestions: loadDismissedSuggestionsMock,
+      markLandingSeen: markLandingSeenMock,
+      showLanding,
+      setShowLanding: setShowLandingMock
+    })
+}))
+
+vi.mock("../WorkflowLanding", () => ({
+  WorkflowLandingModal: () =>
+    showLanding ? <div data-testid="workflow-landing-modal">Workflow landing</div> : null
+}))
+
+vi.mock("../WorkflowContainer", () => ({
+  WorkflowOverlay: () => <div data-testid="workflow-overlay" />
+}))
+
+import { WorkflowIntegrationHost } from "../WorkflowIntegrationHost"
+
+const renderHost = (path: string, autoShowPaths: string[]) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <WorkflowIntegrationHost autoShowPaths={autoShowPaths} />
+    </MemoryRouter>
+  )
+
+describe("WorkflowIntegrationHost", () => {
+  beforeEach(() => {
+    hasCompletedFirstRun = true
+    showLanding = false
+    loadLandingConfigMock.mockClear()
+    loadDismissedSuggestionsMock.mockClear()
+    markLandingSeenMock.mockClear()
+    setShowLandingMock.mockClear()
+  })
+
+  it("does not auto-open workflow landing on the dedicated home route", async () => {
+    renderHost("/", ["/"])
+
+    await waitFor(() => {
+      expect(loadDismissedSuggestionsMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(loadLandingConfigMock).not.toHaveBeenCalled()
+    expect(screen.queryByTestId("workflow-landing-modal")).toBeNull()
+  })
+
+  it("still auto-loads workflow landing on non-home routes when configured", async () => {
+    renderHost("/knowledge", ["/knowledge"])
+
+    await waitFor(() => {
+      expect(loadLandingConfigMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(loadDismissedSuggestionsMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
+++ b/apps/packages/ui/src/components/Option/STT/SttPlaygroundPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { useStorage } from "@plasmohq/storage/hook"
 import { useTranslation } from "react-i18next"
-import { Typography } from "antd"
+import { Alert, Button, Typography } from "antd"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { PageShell } from "@/components/Common/PageShell"
 import { useAntdNotification } from "@/hooks/useAntdNotification"
@@ -27,10 +27,15 @@ export const SttPlaygroundPage: React.FC = () => {
 
   // ── Server models (fetched on mount) ──────────────────────────────
   const [serverModels, setServerModels] = useState<string[]>([])
+  const [serverModelsLoading, setServerModelsLoading] = useState(false)
+  const [serverModelsError, setServerModelsError] = useState<string | null>(null)
+  const [modelsLoadAttempt, setModelsLoadAttempt] = useState(0)
 
   useEffect(() => {
     let cancelled = false
     const fetchModels = async () => {
+      setServerModelsLoading(true)
+      setServerModelsError(null)
       try {
         const res = await tldwClient.getTranscriptionModels({
           timeoutMs: 10_000
@@ -38,18 +43,28 @@ export const SttPlaygroundPage: React.FC = () => {
         const all = Array.isArray(res?.all_models)
           ? (res.all_models as string[])
           : []
-        if (!cancelled && all.length > 0) {
+        if (!cancelled) {
           const unique = Array.from(new Set(all)).sort()
           setServerModels(unique)
+          setServerModelsError(null)
         }
       } catch (e) {
         if (!cancelled) {
-          notification.error({
-            message: t("playground:stt.modelsLoadError", "Model load failed"),
-            description: isTimeoutLikeError(e)
-              ? t("playground:stt.modelsTimeout", "Model list took longer than 10 seconds. Check server health and retry.")
-              : t("playground:stt.modelsLoadErrorDesc", "Unable to load transcription models. Retry or check server settings.")
-          })
+          setServerModelsError(
+            isTimeoutLikeError(e)
+              ? t(
+                  "playground:stt.modelsTimeout",
+                  "Model list took longer than 10 seconds. Check server health and retry."
+                )
+              : t(
+                  "playground:stt.modelsLoadErrorDesc",
+                  "Unable to load transcription models. Retry or check server settings."
+                )
+          )
+        }
+      } finally {
+        if (!cancelled) {
+          setServerModelsLoading(false)
         }
       }
     }
@@ -57,8 +72,9 @@ export const SttPlaygroundPage: React.FC = () => {
     return () => {
       cancelled = true
     }
+    // Retry is explicit via modelsLoadAttempt; translation changes do not need a refetch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [modelsLoadAttempt])
 
   // ── Current blob from RecordingStrip ──────────────────────────────
   const [currentBlob, setCurrentBlob] = useState<Blob | null>(null)
@@ -349,6 +365,22 @@ export const SttPlaygroundPage: React.FC = () => {
       </Text>
 
       <div className="mt-4 space-y-4">
+        {serverModelsError && (
+          <Alert
+            type="warning"
+            showIcon
+            title={serverModelsError}
+            action={
+              <Button
+                size="small"
+                loading={serverModelsLoading}
+                onClick={() => setModelsLoadAttempt((prev) => prev + 1)}
+              >
+                {t("common:retry", "Retry")}
+              </Button>
+            }
+          />
+        )}
         <RecordingStrip
           onBlobReady={handleBlobReady}
           onSettingsToggle={toggleSettings}

--- a/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/STT/__tests__/SttPlaygroundPage.test.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 
 const storageValues: Record<string, unknown> = {
   speechToTextLanguage: "fr",
@@ -21,6 +21,15 @@ const storageValues: Record<string, unknown> = {
 }
 
 let comparisonPanelProps: Record<string, unknown> | null = null
+const {
+  getTranscriptionModelsMock,
+  transcribeAudioMock,
+  createNoteMock
+} = vi.hoisted(() => ({
+  getTranscriptionModelsMock: vi.fn(),
+  transcribeAudioMock: vi.fn(),
+  createNoteMock: vi.fn()
+}))
 
 // Mock all dependencies before importing the component
 vi.mock("@plasmohq/storage/hook", () => ({
@@ -36,11 +45,9 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/services/tldw/TldwApiClient", () => ({
   tldwClient: {
-    getTranscriptionModels: vi
-      .fn()
-      .mockResolvedValue({ all_models: ["whisper-1", "distil-v3"] }),
-    transcribeAudio: vi.fn().mockResolvedValue({ text: "test" }),
-    createNote: vi.fn().mockResolvedValue({})
+    getTranscriptionModels: getTranscriptionModelsMock,
+    transcribeAudio: transcribeAudioMock,
+    createNote: createNoteMock
   }
 }))
 
@@ -59,7 +66,11 @@ vi.mock("@/hooks/useAntdNotification", () => ({
 }))
 
 vi.mock("@/utils/request-timeout", () => ({
-  isTimeoutLikeError: () => false
+  isTimeoutLikeError: (error: unknown) => {
+    const message =
+      error instanceof Error ? `${error.name} ${error.message}` : String(error ?? "")
+    return /timeout|timed out/i.test(message)
+  }
 }))
 
 // Mock the sub-components to keep tests focused
@@ -99,6 +110,14 @@ import { SttPlaygroundPage } from "../SttPlaygroundPage"
 describe("SttPlaygroundPage", () => {
   beforeEach(() => {
     comparisonPanelProps = null
+    getTranscriptionModelsMock.mockReset()
+    transcribeAudioMock.mockReset()
+    createNoteMock.mockReset()
+    getTranscriptionModelsMock.mockResolvedValue({
+      all_models: ["whisper-1", "distil-v3"]
+    })
+    transcribeAudioMock.mockResolvedValue({ text: "test" })
+    createNoteMock.mockResolvedValue({})
   })
 
   it("renders page title 'STT Playground'", () => {
@@ -134,6 +153,32 @@ describe("SttPlaygroundPage", () => {
       seg_utterance_expansion_width: 3,
       seg_embeddings_provider: "openai",
       seg_embeddings_model: "text-embedding-3-small"
+    })
+  })
+
+  it("shows inline retry recovery when transcription model loading fails", async () => {
+    getTranscriptionModelsMock
+      .mockRejectedValueOnce(new Error("timeout while loading transcription models"))
+      .mockResolvedValueOnce({ all_models: ["whisper-1", "canary"] })
+
+    render(<SttPlaygroundPage />)
+
+    await screen.findByText(
+      "Model list took longer than 10 seconds. Check server health and retry."
+    )
+
+    const retryButton = screen.getByRole("button", { name: "Retry" })
+    fireEvent.click(retryButton)
+
+    await waitFor(() => {
+      expect(getTranscriptionModelsMock).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "Model list took longer than 10 seconds. Check server health and retry."
+        )
+      ).toBeNull()
     })
   })
 })

--- a/apps/packages/ui/src/store/__tests__/connection.test.ts
+++ b/apps/packages/ui/src/store/__tests__/connection.test.ts
@@ -252,4 +252,44 @@ describe("connection store stability", () => {
     expect(state.serverUrl).toBe("http://192.168.5.184:8000")
     expect(mockedApiSend).toHaveBeenCalledTimes(2)
   })
+
+  it("preserves persisted first-run completion when offline bypass is enabled", async () => {
+    setConnectionState({
+      hasCompletedFirstRun: false,
+      phase: ConnectionPhase.SEARCHING,
+      isConnected: false,
+      isChecking: false
+    })
+    localStorage.setItem("__tldw_first_run_complete", "true")
+    localStorage.setItem("__tldw_allow_offline", "true")
+
+    await useConnectionStore.getState().checkOnce()
+
+    const state = useConnectionStore.getState().state
+    expect(state.phase).toBe(ConnectionPhase.CONNECTED)
+    expect(state.offlineBypass).toBe(true)
+    expect(state.hasCompletedFirstRun).toBe(true)
+  })
+
+  it("preserves persisted first-run completion through a successful health check", async () => {
+    setConnectionState({
+      hasCompletedFirstRun: false,
+      phase: ConnectionPhase.SEARCHING,
+      isConnected: false,
+      isChecking: false
+    })
+    localStorage.setItem("__tldw_first_run_complete", "true")
+    mockedApiSend.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: { status: "alive" }
+    })
+
+    await useConnectionStore.getState().checkOnce()
+
+    const state = useConnectionStore.getState().state
+    expect(state.phase).toBe(ConnectionPhase.CONNECTED)
+    expect(state.isConnected).toBe(true)
+    expect(state.hasCompletedFirstRun).toBe(true)
+  })
 })

--- a/apps/packages/ui/src/store/connection.tsx
+++ b/apps/packages/ui/src/store/connection.tsx
@@ -412,13 +412,18 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
     const bypass = await getOfflineBypassFlag()
     console.log('[CONN_DEBUG] flags loaded', { persistedFirstRun, persistedServerUrl, forceUnconfigured, bypass })
 
+    const currentState =
+      !prev.hasCompletedFirstRun && persistedFirstRun
+        ? {
+            ...prev,
+            hasCompletedFirstRun: true
+          }
+        : prev
+
     // Apply persisted first-run flag if not already set
-    if (!prev.hasCompletedFirstRun && persistedFirstRun) {
+    if (currentState !== prev) {
       set({
-        state: {
-          ...prev,
-          hasCompletedFirstRun: true
-        }
+        state: currentState
       })
     }
 
@@ -426,7 +431,7 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
     if (forceUnconfigured) {
       set({
         state: {
-          ...prev,
+          ...currentState,
           errorKind: "none",
           phase: ConnectionPhase.UNCONFIGURED,
           serverUrl: persistedServerUrl,
@@ -452,12 +457,12 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
       const serverUrl =
         persistedServerUrl ??
         (await ensurePlaceholderConfig()) ??
-        prev.serverUrl ??
+        currentState.serverUrl ??
         "offline://local"
 
       set({
         state: {
-          ...prev,
+          ...currentState,
           phase: ConnectionPhase.CONNECTED,
           serverUrl,
           isConnected: true,
@@ -479,29 +484,29 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
     // Throttle repeated checks when already connected recently.
     // This prevents the landing page/header from hammering the server.
     const now = Date.now()
-    const nextChecksSinceConfigChange = prev.checksSinceConfigChange + 1
+    const nextChecksSinceConfigChange = currentState.checksSinceConfigChange + 1
     if (
-      prev.isConnected &&
-      prev.phase === ConnectionPhase.CONNECTED &&
-      prev.lastCheckedAt != null &&
-      now - prev.lastCheckedAt < CONNECTED_THROTTLE_MS
+      currentState.isConnected &&
+      currentState.phase === ConnectionPhase.CONNECTED &&
+      currentState.lastCheckedAt != null &&
+      now - currentState.lastCheckedAt < CONNECTED_THROTTLE_MS
     ) {
       return
     }
 
     const isBackgroundRefresh =
-      prev.isConnected && prev.phase === ConnectionPhase.CONNECTED
+      currentState.isConnected && currentState.phase === ConnectionPhase.CONNECTED
     set({
       state: {
-        ...prev,
+        ...currentState,
         phase: isBackgroundRefresh
           ? ConnectionPhase.CONNECTED
           : ConnectionPhase.SEARCHING,
-        serverUrl: persistedServerUrl ?? prev.serverUrl,
-        errorKind: isBackgroundRefresh ? prev.errorKind : "none",
+        serverUrl: persistedServerUrl ?? currentState.serverUrl,
+        errorKind: isBackgroundRefresh ? currentState.errorKind : "none",
         isChecking: true,
         offlineBypass: false,
-        lastError: isBackgroundRefresh ? prev.lastError : null,
+        lastError: isBackgroundRefresh ? currentState.lastError : null,
         checksSinceConfigChange: nextChecksSinceConfigChange
       }
     })
@@ -539,7 +544,7 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
       if (!serverUrl) {
         set({
           state: {
-            ...prev,
+            ...currentState,
             phase: ConnectionPhase.UNCONFIGURED,
             serverUrl: null,
             isConnected: false,
@@ -654,13 +659,13 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
         serverUrl
       })
 
-      let knowledgeStatus: KnowledgeStatus = prev.knowledgeStatus
-      let knowledgeLastCheckedAt = prev.knowledgeLastCheckedAt
-      let knowledgeError = prev.knowledgeError
+      let knowledgeStatus: KnowledgeStatus = currentState.knowledgeStatus
+      let knowledgeLastCheckedAt = currentState.knowledgeLastCheckedAt
+      let knowledgeError = currentState.knowledgeError
       const shouldRefreshKnowledge =
-        !prev.knowledgeLastCheckedAt ||
-        now - prev.knowledgeLastCheckedAt >= KNOWLEDGE_RECHECK_INTERVAL_MS ||
-        prev.knowledgeStatus !== "ready"
+        !currentState.knowledgeLastCheckedAt ||
+        now - currentState.knowledgeLastCheckedAt >= KNOWLEDGE_RECHECK_INTERVAL_MS ||
+        currentState.knowledgeStatus !== "ready"
 
       if (ok && shouldRefreshKnowledge) {
         try {
@@ -696,7 +701,7 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
       }
 
       let errorKind: ConnectionState["errorKind"] = "none"
-      const nextConsecutiveFailures = ok ? 0 : prev.consecutiveFailures + 1
+      const nextConsecutiveFailures = ok ? 0 : currentState.consecutiveFailures + 1
 
       if (ok) {
         if (knowledgeStatus === "offline") {
@@ -716,14 +721,14 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
       const holdConnectedOnTransientFailure =
         !ok &&
         errorKind === "unreachable" &&
-        prev.isConnected &&
-        prev.phase === ConnectionPhase.CONNECTED &&
+        currentState.isConnected &&
+        currentState.phase === ConnectionPhase.CONNECTED &&
         nextConsecutiveFailures < CONNECTED_FAILURE_THRESHOLD
 
       if (holdConnectedOnTransientFailure) {
         set({
           state: {
-            ...prev,
+            ...currentState,
             phase: ConnectionPhase.CONNECTED,
             isConnected: true,
             isChecking: false,
@@ -747,7 +752,7 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
       })
       set({
         state: {
-          ...prev,
+          ...currentState,
           phase: ok ? ConnectionPhase.CONNECTED : ConnectionPhase.ERROR,
           serverUrl,
           isConnected: ok,
@@ -775,15 +780,15 @@ export const useConnectionStore = createWithEqualityFn<ConnectionStore>((set, ge
         maybeAnnotateCorsMismatchError({
           error: (error as Error)?.message ?? "unknown-error",
           status: 0,
-          serverUrl: prev.serverUrl
+          serverUrl: currentState.serverUrl
         }) ?? "unknown-error"
       set({
         state: {
-          ...prev,
+          ...currentState,
           phase: ConnectionPhase.ERROR,
           isConnected: false,
           isChecking: false,
-          consecutiveFailures: prev.consecutiveFailures + 1,
+          consecutiveFailures: currentState.consecutiveFailures + 1,
           offlineBypass: false,
           lastCheckedAt: Date.now(),
           lastError: fallbackError,

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -155,6 +155,18 @@ router = APIRouter(prefix="/sandbox", tags=["sandbox"], route_class=SandboxArtif
 
 _service = SandboxService(enable_background_tasks=False)
 
+try:
+    import fcntl  # type: ignore
+    _SANDBOX_HAS_FCNTL = True
+except Exception:
+    _SANDBOX_HAS_FCNTL = False
+
+try:
+    import msvcrt  # type: ignore
+    _SANDBOX_HAS_MSVCRT = True
+except Exception:
+    _SANDBOX_HAS_MSVCRT = False
+
 
 @router.on_event("startup")
 async def _sandbox_startup() -> None:
@@ -173,6 +185,71 @@ _SANDBOX_WS_ACTIVE_BY_USER: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_PERSONA: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_SESSION: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_RUN: dict[str, int] = {}
+_SANDBOX_UPLOAD_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
+_SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD = threading.Lock()
+
+
+def _sandbox_upload_lock_path(workspace_root: str) -> str:
+    return os.path.join(workspace_root, ".sandbox-upload.lock")
+
+
+def _get_sandbox_upload_thread_lock(lock_path: str) -> threading.Lock:
+    key = str(os.path.abspath(lock_path))
+    with _SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD:
+        lock = _SANDBOX_UPLOAD_FALLBACK_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SANDBOX_UPLOAD_FALLBACK_LOCKS[key] = lock
+    return lock
+
+
+@contextlib.asynccontextmanager
+async def _sandbox_session_upload_lock(workspace_root: str):
+    os.makedirs(workspace_root, exist_ok=True)
+    lock_path = _sandbox_upload_lock_path(workspace_root)
+
+    if _SANDBOX_HAS_FCNTL:
+        def _open_and_lock():
+            handle = open(lock_path, "a", encoding="utf-8")
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            return handle
+
+        handle = await asyncio.to_thread(_open_and_lock)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(fcntl.flock, handle.fileno(), fcntl.LOCK_UN)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.close)
+        return
+
+    if _SANDBOX_HAS_MSVCRT:
+        def _open_and_lock():
+            handle = open(lock_path, "a+b")
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            return handle
+
+        handle = await asyncio.to_thread(_open_and_lock)
+        try:
+            yield
+        finally:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.seek, 0)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(msvcrt.locking, handle.fileno(), msvcrt.LK_UNLCK, 1)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                await asyncio.to_thread(handle.close)
+        return
+
+    lock = _get_sandbox_upload_thread_lock(lock_path)
+    await asyncio.to_thread(lock.acquire)
+    try:
+        yield
+    finally:
+        lock.release()
 
 
 def _sandbox_ws_limit(env_key: str, settings_attr: str, default: int) -> int:
@@ -910,183 +987,184 @@ async def upload_files(
     if not ws_root:
         raise HTTPException(status_code=404, detail="session_not_found")
 
-    try:
-        cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
-    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-        cap_mb = 256
-    cap_bytes = cap_mb * 1024 * 1024
-    chunk_size = 64 * 1024
-    written = 0
-    count = 0
-
-    import tarfile
-    import zipfile
-    def _workspace_usage_bytes(root: str) -> int:
-        total = 0
-        for dirpath, _dirnames, filenames in os.walk(root):
-            for filename in filenames:
-                full_path = os.path.join(dirpath, filename)
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    if os.path.isfile(full_path):
-                        total += int(os.path.getsize(full_path))
-        return total
-
-    def _existing_file_size(target: str) -> int:
+    async with _sandbox_session_upload_lock(ws_root):
         try:
-            if os.path.isfile(target):
-                return int(os.path.getsize(target))
+            cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
         except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            cap_mb = 256
+        cap_bytes = cap_mb * 1024 * 1024
+        chunk_size = 64 * 1024
+        written = 0
+        count = 0
+
+        import tarfile
+        import zipfile
+        def _workspace_usage_bytes(root: str) -> int:
+            total = 0
+            for dirpath, _dirnames, filenames in os.walk(root):
+                for filename in filenames:
+                    full_path = os.path.join(dirpath, filename)
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        if os.path.isfile(full_path):
+                            total += int(os.path.getsize(full_path))
+            return total
+
+        def _existing_file_size(target: str) -> int:
+            try:
+                if os.path.isfile(target):
+                    return int(os.path.getsize(target))
+            except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                return 0
             return 0
-        return 0
 
-    def _stream_reader_to_target(
-        target: str,
-        read_chunk,
-        *,
-        workspace_used: int,
-    ) -> tuple[int, int]:
-        parent = os.path.dirname(target)
-        os.makedirs(parent, exist_ok=True)
-        existing_size = _existing_file_size(target)
-        fd, temp_path = tempfile.mkstemp(
-            dir=parent,
-            prefix=f".{os.path.basename(target)}.",
-            suffix=".upload",
-        )
-        os.close(fd)
-        file_bytes = 0
-        try:
-            with open(temp_path, "wb") as out:
-                while True:
-                    chunk = read_chunk(chunk_size)
-                    if not chunk:
-                        break
-                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                    if next_total > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    out.write(chunk)
-                    file_bytes += len(chunk)
-            os.replace(temp_path, target)
-            return file_bytes, workspace_used - existing_size + file_bytes
-        except Exception:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                os.unlink(temp_path)
-            raise
-
-    async def _stream_upload_to_target(
-        upload: UploadFile,
-        target: str,
-        *,
-        workspace_used: int,
-    ) -> tuple[int, int]:
-        parent = os.path.dirname(target)
-        os.makedirs(parent, exist_ok=True)
-        existing_size = _existing_file_size(target)
-        fd, temp_path = tempfile.mkstemp(
-            dir=parent,
-            prefix=f".{os.path.basename(target)}.",
-            suffix=".upload",
-        )
-        os.close(fd)
-        file_bytes = 0
-        try:
-            with open(temp_path, "wb") as out:
-                while True:
-                    chunk = await upload.read(chunk_size)
-                    if not chunk:
-                        break
-                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                    if next_total > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    out.write(chunk)
-                    file_bytes += len(chunk)
-            os.replace(temp_path, target)
-            return file_bytes, workspace_used - existing_size + file_bytes
-        except Exception:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                os.unlink(temp_path)
-            raise
-
-    workspace_used = _workspace_usage_bytes(ws_root)
-
-    for up in files:
-        lower = (up.filename or "").lower()
-        if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+        def _stream_reader_to_target(
+            target: str,
+            read_chunk,
+            *,
+            workspace_used: int,
+        ) -> tuple[int, int]:
+            parent = os.path.dirname(target)
+            os.makedirs(parent, exist_ok=True)
+            existing_size = _existing_file_size(target)
+            fd, temp_path = tempfile.mkstemp(
+                dir=parent,
+                prefix=f".{os.path.basename(target)}.",
+                suffix=".upload",
+            )
+            os.close(fd)
+            file_bytes = 0
             try:
+                with open(temp_path, "wb") as out:
+                    while True:
+                        chunk = read_chunk(chunk_size)
+                        if not chunk:
+                            break
+                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                        if next_total > cap_bytes:
+                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                        out.write(chunk)
+                        file_bytes += len(chunk)
+                os.replace(temp_path, target)
+                return file_bytes, workspace_used - existing_size + file_bytes
+            except Exception:
                 with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                with tarfile.open(fileobj=up.file, mode="r:*") as tf:
-                    for member in tf.getmembers():
-                        if member.isdev() or member.issym() or member.islnk():
-                            continue
-                        target = safe_join(ws_root, member.name)
-                        if target is None:
-                            continue
-                        if member.isdir():
-                            os.makedirs(target, exist_ok=True)
-                            continue
-                        fileobj = tf.extractfile(member)
-                        if fileobj is None:
-                            continue
-                        try:
-                            file_bytes, workspace_used = _stream_reader_to_target(
-                                target,
-                                fileobj.read,
-                                workspace_used=workspace_used,
-                            )
-                        finally:
-                            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                                fileobj.close()
-                        written += file_bytes
-                        count += 1
-            except HTTPException:
+                    os.unlink(temp_path)
                 raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to extract tar: {e}")
-        elif lower.endswith(".zip"):
+
+        async def _stream_upload_to_target(
+            upload: UploadFile,
+            target: str,
+            *,
+            workspace_used: int,
+        ) -> tuple[int, int]:
+            parent = os.path.dirname(target)
+            os.makedirs(parent, exist_ok=True)
+            existing_size = _existing_file_size(target)
+            fd, temp_path = tempfile.mkstemp(
+                dir=parent,
+                prefix=f".{os.path.basename(target)}.",
+                suffix=".upload",
+            )
+            os.close(fd)
+            file_bytes = 0
             try:
+                with open(temp_path, "wb") as out:
+                    while True:
+                        chunk = await upload.read(chunk_size)
+                        if not chunk:
+                            break
+                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                        if next_total > cap_bytes:
+                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                        out.write(chunk)
+                        file_bytes += len(chunk)
+                os.replace(temp_path, target)
+                return file_bytes, workspace_used - existing_size + file_bytes
+            except Exception:
                 with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                with zipfile.ZipFile(up.file) as zf:
-                    for member in zf.infolist():
-                        if member.is_dir():
-                            continue
-                        if (member.external_attr >> 16) & 0xF000 == 0xA000:
-                            continue
-                        target = safe_join(ws_root, member.filename)
-                        if target is None:
-                            continue
-                        with zf.open(member) as fileobj:
-                            file_bytes, workspace_used = _stream_reader_to_target(
-                                target,
-                                fileobj.read,
-                                workspace_used=workspace_used,
-                            )
-                        written += file_bytes
-                        count += 1
-            except HTTPException:
+                    os.unlink(temp_path)
                 raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to extract zip: {e}")
-        else:
-            target = safe_join(ws_root, up.filename or f"file_{count}")
-            if target is None:
-                continue
-            try:
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    await up.seek(0)
-                file_bytes, workspace_used = await _stream_upload_to_target(
-                    up,
-                    target,
-                    workspace_used=workspace_used,
-                )
-            except HTTPException:
-                raise
-            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed reading upload file {up.filename}: {e}")
-                continue
-            written += file_bytes
-            count += 1
+
+        workspace_used = _workspace_usage_bytes(ws_root)
+
+        for up in files:
+            lower = (up.filename or "").lower()
+            if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    with tarfile.open(fileobj=up.file, mode="r:*") as tf:
+                        for member in tf.getmembers():
+                            if member.isdev() or member.issym() or member.islnk():
+                                continue
+                            target = safe_join(ws_root, member.name)
+                            if target is None:
+                                continue
+                            if member.isdir():
+                                os.makedirs(target, exist_ok=True)
+                                continue
+                            fileobj = tf.extractfile(member)
+                            if fileobj is None:
+                                continue
+                            try:
+                                file_bytes, workspace_used = _stream_reader_to_target(
+                                    target,
+                                    fileobj.read,
+                                    workspace_used=workspace_used,
+                                )
+                            finally:
+                                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                                    fileobj.close()
+                            written += file_bytes
+                            count += 1
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed to extract tar: {e}")
+            elif lower.endswith(".zip"):
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    with zipfile.ZipFile(up.file) as zf:
+                        for member in zf.infolist():
+                            if member.is_dir():
+                                continue
+                            if (member.external_attr >> 16) & 0xF000 == 0xA000:
+                                continue
+                            target = safe_join(ws_root, member.filename)
+                            if target is None:
+                                continue
+                            with zf.open(member) as fileobj:
+                                file_bytes, workspace_used = _stream_reader_to_target(
+                                    target,
+                                    fileobj.read,
+                                    workspace_used=workspace_used,
+                                )
+                            written += file_bytes
+                            count += 1
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed to extract zip: {e}")
+            else:
+                target = safe_join(ws_root, up.filename or f"file_{count}")
+                if target is None:
+                    continue
+                try:
+                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                        await up.seek(0)
+                    file_bytes, workspace_used = await _stream_upload_to_target(
+                        up,
+                        target,
+                        workspace_used=workspace_used,
+                    )
+                except HTTPException:
+                    raise
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                    logger.warning(f"Failed reading upload file {up.filename}: {e}")
+                    continue
+                written += file_bytes
+                count += 1
 
     # Metrics
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -308,6 +308,88 @@ def _model_field_names(model: object | None) -> set[str]:
     return {str(field) for field in (fields or set())}
 
 
+def _workspace_usage_bytes_sync(root: str) -> int:
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            full_path = os.path.join(dirpath, filename)
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                if os.path.isfile(full_path):
+                    total += int(os.path.getsize(full_path))
+    return total
+
+
+def _existing_file_size_sync(target: str) -> int:
+    try:
+        if os.path.isfile(target):
+            return int(os.path.getsize(target))
+    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+        return 0
+    return 0
+
+
+def _prepare_temp_target_sync(target: str) -> tuple[int, str, int]:
+    parent = os.path.dirname(target)
+    os.makedirs(parent, exist_ok=True)
+    existing_size = _existing_file_size_sync(target)
+    fd, temp_path = tempfile.mkstemp(
+        dir=parent,
+        prefix=f".{os.path.basename(target)}.",
+        suffix=".upload",
+    )
+    return fd, temp_path, existing_size
+
+
+def _write_fd_chunk_sync(fd: int, chunk: bytes) -> None:
+    os.write(fd, chunk)
+
+
+def _finalize_temp_target_sync(fd: int, temp_path: str, target: str) -> None:
+    try:
+        os.close(fd)
+    except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+        pass
+    os.replace(temp_path, target)
+
+
+def _cleanup_temp_target_sync(fd: int, temp_path: str) -> None:
+    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+        os.close(fd)
+    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+        os.unlink(temp_path)
+
+
+def _make_directory_sync(path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+
+
+def _stream_reader_to_target_sync(
+    target: str,
+    read_chunk,
+    *,
+    chunk_size: int,
+    workspace_used: int,
+    cap_bytes: int,
+) -> tuple[int, int]:
+    fd, temp_path, existing_size = _prepare_temp_target_sync(target)
+    file_bytes = 0
+    try:
+        while True:
+            chunk = read_chunk(chunk_size)
+            if not chunk:
+                break
+            next_total = workspace_used - existing_size + file_bytes + len(chunk)
+            if next_total > cap_bytes:
+                raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+            _write_fd_chunk_sync(fd, chunk)
+            file_bytes += len(chunk)
+        _finalize_temp_target_sync(fd, temp_path, target)
+        return file_bytes, workspace_used - existing_size + file_bytes
+    except Exception:
+        _cleanup_temp_target_sync(fd, temp_path)
+        raise
+
+
 def _looks_like_jwt(token: str | None) -> bool:
     return isinstance(token, str) and token.count(".") == 2
 
@@ -950,57 +1032,6 @@ async def upload_files(
 
             import tarfile
             import zipfile
-            def _workspace_usage_bytes(root: str) -> int:
-                total = 0
-                for dirpath, _dirnames, filenames in os.walk(root):
-                    for filename in filenames:
-                        full_path = os.path.join(dirpath, filename)
-                        with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                            if os.path.isfile(full_path):
-                                total += int(os.path.getsize(full_path))
-                return total
-
-            def _existing_file_size(target: str) -> int:
-                try:
-                    if os.path.isfile(target):
-                        return int(os.path.getsize(target))
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-                    return 0
-                return 0
-
-            def _stream_reader_to_target(
-                target: str,
-                read_chunk,
-                *,
-                workspace_used: int,
-            ) -> tuple[int, int]:
-                parent = os.path.dirname(target)
-                os.makedirs(parent, exist_ok=True)
-                existing_size = _existing_file_size(target)
-                fd, temp_path = tempfile.mkstemp(
-                    dir=parent,
-                    prefix=f".{os.path.basename(target)}.",
-                    suffix=".upload",
-                )
-                os.close(fd)
-                file_bytes = 0
-                try:
-                    with open(temp_path, "wb") as out:
-                        while True:
-                            chunk = read_chunk(chunk_size)
-                            if not chunk:
-                                break
-                            next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                            if next_total > cap_bytes:
-                                raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                            out.write(chunk)
-                            file_bytes += len(chunk)
-                    os.replace(temp_path, target)
-                    return file_bytes, workspace_used - existing_size + file_bytes
-                except Exception:
-                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        os.unlink(temp_path)
-                    raise
 
             async def _stream_upload_to_target(
                 upload: UploadFile,
@@ -1008,35 +1039,25 @@ async def upload_files(
                 *,
                 workspace_used: int,
             ) -> tuple[int, int]:
-                parent = os.path.dirname(target)
-                os.makedirs(parent, exist_ok=True)
-                existing_size = _existing_file_size(target)
-                fd, temp_path = tempfile.mkstemp(
-                    dir=parent,
-                    prefix=f".{os.path.basename(target)}.",
-                    suffix=".upload",
-                )
-                os.close(fd)
+                fd, temp_path, existing_size = await asyncio.to_thread(_prepare_temp_target_sync, target)
                 file_bytes = 0
                 try:
-                    with open(temp_path, "wb") as out:
-                        while True:
-                            chunk = await upload.read(chunk_size)
-                            if not chunk:
-                                break
-                            next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                            if next_total > cap_bytes:
-                                raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                            out.write(chunk)
-                            file_bytes += len(chunk)
-                    os.replace(temp_path, target)
+                    while True:
+                        chunk = await upload.read(chunk_size)
+                        if not chunk:
+                            break
+                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                        if next_total > cap_bytes:
+                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                        await asyncio.to_thread(_write_fd_chunk_sync, fd, chunk)
+                        file_bytes += len(chunk)
+                    await asyncio.to_thread(_finalize_temp_target_sync, fd, temp_path, target)
                     return file_bytes, workspace_used - existing_size + file_bytes
                 except Exception:
-                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        os.unlink(temp_path)
+                    await asyncio.to_thread(_cleanup_temp_target_sync, fd, temp_path)
                     raise
 
-            workspace_used = _workspace_usage_bytes(ws_root)
+            workspace_used = await asyncio.to_thread(_workspace_usage_bytes_sync, ws_root)
 
             for up in files:
                 lower = (up.filename or "").lower()
@@ -1052,16 +1073,19 @@ async def upload_files(
                                 if target is None:
                                     continue
                                 if member.isdir():
-                                    os.makedirs(target, exist_ok=True)
+                                    await asyncio.to_thread(_make_directory_sync, target)
                                     continue
                                 fileobj = tf.extractfile(member)
                                 if fileobj is None:
                                     continue
                                 try:
-                                    file_bytes, workspace_used = _stream_reader_to_target(
+                                    file_bytes, workspace_used = await asyncio.to_thread(
+                                        _stream_reader_to_target_sync,
                                         target,
                                         fileobj.read,
+                                        chunk_size=chunk_size,
                                         workspace_used=workspace_used,
+                                        cap_bytes=cap_bytes,
                                     )
                                 finally:
                                     with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
@@ -1086,10 +1110,13 @@ async def upload_files(
                                 if target is None:
                                     continue
                                 with zf.open(member) as fileobj:
-                                    file_bytes, workspace_used = _stream_reader_to_target(
+                                    file_bytes, workspace_used = await asyncio.to_thread(
+                                        _stream_reader_to_target_sync,
                                         target,
                                         fileobj.read,
+                                        chunk_size=chunk_size,
                                         workspace_used=workspace_used,
+                                        cap_bytes=cap_bytes,
                                     )
                                 written += file_bytes
                                 count += 1
@@ -1185,12 +1212,8 @@ async def start_run(
         HTTPException: 409 with code "idempotency_conflict" when an idempotent request conflicts.
         HTTPException: 400 with code "invalid_spec_version" when the provided spec_version is unsupported.
     """
-    session = None
     if payload.session_id:
         _require_session_owner(payload.session_id, current_user)
-        session = _service.get_session(payload.session_id)
-        if session is None:
-            raise HTTPException(status_code=404, detail="session_not_found")
     try:
         files_inline = _service.parse_inline_files([(f.model_dump() if hasattr(f, "model_dump") else f.dict()) for f in (payload.files or [])])
     except ValueError as e:
@@ -1215,57 +1238,21 @@ async def start_run(
 
     payload_fields = _model_field_names(payload)
     resource_fields = _model_field_names(payload.resources)
+    explicit_fields = set(payload_fields)
+    explicit_fields.update({f"resources.{field}" for field in resource_fields})
 
-    runtime = (CoreRuntimeType(payload.runtime) if payload.runtime else None) if "runtime" in payload_fields else None
-    if runtime is None and session is not None and session.runtime is not None:
-        runtime = session.runtime
-
-    base_image = payload.base_image if "base_image" in payload_fields else None
-    if base_image is None and session is not None and session.base_image:
-        base_image = session.base_image
-    if payload.session_id and not base_image:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": {
-                    "code": "session_base_image_required",
-                    "message": "Session-backed runs require a base_image",
-                }
-            },
-        )
-
-    env = dict(payload.env or {}) if "env" in payload_fields else (
-        dict(session.env or {}) if session is not None else {}
-    )
-    timeout_sec = int(payload.timeout_sec) if "timeout_sec" in payload_fields else (
-        int(session.timeout_sec) if session is not None and session.timeout_sec is not None else default_exec_to
-    )
-    cpu = (payload.resources.cpu if payload.resources else None) if "cpu" in resource_fields else (
-        session.cpu_limit if session is not None else None
-    )
-    memory_mb = (payload.resources.memory_mb if payload.resources else None) if "memory_mb" in resource_fields else (
-        session.memory_mb if session is not None else None
-    )
-    network_policy = payload.network_policy if "network_policy" in payload_fields else (
-        session.network_policy if session is not None else None
-    )
-    trust_level = (
-        CoreTrustLevel(payload.trust_level) if payload.trust_level else None
-    ) if "trust_level" in payload_fields else (
-        session.trust_level if session is not None else None
-    )
-    persona_id = payload.persona_id if "persona_id" in payload_fields else (
-        session.persona_id if session is not None else None
-    )
-    workspace_id = payload.workspace_id if "workspace_id" in payload_fields else (
-        session.workspace_id if session is not None else None
-    )
-    workspace_group_id = payload.workspace_group_id if "workspace_group_id" in payload_fields else (
-        session.workspace_group_id if session is not None else None
-    )
-    scope_snapshot_id = payload.scope_snapshot_id if "scope_snapshot_id" in payload_fields else (
-        session.scope_snapshot_id if session is not None else None
-    )
+    runtime = CoreRuntimeType(payload.runtime) if payload.runtime else None
+    base_image = payload.base_image or None
+    env = dict(payload.env or {})
+    timeout_sec = int(payload.timeout_sec) if payload.timeout_sec is not None else default_exec_to
+    cpu = payload.resources.cpu if payload.resources else None
+    memory_mb = payload.resources.memory_mb if payload.resources else None
+    network_policy = payload.network_policy
+    trust_level = CoreTrustLevel(payload.trust_level) if payload.trust_level else None
+    persona_id = payload.persona_id
+    workspace_id = payload.workspace_id
+    workspace_group_id = payload.workspace_group_id
+    scope_snapshot_id = payload.scope_snapshot_id
 
     spec = RunSpec(
         session_id=payload.session_id,
@@ -1299,6 +1286,7 @@ async def start_run(
             spec_version=payload.spec_version,
             idem_key=idempotency_key,
             raw_body=payload.model_dump(exclude_none=True),
+            explicit_fields=explicit_fields,
         )
     except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
         if isinstance(e, SandboxPolicy.RuntimeUnavailable):
@@ -1391,6 +1379,16 @@ async def start_run(
             })
         if isinstance(e, ValueError) and str(e) == "session_not_found":
             raise HTTPException(status_code=404, detail="session_not_found") from e
+        if isinstance(e, ValueError) and str(e) == "session_base_image_required":
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "error": {
+                        "code": "session_base_image_required",
+                        "message": "Session-backed runs require a base_image",
+                    }
+                },
+            ) from e
         raise
     try:
         rt = (status.runtime.value if status.runtime else (payload.runtime or "unknown"))

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -155,18 +155,6 @@ router = APIRouter(prefix="/sandbox", tags=["sandbox"], route_class=SandboxArtif
 
 _service = SandboxService(enable_background_tasks=False)
 
-try:
-    import fcntl  # type: ignore
-    _SANDBOX_HAS_FCNTL = True
-except Exception:
-    _SANDBOX_HAS_FCNTL = False
-
-try:
-    import msvcrt  # type: ignore
-    _SANDBOX_HAS_MSVCRT = True
-except Exception:
-    _SANDBOX_HAS_MSVCRT = False
-
 
 @router.on_event("startup")
 async def _sandbox_startup() -> None:
@@ -185,71 +173,6 @@ _SANDBOX_WS_ACTIVE_BY_USER: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_PERSONA: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_SESSION: dict[str, int] = {}
 _SANDBOX_WS_ACTIVE_BY_RUN: dict[str, int] = {}
-_SANDBOX_UPLOAD_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
-_SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD = threading.Lock()
-
-
-def _sandbox_upload_lock_path(workspace_root: str) -> str:
-    return os.path.join(workspace_root, ".sandbox-upload.lock")
-
-
-def _get_sandbox_upload_thread_lock(lock_path: str) -> threading.Lock:
-    key = str(os.path.abspath(lock_path))
-    with _SANDBOX_UPLOAD_FALLBACK_LOCKS_GUARD:
-        lock = _SANDBOX_UPLOAD_FALLBACK_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _SANDBOX_UPLOAD_FALLBACK_LOCKS[key] = lock
-    return lock
-
-
-@contextlib.asynccontextmanager
-async def _sandbox_session_upload_lock(workspace_root: str):
-    os.makedirs(workspace_root, exist_ok=True)
-    lock_path = _sandbox_upload_lock_path(workspace_root)
-
-    if _SANDBOX_HAS_FCNTL:
-        def _open_and_lock():
-            handle = open(lock_path, "a", encoding="utf-8")
-            fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-            return handle
-
-        handle = await asyncio.to_thread(_open_and_lock)
-        try:
-            yield
-        finally:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await asyncio.to_thread(fcntl.flock, handle.fileno(), fcntl.LOCK_UN)
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await asyncio.to_thread(handle.close)
-        return
-
-    if _SANDBOX_HAS_MSVCRT:
-        def _open_and_lock():
-            handle = open(lock_path, "a+b")
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                handle.seek(0)
-            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
-            return handle
-
-        handle = await asyncio.to_thread(_open_and_lock)
-        try:
-            yield
-        finally:
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await asyncio.to_thread(handle.seek, 0)
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await asyncio.to_thread(msvcrt.locking, handle.fileno(), msvcrt.LK_UNLCK, 1)
-            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                await asyncio.to_thread(handle.close)
-        return
-
-    lock = _get_sandbox_upload_thread_lock(lock_path)
-    await asyncio.to_thread(lock.acquire)
-    try:
-        yield
-    finally:
-        lock.release()
 
 
 def _sandbox_ws_limit(env_key: str, settings_attr: str, default: int) -> int:
@@ -871,6 +794,16 @@ async def create_snapshot(
             created_at=result["created_at"],
             size_bytes=result["size_bytes"],
         )
+    except SessionActiveRunsConflict as e:
+        err = str(e) or "session_has_active_runs"
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": err,
+                "active_runs": int(getattr(e, "active_runs", 0) or 0),
+                "session_id": str(session_id),
+            },
+        ) from e
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except OSError as e:
@@ -898,6 +831,16 @@ async def restore_snapshot(
             restored=restored,
             snapshot_id=payload.snapshot_id,
         )
+    except SessionActiveRunsConflict as e:
+        err = str(e) or "session_has_active_runs"
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": err,
+                "active_runs": int(getattr(e, "active_runs", 0) or 0),
+                "session_id": str(session_id),
+            },
+        ) from e
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except OSError as e:
@@ -928,6 +871,16 @@ async def clone_session(
             session_id=new_session.id,
             cloned_from=session_id,
         )
+    except SessionActiveRunsConflict as e:
+        err = str(e) or "session_has_active_runs"
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": err,
+                "active_runs": int(getattr(e, "active_runs", 0) or 0),
+                "session_id": str(session_id),
+            },
+        ) from e
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
@@ -983,188 +936,190 @@ async def upload_files(
     audit_service=Depends(get_audit_service_for_user),
 ) -> SandboxFileUploadResponse:
     _require_session_owner(session_id, current_user)
-    ws_root = _service.get_session_workspace_path(session_id)
-    if not ws_root:
-        raise HTTPException(status_code=404, detail="session_not_found")
+    written = 0
+    count = 0
 
-    async with _sandbox_session_upload_lock(ws_root):
-        try:
-            cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
-        except _SANDBOX_NONCRITICAL_EXCEPTIONS:
-            cap_mb = 256
-        cap_bytes = cap_mb * 1024 * 1024
-        chunk_size = 64 * 1024
-        written = 0
-        count = 0
-
-        import tarfile
-        import zipfile
-        def _workspace_usage_bytes(root: str) -> int:
-            total = 0
-            for dirpath, _dirnames, filenames in os.walk(root):
-                for filename in filenames:
-                    full_path = os.path.join(dirpath, filename)
-                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        if os.path.isfile(full_path):
-                            total += int(os.path.getsize(full_path))
-            return total
-
-        def _existing_file_size(target: str) -> int:
+    try:
+        async with _service.async_workspace_operation_lock(session_id) as ws_root:
             try:
-                if os.path.isfile(target):
-                    return int(os.path.getsize(target))
+                cap_mb = int(os.getenv("SANDBOX_WORKSPACE_CAP_MB") or 256)
             except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                cap_mb = 256
+            cap_bytes = cap_mb * 1024 * 1024
+            chunk_size = 64 * 1024
+
+            import tarfile
+            import zipfile
+            def _workspace_usage_bytes(root: str) -> int:
+                total = 0
+                for dirpath, _dirnames, filenames in os.walk(root):
+                    for filename in filenames:
+                        full_path = os.path.join(dirpath, filename)
+                        with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                            if os.path.isfile(full_path):
+                                total += int(os.path.getsize(full_path))
+                return total
+
+            def _existing_file_size(target: str) -> int:
+                try:
+                    if os.path.isfile(target):
+                        return int(os.path.getsize(target))
+                except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+                    return 0
                 return 0
-            return 0
 
-        def _stream_reader_to_target(
-            target: str,
-            read_chunk,
-            *,
-            workspace_used: int,
-        ) -> tuple[int, int]:
-            parent = os.path.dirname(target)
-            os.makedirs(parent, exist_ok=True)
-            existing_size = _existing_file_size(target)
-            fd, temp_path = tempfile.mkstemp(
-                dir=parent,
-                prefix=f".{os.path.basename(target)}.",
-                suffix=".upload",
-            )
-            os.close(fd)
-            file_bytes = 0
-            try:
-                with open(temp_path, "wb") as out:
-                    while True:
-                        chunk = read_chunk(chunk_size)
-                        if not chunk:
-                            break
-                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                        if next_total > cap_bytes:
-                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                        out.write(chunk)
-                        file_bytes += len(chunk)
-                os.replace(temp_path, target)
-                return file_bytes, workspace_used - existing_size + file_bytes
-            except Exception:
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    os.unlink(temp_path)
-                raise
-
-        async def _stream_upload_to_target(
-            upload: UploadFile,
-            target: str,
-            *,
-            workspace_used: int,
-        ) -> tuple[int, int]:
-            parent = os.path.dirname(target)
-            os.makedirs(parent, exist_ok=True)
-            existing_size = _existing_file_size(target)
-            fd, temp_path = tempfile.mkstemp(
-                dir=parent,
-                prefix=f".{os.path.basename(target)}.",
-                suffix=".upload",
-            )
-            os.close(fd)
-            file_bytes = 0
-            try:
-                with open(temp_path, "wb") as out:
-                    while True:
-                        chunk = await upload.read(chunk_size)
-                        if not chunk:
-                            break
-                        next_total = workspace_used - existing_size + file_bytes + len(chunk)
-                        if next_total > cap_bytes:
-                            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                        out.write(chunk)
-                        file_bytes += len(chunk)
-                os.replace(temp_path, target)
-                return file_bytes, workspace_used - existing_size + file_bytes
-            except Exception:
-                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                    os.unlink(temp_path)
-                raise
-
-        workspace_used = _workspace_usage_bytes(ws_root)
-
-        for up in files:
-            lower = (up.filename or "").lower()
-            if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+            def _stream_reader_to_target(
+                target: str,
+                read_chunk,
+                *,
+                workspace_used: int,
+            ) -> tuple[int, int]:
+                parent = os.path.dirname(target)
+                os.makedirs(parent, exist_ok=True)
+                existing_size = _existing_file_size(target)
+                fd, temp_path = tempfile.mkstemp(
+                    dir=parent,
+                    prefix=f".{os.path.basename(target)}.",
+                    suffix=".upload",
+                )
+                os.close(fd)
+                file_bytes = 0
                 try:
+                    with open(temp_path, "wb") as out:
+                        while True:
+                            chunk = read_chunk(chunk_size)
+                            if not chunk:
+                                break
+                            next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                            if next_total > cap_bytes:
+                                raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                            out.write(chunk)
+                            file_bytes += len(chunk)
+                    os.replace(temp_path, target)
+                    return file_bytes, workspace_used - existing_size + file_bytes
+                except Exception:
                     with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        await up.seek(0)
-                    with tarfile.open(fileobj=up.file, mode="r:*") as tf:
-                        for member in tf.getmembers():
-                            if member.isdev() or member.issym() or member.islnk():
-                                continue
-                            target = safe_join(ws_root, member.name)
-                            if target is None:
-                                continue
-                            if member.isdir():
-                                os.makedirs(target, exist_ok=True)
-                                continue
-                            fileobj = tf.extractfile(member)
-                            if fileobj is None:
-                                continue
-                            try:
-                                file_bytes, workspace_used = _stream_reader_to_target(
-                                    target,
-                                    fileobj.read,
-                                    workspace_used=workspace_used,
-                                )
-                            finally:
-                                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                                    fileobj.close()
-                            written += file_bytes
-                            count += 1
-                except HTTPException:
+                        os.unlink(temp_path)
                     raise
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"Failed to extract tar: {e}")
-            elif lower.endswith(".zip"):
+
+            async def _stream_upload_to_target(
+                upload: UploadFile,
+                target: str,
+                *,
+                workspace_used: int,
+            ) -> tuple[int, int]:
+                parent = os.path.dirname(target)
+                os.makedirs(parent, exist_ok=True)
+                existing_size = _existing_file_size(target)
+                fd, temp_path = tempfile.mkstemp(
+                    dir=parent,
+                    prefix=f".{os.path.basename(target)}.",
+                    suffix=".upload",
+                )
+                os.close(fd)
+                file_bytes = 0
                 try:
+                    with open(temp_path, "wb") as out:
+                        while True:
+                            chunk = await upload.read(chunk_size)
+                            if not chunk:
+                                break
+                            next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                            if next_total > cap_bytes:
+                                raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                            out.write(chunk)
+                            file_bytes += len(chunk)
+                    os.replace(temp_path, target)
+                    return file_bytes, workspace_used - existing_size + file_bytes
+                except Exception:
                     with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        await up.seek(0)
-                    with zipfile.ZipFile(up.file) as zf:
-                        for member in zf.infolist():
-                            if member.is_dir():
-                                continue
-                            if (member.external_attr >> 16) & 0xF000 == 0xA000:
-                                continue
-                            target = safe_join(ws_root, member.filename)
-                            if target is None:
-                                continue
-                            with zf.open(member) as fileobj:
-                                file_bytes, workspace_used = _stream_reader_to_target(
-                                    target,
-                                    fileobj.read,
-                                    workspace_used=workspace_used,
-                                )
-                            written += file_bytes
-                            count += 1
-                except HTTPException:
+                        os.unlink(temp_path)
                     raise
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"Failed to extract zip: {e}")
-            else:
-                target = safe_join(ws_root, up.filename or f"file_{count}")
-                if target is None:
-                    continue
-                try:
-                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
-                        await up.seek(0)
-                    file_bytes, workspace_used = await _stream_upload_to_target(
-                        up,
-                        target,
-                        workspace_used=workspace_used,
-                    )
-                except HTTPException:
-                    raise
-                except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-                    logger.warning(f"Failed reading upload file {up.filename}: {e}")
-                    continue
-                written += file_bytes
-                count += 1
+
+            workspace_used = _workspace_usage_bytes(ws_root)
+
+            for up in files:
+                lower = (up.filename or "").lower()
+                if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
+                    try:
+                        with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                            await up.seek(0)
+                        with tarfile.open(fileobj=up.file, mode="r:*") as tf:
+                            for member in tf.getmembers():
+                                if member.isdev() or member.issym() or member.islnk():
+                                    continue
+                                target = safe_join(ws_root, member.name)
+                                if target is None:
+                                    continue
+                                if member.isdir():
+                                    os.makedirs(target, exist_ok=True)
+                                    continue
+                                fileobj = tf.extractfile(member)
+                                if fileobj is None:
+                                    continue
+                                try:
+                                    file_bytes, workspace_used = _stream_reader_to_target(
+                                        target,
+                                        fileobj.read,
+                                        workspace_used=workspace_used,
+                                    )
+                                finally:
+                                    with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                                        fileobj.close()
+                                written += file_bytes
+                                count += 1
+                    except HTTPException:
+                        raise
+                    except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(f"Failed to extract tar: {e}")
+                elif lower.endswith(".zip"):
+                    try:
+                        with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                            await up.seek(0)
+                        with zipfile.ZipFile(up.file) as zf:
+                            for member in zf.infolist():
+                                if member.is_dir():
+                                    continue
+                                if (member.external_attr >> 16) & 0xF000 == 0xA000:
+                                    continue
+                                target = safe_join(ws_root, member.filename)
+                                if target is None:
+                                    continue
+                                with zf.open(member) as fileobj:
+                                    file_bytes, workspace_used = _stream_reader_to_target(
+                                        target,
+                                        fileobj.read,
+                                        workspace_used=workspace_used,
+                                    )
+                                written += file_bytes
+                                count += 1
+                    except HTTPException:
+                        raise
+                    except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(f"Failed to extract zip: {e}")
+                else:
+                    target = safe_join(ws_root, up.filename or f"file_{count}")
+                    if target is None:
+                        continue
+                    try:
+                        with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                            await up.seek(0)
+                        file_bytes, workspace_used = await _stream_upload_to_target(
+                            up,
+                            target,
+                            workspace_used=workspace_used,
+                        )
+                    except HTTPException:
+                        raise
+                    except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                        logger.warning(f"Failed reading upload file {up.filename}: {e}")
+                        continue
+                    written += file_bytes
+                    count += 1
+    except ValueError as e:
+        if str(e) == "session_not_found":
+            raise HTTPException(status_code=404, detail="session_not_found") from e
+        raise
 
     # Metrics
     try:
@@ -1434,6 +1389,8 @@ async def start_run(
                     "details": e.details,
                 }
             })
+        if isinstance(e, ValueError) and str(e) == "session_not_found":
+            raise HTTPException(status_code=404, detail="session_not_found") from e
         raise
     try:
         rt = (status.runtime.value if status.runtime else (payload.runtime or "unknown"))

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import mimetypes
 import os
+import tempfile
 import threading
 import time
 
@@ -24,7 +25,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 from loguru import logger
 
@@ -296,6 +297,15 @@ def _require_session_owner(session_id: str, current_user: User) -> str:
     if not _is_admin_user(current_user) and str(owner) != str(current_user.id):
         raise HTTPException(status_code=404, detail="session_not_found")
     return str(owner)
+
+
+def _model_field_names(model: object | None) -> set[str]:
+    if model is None:
+        return set()
+    fields = getattr(model, "model_fields_set", None)
+    if fields is None:
+        fields = getattr(model, "__fields_set__", set())
+    return {str(field) for field in (fields or set())}
 
 
 def _looks_like_jwt(token: str | None) -> bool:
@@ -720,6 +730,13 @@ async def create_session(
         id=session.id,
         runtime=session.runtime.value,
         base_image=session.base_image,
+        cpu_limit=session.cpu_limit,
+        memory_mb=session.memory_mb,
+        timeout_sec=session.timeout_sec,
+        network_policy=session.network_policy,
+        env=dict(session.env or {}),
+        labels=dict(session.labels or {}),
+        trust_level=(session.trust_level.value if session.trust_level else None),
         expires_at=session.expires_at,
         policy_hash=ph,
         persona_id=session.persona_id,
@@ -898,86 +915,177 @@ async def upload_files(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
         cap_mb = 256
     cap_bytes = cap_mb * 1024 * 1024
+    chunk_size = 64 * 1024
     written = 0
     count = 0
 
-    import io
     import tarfile
     import zipfile
-    for up in files:
+    def _workspace_usage_bytes(root: str) -> int:
+        total = 0
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for filename in filenames:
+                full_path = os.path.join(dirpath, filename)
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    if os.path.isfile(full_path):
+                        total += int(os.path.getsize(full_path))
+        return total
+
+    def _existing_file_size(target: str) -> int:
         try:
-            content = await up.read()
-        except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
-            logger.warning(f"Failed reading upload file {up.filename}: {e}")
-            continue
-        if written + len(content) > cap_bytes:
-            raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+            if os.path.isfile(target):
+                return int(os.path.getsize(target))
+        except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            return 0
+        return 0
+
+    def _stream_reader_to_target(
+        target: str,
+        read_chunk,
+        *,
+        workspace_used: int,
+    ) -> tuple[int, int]:
+        parent = os.path.dirname(target)
+        os.makedirs(parent, exist_ok=True)
+        existing_size = _existing_file_size(target)
+        fd, temp_path = tempfile.mkstemp(
+            dir=parent,
+            prefix=f".{os.path.basename(target)}.",
+            suffix=".upload",
+        )
+        os.close(fd)
+        file_bytes = 0
+        try:
+            with open(temp_path, "wb") as out:
+                while True:
+                    chunk = read_chunk(chunk_size)
+                    if not chunk:
+                        break
+                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                    if next_total > cap_bytes:
+                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                    out.write(chunk)
+                    file_bytes += len(chunk)
+            os.replace(temp_path, target)
+            return file_bytes, workspace_used - existing_size + file_bytes
+        except Exception:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                os.unlink(temp_path)
+            raise
+
+    async def _stream_upload_to_target(
+        upload: UploadFile,
+        target: str,
+        *,
+        workspace_used: int,
+    ) -> tuple[int, int]:
+        parent = os.path.dirname(target)
+        os.makedirs(parent, exist_ok=True)
+        existing_size = _existing_file_size(target)
+        fd, temp_path = tempfile.mkstemp(
+            dir=parent,
+            prefix=f".{os.path.basename(target)}.",
+            suffix=".upload",
+        )
+        os.close(fd)
+        file_bytes = 0
+        try:
+            with open(temp_path, "wb") as out:
+                while True:
+                    chunk = await upload.read(chunk_size)
+                    if not chunk:
+                        break
+                    next_total = workspace_used - existing_size + file_bytes + len(chunk)
+                    if next_total > cap_bytes:
+                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
+                    out.write(chunk)
+                    file_bytes += len(chunk)
+            os.replace(temp_path, target)
+            return file_bytes, workspace_used - existing_size + file_bytes
+        except Exception:
+            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                os.unlink(temp_path)
+            raise
+
+    workspace_used = _workspace_usage_bytes(ws_root)
+
+    for up in files:
         lower = (up.filename or "").lower()
         if lower.endswith((".tar", ".tar.gz", ".tgz", ".tar.bz2", ".tbz2")):
             try:
-                mode = "r:*"
-                tf = tarfile.open(fileobj=io.BytesIO(content), mode=mode)
-                for m in tf.getmembers():
-                    # Skip device files, symlinks, and hard links
-                    if m.isdev() or m.issym() or m.islnk():
-                        continue
-                    # Use secure path join to prevent traversal
-                    target = safe_join(ws_root, m.name)
-                    if target is None:
-                        # Path traversal attempt detected, skip this entry
-                        continue
-                    if m.isdir():
-                        os.makedirs(target, exist_ok=True)
-                        continue
-                    os.makedirs(os.path.dirname(target), exist_ok=True)
-                    f = tf.extractfile(m)
-                    if f is None:
-                        continue
-                    data = f.read()
-                    if written + len(data) > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    with open(target, "wb") as out:
-                        out.write(data)
-                    written += len(data)
-                    count += 1
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                with tarfile.open(fileobj=up.file, mode="r:*") as tf:
+                    for member in tf.getmembers():
+                        if member.isdev() or member.issym() or member.islnk():
+                            continue
+                        target = safe_join(ws_root, member.name)
+                        if target is None:
+                            continue
+                        if member.isdir():
+                            os.makedirs(target, exist_ok=True)
+                            continue
+                        fileobj = tf.extractfile(member)
+                        if fileobj is None:
+                            continue
+                        try:
+                            file_bytes, workspace_used = _stream_reader_to_target(
+                                target,
+                                fileobj.read,
+                                workspace_used=workspace_used,
+                            )
+                        finally:
+                            with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                                fileobj.close()
+                        written += file_bytes
+                        count += 1
+            except HTTPException:
+                raise
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Failed to extract tar: {e}")
         elif lower.endswith(".zip"):
             try:
-                zf = zipfile.ZipFile(io.BytesIO(content))
-                for m in zf.infolist():
-                    if m.is_dir():
-                        continue
-                    # Check for symlinks in zip files (external_attr >> 28 == 0xA indicates symlink)
-                    # Unix symlink mode is 0o120000 (0xA000), stored in high 16 bits of external_attr
-                    if (m.external_attr >> 16) & 0xF000 == 0xA000:
-                        continue
-                    name = m.filename
-                    # Use secure path join to prevent traversal
-                    target = safe_join(ws_root, name)
-                    if target is None:
-                        # Path traversal attempt detected, skip this entry
-                        continue
-                    data = zf.read(m)
-                    if written + len(data) > cap_bytes:
-                        raise HTTPException(status_code=413, detail="workspace_cap_exceeded")
-                    os.makedirs(os.path.dirname(target), exist_ok=True)
-                    with open(target, "wb") as out:
-                        out.write(data)
-                    written += len(data)
-                    count += 1
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                with zipfile.ZipFile(up.file) as zf:
+                    for member in zf.infolist():
+                        if member.is_dir():
+                            continue
+                        if (member.external_attr >> 16) & 0xF000 == 0xA000:
+                            continue
+                        target = safe_join(ws_root, member.filename)
+                        if target is None:
+                            continue
+                        with zf.open(member) as fileobj:
+                            file_bytes, workspace_used = _stream_reader_to_target(
+                                target,
+                                fileobj.read,
+                                workspace_used=workspace_used,
+                            )
+                        written += file_bytes
+                        count += 1
+            except HTTPException:
+                raise
             except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
                 logger.warning(f"Failed to extract zip: {e}")
         else:
-            # Use secure path join for regular file uploads
             target = safe_join(ws_root, up.filename or f"file_{count}")
             if target is None:
-                # Path traversal attempt detected, skip this file
                 continue
-            os.makedirs(os.path.dirname(target), exist_ok=True)
-            with open(target, "wb") as out:
-                out.write(content)
-            written += len(content)
+            try:
+                with contextlib.suppress(_SANDBOX_NONCRITICAL_EXCEPTIONS):
+                    await up.seek(0)
+                file_bytes, workspace_used = await _stream_upload_to_target(
+                    up,
+                    target,
+                    workspace_used=workspace_used,
+                )
+            except HTTPException:
+                raise
+            except _SANDBOX_NONCRITICAL_EXCEPTIONS as e:
+                logger.warning(f"Failed reading upload file {up.filename}: {e}")
+                continue
+            written += file_bytes
             count += 1
 
     # Metrics
@@ -1044,9 +1152,24 @@ async def start_run(
         HTTPException: 409 with code "idempotency_conflict" when an idempotent request conflicts.
         HTTPException: 400 with code "invalid_spec_version" when the provided spec_version is unsupported.
     """
+    session = None
     if payload.session_id:
         _require_session_owner(payload.session_id, current_user)
-    files_inline = _service.parse_inline_files([f.dict() for f in (payload.files or [])])
+        session = _service.get_session(payload.session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="session_not_found")
+    try:
+        files_inline = _service.parse_inline_files([(f.model_dump() if hasattr(f, "model_dump") else f.dict()) for f in (payload.files or [])])
+    except ValueError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": {
+                    "code": "invalid_inline_file",
+                    "message": str(e),
+                }
+            },
+        ) from e
     try:
         default_exec_to = int(getattr(app_settings, "SANDBOX_DEFAULT_EXEC_TIMEOUT_SEC", 300))
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
@@ -1057,17 +1180,71 @@ async def start_run(
     except _SANDBOX_NONCRITICAL_EXCEPTIONS:
         default_startup_to = 20
 
+    payload_fields = _model_field_names(payload)
+    resource_fields = _model_field_names(payload.resources)
+
+    runtime = (CoreRuntimeType(payload.runtime) if payload.runtime else None) if "runtime" in payload_fields else None
+    if runtime is None and session is not None and session.runtime is not None:
+        runtime = session.runtime
+
+    base_image = payload.base_image if "base_image" in payload_fields else None
+    if base_image is None and session is not None and session.base_image:
+        base_image = session.base_image
+    if payload.session_id and not base_image:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": {
+                    "code": "session_base_image_required",
+                    "message": "Session-backed runs require a base_image",
+                }
+            },
+        )
+
+    env = dict(payload.env or {}) if "env" in payload_fields else (
+        dict(session.env or {}) if session is not None else {}
+    )
+    timeout_sec = int(payload.timeout_sec) if "timeout_sec" in payload_fields else (
+        int(session.timeout_sec) if session is not None and session.timeout_sec is not None else default_exec_to
+    )
+    cpu = (payload.resources.cpu if payload.resources else None) if "cpu" in resource_fields else (
+        session.cpu_limit if session is not None else None
+    )
+    memory_mb = (payload.resources.memory_mb if payload.resources else None) if "memory_mb" in resource_fields else (
+        session.memory_mb if session is not None else None
+    )
+    network_policy = payload.network_policy if "network_policy" in payload_fields else (
+        session.network_policy if session is not None else None
+    )
+    trust_level = (
+        CoreTrustLevel(payload.trust_level) if payload.trust_level else None
+    ) if "trust_level" in payload_fields else (
+        session.trust_level if session is not None else None
+    )
+    persona_id = payload.persona_id if "persona_id" in payload_fields else (
+        session.persona_id if session is not None else None
+    )
+    workspace_id = payload.workspace_id if "workspace_id" in payload_fields else (
+        session.workspace_id if session is not None else None
+    )
+    workspace_group_id = payload.workspace_group_id if "workspace_group_id" in payload_fields else (
+        session.workspace_group_id if session is not None else None
+    )
+    scope_snapshot_id = payload.scope_snapshot_id if "scope_snapshot_id" in payload_fields else (
+        session.scope_snapshot_id if session is not None else None
+    )
+
     spec = RunSpec(
         session_id=payload.session_id,
-        runtime=(CoreRuntimeType(payload.runtime) if payload.runtime else None),
-        base_image=payload.base_image,
+        runtime=runtime,
+        base_image=base_image,
         command=list(payload.command),
-        env=payload.env or {},
+        env=env,
         startup_timeout_sec=payload.startup_timeout_sec or default_startup_to,
-        timeout_sec=payload.timeout_sec or default_exec_to,
-        cpu=(payload.resources.cpu if payload.resources else None) if hasattr(payload, "resources") and payload.resources else None,
-        memory_mb=(payload.resources.memory_mb if payload.resources else None) if hasattr(payload, "resources") and payload.resources else None,
-        network_policy=payload.network_policy,
+        timeout_sec=timeout_sec,
+        cpu=cpu,
+        memory_mb=memory_mb,
+        network_policy=network_policy,
         files_inline=files_inline,
         capture_patterns=payload.capture_patterns or [],
         interactive=(bool(payload.interactive) if hasattr(payload, "interactive") and payload.interactive is not None else None),
@@ -1075,11 +1252,11 @@ async def start_run(
         stdin_max_frame_bytes=(int(payload.stdin_max_frame_bytes) if hasattr(payload, "stdin_max_frame_bytes") and payload.stdin_max_frame_bytes is not None else None),
         stdin_bps=(int(payload.stdin_bps) if hasattr(payload, "stdin_bps") and payload.stdin_bps is not None else None),
         stdin_idle_timeout_sec=(int(payload.stdin_idle_timeout_sec) if hasattr(payload, "stdin_idle_timeout_sec") and payload.stdin_idle_timeout_sec is not None else None),
-        trust_level=(CoreTrustLevel(payload.trust_level) if hasattr(payload, "trust_level") and payload.trust_level else None),
-        persona_id=payload.persona_id,
-        workspace_id=payload.workspace_id,
-        workspace_group_id=payload.workspace_group_id,
-        scope_snapshot_id=payload.scope_snapshot_id,
+        trust_level=trust_level,
+        persona_id=persona_id,
+        workspace_id=workspace_id,
+        workspace_group_id=workspace_group_id,
+        scope_snapshot_id=scope_snapshot_id,
     )
     # Scaffold: return immediate completed status without real execution
     try:
@@ -1532,10 +1709,19 @@ async def download_artifact(
         or ".." in raw
     ):
         raise HTTPException(status_code=400, detail="invalid_path")
-    data = _service._orch.get_artifact(run_id, path)  # type: ignore[attr-defined]
-    if data is None:
-        raise HTTPException(status_code=404, detail="artifact_not_found")
-    size = len(data)
+
+    artifact_path = _service._orch.get_artifact_path(run_id, path)  # type: ignore[attr-defined]
+    data = None
+    if artifact_path is not None:
+        try:
+            size = int(artifact_path.stat().st_size)
+        except _SANDBOX_NONCRITICAL_EXCEPTIONS:
+            raise HTTPException(status_code=404, detail="artifact_not_found") from None
+    else:
+        data = _service._orch.get_artifact(run_id, path)  # type: ignore[attr-defined]
+        if data is None:
+            raise HTTPException(status_code=404, detail="artifact_not_found")
+        size = len(data)
     ctype, _ = mimetypes.guess_type(path)
     ctype = ctype or "application/octet-stream"
 
@@ -1566,6 +1752,19 @@ async def download_artifact(
         except _SANDBOX_NONCRITICAL_EXCEPTIONS:
             return None
 
+    def _iter_artifact_file(file_path: str, start: int, end: int):
+        if end < start:
+            return
+        remaining = end - start + 1
+        with open(file_path, "rb") as handle:
+            handle.seek(start)
+            while remaining > 0:
+                chunk = handle.read(min(64 * 1024, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+                yield chunk
+
     headers = {"Accept-Ranges": "bytes"}
     if range_header:
         rng = _parse_range(range_header)
@@ -1573,14 +1772,27 @@ async def download_artifact(
             # Invalid or unsupported range
             return Response(status_code=416, headers={"Content-Range": f"bytes */{size}"})
         start, end = rng
-        chunk = data[start:end + 1]
+        chunk_len = end - start + 1
         headers.update({
             "Content-Range": f"bytes {start}-{end}/{size}",
-            "Content-Length": str(len(chunk)),
+            "Content-Length": str(chunk_len),
         })
-        return Response(content=chunk, media_type=ctype, headers=headers, status_code=206)
-    # Default: return full content
+        if artifact_path is not None:
+            return StreamingResponse(
+                _iter_artifact_file(str(artifact_path), start, end),
+                media_type=ctype,
+                headers=headers,
+                status_code=206,
+            )
+        return Response(content=data[start:end + 1], media_type=ctype, headers=headers, status_code=206)
+
     headers["Content-Length"] = str(size)
+    if artifact_path is not None:
+        return StreamingResponse(
+            _iter_artifact_file(str(artifact_path), 0, size - 1),
+            media_type=ctype,
+            headers=headers,
+        )
     return Response(content=data, media_type=ctype, headers=headers)
 
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -4,6 +4,10 @@ from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
+try:
+    from pydantic import model_validator
+except ImportError:  # pragma: no cover - pydantic v1 fallback
+    from pydantic import root_validator as model_validator  # type: ignore
 
 RuntimeType = Literal["docker", "firecracker", "lima"]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
@@ -60,6 +64,13 @@ class SandboxSession(BaseModel):
     id: str
     runtime: RuntimeType
     base_image: str | None = None
+    cpu_limit: float | None = None
+    memory_mb: int | None = None
+    timeout_sec: int | None = None
+    network_policy: Literal["deny_all", "allowlist"] | None = None
+    env: dict[str, str] | None = None
+    labels: dict[str, str] | None = None
+    trust_level: TrustLevelType | None = None
     expires_at: datetime | None = None
     policy_hash: str | None = None
     persona_id: str | None = None
@@ -114,6 +125,14 @@ class SandboxRunCreateRequest(BaseModel):
     workspace_id: str | None = Field(default=None, description="Optional workspace identifier bound to this run")
     workspace_group_id: str | None = Field(default=None, description="Optional workspace-group identifier bound to this run")
     scope_snapshot_id: str | None = Field(default=None, description="Optional scope snapshot identifier bound to this run")
+
+    @model_validator(mode="after")
+    def validate_session_or_base_image(self):
+        has_session = isinstance(self.session_id, str) and bool(self.session_id.strip())
+        has_image = isinstance(self.base_image, str) and bool(self.base_image.strip())
+        if has_session == has_image:
+            raise ValueError("Provide exactly one of session_id or base_image")
+        return self
 
 
 class SandboxRun(BaseModel):

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -21,6 +21,7 @@ from loguru import logger
 
 from ....Sandbox.models import RunSpec
 from ....Sandbox.models import RuntimeType as SbxRuntimeType
+from ....Sandbox.models import TrustLevel
 from ....Sandbox.service import SandboxService
 from ..base import BaseModule
 
@@ -64,12 +65,17 @@ class SandboxModule(BaseModule):
                             }
                         },
                         "timeout_sec": {"type": "integer", "minimum": 1},
+                        "cpu": {"type": "number", "minimum": 0},
+                        "memory_mb": {"type": "integer", "minimum": 64},
+                        "network_policy": {"type": "string", "enum": ["deny_all", "allowlist"]},
                         "env": {"type": "object"},
+                        "trust_level": {"type": "string", "enum": ["trusted", "standard", "untrusted"]},
                         "persona_id": {"type": "string"},
                         "workspace_id": {"type": "string"},
                         "workspace_group_id": {"type": "string"},
                         "scope_snapshot_id": {"type": "string"},
-                        "spec_version": {"type": "string"}
+                        "spec_version": {"type": "string"},
+                        "idempotency_key": {"type": "string"},
                     },
                     "oneOf": [
                         {"required": ["session_id", "command"]},
@@ -89,61 +95,97 @@ class SandboxModule(BaseModule):
         # Validate strictly (write-capable tool)
         self.validate_tool_arguments(tool_name, args)
 
-        # Prepare RunSpec
-        runtime_raw = (args.get("runtime") or "").strip().lower()
-        runtime: SbxRuntimeType | None = None
-        if runtime_raw in ("docker", "firecracker", "lima"):
-            runtime = SbxRuntimeType(runtime_raw)
-        # files (inline)
-        files_inline: list[tuple[str, bytes]] = []
-        for f in (args.get("files") or []):
-            try:
-                p = str(f.get("path", ""))
-                b64 = str(f.get("content_b64", ""))
-                data = base64.b64decode(b64)
-                files_inline.append((p, data))
-            except (TypeError, ValueError, binascii.Error, AttributeError) as exc:
-                logger.debug("sandbox.run: skipping invalid inline file payload: {}", exc)
-                continue
-        command = [str(x) for x in (args.get("command") or [])]
+        # Require authenticated principal binding; no synthetic fallback identity.
+        user_id = getattr(context, "user_id", None) if context is not None else None
+        if user_id is None or not str(user_id).strip():
+            raise PermissionError("sandbox.run requires an authenticated user context")
+        user_id = str(user_id)
+
+        runtime = self._coerce_runtime(args.get("runtime"))
+        base_image = (str(args.get("base_image")).strip() if args.get("base_image") is not None else None) or None
         env = args.get("env") or {}
         if not isinstance(env, dict):
             env = {}
         timeout = int(args.get("timeout_sec") or 300)
+        cpu = float(args.get("cpu")) if args.get("cpu") is not None else None
+        memory_mb = int(args.get("memory_mb")) if args.get("memory_mb") is not None else None
+        network_policy = (str(args.get("network_policy")).strip() if args.get("network_policy") is not None else None) or None
+        trust_level = self._coerce_trust_level(args.get("trust_level"))
+        persona_id = (str(args.get("persona_id")) if args.get("persona_id") is not None else None)
+        workspace_id = (str(args.get("workspace_id")) if args.get("workspace_id") is not None else None)
+        workspace_group_id = (str(args.get("workspace_group_id")) if args.get("workspace_group_id") is not None else None)
+        scope_snapshot_id = (str(args.get("scope_snapshot_id")) if args.get("scope_snapshot_id") is not None else None)
+
+        session_id = args.get("session_id")
+        if session_id is not None:
+            session_id = str(session_id).strip() or None
+        if session_id:
+            owner = self._svc.get_session_owner(session_id)
+            if owner is None:
+                raise ValueError("session_not_found")
+            if not self._is_admin(context) and str(owner) != user_id:
+                raise PermissionError("sandbox.run session not found")
+            session = self._svc.get_session(session_id)
+            if session is None:
+                raise ValueError("session_not_found")
+            if "runtime" not in args and session.runtime is not None:
+                runtime = session.runtime
+            if "base_image" not in args and session.base_image:
+                base_image = session.base_image
+            if "env" not in args:
+                env = dict(session.env or {})
+            if "timeout_sec" not in args and session.timeout_sec is not None:
+                timeout = int(session.timeout_sec)
+            if "cpu" not in args and session.cpu_limit is not None:
+                cpu = float(session.cpu_limit)
+            if "memory_mb" not in args and session.memory_mb is not None:
+                memory_mb = int(session.memory_mb)
+            if "network_policy" not in args and session.network_policy:
+                network_policy = str(session.network_policy)
+            if "trust_level" not in args and session.trust_level is not None:
+                trust_level = session.trust_level
+            if "persona_id" not in args and session.persona_id is not None:
+                persona_id = str(session.persona_id)
+            if "workspace_id" not in args and session.workspace_id is not None:
+                workspace_id = str(session.workspace_id)
+            if "workspace_group_id" not in args and session.workspace_group_id is not None:
+                workspace_group_id = str(session.workspace_group_id)
+            if "scope_snapshot_id" not in args and session.scope_snapshot_id is not None:
+                scope_snapshot_id = str(session.scope_snapshot_id)
+            if not base_image:
+                raise ValueError("session-backed runs require a base_image")
+
+        files_inline = self._decode_inline_files(args.get("files") or [])
+        command = [str(x) for x in (args.get("command") or [])]
         spec = RunSpec(
-            session_id=args.get("session_id"),
+            session_id=session_id,
             runtime=runtime,
-            base_image=args.get("base_image"),
+            base_image=base_image,
             command=command,
             env={str(k): str(v) for k, v in env.items()},
             timeout_sec=timeout,
-            cpu=None,
-            memory_mb=None,
-            network_policy=None,
+            cpu=cpu,
+            memory_mb=memory_mb,
+            network_policy=network_policy,
             files_inline=files_inline,
             capture_patterns=[],
-            persona_id=(str(args.get("persona_id")) if args.get("persona_id") is not None else None),
-            workspace_id=(str(args.get("workspace_id")) if args.get("workspace_id") is not None else None),
-            workspace_group_id=(str(args.get("workspace_group_id")) if args.get("workspace_group_id") is not None else None),
-            scope_snapshot_id=(str(args.get("scope_snapshot_id")) if args.get("scope_snapshot_id") is not None else None),
+            trust_level=trust_level,
+            persona_id=persona_id,
+            workspace_id=workspace_id,
+            workspace_group_id=workspace_group_id,
+            scope_snapshot_id=scope_snapshot_id,
         )
 
-        # Spec version
         spec_version = str(args.get("spec_version") or "1.0")
-        # Idempotency optional
         idem_key = None
         try:
             idem_key = str(args.get("idempotency_key") or args.get("idempotencyKey") or "") or None
         except Exception:
             idem_key = None
 
-        # Require authenticated principal binding; no synthetic fallback identity.
-        user_id = getattr(context, "user_id", None) if context is not None else None
-        if user_id is None or not str(user_id).strip():
-            raise PermissionError("sandbox.run requires an authenticated user context")
         try:
             status = self._svc.start_run_scaffold(
-                user_id=str(user_id),
+                user_id=user_id,
                 spec=spec,
                 spec_version=spec_version,
                 idem_key=idem_key,
@@ -176,6 +218,41 @@ class SandboxModule(BaseModule):
             "workspace_group_id": status.workspace_group_id,
             "scope_snapshot_id": status.scope_snapshot_id,
         }
+
+    def _is_admin(self, context: Any | None) -> bool:
+        try:
+            if bool(getattr(context, "is_admin", False)):
+                return True
+            roles = (getattr(context, "metadata", {}) or {}).get("roles")
+            if isinstance(roles, str):
+                roles = [roles]
+            return isinstance(roles, list) and any(str(r).lower() == "admin" for r in roles)
+        except Exception:
+            return False
+
+    def _coerce_runtime(self, value: Any) -> SbxRuntimeType | None:
+        runtime_raw = (str(value).strip().lower() if value is not None else "")
+        if runtime_raw in ("docker", "firecracker", "lima"):
+            return SbxRuntimeType(runtime_raw)
+        return None
+
+    def _coerce_trust_level(self, value: Any) -> TrustLevel | None:
+        trust_raw = (str(value).strip().lower() if value is not None else "")
+        if trust_raw in ("trusted", "standard", "untrusted"):
+            return TrustLevel(trust_raw)
+        return None
+
+    def _decode_inline_files(self, files: list[dict[str, Any]]) -> list[tuple[str, bytes]]:
+        decoded: list[tuple[str, bytes]] = []
+        for index, file_entry in enumerate(files):
+            try:
+                path = str(file_entry.get("path", ""))
+                content_b64 = str(file_entry.get("content_b64", ""))
+                data = base64.b64decode(content_b64, validate=True)
+            except (TypeError, ValueError, binascii.Error, AttributeError) as exc:
+                raise ValueError(f"invalid inline file at index {index}") from exc
+            decoded.append((path, data))
+        return decoded
 
     def sanitize_input(self, input_data: Any, _depth: int = 0) -> Any:
         """
@@ -227,3 +304,25 @@ class SandboxModule(BaseModule):
             for i, f in enumerate(files):
                 if not isinstance(f, dict) or not f.get("path") or not f.get("content_b64"):
                     raise ValueError(f"files[{i}] must include path and content_b64")
+                try:
+                    base64.b64decode(str(f.get("content_b64", "")), validate=True)
+                except (TypeError, ValueError, binascii.Error):
+                    raise ValueError(f"files[{i}].content_b64 must be valid base64") from None
+        if arguments.get("cpu") is not None:
+            try:
+                cpu = float(arguments.get("cpu"))
+                if cpu < 0:
+                    raise ValueError
+            except Exception:
+                raise ValueError("cpu must be a non-negative number") from None
+        if arguments.get("memory_mb") is not None:
+            try:
+                memory_mb = int(arguments.get("memory_mb"))
+                if memory_mb < 64:
+                    raise ValueError
+            except Exception:
+                raise ValueError("memory_mb must be an integer >= 64") from None
+        if arguments.get("network_policy") is not None and str(arguments.get("network_policy")) not in {"deny_all", "allowlist"}:
+            raise ValueError("network_policy must be deny_all|allowlist when provided")
+        if arguments.get("trust_level") is not None and str(arguments.get("trust_level")).lower() not in {"trusted", "standard", "untrusted"}:
+            raise ValueError("trust_level must be trusted|standard|untrusted when provided")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -223,10 +223,20 @@ class SandboxModule(BaseModule):
         try:
             if bool(getattr(context, "is_admin", False)):
                 return True
-            roles = (getattr(context, "metadata", {}) or {}).get("roles")
+            metadata = getattr(context, "metadata", {}) or {}
+            roles = metadata.get("roles")
             if isinstance(roles, str):
                 roles = [roles]
-            return isinstance(roles, list) and any(str(r).lower() == "admin" for r in roles)
+            if isinstance(roles, list) and any(str(r).strip().lower() == "admin" for r in roles):
+                return True
+            permissions = metadata.get("permissions")
+            if isinstance(permissions, str):
+                permissions = [permissions]
+            if isinstance(permissions, list):
+                normalized = {str(permission).strip().lower() for permission in permissions if str(permission).strip()}
+                if "*" in normalized or "system.configure" in normalized:
+                    return True
+            return False
         except Exception:
             return False
 

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -125,35 +125,6 @@ class SandboxModule(BaseModule):
                 raise ValueError("session_not_found")
             if not self._is_admin(context) and str(owner) != user_id:
                 raise PermissionError("sandbox.run session not found")
-            session = self._svc.get_session(session_id)
-            if session is None:
-                raise ValueError("session_not_found")
-            if "runtime" not in args and session.runtime is not None:
-                runtime = session.runtime
-            if "base_image" not in args and session.base_image:
-                base_image = session.base_image
-            if "env" not in args:
-                env = dict(session.env or {})
-            if "timeout_sec" not in args and session.timeout_sec is not None:
-                timeout = int(session.timeout_sec)
-            if "cpu" not in args and session.cpu_limit is not None:
-                cpu = float(session.cpu_limit)
-            if "memory_mb" not in args and session.memory_mb is not None:
-                memory_mb = int(session.memory_mb)
-            if "network_policy" not in args and session.network_policy:
-                network_policy = str(session.network_policy)
-            if "trust_level" not in args and session.trust_level is not None:
-                trust_level = session.trust_level
-            if "persona_id" not in args and session.persona_id is not None:
-                persona_id = str(session.persona_id)
-            if "workspace_id" not in args and session.workspace_id is not None:
-                workspace_id = str(session.workspace_id)
-            if "workspace_group_id" not in args and session.workspace_group_id is not None:
-                workspace_group_id = str(session.workspace_group_id)
-            if "scope_snapshot_id" not in args and session.scope_snapshot_id is not None:
-                scope_snapshot_id = str(session.scope_snapshot_id)
-            if not base_image:
-                raise ValueError("session-backed runs require a base_image")
 
         files_inline = self._decode_inline_files(args.get("files") or [])
         command = [str(x) for x in (args.get("command") or [])]
@@ -190,6 +161,7 @@ class SandboxModule(BaseModule):
                 spec_version=spec_version,
                 idem_key=idem_key,
                 raw_body=args,
+                explicit_fields={str(key) for key in args.keys()},
             )
         except Exception as e:
             raise RuntimeError(f"Sandbox execution failed: {e}") from e

--- a/tldw_Server_API/app/core/Sandbox/models.py
+++ b/tldw_Server_API/app/core/Sandbox/models.py
@@ -46,6 +46,13 @@ class Session:
     runtime: RuntimeType
     base_image: str | None
     expires_at: datetime | None
+    cpu_limit: float | None = None
+    memory_mb: int | None = None
+    timeout_sec: int = 300
+    network_policy: str = "deny_all"
+    env: dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
+    trust_level: TrustLevel | None = None
     persona_id: str | None = None
     workspace_id: str | None = None
     workspace_group_id: str | None = None

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -1194,12 +1194,6 @@ class SandboxOrchestrator:
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
             cap_user = 128 * 1024 * 1024
 
-        # Determine remaining budget
-        try:
-            current_user_bytes = int(self._store.get_user_artifact_bytes(owner))
-        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
-            current_user_bytes = 0
-
         selected: dict[str, bytes] = {}
         total_run = 0
         # Deterministic order
@@ -1208,16 +1202,20 @@ class SandboxOrchestrator:
             sz = len(data)
             if total_run + sz > cap_run:
                 break
-            if current_user_bytes + sz > cap_user:
+            try:
+                admitted = bool(self._store.try_reserve_user_artifact_bytes(owner, sz, cap_user))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                admitted = False
+            if not admitted:
                 break
             selected[path] = data
             total_run += sz
-            current_user_bytes += sz
 
         # Persist selected to FS and memory map for backward compatibility
         art_dir = self._artifact_dir(owner, run_id)
         with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
             art_dir.mkdir(parents=True, exist_ok=True)
+        persisted: dict[str, bytes] = {}
         for path, data in selected.items():
             rel = self._safe_rel(path)
             full = art_dir / rel
@@ -1227,11 +1225,13 @@ class SandboxOrchestrator:
                     f.write(data)
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"Failed to persist artifact {rel}: {e}")
+                with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
+                    self._store.increment_user_artifact_bytes(owner, -len(data))
+                continue
+            persisted[path] = data
 
         with self._lock:
-            self._artifacts[run_id] = selected
-        with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
-            self._store.increment_user_artifact_bytes(owner, int(total_run))
+            self._artifacts[run_id] = persisted
 
     def list_artifacts(self, run_id: str) -> dict[str, int]:
         self._maybe_prune_expired_artifacts()

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -18,7 +18,7 @@ from loguru import logger
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.testing import is_truthy
 
-from .models import RunPhase, RunSpec, RunStatus, RuntimeType, Session, SessionSpec
+from .models import RunPhase, RunSpec, RunStatus, RuntimeType, Session, SessionSpec, TrustLevel
 from .policy import SandboxPolicy, SandboxPolicyConfig
 from .store import IdempotencyConflict as StoreIdemConflict
 from .store import get_store
@@ -211,11 +211,51 @@ class SandboxOrchestrator:
                 expires_at = datetime.fromisoformat(str(expires_raw))
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
                 expires_at = None
+        cpu_limit = None
+        if record.get("cpu_limit") is not None:
+            try:
+                cpu_limit = float(record.get("cpu_limit"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                cpu_limit = None
+        memory_mb = None
+        if record.get("memory_mb") is not None:
+            try:
+                memory_mb = int(record.get("memory_mb"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                memory_mb = None
+        timeout_sec = 300
+        if record.get("timeout_sec") is not None:
+            try:
+                timeout_sec = int(record.get("timeout_sec"))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                timeout_sec = 300
+        trust_level = None
+        trust_raw = record.get("trust_level")
+        if trust_raw:
+            try:
+                trust_level = TrustLevel(str(trust_raw))
+            except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+                trust_level = None
         return Session(
             id=sid,
             runtime=runtime,
             base_image=(str(record.get("base_image")) if record.get("base_image") is not None else None),
             expires_at=expires_at,
+            cpu_limit=cpu_limit,
+            memory_mb=memory_mb,
+            timeout_sec=timeout_sec,
+            network_policy=(str(record.get("network_policy") or "deny_all")),
+            env=(
+                {str(k): str(v) for k, v in (record.get("env") or {}).items()}
+                if isinstance(record.get("env"), dict)
+                else {}
+            ),
+            labels=(
+                {str(k): str(v) for k, v in (record.get("labels") or {}).items()}
+                if isinstance(record.get("labels"), dict)
+                else {}
+            ),
+            trust_level=trust_level,
             persona_id=(str(record.get("persona_id")) if record.get("persona_id") is not None else None),
             workspace_id=(str(record.get("workspace_id")) if record.get("workspace_id") is not None else None),
             workspace_group_id=(str(record.get("workspace_group_id")) if record.get("workspace_group_id") is not None else None),
@@ -301,6 +341,41 @@ class SandboxOrchestrator:
                 runtime=runtime,
                 base_image=(stored.get("base_image") if stored.get("base_image") is not None else spec.base_image),
                 expires_at=expires_at,
+                cpu_limit=(
+                    float(stored.get("cpu_limit"))
+                    if stored.get("cpu_limit") is not None
+                    else spec.cpu_limit
+                ),
+                memory_mb=(
+                    int(stored.get("memory_mb"))
+                    if stored.get("memory_mb") is not None
+                    else spec.memory_mb
+                ),
+                timeout_sec=(
+                    int(stored.get("timeout_sec"))
+                    if stored.get("timeout_sec") is not None
+                    else spec.timeout_sec
+                ),
+                network_policy=(
+                    str(stored.get("network_policy"))
+                    if stored.get("network_policy") is not None
+                    else spec.network_policy
+                ),
+                env=(
+                    {str(k): str(v) for k, v in (stored.get("env") or {}).items()}
+                    if isinstance(stored.get("env"), dict)
+                    else dict(spec.env or {})
+                ),
+                labels=(
+                    {str(k): str(v) for k, v in (stored.get("labels") or {}).items()}
+                    if isinstance(stored.get("labels"), dict)
+                    else dict(spec.labels or {})
+                ),
+                trust_level=(
+                    TrustLevel(str(stored.get("trust_level")))
+                    if stored.get("trust_level") is not None
+                    else spec.trust_level
+                ),
                 persona_id=(
                     str(stored.get("persona_id"))
                     if stored.get("persona_id") is not None
@@ -332,6 +407,13 @@ class SandboxOrchestrator:
                     session_id=sid_str,
                     runtime=sess.runtime.value if sess.runtime else None,
                     base_image=sess.base_image,
+                    cpu_limit=sess.cpu_limit,
+                    memory_mb=sess.memory_mb,
+                    timeout_sec=sess.timeout_sec,
+                    network_policy=sess.network_policy,
+                    env=sess.env,
+                    labels=sess.labels,
+                    trust_level=(sess.trust_level.value if sess.trust_level else None),
                     expires_at_iso=(sess.expires_at.isoformat() if sess.expires_at else None),
                     workspace_path=ws_path,
                     persona_id=sess.persona_id,
@@ -357,6 +439,13 @@ class SandboxOrchestrator:
             runtime=spec.runtime or self.policy.cfg.default_runtime,
             base_image=spec.base_image,
             expires_at=expires_at,
+            cpu_limit=spec.cpu_limit,
+            memory_mb=spec.memory_mb,
+            timeout_sec=spec.timeout_sec,
+            network_policy=spec.network_policy,
+            env=dict(spec.env or {}),
+            labels=dict(spec.labels or {}),
+            trust_level=spec.trust_level,
             persona_id=spec.persona_id,
             workspace_id=spec.workspace_id,
             workspace_group_id=spec.workspace_group_id,
@@ -372,6 +461,13 @@ class SandboxOrchestrator:
                 session_id=sid,
                 runtime=sess.runtime.value if sess.runtime else None,
                 base_image=sess.base_image,
+                cpu_limit=sess.cpu_limit,
+                memory_mb=sess.memory_mb,
+                timeout_sec=sess.timeout_sec,
+                network_policy=sess.network_policy,
+                env=sess.env,
+                labels=sess.labels,
+                trust_level=(sess.trust_level.value if sess.trust_level else None),
                 expires_at_iso=(sess.expires_at.isoformat() if sess.expires_at else None),
                 workspace_path=ws_path,
                 persona_id=sess.persona_id,
@@ -386,6 +482,13 @@ class SandboxOrchestrator:
             "id": sid,
             "runtime": sess.runtime.value,
             "base_image": sess.base_image,
+            "cpu_limit": sess.cpu_limit,
+            "memory_mb": sess.memory_mb,
+            "timeout_sec": sess.timeout_sec,
+            "network_policy": sess.network_policy,
+            "env": dict(sess.env or {}),
+            "labels": dict(sess.labels or {}),
+            "trust_level": (sess.trust_level.value if sess.trust_level else None),
             "expires_at": (sess.expires_at.isoformat() if sess.expires_at else None),
             "persona_id": sess.persona_id,
             "workspace_id": sess.workspace_id,
@@ -1175,6 +1278,23 @@ class SandboxOrchestrator:
         with self._lock:
             mapping = self._artifacts.get(run_id) or {}
             return mapping.get(path)
+
+    def get_artifact_path(self, run_id: str, path: str) -> Path | None:
+        self._maybe_prune_expired_artifacts()
+        owner = None
+        try:
+            owner = self._store.get_run_owner(run_id)
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            owner = None
+        art_dir = self._artifact_dir((owner or "unknown"), run_id)
+        rel = self._safe_rel(path)
+        full = art_dir / rel
+        try:
+            if full.exists() and full.is_file():
+                return full
+        except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
+            return None
+        return None
 
     # -----------------
     # Workspaces

--- a/tldw_Server_API/app/core/Sandbox/orchestrator.py
+++ b/tldw_Server_API/app/core/Sandbox/orchestrator.py
@@ -270,7 +270,7 @@ class SandboxOrchestrator:
             self._sessions.pop(sid, None)
             self._session_roots.pop(sid, None)
 
-    def get_session(self, session_id: str) -> Session | None:
+    def get_session(self, session_id: str, *, allow_cache_on_store_error: bool = True) -> Session | None:
         sid = str(session_id or "").strip()
         if not sid:
             return None
@@ -283,7 +283,9 @@ class SandboxOrchestrator:
                 record = self._store.get_session(sid)
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
                 logger.debug(f"store.get_session failed during cache validation: {e}")
-                return cached
+                if allow_cache_on_store_error:
+                    return cached
+                return None
             if not isinstance(record, dict):
                 self._drop_cached_session(sid)
                 return None
@@ -832,7 +834,7 @@ class SandboxOrchestrator:
             except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS:
                 continue
 
-    def destroy_session(self, session_id: str) -> bool:
+    def destroy_session(self, session_id: str, *, remove_workspace_tree: bool = True) -> bool:
         sid = str(session_id or "").strip()
         if not sid:
             return False
@@ -887,9 +889,11 @@ class SandboxOrchestrator:
                 owner = "unknown"
             with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
                 self._remove_run_artifacts(rid, owner=owner, decrement_usage=True)
-        if ws_path:
+        if remove_workspace_tree and ws_path:
             with contextlib.suppress(_SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS):
-                shutil.rmtree(ws_path, ignore_errors=True)
+                ws_path_obj = Path(str(ws_path))
+                session_root = ws_path_obj.parent if ws_path_obj.name == "workspace" else ws_path_obj
+                shutil.rmtree(session_root, ignore_errors=True)
         return bool(removed or store_removed)
 
     # -----------------
@@ -1330,7 +1334,7 @@ class SandboxOrchestrator:
             self._session_roots[session_id] = str(ws)
         return str(ws)
 
-    def get_session_workspace_path(self, session_id: str) -> str | None:
+    def get_session_workspace_path(self, session_id: str, *, allow_cache_on_store_error: bool = True) -> str | None:
         sid = str(session_id or "").strip()
         if not sid:
             return None
@@ -1340,6 +1344,8 @@ class SandboxOrchestrator:
             row = self._store.get_session(sid)
         except _SANDBOX_ORCH_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"store.get_session workspace lookup failed: {e}")
+            if not allow_cache_on_store_error:
+                return None
             with self._lock:
                 ws = self._session_roots.get(sid)
                 return ws

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import contextlib
 import os
 import threading
@@ -824,6 +825,12 @@ class SandboxService:
         sess = self._orch.create_session(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
         return sess
 
+    def get_session(self, session_id: str) -> Session | None:
+        return self._orch.get_session(session_id)
+
+    def get_session_owner(self, session_id: str) -> str | None:
+        return self._orch.get_session_owner(session_id)
+
     def destroy_session(self, session_id: str) -> bool:
         try:
             destroyed = bool(self._orch.destroy_session(session_id))
@@ -898,14 +905,14 @@ class SandboxService:
         results: list[tuple[str, bytes]] = []
         if not files:
             return results
-        for f in files:
+        for index, f in enumerate(files):
             try:
                 p = str(f.get("path", ""))
                 b64 = str(f.get("content_b64", ""))
-                data = base64.b64decode(b64)
+                data = base64.b64decode(b64, validate=True)
                 results.append((p, data))
-            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
-                logger.warning(f"Failed to parse inline file: {e}")
+            except (binascii.Error, ValueError, TypeError, AttributeError) as e:
+                raise ValueError(f"invalid inline file at index {index}") from e
         return results
 
     def start_run_scaffold(self, user_id: str | int, spec: RunSpec, spec_version: str, idem_key: str | None, raw_body: dict) -> RunStatus:
@@ -1456,6 +1463,13 @@ class SandboxService:
             spec = SessionSpec(
                 runtime=source_sess.runtime,
                 base_image=source_sess.base_image,
+                cpu_limit=source_sess.cpu_limit,
+                memory_mb=source_sess.memory_mb,
+                timeout_sec=source_sess.timeout_sec,
+                network_policy=source_sess.network_policy,
+                env=dict(source_sess.env or {}),
+                labels=dict(source_sess.labels or {}),
+                trust_level=source_sess.trust_level,
                 persona_id=source_sess.persona_id,
                 workspace_id=source_sess.workspace_id,
                 workspace_group_id=source_sess.workspace_group_id,

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -969,33 +969,150 @@ class SandboxService:
                 raise ValueError(f"invalid inline file at index {index}") from e
         return results
 
-    def start_run_scaffold(self, user_id: str | int, spec: RunSpec, spec_version: str, idem_key: str | None, raw_body: dict) -> RunStatus:
+    def _run_field_explicit(self, explicit_fields: set[str] | None, *field_names: str) -> bool:
+        if explicit_fields is None:
+            return True
+        for field_name in field_names:
+            normalized = str(field_name or "").strip()
+            if not normalized:
+                continue
+            if normalized in explicit_fields:
+                return True
+            if "." not in normalized and f"resources.{normalized}" in explicit_fields:
+                return True
+        return False
+
+    def _resolve_session_backed_run_spec(
+        self,
+        spec: RunSpec,
+        *,
+        session: Session,
+        explicit_fields: set[str] | None,
+    ) -> RunSpec:
+        runtime = spec.runtime
+        if not self._run_field_explicit(explicit_fields, "runtime") and session.runtime is not None:
+            runtime = session.runtime
+
+        base_image = spec.base_image
+        if not self._run_field_explicit(explicit_fields, "base_image") and session.base_image:
+            base_image = session.base_image
+
+        env = dict(spec.env or {})
+        if not self._run_field_explicit(explicit_fields, "env"):
+            env = dict(session.env or {})
+
+        timeout_sec = spec.timeout_sec
+        if not self._run_field_explicit(explicit_fields, "timeout_sec") and session.timeout_sec is not None:
+            timeout_sec = int(session.timeout_sec)
+
+        cpu = spec.cpu
+        if not self._run_field_explicit(explicit_fields, "cpu") and session.cpu_limit is not None:
+            cpu = float(session.cpu_limit)
+
+        memory_mb = spec.memory_mb
+        if not self._run_field_explicit(explicit_fields, "memory_mb") and session.memory_mb is not None:
+            memory_mb = int(session.memory_mb)
+
+        network_policy = spec.network_policy
+        if not self._run_field_explicit(explicit_fields, "network_policy") and session.network_policy:
+            network_policy = str(session.network_policy)
+
+        trust_level = spec.trust_level
+        if not self._run_field_explicit(explicit_fields, "trust_level") and session.trust_level is not None:
+            trust_level = session.trust_level
+
+        persona_id = spec.persona_id
+        if not self._run_field_explicit(explicit_fields, "persona_id") and session.persona_id is not None:
+            persona_id = str(session.persona_id)
+
+        workspace_id = spec.workspace_id
+        if not self._run_field_explicit(explicit_fields, "workspace_id") and session.workspace_id is not None:
+            workspace_id = str(session.workspace_id)
+
+        workspace_group_id = spec.workspace_group_id
+        if not self._run_field_explicit(explicit_fields, "workspace_group_id") and session.workspace_group_id is not None:
+            workspace_group_id = str(session.workspace_group_id)
+
+        scope_snapshot_id = spec.scope_snapshot_id
+        if not self._run_field_explicit(explicit_fields, "scope_snapshot_id") and session.scope_snapshot_id is not None:
+            scope_snapshot_id = str(session.scope_snapshot_id)
+
+        return RunSpec(
+            session_id=spec.session_id,
+            runtime=runtime,
+            base_image=base_image,
+            command=list(spec.command),
+            env=env,
+            startup_timeout_sec=spec.startup_timeout_sec,
+            timeout_sec=timeout_sec,
+            cpu=cpu,
+            memory_mb=memory_mb,
+            network_policy=network_policy,
+            files_inline=list(spec.files_inline or []),
+            capture_patterns=list(spec.capture_patterns or []),
+            interactive=spec.interactive,
+            stdin_max_bytes=spec.stdin_max_bytes,
+            stdin_max_frame_bytes=spec.stdin_max_frame_bytes,
+            stdin_bps=spec.stdin_bps,
+            stdin_idle_timeout_sec=spec.stdin_idle_timeout_sec,
+            trust_level=trust_level,
+            port_mappings=list(spec.port_mappings or []),
+            run_as_root=spec.run_as_root,
+            read_only_root=spec.read_only_root,
+            persona_id=persona_id,
+            workspace_id=workspace_id,
+            workspace_group_id=workspace_group_id,
+            scope_snapshot_id=scope_snapshot_id,
+        )
+
+    def start_run_scaffold(
+        self,
+        user_id: str | int,
+        spec: RunSpec,
+        spec_version: str,
+        idem_key: str | None,
+        raw_body: dict,
+        *,
+        explicit_fields: set[str] | None = None,
+    ) -> RunStatus:
         # Validate requested spec version
         self._validate_spec_version(spec_version)
-        # Apply policy then enqueue via orchestrator (idempotency-aware)
-        runtime_preflights = self._collect_runtime_preflights(network_policy="deny_all")
-        firecracker_preflight = runtime_preflights.get(RuntimeType.firecracker)
-        lima_preflight = runtime_preflights.get(RuntimeType.lima)
-        spec = self.policy.apply_to_run(
-            spec,
-            firecracker_available=bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
-            lima_available=bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
-            runtime_preflights=runtime_preflights,
-        )
-        self._validate_lima_policy(
-            runtime=spec.runtime,
-            network_policy=spec.network_policy,
-            runtime_preflight=lima_preflight,
-        )
-        # Validate Firecracker kernel/rootfs when real execution is enabled
-        self._validate_firecracker_config(spec)
+
+        def _prepare_spec_for_enqueue(candidate: RunSpec) -> RunSpec:
+            runtime_preflights = self._collect_runtime_preflights(network_policy="deny_all")
+            firecracker_preflight = runtime_preflights.get(RuntimeType.firecracker)
+            lima_preflight = runtime_preflights.get(RuntimeType.lima)
+            candidate = self.policy.apply_to_run(
+                candidate,
+                firecracker_available=bool(firecracker_preflight.available) if firecracker_preflight is not None else bool(firecracker_available()),
+                lima_available=bool(lima_preflight.available) if lima_preflight is not None else bool(lima_available()),
+                runtime_preflights=runtime_preflights,
+            )
+            self._validate_lima_policy(
+                runtime=candidate.runtime,
+                network_policy=candidate.network_policy,
+                runtime_preflight=lima_preflight,
+            )
+            self._validate_firecracker_config(candidate)
+            return candidate
+
         session_id = str(spec.session_id or "").strip() if getattr(spec, "session_id", None) is not None else ""
         if session_id:
             with self._workspace_operation_lock(session_id):
-                if self._orch.get_session(session_id, allow_cache_on_store_error=False) is None:
+                session = self._orch.get_session(session_id, allow_cache_on_store_error=False)
+                if session is None:
                     raise ValueError("session_not_found")
+                spec = self._resolve_session_backed_run_spec(
+                    spec,
+                    session=session,
+                    explicit_fields=explicit_fields,
+                )
+                if not spec.base_image:
+                    raise ValueError("session_base_image_required")
+                spec = _prepare_spec_for_enqueue(spec)
                 status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
         else:
+            spec = _prepare_spec_for_enqueue(spec)
             status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
         # Configure stdin caps in hub if interactive is requested (spec 1.1)
         try:
@@ -1546,11 +1663,6 @@ class SandboxService:
         session_root = os.path.dirname(ws_path) if os.path.basename(ws_path) == "workspace" else ws_path
         shutil.rmtree(session_root, ignore_errors=True)
 
-    def _cleanup_workspace_operation_lock_file(self, session_id: str, workspace_root: str | None = None) -> None:
-        lock_path = self._workspace_operation_lock_path(session_id, workspace_root)
-        with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-            os.unlink(lock_path)
-
     def _destroy_session_serialized(self, session_id: str) -> bool:
         ws = self._orch.get_session_workspace_path(session_id)
         if not ws:
@@ -1559,7 +1671,6 @@ class SandboxService:
                 with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
                     with self._snapshot_lock(session_id):
                         self._snapshots.cleanup_session_snapshots(session_id)
-                self._cleanup_workspace_operation_lock_file(session_id)
             return destroyed
 
         destroyed = False
@@ -1571,7 +1682,6 @@ class SandboxService:
         if destroyed:
             with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
                 self._remove_session_workspace_tree(ws)
-            self._cleanup_workspace_operation_lock_file(session_id, ws)
         return destroyed
 
     def create_snapshot(self, session_id: str) -> dict:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -4,11 +4,15 @@ import asyncio
 import base64
 import binascii
 import contextlib
+import hashlib
 import os
+import shutil
+import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from typing import Any
 
 from loguru import logger
 
@@ -62,6 +66,66 @@ _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
 )
 
+try:
+    import fcntl  # type: ignore
+    _SANDBOX_SERVICE_HAS_FCNTL = True
+except Exception:
+    _SANDBOX_SERVICE_HAS_FCNTL = False
+
+try:
+    import msvcrt  # type: ignore
+    _SANDBOX_SERVICE_HAS_MSVCRT = True
+except Exception:
+    _SANDBOX_SERVICE_HAS_MSVCRT = False
+
+_SANDBOX_WORKSPACE_FALLBACK_LOCKS: dict[str, threading.Lock] = {}
+_SANDBOX_WORKSPACE_FALLBACK_LOCKS_GUARD = threading.Lock()
+
+
+def _get_sandbox_workspace_thread_lock(lock_path: str) -> threading.Lock:
+    key = str(os.path.abspath(lock_path))
+    with _SANDBOX_WORKSPACE_FALLBACK_LOCKS_GUARD:
+        lock = _SANDBOX_WORKSPACE_FALLBACK_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _SANDBOX_WORKSPACE_FALLBACK_LOCKS[key] = lock
+    return lock
+
+
+def _acquire_workspace_file_lock(lock_path: str) -> tuple[str, Any]:
+    if _SANDBOX_SERVICE_HAS_FCNTL:
+        handle = open(lock_path, "a", encoding="utf-8")
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        return ("fcntl", handle)
+
+    if _SANDBOX_SERVICE_HAS_MSVCRT:
+        handle = open(lock_path, "a+b")
+        with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+            handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        return ("msvcrt", handle)
+
+    lock = _get_sandbox_workspace_thread_lock(lock_path)
+    lock.acquire()
+    return ("thread", lock)
+
+
+def _release_workspace_file_lock(lock_handle: tuple[str, Any]) -> None:
+    kind, handle = lock_handle
+    if kind == "fcntl":
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        handle.close()
+        return
+
+    if kind == "msvcrt":
+        with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+            handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        handle.close()
+        return
+
+    handle.release()
+
 
 class SandboxService:
     """High-level orchestrator facade for sandbox operations.
@@ -84,7 +148,7 @@ class SandboxService:
             storage_path=os.getenv("SANDBOX_SNAPSHOT_PATH")
         )
         self._snapshot_locks_guard = threading.RLock()
-        self._snapshot_locks: dict[str, threading.RLock] = {}
+        self._snapshot_locks: dict[str, threading.Lock] = {}
         self._maintenance_lock = threading.RLock()
         self._maintenance_stop = threading.Event()
         self._maintenance_thread: threading.Thread | None = None
@@ -833,12 +897,7 @@ class SandboxService:
 
     def destroy_session(self, session_id: str) -> bool:
         try:
-            destroyed = bool(self._orch.destroy_session(session_id))
-            if destroyed:
-                with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                    with self._snapshot_lock(session_id):
-                        self._snapshots.cleanup_session_snapshots(session_id)
-            return destroyed
+            return self._destroy_session_serialized(session_id)
         except SessionActiveRunsConflict:
             timeout_sec = 10.0
             try:
@@ -891,12 +950,7 @@ class SandboxService:
                     )
                 time.sleep(0.05)
 
-            destroyed = bool(self._orch.destroy_session(session_id))
-            if destroyed:
-                with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
-                    with self._snapshot_lock(session_id):
-                        self._snapshots.cleanup_session_snapshots(session_id)
-            return destroyed
+            return self._destroy_session_serialized(session_id)
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"destroy_session failed: {e}")
             return False
@@ -935,7 +989,14 @@ class SandboxService:
         )
         # Validate Firecracker kernel/rootfs when real execution is enabled
         self._validate_firecracker_config(spec)
-        status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
+        session_id = str(spec.session_id or "").strip() if getattr(spec, "session_id", None) is not None else ""
+        if session_id:
+            with self._workspace_operation_lock(session_id):
+                if self._orch.get_session(session_id, allow_cache_on_store_error=False) is None:
+                    raise ValueError("session_not_found")
+                status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
+        else:
+            status = self._orch.enqueue_run(user_id=user_id, spec=spec, spec_version=spec_version, idem_key=idem_key, body=raw_body)
         # Configure stdin caps in hub if interactive is requested (spec 1.1)
         try:
             interactive = bool(spec.interactive) if getattr(spec, "interactive", None) is not None else False
@@ -1376,14 +1437,142 @@ class SandboxService:
     # Snapshot Operations
     # -----------------
 
-    def _snapshot_lock(self, session_id: str) -> threading.RLock:
+    def _snapshot_lock(self, session_id: str) -> threading.Lock:
         sid = str(session_id or "")
         with self._snapshot_locks_guard:
             lock = self._snapshot_locks.get(sid)
             if lock is None:
-                lock = threading.RLock()
+                lock = threading.Lock()
                 self._snapshot_locks[sid] = lock
             return lock
+
+    def _workspace_operation_lock_dir(self) -> str:
+        raw_root = ""
+        try:
+            raw_root = str(
+                os.getenv("SANDBOX_ROOT_DIR")
+                or getattr(app_settings, "SANDBOX_ROOT_DIR", "")
+                or ""
+            ).strip()
+        except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+            raw_root = ""
+        if raw_root:
+            base_dir = os.path.join(os.path.abspath(raw_root), ".sandbox-workspace-locks")
+        else:
+            base_dir = os.path.join(tempfile.gettempdir(), "tldw-sandbox-workspace-locks")
+        os.makedirs(base_dir, exist_ok=True)
+        return base_dir
+
+    def _workspace_operation_lock_path(self, session_id: str, workspace_root: str | None = None) -> str:
+        sid = str(session_id or "").strip()
+        if sid:
+            lock_key = f"session:{sid}"
+        else:
+            workspace_path = os.path.abspath(str(workspace_root or "")).strip()
+            if not workspace_path:
+                raise ValueError("Session not found or no workspace")
+            lock_key = f"workspace:{workspace_path}"
+        digest = hashlib.sha256(lock_key.encode("utf-8")).hexdigest()
+        return os.path.join(self._workspace_operation_lock_dir(), f"{digest}.lock")
+
+    def _resolve_workspace_operation_root(self, session_id: str, workspace_root: str | None = None) -> str:
+        sid = str(session_id or "").strip()
+        if sid:
+            live_ws = str(
+                self._orch.get_session_workspace_path(
+                    sid,
+                    allow_cache_on_store_error=False,
+                ) or ""
+            ).strip()
+            if not live_ws:
+                raise ValueError("session_not_found")
+            return live_ws
+        ws = str(workspace_root or "").strip()
+        if not ws:
+            raise ValueError("Session not found or no workspace")
+        return ws
+
+    @contextlib.contextmanager
+    def _workspace_operation_lock(self, session_id: str, workspace_root: str | None = None):
+        sid = str(session_id or "").strip()
+        with self._snapshot_lock(sid):
+            lock_path = self._workspace_operation_lock_path(sid, workspace_root)
+            lock_handle = _acquire_workspace_file_lock(lock_path)
+            try:
+                ws = self._resolve_workspace_operation_root(sid, workspace_root)
+                yield ws
+            finally:
+                _release_workspace_file_lock(lock_handle)
+
+    @contextlib.asynccontextmanager
+    async def async_workspace_operation_lock(self, session_id: str, workspace_root: str | None = None):
+        sid = str(session_id or "").strip()
+        thread_lock = self._snapshot_lock(sid)
+        await asyncio.to_thread(thread_lock.acquire)
+        try:
+            lock_path = self._workspace_operation_lock_path(sid, workspace_root)
+            lock_handle = await asyncio.to_thread(_acquire_workspace_file_lock, lock_path)
+            try:
+                ws = await asyncio.to_thread(self._resolve_workspace_operation_root, sid, workspace_root)
+                yield ws
+            finally:
+                await asyncio.to_thread(_release_workspace_file_lock, lock_handle)
+        finally:
+            thread_lock.release()
+
+    def _active_session_run_count(self, session_id: str) -> int:
+        sid = str(session_id or "").strip()
+        if not sid:
+            return 0
+        return (
+            self._orch.count_runs(session_id=sid, phase=RunPhase.queued.value)
+            + self._orch.count_runs(session_id=sid, phase=RunPhase.starting.value)
+            + self._orch.count_runs(session_id=sid, phase=RunPhase.running.value)
+        )
+
+    def _ensure_no_active_session_runs(self, session_id: str) -> None:
+        active_runs = self._active_session_run_count(session_id)
+        if active_runs > 0:
+            raise SessionActiveRunsConflict(
+                session_id=str(session_id),
+                active_runs=active_runs,
+            )
+
+    def _remove_session_workspace_tree(self, workspace_root: str | None) -> None:
+        ws = str(workspace_root or "").strip()
+        if not ws:
+            return
+        ws_path = os.path.abspath(ws)
+        session_root = os.path.dirname(ws_path) if os.path.basename(ws_path) == "workspace" else ws_path
+        shutil.rmtree(session_root, ignore_errors=True)
+
+    def _cleanup_workspace_operation_lock_file(self, session_id: str, workspace_root: str | None = None) -> None:
+        lock_path = self._workspace_operation_lock_path(session_id, workspace_root)
+        with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+            os.unlink(lock_path)
+
+    def _destroy_session_serialized(self, session_id: str) -> bool:
+        ws = self._orch.get_session_workspace_path(session_id)
+        if not ws:
+            destroyed = bool(self._orch.destroy_session(session_id))
+            if destroyed:
+                with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+                    with self._snapshot_lock(session_id):
+                        self._snapshots.cleanup_session_snapshots(session_id)
+                self._cleanup_workspace_operation_lock_file(session_id)
+            return destroyed
+
+        destroyed = False
+        with self._workspace_operation_lock(session_id, ws):
+            destroyed = bool(self._orch.destroy_session(session_id, remove_workspace_tree=False))
+            if destroyed:
+                with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+                    self._snapshots.cleanup_session_snapshots(session_id)
+        if destroyed:
+            with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
+                self._remove_session_workspace_tree(ws)
+            self._cleanup_workspace_operation_lock_file(session_id, ws)
+        return destroyed
 
     def create_snapshot(self, session_id: str) -> dict:
         """Create a snapshot of a session's workspace.
@@ -1397,10 +1586,8 @@ class SandboxService:
         Raises:
             ValueError: If session not found or has no workspace.
         """
-        with self._snapshot_lock(session_id):
-            ws = self._orch.get_session_workspace_path(session_id)
-            if not ws:
-                raise ValueError("Session not found or no workspace")
+        with self._workspace_operation_lock(session_id) as ws:
+            self._ensure_no_active_session_runs(session_id)
             result = self._snapshots.create_snapshot(session_id, ws)
             deleted = self._snapshots.enforce_quota(
                 session_id,
@@ -1424,10 +1611,8 @@ class SandboxService:
         Raises:
             ValueError: If session or snapshot not found.
         """
-        with self._snapshot_lock(session_id):
-            ws = self._orch.get_session_workspace_path(session_id)
-            if not ws:
-                raise ValueError("Session not found or no workspace")
+        with self._workspace_operation_lock(session_id) as ws:
+            self._ensure_no_active_session_runs(session_id)
             return self._snapshots.restore_snapshot(session_id, snapshot_id, ws)
 
     def clone_session(self, session_id: str, new_name: str | None = None) -> Session:
@@ -1443,12 +1628,8 @@ class SandboxService:
         Raises:
             ValueError: If source session not found.
         """
-        with self._snapshot_lock(session_id):
-            # Get source session info
-            source_ws = self._orch.get_session_workspace_path(session_id)
-            if not source_ws:
-                raise ValueError("Source session not found or no workspace")
-
+        with self._workspace_operation_lock(session_id) as source_ws:
+            self._ensure_no_active_session_runs(session_id)
             source_owner = self._orch.get_session_owner(session_id)
             if not source_owner:
                 raise ValueError("Source session owner not found")
@@ -1505,7 +1686,7 @@ class SandboxService:
         Returns:
             List of snapshot metadata dictionaries.
         """
-        with self._snapshot_lock(session_id):
+        with self._workspace_operation_lock(session_id):
             return self._snapshots.list_snapshots(session_id)
 
     def delete_snapshot(self, session_id: str, snapshot_id: str) -> bool:
@@ -1518,7 +1699,7 @@ class SandboxService:
         Returns:
             True if deleted successfully.
         """
-        with self._snapshot_lock(session_id):
+        with self._workspace_operation_lock(session_id):
             return self._snapshots.delete_snapshot(session_id, snapshot_id)
 
     def get_snapshot_info(self, session_id: str, snapshot_id: str) -> dict | None:
@@ -1531,5 +1712,5 @@ class SandboxService:
         Returns:
             Snapshot metadata or None if not found.
         """
-        with self._snapshot_lock(session_id):
+        with self._workspace_operation_lock(session_id):
             return self._snapshots.get_snapshot_info(session_id, snapshot_id)

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -201,6 +201,16 @@ class SandboxStore:
     def get_user_artifact_bytes(self, user_id: str) -> int:
         return 0
 
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        if int(delta or 0) <= 0:
+            self.increment_user_artifact_bytes(user_id, int(delta or 0))
+            return True
+        current = int(self.get_user_artifact_bytes(user_id))
+        if current + int(delta) > int(cap_bytes):
+            return False
+        self.increment_user_artifact_bytes(user_id, int(delta))
+        return True
+
     def increment_user_artifact_bytes(self, user_id: str, delta: int) -> None:
         pass
 
@@ -638,6 +648,18 @@ class InMemoryStore(SandboxStore):
         with self._lock:
             cur = int(self._user_bytes.get(user_id, 0))
             self._user_bytes[user_id] = max(0, cur + int(delta))
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock:
+            cur = int(self._user_bytes.get(user_id, 0))
+            if cur + d > int(cap_bytes):
+                return False
+            self._user_bytes[user_id] = cur + d
+            return True
 
     def list_runs(
         self,
@@ -1676,6 +1698,25 @@ class SQLiteStore(SandboxStore):
                 "REPLACE INTO sandbox_usage(user_id, artifact_bytes) VALUES (?,?)",
                 (user_id, new_val),
             )
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock, self._conn() as con:
+            con.execute("BEGIN IMMEDIATE")
+            cur = con.execute("SELECT artifact_bytes FROM sandbox_usage WHERE user_id=?", (user_id,))
+            row = cur.fetchone()
+            cur_val = int(row["artifact_bytes"]) if row and row["artifact_bytes"] is not None else 0
+            if cur_val + d > int(cap_bytes):
+                con.rollback()
+                return False
+            con.execute(
+                "REPLACE INTO sandbox_usage(user_id, artifact_bytes) VALUES (?,?)",
+                (user_id, cur_val + d),
+            )
+            return True
 
     def list_runs(
         self,
@@ -2793,6 +2834,29 @@ class PostgresStore(SandboxStore):
                     """,
                     (user_id, d),
                 )
+
+    def try_reserve_user_artifact_bytes(self, user_id: str, delta: int, cap_bytes: int) -> bool:
+        if not user_id:
+            return False
+        d = int(delta or 0)
+        if d <= 0:
+            self.increment_user_artifact_bytes(user_id, d)
+            return True
+        with self._lock, self._conn() as con:
+            with con.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO sandbox_usage(user_id, artifact_bytes)
+                    SELECT %s, %s
+                    WHERE %s <= %s
+                    ON CONFLICT (user_id) DO UPDATE
+                    SET artifact_bytes = COALESCE(sandbox_usage.artifact_bytes, 0) + EXCLUDED.artifact_bytes
+                    WHERE COALESCE(sandbox_usage.artifact_bytes, 0) + EXCLUDED.artifact_bytes <= %s
+                    RETURNING artifact_bytes
+                    """,
+                    (user_id, d, d, int(cap_bytes), int(cap_bytes)),
+                )
+                return cur.fetchone() is not None
 
     def list_runs(
         self,

--- a/tldw_Server_API/app/core/Sandbox/store.py
+++ b/tldw_Server_API/app/core/Sandbox/store.py
@@ -64,6 +64,23 @@ def _parse_optional_iso_datetime(value: Any) -> datetime | None:
         return None
 
 
+def _normalize_string_dict(value: Any) -> dict[str, str]:
+    if isinstance(value, dict):
+        return {str(k): str(v) for k, v in value.items()}
+    if value is None:
+        return {}
+    text = str(value).strip()
+    if not text:
+        return {}
+    try:
+        loaded = json.loads(text)
+    except _SANDBOX_STORE_NONCRITICAL_EXCEPTIONS:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    return {str(k): str(v) for k, v in loaded.items()}
+
+
 class IdempotencyConflict(Exception):
     def __init__(self, original_id: str, key: str | None = None, created_at: float | None = None, message: str = "Idempotency conflict") -> None:
         super().__init__(message)
@@ -131,6 +148,13 @@ class SandboxStore:
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -508,6 +532,13 @@ class InMemoryStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -521,6 +552,13 @@ class InMemoryStore(SandboxStore):
                 "user_id": self._user_key(user_id),
                 "runtime": runtime,
                 "base_image": base_image,
+                "cpu_limit": (float(cpu_limit) if cpu_limit is not None else None),
+                "memory_mb": (int(memory_mb) if memory_mb is not None else None),
+                "timeout_sec": (int(timeout_sec) if timeout_sec is not None else None),
+                "network_policy": (str(network_policy) if network_policy is not None else None),
+                "env": _normalize_string_dict(env),
+                "labels": _normalize_string_dict(labels),
+                "trust_level": (str(trust_level) if trust_level is not None else None),
                 "expires_at": expires_at_iso,
                 "workspace_path": workspace_path,
                 "persona_id": (str(persona_id) if persona_id is not None else None),
@@ -891,6 +929,13 @@ class SQLiteStore(SandboxStore):
                     user_id TEXT,
                     runtime TEXT,
                     base_image TEXT,
+                    cpu_limit REAL,
+                    memory_mb INTEGER,
+                    timeout_sec INTEGER,
+                    network_policy TEXT,
+                    env TEXT,
+                    labels TEXT,
+                    trust_level TEXT,
                     persona_id TEXT,
                     workspace_id TEXT,
                     workspace_group_id TEXT,
@@ -951,6 +996,13 @@ class SQLiteStore(SandboxStore):
             _ensure_sqlite_column("sandbox_runs", "scope_snapshot_id", "TEXT")
             _ensure_sqlite_column("sandbox_runs", "claim_owner", "TEXT")
             _ensure_sqlite_column("sandbox_runs", "claim_expires_at", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "cpu_limit", "REAL")
+            _ensure_sqlite_column("sandbox_sessions", "memory_mb", "INTEGER")
+            _ensure_sqlite_column("sandbox_sessions", "timeout_sec", "INTEGER")
+            _ensure_sqlite_column("sandbox_sessions", "network_policy", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "env", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "labels", "TEXT")
+            _ensure_sqlite_column("sandbox_sessions", "trust_level", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "persona_id", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "workspace_id", "TEXT")
             _ensure_sqlite_column("sandbox_sessions", "workspace_group_id", "TEXT")
@@ -1413,6 +1465,13 @@ class SQLiteStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -1425,13 +1484,20 @@ class SQLiteStore(SandboxStore):
             con.execute(
                 (
                     "INSERT INTO sandbox_sessions("
-                    "id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
-                    "expires_at,workspace_path,created_at,updated_at"
-                    ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?) "
+                    "id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,expires_at,workspace_path,created_at,updated_at"
+                    ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
                     "ON CONFLICT(id) DO UPDATE SET "
                     "user_id=excluded.user_id,"
                     "runtime=excluded.runtime,"
                     "base_image=excluded.base_image,"
+                    "cpu_limit=excluded.cpu_limit,"
+                    "memory_mb=excluded.memory_mb,"
+                    "timeout_sec=excluded.timeout_sec,"
+                    "network_policy=excluded.network_policy,"
+                    "env=excluded.env,"
+                    "labels=excluded.labels,"
+                    "trust_level=excluded.trust_level,"
                     "persona_id=excluded.persona_id,"
                     "workspace_id=excluded.workspace_id,"
                     "workspace_group_id=excluded.workspace_group_id,"
@@ -1445,6 +1511,13 @@ class SQLiteStore(SandboxStore):
                     self._user_key(user_id),
                     (str(runtime) if runtime is not None else None),
                     (str(base_image) if base_image is not None else None),
+                    (float(cpu_limit) if cpu_limit is not None else None),
+                    (int(memory_mb) if memory_mb is not None else None),
+                    (int(timeout_sec) if timeout_sec is not None else None),
+                    (str(network_policy) if network_policy is not None else None),
+                    (json.dumps(_normalize_string_dict(env)) if env is not None else None),
+                    (json.dumps(_normalize_string_dict(labels)) if labels is not None else None),
+                    (str(trust_level) if trust_level is not None else None),
                     (str(persona_id) if persona_id is not None else None),
                     (str(workspace_id) if workspace_id is not None else None),
                     (str(workspace_group_id) if workspace_group_id is not None else None),
@@ -1460,7 +1533,8 @@ class SQLiteStore(SandboxStore):
         with self._lock, self._conn() as con:
             cur = con.execute(
                 (
-                    "SELECT id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
+                    "SELECT id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
                     "expires_at,workspace_path,created_at,updated_at "
                     "FROM sandbox_sessions WHERE id=?"
                 ),
@@ -1475,6 +1549,13 @@ class SQLiteStore(SandboxStore):
                 "user_id": row_dict.get("user_id"),
                 "runtime": row_dict.get("runtime"),
                 "base_image": row_dict.get("base_image"),
+                "cpu_limit": row_dict.get("cpu_limit"),
+                "memory_mb": row_dict.get("memory_mb"),
+                "timeout_sec": row_dict.get("timeout_sec"),
+                "network_policy": row_dict.get("network_policy"),
+                "env": _normalize_string_dict(row_dict.get("env")),
+                "labels": _normalize_string_dict(row_dict.get("labels")),
+                "trust_level": row_dict.get("trust_level"),
                 "persona_id": row_dict.get("persona_id"),
                 "workspace_id": row_dict.get("workspace_id"),
                 "workspace_group_id": row_dict.get("workspace_group_id"),
@@ -1955,6 +2036,13 @@ class PostgresStore(SandboxStore):
                         user_id TEXT,
                         runtime TEXT,
                         base_image TEXT,
+                        cpu_limit DOUBLE PRECISION,
+                        memory_mb INTEGER,
+                        timeout_sec INTEGER,
+                        network_policy TEXT,
+                        env TEXT,
+                        labels TEXT,
+                        trust_level TEXT,
                         persona_id TEXT,
                         workspace_id TEXT,
                         workspace_group_id TEXT,
@@ -2011,6 +2099,13 @@ class PostgresStore(SandboxStore):
             _ensure_column("sandbox_runs", "scope_snapshot_id", "TEXT")
             _ensure_column("sandbox_runs", "claim_owner", "TEXT")
             _ensure_column("sandbox_runs", "claim_expires_at", "TEXT")
+            _ensure_column("sandbox_sessions", "cpu_limit", "DOUBLE PRECISION")
+            _ensure_column("sandbox_sessions", "memory_mb", "INTEGER")
+            _ensure_column("sandbox_sessions", "timeout_sec", "INTEGER")
+            _ensure_column("sandbox_sessions", "network_policy", "TEXT")
+            _ensure_column("sandbox_sessions", "env", "TEXT")
+            _ensure_column("sandbox_sessions", "labels", "TEXT")
+            _ensure_column("sandbox_sessions", "trust_level", "TEXT")
             _ensure_column("sandbox_sessions", "persona_id", "TEXT")
             _ensure_column("sandbox_sessions", "workspace_id", "TEXT")
             _ensure_column("sandbox_sessions", "workspace_group_id", "TEXT")
@@ -2492,6 +2587,13 @@ class PostgresStore(SandboxStore):
         session_id: str,
         runtime: str | None,
         base_image: str | None,
+        cpu_limit: float | None,
+        memory_mb: int | None,
+        timeout_sec: int | None,
+        network_policy: str | None,
+        env: dict[str, str] | None,
+        labels: dict[str, str] | None,
+        trust_level: str | None,
         expires_at_iso: str | None,
         workspace_path: str | None,
         persona_id: str | None = None,
@@ -2505,14 +2607,21 @@ class PostgresStore(SandboxStore):
                 cur.execute(
                     """
                     INSERT INTO sandbox_sessions(
-                        id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,
-                        expires_at,workspace_path,created_at,updated_at
+                        id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,
+                        persona_id,workspace_id,workspace_group_id,scope_snapshot_id,expires_at,workspace_path,created_at,updated_at
                     )
-                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
                     ON CONFLICT (id) DO UPDATE SET
                         user_id=EXCLUDED.user_id,
                         runtime=EXCLUDED.runtime,
                         base_image=EXCLUDED.base_image,
+                        cpu_limit=EXCLUDED.cpu_limit,
+                        memory_mb=EXCLUDED.memory_mb,
+                        timeout_sec=EXCLUDED.timeout_sec,
+                        network_policy=EXCLUDED.network_policy,
+                        env=EXCLUDED.env,
+                        labels=EXCLUDED.labels,
+                        trust_level=EXCLUDED.trust_level,
                         persona_id=EXCLUDED.persona_id,
                         workspace_id=EXCLUDED.workspace_id,
                         workspace_group_id=EXCLUDED.workspace_group_id,
@@ -2526,6 +2635,13 @@ class PostgresStore(SandboxStore):
                         self._user_key(user_id),
                         (str(runtime) if runtime is not None else None),
                         (str(base_image) if base_image is not None else None),
+                        (float(cpu_limit) if cpu_limit is not None else None),
+                        (int(memory_mb) if memory_mb is not None else None),
+                        (int(timeout_sec) if timeout_sec is not None else None),
+                        (str(network_policy) if network_policy is not None else None),
+                        (json.dumps(_normalize_string_dict(env)) if env is not None else None),
+                        (json.dumps(_normalize_string_dict(labels)) if labels is not None else None),
+                        (str(trust_level) if trust_level is not None else None),
                         (str(persona_id) if persona_id is not None else None),
                         (str(workspace_id) if workspace_id is not None else None),
                         (str(workspace_group_id) if workspace_group_id is not None else None),
@@ -2541,14 +2657,20 @@ class PostgresStore(SandboxStore):
         with self._lock, self._conn() as con, con.cursor() as cur:
             cur.execute(
                 (
-                    "SELECT id,user_id,runtime,base_image,persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
+                    "SELECT id,user_id,runtime,base_image,cpu_limit,memory_mb,timeout_sec,network_policy,env,labels,trust_level,"
+                    "persona_id,workspace_id,workspace_group_id,scope_snapshot_id,"
                     "expires_at,workspace_path,created_at,updated_at "
                     "FROM sandbox_sessions WHERE id=%s"
                 ),
                 (str(session_id),),
             )
             row = cur.fetchone()
-            return dict(row) if isinstance(row, dict) else None
+            if not isinstance(row, dict):
+                return None
+            result = dict(row)
+            result["env"] = _normalize_string_dict(result.get("env"))
+            result["labels"] = _normalize_string_dict(result.get("labels"))
+            return result
 
     def get_session_owner(self, session_id: str) -> str | None:
         row = self.get_session(str(session_id))

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
@@ -16,6 +16,7 @@ class _FakeSandboxService:
         self.specs: list[object] = []
         self.sessions: dict[str, Session] = {}
         self.session_owners: dict[str, str] = {}
+        self.explicit_fields: list[set[str] | None] = []
 
     def start_run_scaffold(
         self,
@@ -25,7 +26,28 @@ class _FakeSandboxService:
         spec_version: str,
         idem_key: str | None,
         raw_body,  # noqa: ANN001 - minimal test stub
+        explicit_fields: set[str] | None = None,
     ) -> RunStatus:
+        self.explicit_fields.append(set(explicit_fields) if explicit_fields is not None else None)
+        if spec.session_id and explicit_fields is not None:
+            session = self.get_session(spec.session_id)
+            if session is not None:
+                if "runtime" not in explicit_fields and session.runtime is not None:
+                    spec.runtime = session.runtime
+                if "base_image" not in explicit_fields and session.base_image:
+                    spec.base_image = session.base_image
+                if "env" not in explicit_fields:
+                    spec.env = dict(session.env or {})
+                if "timeout_sec" not in explicit_fields and session.timeout_sec is not None:
+                    spec.timeout_sec = int(session.timeout_sec)
+                if "cpu" not in explicit_fields and session.cpu_limit is not None:
+                    spec.cpu = float(session.cpu_limit)
+                if "memory_mb" not in explicit_fields and session.memory_mb is not None:
+                    spec.memory_mb = int(session.memory_mb)
+                if "network_policy" not in explicit_fields and session.network_policy:
+                    spec.network_policy = str(session.network_policy)
+                if "trust_level" not in explicit_fields and session.trust_level is not None:
+                    spec.trust_level = session.trust_level
         self.user_ids.append(str(user_id))
         self.specs.append(spec)
         return RunStatus(
@@ -196,3 +218,59 @@ async def test_sandbox_run_allows_permission_based_admin_override() -> None:
 
     assert result["id"] == "run-test-1"
     assert module._svc.user_ids == ["77"]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_refreshes_session_defaults_after_prelock_work(monkeypatch) -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-refresh"] = Session(
+        id="sess-refresh",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+        timeout_sec=30,
+        env={"SESSION_TOKEN": "old"},
+        trust_level=TrustLevel.standard,
+    )
+    module._svc.session_owners["sess-refresh"] = "77"
+    refreshed_session = Session(
+        id="sess-refresh",
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        expires_at=None,
+        timeout_sec=77,
+        env={"SESSION_TOKEN": "new"},
+        trust_level=TrustLevel.trusted,
+    )
+    ctx = RequestContext(
+        request_id="req-refresh",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    original_decode_inline_files = module._decode_inline_files
+
+    def _switch_session_then_decode(files):
+        module._svc.sessions["sess-refresh"] = refreshed_session
+        return original_decode_inline_files(files)
+
+    monkeypatch.setattr(module, "_decode_inline_files", _switch_session_then_decode)
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {
+            "session_id": "sess-refresh",
+            "command": ["python", "-c", "print('ok')"],
+        },
+        context=ctx,
+    )
+
+    spec = module._svc.specs[-1]
+    assert result["base_image"] == "python:3.12-slim"
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.timeout_sec == 77
+    assert spec.env == {"SESSION_TOKEN": "new"}
+    assert spec.trust_level == TrustLevel.trusted

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
@@ -7,12 +7,15 @@ import pytest
 from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module import SandboxModule
 from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, Session, TrustLevel
 
 
 class _FakeSandboxService:
     def __init__(self) -> None:
         self.user_ids: list[str] = []
+        self.specs: list[object] = []
+        self.sessions: dict[str, Session] = {}
+        self.session_owners: dict[str, str] = {}
 
     def start_run_scaffold(
         self,
@@ -24,6 +27,7 @@ class _FakeSandboxService:
         raw_body,  # noqa: ANN001 - minimal test stub
     ) -> RunStatus:
         self.user_ids.append(str(user_id))
+        self.specs.append(spec)
         return RunStatus(
             id="run-test-1",
             phase=RunPhase.queued,
@@ -32,6 +36,12 @@ class _FakeSandboxService:
             base_image=spec.base_image,
             started_at=datetime.now(timezone.utc),
         )
+
+    def get_session(self, session_id: str) -> Session | None:
+        return self.sessions.get(str(session_id))
+
+    def get_session_owner(self, session_id: str) -> str | None:
+        return self.session_owners.get(str(session_id))
 
 
 @pytest.mark.asyncio
@@ -75,3 +85,82 @@ async def test_sandbox_run_binds_authenticated_context_user_id() -> None:
 
     assert module._svc.user_ids == ["77"]
     assert result["id"] == "run-test-1"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_rejects_unowned_session_id() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-1"] = Session(
+        id="sess-1",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+    )
+    module._svc.session_owners["sess-1"] = "88"
+    ctx = RequestContext(
+        request_id="req-2",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    with pytest.raises(PermissionError):
+        await module.execute_tool(
+            "sandbox.run",
+            {
+                "session_id": "sess-1",
+                "command": ["python", "-c", "print('ok')"],
+            },
+            context=ctx,
+        )
+
+    assert module._svc.user_ids == []
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_inherits_owned_session_defaults() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-2"] = Session(
+        id="sess-2",
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        expires_at=None,
+        cpu_limit=1.5,
+        memory_mb=768,
+        timeout_sec=77,
+        network_policy="deny_all",
+        env={"SESSION_TOKEN": "present"},
+        labels={"team": "sandbox"},
+        trust_level=TrustLevel.untrusted,
+    )
+    module._svc.session_owners["sess-2"] = "77"
+    ctx = RequestContext(
+        request_id="req-3",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={},
+    )
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {
+            "session_id": "sess-2",
+            "command": ["python", "-c", "print('ok')"],
+        },
+        context=ctx,
+    )
+
+    assert result["base_image"] == "python:3.12-slim"
+    spec = module._svc.specs[-1]
+    assert spec.runtime == RuntimeType.docker
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.cpu == 1.5
+    assert spec.memory_mb == 768
+    assert spec.timeout_sec == 77
+    assert spec.network_policy == "deny_all"
+    assert spec.env == {"SESSION_TOKEN": "present"}
+    assert spec.trust_level == TrustLevel.untrusted

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_auth_binding.py
@@ -164,3 +164,35 @@ async def test_sandbox_run_inherits_owned_session_defaults() -> None:
     assert spec.network_policy == "deny_all"
     assert spec.env == {"SESSION_TOKEN": "present"}
     assert spec.trust_level == TrustLevel.untrusted
+
+
+@pytest.mark.asyncio
+async def test_sandbox_run_allows_permission_based_admin_override() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+    module._svc = _FakeSandboxService()
+    module._svc.sessions["sess-admin"] = Session(
+        id="sess-admin",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+    )
+    module._svc.session_owners["sess-admin"] = "88"
+    ctx = RequestContext(
+        request_id="req-admin-1",
+        user_id="77",
+        client_id="test-client",
+        session_id=None,
+        metadata={"permissions": ["system.configure"]},
+    )
+
+    result = await module.execute_tool(
+        "sandbox.run",
+        {
+            "session_id": "sess-admin",
+            "command": ["python", "-c", "print('ok')"],
+        },
+        context=ctx,
+    )
+
+    assert result["id"] == "run-test-1"
+    assert module._svc.user_ids == ["77"]

--- a/tldw_Server_API/tests/MCP_unified/test_sandbox_module_runtime_lima.py
+++ b/tldw_Server_API/tests/MCP_unified/test_sandbox_module_runtime_lima.py
@@ -22,6 +22,7 @@ class _FakeSandboxService:
         spec_version: str,
         idem_key: str | None,
         raw_body,  # noqa: ANN001 - minimal test stub
+        explicit_fields=None,  # noqa: ANN001 - minimal test stub
     ) -> RunStatus:
         self.runtimes.append(spec.runtime)
         return RunStatus(
@@ -54,4 +55,3 @@ async def test_sandbox_module_accepts_lima_runtime() -> None:
 
     assert module._svc.runtimes == [RuntimeType.lima]
     assert result["runtime"] == "lima"
-

--- a/tldw_Server_API/tests/sandbox/test_artifact_range.py
+++ b/tldw_Server_API/tests/sandbox/test_artifact_range.py
@@ -55,3 +55,33 @@ def test_artifact_download_range_support(monkeypatch) -> None:
         assert r3.headers.get("Content-Range") == "bytes 7-9/10"
         assert r3.headers.get("Content-Length") == "3"
         assert r3.content == b"789"
+
+
+def test_artifact_download_range_avoids_full_artifact_read(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body: Dict[str, Any] = {
+            "spec_version": "1.0",
+            "runtime": "docker",
+            "base_image": "python:3.11-slim",
+            "command": ["bash", "-lc", "echo done"],
+            "timeout_sec": 5,
+            "capture_patterns": ["out.txt"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 200
+        run_id = r.json()["id"]
+
+        from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+        payload = b"0123456789"
+        sb._service._orch.store_artifacts(run_id, {"out.txt": payload})  # type: ignore[attr-defined]
+
+        def _fail_get_artifact(*args, **kwargs):
+            raise AssertionError("download path should stream from disk instead of loading full artifact")
+
+        monkeypatch.setattr(sb._service._orch, "get_artifact", _fail_get_artifact)
+
+        r2 = client.get(f"/api/v1/sandbox/runs/{run_id}/artifacts/out.txt", headers={"Range": "bytes=0-4"})
+        assert r2.status_code == 206
+        assert r2.headers.get("Content-Range") == "bytes 0-4/10"
+        assert r2.content == b"01234"

--- a/tldw_Server_API/tests/sandbox/test_artifact_usage_accounting.py
+++ b/tldw_Server_API/tests/sandbox/test_artifact_usage_accounting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import threading
 
 import pytest
 
@@ -35,3 +36,61 @@ def test_artifact_usage_bytes_incremented(monkeypatch: pytest.MonkeyPatch, tmp_p
     orch.store_artifacts(run_id, {"out.txt": b"hello"})
     used = orch._store.get_user_artifact_bytes("user-1")
     assert used == 5
+
+
+def test_artifact_usage_cap_holds_under_concurrent_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+    monkeypatch.setenv("SANDBOX_MAX_ARTIFACT_BYTES_PER_USER_MB", "1")
+
+    orch = SandboxOrchestrator()
+    run_a = "run-art-concurrent-a"
+    run_b = "run-art-concurrent-b"
+    orch._store.put_run("user-1", RunStatus(id=run_a, phase=RunPhase.completed))
+    orch._store.put_run("user-1", RunStatus(id=run_b, phase=RunPhase.completed))
+
+    original_get = orch._store.get_user_artifact_bytes
+    barrier = threading.Barrier(2)
+
+    def _synchronized_get(user_id: str) -> int:
+        value = original_get(user_id)
+        try:
+            barrier.wait(timeout=1.0)
+        except threading.BrokenBarrierError:
+            pass
+        return value
+
+    monkeypatch.setattr(orch._store, "get_user_artifact_bytes", _synchronized_get)
+
+    errors: list[BaseException] = []
+
+    def _worker(run_id: str, payload: bytes) -> None:
+        try:
+            orch.store_artifacts(run_id, {"out.txt": payload})
+        except BaseException as exc:  # pragma: no cover - assertion capture path
+            errors.append(exc)
+
+    payload = b"x" * (700 * 1024)
+    thread_a = threading.Thread(target=_worker, args=(run_a, payload))
+    thread_b = threading.Thread(target=_worker, args=(run_b, payload))
+    thread_a.start()
+    thread_b.start()
+    thread_a.join(timeout=2.0)
+    thread_b.join(timeout=2.0)
+
+    assert not thread_a.is_alive()
+    assert not thread_b.is_alive()
+    assert errors == []
+
+    cap_bytes = 1 * 1024 * 1024
+    used = original_get("user-1")
+    total_persisted = sum(
+        orch.list_artifacts(run_id).get("out.txt", 0)
+        for run_id in (run_a, run_b)
+    )
+
+    assert used <= cap_bytes
+    assert total_persisted <= cap_bytes
+    assert any(
+        orch.list_artifacts(run_id).get("out.txt", 0) == 0
+        for run_id in (run_a, run_b)
+    )

--- a/tldw_Server_API/tests/sandbox/test_docker_runner_integration.py
+++ b/tldw_Server_API/tests/sandbox/test_docker_runner_integration.py
@@ -90,13 +90,12 @@ def test_full_lifecycle(sandbox_client):
         "session_id": session_id,
         "spec_version": "1.0",
         "runtime": "docker",
-        "base_image": "python:3.11-slim",
         "command": ["python", "/workspace/hello.py"],
-        "files_inline": [
-            [
-                "hello.py",
-                "aW1wb3J0IHN5cwpwcmludCgiSGVsbG8gZnJvbSBzYW5kYm94ISIpCnN5cy5leGl0KDAp",
-            ]
+        "files": [
+            {
+                "path": "hello.py",
+                "content_b64": "aW1wb3J0IHN5cwpwcmludCgiSGVsbG8gZnJvbSBzYW5kYm94ISIpCnN5cy5leGl0KDAp",
+            }
         ],
         "capture_patterns": ["*.py"],
         "timeout_sec": 30,

--- a/tldw_Server_API/tests/sandbox/test_run_started_metric_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_run_started_metric_contract.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("MINIMAL_TEST_APP", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "false")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "false")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "1")
+
+    from tldw_Server_API.app.api.v1.endpoints.sandbox import router as sandbox_router
+
+    app = FastAPI()
+    app.include_router(sandbox_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_started_metric_not_emitted_for_runtime_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    import tldw_Server_API.app.api.v1.endpoints.sandbox as sandbox_endpoint
+
+    def _inc(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(sandbox_endpoint, "increment_counter", _inc, raising=True)
+    monkeypatch.setenv("TLDW_SANDBOX_FIRECRACKER_AVAILABLE", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_AVAILABLE", "1")
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "runtime": "firecracker",
+                "base_image": "python:3.11-slim",
+                "command": ["bash", "-lc", "echo"],
+                "timeout_sec": 5,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "runtime_unavailable"
+    assert not any(args and args[0] == "sandbox_runs_started_total" for args, _kwargs in calls)
+
+
+@pytest.mark.unit
+def test_started_metric_emitted_for_accepted_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    import tldw_Server_API.app.api.v1.endpoints.sandbox as sandbox_endpoint
+
+    def _inc(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(sandbox_endpoint, "increment_counter", _inc, raising=True)
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.11-slim",
+                "command": ["bash", "-lc", "echo ok"],
+                "timeout_sec": 5,
+            },
+        )
+
+    assert response.status_code == 200
+    assert any(args and args[0] == "sandbox_runs_started_total" for args, _kwargs in calls)

--- a/tldw_Server_API/tests/sandbox/test_runner_failure_state_recovery.py
+++ b/tldw_Server_API/tests/sandbox/test_runner_failure_state_recovery.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def _spec() -> RunSpec:
+    return RunSpec(
+        session_id=None,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        command=["python", "-c", "print(1)"],
+        env={},
+        timeout_sec=5,
+    )
+
+
+@pytest.mark.unit
+def test_foreground_docker_runner_exception_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+
+    svc = SandboxService()
+
+    with patch(
+        "tldw_Server_API.app.core.Sandbox.runners.docker_runner.DockerRunner.start_run",
+        side_effect=RuntimeError("boom"),
+    ):
+        status = svc.start_run_scaffold(
+            user_id="1",
+            spec=_spec(),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+
+    stored = svc.get_run(status.id)
+    assert status.phase.value == "failed"
+    assert status.message == "docker_failed"
+    assert status.finished_at is not None
+    assert stored is not None
+    assert stored.phase.value == "failed"
+    assert stored.message == "docker_failed"
+    assert stored.finished_at is not None
+
+
+@pytest.mark.unit
+def test_background_docker_runner_exception_marks_run_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_DOCKER_FAKE_EXEC", "0")
+
+    svc = SandboxService()
+
+    with patch(
+        "tldw_Server_API.app.core.Sandbox.runners.docker_runner.DockerRunner.start_run",
+        side_effect=RuntimeError("boom"),
+    ):
+        with patch.object(SandboxService, "_submit_background_worker", lambda self, fn: fn()):
+            status = svc.start_run_scaffold(
+                user_id="1",
+                spec=_spec(),
+                spec_version="1.0",
+                idem_key=None,
+                raw_body={},
+            )
+
+    stored = svc.get_run(status.id)
+    assert status.phase.value == "failed"
+    assert status.message == "docker_failed"
+    assert status.finished_at is not None
+    assert stored is not None
+    assert stored.phase.value == "failed"
+    assert stored.message == "docker_failed"
+    assert stored.finished_at is not None

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, TrustLevel
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, Session, TrustLevel
 from tldw_Server_API.app.core.Sandbox.orchestrator import SessionActiveRunsConflict
 
 
@@ -169,7 +169,25 @@ def test_session_backed_run_inherits_session_defaults(monkeypatch) -> None:
 
     captured: dict[str, Any] = {}
 
-    def _fake_start_run_scaffold(*, user_id, spec, spec_version, idem_key, raw_body):
+    def _fake_start_run_scaffold(*, user_id, spec, spec_version, idem_key, raw_body, explicit_fields=None):
+        session = sb._service.get_session(spec.session_id) if spec.session_id else None
+        if session is not None and explicit_fields is not None:
+            if "runtime" not in explicit_fields and session.runtime is not None:
+                spec.runtime = session.runtime
+            if "base_image" not in explicit_fields and session.base_image:
+                spec.base_image = session.base_image
+            if "resources.cpu" not in explicit_fields and session.cpu_limit is not None:
+                spec.cpu = session.cpu_limit
+            if "resources.memory_mb" not in explicit_fields and session.memory_mb is not None:
+                spec.memory_mb = session.memory_mb
+            if "timeout_sec" not in explicit_fields and session.timeout_sec is not None:
+                spec.timeout_sec = int(session.timeout_sec)
+            if "network_policy" not in explicit_fields and session.network_policy is not None:
+                spec.network_policy = session.network_policy
+            if "env" not in explicit_fields:
+                spec.env = dict(session.env or {})
+            if "trust_level" not in explicit_fields and session.trust_level is not None:
+                spec.trust_level = session.trust_level
         captured["user_id"] = user_id
         captured["spec"] = spec
         return RunStatus(
@@ -225,6 +243,72 @@ def test_session_backed_run_inherits_session_defaults(monkeypatch) -> None:
     assert spec.trust_level == TrustLevel.trusted
 
 
+def test_session_backed_run_refreshes_session_defaults_after_prelock_work(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    old_session = Session(
+        id="sess-refresh",
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+        timeout_sec=30,
+        env={"SESSION_TOKEN": "old"},
+        trust_level=TrustLevel.standard,
+    )
+    new_session = Session(
+        id="sess-refresh",
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        expires_at=None,
+        timeout_sec=77,
+        env={"SESSION_TOKEN": "new"},
+        trust_level=TrustLevel.trusted,
+    )
+    state = {"session": old_session}
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session", lambda session_id: state["session"])
+    monkeypatch.setattr(sb._service._orch, "get_session", lambda session_id, **kwargs: state["session"])
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
+
+    def _switch_session_and_parse(files):
+        state["session"] = new_session
+        return []
+
+    def _capture_enqueue(*, user_id, spec, spec_version, idem_key, body):
+        captured["spec"] = spec
+        return RunStatus(
+            id="run-refresh",
+            phase=RunPhase.queued,
+            spec_version=spec_version,
+            runtime=spec.runtime or RuntimeType.docker,
+            base_image=spec.base_image,
+            session_id=spec.session_id,
+            started_at=datetime.now(timezone.utc),
+        )
+
+    monkeypatch.setattr(sb._service, "parse_inline_files", _switch_session_and_parse)
+    monkeypatch.setattr(sb._service._orch, "enqueue_run", _capture_enqueue)
+
+    with _client(monkeypatch) as client:
+        run_resp = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": "sess-refresh",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert run_resp.status_code == 200
+
+    spec = captured["spec"]
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.timeout_sec == 77
+    assert spec.env == {"SESSION_TOKEN": "new"}
+    assert spec.trust_level == TrustLevel.trusted
+
+
 def test_session_backed_run_returns_not_found_if_session_disappears_during_start(monkeypatch) -> None:
     from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
 
@@ -248,7 +332,7 @@ def test_session_backed_run_returns_not_found_if_session_disappears_during_start
         ),
     )
 
-    def _raise_session_not_found(*, user_id, spec, spec_version, idem_key, raw_body):
+    def _raise_session_not_found(*, user_id, spec, spec_version, idem_key, raw_body, explicit_fields=None):
         raise ValueError("session_not_found")
 
     monkeypatch.setattr(sb._service, "start_run_scaffold", _raise_session_not_found)

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import os
 from typing import Any, Dict
+from datetime import datetime, timezone
 
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, TrustLevel
 
 
 def _client(monkeypatch) -> TestClient:
@@ -65,6 +67,33 @@ def test_create_session_scaffold(monkeypatch) -> None:
         assert r3.status_code == 409
 
 
+def test_create_session_returns_execution_defaults(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        body: Dict[str, Any] = {
+            "spec_version": "1.0",
+            "runtime": "docker",
+            "base_image": "python:3.12-slim",
+            "cpu_limit": 1.5,
+            "memory_mb": 768,
+            "timeout_sec": 77,
+            "network_policy": "deny_all",
+            "env": {"SESSION_TOKEN": "present"},
+            "labels": {"team": "sandbox"},
+            "trust_level": "trusted",
+        }
+        r = client.post("/api/v1/sandbox/sessions", json=body)
+        assert r.status_code == 200
+        j = r.json()
+        assert j["base_image"] == "python:3.12-slim"
+        assert j["cpu_limit"] == 1.5
+        assert j["memory_mb"] == 768
+        assert j["timeout_sec"] == 77
+        assert j["network_policy"] == "deny_all"
+        assert j["env"] == {"SESSION_TOKEN": "present"}
+        assert j["labels"] == {"team": "sandbox"}
+        assert j["trust_level"] == "trusted"
+
+
 def test_start_run_scaffold_returns_completed_with_metadata(monkeypatch) -> None:
 
 
@@ -96,6 +125,104 @@ def test_start_run_scaffold_returns_completed_with_metadata(monkeypatch) -> None
         assert r3.status_code == 409
 
 
+def test_start_run_rejects_missing_session_and_base_image(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        r = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert r.status_code == 422
+
+
+def test_start_run_rejects_both_session_and_base_image(monkeypatch) -> None:
+    with _client(monkeypatch) as client:
+        session_resp = client.post(
+            "/api/v1/sandbox/sessions",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.11-slim",
+            },
+        )
+        assert session_resp.status_code == 200
+        session_id = str(session_resp.json()["id"])
+
+        r = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": session_id,
+                "base_image": "python:3.11-slim",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert r.status_code == 422
+
+
+def test_session_backed_run_inherits_session_defaults(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    captured: dict[str, Any] = {}
+
+    def _fake_start_run_scaffold(*, user_id, spec, spec_version, idem_key, raw_body):
+        captured["user_id"] = user_id
+        captured["spec"] = spec
+        return RunStatus(
+            id="run-session-defaults",
+            phase=RunPhase.queued,
+            spec_version=spec_version,
+            runtime=spec.runtime or RuntimeType.docker,
+            base_image=spec.base_image,
+            session_id=spec.session_id,
+            started_at=datetime.now(timezone.utc),
+        )
+
+    monkeypatch.setattr(sb._service, "start_run_scaffold", _fake_start_run_scaffold)
+
+    with _client(monkeypatch) as client:
+        session_resp = client.post(
+            "/api/v1/sandbox/sessions",
+            json={
+                "spec_version": "1.0",
+                "runtime": "docker",
+                "base_image": "python:3.12-slim",
+                "cpu_limit": 1.5,
+                "memory_mb": 768,
+                "timeout_sec": 77,
+                "network_policy": "deny_all",
+                "env": {"SESSION_TOKEN": "present"},
+                "trust_level": "trusted",
+            },
+        )
+        assert session_resp.status_code == 200
+        session_id = str(session_resp.json()["id"])
+
+        run_resp = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": session_id,
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+        assert run_resp.status_code == 200
+        assert run_resp.json()["base_image"] == "python:3.12-slim"
+
+    spec = captured["spec"]
+    assert spec.session_id == session_id
+    assert spec.runtime == RuntimeType.docker
+    assert spec.base_image == "python:3.12-slim"
+    assert spec.cpu == 1.5
+    assert spec.memory_mb == 768
+    assert spec.timeout_sec == 77
+    assert spec.network_policy == "deny_all"
+    assert spec.env == {"SESSION_TOKEN": "present"}
+    assert spec.trust_level == TrustLevel.trusted
+
+
 def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
     monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
 
@@ -116,7 +243,6 @@ def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
             json={
                 "spec_version": "1.0",
                 "runtime": "docker",
-                "base_image": "python:3.11-slim",
                 "session_id": session_id,
                 "command": ["python", "-c", "print('queued')"],
                 "timeout_sec": 15,

--- a/tldw_Server_API/tests/sandbox/test_sandbox_api.py
+++ b/tldw_Server_API/tests/sandbox/test_sandbox_api.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import os
 from typing import Any, Dict
 from datetime import datetime, timezone
+from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, TrustLevel
+from tldw_Server_API.app.core.Sandbox.orchestrator import SessionActiveRunsConflict
 
 
 def _client(monkeypatch) -> TestClient:
@@ -223,6 +225,48 @@ def test_session_backed_run_inherits_session_defaults(monkeypatch) -> None:
     assert spec.trust_level == TrustLevel.trusted
 
 
+def test_session_backed_run_returns_not_found_if_session_disappears_during_start(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(
+        sb._service,
+        "get_session",
+        lambda session_id: SimpleNamespace(
+            runtime=RuntimeType.docker,
+            base_image="python:3.11-slim",
+            env={},
+            timeout_sec=None,
+            cpu_limit=None,
+            memory_mb=None,
+            network_policy=None,
+            trust_level=None,
+            persona_id=None,
+            workspace_id=None,
+            workspace_group_id=None,
+            scope_snapshot_id=None,
+        ),
+    )
+
+    def _raise_session_not_found(*, user_id, spec, spec_version, idem_key, raw_body):
+        raise ValueError("session_not_found")
+
+    monkeypatch.setattr(sb._service, "start_run_scaffold", _raise_session_not_found)
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/runs",
+            json={
+                "spec_version": "1.0",
+                "session_id": "sess-gone",
+                "command": ["python", "-c", "print('hello')"],
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "session_not_found"}
+
+
 def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
     monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
 
@@ -259,3 +303,87 @@ def test_delete_session_cancels_and_drains_active_runs(monkeypatch) -> None:
         run_after = client.get(f"/api/v1/sandbox/runs/{run_id}")
         assert run_after.status_code == 200
         assert run_after.json().get("phase") == "killed"
+
+
+def test_restore_snapshot_returns_conflict_when_active_runs_exist(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+
+    def _raise_active_runs(session_id: str, snapshot_id: str) -> bool:
+        raise SessionActiveRunsConflict(
+            session_id=session_id,
+            active_runs=1,
+        )
+
+    monkeypatch.setattr(sb._service, "restore_snapshot", _raise_active_runs)
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/sessions/sess-restore-busy/restore",
+            json={"snapshot_id": "snap-123"},
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "error": "session_has_active_runs",
+            "active_runs": 1,
+            "session_id": "sess-restore-busy",
+        }
+    }
+
+
+def test_create_snapshot_returns_conflict_when_active_runs_exist(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+
+    def _raise_active_runs(session_id: str) -> dict[str, Any]:
+        raise SessionActiveRunsConflict(
+            session_id=session_id,
+            active_runs=1,
+        )
+
+    monkeypatch.setattr(sb._service, "create_snapshot", _raise_active_runs)
+
+    with _client(monkeypatch) as client:
+        response = client.post("/api/v1/sandbox/sessions/sess-snapshot-busy/snapshot")
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "error": "session_has_active_runs",
+            "active_runs": 1,
+            "session_id": "sess-snapshot-busy",
+        }
+    }
+
+
+def test_clone_session_returns_conflict_when_active_runs_exist(monkeypatch) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+
+    def _raise_active_runs(session_id: str, new_name: str | None = None):
+        raise SessionActiveRunsConflict(
+            session_id=session_id,
+            active_runs=1,
+        )
+
+    monkeypatch.setattr(sb._service, "clone_session", _raise_active_runs)
+
+    with _client(monkeypatch) as client:
+        response = client.post(
+            "/api/v1/sandbox/sessions/sess-clone-busy/clone",
+            json={"new_session_name": "copy"},
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": {
+            "error": "session_has_active_runs",
+            "active_runs": 1,
+            "session_id": "sess-clone-busy",
+        }
+    }

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -102,7 +102,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
         network_policy="deny_all",
         env={"SESSION_TOKEN": "present"},
         labels={"team": "sandbox"},
-        trust_level=TrustLevel.untrusted,
+        trust_level=TrustLevel.trusted,
         persona_id="persona-77",
         workspace_id="workspace-77",
         workspace_group_id="wg-77",
@@ -126,7 +126,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
     assert restored.network_policy == "deny_all"
     assert restored.env == {"SESSION_TOKEN": "present"}
     assert restored.labels == {"team": "sandbox"}
-    assert restored.trust_level == TrustLevel.untrusted
+    assert restored.trust_level == TrustLevel.trusted
 
     cloned = restarted_service.clone_session(source.id)
     assert cloned.base_image == "python:3.12-slim"
@@ -136,7 +136,7 @@ def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: P
     assert cloned.network_policy == "deny_all"
     assert cloned.env == {"SESSION_TOKEN": "present"}
     assert cloned.labels == {"team": "sandbox"}
-    assert cloned.trust_level == TrustLevel.untrusted
+    assert cloned.trust_level == TrustLevel.trusted
 
 
 def test_cross_node_delete_invalidates_cached_session_state(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -247,7 +247,7 @@ def test_destroy_session_cleans_snapshots_artifacts_and_usage(monkeypatch, tmp_p
     assert svc._orch._store.get_user_artifact_bytes("user-77") == 0  # type: ignore[attr-defined]
 
 
-def test_destroy_session_removes_session_root_and_workspace_lock_file(monkeypatch, tmp_path: Path) -> None:
+def test_destroy_session_removes_session_root_but_keeps_workspace_lock_file(monkeypatch, tmp_path: Path) -> None:
     _configure_sqlite_store(monkeypatch, tmp_path)
 
     svc = SandboxService()
@@ -273,7 +273,7 @@ def test_destroy_session_removes_session_root_and_workspace_lock_file(monkeypatc
     assert svc.destroy_session(session.id) is True
 
     assert not session_root.exists()
-    assert not lock_path.exists()
+    assert lock_path.exists()
 
 
 def test_create_snapshot_rejects_active_session_runs(monkeypatch, tmp_path: Path) -> None:
@@ -448,10 +448,15 @@ def test_session_backed_start_run_waits_for_snapshot_workspace_operation(monkeyp
     snapshot_thread.start()
     assert snapshot_entered.wait(timeout=1.0)
 
-    run_thread = threading.Thread(target=_run_start, daemon=True)
-    run_thread.start()
+    run_attempted = threading.Event()
 
-    time.sleep(0.05)
+    def _run_start_with_signal() -> None:
+        run_attempted.set()
+        _run_start()
+
+    run_thread = threading.Thread(target=_run_start_with_signal, daemon=True)
+    run_thread.start()
+    assert run_attempted.wait(timeout=1.0)
     assert not enqueue_entered.is_set(), "session-backed run enqueue should wait for workspace operations"
 
     release_snapshot.set()
@@ -537,10 +542,15 @@ def test_session_backed_start_run_waits_for_snapshot_workspace_operation_across_
     snapshot_thread.start()
     assert snapshot_entered.wait(timeout=1.0)
 
-    run_thread = threading.Thread(target=_run_start, daemon=True)
-    run_thread.start()
+    run_attempted = threading.Event()
 
-    time.sleep(0.05)
+    def _run_start_with_signal() -> None:
+        run_attempted.set()
+        _run_start()
+
+    run_thread = threading.Thread(target=_run_start_with_signal, daemon=True)
+    run_thread.start()
+    assert run_attempted.wait(timeout=1.0)
     assert not enqueue_entered.is_set(), "cross-service session-backed enqueue should wait for workspace operations"
 
     release_snapshot.set()
@@ -595,6 +605,15 @@ def test_list_snapshots_waits_for_cross_service_snapshot_create(monkeypatch, tmp
         except BaseException as exc:  # pragma: no cover - asserted via errors list
             create_errors.append(exc)
 
+    list_called = threading.Event()
+    original_list_snapshots = svc_list._snapshots.list_snapshots
+
+    def _tracked_list_snapshots(session_id: str):
+        list_called.set()
+        return original_list_snapshots(session_id)
+
+    monkeypatch.setattr(svc_list._snapshots, "list_snapshots", _tracked_list_snapshots)
+
     def _run_list() -> None:
         try:
             list_result["snapshots"] = svc_list.list_snapshots(session.id)
@@ -605,10 +624,16 @@ def test_list_snapshots_waits_for_cross_service_snapshot_create(monkeypatch, tmp
     create_thread.start()
     assert snapshot_entered.wait(timeout=1.0)
 
-    list_thread = threading.Thread(target=_run_list, daemon=True)
-    list_thread.start()
+    list_attempted = threading.Event()
 
-    time.sleep(0.05)
+    def _run_list_with_signal() -> None:
+        list_attempted.set()
+        _run_list()
+
+    list_thread = threading.Thread(target=_run_list_with_signal, daemon=True)
+    list_thread.start()
+    assert list_attempted.wait(timeout=1.0)
+    assert not list_called.is_set(), "snapshot listing should not reach the underlying store while create holds the lock"
     assert "snapshots" not in list_result, "cross-service snapshot listing should wait for in-progress create"
 
     release_snapshot.set()
@@ -662,6 +687,15 @@ def test_get_snapshot_info_waits_for_cross_service_snapshot_create(monkeypatch, 
         except BaseException as exc:  # pragma: no cover - asserted via errors list
             create_errors.append(exc)
 
+    info_called = threading.Event()
+    original_get_snapshot_info = svc_info._snapshots.get_snapshot_info
+
+    def _tracked_get_snapshot_info(session_id: str, snapshot_id_arg: str):
+        info_called.set()
+        return original_get_snapshot_info(session_id, snapshot_id_arg)
+
+    monkeypatch.setattr(svc_info._snapshots, "get_snapshot_info", _tracked_get_snapshot_info)
+
     def _run_info() -> None:
         try:
             info_result["snapshot"] = svc_info.get_snapshot_info(session.id, snapshot_id)
@@ -672,10 +706,16 @@ def test_get_snapshot_info_waits_for_cross_service_snapshot_create(monkeypatch, 
     create_thread.start()
     assert snapshot_entered.wait(timeout=1.0)
 
-    info_thread = threading.Thread(target=_run_info, daemon=True)
-    info_thread.start()
+    info_attempted = threading.Event()
 
-    time.sleep(0.05)
+    def _run_info_with_signal() -> None:
+        info_attempted.set()
+        _run_info()
+
+    info_thread = threading.Thread(target=_run_info_with_signal, daemon=True)
+    info_thread.start()
+    assert info_attempted.wait(timeout=1.0)
+    assert not info_called.is_set(), "snapshot info should not reach the underlying store while create holds the lock"
     assert "snapshot" not in info_result, "cross-service snapshot info should wait for in-progress create"
 
     release_snapshot.set()
@@ -729,6 +769,15 @@ def test_delete_snapshot_waits_for_cross_service_snapshot_create(monkeypatch, tm
         except BaseException as exc:  # pragma: no cover - asserted via errors list
             create_errors.append(exc)
 
+    delete_called = threading.Event()
+    original_delete_snapshot = svc_delete._snapshots.delete_snapshot
+
+    def _tracked_delete_snapshot(session_id: str, snapshot_id_arg: str):
+        delete_called.set()
+        return original_delete_snapshot(session_id, snapshot_id_arg)
+
+    monkeypatch.setattr(svc_delete._snapshots, "delete_snapshot", _tracked_delete_snapshot)
+
     def _run_delete() -> None:
         try:
             delete_result["deleted"] = svc_delete.delete_snapshot(session.id, snapshot_id)
@@ -739,10 +788,16 @@ def test_delete_snapshot_waits_for_cross_service_snapshot_create(monkeypatch, tm
     create_thread.start()
     assert snapshot_entered.wait(timeout=1.0)
 
-    delete_thread = threading.Thread(target=_run_delete, daemon=True)
-    delete_thread.start()
+    delete_attempted = threading.Event()
 
-    time.sleep(0.05)
+    def _run_delete_with_signal() -> None:
+        delete_attempted.set()
+        _run_delete()
+
+    delete_thread = threading.Thread(target=_run_delete_with_signal, daemon=True)
+    delete_thread.start()
+    assert delete_attempted.wait(timeout=1.0)
+    assert not delete_called.is_set(), "snapshot delete should not reach the underlying store while create holds the lock"
     assert "deleted" not in delete_result, "cross-service snapshot delete should wait for in-progress create"
 
     release_snapshot.set()

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import threading
+import time
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from tldw_Server_API.app.core.config import clear_config_cache, settings as app_settings
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType, RunSpec, SessionSpec, TrustLevel
-from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunStatus, RuntimeType, RunSpec, Session, SessionSpec, TrustLevel
+from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator, SessionActiveRunsConflict
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 from tldw_Server_API.app.core.Sandbox.store import get_store
 
@@ -240,6 +245,572 @@ def test_destroy_session_cleans_snapshots_artifacts_and_usage(monkeypatch, tmp_p
     assert not snapshot_dir.exists()
     assert not artifact_dir.exists()
     assert svc._orch._store.get_user_artifact_bytes("user-77") == 0  # type: ignore[attr-defined]
+
+
+def test_destroy_session_removes_session_root_and_workspace_lock_file(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc = SandboxService()
+    session = svc.create_session(
+        user_id="user-lock-cleanup",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    workspace_path = Path(str(ws))
+    session_root = workspace_path.parent
+    lock_path = Path(svc._workspace_operation_lock_path(session.id))
+
+    (workspace_path / "state.txt").write_text("cleanup me", encoding="utf-8")
+    svc.create_snapshot(session.id)
+
+    assert session_root.exists()
+    assert lock_path.exists()
+
+    assert svc.destroy_session(session.id) is True
+
+    assert not session_root.exists()
+    assert not lock_path.exists()
+
+
+def test_create_snapshot_rejects_active_session_runs(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc = SandboxService()
+    session = svc.create_session(
+        user_id="user-snapshot-busy",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+
+    svc._orch.enqueue_run(
+        user_id="user-snapshot-busy",
+        spec=RunSpec(
+            session_id=session.id,
+            runtime=RuntimeType.docker,
+            base_image="python:3.11-slim",
+            command=["python", "-c", "print('queued')"],
+        ),
+        spec_version="1.0",
+        idem_key=None,
+        body={"command": ["python", "-c", "print('queued')"], "session_id": session.id},
+    )
+
+    with pytest.raises(SessionActiveRunsConflict) as exc_info:
+        svc.create_snapshot(session.id)
+
+    assert exc_info.value.session_id == session.id
+    assert exc_info.value.active_runs == 1
+
+
+def test_restore_snapshot_rejects_active_session_runs(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc = SandboxService()
+    session = svc.create_session(
+        user_id="user-restore",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    (Path(str(ws)) / "state.txt").write_text("before snapshot", encoding="utf-8")
+    snap = svc.create_snapshot(session.id)
+
+    svc._orch.enqueue_run(
+        user_id="user-restore",
+        spec=RunSpec(
+            session_id=session.id,
+            runtime=RuntimeType.docker,
+            base_image="python:3.11-slim",
+            command=["python", "-c", "print('queued')"],
+        ),
+        spec_version="1.0",
+        idem_key=None,
+        body={"command": ["python", "-c", "print('queued')"], "session_id": session.id},
+    )
+
+    with pytest.raises(SessionActiveRunsConflict) as exc_info:
+        svc.restore_snapshot(session.id, str(snap["snapshot_id"]))
+
+    assert exc_info.value.session_id == session.id
+    assert exc_info.value.active_runs == 1
+
+
+def test_clone_session_rejects_active_session_runs(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc = SandboxService()
+    session = svc.create_session(
+        user_id="user-clone-busy",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    (Path(str(ws)) / "notes.txt").write_text("clone state", encoding="utf-8")
+
+    svc._orch.enqueue_run(
+        user_id="user-clone-busy",
+        spec=RunSpec(
+            session_id=session.id,
+            runtime=RuntimeType.docker,
+            base_image="python:3.11-slim",
+            command=["python", "-c", "print('queued')"],
+        ),
+        spec_version="1.0",
+        idem_key=None,
+        body={"command": ["python", "-c", "print('queued')"], "session_id": session.id},
+    )
+
+    with pytest.raises(SessionActiveRunsConflict) as exc_info:
+        svc.clone_session(session.id)
+
+    assert exc_info.value.session_id == session.id
+    assert exc_info.value.active_runs == 1
+
+
+def test_session_backed_start_run_waits_for_snapshot_workspace_operation(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+
+    svc = SandboxService()
+    session = svc.create_session(
+        user_id="user-run-lock",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    (Path(str(ws)) / "state.txt").write_text("snapshot me", encoding="utf-8")
+
+    snapshot_entered = threading.Event()
+    release_snapshot = threading.Event()
+    snapshot_errors: list[BaseException] = []
+    run_errors: list[BaseException] = []
+    enqueue_entered = threading.Event()
+    run_result: dict[str, object] = {}
+
+    def _blocked_snapshot(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        release_snapshot.wait(timeout=2.0)
+        return {
+            "snapshot_id": "snap-lock",
+            "created_at": "2026-03-08T00:00:00+00:00",
+            "size_bytes": 0,
+        }
+
+    original_enqueue = svc._orch.enqueue_run
+
+    def _tracked_enqueue(*args, **kwargs):
+        enqueue_entered.set()
+        return original_enqueue(*args, **kwargs)
+
+    monkeypatch.setattr(svc._snapshots, "create_snapshot", _blocked_snapshot)
+    monkeypatch.setattr(svc._snapshots, "enforce_quota", lambda *args, **kwargs: [])
+    monkeypatch.setattr(svc._orch, "enqueue_run", _tracked_enqueue)
+
+    def _run_snapshot() -> None:
+        try:
+            svc.create_snapshot(session.id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            snapshot_errors.append(exc)
+
+    def _run_start() -> None:
+        try:
+            run_result["status"] = svc.start_run_scaffold(
+                user_id="user-run-lock",
+                spec=RunSpec(
+                    session_id=session.id,
+                    runtime=RuntimeType.docker,
+                    base_image="python:3.11-slim",
+                    command=["python", "-c", "print('queued')"],
+                ),
+                spec_version="1.0",
+                idem_key=None,
+                raw_body={"command": ["python", "-c", "print('queued')"], "session_id": session.id},
+            )
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            run_errors.append(exc)
+
+    snapshot_thread = threading.Thread(target=_run_snapshot, daemon=True)
+    snapshot_thread.start()
+    assert snapshot_entered.wait(timeout=1.0)
+
+    run_thread = threading.Thread(target=_run_start, daemon=True)
+    run_thread.start()
+
+    time.sleep(0.05)
+    assert not enqueue_entered.is_set(), "session-backed run enqueue should wait for workspace operations"
+
+    release_snapshot.set()
+    snapshot_thread.join(timeout=1.0)
+    run_thread.join(timeout=1.0)
+
+    assert not snapshot_errors
+    assert not run_errors
+    assert enqueue_entered.is_set()
+    status = run_result.get("status")
+    assert status is not None
+    assert status.phase == RunPhase.queued  # type: ignore[union-attr]
+
+
+def test_session_backed_start_run_waits_for_snapshot_workspace_operation_across_services(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+
+    session_id = "sess-cross-worker-run"
+    workspace_root = tmp_path / session_id / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+    (workspace_root / "state.txt").write_text("snapshot me", encoding="utf-8")
+
+    svc_snapshot = SandboxService()
+    svc_run = SandboxService()
+
+    monkeypatch.setattr(svc_snapshot._orch, "get_session_workspace_path", lambda _sid, **kwargs: str(workspace_root))
+    monkeypatch.setattr(svc_run._orch, "get_session_workspace_path", lambda _sid, **kwargs: str(workspace_root))
+    monkeypatch.setattr(svc_run._orch, "get_session", lambda _sid, **kwargs: SimpleNamespace(id=session_id))
+
+    snapshot_entered = threading.Event()
+    release_snapshot = threading.Event()
+    snapshot_errors: list[BaseException] = []
+    run_errors: list[BaseException] = []
+    enqueue_entered = threading.Event()
+    run_result: dict[str, object] = {}
+
+    def _blocked_snapshot(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        release_snapshot.wait(timeout=2.0)
+        return {
+            "snapshot_id": "snap-cross-worker",
+            "created_at": "2026-03-08T00:00:00+00:00",
+            "size_bytes": 0,
+        }
+
+    original_enqueue = svc_run._orch.enqueue_run
+
+    def _tracked_enqueue(*args, **kwargs):
+        enqueue_entered.set()
+        return original_enqueue(*args, **kwargs)
+
+    monkeypatch.setattr(svc_snapshot._snapshots, "create_snapshot", _blocked_snapshot)
+    monkeypatch.setattr(svc_snapshot._snapshots, "enforce_quota", lambda *args, **kwargs: [])
+    monkeypatch.setattr(svc_run._orch, "enqueue_run", _tracked_enqueue)
+
+    def _run_snapshot() -> None:
+        try:
+            svc_snapshot.create_snapshot(session_id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            snapshot_errors.append(exc)
+
+    def _run_start() -> None:
+        try:
+            run_result["status"] = svc_run.start_run_scaffold(
+                user_id="user-run-lock",
+                spec=RunSpec(
+                    session_id=session_id,
+                    runtime=RuntimeType.docker,
+                    base_image="python:3.11-slim",
+                    command=["python", "-c", "print('queued')"],
+                ),
+                spec_version="1.0",
+                idem_key=None,
+                raw_body={"command": ["python", "-c", "print('queued')"], "session_id": session_id},
+            )
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            run_errors.append(exc)
+
+    snapshot_thread = threading.Thread(target=_run_snapshot, daemon=True)
+    snapshot_thread.start()
+    assert snapshot_entered.wait(timeout=1.0)
+
+    run_thread = threading.Thread(target=_run_start, daemon=True)
+    run_thread.start()
+
+    time.sleep(0.05)
+    assert not enqueue_entered.is_set(), "cross-service session-backed enqueue should wait for workspace operations"
+
+    release_snapshot.set()
+    snapshot_thread.join(timeout=1.0)
+    run_thread.join(timeout=1.0)
+
+    assert not snapshot_errors
+    assert not run_errors
+    assert enqueue_entered.is_set()
+    status = run_result.get("status")
+    assert status is not None
+    assert status.phase == RunPhase.queued  # type: ignore[union-attr]
+
+
+def test_list_snapshots_waits_for_cross_service_snapshot_create(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc_create = SandboxService()
+    svc_list = SandboxService()
+    session = svc_create.create_session(
+        user_id="user-snapshot-list-lock",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc_create._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    workspace = Path(str(ws))
+    (workspace / "state.txt").write_text("before", encoding="utf-8")
+    first = svc_create.create_snapshot(session.id)
+    assert first.get("snapshot_id")
+
+    snapshot_entered = threading.Event()
+    release_snapshot = threading.Event()
+    create_errors: list[BaseException] = []
+    list_errors: list[BaseException] = []
+    list_result: dict[str, object] = {}
+    base_create = svc_create._snapshots.create_snapshot
+
+    def _blocked_create(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        release_snapshot.wait(timeout=2.0)
+        return base_create(session_id, workspace_path)
+
+    monkeypatch.setattr(svc_create._snapshots, "create_snapshot", _blocked_create)
+    (workspace / "state.txt").write_text("after", encoding="utf-8")
+
+    def _run_create() -> None:
+        try:
+            list_result["created"] = svc_create.create_snapshot(session.id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            create_errors.append(exc)
+
+    def _run_list() -> None:
+        try:
+            list_result["snapshots"] = svc_list.list_snapshots(session.id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            list_errors.append(exc)
+
+    create_thread = threading.Thread(target=_run_create, daemon=True)
+    create_thread.start()
+    assert snapshot_entered.wait(timeout=1.0)
+
+    list_thread = threading.Thread(target=_run_list, daemon=True)
+    list_thread.start()
+
+    time.sleep(0.05)
+    assert "snapshots" not in list_result, "cross-service snapshot listing should wait for in-progress create"
+
+    release_snapshot.set()
+    create_thread.join(timeout=1.0)
+    list_thread.join(timeout=1.0)
+
+    assert not create_errors
+    assert not list_errors
+    snapshots = list_result.get("snapshots")
+    assert isinstance(snapshots, list)
+    assert len(snapshots) == 2
+
+
+def test_get_snapshot_info_waits_for_cross_service_snapshot_create(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc_create = SandboxService()
+    svc_info = SandboxService()
+    session = svc_create.create_session(
+        user_id="user-snapshot-info-lock",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc_create._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    workspace = Path(str(ws))
+    (workspace / "state.txt").write_text("before", encoding="utf-8")
+    first = svc_create.create_snapshot(session.id)
+    snapshot_id = str(first["snapshot_id"])
+
+    snapshot_entered = threading.Event()
+    release_snapshot = threading.Event()
+    create_errors: list[BaseException] = []
+    info_errors: list[BaseException] = []
+    info_result: dict[str, object] = {}
+    base_create = svc_create._snapshots.create_snapshot
+
+    def _blocked_create(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        release_snapshot.wait(timeout=2.0)
+        return base_create(session_id, workspace_path)
+
+    monkeypatch.setattr(svc_create._snapshots, "create_snapshot", _blocked_create)
+    (workspace / "state.txt").write_text("after", encoding="utf-8")
+
+    def _run_create() -> None:
+        try:
+            info_result["created"] = svc_create.create_snapshot(session.id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            create_errors.append(exc)
+
+    def _run_info() -> None:
+        try:
+            info_result["snapshot"] = svc_info.get_snapshot_info(session.id, snapshot_id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            info_errors.append(exc)
+
+    create_thread = threading.Thread(target=_run_create, daemon=True)
+    create_thread.start()
+    assert snapshot_entered.wait(timeout=1.0)
+
+    info_thread = threading.Thread(target=_run_info, daemon=True)
+    info_thread.start()
+
+    time.sleep(0.05)
+    assert "snapshot" not in info_result, "cross-service snapshot info should wait for in-progress create"
+
+    release_snapshot.set()
+    create_thread.join(timeout=1.0)
+    info_thread.join(timeout=1.0)
+
+    assert not create_errors
+    assert not info_errors
+    snapshot_info = info_result.get("snapshot")
+    assert isinstance(snapshot_info, dict)
+    assert snapshot_info.get("snapshot_id") == snapshot_id
+
+
+def test_delete_snapshot_waits_for_cross_service_snapshot_create(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    svc_create = SandboxService()
+    svc_delete = SandboxService()
+    session = svc_create.create_session(
+        user_id="user-snapshot-delete-lock",
+        spec=SessionSpec(runtime=RuntimeType.docker, base_image="python:3.11-slim"),
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+    ws = svc_create._orch.get_session_workspace_path(session.id)
+    assert ws is not None
+    workspace = Path(str(ws))
+    (workspace / "state.txt").write_text("before", encoding="utf-8")
+    first = svc_create.create_snapshot(session.id)
+    snapshot_id = str(first["snapshot_id"])
+
+    snapshot_entered = threading.Event()
+    release_snapshot = threading.Event()
+    create_errors: list[BaseException] = []
+    delete_errors: list[BaseException] = []
+    delete_result: dict[str, object] = {}
+    base_create = svc_create._snapshots.create_snapshot
+
+    def _blocked_create(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        release_snapshot.wait(timeout=2.0)
+        return base_create(session_id, workspace_path)
+
+    monkeypatch.setattr(svc_create._snapshots, "create_snapshot", _blocked_create)
+    (workspace / "state.txt").write_text("after", encoding="utf-8")
+
+    def _run_create() -> None:
+        try:
+            delete_result["created"] = svc_create.create_snapshot(session.id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            create_errors.append(exc)
+
+    def _run_delete() -> None:
+        try:
+            delete_result["deleted"] = svc_delete.delete_snapshot(session.id, snapshot_id)
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            delete_errors.append(exc)
+
+    create_thread = threading.Thread(target=_run_create, daemon=True)
+    create_thread.start()
+    assert snapshot_entered.wait(timeout=1.0)
+
+    delete_thread = threading.Thread(target=_run_delete, daemon=True)
+    delete_thread.start()
+
+    time.sleep(0.05)
+    assert "deleted" not in delete_result, "cross-service snapshot delete should wait for in-progress create"
+
+    release_snapshot.set()
+    create_thread.join(timeout=1.0)
+    delete_thread.join(timeout=1.0)
+
+    assert not create_errors
+    assert not delete_errors
+    assert delete_result.get("deleted") is True
+    assert svc_create.get_snapshot_info(session.id, snapshot_id) is None
+
+
+def test_session_backed_start_run_rejects_stale_cached_session_when_store_lookup_fails(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+
+    svc = SandboxService()
+    session_id = "sess-stale-run-cache"
+    workspace_root = tmp_path / session_id / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    cached_session = Session(
+        id=session_id,
+        runtime=RuntimeType.docker,
+        base_image="python:3.11-slim",
+        expires_at=None,
+    )
+    with svc._orch._lock:
+        svc._orch._sessions[session_id] = cached_session
+        svc._orch._session_roots[session_id] = str(workspace_root)
+
+    monkeypatch.setattr(svc._orch, "_prune_expired_sessions", lambda: None)
+
+    def _raise_store_lookup(_sid: str):
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setattr(svc._orch._store, "get_session", _raise_store_lookup)
+
+    enqueue_called = {"value": False}
+
+    def _tracked_enqueue(*args, **kwargs):
+        enqueue_called["value"] = True
+        return RunStatus(
+            id="run-stale-cache",
+            phase=RunPhase.queued,
+            runtime=RuntimeType.docker,
+            base_image="python:3.11-slim",
+        )
+
+    monkeypatch.setattr(svc._orch, "enqueue_run", _tracked_enqueue)
+
+    with pytest.raises(ValueError, match="session_not_found"):
+        svc.start_run_scaffold(
+            user_id="user-stale-run",
+            spec=RunSpec(
+                session_id=session_id,
+                runtime=RuntimeType.docker,
+                base_image="python:3.11-slim",
+                command=["python", "-c", "print('queued')"],
+            ),
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={"command": ["python", "-c", "print('queued')"], "session_id": session_id},
+        )
+
+    assert enqueue_called["value"] is False
 
 
 def test_session_tenancy_metadata_roundtrips_across_orchestrators(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_session_store_durability.py
+++ b/tldw_Server_API/tests/sandbox/test_session_store_durability.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from tldw_Server_API.app.core.config import clear_config_cache, settings as app_settings
-from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType, RunSpec, SessionSpec
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RuntimeType, RunSpec, SessionSpec, TrustLevel
 from tldw_Server_API.app.core.Sandbox.orchestrator import SandboxOrchestrator
 from tldw_Server_API.app.core.Sandbox.service import SandboxService
 from tldw_Server_API.app.core.Sandbox.store import get_store
@@ -87,6 +87,56 @@ def test_clone_session_works_after_service_restart(monkeypatch, tmp_path: Path) 
     assert cloned_ws is not None
     assert restarted_service._orch.get_session_owner(cloned.id) == "user-7"
     assert (Path(str(cloned_ws)) / "notes.txt").read_text(encoding="utf-8") == "stateful data"
+
+
+def test_session_execution_defaults_roundtrip_and_clone(monkeypatch, tmp_path: Path) -> None:
+    _configure_sqlite_store(monkeypatch, tmp_path)
+
+    source_service = SandboxService()
+    spec = SessionSpec(
+        runtime=RuntimeType.docker,
+        base_image="python:3.12-slim",
+        cpu_limit=1.5,
+        memory_mb=768,
+        timeout_sec=77,
+        network_policy="deny_all",
+        env={"SESSION_TOKEN": "present"},
+        labels={"team": "sandbox"},
+        trust_level=TrustLevel.untrusted,
+        persona_id="persona-77",
+        workspace_id="workspace-77",
+        workspace_group_id="wg-77",
+        scope_snapshot_id="scope-77",
+    )
+    source = source_service.create_session(
+        user_id="user-7",
+        spec=spec,
+        spec_version="1.0",
+        idem_key=None,
+        raw_body={"spec_version": "1.0", "runtime": "docker"},
+    )
+
+    restarted_service = SandboxService()
+    restored = restarted_service._orch.get_session(source.id)
+    assert restored is not None
+    assert restored.base_image == "python:3.12-slim"
+    assert restored.cpu_limit == 1.5
+    assert restored.memory_mb == 768
+    assert restored.timeout_sec == 77
+    assert restored.network_policy == "deny_all"
+    assert restored.env == {"SESSION_TOKEN": "present"}
+    assert restored.labels == {"team": "sandbox"}
+    assert restored.trust_level == TrustLevel.untrusted
+
+    cloned = restarted_service.clone_session(source.id)
+    assert cloned.base_image == "python:3.12-slim"
+    assert cloned.cpu_limit == 1.5
+    assert cloned.memory_mb == 768
+    assert cloned.timeout_sec == 77
+    assert cloned.network_policy == "deny_all"
+    assert cloned.env == {"SESSION_TOKEN": "present"}
+    assert cloned.labels == {"team": "sandbox"}
+    assert cloned.trust_level == TrustLevel.untrusted
 
 
 def test_cross_node_delete_invalidates_cached_session_state(monkeypatch, tmp_path: Path) -> None:

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import io
 import os
+import shutil
 import tarfile
+import threading
 import zipfile
 import tempfile
+from pathlib import Path
 
 from fastapi import HTTPException, UploadFile
 from fastapi.testclient import TestClient
@@ -66,6 +70,7 @@ async def test_upload_files_streams_plain_upload_without_unbounded_read(monkeypa
 
     monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
     monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
 
     upload = UploadFile(filename="hello.txt", file=io.BytesIO(b"hello world"))
     original_read = upload.read
@@ -96,6 +101,7 @@ async def test_upload_files_streams_tar_members_without_full_member_read(monkeyp
 
     monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
     monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
 
     tar_buffer = io.BytesIO()
     with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tf:
@@ -146,6 +152,7 @@ async def test_upload_files_streams_zip_members_without_zipfile_read(monkeypatch
 
     monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
     monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
 
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w") as zf:
@@ -176,6 +183,7 @@ async def test_upload_files_enforces_cap_against_existing_workspace_bytes(monkey
 
     monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
     monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
     monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
 
     first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
@@ -210,6 +218,7 @@ async def test_concurrent_uploads_are_serialized_per_session(monkeypatch, tmp_pa
 
     monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
     monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
     monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
 
     first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
@@ -270,6 +279,440 @@ async def test_concurrent_uploads_are_serialized_per_session(monkeypatch, tmp_pa
     assert second_entered.is_set()
     assert (tmp_path / "first.bin").exists()
     assert not (tmp_path / "second.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_create_snapshot_waits_for_shared_workspace_lock_even_when_upload_targets_legacy_lock_name(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+    svc = SandboxService()
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb, "_service", svc)
+    monkeypatch.setattr(svc, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(svc._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
+    monkeypatch.setattr(svc._snapshots, "enforce_quota", lambda *args, **kwargs: [])
+
+    snapshot_entered = threading.Event()
+    snapshot_errors: list[BaseException] = []
+
+    def _fake_create_snapshot(session_id: str, workspace_path: str) -> dict:
+        snapshot_entered.set()
+        return {
+            "snapshot_id": "snap-test",
+            "created_at": "2026-03-07T00:00:00+00:00",
+            "size_bytes": 0,
+        }
+
+    monkeypatch.setattr(svc._snapshots, "create_snapshot", _fake_create_snapshot)
+
+    upload = UploadFile(filename=".sandbox-upload.lock", file=io.BytesIO(b"legacy lock payload"))
+    upload_entered = asyncio.Event()
+    release_upload = asyncio.Event()
+    original_read = upload.read
+
+    async def _blocked_read(size: int = -1):
+        if not upload_entered.is_set():
+            upload_entered.set()
+            await release_upload.wait()
+        return await original_read(size)
+
+    upload.read = _blocked_read  # type: ignore[assignment]
+
+    upload_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-shared-lock",
+            files=[upload],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+    await asyncio.wait_for(upload_entered.wait(), timeout=1.0)
+
+    def _run_snapshot() -> None:
+        try:
+            svc.create_snapshot("sess-shared-lock")
+        except BaseException as exc:  # pragma: no cover - assertion path below
+            snapshot_errors.append(exc)
+
+    snapshot_thread = threading.Thread(target=_run_snapshot, daemon=True)
+    snapshot_thread.start()
+
+    await asyncio.sleep(0.05)
+    assert not snapshot_entered.is_set(), "snapshot should wait until the upload releases the workspace lock"
+
+    release_upload.set()
+    upload_response = await asyncio.wait_for(upload_task, timeout=2.0)
+    snapshot_thread.join(timeout=1.0)
+
+    assert not snapshot_errors
+    assert snapshot_entered.is_set()
+    assert upload_response.file_count == 1
+    assert (tmp_path / ".sandbox-upload.lock").read_bytes() == b"legacy lock payload"
+
+
+@pytest.mark.asyncio
+async def test_destroy_session_waits_for_shared_workspace_lock_during_upload(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+    svc = SandboxService()
+    workspace_root = tmp_path / "session-destroy" / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb, "_service", svc)
+    monkeypatch.setattr(svc, "get_session_workspace_path", lambda session_id: str(workspace_root))
+    monkeypatch.setattr(svc._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(workspace_root))
+    monkeypatch.setattr(svc._snapshots, "cleanup_session_snapshots", lambda session_id: None)
+
+    destroy_entered = threading.Event()
+    destroy_errors: list[BaseException] = []
+
+    def _fake_destroy_session(session_id: str, remove_workspace_tree: bool = True) -> bool:
+        destroy_entered.set()
+        return True
+
+    monkeypatch.setattr(svc._orch, "destroy_session", _fake_destroy_session)
+
+    upload = UploadFile(filename="payload.txt", file=io.BytesIO(b"delete waits"))
+    upload_entered = asyncio.Event()
+    release_upload = asyncio.Event()
+    original_read = upload.read
+
+    async def _blocked_read(size: int = -1):
+        if not upload_entered.is_set():
+            upload_entered.set()
+            await release_upload.wait()
+        return await original_read(size)
+
+    upload.read = _blocked_read  # type: ignore[assignment]
+
+    upload_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-destroy-lock",
+            files=[upload],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+    await asyncio.wait_for(upload_entered.wait(), timeout=1.0)
+
+    def _run_destroy() -> None:
+        try:
+            svc.destroy_session("sess-destroy-lock")
+        except BaseException as exc:  # pragma: no cover - asserted via errors list
+            destroy_errors.append(exc)
+
+    destroy_thread = threading.Thread(target=_run_destroy, daemon=True)
+    destroy_thread.start()
+
+    await asyncio.sleep(0.05)
+    assert not destroy_entered.is_set(), "destroy should wait until the upload releases the workspace lock"
+
+    release_upload.set()
+    upload_response = await asyncio.wait_for(upload_task, timeout=2.0)
+    destroy_thread.join(timeout=1.0)
+
+    assert not destroy_errors
+    assert destroy_entered.is_set()
+    assert upload_response.file_count == 1
+
+
+@pytest.mark.asyncio
+async def test_upload_files_returns_404_if_session_is_deleted_while_waiting_for_lock(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+    svc = SandboxService()
+    session_root = tmp_path / "session-deleted"
+    workspace_root = session_root / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    state = {"exists": True}
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb, "_service", svc)
+    monkeypatch.setattr(
+        svc._orch,
+        "get_session_workspace_path",
+        lambda session_id, **kwargs: str(workspace_root) if state["exists"] else None,
+    )
+    monkeypatch.setattr(svc._snapshots, "cleanup_session_snapshots", lambda session_id: None)
+
+    destroy_entered = threading.Event()
+    release_destroy = threading.Event()
+    destroy_errors: list[BaseException] = []
+
+    def _fake_destroy_session(session_id: str, remove_workspace_tree: bool = True) -> bool:
+        destroy_entered.set()
+        release_destroy.wait(timeout=2.0)
+        state["exists"] = False
+        return True
+
+    monkeypatch.setattr(svc._orch, "destroy_session", _fake_destroy_session)
+
+    upload = UploadFile(filename="payload.txt", file=io.BytesIO(b"should not survive delete"))
+    upload_started = asyncio.Event()
+    original_read = upload.read
+
+    async def _tracked_read(size: int = -1):
+        upload_started.set()
+        return await original_read(size)
+
+    upload.read = _tracked_read  # type: ignore[assignment]
+
+    def _run_destroy() -> None:
+        try:
+            svc.destroy_session("sess-deleted")
+        except BaseException as exc:  # pragma: no cover - asserted below
+            destroy_errors.append(exc)
+
+    destroy_thread = threading.Thread(target=_run_destroy, daemon=True)
+    destroy_thread.start()
+
+    assert destroy_entered.wait(timeout=1.0)
+
+    upload_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-deleted",
+            files=[upload],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    assert not upload_started.is_set(), "upload should wait behind destroy before reading the body"
+
+    release_destroy.set()
+    destroy_thread.join(timeout=1.0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await asyncio.wait_for(upload_task, timeout=2.0)
+
+    assert not destroy_errors
+    assert exc_info.value.status_code == 404
+    assert not upload_started.is_set()
+    assert not session_root.exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_files_does_not_recreate_deleted_session_root_across_services(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+    from tldw_Server_API.app.core.Sandbox import service as svc_mod
+
+    svc_delete = SandboxService()
+    svc_upload = SandboxService()
+    session_id = "sess-cross-worker-delete"
+    session_root = tmp_path / session_id
+    workspace_root = session_root / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    state = {"exists": True}
+
+    def _workspace_lookup(_session_id: str, **kwargs) -> str | None:
+        return str(workspace_root) if state["exists"] else None
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb, "_service", svc_upload)
+    monkeypatch.setattr(svc_delete._orch, "get_session_workspace_path", _workspace_lookup)
+    monkeypatch.setattr(svc_upload._orch, "get_session_workspace_path", _workspace_lookup)
+
+    original_acquire = svc_mod._acquire_workspace_file_lock
+    acquire_calls = {"count": 0}
+    waiter_opened = threading.Event()
+    delete_holding_lock = threading.Event()
+    delete_errors: list[BaseException] = []
+
+    def _instrumented_acquire(lock_path: str):
+        acquire_calls["count"] += 1
+        if acquire_calls["count"] != 2:
+            return original_acquire(lock_path)
+
+        if svc_mod._SANDBOX_SERVICE_HAS_FCNTL:
+            handle = open(lock_path, "a", encoding="utf-8")
+            waiter_opened.set()
+            svc_mod.fcntl.flock(handle.fileno(), svc_mod.fcntl.LOCK_EX)
+            return ("fcntl", handle)
+
+        if svc_mod._SANDBOX_SERVICE_HAS_MSVCRT:
+            handle = open(lock_path, "a+b")
+            waiter_opened.set()
+            with contextlib.suppress(Exception):
+                handle.seek(0)
+            svc_mod.msvcrt.locking(handle.fileno(), svc_mod.msvcrt.LK_LOCK, 1)
+            return ("msvcrt", handle)
+
+        waiter_opened.set()
+        return original_acquire(lock_path)
+
+    monkeypatch.setattr(svc_mod, "_acquire_workspace_file_lock", _instrumented_acquire)
+
+    def _run_delete() -> None:
+        try:
+            with svc_delete._workspace_operation_lock(session_id, str(workspace_root)) as ws:
+                delete_holding_lock.set()
+                assert waiter_opened.wait(timeout=1.0)
+                state["exists"] = False
+            shutil.rmtree(Path(ws).parent, ignore_errors=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            delete_errors.append(exc)
+
+    delete_thread = threading.Thread(target=_run_delete, daemon=True)
+    delete_thread.start()
+    assert delete_holding_lock.wait(timeout=1.0)
+
+    upload = UploadFile(filename="payload.txt", file=io.BytesIO(b"cross worker upload"))
+    upload_started = asyncio.Event()
+    original_read = upload.read
+
+    async def _tracked_read(size: int = -1):
+        upload_started.set()
+        return await original_read(size)
+
+    upload.read = _tracked_read  # type: ignore[assignment]
+
+    upload_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id=session_id,
+            files=[upload],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+
+    await asyncio.to_thread(waiter_opened.wait, 1.0)
+    delete_thread.join(timeout=1.0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await asyncio.wait_for(upload_task, timeout=2.0)
+
+    assert not delete_errors
+    assert exc_info.value.status_code == 404
+    assert not upload_started.is_set()
+    assert not session_root.exists()
+
+
+@pytest.mark.asyncio
+async def test_upload_files_rejects_stale_cached_workspace_when_store_lookup_fails(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+    from tldw_Server_API.app.core.Sandbox import service as svc_mod
+
+    svc_delete = SandboxService()
+    svc_upload = SandboxService()
+    session_id = "sess-store-failure-delete"
+    session_root = tmp_path / session_id
+    workspace_root = session_root / "workspace"
+    workspace_root.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb, "_service", svc_upload)
+    monkeypatch.setattr(svc_delete._orch, "get_session_workspace_path", lambda _sid, **kwargs: str(workspace_root))
+    monkeypatch.setattr(svc_upload._orch, "_prune_expired_sessions", lambda: None)
+
+    with svc_upload._orch._lock:
+        svc_upload._orch._session_roots[session_id] = str(workspace_root)
+
+    def _raise_store_lookup(_sid: str):
+        raise RuntimeError("store unavailable")
+
+    monkeypatch.setattr(svc_upload._orch._store, "get_session", _raise_store_lookup)
+
+    original_acquire = svc_mod._acquire_workspace_file_lock
+    acquire_calls = {"count": 0}
+    waiter_opened = threading.Event()
+    delete_holding_lock = threading.Event()
+    delete_errors: list[BaseException] = []
+
+    def _instrumented_acquire(lock_path: str):
+        acquire_calls["count"] += 1
+        if acquire_calls["count"] != 2:
+            return original_acquire(lock_path)
+
+        if svc_mod._SANDBOX_SERVICE_HAS_FCNTL:
+            handle = open(lock_path, "a", encoding="utf-8")
+            waiter_opened.set()
+            svc_mod.fcntl.flock(handle.fileno(), svc_mod.fcntl.LOCK_EX)
+            return ("fcntl", handle)
+
+        if svc_mod._SANDBOX_SERVICE_HAS_MSVCRT:
+            handle = open(lock_path, "a+b")
+            waiter_opened.set()
+            with contextlib.suppress(Exception):
+                handle.seek(0)
+            svc_mod.msvcrt.locking(handle.fileno(), svc_mod.msvcrt.LK_LOCK, 1)
+            return ("msvcrt", handle)
+
+        waiter_opened.set()
+        return original_acquire(lock_path)
+
+    monkeypatch.setattr(svc_mod, "_acquire_workspace_file_lock", _instrumented_acquire)
+
+    def _run_delete() -> None:
+        try:
+            with svc_delete._workspace_operation_lock(session_id, str(workspace_root)) as ws:
+                delete_holding_lock.set()
+                assert waiter_opened.wait(timeout=1.0)
+            shutil.rmtree(Path(ws).parent, ignore_errors=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            delete_errors.append(exc)
+
+    delete_thread = threading.Thread(target=_run_delete, daemon=True)
+    delete_thread.start()
+    assert delete_holding_lock.wait(timeout=1.0)
+
+    upload = UploadFile(filename="payload.txt", file=io.BytesIO(b"stale cache upload"))
+    upload_started = asyncio.Event()
+    original_read = upload.read
+
+    async def _tracked_read(size: int = -1):
+        upload_started.set()
+        return await original_read(size)
+
+    upload.read = _tracked_read  # type: ignore[assignment]
+
+    upload_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id=session_id,
+            files=[upload],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+
+    await asyncio.to_thread(waiter_opened.wait, 1.0)
+    delete_thread.join(timeout=1.0)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await asyncio.wait_for(upload_task, timeout=2.0)
+
+    assert not delete_errors
+    assert exc_info.value.status_code == 404
+    assert not upload_started.is_set()
+    assert not session_root.exists()
 
 
 # =============================================================================

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -6,6 +6,7 @@ import tarfile
 import zipfile
 import tempfile
 
+from fastapi import HTTPException, UploadFile
 from fastapi.testclient import TestClient
 import pytest
 
@@ -56,6 +57,150 @@ def test_session_upload_creates_workspace(monkeypatch) -> None:
         assert payload.get("file_count") == 1
     finally:
         app.dependency_overrides.pop(get_request_user, None)
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_plain_upload_without_unbounded_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    upload = UploadFile(filename="hello.txt", file=io.BytesIO(b"hello world"))
+    original_read = upload.read
+
+    async def _guarded_read(size: int = -1):
+        if size in (-1, None):
+            raise AssertionError("plain upload should be read in bounded chunks")
+        return await original_read(size)
+
+    upload.read = _guarded_read  # type: ignore[assignment]
+
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-plain",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.bytes_received == 11
+    assert response.file_count == 1
+    assert (tmp_path / "hello.txt").read_bytes() == b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_tar_members_without_full_member_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tf:
+        info = tarfile.TarInfo(name="safe.txt")
+        data = b"streamed tar content"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    tar_buffer.seek(0)
+
+    original_extractfile = tarfile.TarFile.extractfile
+
+    class _GuardedReader:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+
+        def read(self, size: int = -1):
+            if size in (-1, None):
+                raise AssertionError("tar members should be copied in bounded chunks")
+            return self._wrapped.read(size)
+
+        def close(self):
+            return self._wrapped.close()
+
+    def _guarded_extractfile(self, member, *args, **kwargs):
+        reader = original_extractfile(self, member, *args, **kwargs)
+        if reader is None:
+            return None
+        return _GuardedReader(reader)
+
+    monkeypatch.setattr(tarfile.TarFile, "extractfile", _guarded_extractfile)
+
+    upload = UploadFile(filename="archive.tar.gz", file=tar_buffer)
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-tar",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.file_count == 1
+    assert (tmp_path / "safe.txt").read_bytes() == b"streamed tar content"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_streams_zip_members_without_zipfile_read(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w") as zf:
+        zf.writestr("safe.txt", "streamed zip content")
+    zip_buffer.seek(0)
+
+    def _forbidden_read(self, name, pwd=None):
+        raise AssertionError("zip uploads should stream via ZipFile.open, not ZipFile.read")
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", _forbidden_read)
+
+    upload = UploadFile(filename="archive.zip", file=zip_buffer)
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-zip",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.file_count == 1
+    assert (tmp_path / "safe.txt").read_text(encoding="utf-8") == "streamed zip content"
+
+
+@pytest.mark.asyncio
+async def test_upload_files_enforces_cap_against_existing_workspace_bytes(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
+
+    first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
+    second = UploadFile(filename="second.bin", file=io.BytesIO(b"b" * (700 * 1024)))
+
+    first_response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-cap",
+        files=[first],
+        current_user=_user(1),
+        audit_service=None,
+    )
+    assert first_response.file_count == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        await sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-cap",
+            files=[second],
+            current_user=_user(1),
+            audit_service=None,
+        )
+
+    assert exc_info.value.status_code == 413
+    assert (tmp_path / "first.bin").exists()
+    assert not (tmp_path / "second.bin").exists()
 
 
 # =============================================================================

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 import tarfile
@@ -199,6 +200,74 @@ async def test_upload_files_enforces_cap_against_existing_workspace_bytes(monkey
         )
 
     assert exc_info.value.status_code == 413
+    assert (tmp_path / "first.bin").exists()
+    assert not (tmp_path / "second.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_uploads_are_serialized_per_session(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setenv("SANDBOX_WORKSPACE_CAP_MB", "1")
+
+    first = UploadFile(filename="first.bin", file=io.BytesIO(b"a" * (700 * 1024)))
+    second = UploadFile(filename="second.bin", file=io.BytesIO(b"b" * (700 * 1024)))
+
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_entered = asyncio.Event()
+
+    original_first_read = first.read
+    original_second_read = second.read
+
+    async def _first_read(size: int = -1):
+        if not first_entered.is_set():
+            first_entered.set()
+            await release_first.wait()
+        return await original_first_read(size)
+
+    async def _second_read(size: int = -1):
+        second_entered.set()
+        return await original_second_read(size)
+
+    first.read = _first_read  # type: ignore[assignment]
+    second.read = _second_read  # type: ignore[assignment]
+
+    first_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-concurrent",
+            files=[first],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+    await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+
+    second_task = asyncio.create_task(
+        sb.upload_files(
+            request=None,  # type: ignore[arg-type]
+            session_id="sess-concurrent",
+            files=[second],
+            current_user=_user(1),
+            audit_service=None,
+        )
+    )
+
+    await asyncio.sleep(0.05)
+    assert not second_entered.is_set(), "second upload should wait for the session lock"
+
+    release_first.set()
+    first_response = await asyncio.wait_for(first_task, timeout=2.0)
+    assert first_response.file_count == 1
+
+    with pytest.raises(HTTPException) as exc_info:
+        await asyncio.wait_for(second_task, timeout=2.0)
+
+    assert exc_info.value.status_code == 413
+    assert second_entered.is_set()
     assert (tmp_path / "first.bin").exists()
     assert not (tmp_path / "second.bin").exists()
 

--- a/tldw_Server_API/tests/sandbox/test_session_upload.py
+++ b/tldw_Server_API/tests/sandbox/test_session_upload.py
@@ -96,6 +96,39 @@ async def test_upload_files_streams_plain_upload_without_unbounded_read(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_upload_files_offloads_filesystem_work_to_threads(monkeypatch, tmp_path) -> None:
+    from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
+
+    monkeypatch.setattr(sb, "_require_session_owner", lambda session_id, current_user: "1")
+    monkeypatch.setattr(sb._service, "get_session_workspace_path", lambda session_id: str(tmp_path))
+    monkeypatch.setattr(sb._service._orch, "get_session_workspace_path", lambda session_id, **kwargs: str(tmp_path))
+
+    upload = UploadFile(filename="threaded.txt", file=io.BytesIO(b"threaded upload"))
+    original_to_thread = sb.asyncio.to_thread
+    calls: list[str] = []
+
+    async def _tracked_to_thread(func, /, *args, **kwargs):
+        calls.append(getattr(func, "__name__", repr(func)))
+        return await original_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(sb.asyncio, "to_thread", _tracked_to_thread)
+
+    response = await sb.upload_files(
+        request=None,  # type: ignore[arg-type]
+        session_id="sess-offload",
+        files=[upload],
+        current_user=_user(1),
+        audit_service=None,
+    )
+
+    assert response.file_count == 1
+    assert "_workspace_usage_bytes_sync" in calls
+    assert "_prepare_temp_target_sync" in calls
+    assert "_write_fd_chunk_sync" in calls
+    assert "_finalize_temp_target_sync" in calls
+
+
+@pytest.mark.asyncio
 async def test_upload_files_streams_tar_members_without_full_member_read(monkeypatch, tmp_path) -> None:
     from tldw_Server_API.app.api.v1.endpoints import sandbox as sb
 


### PR DESCRIPTION
## Summary
- harden sandbox workspace locking and session-backed run admission so locked operations fail closed when the shared store cannot confirm the session
- keep upload/delete and snapshot-related workspace operations serialized across workers through the shared lock path
- add regression coverage for stale-cache, delete, and cross-service sandbox workspace races

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/sandbox/test_session_upload.py tldw_Server_API/tests/sandbox/test_session_store_durability.py tldw_Server_API/tests/sandbox/test_snapshot_quota_enforcement.py tldw_Server_API/tests/sandbox/test_sandbox_api.py
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/core/Sandbox/orchestrator.py tldw_Server_API/app/core/Sandbox/service.py -f json -o /tmp/bandit_sandbox_pr_isolation.json
