### PR TITLE
Add llama.cpp grammar library and thinking controls

### DIFF
--- a/Docs/API-related/Chat_API_Documentation.md
+++ b/Docs/API-related/Chat_API_Documentation.md
@@ -5,7 +5,7 @@
 - Endpoint: `POST /api/v1/chat/completions` (OpenAI-compatible)
 - Purpose: Route chat requests to configured LLM providers with optional streaming and persistence.
 - Scope note: Chat Dictionaries and the Document Generator are implemented as sub-routes under `/api/v1/chat`, but documented in Chatbook features. See `./Chatbook_Features_API_Documentation.md`.
-- OpenAPI tags: `chat`, `chat-dictionaries`, `chat-documents`
+- OpenAPI tags: `chat`, `chat-grammars`, `chat-dictionaries`, `chat-documents`
 
 ## Conversation Metadata Endpoints
 Conversation list/search, lifecycle updates, message trees, analytics, and knowledge-save endpoints live under `/api/v1/chat`. Session CRUD for character chats remains under `/api/v1/chats`.
@@ -16,6 +16,11 @@ Endpoints:
 - `GET /api/v1/chat/conversations/{id}/tree` — root-thread tree view with `max_depth` + truncation.
 - `GET /api/v1/chat/analytics` — UTC histogram buckets by date/topic/state.
 - `POST /api/v1/chat/knowledge/save` — save a snippet to Notes/Flashcards with backlinks.
+- `GET /api/v1/chat/grammars` — list saved user-scoped GBNF grammars for llama.cpp.
+- `POST /api/v1/chat/grammars` — create a saved user-scoped GBNF grammar.
+- `GET /api/v1/chat/grammars/{grammar_id}` — fetch one saved grammar.
+- `PATCH /api/v1/chat/grammars/{grammar_id}` — update grammar text or metadata.
+- `DELETE /api/v1/chat/grammars/{grammar_id}` — soft-delete by default; use `hard_delete=true` to permanently remove it.
 
 Note:
 - `/api/v1/chats` continues to serve character chat session CRUD and exports.
@@ -83,6 +88,24 @@ Provider-specific extensions:
   - `extra_headers`: include Bedrock guardrail headers like `X-Amzn-Bedrock-GuardrailIdentifier`, `X-Amzn-Bedrock-GuardrailVersion`, optional `X-Amzn-Bedrock-Trace`.
   - `extra_body`: include `amazon-bedrock-guardrailConfig` object when needed.
   - Merge behavior: `extra_headers`/`extra_body` are additive; explicit headers/body keys in the request win on conflicts.
+- llama.cpp advanced controls (`/api/v1/chat/completions` only in v1):
+  - `thinking_budget_tokens` (int, optional): app-level thinking budget. Only accepted when the resolved provider is llama.cpp and the deployment has a configured mapping for the upstream request key.
+  - `grammar_mode` (`none` | `library` | `inline`, optional): selects how the outbound GBNF grammar is resolved.
+  - `grammar_id` (string, optional): required when `grammar_mode=library`.
+  - `grammar_inline` (string, optional): required when `grammar_mode=inline`.
+  - `grammar_override` (string, optional): optional request-only override when using a saved grammar.
+  - Guardrails:
+    - These fields are rejected with `400` if the resolved provider is not llama.cpp.
+    - These fields are rejected with `400` when `strict_openai_compat` is active for the local-provider runtime.
+    - First-class llama.cpp controls override reserved `extra_body` keys such as `grammar` and the configured thinking-budget request key.
+  - Scope boundary:
+    - v1 support is limited to `POST /api/v1/chat/completions`.
+    - `/api/v1/messages` does not yet accept these first-class llama.cpp fields.
+
+Saved grammar resource notes:
+- Grammars are user-scoped and stored in the chat domain.
+- Grammar records expose `validation_status` as `unchecked | valid | invalid`.
+- `DELETE /api/v1/chat/grammars/{grammar_id}` soft-deletes unless `hard_delete=true` is sent.
 
 Minimal example (non-streaming):
 ```bash
@@ -181,6 +204,20 @@ curl -s -X POST http://127.0.0.1:8000/api/v1/chat/completions \
       "mode": "append",
       "assistant_prefill": "Draft: "
     }
+  }'
+```
+
+llama.cpp grammar example (inline):
+```bash
+curl -s -X POST http://127.0.0.1:8000/api/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "X-API-KEY: $API_KEY" \
+  -d '{
+    "api_provider": "llama.cpp",
+    "model": "llama.cpp/local-model",
+    "messages": [{"role":"user","content":"Reply with ok only."}],
+    "grammar_mode": "inline",
+    "grammar_inline": "root ::= \"ok\""
   }'
 ```
 

--- a/Docs/API-related/Providers_API_Documentation.md
+++ b/Docs/API-related/Providers_API_Documentation.md
@@ -65,6 +65,9 @@
 ### 2) GET /api/v1/llm/providers
 - Summary: List configured LLM providers and their models.
 - Query params: `include_deprecated` (bool, default false)
+- llama.cpp note:
+  - The `Llama.cpp` provider entry may include a first-class `llama_cpp_controls` block for UI-facing capability discovery.
+  - This block is separate from `extra_body_compat`. `extra_body_compat` documents raw passthrough keys; `llama_cpp_controls` documents the stable app-level contract for llama.cpp grammar/thinking controls.
 - Response (example):
 ```json
 {
@@ -108,6 +111,35 @@
   "total_configured": 1
 }
 ```
+
+llama.cpp capability example:
+```json
+{
+  "name": "llama",
+  "display_name": "Llama.cpp",
+  "llama_cpp_controls": {
+    "grammar": {
+      "supported": true,
+      "effective_reason": "supported in current deployment",
+      "source": "first_class+extra_body"
+    },
+    "thinking_budget": {
+      "supported": false,
+      "request_key": null,
+      "effective_reason": "no configured thinking-budget mapping for this deployment"
+    },
+    "reserved_extra_body_keys": ["grammar"]
+  }
+}
+```
+
+`llama_cpp_controls` semantics:
+- `grammar.supported=false` means llama.cpp advanced controls are disabled for the current runtime, typically because `strict_openai_compat` is effective.
+- `thinking_budget.supported=true` only when the deployment explicitly maps the app-level field to an upstream llama.cpp request key.
+- `thinking_budget.request_key` is populated from:
+  - environment: `LLAMA_CPP_THINKING_BUDGET_PARAM`
+  - config: `Local-API.llama_cpp_thinking_budget_param`
+- `reserved_extra_body_keys` is the list UIs should treat as first-class/reserved when editing raw `extra_body`.
 
 ### 3) GET /api/v1/llm/providers/{provider_name}
 - Summary: Details for a single provider.
@@ -181,6 +213,7 @@ Tip: For chat-only models, use `/api/v1/llm/models?type=chat`.
 - By default, deprecated models are filtered from responses; set `include_deprecated=true` to include them.
 - Health information reflects in-process runtime state, including circuit-breaker status and queue statistics.
 - Provider objects may include additional fields when present in config, such as `endpoint` (for local providers), `default_temperature`, `max_tokens`, `supports_streaming`, `requires_api_key`, `capabilities`, and a `health` sub-object when the provider manager is initialized.
+- `models_info[]` entries may also repeat provider-level llama.cpp control metadata so clients that work from model selections can gate controls without hard-coding provider-specific rules.
 - Note: `total_configured` reflects the number of providers returned in the response; individual providers indicate configuration with the `is_configured` flag.
 - The response from `/llm/providers` may also include `diagnostics_ui` with UI auto-refresh intervals for queue status/activity, derived from the server configuration.
 - Recognized providers include (commercial): OpenAI, AWS Bedrock, Anthropic, Google, Mistral, Cohere, Groq, HuggingFace, OpenRouter, DeepSeek, Qwen, Moonshot, Z.AI; and (local/OpenAI-compatible): Llama.cpp, Kobold.cpp, Oobabooga, TabbyAPI, vLLM, Local LLM, Ollama, Aphrodite, Custom OpenAI API (1/2).

--- a/Docs/API-related/llamacpp_integration_modes.md
+++ b/Docs/API-related/llamacpp_integration_modes.md
@@ -19,6 +19,7 @@ This project supports two distinct `llama.cpp` integration planes. They are both
 | `GET /api/v1/llamacpp/models` | managed plane | Lists model files from managed-plane runtime |
 | `POST /api/v1/llamacpp/inference` | managed plane | Runs inference against managed server context |
 | `POST /api/v1/chat/completions` + `provider=llama.cpp` | provider plane | Sends request through provider adapter to configured `llama_api` endpoint |
+| `GET/POST/PATCH/DELETE /api/v1/chat/grammars*` | provider plane support surface | Manages user-scoped saved GBNF grammars used by the provider-plane chat workflow |
 
 ## Critical Rule
 
@@ -34,10 +35,33 @@ Starting/stopping a managed server does not automatically rewrite provider-plane
 | `/api/v1/llamacpp/models` returns unavailable while `provider=llama.cpp` chat works | managed plane | Provider plane configured, but no managed handler/runtime | Configure managed handler/model directory; do not assume provider mode enables lifecycle API |
 | `provider=llama.cpp` chat fails while managed status is running | provider plane | `llama_api` endpoint/auth/config mismatch | Fix provider configuration (`llama_api` host/path/key), validate OpenAI-compatible endpoint |
 | Tools payloads rejected for `provider=llama.cpp` | provider plane | Current contract blocks tools for this adapter path | Remove tools/tool_choice or switch provider that advertises tool support |
+| llama.cpp grammar/thinking fields are rejected with `400` | provider plane | Resolved provider is not llama.cpp, or `strict_openai_compat` disabled non-standard fields | Route through `POST /api/v1/chat/completions` with llama.cpp selected and check local-provider strict compatibility |
+| `thinking_budget_tokens` is ignored by UI or rejected by API | provider plane | No operator-configured upstream request-key mapping | Set `LLAMA_CPP_THINKING_BUDGET_PARAM` or `Local-API.llama_cpp_thinking_budget_param` for the deployment |
+
+## Advanced Controls On The Provider Plane
+
+The llama.cpp provider plane now exposes first-class advanced controls for `POST /api/v1/chat/completions`:
+
+- `grammar_mode`, `grammar_id`, `grammar_inline`, `grammar_override`
+- `thinking_budget_tokens` when the deployment advertises support
+
+Important boundaries:
+
+1. These first-class fields are only supported on `POST /api/v1/chat/completions` in v1.
+2. `/api/v1/messages` does not yet accept the first-class llama.cpp grammar/thinking fields.
+3. `strict_openai_compat` disables these advanced fields because they rely on non-standard request keys.
+4. The grammar library endpoints only store user-scoped reusable GBNF text; the actual grammar is resolved into provider-plane `extra_body` at send time.
+
+Provider metadata for this surface is exposed under `GET /api/v1/llm/providers` as `llama_cpp_controls`, including:
+
+- whether grammar is currently supported
+- whether thinking-budget control is currently supported
+- the reserved raw `extra_body` keys that first-class UI controls can overwrite
 
 ## Verification Checklist
 
 1. Confirm which plane your workflow targets first.
 2. For lifecycle operations, use only `/api/v1/llamacpp/*` managed plane endpoints.
 3. For chat-provider routing, validate `provider=llama.cpp` and `llama_api` config independently.
-4. Treat managed and provider diagnostics separately during incident triage.
+4. If you need per-request thinking budget, verify `LLAMA_CPP_THINKING_BUDGET_PARAM` or `Local-API.llama_cpp_thinking_budget_param` is configured before testing.
+5. Treat managed and provider diagnostics separately during incident triage.

--- a/Docs/Plans/2026-03-09-mcp-hub-tool-permissions-design.md
+++ b/Docs/Plans/2026-03-09-mcp-hub-tool-permissions-design.md
@@ -1,0 +1,598 @@
+# MCP Hub Tool Permissions Design
+
+Date: 2026-03-09
+Status: Approved for planning
+
+## Summary
+
+`MCP Hub` becomes the canonical control plane for tool governance. It owns reusable permission profiles, context assignments, overrides, runtime approval rules, credential bindings, and the effective policy resolver used by MCP tool execution.
+
+`Persona/Agents` UI remains responsible for non-tool configuration. For tool access, it becomes a consumer of MCP Hub state and shows an effective summary plus links back to MCP Hub for editing.
+
+This design avoids coupling the new system to the current ACP-specific policy scaffolding, which is being re-architected elsewhere. ACP integration is treated as a compatibility boundary, not the source of truth.
+
+## Goals
+
+- Make `MCP Hub` the main editor for tool permissions, tool approvals, and tool-related credentials.
+- Support reusable named permission profiles.
+- Allow `default`, `group`, and `persona` contexts to reference a profile or use manual configuration.
+- Allow per-context overrides that may either restrict or broaden access when the editor has authority to grant the broader capability.
+- Support runtime approval policies such as `ask every time`, `ask outside profile`, and temporary elevation.
+- Keep secret material out of persona records.
+- Provide a model that can survive ACP re-architecture without rework.
+
+## Non-Goals
+
+- Moving non-tool persona attributes into MCP Hub.
+- Making ACP-specific runtime stores the canonical policy backend.
+- Implementing full policy enforcement for every possible tool without first establishing a capability registry and metadata contract.
+
+## Current Constraints
+
+The existing codebase has partial MCP Hub support, but the current model is not enough for the target system:
+
+- `MCP Hub` currently exposes `ACP Profiles`, `Tool Catalogs`, and `External Servers` in the UI.
+- MCP Hub storage is currently ACP-profile-shaped and uses ownership scopes of `global`, `org`, `team`, and `user`.
+- MCP runtime enforcement currently understands RBAC tool permissions and generic `mcp:*` scopes, but not the full capability model proposed here.
+- External server federation still reads YAML or env-backed configuration at startup.
+- Persona policy rules already exist and must not remain a peer source of truth for tool policy after this design lands.
+
+## Core Decisions
+
+### 1. MCP Hub is the canonical tool policy domain
+
+All tool-related governance is edited in MCP Hub:
+
+- permission profiles
+- assignment of profiles to contexts
+- inline overrides
+- runtime approval behavior
+- external-service credential bindings
+
+Persona and agent UIs keep non-tool settings and consume effective tool policy summaries from MCP Hub.
+
+### 2. Reusable profiles are optional accelerators, not mandatory
+
+Users may:
+
+- assign an existing reusable profile
+- create a new custom profile
+- configure a target context manually without first creating a reusable profile
+
+This supports both curated presets and direct editing.
+
+### 3. Overrides may broaden access, but only with grant authority
+
+A user editing a persona or group assignment may broaden access beyond inherited policy only if the acting user has authority to grant the broader capability. The UI must reject or disable broadening changes the acting user is not authorized to grant.
+
+### 4. Runtime approval is part of policy, not an afterthought
+
+Static permissions and runtime approvals are part of one system. A policy can allow an action silently, allow it only after confirmation, or allow temporary elevation with explicit scope and expiry.
+
+## Domain Model
+
+### Distinguish ownership from applicability
+
+This is a required correction to avoid overloading the current `owner_scope_type` model.
+
+#### Config owner scope
+
+Defines who owns and can administer a stored object:
+
+- `global`
+- `org`
+- `team`
+- `user`
+
+This is used for visibility, administration, and storage boundaries.
+
+#### Assignment target
+
+Defines where a policy applies at runtime:
+
+- `default`
+- `group`
+- `persona`
+
+Each assignment target also carries a target identifier when needed:
+
+- `default` has no target id
+- `group` uses a group id
+- `persona` uses a persona id
+
+These are separate concepts and must be stored separately.
+
+### Proposed objects
+
+#### PermissionProfile
+
+Reusable named tool policy bundle.
+
+Fields:
+
+- `id`
+- `name`
+- `description`
+- `owner_scope_type`
+- `owner_scope_id`
+- `mode` (`preset` or `custom`)
+- `policy_document`
+- `is_active`
+- timestamps and actor metadata
+
+#### PolicyAssignment
+
+Connects policy to a runtime target.
+
+Fields:
+
+- `id`
+- `target_type` (`default`, `group`, `persona`)
+- `target_id`
+- `owner_scope_type`
+- `owner_scope_id`
+- `profile_id` nullable
+- `inline_policy_document` nullable
+- `approval_policy_id` nullable
+- `is_active`
+- timestamps and actor metadata
+
+Rule:
+
+- a target may use a reusable profile, manual config, or a reusable profile plus overrides
+
+#### PolicyOverride
+
+Delta applied on top of the base assignment.
+
+Fields:
+
+- `id`
+- `assignment_id`
+- `override_document`
+- `broadens_access` boolean
+- `grant_authority_snapshot`
+- timestamps and actor metadata
+
+#### ApprovalPolicy
+
+Defines runtime approval behavior.
+
+Fields:
+
+- `id`
+- `name`
+- `mode`
+- `rules`
+- `owner_scope_type`
+- `owner_scope_id`
+- timestamps and actor metadata
+
+#### CredentialBinding
+
+Associates profiles or assignments with external service credentials and server definitions without embedding raw secrets into persona config.
+
+Fields:
+
+- `id`
+- `binding_target_type`
+- `binding_target_id`
+- `external_server_id`
+- `credential_ref`
+- `usage_rules`
+- timestamps and actor metadata
+
+#### EffectivePolicy
+
+Computed runtime result returned by the resolver, not necessarily persisted as the source record.
+
+Contents:
+
+- resolved capabilities
+- resolved resource constraints
+- required approval mode
+- credential availability state
+- provenance metadata
+- deny reasons or missing prerequisites
+
+## Capability Model
+
+Tool permissions must be capability-based rather than only tool-name-based. Tool names remain enforceable units, but they are not expressive enough for the target UX.
+
+### Capability families
+
+- `filesystem.read`
+- `filesystem.write`
+- `filesystem.delete`
+- `process.execute`
+- `network.external`
+- `credentials.use`
+- `mcp.server.connect`
+- `tool.invoke`
+
+### Constraint dimensions
+
+- path scope
+- tool scope
+- module scope
+- external service scope
+- credential scope
+
+Examples:
+
+- current folder only
+- current folder and descendants
+- explicit path allowlist
+- all tools in a module
+- selected individual tools
+- approved external services only
+
+### Sensitivity classes
+
+The editor and approval system should understand tool risk classes such as:
+
+- destructive
+- external side effects
+- secret-bearing
+- executes processes
+- broad filesystem reach
+
+## Tool Capability Registry
+
+This is a required addition because current MCP runtime checks do not understand the full proposed capability model.
+
+Each tool should have machine-readable metadata or a registry entry describing:
+
+- tool name
+- module
+- capability families used
+- whether it is read-only or mutating
+- whether it can affect filesystem, processes, network, or credentials
+- risk class
+- optional resource-specific constraints
+
+The UI reads this registry to present grouped controls. The runtime resolver uses it to determine whether a requested tool call fits within policy.
+
+Without this registry, the system would only be able to approximate the promised permission model.
+
+## Preset Profiles
+
+Presets should be implemented as normal profiles shipped by the system:
+
+- `No Security`
+- `Read Only`
+- `Read In Current Folder`
+- `RW Current Folder`
+- `External Services`
+
+Presets are editable by duplication, not by mutating the built-in definition directly. They act as starting points, not a separate policy mechanism.
+
+## Grant Authority Model
+
+The current coarse MCP Hub mutation gate is not sufficient for safe broadening behavior. Editing and granting must be distinct.
+
+### Needed grant classes
+
+- `grant.tool.invoke`
+- `grant.filesystem.read`
+- `grant.filesystem.write`
+- `grant.filesystem.delete`
+- `grant.process.execute`
+- `grant.network.external`
+- `grant.credentials.use`
+- `grant.mcp.server.connect`
+
+These grant permissions define which capabilities a user may add when editing another context's policy.
+
+### Grant evaluation rules
+
+When a proposed change is more permissive than the inherited effective policy:
+
+1. detect the broadened capabilities
+2. compare them against the acting user's grant authority
+3. allow save only when all broadened capabilities are grantable
+4. record in audit history that access was broadened
+
+If the acting user lacks authority, the UI should explain which capability could not be granted.
+
+## Policy Resolution Rules
+
+Resolution order:
+
+1. start with the applicable `default` assignment
+2. merge in any applicable `group` assignment
+3. merge in the `persona` assignment if present
+4. apply explicit overrides
+5. apply approval policy rules
+6. apply hard upper bounds from platform authorization
+
+### Merge semantics
+
+These rules must be explicit in implementation:
+
+- capability grants are additive unless explicitly denied
+- explicit denies take precedence over inherited allows
+- tighter resource constraints win when two grants overlap
+- broader overrides are allowed only with grant authority
+- approval policies can require confirmation even for otherwise allowed actions
+
+### Hard upper bounds
+
+The resolved MCP Hub policy is not the only gate. The runtime must still honor:
+
+- AuthNZ identity and session validity
+- RBAC permissions
+- API key scope ceilings
+- missing credential material
+- unavailable external service definitions
+
+This is why the system must distinguish `configured policy` from `effective policy`.
+
+## Runtime Approval Model
+
+Approval policy is attached to assignments or profiles and evaluated at tool-call time.
+
+### Supported modes
+
+- `allow_silently`
+- `ask_every_time`
+- `ask_outside_profile`
+- `ask_on_sensitive_actions`
+- `temporary_elevation_allowed`
+
+### Approval request contents
+
+Every approval request should include:
+
+- acting user
+- persona id if any
+- group id if any
+- conversation or session id if applicable
+- tool name
+- summarized arguments
+- trigger reason
+- requested elevation scope
+- available duration options
+
+### Approval token scope
+
+To avoid accidental over-broad approvals, approval decisions should be keyed by:
+
+- user
+- target context
+- conversation or session id when relevant
+- tool or tool risk class
+- resource scope if applicable
+- approval reason
+
+### Expiry
+
+Temporary elevation must always include TTL. Examples:
+
+- once
+- until end of current conversation
+- until end of current session
+- fixed expiration timestamp
+
+## MCP Hub UI Structure
+
+The UI should be reorganized around governance tasks rather than current backend categories.
+
+### Top-level tabs
+
+- `Profiles`
+- `Assignments`
+- `Approvals`
+- `Credentials`
+- `Catalog`
+
+### Profiles
+
+Create and edit reusable profiles.
+
+Modes:
+
+- simple editor for common controls
+- advanced editor for capability and constraint detail
+
+### Assignments
+
+Attach policy to:
+
+- `default`
+- `group`
+- `persona`
+
+Each assignment may:
+
+- reference a reusable profile
+- use inline manual configuration
+- add overrides
+
+This view should also display an effective policy preview.
+
+### Approvals
+
+Configure runtime approval modes and approval rules.
+
+### Credentials
+
+Manage external server definitions, secret presence, bindings, rotation state, and which policies may use each credential class.
+
+### Catalog
+
+Show tool and module catalog enriched with policy metadata from the capability registry.
+
+## Effective Policy Explainability
+
+The effective-policy view must show provenance, not only the final result.
+
+For each major capability or denial, the UI should show:
+
+- granted by
+- denied by
+- overridden by
+- approval required because
+- missing prerequisite because
+
+This is necessary to make inherited policy debuggable.
+
+## External Servers And Credential Source Of Truth
+
+This area needs an explicit migration rule because current federation still reads file or env-backed configuration.
+
+### Recommended precedence
+
+Phase 1:
+
+- support both DB-backed MCP Hub state and file-backed external config
+- DB-backed state is authoritative for UI-managed servers
+- file-backed state remains readable for migration and compatibility
+
+Phase 2:
+
+- runtime federation reads merged registry through a single abstraction, not directly from YAML
+- MCP Hub-managed definitions override file definitions when ids collide
+
+Phase 3:
+
+- deprecate direct file-backed configuration for interactive management
+
+Secrets should continue to be stored through secure server-side secret storage and referenced indirectly. Persona records should never hold raw secrets.
+
+## Persona Policy Compatibility
+
+Existing persona policy rules must not remain a second peer authority for tool governance.
+
+Recommended transition:
+
+- MCP Hub becomes canonical for tool policy
+- persona policy rule endpoints remain for compatibility only
+- tool-related persona rules become derived or adapter-backed views
+- persona UI shows effective MCP Hub policy summary rather than owning separate tool policy logic
+
+This preserves backward compatibility while removing split-brain governance.
+
+## Persistence
+
+Add MCP Hub-owned durable tables for:
+
+- permission profiles
+- profile preset metadata
+- policy assignments
+- policy overrides
+- approval policies
+- approval decisions and temporary elevations
+- credential bindings
+- policy audit history
+- optional capability registry metadata if not generated elsewhere
+
+Do not rely on the current in-memory ACP admin session service for durable permission configuration.
+
+## Audit Requirements
+
+Every mutation should log:
+
+- actor
+- target context
+- previous state
+- new state
+- whether the change broadened access
+- which grant authority justified the broadened access
+
+Every runtime approval should log:
+
+- requester
+- context
+- tool
+- summarized args or arg hash
+- approval reason
+- approval scope
+- expiry
+- decision
+
+## Rollout Plan
+
+### Phase 1: Storage and read path
+
+- add new MCP Hub domain objects
+- add read APIs
+- expose capability registry metadata
+
+### Phase 2: UI foundation
+
+- replace current ACP-tab framing with governance tabs
+- build profile editor and assignments UI
+- add effective-policy preview and provenance
+
+### Phase 3: Resolver integration
+
+- add policy resolver service
+- make MCP protocol ask the resolver before execution
+- keep behind a feature flag until validated
+
+### Phase 4: Approval flow
+
+- add runtime approval service
+- add temporary elevation handling
+- add audit integration
+
+### Phase 5: Compatibility cleanup
+
+- adapt persona policy endpoints to MCP Hub-backed views
+- reduce reliance on ACP-specific tool policy mechanisms
+- deprecate file-first external server management
+
+## Testing Strategy
+
+### Backend unit tests
+
+- profile resolution
+- assignment precedence
+- override broadening detection
+- grant authority checks
+- approval trigger logic
+- credential availability effects
+
+### Backend integration tests
+
+- MCP execution allowed or denied based on resolved policy
+- approval flow lifecycle
+- temporary elevation expiry
+- external server precedence behavior
+- persona summary consuming MCP Hub state
+
+### Frontend tests
+
+- profile editor simple and advanced modes
+- assignment flows
+- effective-policy explainability
+- approval policy configuration
+- credential binding flows
+
+### Migration tests
+
+- old MCP Hub data remains readable
+- compatibility adapters behave predictably
+- file-backed external config and DB-backed config coexist during migration
+
+## Open Implementation Questions
+
+- Whether group assignment should initially map to existing team or org structures, or support a separate MCP-specific group concept later.
+- Whether capability registry data should be stored centrally or derived from tool definitions at startup.
+- Whether approval dialogs should support user-defined reason templates or only system-generated explanations in the first version.
+
+## Recommended First Implementation Slice
+
+The first implementation should not attempt the whole system at once.
+
+Recommended slice:
+
+1. introduce new MCP Hub domain model and read APIs
+2. build `Profiles` and `Assignments`
+3. expose effective-policy preview
+4. add resolver and feature-flagged enforcement
+5. add `Approvals`
+6. expand `Credentials`
+
+This yields visible product value early while keeping runtime migration risk contained.

--- a/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-design.md
+++ b/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-design.md
@@ -1,0 +1,348 @@
+# Llama.cpp Thinking Budget And Grammar Library Design
+
+Date: 2026-03-10
+Status: Approved
+Scope: `POST /api/v1/chat/completions`, shared chat/playground UI state, sidepanel/workspace session persistence, user-scoped grammar library
+
+## 1. Summary
+
+Add first-class llama.cpp advanced controls for:
+
+- constrained generation via reusable custom GBNF grammars
+- thinking-budget control when the deployment can map an app-level budget field to a verified llama.cpp request parameter
+
+The design keeps these controls llama.cpp-specific, reuses the existing chat model settings state pipeline, stores reusable grammars as a user-owned resource, and translates app-level fields into llama.cpp request payload extensions at send time.
+
+## 2. User-Approved Decisions
+
+1. Ship a full-stack feature, not API-only.
+2. Scope the feature to `llama.cpp` only.
+3. Support both per-request use and persistence in saved chat/session state.
+4. Use a user-scoped reusable grammar library.
+5. Support selecting a saved grammar with an optional per-request inline override.
+6. Prefer first-class UI controls over a raw `extra_body`-only UX.
+7. Keep raw transport details behind a backend translation layer.
+
+## 3. Review-Driven Revisions
+
+This design was revised after a design review to address these issues:
+
+1. Do not assume a stable upstream per-request thinking-budget request key for llama.cpp.
+2. Reuse the existing `ChatModelSettings` store and session snapshot pipeline instead of inventing a new preset backend.
+3. Treat advanced llama.cpp controls as unavailable when `strict_openai_compat` disables non-standard request keys.
+4. Make `chat/completions` the only v1 request surface. `/api/v1/messages` support is a follow-on task.
+5. Define conflict rules between first-class controls and raw `extra_body`.
+
+## 4. Current State
+
+### 4.1 Existing Capabilities
+
+- Chat/playground UI already persists model settings such as `apiProvider`, `numPredict`, `reasoningEffort`, and raw `extraBody` in `apps/packages/ui/src/store/model.tsx`.
+- Sidepanel chat already snapshots `modelSettings` into per-tab session state, and workspace/playground paths already reuse the same store family.
+- The backend already forwards provider-specific payload extensions through `extra_body`.
+- llama.cpp already advertises `grammar` as a known extra-body compatibility key in `tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py`.
+- `GET /api/v1/llm/providers` already exposes capability metadata and extra-body compatibility hints that UIs can consume.
+
+### 4.2 Gaps
+
+- There is no first-class grammar library resource.
+- The UI exposes raw `extraBody` JSON but no guided grammar workflow.
+- There is no stable app-level contract for a llama.cpp thinking budget.
+- `strict_openai_compat` can drop non-standard payload keys, which would silently break naive advanced-control implementations.
+- `/api/v1/messages` also supports llama.cpp, but there is no aligned advanced-control story there yet.
+
+## 5. Goals And Non-Goals
+
+### 5.1 Goals
+
+- Add first-class llama.cpp grammar selection and editing in the chat/playground UI.
+- Persist grammar/thinking selections in existing chat/session state and snapshots.
+- Introduce a user-scoped grammar library with CRUD operations.
+- Keep the request contract safe when llama.cpp deployment/runtime settings disable non-standard keys.
+- Centralize translation from app-level fields to llama.cpp request payload extensions.
+
+### 5.2 Non-Goals
+
+- No generic advanced-controls framework for other providers in this phase.
+- No new reusable server-side chat preset backend in this phase.
+- No `/api/v1/messages` llama.cpp advanced-control support in v1.
+- No promise that the server can validate every GBNF grammar offline without a llama.cpp-compatible validator/runtime.
+
+## 6. Proposed Architecture
+
+### 6.1 Canonical UI State Path
+
+Extend the existing shared chat settings store instead of creating a parallel state model.
+
+Add llama.cpp-specific state keys to `ChatModelSettings`:
+
+- `llamaThinkingBudgetTokens?: number`
+- `llamaGrammarMode?: "none" | "library" | "inline"`
+- `llamaGrammarId?: string`
+- `llamaGrammarInline?: string`
+- `llamaGrammarOverride?: string`
+
+These values become part of the same snapshot flow already used by sidepanel/workspace chat state.
+
+This means “saved chat/session presets” in v1 are implemented by:
+
+- existing session/tab snapshots
+- existing persisted model settings consumers
+
+This phase does not add a separate reusable preset resource.
+
+### 6.2 Backend Translation Layer
+
+Add a dedicated llama.cpp request-extension resolver, for example:
+
+`tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py`
+
+Responsibilities:
+
+1. Accept app-level request fields from `ChatCompletionRequest`.
+2. Enforce provider guard: only valid when `api_provider == "llama.cpp"`.
+3. Resolve grammar selection into final GBNF text.
+4. Merge first-class llama.cpp controls into `extra_body` with deterministic precedence.
+5. Refuse advanced llama.cpp controls when runtime strict compatibility disables non-standard fields.
+6. Map `thinking_budget_tokens` into the deployment’s configured/verified upstream request key.
+
+### 6.3 Capability-Gated Thinking Budget
+
+Grammar support is always first-class for llama.cpp because the current compatibility catalog already knows about `grammar`.
+
+Thinking-budget support must be capability-gated.
+
+The server should not hard-code a guessed upstream request-body field. Instead:
+
+1. Expose a dedicated capability such as `llama_cpp_controls.thinking_budget`.
+2. Mark it `supported=true` only when the deployment can map the app-level field to a verified upstream request key.
+3. Return `supported=false` with an `effective_reason` when the deployment cannot safely support it.
+
+This allows the grammar workflow to ship even if a given llama.cpp deployment cannot yet expose a safe per-request thinking budget.
+
+## 7. API And Data Model
+
+### 7.1 Chat Request Extensions
+
+Extend `ChatCompletionRequest` with llama.cpp-only top-level extension fields:
+
+- `thinking_budget_tokens: int | null`
+- `grammar_mode: "none" | "library" | "inline" | null`
+- `grammar_id: str | null`
+- `grammar_inline: str | null`
+- `grammar_override: str | null`
+
+Server behavior:
+
+1. Reject these fields with `400` when `api_provider != "llama.cpp"`.
+2. Reject these fields with `400` when llama.cpp strict compatibility disables advanced controls.
+3. Reject invalid combinations:
+   - `grammar_mode == "library"` without `grammar_id`
+   - `grammar_mode == "inline"` without `grammar_inline`
+4. Translate accepted values into llama.cpp `extra_body`.
+
+### 7.2 Grammar Library Resource
+
+Add a user-scoped grammar library API under the chat domain:
+
+- `GET /api/v1/chat/grammars`
+- `POST /api/v1/chat/grammars`
+- `GET /api/v1/chat/grammars/{grammar_id}`
+- `PATCH /api/v1/chat/grammars/{grammar_id}`
+- `DELETE /api/v1/chat/grammars/{grammar_id}`
+
+Grammar record shape:
+
+- `id`
+- `name`
+- `description`
+- `grammar_text`
+- `validation_status: "unchecked" | "valid" | "invalid"`
+- `validation_error: str | null`
+- `last_validated_at`
+- `created_at`
+- `updated_at`
+- `is_archived`
+
+Storage should follow the same user-scoped pattern as existing chat-owned resources such as chat dictionaries, using the per-user ChaChaNotes database layer rather than a new global database.
+
+### 7.3 Provider Metadata Additions
+
+Extend provider capability metadata returned from `GET /api/v1/llm/providers` with a stable app-level capability block for llama.cpp controls:
+
+```json
+{
+  "llama_cpp_controls": {
+    "grammar": {
+      "supported": true,
+      "source": "first_class+extra_body",
+      "effective_reason": "supported in current deployment"
+    },
+    "thinking_budget": {
+      "supported": false,
+      "effective_reason": "no verified request mapping configured for this deployment"
+    }
+  }
+}
+```
+
+This metadata is separate from existing `extra_body_compat`. `extra_body_compat` remains a low-level passthrough hint; `llama_cpp_controls` becomes the first-class UI contract.
+
+## 8. Persistence Model
+
+### 8.1 Session And Snapshot Persistence
+
+Persist the new llama.cpp settings in the same client-side/session snapshot structures that already store `modelSettings`.
+
+This covers:
+
+- sidepanel tab snapshots
+- workspace/playground session persistence
+- any existing restore flows that already round-trip `ChatModelSettings`
+
+### 8.2 Reusable Grammar Persistence
+
+Reusable grammars live in the new user-scoped grammar library resource, not inside session snapshots.
+
+Snapshots store:
+
+- grammar mode
+- grammar id
+- inline grammar text
+- inline override text
+- thinking budget value
+
+Library records store:
+
+- reusable named grammar text and metadata
+
+## 9. UX Flow
+
+### 9.1 Surface
+
+Show a llama.cpp-only advanced section when the selected provider is `llama.cpp`.
+
+Controls:
+
+- `Thinking budget` numeric input
+- `Grammar source` segmented control: `None`, `Saved grammar`, `Inline`
+- saved grammar picker when `Saved grammar` is selected
+- inline grammar editor when `Inline` is selected
+- optional override editor when `Saved grammar` is selected
+- `Manage grammars` entry point into the grammar library CRUD UI
+
+### 9.2 Runtime Behavior
+
+1. When provider changes away from `llama.cpp`, keep the values in local state but disable the controls.
+2. Exclude llama.cpp extension fields from outgoing non-llama.cpp requests.
+3. When a saved grammar reference is missing or archived, surface a degraded-state warning and require reselection or inline replacement before send.
+4. When capability metadata says `thinking_budget.supported == false`, disable the numeric input and show the provider-reported reason.
+
+## 10. Conflict And Precedence Rules
+
+This phase must define deterministic merge behavior between first-class controls and raw `extraBody`.
+
+Rule set:
+
+1. First-class llama.cpp controls win over conflicting raw `extraBody` keys.
+2. If raw `extraBody` contains reserved keys such as `grammar` or the deployment’s configured thinking-budget key, the UI should warn and the backend should overwrite them with first-class values.
+3. Raw `extraBody` remains available for other advanced llama.cpp keys.
+
+Reserved keys:
+
+- `grammar`
+- configured thinking-budget request key for this deployment
+
+## 11. Validation And Error Handling
+
+### 11.1 Client-Side
+
+- grammar mode combination checks
+- empty grammar text checks
+- grammar size bounds
+- missing grammar reference handling
+- JSON validity for raw `extraBody`
+
+### 11.2 Server-Side
+
+- provider guard
+- strict-compat guard
+- grammar lookup authorization
+- missing/archived grammar rejection
+- request combination validation
+- bounded length checks on grammar text and override fields
+- upstream llama.cpp rejection translated into grammar/thinking-specific errors
+
+### 11.3 Grammar Validation Semantics
+
+`validation_status` must mean:
+
+- `unchecked`: stored but not validated against a compatible validator/runtime
+- `valid`: validated successfully by the server/runtime
+- `invalid`: validation failed; `validation_error` contains the last known reason
+
+Do not label a grammar as `valid` unless the server has actually performed validation.
+
+## 12. Scope Boundary For `/messages`
+
+`/api/v1/messages` already treats `llama.cpp` as a native provider, but this design intentionally does not include that surface in v1.
+
+v1 contract:
+
+- supported: `POST /api/v1/chat/completions`
+- follow-on: `/api/v1/messages` parity
+
+This must be explicit in docs and tests to avoid mismatched user expectations.
+
+## 13. Testing Strategy
+
+### 13.1 Backend Unit
+
+- chat schema validation for new llama.cpp extension fields
+- llama.cpp provider guard
+- strict-compat rejection path
+- grammar resolution precedence over raw `extra_body`
+- capability derivation for grammar and thinking-budget support
+
+### 13.2 Backend Integration
+
+- grammar library CRUD
+- per-user isolation for grammar records
+- successful chat request translation with saved grammar
+- successful chat request translation with inline grammar
+- degraded/missing grammar reference handling
+- thinking-budget translation only when supported
+
+### 13.3 Frontend
+
+- `ChatModelSettings` store round-trip of new fields
+- sidepanel/workspace snapshot persistence
+- provider-gated rendering for llama.cpp controls
+- disabled thinking-budget UI when provider metadata says unsupported
+- warning state when raw `extraBody` conflicts with first-class controls
+
+### 13.4 Regression
+
+- existing raw `extraBody` workflows remain functional
+- non-llama.cpp chat flows remain unchanged
+- existing session snapshot restore behavior remains unchanged
+
+## 14. Rollout
+
+1. Add backend capability metadata and grammar library resource.
+2. Add request translation and provider/strict guards.
+3. Extend shared chat settings state and persistence.
+4. Add llama.cpp advanced UI controls.
+5. Add conflict warnings around raw `extraBody`.
+6. Document the v1 boundary: `chat/completions` only.
+
+## 15. Acceptance Criteria
+
+1. Users can create, edit, archive, list, and delete reusable GBNF grammars in a user-scoped library.
+2. Users can choose `None`, `Saved grammar`, or `Inline` grammar in the llama.cpp chat UI.
+3. Existing chat/session persistence restores grammar and thinking-budget selections.
+4. Grammar selections are translated into llama.cpp request payloads without requiring users to hand-edit `extra_body`.
+5. If strict OpenAI compatibility disables advanced llama.cpp fields, the UI reflects that and the backend rejects unsupported requests clearly.
+6. Thinking budget is only exposed when the deployment can safely map it to a verified llama.cpp request parameter.
+7. Raw `extraBody` conflicts are handled deterministically and documented.
+8. `/api/v1/messages` is explicitly documented as out of scope for this phase.

--- a/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-design.md
+++ b/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-design.md
@@ -9,7 +9,7 @@ Scope: `POST /api/v1/chat/completions`, shared chat/playground UI state, sidepan
 Add first-class llama.cpp advanced controls for:
 
 - constrained generation via reusable custom GBNF grammars
-- thinking-budget control when the deployment can map an app-level budget field to a verified llama.cpp request parameter
+- thinking-budget control when the deployment has an explicit operator-configured mapping from the app-level budget field to a llama.cpp request parameter
 
 The design keeps these controls llama.cpp-specific, reuses the existing chat model settings state pipeline, stores reusable grammars as a user-owned resource, and translates app-level fields into llama.cpp request payload extensions at send time.
 
@@ -28,10 +28,12 @@ The design keeps these controls llama.cpp-specific, reuses the existing chat mod
 This design was revised after a design review to address these issues:
 
 1. Do not assume a stable upstream per-request thinking-budget request key for llama.cpp.
-2. Reuse the existing `ChatModelSettings` store and session snapshot pipeline instead of inventing a new preset backend.
-3. Treat advanced llama.cpp controls as unavailable when `strict_openai_compat` disables non-standard request keys.
-4. Make `chat/completions` the only v1 request surface. `/api/v1/messages` support is a follow-on task.
-5. Define conflict rules between first-class controls and raw `extra_body`.
+2. Guard on the resolved target provider, not only the raw `api_provider` field.
+3. Reuse the existing `ChatModelSettings` store and session snapshot pipeline instead of inventing a new preset backend.
+4. Treat advanced llama.cpp controls as unavailable when `strict_openai_compat` disables non-standard request keys.
+5. Make `chat/completions` the only v1 request surface. `/api/v1/messages` support is a follow-on task.
+6. Define conflict rules between first-class controls and raw `extra_body`.
+7. Expose enough provider metadata for the UI to detect reserved `extra_body` key conflicts.
 
 ## 4. Current State
 
@@ -42,6 +44,7 @@ This design was revised after a design review to address these issues:
 - The backend already forwards provider-specific payload extensions through `extra_body`.
 - llama.cpp already advertises `grammar` as a known extra-body compatibility key in `tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py`.
 - `GET /api/v1/llm/providers` already exposes capability metadata and extra-body compatibility hints that UIs can consume.
+- The chat service can resolve the effective provider from the model name or alias routing even when `api_provider` is omitted.
 
 ### 4.2 Gaps
 
@@ -91,6 +94,16 @@ This means “saved chat/session presets” in v1 are implemented by:
 
 This phase does not add a separate reusable preset resource.
 
+### 6.1.1 Frontend Provider Resolution
+
+The llama.cpp controls must be gated by the resolved provider for the currently selected model, not by the raw `apiProvider` override field alone.
+
+Implications:
+
+1. If the selected model resolves to `llama.cpp`, the controls should appear even when `apiProvider` is blank.
+2. If the user forces a different provider through `apiProvider`, the controls should hide/disable based on that resolved result.
+3. `ModelParamsPanel` may need selected-model context or a precomputed resolved-provider prop from its parent; this should be treated as explicit UI plumbing work, not assumed to already exist.
+
 ### 6.2 Backend Translation Layer
 
 Add a dedicated llama.cpp request-extension resolver, for example:
@@ -100,11 +113,11 @@ Add a dedicated llama.cpp request-extension resolver, for example:
 Responsibilities:
 
 1. Accept app-level request fields from `ChatCompletionRequest`.
-2. Enforce provider guard: only valid when `api_provider == "llama.cpp"`.
+2. Enforce provider guard against the resolved target provider selected by chat normalization, not just the raw `api_provider` request field.
 3. Resolve grammar selection into final GBNF text.
 4. Merge first-class llama.cpp controls into `extra_body` with deterministic precedence.
 5. Refuse advanced llama.cpp controls when runtime strict compatibility disables non-standard fields.
-6. Map `thinking_budget_tokens` into the deployment’s configured/verified upstream request key.
+6. Map `thinking_budget_tokens` into the deployment’s configured thinking-budget request key.
 
 ### 6.3 Capability-Gated Thinking Budget
 
@@ -115,10 +128,26 @@ Thinking-budget support must be capability-gated.
 The server should not hard-code a guessed upstream request-body field. Instead:
 
 1. Expose a dedicated capability such as `llama_cpp_controls.thinking_budget`.
-2. Mark it `supported=true` only when the deployment can map the app-level field to a verified upstream request key.
+2. Mark it `supported=true` only when the deployment has an explicit configured mapping to an upstream request key.
 3. Return `supported=false` with an `effective_reason` when the deployment cannot safely support it.
 
 This allows the grammar workflow to ship even if a given llama.cpp deployment cannot yet expose a safe per-request thinking budget.
+
+### 6.4 Operator Configuration Contract For Thinking Budget
+
+v1 treats thinking-budget mapping as explicit operator opt-in.
+
+Runtime configuration contract:
+
+1. Environment variable override: `LLAMA_CPP_THINKING_BUDGET_PARAM`
+2. Config fallback: `Local-API.llama_cpp_thinking_budget_param`
+3. Shared runtime helpers must read the same contract for both:
+   - `GET /api/v1/llm/providers` capability metadata
+   - chat request translation at send time
+
+If no mapping is configured, `thinking_budget.supported` must be `false`.
+
+v1 does not attempt active probing of the upstream llama.cpp deployment. In this phase, “verified mapping” means the operator explicitly configured the request key for the deployment they run.
 
 ## 7. API And Data Model
 
@@ -134,7 +163,7 @@ Extend `ChatCompletionRequest` with llama.cpp-only top-level extension fields:
 
 Server behavior:
 
-1. Reject these fields with `400` when `api_provider != "llama.cpp"`.
+1. Reject these fields with `400` when the resolved target provider is not `llama.cpp`.
 2. Reject these fields with `400` when llama.cpp strict compatibility disables advanced controls.
 3. Reject invalid combinations:
    - `grammar_mode == "library"` without `grammar_id`
@@ -180,13 +209,17 @@ Extend provider capability metadata returned from `GET /api/v1/llm/providers` wi
     },
     "thinking_budget": {
       "supported": false,
-      "effective_reason": "no verified request mapping configured for this deployment"
-    }
+      "request_key": null,
+      "effective_reason": "no configured thinking-budget mapping for this deployment"
+    },
+    "reserved_extra_body_keys": ["grammar"]
   }
 }
 ```
 
 This metadata is separate from existing `extra_body_compat`. `extra_body_compat` remains a low-level passthrough hint; `llama_cpp_controls` becomes the first-class UI contract.
+
+When a thinking-budget mapping is configured, `reserved_extra_body_keys` must also include that configured request key so the UI can warn about raw `extraBody` conflicts without hard-coding backend transport details.
 
 ## 8. Persistence Model
 
@@ -216,11 +249,24 @@ Library records store:
 
 - reusable named grammar text and metadata
 
+### 8.3 Exact Frontend Touchpoints
+
+The persistence/send path is currently duplicated across several files. This feature is not complete unless all of these are updated consistently:
+
+- `apps/packages/ui/src/store/model.tsx`
+- `apps/packages/ui/src/store/sidepanel-chat-tabs.tsx`
+- `apps/packages/ui/src/routes/sidepanel-chat.tsx`
+- `apps/packages/ui/src/services/model-settings.ts`
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+- `apps/packages/ui/src/services/tldw/TldwChat.ts`
+
+Missing any one of these will silently drop the new fields during restore, persistence, or outbound request serialization.
+
 ## 9. UX Flow
 
 ### 9.1 Surface
 
-Show a llama.cpp-only advanced section when the selected provider is `llama.cpp`.
+Show a llama.cpp-only advanced section when the selected model/provider resolution resolves to `llama.cpp`.
 
 Controls:
 
@@ -233,7 +279,7 @@ Controls:
 
 ### 9.2 Runtime Behavior
 
-1. When provider changes away from `llama.cpp`, keep the values in local state but disable the controls.
+1. When the resolved provider changes away from `llama.cpp`, keep the values in local state but disable the controls.
 2. Exclude llama.cpp extension fields from outgoing non-llama.cpp requests.
 3. When a saved grammar reference is missing or archived, surface a degraded-state warning and require reselection or inline replacement before send.
 4. When capability metadata says `thinking_budget.supported == false`, disable the numeric input and show the provider-reported reason.
@@ -245,7 +291,7 @@ This phase must define deterministic merge behavior between first-class controls
 Rule set:
 
 1. First-class llama.cpp controls win over conflicting raw `extraBody` keys.
-2. If raw `extraBody` contains reserved keys such as `grammar` or the deployment’s configured thinking-budget key, the UI should warn and the backend should overwrite them with first-class values.
+2. If raw `extraBody` contains reserved keys such as `grammar` or the deployment’s configured thinking-budget key, the UI should warn using provider metadata and the backend should overwrite them with first-class values.
 3. Raw `extraBody` remains available for other advanced llama.cpp keys.
 
 Reserved keys:
@@ -317,7 +363,7 @@ This must be explicit in docs and tests to avoid mismatched user expectations.
 
 - `ChatModelSettings` store round-trip of new fields
 - sidepanel/workspace snapshot persistence
-- provider-gated rendering for llama.cpp controls
+- resolved-provider-gated rendering for llama.cpp controls
 - disabled thinking-budget UI when provider metadata says unsupported
 - warning state when raw `extraBody` conflicts with first-class controls
 
@@ -343,6 +389,7 @@ This must be explicit in docs and tests to avoid mismatched user expectations.
 3. Existing chat/session persistence restores grammar and thinking-budget selections.
 4. Grammar selections are translated into llama.cpp request payloads without requiring users to hand-edit `extra_body`.
 5. If strict OpenAI compatibility disables advanced llama.cpp fields, the UI reflects that and the backend rejects unsupported requests clearly.
-6. Thinking budget is only exposed when the deployment can safely map it to a verified llama.cpp request parameter.
+6. Thinking budget is only exposed when the deployment has an explicit configured llama.cpp request-key mapping.
 7. Raw `extraBody` conflicts are handled deterministically and documented.
 8. `/api/v1/messages` is explicitly documented as out of scope for this phase.
+9. The UI surfaces llama.cpp controls whenever the selected model resolves to `llama.cpp`, even when `api_provider` is omitted.

--- a/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-llamacpp-thinking-grammar-implementation-plan.md
@@ -1,0 +1,863 @@
+# Llama.cpp Thinking Budget And Grammar Library Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add first-class llama.cpp grammar controls and a user-scoped grammar library, plus capability-gated thinking-budget support, across the existing chat/playground stack without introducing a new reusable preset backend.
+
+**Architecture:** Reuse the existing `ChatModelSettings` and sidepanel/workspace snapshot pipeline for per-session persistence, add a new user-owned grammar library resource backed by the per-user ChaChaNotes database, and centralize llama.cpp request translation in a shared resolver that turns app-level fields into provider-specific `extra_body`. The resolver must guard on the resolved target provider after model normalization, not only the raw `api_provider` field. Grammar ships as a stable first-class control; thinking budget is surfaced only when shared runtime helpers find an explicit operator-configured request-key mapping and when `strict_openai_compat` does not disable advanced fields.
+
+**Tech Stack:** FastAPI, Pydantic v2, SQLite via `CharactersRAGDB`, Zustand, React, Ant Design, Vitest, pytest, Bandit.
+
+---
+
+**Execution skills:** `@test-driven-development`, `@verification-before-completion`
+
+### Task 0: Isolated Worktree Preflight (Required)
+
+**Files:**
+- Verify only: git worktree metadata and branch state
+
+**Step 1: Create or switch to an isolated worktree**
+
+Run:
+`git worktree add .worktrees/llamacpp-grammar-thinking -b codex/llamacpp-grammar-thinking`
+
+Expected: New isolated worktree is created on a `codex/` branch.
+
+**Step 2: Verify branch isolation**
+
+Run:
+`cd .worktrees/llamacpp-grammar-thinking && git branch --show-current && git rev-parse --show-toplevel`
+
+Expected:
+- Branch name is `codex/llamacpp-grammar-thinking`
+- Repo root is the worktree path, not the primary workspace
+
+**Step 3: Run a narrow baseline**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py`
+
+Expected: Current baseline passes before changes begin.
+
+### Task 1: Extend Chat Request Schema For Llama.cpp First-Class Fields
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py`
+- Test: `tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_chat_request_accepts_llamacpp_grammar_fields():
+    req = ChatCompletionRequest(
+        model="llama.cpp/local-model",
+        messages=[{"role": "user", "content": "reply in JSON"}],
+        grammar_mode="library",
+        grammar_id="grammar_123",
+        grammar_override='root ::= "ok"',
+        thinking_budget_tokens=128,
+    )
+    assert req.grammar_mode == "library"
+    assert req.grammar_id == "grammar_123"
+    assert req.thinking_budget_tokens == 128
+
+
+def test_chat_request_rejects_library_mode_without_grammar_id():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            api_provider="llama.cpp",
+            model="llama.cpp/local-model",
+            messages=[{"role": "user", "content": "x"}],
+            grammar_mode="library",
+        )
+
+
+def test_chat_request_rejects_inline_mode_without_grammar_inline():
+    with pytest.raises(ValidationError):
+        ChatCompletionRequest(
+            api_provider="llama.cpp",
+            model="llama.cpp/local-model",
+            messages=[{"role": "user", "content": "x"}],
+            grammar_mode="inline",
+        )
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py -k llamacpp`
+
+Expected: FAIL because the request model does not yet define the new fields or invariants.
+
+**Step 3: Write the minimal schema implementation**
+
+```python
+class ChatCompletionRequest(BaseModel):
+    ...
+    thinking_budget_tokens: Optional[int] = Field(
+        None,
+        ge=0,
+        description="[llama.cpp extension] App-level thinking budget in tokens. Only valid when the resolved target provider is llama.cpp.",
+    )
+    grammar_mode: Optional[Literal["none", "library", "inline"]] = Field(
+        None,
+        description="[llama.cpp extension] How to resolve the outbound grammar payload.",
+    )
+    grammar_id: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=128,
+        description="[llama.cpp extension] Saved grammar identifier when grammar_mode='library'.",
+    )
+    grammar_inline: Optional[str] = Field(
+        None,
+        max_length=200_000,
+        description="[llama.cpp extension] Inline grammar when grammar_mode='inline'.",
+    )
+    grammar_override: Optional[str] = Field(
+        None,
+        max_length=200_000,
+        description="[llama.cpp extension] Optional per-request override applied on top of a saved grammar selection.",
+    )
+
+    @model_validator(mode="after")
+    def validate_llamacpp_grammar_fields(self):
+        if self.grammar_mode == "library" and not self.grammar_id:
+            raise ValueError("grammar_id is required when grammar_mode is 'library'")
+        if self.grammar_mode == "inline" and not self.grammar_inline:
+            raise ValueError("grammar_inline is required when grammar_mode is 'inline'")
+        return self
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py -k llamacpp`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py \
+  tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py
+git commit -m "feat(chat-schema): add llama.cpp grammar request fields"
+```
+
+### Task 2: Add Shared Llama.cpp Request Extension Resolver
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py`
+- Modify: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Test: `tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py`
+- Test: `tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_resolver_merges_saved_grammar_into_extra_body():
+    payload = resolve_llamacpp_request_extensions(
+        request_fields={
+            "grammar_mode": "library",
+            "grammar_id": "grammar_1",
+            "grammar_override": None,
+            "thinking_budget_tokens": None,
+            "extra_body": {"mirostat": 2},
+        },
+        provider="llama.cpp",
+        grammar_record={"id": "grammar_1", "grammar_text": 'root ::= "ok"'},
+        runtime_caps={"strict_openai_compat": False, "thinking_budget": {"supported": False}},
+    )
+    assert payload["extra_body"]["grammar"] == 'root ::= "ok"'
+    assert payload["extra_body"]["mirostat"] == 2
+
+
+def test_resolver_overrides_conflicting_raw_extra_body_grammar():
+    payload = resolve_llamacpp_request_extensions(
+        request_fields={
+            "grammar_mode": "inline",
+            "grammar_inline": 'root ::= "inline"',
+            "extra_body": {"grammar": 'root ::= "raw"'},
+        },
+        provider="llama.cpp",
+        grammar_record=None,
+        runtime_caps={"strict_openai_compat": False, "thinking_budget": {"supported": False}},
+    )
+    assert payload["extra_body"]["grammar"] == 'root ::= "inline"'
+
+
+def test_resolver_rejects_advanced_fields_when_strict_mode_is_effective():
+    with pytest.raises(ChatBadRequestError):
+        resolve_llamacpp_request_extensions(
+            request_fields={"grammar_mode": "inline", "grammar_inline": 'root ::= "x"'},
+            provider="llama.cpp",
+            grammar_record=None,
+            runtime_caps={"strict_openai_compat": True, "thinking_budget": {"supported": False}},
+        )
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py`
+
+Expected: FAIL because the resolver module does not exist and the strict guard does not understand the new fields.
+
+**Step 3: Write the minimal resolver and wire it into `build_call_params_from_request`**
+
+```python
+def resolve_llamacpp_request_extensions(
+    *,
+    request_fields: Mapping[str, Any],
+    provider: str,
+    grammar_record: Mapping[str, Any] | None,
+    runtime_caps: Mapping[str, Any],
+) -> dict[str, Any]:
+    if provider != "llama.cpp":
+        if any(request_fields.get(key) is not None for key in (
+            "thinking_budget_tokens", "grammar_mode", "grammar_id", "grammar_inline", "grammar_override"
+        )):
+            raise ChatBadRequestError(provider=provider, message="llama.cpp extension fields require the resolved target provider to be 'llama.cpp'")
+        return {"extra_body": dict(request_fields.get("extra_body") or {})}
+
+    if runtime_caps.get("strict_openai_compat"):
+        raise ChatBadRequestError(provider=provider, message="llama.cpp advanced controls are disabled by strict_openai_compat")
+
+    extra_body = dict(request_fields.get("extra_body") or {})
+    grammar_text = ...
+    if grammar_text:
+        extra_body["grammar"] = grammar_text
+
+    thinking_caps = runtime_caps.get("thinking_budget") or {}
+    if request_fields.get("thinking_budget_tokens") is not None:
+        if not thinking_caps.get("supported"):
+            raise ChatBadRequestError(provider=provider, message="thinking_budget_tokens is not supported by this deployment")
+        extra_body[thinking_caps["request_key"]] = int(request_fields["thinking_budget_tokens"])
+
+    return {"extra_body": extra_body}
+```
+
+In `chat_service.build_call_params_from_request(...)`, call the resolver before `cleaned_args` is finalized and replace `extra_body` with the resolved value.
+
+Important:
+
+1. Pass `target_api_provider` into the resolver. Do not guard on `request_data.api_provider`.
+2. Add a shared runtime helper in this module that resolves:
+   - `strict_openai_compat`
+   - `thinking_budget_request_key`
+   from `LLAMA_CPP_THINKING_BUDGET_PARAM` first, then `Local-API.llama_cpp_thinking_budget_param`.
+3. Use that same runtime helper from provider metadata code in Task 3 to avoid drift.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py \
+  tldw_Server_API/app/core/Chat/chat_service.py \
+  tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py \
+  tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py
+git commit -m "feat(chat): add llama.cpp request extension resolver"
+```
+
+### Task 3: Expose Stable `llama_cpp_controls` Capability Metadata
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/llm_providers.py`
+- Modify: `tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py`
+- Test: `tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_llm_providers_exposes_llama_cpp_controls_block(llm_client):
+    response = llm_client.get("/api/v1/llm/providers")
+    data = response.json()["providers"]
+    llama = data["llama.cpp"]
+    controls = llama["llama_cpp_controls"]
+    assert controls["grammar"]["supported"] is True
+    assert "thinking_budget" in controls
+    assert "reserved_extra_body_keys" in controls
+
+
+def test_llm_providers_disables_thinking_budget_without_verified_mapping(monkeypatch, llm_client):
+    monkeypatch.delenv("LLAMA_CPP_THINKING_BUDGET_PARAM", raising=False)
+    response = llm_client.get("/api/v1/llm/providers")
+    controls = response.json()["providers"]["llama.cpp"]["llama_cpp_controls"]
+    assert controls["thinking_budget"]["supported"] is False
+
+
+def test_llm_providers_exposes_reserved_key_when_mapping_configured(monkeypatch, llm_client):
+    monkeypatch.setenv("LLAMA_CPP_THINKING_BUDGET_PARAM", "reasoning_budget")
+    response = llm_client.get("/api/v1/llm/providers")
+    controls = response.json()["providers"]["llama.cpp"]["llama_cpp_controls"]
+    assert controls["thinking_budget"]["request_key"] == "reasoning_budget"
+    assert "reasoning_budget" in controls["reserved_extra_body_keys"]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py -k llama_cpp_controls`
+
+Expected: FAIL because the endpoint does not yet return the new capability block.
+
+**Step 3: Implement runtime capability helpers**
+
+```python
+def resolve_llama_cpp_control_caps(runtime_context: Mapping[str, Any]) -> dict[str, Any]:
+    strict_mode = bool(runtime_context.get("strict_openai_compat"))
+    request_key = str(runtime_context.get("thinking_budget_request_key") or "").strip()
+    reserved_keys = ["grammar"]
+    if request_key:
+        reserved_keys.append(request_key)
+    return {
+        "grammar": {
+            "supported": not strict_mode,
+            "effective_reason": "disabled by strict_openai_compat runtime setting" if strict_mode else "supported in current deployment",
+            "source": "first_class+extra_body",
+        },
+        "thinking_budget": {
+            "supported": (not strict_mode) and bool(request_key),
+            "request_key": request_key or None,
+            "effective_reason": (
+                "disabled by strict_openai_compat runtime setting" if strict_mode
+                else "no configured thinking-budget mapping for this deployment"
+                if not request_key else "supported in current deployment"
+            ),
+        },
+        "reserved_extra_body_keys": reserved_keys,
+    }
+```
+
+Update `_build_runtime_context(...)` to read:
+
+- `LOCAL_LLM_STRICT_OPENAI_COMPAT`
+- `LLAMA_CPP_THINKING_BUDGET_PARAM`
+- `Local-API.llama_cpp_thinking_budget_param`
+
+Attach `llama_cpp_controls` only for the `llama.cpp` provider object and its `models_info` entries where relevant.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py -k llama_cpp_controls`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/llm_providers.py \
+  tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py \
+  tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py
+git commit -m "feat(providers): expose llama.cpp controls capability metadata"
+```
+
+### Task 4: Add User-Scoped Grammar Library Persistence And Service
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py`
+- Create: `tldw_Server_API/app/core/Character_Chat/chat_grammar.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Test: `tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_chat_grammar_service_creates_and_reads_grammar(chacha_db):
+    service = ChatGrammarService(chacha_db)
+    grammar_id = service.create_grammar(
+        name="JSON Root",
+        description="Simple test grammar",
+        grammar_text='root ::= "ok"',
+    )
+    grammar = service.get_grammar(grammar_id)
+    assert grammar["name"] == "JSON Root"
+    assert grammar["validation_status"] == "unchecked"
+
+
+def test_chat_grammar_service_archives_without_deleting_text(chacha_db):
+    service = ChatGrammarService(chacha_db)
+    grammar_id = service.create_grammar(name="Archive Me", description="", grammar_text='root ::= "x"')
+    service.archive_grammar(grammar_id)
+    grammar = service.get_grammar(grammar_id, include_archived=True)
+    assert grammar["is_archived"] is True
+    assert grammar["grammar_text"] == 'root ::= "x"'
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py`
+
+Expected: FAIL because the service and DB support do not exist.
+
+**Step 3: Implement the DB table and service**
+
+```python
+CREATE TABLE IF NOT EXISTS chat_grammars (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    grammar_text TEXT NOT NULL,
+    validation_status TEXT NOT NULL DEFAULT 'unchecked',
+    validation_error TEXT,
+    last_validated_at TIMESTAMP,
+    is_archived BOOLEAN NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted BOOLEAN NOT NULL DEFAULT 0
+);
+```
+
+```python
+class ChatGrammarService:
+    def __init__(self, db: CharactersRAGDB):
+        self.db = db
+
+    def create_grammar(...): ...
+    def list_grammars(...): ...
+    def get_grammar(...): ...
+    def update_grammar(...): ...
+    def archive_grammar(...): ...
+    def delete_grammar(...): ...
+```
+
+Mirror the optimistic-locking and per-user ownership style used by `ChatDictionaryService`.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py \
+  tldw_Server_API/app/core/Character_Chat/chat_grammar.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py
+git commit -m "feat(chat): add user-scoped grammar library service"
+```
+
+### Task 5: Add Grammar Library API Endpoints And Router Wiring
+
+**Files:**
+- Create: `tldw_Server_API/app/api/v1/endpoints/chat_grammars.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py`
+
+**Step 1: Write the failing endpoint tests**
+
+```python
+@pytest.mark.asyncio
+async def test_create_and_list_chat_grammars(chacha_db):
+    created = await chat_grammar_endpoints.create_chat_grammar(
+        ChatGrammarCreate(name="Root", description="desc", grammar_text='root ::= "ok"'),
+        db=chacha_db,
+    )
+    assert created.name == "Root"
+
+    listing = await chat_grammar_endpoints.list_chat_grammars(db=chacha_db)
+    assert listing.total == 1
+    assert listing.items[0].id == created.id
+
+
+@pytest.mark.asyncio
+async def test_get_archived_grammar_requires_include_archived(chacha_db):
+    ...
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py`
+
+Expected: FAIL because the router and schemas are missing.
+
+**Step 3: Implement router and include it from `chat.py`**
+
+```python
+router = APIRouter(prefix="/grammars", tags=["chat-grammars"])
+
+@router.post("", response_model=ChatGrammarResponse, status_code=201)
+async def create_chat_grammar(...): ...
+
+@router.get("", response_model=ChatGrammarListResponse)
+async def list_chat_grammars(...): ...
+
+@router.get("/{grammar_id}", response_model=ChatGrammarResponse)
+async def get_chat_grammar(...): ...
+
+@router.patch("/{grammar_id}", response_model=ChatGrammarResponse)
+async def update_chat_grammar(...): ...
+
+@router.delete("/{grammar_id}", status_code=204)
+async def delete_chat_grammar(...): ...
+```
+
+In `tldw_Server_API/app/api/v1/endpoints/chat.py`:
+
+```python
+from . import chat_dictionaries, chat_documents, chat_grammars
+router.include_router(chat_grammars.router)
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/chat_grammars.py \
+  tldw_Server_API/app/api/v1/endpoints/chat.py \
+  tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+git commit -m "feat(chat-api): add grammar library endpoints"
+```
+
+### Task 6: Add Chat-Completions Integration Coverage For Grammar Resolution And Guards
+
+**Files:**
+- Create: `tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py`
+- Modify: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Modify: `tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py`
+
+**Step 1: Write the failing integration tests**
+
+```python
+def test_chat_completions_resolves_saved_grammar_into_llamacpp_payload(client, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Chat.chat_service.perform_chat_api_call",
+        lambda **kwargs: captured.update(kwargs) or {"choices": [{"message": {"content": "ok"}}]},
+    )
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "model": "llama.cpp/local-model",
+            "messages": [{"role": "user", "content": "x"}],
+            "grammar_mode": "inline",
+            "grammar_inline": 'root ::= "ok"',
+        },
+    )
+    assert response.status_code == 200
+    assert captured["api_endpoint"] == "llama.cpp"
+    assert captured["extra_body"]["grammar"] == 'root ::= "ok"'
+
+
+def test_chat_completions_rejects_llamacpp_fields_for_openai(client):
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={
+            "api_provider": "openai",
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "x"}],
+            "grammar_mode": "inline",
+            "grammar_inline": 'root ::= "ok"',
+        },
+    )
+    assert response.status_code == 400
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py`
+
+Expected: FAIL because the endpoint path does not yet resolve grammars or enforce the provider guard end to end.
+
+**Step 3: Finish integration wiring**
+
+Ensure `build_call_params_from_request(...)`:
+
+1. loads the grammar record when `grammar_mode == "library"`
+2. calls the shared resolver
+3. passes the resolved `target_api_provider` into the resolver
+4. returns translated `extra_body`
+5. raises stable `HTTPException`/`ChatBadRequestError` for invalid provider or missing grammar references
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py \
+  tldw_Server_API/app/core/Chat/chat_service.py \
+  tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py
+git commit -m "test(chat): cover llama.cpp grammar request integration"
+```
+
+### Task 7: Extend Frontend Shared State And Session Persistence
+
+**Files:**
+- Modify: `apps/packages/ui/src/store/model.tsx`
+- Modify: `apps/packages/ui/src/store/sidepanel-chat-tabs.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-chat.tsx`
+- Modify: `apps/packages/ui/src/services/model-settings.ts`
+- Test: `apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx`
+- Create: `apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts`
+
+**Step 1: Write the failing frontend tests**
+
+```ts
+it("stores llama.cpp grammar settings in ChatModelSettings", () => {
+  const store = useStoreChatModelSettings.getState()
+  store.updateSettings({
+    llamaGrammarMode: "library",
+    llamaGrammarId: "grammar_1",
+    llamaGrammarOverride: 'root ::= "override"',
+    llamaThinkingBudgetTokens: 64
+  })
+  const next = useStoreChatModelSettings.getState()
+  expect(next.llamaGrammarMode).toBe("library")
+  expect(next.llamaThinkingBudgetTokens).toBe(64)
+})
+
+it("persists llama.cpp settings in sidepanel snapshots", () => {
+  ...
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`bunx vitest run apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx`
+
+Expected: FAIL because the store and snapshot types do not yet include the new fields.
+
+**Step 3: Add the new state keys everywhere the snapshot model is duplicated**
+
+```ts
+type ChatModelSettings = {
+  ...
+  llamaThinkingBudgetTokens?: number
+  llamaGrammarMode?: "none" | "library" | "inline"
+  llamaGrammarId?: string
+  llamaGrammarInline?: string
+  llamaGrammarOverride?: string
+}
+```
+
+Update:
+
+- the Zustand store state and setters
+- `ChatModelSettingsSnapshot`
+- `MODEL_SETTINGS_KEYS`
+- sidepanel snapshot pick/apply helpers
+- persisted settings helpers in `model-settings.ts`
+
+Do not treat this as a single persistence path. The task is only complete when the new keys round-trip through all duplicated state definitions.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`bunx vitest run apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/store/model.tsx \
+  apps/packages/ui/src/store/sidepanel-chat-tabs.tsx \
+  apps/packages/ui/src/routes/sidepanel-chat.tsx \
+  apps/packages/ui/src/services/model-settings.ts \
+  apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts \
+  apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx
+git commit -m "feat(ui-state): persist llama.cpp grammar settings"
+```
+
+### Task 8: Add Grammar Library Client And Llama.cpp Controls UI
+
+**Files:**
+- Create: `apps/packages/ui/src/services/tldw/TldwLlamaGrammars.ts`
+- Create: `apps/packages/ui/src/components/Common/Settings/LlamaGrammarLibraryModal.tsx`
+- Create: `apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/ModelParamsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Sidepanel/Chat/form.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/TldwChat.ts`
+- Modify: `apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx`
+- Create: `apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx`
+- Create: `apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.integration.test.tsx`
+
+**Step 1: Write the failing UI/request tests**
+
+```tsx
+it("shows llama.cpp advanced controls when the selected model resolves to llama.cpp", () => {
+  mockChatModelSettings({ apiProvider: "" })
+  mockSelectedModel("llama.cpp/local-model")
+  render(<ModelParamsPanel />)
+  expect(screen.getByText(/Grammar source/i)).toBeInTheDocument()
+})
+
+it("builds chat request with first-class llama.cpp fields and parsed extra_body", async () => {
+  mockChatModelSettings({
+    apiProvider: "llama.cpp",
+    llamaGrammarMode: "inline",
+    llamaGrammarInline: 'root ::= "ok"',
+    llamaThinkingBudgetTokens: 64,
+    extraBody: '{"mirostat":2}'
+  })
+  ...
+  expect(sentBody.grammar_mode).toBe("inline")
+  expect(sentBody.grammar_inline).toContain('root ::= "ok"')
+  expect(sentBody.extra_body).toEqual({ mirostat: 2 })
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+`bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.integration.test.tsx`
+
+Expected: FAIL because the controls, client, and request fields do not exist.
+
+**Step 3: Implement the UI and request plumbing**
+
+Add a small client:
+
+```ts
+export class TldwLlamaGrammars {
+  list() { ... }
+  create(input) { ... }
+  update(id, input) { ... }
+  remove(id) { ... }
+}
+```
+
+Add a shared controls component:
+
+```tsx
+export function LlamaCppAdvancedControls({ resolvedProvider }: { resolvedProvider: string | null }) {
+  const grammarMode = useStoreChatModelSettings((s) => s.llamaGrammarMode)
+  ...
+  if (resolvedProvider !== "llama.cpp") return null
+  return (
+    <>
+      <InputNumber ... />
+      <Segmented options={[...]} ... />
+      <Select ... />
+      <TextArea ... />
+    </>
+  )
+}
+```
+
+In the sidepanel path, plumb `selectedModel` or `resolvedProvider` from `form.tsx` into `ModelParamsPanel`/`LlamaCppAdvancedControls`. Do not key this UI off the raw `apiProvider` field alone.
+
+In `PlaygroundForm.tsx` and `TldwChat.ts`, include:
+
+```ts
+thinking_budget_tokens: currentChatModelSettings.llamaThinkingBudgetTokens,
+grammar_mode: currentChatModelSettings.llamaGrammarMode,
+grammar_id: currentChatModelSettings.llamaGrammarId,
+grammar_inline: currentChatModelSettings.llamaGrammarInline,
+grammar_override: currentChatModelSettings.llamaGrammarOverride,
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+`bunx vitest run apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.integration.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/TldwLlamaGrammars.ts \
+  apps/packages/ui/src/components/Common/Settings/LlamaGrammarLibraryModal.tsx \
+  apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/ModelParamsPanel.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/form.tsx \
+  apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx \
+  apps/packages/ui/src/services/tldw/TldwChat.ts \
+  apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx \
+  apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx \
+  apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.integration.test.tsx
+git commit -m "feat(ui): add llama.cpp grammar and thinking controls"
+```
+
+### Task 9: Add Conflict Warnings, API Docs, And Final Verification
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx`
+- Modify: `Docs/API-related/Chat_API_Documentation.md`
+- Modify: `Docs/API-related/Providers_API_Documentation.md`
+- Modify: `Docs/API-related/llamacpp_integration_modes.md`
+
+**Step 1: Write the final failing tests**
+
+```tsx
+it("warns when raw extraBody contains reserved llama.cpp keys", () => {
+  mockChatModelSettings({
+    apiProvider: "llama.cpp",
+    extraBody: '{"grammar":"root ::= \\"raw\\""}',
+    llamaGrammarMode: "inline",
+    llamaGrammarInline: 'root ::= "ui"',
+  })
+  render(<LlamaCppAdvancedControls resolvedProvider="llama.cpp" />)
+  expect(screen.getByText(/first-class llama.cpp controls override raw extra body/i)).toBeInTheDocument()
+})
+```
+
+**Step 2: Run the targeted test suites**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py`
+
+Expected: PASS.
+
+Run:
+`bunx vitest run apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.integration.test.tsx apps/packages/ui/src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx`
+
+Expected: PASS.
+
+**Step 3: Run Bandit on touched backend scope**
+
+Run:
+`source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chat.py tldw_Server_API/app/api/v1/endpoints/chat_grammars.py tldw_Server_API/app/api/v1/endpoints/llm_providers.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/core/Character_Chat/chat_grammar.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py -f json -o /tmp/bandit_llamacpp_grammar.json`
+
+Expected: `No issues identified` or only pre-existing findings outside the touched behavior.
+
+**Step 4: Update docs**
+
+Document:
+
+1. new chat request fields and llama.cpp-only guard
+2. new grammar library endpoints
+3. `llama_cpp_controls` capability metadata
+4. `strict_openai_compat` disabling advanced controls
+5. operator config for thinking-budget mapping: `LLAMA_CPP_THINKING_BUDGET_PARAM` and `Local-API.llama_cpp_thinking_budget_param`
+6. explicit v1 boundary: `/chat/completions` only, `/messages` not yet supported
+
+**Step 5: Commit**
+
+```bash
+git add Docs/API-related/Chat_API_Documentation.md \
+  Docs/API-related/Providers_API_Documentation.md \
+  Docs/API-related/llamacpp_integration_modes.md \
+  apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
+git commit -m "docs: document llama.cpp grammar and thinking controls"
+```

--- a/apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx
@@ -60,6 +60,11 @@ type ModelConfigData = {
   tfsZ?: number
   numKeep?: number
   numThread?: number
+  llamaThinkingBudgetTokens?: number
+  llamaGrammarMode?: "none" | "library" | "inline"
+  llamaGrammarId?: string
+  llamaGrammarInline?: string
+  llamaGrammarOverride?: string
 }
 
 type ModelDetails = {
@@ -113,6 +118,11 @@ const CHAT_MODEL_SETTING_KEYS: ReadonlySet<keyof ChatModelSettings> = new Set([
   "apiProvider",
   "extraHeaders",
   "extraBody",
+  "llamaThinkingBudgetTokens",
+  "llamaGrammarMode",
+  "llamaGrammarId",
+  "llamaGrammarInline",
+  "llamaGrammarOverride",
   "jsonMode"
 ])
 
@@ -156,6 +166,11 @@ export const CurrentChatModelSettings = ({
     apiProvider,
     extraHeaders,
     extraBody,
+    llamaThinkingBudgetTokens: storeLlamaThinkingBudgetTokens,
+    llamaGrammarMode: storeLlamaGrammarMode,
+    llamaGrammarId: storeLlamaGrammarId,
+    llamaGrammarInline: storeLlamaGrammarInline,
+    llamaGrammarOverride: storeLlamaGrammarOverride,
     jsonMode,
     systemPrompt,
     ocrLanguage,
@@ -187,6 +202,11 @@ export const CurrentChatModelSettings = ({
       apiProvider: state.apiProvider,
       extraHeaders: state.extraHeaders,
       extraBody: state.extraBody,
+      llamaThinkingBudgetTokens: state.llamaThinkingBudgetTokens,
+      llamaGrammarMode: state.llamaGrammarMode,
+      llamaGrammarId: state.llamaGrammarId,
+      llamaGrammarInline: state.llamaGrammarInline,
+      llamaGrammarOverride: state.llamaGrammarOverride,
       jsonMode: state.jsonMode,
       systemPrompt: state.systemPrompt,
       ocrLanguage: state.ocrLanguage,
@@ -234,6 +254,12 @@ export const CurrentChatModelSettings = ({
     React.useState<ActorTarget>("user")
   const [newAspectName, setNewAspectName] = React.useState<string>("")
   const actorPositionValue = Form.useWatch("actorChatPosition", form)
+  const llamaThinkingBudgetTokens = Form.useWatch("llamaThinkingBudgetTokens", form)
+  const llamaGrammarMode = Form.useWatch("llamaGrammarMode", form)
+  const llamaGrammarId = Form.useWatch("llamaGrammarId", form)
+  const llamaGrammarInline = Form.useWatch("llamaGrammarInline", form)
+  const llamaGrammarOverride = Form.useWatch("llamaGrammarOverride", form)
+  const llamaExtraBody = Form.useWatch("extraBody", form)
 
   const savePrompt = useCallback(
     (value: string) => {
@@ -319,6 +345,13 @@ export const CurrentChatModelSettings = ({
     [actorSettings, historyId, serverChatId, setActorSettings, updateSetting]
   )
 
+  const handleLlamaControlChange = useCallback(
+    (key: keyof ChatModelSettings, value: number | string | undefined) => {
+      form.setFieldValue(key, value)
+    },
+    [form]
+  )
+
   const buildBaseValues = useCallback(
     (data?: ModelConfigData | null, promptFallback?: string) => ({
       temperature: temperature ?? data?.temperature,
@@ -346,6 +379,13 @@ export const CurrentChatModelSettings = ({
       apiProvider,
       extraHeaders,
       extraBody,
+      llamaThinkingBudgetTokens:
+        storeLlamaThinkingBudgetTokens ?? data?.llamaThinkingBudgetTokens,
+      llamaGrammarMode: storeLlamaGrammarMode ?? data?.llamaGrammarMode,
+      llamaGrammarId: storeLlamaGrammarId ?? data?.llamaGrammarId,
+      llamaGrammarInline: storeLlamaGrammarInline ?? data?.llamaGrammarInline,
+      llamaGrammarOverride:
+        storeLlamaGrammarOverride ?? data?.llamaGrammarOverride,
       jsonMode
     }),
     [
@@ -374,6 +414,11 @@ export const CurrentChatModelSettings = ({
       apiProvider,
       extraHeaders,
       extraBody,
+      storeLlamaThinkingBudgetTokens,
+      storeLlamaGrammarMode,
+      storeLlamaGrammarId,
+      storeLlamaGrammarInline,
+      storeLlamaGrammarOverride,
       jsonMode
     ]
   )
@@ -730,7 +775,16 @@ export const CurrentChatModelSettings = ({
               className="settings-tabs"
             />
             <div className="mt-4">
-              <LlamaCppAdvancedControls selectedModel={selectedModel} />
+              <LlamaCppAdvancedControls
+                selectedModel={selectedModel}
+                thinkingBudget={llamaThinkingBudgetTokens}
+                grammarMode={llamaGrammarMode}
+                grammarId={llamaGrammarId}
+                grammarInline={llamaGrammarInline}
+                grammarOverride={llamaGrammarOverride}
+                extraBody={llamaExtraBody}
+                onChange={handleLlamaControlChange}
+              />
             </div>
             <div className="mt-4 border-t border-border pt-4">
               <SaveButton

--- a/apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/CurrentChatModelSettings.tsx
@@ -35,6 +35,7 @@ import {
   AdvancedParamsTab,
   ActorTab
 } from "./tabs"
+import { LlamaCppAdvancedControls } from "./LlamaCppAdvancedControls"
 
 type Props = {
   open: boolean
@@ -728,6 +729,9 @@ export const CurrentChatModelSettings = ({
               items={tabItems}
               className="settings-tabs"
             />
+            <div className="mt-4">
+              <LlamaCppAdvancedControls selectedModel={selectedModel} />
+            </div>
             <div className="mt-4 border-t border-border pt-4">
               <SaveButton
                 className="w-full text-center inline-flex items-center justify-center"

--- a/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
@@ -39,6 +39,19 @@ const normalizeResolvedProvider = (value: string | null | undefined) => {
   return normalized || null
 }
 
+const parseJsonRecord = (value: string | null | undefined): Record<string, unknown> | null => {
+  if (!value || !value.trim()) return null
+  try {
+    const parsed = JSON.parse(value)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
 const extractLlamaCppControls = (payload: any): LlamaCppControlsMetadata | null => {
   const providers = payload?.providers
   if (!providers) return null
@@ -75,6 +88,7 @@ export function LlamaCppAdvancedControls({
   const grammarOverride = useStoreChatModelSettings(
     (state) => state.llamaGrammarOverride
   )
+  const extraBody = useStoreChatModelSettings((state) => state.extraBody)
   const [libraryOpen, setLibraryOpen] = React.useState(false)
   const [derivedProvider, setDerivedProvider] = React.useState<string | null>(
     normalizeResolvedProvider(resolvedProvider)
@@ -116,18 +130,27 @@ export function LlamaCppAdvancedControls({
     enabled: isLlamaCpp
   })
 
-  if (!isLlamaCpp) {
-    return null
-  }
-
   const controls = extractLlamaCppControls(providersQuery.data)
   const grammarSupported = controls?.grammar?.supported !== false
   const thinkingSupported = controls?.thinking_budget?.supported === true
+  const conflictingExtraBodyKeys = React.useMemo(() => {
+    const reservedKeys = controls?.reserved_extra_body_keys ?? []
+    if (!reservedKeys.length) return []
+    const parsedExtraBody = parseJsonRecord(extraBody)
+    if (!parsedExtraBody) return []
+    return reservedKeys.filter((key) =>
+      Object.prototype.hasOwnProperty.call(parsedExtraBody, key)
+    )
+  }, [controls?.reserved_extra_body_keys, extraBody])
   const grammarOptions =
     grammarsQuery.data?.items?.map((item: LlamaGrammarRecord) => ({
       label: item.name,
       value: item.id
     })) ?? []
+
+  if (!isLlamaCpp) {
+    return null
+  }
 
   return (
     <div className={className}>
@@ -153,7 +176,19 @@ export function LlamaCppAdvancedControls({
           <Alert
             type="info"
             showIcon
-            message={controls.grammar.effective_reason}
+            title={controls.grammar.effective_reason}
+          />
+        ) : null}
+
+        {conflictingExtraBodyKeys.length > 0 ? (
+          <Alert
+            type="warning"
+            showIcon
+            title={t(
+              "sidepanel:llamaControls.extraBodyConflictTitle",
+              "First-class llama.cpp controls override reserved raw extra body keys."
+            )}
+            description={conflictingExtraBodyKeys.join(", ")}
           />
         ) : null}
 

--- a/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
@@ -27,10 +27,28 @@ type LlamaCppControlsMetadata = {
   reserved_extra_body_keys?: string[]
 }
 
+type LlamaGrammarMode = "none" | "library" | "inline"
+type LlamaControlField =
+  | "llamaThinkingBudgetTokens"
+  | "llamaGrammarMode"
+  | "llamaGrammarId"
+  | "llamaGrammarInline"
+  | "llamaGrammarOverride"
+
 type Props = {
   selectedModel?: string | null
   resolvedProvider?: string | null
   className?: string
+  thinkingBudget?: number
+  grammarMode?: LlamaGrammarMode
+  grammarId?: string
+  grammarInline?: string
+  grammarOverride?: string
+  extraBody?: string
+  onChange?: (
+    key: LlamaControlField,
+    value: number | string | undefined
+  ) => void
 }
 
 const normalizeResolvedProvider = (value: string | null | undefined) => {
@@ -74,24 +92,55 @@ const extractLlamaCppControls = (payload: any): LlamaCppControlsMetadata | null 
 export function LlamaCppAdvancedControls({
   selectedModel,
   resolvedProvider,
-  className
+  className,
+  thinkingBudget,
+  grammarMode,
+  grammarId,
+  grammarInline,
+  grammarOverride,
+  extraBody,
+  onChange
 }: Props) {
   const { t } = useTranslation(["common", "sidepanel"])
   const apiProviderOverride = useStoreChatModelSettings((state) => state.apiProvider)
   const updateSetting = useStoreChatModelSettings((state) => state.updateSetting)
-  const thinkingBudget = useStoreChatModelSettings(
+  const storeThinkingBudget = useStoreChatModelSettings(
     (state) => state.llamaThinkingBudgetTokens
   )
-  const grammarMode = useStoreChatModelSettings((state) => state.llamaGrammarMode)
-  const grammarId = useStoreChatModelSettings((state) => state.llamaGrammarId)
-  const grammarInline = useStoreChatModelSettings((state) => state.llamaGrammarInline)
-  const grammarOverride = useStoreChatModelSettings(
+  const storeGrammarMode = useStoreChatModelSettings((state) => state.llamaGrammarMode)
+  const storeGrammarId = useStoreChatModelSettings((state) => state.llamaGrammarId)
+  const storeGrammarInline = useStoreChatModelSettings((state) => state.llamaGrammarInline)
+  const storeGrammarOverride = useStoreChatModelSettings(
     (state) => state.llamaGrammarOverride
   )
-  const extraBody = useStoreChatModelSettings((state) => state.extraBody)
+  const storeExtraBody = useStoreChatModelSettings((state) => state.extraBody)
   const [libraryOpen, setLibraryOpen] = React.useState(false)
   const [derivedProvider, setDerivedProvider] = React.useState<string | null>(
     normalizeResolvedProvider(resolvedProvider)
+  )
+  const useControlledValues = typeof onChange === "function"
+  const currentThinkingBudget = useControlledValues
+    ? thinkingBudget
+    : storeThinkingBudget
+  const currentGrammarMode = useControlledValues ? grammarMode : storeGrammarMode
+  const currentGrammarId = useControlledValues ? grammarId : storeGrammarId
+  const currentGrammarInline = useControlledValues
+    ? grammarInline
+    : storeGrammarInline
+  const currentGrammarOverride = useControlledValues
+    ? grammarOverride
+    : storeGrammarOverride
+  const currentExtraBody = useControlledValues ? extraBody : storeExtraBody
+
+  const updateLlamaField = React.useCallback(
+    (key: LlamaControlField, value: number | string | undefined) => {
+      if (onChange) {
+        onChange(key, value)
+        return
+      }
+      updateSetting(key, value as never)
+    },
+    [onChange, updateSetting]
   )
 
   React.useEffect(() => {
@@ -136,12 +185,12 @@ export function LlamaCppAdvancedControls({
   const conflictingExtraBodyKeys = React.useMemo(() => {
     const reservedKeys = controls?.reserved_extra_body_keys ?? []
     if (!reservedKeys.length) return []
-    const parsedExtraBody = parseJsonRecord(extraBody)
+    const parsedExtraBody = parseJsonRecord(currentExtraBody)
     if (!parsedExtraBody) return []
     return reservedKeys.filter((key) =>
       Object.prototype.hasOwnProperty.call(parsedExtraBody, key)
     )
-  }, [controls?.reserved_extra_body_keys, extraBody])
+  }, [controls?.reserved_extra_body_keys, currentExtraBody])
   const grammarOptions =
     grammarsQuery.data?.items?.map((item: LlamaGrammarRecord) => ({
       label: item.name,
@@ -199,9 +248,9 @@ export function LlamaCppAdvancedControls({
           <InputNumber
             min={0}
             disabled={!thinkingSupported}
-            value={thinkingBudget}
+            value={currentThinkingBudget}
             onChange={(value) =>
-              updateSetting(
+              updateLlamaField(
                 "llamaThinkingBudgetTokens",
                 typeof value === "number" ? value : undefined
               )
@@ -224,19 +273,22 @@ export function LlamaCppAdvancedControls({
             {t("sidepanel:llamaControls.grammarSource", "Grammar source")}
           </label>
           <Select
-            value={grammarMode || "none"}
-            onChange={(value: "none" | "library" | "inline") => {
-              updateSetting("llamaGrammarMode", value === "none" ? undefined : value)
+            value={currentGrammarMode || "none"}
+            onChange={(value: LlamaGrammarMode) => {
+              updateLlamaField(
+                "llamaGrammarMode",
+                value === "none" ? undefined : value
+              )
               if (value === "none") {
-                updateSetting("llamaGrammarId", undefined)
-                updateSetting("llamaGrammarInline", undefined)
-                updateSetting("llamaGrammarOverride", undefined)
+                updateLlamaField("llamaGrammarId", undefined)
+                updateLlamaField("llamaGrammarInline", undefined)
+                updateLlamaField("llamaGrammarOverride", undefined)
               }
               if (value === "inline") {
-                updateSetting("llamaGrammarId", undefined)
+                updateLlamaField("llamaGrammarId", undefined)
               }
               if (value === "library") {
-                updateSetting("llamaGrammarInline", undefined)
+                updateLlamaField("llamaGrammarInline", undefined)
               }
             }}
             options={[
@@ -247,12 +299,12 @@ export function LlamaCppAdvancedControls({
           />
         </div>
 
-        {grammarMode === "library" ? (
+        {currentGrammarMode === "library" ? (
           <div className="space-y-2">
             <Select
-              value={grammarId}
+              value={currentGrammarId}
               options={grammarOptions}
-              onChange={(value) => updateSetting("llamaGrammarId", value)}
+              onChange={(value) => updateLlamaField("llamaGrammarId", value)}
               placeholder={t(
                 "sidepanel:llamaControls.selectSavedGrammar",
                 "Select a saved grammar"
@@ -261,9 +313,9 @@ export function LlamaCppAdvancedControls({
               allowClear
             />
             <TextArea
-              value={grammarOverride || ""}
+              value={currentGrammarOverride || ""}
               onChange={(event) =>
-                updateSetting(
+                updateLlamaField(
                   "llamaGrammarOverride",
                   event.target.value || undefined
                 )
@@ -278,11 +330,11 @@ export function LlamaCppAdvancedControls({
           </div>
         ) : null}
 
-        {grammarMode === "inline" ? (
+        {currentGrammarMode === "inline" ? (
           <TextArea
-            value={grammarInline || ""}
+            value={currentGrammarInline || ""}
             onChange={(event) =>
-              updateSetting(
+              updateLlamaField(
                 "llamaGrammarInline",
                 event.target.value || undefined
               )
@@ -297,10 +349,10 @@ export function LlamaCppAdvancedControls({
       <LlamaGrammarLibraryModal
         open={libraryOpen}
         onClose={() => setLibraryOpen(false)}
-        selectedGrammarId={grammarId}
+        selectedGrammarId={currentGrammarId}
         onSelectGrammar={(grammar) => {
-          updateSetting("llamaGrammarMode", "library")
-          updateSetting("llamaGrammarId", grammar.id)
+          updateLlamaField("llamaGrammarMode", "library")
+          updateLlamaField("llamaGrammarId", grammar.id)
           setLibraryOpen(false)
         }}
       />

--- a/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/LlamaCppAdvancedControls.tsx
@@ -1,0 +1,274 @@
+import React from "react"
+import { Alert, Button, Input, InputNumber, Select, Typography } from "antd"
+import { useQuery } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
+import { useStoreChatModelSettings } from "@/store/model"
+import { resolveApiProviderForModel } from "@/utils/resolve-api-provider"
+import { tldwClient } from "@/services/tldw/TldwApiClient"
+import {
+  tldwLlamaGrammars,
+  type LlamaGrammarRecord
+} from "@/services/tldw/TldwLlamaGrammars"
+import { LlamaGrammarLibraryModal } from "./LlamaGrammarLibraryModal"
+
+const { TextArea } = Input
+const { Text } = Typography
+
+type LlamaCppControlsMetadata = {
+  grammar?: {
+    supported?: boolean
+    effective_reason?: string | null
+  }
+  thinking_budget?: {
+    supported?: boolean
+    request_key?: string | null
+    effective_reason?: string | null
+  }
+  reserved_extra_body_keys?: string[]
+}
+
+type Props = {
+  selectedModel?: string | null
+  resolvedProvider?: string | null
+  className?: string
+}
+
+const normalizeResolvedProvider = (value: string | null | undefined) => {
+  const normalized = String(value || "").trim().toLowerCase()
+  if (normalized === "llamacpp") return "llama.cpp"
+  return normalized || null
+}
+
+const extractLlamaCppControls = (payload: any): LlamaCppControlsMetadata | null => {
+  const providers = payload?.providers
+  if (!providers) return null
+  if (!Array.isArray(providers)) {
+    return (
+      providers?.["llama.cpp"]?.llama_cpp_controls ??
+      providers?.llamacpp?.llama_cpp_controls ??
+      null
+    )
+  }
+  const matched = providers.find((entry: any) => {
+    const key = String(entry?.provider || entry?.id || entry?.name || "")
+      .trim()
+      .toLowerCase()
+    return key === "llama.cpp" || key === "llamacpp"
+  })
+  return matched?.llama_cpp_controls ?? null
+}
+
+export function LlamaCppAdvancedControls({
+  selectedModel,
+  resolvedProvider,
+  className
+}: Props) {
+  const { t } = useTranslation(["common", "sidepanel"])
+  const apiProviderOverride = useStoreChatModelSettings((state) => state.apiProvider)
+  const updateSetting = useStoreChatModelSettings((state) => state.updateSetting)
+  const thinkingBudget = useStoreChatModelSettings(
+    (state) => state.llamaThinkingBudgetTokens
+  )
+  const grammarMode = useStoreChatModelSettings((state) => state.llamaGrammarMode)
+  const grammarId = useStoreChatModelSettings((state) => state.llamaGrammarId)
+  const grammarInline = useStoreChatModelSettings((state) => state.llamaGrammarInline)
+  const grammarOverride = useStoreChatModelSettings(
+    (state) => state.llamaGrammarOverride
+  )
+  const [libraryOpen, setLibraryOpen] = React.useState(false)
+  const [derivedProvider, setDerivedProvider] = React.useState<string | null>(
+    normalizeResolvedProvider(resolvedProvider)
+  )
+
+  React.useEffect(() => {
+    const direct = normalizeResolvedProvider(resolvedProvider)
+    if (direct) {
+      setDerivedProvider(direct)
+      return
+    }
+
+    let cancelled = false
+    void resolveApiProviderForModel({
+      modelId: selectedModel,
+      explicitProvider: apiProviderOverride
+    }).then((nextProvider) => {
+      if (!cancelled) {
+        setDerivedProvider(normalizeResolvedProvider(nextProvider))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [apiProviderOverride, resolvedProvider, selectedModel])
+
+  const isLlamaCpp = derivedProvider === "llama.cpp"
+
+  const providersQuery = useQuery({
+    queryKey: ["tldw:llm-providers"],
+    queryFn: () => tldwClient.getLlmProviders(),
+    enabled: isLlamaCpp
+  })
+
+  const grammarsQuery = useQuery({
+    queryKey: ["tldw:llama-grammars"],
+    queryFn: () => tldwLlamaGrammars.list(),
+    enabled: isLlamaCpp
+  })
+
+  if (!isLlamaCpp) {
+    return null
+  }
+
+  const controls = extractLlamaCppControls(providersQuery.data)
+  const grammarSupported = controls?.grammar?.supported !== false
+  const thinkingSupported = controls?.thinking_budget?.supported === true
+  const grammarOptions =
+    grammarsQuery.data?.items?.map((item: LlamaGrammarRecord) => ({
+      label: item.name,
+      value: item.id
+    })) ?? []
+
+  return (
+    <div className={className}>
+      <div className="rounded-xl border border-border/70 bg-surface2/60 p-3 space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="space-y-0.5">
+            <Text strong>
+              {t("sidepanel:llamaControls.title", "llama.cpp advanced controls")}
+            </Text>
+            <div className="text-xs text-text-muted">
+              {t(
+                "sidepanel:llamaControls.subtitle",
+                "Grammar-constrained output and optional reasoning budget."
+              )}
+            </div>
+          </div>
+          <Button size="small" onClick={() => setLibraryOpen(true)}>
+            {t("sidepanel:llamaControls.manageGrammars", "Manage grammars")}
+          </Button>
+        </div>
+
+        {!grammarSupported && controls?.grammar?.effective_reason ? (
+          <Alert
+            type="info"
+            showIcon
+            message={controls.grammar.effective_reason}
+          />
+        ) : null}
+
+        <div className="space-y-1">
+          <label className="text-xs text-text-muted">
+            {t("sidepanel:llamaControls.thinkingBudget", "Thinking budget")}
+          </label>
+          <InputNumber
+            min={0}
+            disabled={!thinkingSupported}
+            value={thinkingBudget}
+            onChange={(value) =>
+              updateSetting(
+                "llamaThinkingBudgetTokens",
+                typeof value === "number" ? value : undefined
+              )
+            }
+            className="w-full"
+            placeholder={t(
+              "sidepanel:llamaControls.thinkingBudgetPlaceholder",
+              "Disabled for this deployment"
+            )}
+          />
+          {!thinkingSupported && controls?.thinking_budget?.effective_reason ? (
+            <div className="text-xs text-text-muted">
+              {controls.thinking_budget.effective_reason}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="space-y-1">
+          <label className="text-xs text-text-muted">
+            {t("sidepanel:llamaControls.grammarSource", "Grammar source")}
+          </label>
+          <Select
+            value={grammarMode || "none"}
+            onChange={(value: "none" | "library" | "inline") => {
+              updateSetting("llamaGrammarMode", value === "none" ? undefined : value)
+              if (value === "none") {
+                updateSetting("llamaGrammarId", undefined)
+                updateSetting("llamaGrammarInline", undefined)
+                updateSetting("llamaGrammarOverride", undefined)
+              }
+              if (value === "inline") {
+                updateSetting("llamaGrammarId", undefined)
+              }
+              if (value === "library") {
+                updateSetting("llamaGrammarInline", undefined)
+              }
+            }}
+            options={[
+              { label: t("common:none", "None"), value: "none" },
+              { label: t("sidepanel:llamaControls.savedGrammar", "Saved grammar"), value: "library" },
+              { label: t("sidepanel:llamaControls.inlineGrammar", "Inline grammar"), value: "inline" }
+            ]}
+          />
+        </div>
+
+        {grammarMode === "library" ? (
+          <div className="space-y-2">
+            <Select
+              value={grammarId}
+              options={grammarOptions}
+              onChange={(value) => updateSetting("llamaGrammarId", value)}
+              placeholder={t(
+                "sidepanel:llamaControls.selectSavedGrammar",
+                "Select a saved grammar"
+              )}
+              loading={grammarsQuery.isLoading}
+              allowClear
+            />
+            <TextArea
+              value={grammarOverride || ""}
+              onChange={(event) =>
+                updateSetting(
+                  "llamaGrammarOverride",
+                  event.target.value || undefined
+                )
+              }
+              rows={5}
+              className="font-mono text-xs"
+              placeholder={t(
+                "sidepanel:llamaControls.overridePlaceholder",
+                "Optional per-chat override"
+              )}
+            />
+          </div>
+        ) : null}
+
+        {grammarMode === "inline" ? (
+          <TextArea
+            value={grammarInline || ""}
+            onChange={(event) =>
+              updateSetting(
+                "llamaGrammarInline",
+                event.target.value || undefined
+              )
+            }
+            rows={8}
+            className="font-mono text-xs"
+            placeholder={'root ::= "ok"'}
+          />
+        ) : null}
+      </div>
+
+      <LlamaGrammarLibraryModal
+        open={libraryOpen}
+        onClose={() => setLibraryOpen(false)}
+        selectedGrammarId={grammarId}
+        onSelectGrammar={(grammar) => {
+          updateSetting("llamaGrammarMode", "library")
+          updateSetting("llamaGrammarId", grammar.id)
+          setLibraryOpen(false)
+        }}
+      />
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Common/Settings/LlamaGrammarLibraryModal.tsx
+++ b/apps/packages/ui/src/components/Common/Settings/LlamaGrammarLibraryModal.tsx
@@ -1,0 +1,242 @@
+import React from "react"
+import { Button, Empty, Input, List, Modal, Space, Typography } from "antd"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useTranslation } from "react-i18next"
+import {
+  tldwLlamaGrammars,
+  type LlamaGrammarRecord
+} from "@/services/tldw/TldwLlamaGrammars"
+
+const { TextArea } = Input
+const { Text } = Typography
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  selectedGrammarId?: string | null
+  onSelectGrammar?: (grammar: LlamaGrammarRecord) => void
+}
+
+export function LlamaGrammarLibraryModal({
+  open,
+  onClose,
+  selectedGrammarId,
+  onSelectGrammar
+}: Props) {
+  const { t } = useTranslation(["common", "sidepanel"])
+  const queryClient = useQueryClient()
+  const [editingId, setEditingId] = React.useState<string | null>(null)
+  const [name, setName] = React.useState("")
+  const [description, setDescription] = React.useState("")
+  const [grammarText, setGrammarText] = React.useState("")
+
+  const grammarsQuery = useQuery({
+    queryKey: ["tldw:llama-grammars"],
+    queryFn: () => tldwLlamaGrammars.list(),
+    enabled: open
+  })
+
+  const invalidate = React.useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ["tldw:llama-grammars"] })
+  }, [queryClient])
+
+  const createMutation = useMutation({
+    mutationFn: tldwLlamaGrammars.create,
+    onSuccess: async () => {
+      await invalidate()
+      setName("")
+      setDescription("")
+      setGrammarText("")
+    }
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: ({
+      id,
+      version,
+      payload
+    }: {
+      id: string
+      version?: number
+      payload: {
+        name: string
+        description?: string
+        grammar_text: string
+      }
+    }) => tldwLlamaGrammars.update(id, { version, ...payload }),
+    onSuccess: async () => {
+      await invalidate()
+      setEditingId(null)
+      setName("")
+      setDescription("")
+      setGrammarText("")
+    }
+  })
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => tldwLlamaGrammars.remove(id),
+    onSuccess: invalidate
+  })
+
+  const items = grammarsQuery.data?.items ?? []
+  const editingRecord = items.find((item) => item.id === editingId) ?? null
+
+  React.useEffect(() => {
+    if (!open) return
+    if (!editingRecord) return
+    setName(editingRecord.name || "")
+    setDescription(editingRecord.description || "")
+    setGrammarText(editingRecord.grammar_text || "")
+  }, [editingRecord, open])
+
+  const isSaving = createMutation.isPending || updateMutation.isPending
+
+  const handleSubmit = async () => {
+    const payload = {
+      name: name.trim(),
+      description: description.trim() || undefined,
+      grammar_text: grammarText
+    }
+    if (!payload.name || !payload.grammar_text.trim()) {
+      return
+    }
+    if (editingRecord) {
+      await updateMutation.mutateAsync({
+        id: editingRecord.id,
+        version: editingRecord.version,
+        payload
+      })
+      return
+    }
+    await createMutation.mutateAsync(payload)
+  }
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width={900}
+      title={t("sidepanel:llamaGrammarLibrary.title", "Saved grammars")}
+    >
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Text strong>
+              {t("sidepanel:llamaGrammarLibrary.saved", "Library")}
+            </Text>
+            <Button
+              size="small"
+              onClick={() => {
+                setEditingId(null)
+                setName("")
+                setDescription("")
+                setGrammarText("")
+              }}
+            >
+              {t("common:new", "New")}
+            </Button>
+          </div>
+          <div className="max-h-[28rem] overflow-y-auto rounded-lg border border-border/70 bg-surface/50">
+            {items.length === 0 ? (
+              <div className="p-6">
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description={t(
+                    "sidepanel:llamaGrammarLibrary.empty",
+                    "No saved grammars yet."
+                  )}
+                />
+              </div>
+            ) : (
+              <List
+                dataSource={items}
+                renderItem={(item) => (
+                  <List.Item
+                    actions={[
+                      <Button
+                        key="use"
+                        size="small"
+                        type={item.id === selectedGrammarId ? "primary" : "default"}
+                        onClick={() => onSelectGrammar?.(item)}
+                      >
+                        {t("common:use", "Use")}
+                      </Button>,
+                      <Button
+                        key="edit"
+                        size="small"
+                        onClick={() => setEditingId(item.id)}
+                      >
+                        {t("common:edit", "Edit")}
+                      </Button>,
+                      <Button
+                        key="delete"
+                        size="small"
+                        danger
+                        onClick={() => void deleteMutation.mutateAsync(item.id)}
+                      >
+                        {t("common:delete", "Delete")}
+                      </Button>
+                    ]}
+                  >
+                    <List.Item.Meta
+                      title={item.name}
+                      description={item.description || item.id}
+                    />
+                  </List.Item>
+                )}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <Text strong>
+            {editingRecord
+              ? t("sidepanel:llamaGrammarLibrary.edit", "Edit grammar")
+              : t("sidepanel:llamaGrammarLibrary.create", "Create grammar")}
+          </Text>
+          <Input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder={t("sidepanel:llamaGrammarLibrary.name", "Grammar name")}
+          />
+          <Input
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder={t(
+              "sidepanel:llamaGrammarLibrary.description",
+              "Short description"
+            )}
+          />
+          <TextArea
+            value={grammarText}
+            onChange={(event) => setGrammarText(event.target.value)}
+            rows={16}
+            className="font-mono text-xs"
+            placeholder={'root ::= "ok"'}
+          />
+          <Space>
+            <Button type="primary" loading={isSaving} onClick={() => void handleSubmit()}>
+              {editingRecord
+                ? t("common:save", "Save")
+                : t("common:create", "Create")}
+            </Button>
+            {editingRecord ? (
+              <Button
+                onClick={() => {
+                  setEditingId(null)
+                  setName("")
+                  setDescription("")
+                  setGrammarText("")
+                }}
+              >
+                {t("common:cancel", "Cancel")}
+              </Button>
+            ) : null}
+          </Space>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/packages/ui/src/components/Common/Settings/__tests__/CurrentChatModelSettings.llamacpp-controls.guard.test.ts
+++ b/apps/packages/ui/src/components/Common/Settings/__tests__/CurrentChatModelSettings.llamacpp-controls.guard.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("CurrentChatModelSettings llama.cpp controls guard", () => {
+  it("keeps llama.cpp controls on the modal form/save path", () => {
+    const sourcePath = path.resolve(
+      __dirname,
+      "../CurrentChatModelSettings.tsx"
+    )
+    const source = fs.readFileSync(sourcePath, "utf8")
+
+    expect(source).toContain('"llamaThinkingBudgetTokens"')
+    expect(source).toContain('"llamaGrammarMode"')
+    expect(source).toContain('"llamaGrammarId"')
+    expect(source).toContain('"llamaGrammarInline"')
+    expect(source).toContain('"llamaGrammarOverride"')
+    expect(source).toContain('Form.useWatch("llamaThinkingBudgetTokens", form)')
+    expect(source).toContain('Form.useWatch("llamaGrammarMode", form)')
+    expect(source).toContain('Form.useWatch("llamaGrammarId", form)')
+    expect(source).toContain('Form.useWatch("llamaGrammarInline", form)')
+    expect(source).toContain('Form.useWatch("llamaGrammarOverride", form)')
+    expect(source).toContain('Form.useWatch("extraBody", form)')
+    expect(source).toContain("handleLlamaControlChange")
+    expect(source).toContain("thinkingBudget={llamaThinkingBudgetTokens}")
+    expect(source).toContain("grammarMode={llamaGrammarMode}")
+    expect(source).toContain("grammarId={llamaGrammarId}")
+    expect(source).toContain("grammarInline={llamaGrammarInline}")
+    expect(source).toContain("grammarOverride={llamaGrammarOverride}")
+    expect(source).toContain("extraBody={llamaExtraBody}")
+    expect(source).toContain("onChange={handleLlamaControlChange}")
+  })
+})

--- a/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
+++ b/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx
@@ -410,6 +410,11 @@ export const PlaygroundForm = ({ droppedFiles }: Props) => {
     apiProvider: state.apiProvider,
     extraHeaders: state.extraHeaders,
     extraBody: state.extraBody,
+    llamaThinkingBudgetTokens: state.llamaThinkingBudgetTokens,
+    llamaGrammarMode: state.llamaGrammarMode,
+    llamaGrammarId: state.llamaGrammarId,
+    llamaGrammarInline: state.llamaGrammarInline,
+    llamaGrammarOverride: state.llamaGrammarOverride,
     jsonMode: state.jsonMode
   }))
   const numCtx = useStoreChatModelSettings((state) => state.numCtx)
@@ -5209,6 +5214,12 @@ export const PlaygroundForm = ({ droppedFiles }: Props) => {
         api_provider: resolvedProvider || undefined,
         extra_headers: parseJsonObject(currentChatModelSettings.extraHeaders),
         extra_body: parseJsonObject(currentChatModelSettings.extraBody),
+        thinking_budget_tokens:
+          currentChatModelSettings.llamaThinkingBudgetTokens,
+        grammar_mode: currentChatModelSettings.llamaGrammarMode,
+        grammar_id: currentChatModelSettings.llamaGrammarId,
+        grammar_inline: currentChatModelSettings.llamaGrammarInline,
+        grammar_override: currentChatModelSettings.llamaGrammarOverride,
         response_format: currentChatModelSettings.jsonMode
           ? { type: "json_object" }
           : undefined
@@ -5222,6 +5233,11 @@ export const PlaygroundForm = ({ droppedFiles }: Props) => {
       currentChatModelSettings.frequencyPenalty,
       currentChatModelSettings.historyMessageLimit,
       currentChatModelSettings.historyMessageOrder,
+      currentChatModelSettings.llamaGrammarId,
+      currentChatModelSettings.llamaGrammarInline,
+      currentChatModelSettings.llamaGrammarMode,
+      currentChatModelSettings.llamaGrammarOverride,
+      currentChatModelSettings.llamaThinkingBudgetTokens,
       currentChatModelSettings.jsonMode,
       currentChatModelSettings.numPredict,
       currentChatModelSettings.presencePenalty,

--- a/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.guard.test.ts
+++ b/apps/packages/ui/src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.guard.test.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+describe("PlaygroundForm llama.cpp controls guard", () => {
+  it("keeps first-class llama.cpp fields in the preview request payload", () => {
+    const formSourcePath = path.resolve(__dirname, "../PlaygroundForm.tsx")
+    const formSource = fs.readFileSync(formSourcePath, "utf8")
+
+    expect(formSource).toContain("thinking_budget_tokens:")
+    expect(formSource).toContain("grammar_mode:")
+    expect(formSource).toContain("grammar_id:")
+    expect(formSource).toContain("grammar_inline:")
+    expect(formSource).toContain("grammar_override:")
+    expect(formSource).toContain("currentChatModelSettings.llamaThinkingBudgetTokens")
+    expect(formSource).toContain("currentChatModelSettings.llamaGrammarMode")
+    expect(formSource).toContain("currentChatModelSettings.llamaGrammarId")
+    expect(formSource).toContain("currentChatModelSettings.llamaGrammarInline")
+    expect(formSource).toContain("currentChatModelSettings.llamaGrammarOverride")
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/ModelParamsPanel.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/ModelParamsPanel.tsx
@@ -11,16 +11,19 @@ import { useTranslation } from "react-i18next"
 import { classNames } from "@/libs/class-name"
 import { useStoreChatModelSettings } from "@/store/model"
 import { useUiModeStore } from "@/store/ui-mode"
+import { LlamaCppAdvancedControls } from "@/components/Common/Settings/LlamaCppAdvancedControls"
 
 const { TextArea } = Input
 
 interface ModelParamsPanelProps {
   onOpenFullSettings?: () => void
   className?: string
+  selectedModel?: string | null
 }
 
 const PROVIDER_OPTIONS = [
   { value: "", label: "Default" },
+  { value: "llama.cpp", label: "llama.cpp" },
   { value: "openai", label: "OpenAI" },
   { value: "anthropic", label: "Anthropic" },
   { value: "azure", label: "Azure OpenAI" },
@@ -40,7 +43,8 @@ const validateJson = (value: string): string | null => {
 
 const ModelParamsPanelBase: React.FC<ModelParamsPanelProps> = ({
   onOpenFullSettings,
-  className
+  className,
+  selectedModel
 }) => {
   const { t } = useTranslation(["sidepanel", "playground"])
   const mode = useUiModeStore((state) => state.mode)
@@ -215,6 +219,8 @@ const ModelParamsPanelBase: React.FC<ModelParamsPanelProps> = ({
               )}
             />
           </div>
+
+          <LlamaCppAdvancedControls selectedModel={selectedModel} />
 
           {/* JSON Mode Toggle */}
           <div className="flex items-center justify-between gap-2 pt-2 border-t border-border/50">

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ModelParamsPanel } from "../ModelParamsPanel"
+import { useStoreChatModelSettings } from "@/store/model"
+import { useUiModeStore } from "@/store/ui-mode"
+
+const mocks = vi.hoisted(() => ({
+  getLlmProviders: vi.fn(async () => ({
+    providers: {
+      "llama.cpp": {
+        llama_cpp_controls: {
+          grammar: { supported: true },
+          thinking_budget: {
+            supported: true,
+            request_key: "reasoning_budget"
+          },
+          reserved_extra_body_keys: ["grammar", "reasoning_budget"]
+        }
+      }
+    }
+  })),
+  grammarList: vi.fn(async () => ({
+    items: [
+      {
+        id: "grammar_1",
+        name: "JSON grammar",
+        grammar_text: 'root ::= "ok"',
+        version: 1
+      }
+    ],
+    total: 1,
+    limit: 100,
+    offset: 0
+  }))
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback || _key
+  })
+}))
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    getLlmProviders: mocks.getLlmProviders
+  }
+}))
+
+vi.mock("@/services/tldw/TldwLlamaGrammars", () => ({
+  tldwLlamaGrammars: {
+    list: mocks.grammarList,
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn()
+  }
+}))
+
+describe("ModelParamsPanel llama.cpp controls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useStoreChatModelSettings.getState().reset()
+    useUiModeStore.setState({ mode: "pro" })
+  })
+
+  it("shows llama.cpp advanced controls when the selected model resolves to llama.cpp", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ModelParamsPanel selectedModel="llama.cpp/local-model" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Provider & API" }))
+
+    expect(
+      await screen.findByText("llama.cpp advanced controls")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Grammar source")).toBeInTheDocument()
+    expect(screen.getByText("Thinking budget")).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx
@@ -86,4 +86,33 @@ describe("ModelParamsPanel llama.cpp controls", () => {
     expect(screen.getByText("Grammar source")).toBeInTheDocument()
     expect(screen.getByText("Thinking budget")).toBeInTheDocument()
   })
+
+  it("warns when raw extra body contains reserved llama.cpp keys", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false }
+      }
+    })
+
+    useStoreChatModelSettings.getState().updateSettings({
+      extraBody: '{"grammar":"root ::= \\"raw\\""}',
+      llamaGrammarMode: "inline",
+      llamaGrammarInline: 'root ::= "ui"'
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ModelParamsPanel selectedModel="llama.cpp/local-model" />
+      </QueryClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Provider & API" }))
+
+    expect(
+      await screen.findByText(
+        "First-class llama.cpp controls override reserved raw extra body keys."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText("grammar")).toBeInTheDocument()
+  })
 })

--- a/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
+++ b/apps/packages/ui/src/components/Sidepanel/Chat/form.tsx
@@ -2529,7 +2529,10 @@ export const SidepanelForm = ({
               {/* Inline Model Parameters Panel (Pro mode only) */}
               {wrapComposerProfile(
                 "sidepanel-model-params-panel",
-                <ModelParamsPanel onOpenFullSettings={handleOpenModelSettings} />
+                <ModelParamsPanel
+                  onOpenFullSettings={handleOpenModelSettings}
+                  selectedModel={selectedModel}
+                />
               )}
               <div className="flex">
                 <form

--- a/apps/packages/ui/src/routes/sidepanel-chat.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-chat.tsx
@@ -307,7 +307,12 @@ const MODEL_SETTINGS_KEYS = [
   "slashCommandInjectionMode",
   "apiProvider",
   "extraHeaders",
-  "extraBody"
+  "extraBody",
+  "llamaThinkingBudgetTokens",
+  "llamaGrammarMode",
+  "llamaGrammarId",
+  "llamaGrammarInline",
+  "llamaGrammarOverride"
 ] as const
 
 type ModelSettingsKey = (typeof MODEL_SETTINGS_KEYS)[number]

--- a/apps/packages/ui/src/services/__tests__/model-settings.llamacpp-controls.test.ts
+++ b/apps/packages/ui/src/services/__tests__/model-settings.llamacpp-controls.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { storageState } = vi.hoisted(() => ({
+  storageState: new Map<string, unknown>()
+}))
+
+vi.mock("@/utils/safe-storage", () => ({
+  createSafeStorage: () => ({
+    get: async (key: string) => storageState.get(key),
+    set: async (key: string, value: unknown) => {
+      storageState.set(key, value)
+    },
+    remove: async (key: string) => {
+      storageState.delete(key)
+    }
+  })
+}))
+
+import {
+  getAllModelSettings,
+  getModelSettings,
+  setModelSetting,
+  setModelSettings
+} from "../model-settings"
+
+describe("model-settings llama.cpp controls", () => {
+  beforeEach(() => {
+    storageState.clear()
+  })
+
+  it("persists llama.cpp default chat model settings", async () => {
+    await setModelSetting("llamaThinkingBudgetTokens", 64)
+    await setModelSetting("llamaGrammarMode", "library")
+    await setModelSetting("llamaGrammarId", "grammar_1")
+    await setModelSetting("llamaGrammarOverride", 'root ::= "override"')
+
+    await expect(getAllModelSettings()).resolves.toMatchObject({
+      llamaThinkingBudgetTokens: 64,
+      llamaGrammarMode: "library",
+      llamaGrammarId: "grammar_1",
+      llamaGrammarOverride: 'root ::= "override"'
+    })
+  })
+
+  it("persists per-model llama.cpp settings bundles", async () => {
+    await setModelSettings({
+      model_id: "llama.cpp/local-model",
+      settings: {
+        llamaGrammarMode: "inline",
+        llamaGrammarInline: 'root ::= "ok"',
+        llamaThinkingBudgetTokens: 24
+      }
+    })
+
+    await expect(getModelSettings("llama.cpp/local-model")).resolves.toMatchObject({
+      llamaGrammarMode: "inline",
+      llamaGrammarInline: 'root ::= "ok"',
+      llamaThinkingBudgetTokens: 24
+    })
+  })
+})

--- a/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
+++ b/apps/packages/ui/src/services/__tests__/tldw-chat.message-sanitization.test.ts
@@ -174,4 +174,37 @@ describe("TldwChatService message sanitization", () => {
       { role: "user", content: "stream hello" }
     ])
   })
+
+  it("forwards first-class llama.cpp grammar and thinking fields", async () => {
+    const service = new TldwChatService()
+
+    await service.sendMessage([{ role: "user", content: "hello" }], {
+      model: "llama.cpp/local-model",
+      apiProvider: "llama.cpp",
+      systemPrompt: "Return JSON",
+      extraBody: { mirostat: 2 },
+      thinkingBudgetTokens: 64,
+      grammarMode: "inline",
+      grammarInline: 'root ::= "ok"',
+      grammarOverride: 'root ::= "override"'
+    })
+
+    const request = mocks.createChatCompletion.mock.calls.at(-1)?.[0] as {
+      api_provider?: string
+      extra_body?: Record<string, unknown>
+      thinking_budget_tokens?: number
+      grammar_mode?: string
+      grammar_inline?: string
+      grammar_override?: string
+    }
+
+    expect(request).toMatchObject({
+      api_provider: "llama.cpp",
+      extra_body: { mirostat: 2 },
+      thinking_budget_tokens: 64,
+      grammar_mode: "inline",
+      grammar_inline: 'root ::= "ok"',
+      grammar_override: 'root ::= "override"'
+    })
+  })
 })

--- a/apps/packages/ui/src/services/model-settings.ts
+++ b/apps/packages/ui/src/services/model-settings.ts
@@ -41,6 +41,11 @@ type ModelSettings = {
   minP?: number
   useMlock?: boolean
   reasoningEffort?: any
+  llamaThinkingBudgetTokens?: number
+  llamaGrammarMode?: "none" | "library" | "inline"
+  llamaGrammarId?: string
+  llamaGrammarInline?: string
+  llamaGrammarOverride?: string
 }
 
 const MODEL_SETTING_KEYS = [
@@ -74,7 +79,12 @@ const MODEL_SETTING_KEYS = [
   "vocabOnly",
   "minP",
   "useMlock",
-  "reasoningEffort"
+  "reasoningEffort",
+  "llamaThinkingBudgetTokens",
+  "llamaGrammarMode",
+  "llamaGrammarId",
+  "llamaGrammarInline",
+  "llamaGrammarOverride"
 ] as const satisfies readonly (keyof ModelSettings)[]
 
 type ModelSettingKey = (typeof MODEL_SETTING_KEYS)[number]

--- a/apps/packages/ui/src/services/tldw/TldwApiClient.ts
+++ b/apps/packages/ui/src/services/tldw/TldwApiClient.ts
@@ -234,6 +234,11 @@ export interface ChatCompletionRequest {
   api_provider?: string
   extra_headers?: Record<string, unknown>
   extra_body?: Record<string, unknown>
+  thinking_budget_tokens?: number
+  grammar_mode?: "none" | "library" | "inline"
+  grammar_id?: string
+  grammar_inline?: string
+  grammar_override?: string
   response_format?: { type: "json_object" | "text" }
 }
 

--- a/apps/packages/ui/src/services/tldw/TldwChat.ts
+++ b/apps/packages/ui/src/services/tldw/TldwChat.ts
@@ -252,6 +252,11 @@ export interface TldwChatOptions {
   apiProvider?: string
   extraHeaders?: Record<string, unknown>
   extraBody?: Record<string, unknown>
+  thinkingBudgetTokens?: number
+  grammarMode?: "none" | "library" | "inline"
+  grammarId?: string
+  grammarInline?: string
+  grammarOverride?: string
   jsonMode?: boolean
 }
 export { getLastChatCompletionDebugSnapshot }
@@ -341,6 +346,11 @@ export class TldwChatService {
         api_provider: options.apiProvider,
         extra_headers: options.extraHeaders,
         extra_body: options.extraBody,
+        thinking_budget_tokens: options.thinkingBudgetTokens,
+        grammar_mode: options.grammarMode,
+        grammar_id: options.grammarId,
+        grammar_inline: options.grammarInline,
+        grammar_override: options.grammarOverride,
         response_format: options.jsonMode ? { type: "json_object" } : undefined
       }
       captureChatRequestDebugSnapshot({
@@ -416,6 +426,11 @@ export class TldwChatService {
         api_provider: options.apiProvider,
         extra_headers: options.extraHeaders,
         extra_body: options.extraBody,
+        thinking_budget_tokens: options.thinkingBudgetTokens,
+        grammar_mode: options.grammarMode,
+        grammar_id: options.grammarId,
+        grammar_inline: options.grammarInline,
+        grammar_override: options.grammarOverride,
         response_format: options.jsonMode ? { type: "json_object" } : undefined
       }
       captureChatRequestDebugSnapshot({

--- a/apps/packages/ui/src/services/tldw/TldwLlamaGrammars.ts
+++ b/apps/packages/ui/src/services/tldw/TldwLlamaGrammars.ts
@@ -1,0 +1,85 @@
+import { bgRequest } from "@/services/background-proxy"
+import { tldwClient } from "./TldwApiClient"
+
+export type LlamaGrammarRecord = {
+  id: string
+  name: string
+  description?: string | null
+  grammar_text: string
+  validation_status?: "unchecked" | "valid" | "invalid"
+  validation_error?: string | null
+  last_validated_at?: string | null
+  is_archived?: boolean
+  created_at?: string | null
+  updated_at?: string | null
+  version?: number
+}
+
+export type LlamaGrammarListResponse = {
+  items: LlamaGrammarRecord[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export type CreateLlamaGrammarInput = {
+  name: string
+  description?: string
+  grammar_text: string
+}
+
+export type UpdateLlamaGrammarInput = Partial<CreateLlamaGrammarInput> & {
+  version?: number
+}
+
+export class TldwLlamaGrammarsService {
+  async list(params?: {
+    include_archived?: boolean
+    limit?: number
+    offset?: number
+  }): Promise<LlamaGrammarListResponse> {
+    await tldwClient.initialize().catch(() => null)
+    const qs = new URLSearchParams()
+    if (params?.include_archived) qs.set("include_archived", "true")
+    if (typeof params?.limit === "number") qs.set("limit", String(params.limit))
+    if (typeof params?.offset === "number") qs.set("offset", String(params.offset))
+    const query = qs.toString()
+    return await bgRequest<LlamaGrammarListResponse>({
+      path: `/api/v1/chat/grammars${query ? `?${query}` : ""}`,
+      method: "GET"
+    })
+  }
+
+  async create(input: CreateLlamaGrammarInput): Promise<LlamaGrammarRecord> {
+    await tldwClient.initialize().catch(() => null)
+    return await bgRequest<LlamaGrammarRecord>({
+      path: "/api/v1/chat/grammars",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: input
+    })
+  }
+
+  async update(id: string, input: UpdateLlamaGrammarInput): Promise<LlamaGrammarRecord> {
+    await tldwClient.initialize().catch(() => null)
+    return await bgRequest<LlamaGrammarRecord>({
+      path: `/api/v1/chat/grammars/${encodeURIComponent(id)}`,
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: input
+    })
+  }
+
+  async remove(id: string, params?: {
+    hard_delete?: boolean
+  }): Promise<void> {
+    await tldwClient.initialize().catch(() => null)
+    const query = params?.hard_delete ? "?hard_delete=true" : ""
+    await bgRequest({
+      path: `/api/v1/chat/grammars/${encodeURIComponent(id)}${query}`,
+      method: "DELETE"
+    })
+  }
+}
+
+export const tldwLlamaGrammars = new TldwLlamaGrammarsService()

--- a/apps/packages/ui/src/services/tldw/openapi-guard.ts
+++ b/apps/packages/ui/src/services/tldw/openapi-guard.ts
@@ -87,6 +87,8 @@ export type ClientPath =
   | "/api/v1/chat/dictionaries/import/json"
   | "/api/v1/chat/dictionaries/validate"
   | "/api/v1/chat/dictionaries/process"
+  | "/api/v1/chat/grammars"
+  | "/api/v1/chat/grammars/{grammar_id}"
   | "/api/v1/chat/knowledge/save"
   | "/api/v1/chat/documents"
   | "/api/v1/chat/documents/generate"

--- a/apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts
+++ b/apps/packages/ui/src/store/__tests__/model.llamacpp-controls.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs"
+import path from "node:path"
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  useSidepanelChatTabsStore,
+  type ChatModelSettingsSnapshot,
+  type SidepanelChatSnapshot
+} from "../sidepanel-chat-tabs"
+import { useStoreChatModelSettings } from "../model"
+
+const LLAMA_SETTING_KEYS = [
+  "llamaThinkingBudgetTokens",
+  "llamaGrammarMode",
+  "llamaGrammarId",
+  "llamaGrammarInline",
+  "llamaGrammarOverride"
+] as const
+
+const readSource = (relativePath: string) =>
+  fs.readFileSync(path.resolve(__dirname, relativePath), "utf8")
+
+describe("llama.cpp chat model settings state", () => {
+  beforeEach(() => {
+    useStoreChatModelSettings.getState().reset()
+    useSidepanelChatTabsStore.getState().clear()
+  })
+
+  it("stores llama.cpp controls in the shared chat model settings store", () => {
+    useStoreChatModelSettings.getState().updateSettings({
+      llamaGrammarMode: "library",
+      llamaGrammarId: "grammar_1",
+      llamaGrammarOverride: 'root ::= "override"',
+      llamaThinkingBudgetTokens: 64
+    })
+
+    const next = useStoreChatModelSettings.getState()
+
+    expect(next.llamaGrammarMode).toBe("library")
+    expect(next.llamaGrammarId).toBe("grammar_1")
+    expect(next.llamaGrammarOverride).toBe('root ::= "override"')
+    expect(next.llamaThinkingBudgetTokens).toBe(64)
+  })
+
+  it("round-trips llama.cpp controls through sidepanel snapshots and route allowlists", () => {
+    const modelSettings: ChatModelSettingsSnapshot = {
+      llamaThinkingBudgetTokens: 32,
+      llamaGrammarMode: "inline",
+      llamaGrammarId: "grammar_saved",
+      llamaGrammarInline: 'root ::= "ok"',
+      llamaGrammarOverride: 'root ::= "override"'
+    }
+    const snapshot: SidepanelChatSnapshot = {
+      history: [] as any,
+      messages: [],
+      chatMode: "normal",
+      historyId: null,
+      webSearch: false,
+      toolChoice: "none",
+      selectedModel: "llama.cpp/local-model",
+      selectedSystemPrompt: null,
+      selectedQuickPrompt: null,
+      temporaryChat: false,
+      useOCR: false,
+      serverChatId: null,
+      serverChatState: null,
+      serverChatTopic: null,
+      serverChatClusterId: null,
+      serverChatSource: null,
+      serverChatExternalRef: null,
+      queuedMessages: [],
+      modelSettings
+    }
+
+    useSidepanelChatTabsStore.getState().setSnapshot("tab-1", snapshot)
+    const restored = useSidepanelChatTabsStore.getState().getSnapshot("tab-1")
+
+    expect(restored?.modelSettings.llamaThinkingBudgetTokens).toBe(32)
+    expect(restored?.modelSettings.llamaGrammarMode).toBe("inline")
+    expect(restored?.modelSettings.llamaGrammarInline).toBe('root ::= "ok"')
+
+    const sharedRouteSource = readSource("../../routes/sidepanel-chat.tsx")
+    const extensionRouteSource = readSource(
+      "../../../../../tldw-frontend/extension/routes/sidepanel-chat.tsx"
+    )
+
+    for (const key of LLAMA_SETTING_KEYS) {
+      expect(sharedRouteSource).toContain(`"${key}"`)
+      expect(extensionRouteSource).toContain(`"${key}"`)
+    }
+  })
+})

--- a/apps/packages/ui/src/store/model.tsx
+++ b/apps/packages/ui/src/store/model.tsx
@@ -52,6 +52,11 @@ export type ChatModelSettings = {
   apiProvider?: string
   extraHeaders?: string
   extraBody?: string
+  llamaThinkingBudgetTokens?: number
+  llamaGrammarMode?: "none" | "library" | "inline"
+  llamaGrammarId?: string
+  llamaGrammarInline?: string
+  llamaGrammarOverride?: string
 
   // Response format
   jsonMode?: boolean
@@ -111,6 +116,13 @@ type ChatModelSettingsStore = ChatModelSettings & {
   setApiProvider: (value: string) => void
   setExtraHeaders: (value: string) => void
   setExtraBody: (value: string) => void
+  setLlamaThinkingBudgetTokens: (value: number | undefined) => void
+  setLlamaGrammarMode: (
+    value: "none" | "library" | "inline" | undefined
+  ) => void
+  setLlamaGrammarId: (value: string | undefined) => void
+  setLlamaGrammarInline: (value: string | undefined) => void
+  setLlamaGrammarOverride: (value: string | undefined) => void
   setJsonMode: (value: boolean | undefined) => void
 }
 
@@ -156,6 +168,11 @@ const INITIAL_STATE: ChatModelSettings = {
   apiProvider: undefined,
   extraHeaders: undefined,
   extraBody: undefined,
+  llamaThinkingBudgetTokens: undefined,
+  llamaGrammarMode: undefined,
+  llamaGrammarId: undefined,
+  llamaGrammarInline: undefined,
+  llamaGrammarOverride: undefined,
   jsonMode: undefined
 }
 
@@ -215,6 +232,13 @@ export const useStoreChatModelSettings = createWithEqualityFn<ChatModelSettingsS
     setApiProvider: (value) => set({ apiProvider: value }),
     setExtraHeaders: (value) => set({ extraHeaders: value }),
     setExtraBody: (value) => set({ extraBody: value }),
+    setLlamaThinkingBudgetTokens: (value) =>
+      set({ llamaThinkingBudgetTokens: value }),
+    setLlamaGrammarMode: (value) => set({ llamaGrammarMode: value }),
+    setLlamaGrammarId: (value) => set({ llamaGrammarId: value }),
+    setLlamaGrammarInline: (value) => set({ llamaGrammarInline: value }),
+    setLlamaGrammarOverride: (value) =>
+      set({ llamaGrammarOverride: value }),
     setJsonMode: (value) => set({ jsonMode: value })
   })
 )

--- a/apps/packages/ui/src/store/sidepanel-chat-tabs.tsx
+++ b/apps/packages/ui/src/store/sidepanel-chat-tabs.tsx
@@ -44,6 +44,11 @@ export type ChatModelSettingsSnapshot = {
   apiProvider?: string
   extraHeaders?: string
   extraBody?: string
+  llamaThinkingBudgetTokens?: number
+  llamaGrammarMode?: "none" | "library" | "inline"
+  llamaGrammarId?: string
+  llamaGrammarInline?: string
+  llamaGrammarOverride?: string
 }
 
 export type SidepanelChatSnapshot = {

--- a/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
+++ b/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx
@@ -203,7 +203,12 @@ const MODEL_SETTINGS_KEYS = [
   "slashCommandInjectionMode",
   "apiProvider",
   "extraHeaders",
-  "extraBody"
+  "extraBody",
+  "llamaThinkingBudgetTokens",
+  "llamaGrammarMode",
+  "llamaGrammarId",
+  "llamaGrammarInline",
+  "llamaGrammarOverride"
 ] as const
 
 type ModelSettingsKey = (typeof MODEL_SETTINGS_KEYS)[number]

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -2803,20 +2803,25 @@ async def create_chat_completion(
                     loop=current_loop,
                 )
 
-            llamacpp_grammar_record: dict[str, Any] | None = None
-            if target_api_provider == "llama.cpp" and getattr(request_data, "grammar_mode", None) == "library":
+            def _resolve_llamacpp_grammar_record(target_provider: str) -> dict[str, Any] | None:
+                """Resolve the saved llama.cpp grammar record for the active provider."""
+                if target_provider != "llama.cpp" or getattr(request_data, "grammar_mode", None) != "library":
+                    return None
                 grammar_id = str(getattr(request_data, "grammar_id", "") or "").strip()
                 if not grammar_id:
                     raise ChatBadRequestError(
-                        provider=target_api_provider,
+                        provider=target_provider,
                         message="grammar_id is required when grammar_mode is 'library'",
                     )
-                llamacpp_grammar_record = chat_db.get_chat_grammar(grammar_id)
-                if not isinstance(llamacpp_grammar_record, dict):
+                grammar_record = chat_db.get_chat_grammar(grammar_id)
+                if not isinstance(grammar_record, dict):
                     raise ChatBadRequestError(
-                        provider=target_api_provider,
+                        provider=target_provider,
                         message="Saved grammar could not be resolved",
                     )
+                return grammar_record
+
+            llamacpp_grammar_record = _resolve_llamacpp_grammar_record(target_api_provider)
 
             # --- LLM Call ---
             cleaned_args = build_call_params_from_request(
@@ -2907,6 +2912,7 @@ async def create_chat_completion(
                         },
                     )
 
+                refreshed_llamacpp_grammar_record = _resolve_llamacpp_grammar_record(target_provider)
                 refreshed_args = build_call_params_from_request(
                     request_data=request_data,
                     target_api_provider=target_provider,
@@ -2914,7 +2920,7 @@ async def create_chat_completion(
                     templated_llm_payload=templated_llm_payload,
                     final_system_message=final_system_message,
                     app_config=refreshed_resolution.app_config,
-                    grammar_record=llamacpp_grammar_record,
+                    grammar_record=refreshed_llamacpp_grammar_record,
                 )
                 refreshed_args["request"] = request
                 refreshed_model = refreshed_args.get("model")

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -234,7 +234,7 @@ from tldw_Server_API.app.core.testing import (
 )
 from tldw_Server_API.app.core.Usage.usage_tracker import backfill_legacy_tokens_to_ledger
 
-from . import chat_dictionaries, chat_documents
+from . import chat_dictionaries, chat_documents, chat_grammars
 
 _CHAT_ENDPOINT_NONCRITICAL_EXCEPTIONS = (
     asyncio.CancelledError,
@@ -278,6 +278,7 @@ conversations_alias_router = APIRouter()
 
 router.include_router(chat_dictionaries.router)
 router.include_router(chat_documents.router)
+router.include_router(chat_grammars.router)
 
 # Backward-compatible endpoint re-exports for unit tests and legacy imports
 # that still reference dictionary handlers from this module.
@@ -302,6 +303,11 @@ list_dictionary_versions = chat_dictionaries.list_dictionary_versions
 get_dictionary_version = chat_dictionaries.get_dictionary_version
 revert_dictionary_version = chat_dictionaries.revert_dictionary_version
 get_dictionary_statistics = chat_dictionaries.get_dictionary_statistics
+create_chat_grammar = chat_grammars.create_chat_grammar
+list_chat_grammars = chat_grammars.list_chat_grammars
+get_chat_grammar = chat_grammars.get_chat_grammar
+update_chat_grammar = chat_grammars.update_chat_grammar
+delete_chat_grammar = chat_grammars.delete_chat_grammar
 
 def _chat_connectors_enabled() -> bool:
     """Feature flag for chat connectors v2 (email/issue/wiki exports)."""

--- a/tldw_Server_API/app/api/v1/endpoints/chat.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat.py
@@ -127,7 +127,7 @@ from tldw_Server_API.app.core.Character_Chat.modules.persona_exemplar_selector i
 from tldw_Server_API.app.core.Character_Chat.modules.persona_exemplar_telemetry import (
     compute_persona_exemplar_telemetry,
 )
-from tldw_Server_API.app.core.Chat.Chat_Deps import ChatAPIError
+from tldw_Server_API.app.core.Chat.Chat_Deps import ChatAPIError, ChatBadRequestError
 from tldw_Server_API.app.core.Chat.chat_exceptions import (
     ChatDatabaseError,
     ChatErrorCode,
@@ -2803,6 +2803,21 @@ async def create_chat_completion(
                     loop=current_loop,
                 )
 
+            llamacpp_grammar_record: dict[str, Any] | None = None
+            if target_api_provider == "llama.cpp" and getattr(request_data, "grammar_mode", None) == "library":
+                grammar_id = str(getattr(request_data, "grammar_id", "") or "").strip()
+                if not grammar_id:
+                    raise ChatBadRequestError(
+                        provider=target_api_provider,
+                        message="grammar_id is required when grammar_mode is 'library'",
+                    )
+                llamacpp_grammar_record = chat_db.get_chat_grammar(grammar_id)
+                if not isinstance(llamacpp_grammar_record, dict):
+                    raise ChatBadRequestError(
+                        provider=target_api_provider,
+                        message="Saved grammar could not be resolved",
+                    )
+
             # --- LLM Call ---
             cleaned_args = build_call_params_from_request(
                 request_data=request_data,
@@ -2811,6 +2826,7 @@ async def create_chat_completion(
                 templated_llm_payload=templated_llm_payload,
                 final_system_message=final_system_message,
                 app_config=app_config_override,
+                grammar_record=llamacpp_grammar_record,
             )
             cleaned_args["request"] = request
             try:
@@ -2898,6 +2914,7 @@ async def create_chat_completion(
                     templated_llm_payload=templated_llm_payload,
                     final_system_message=final_system_message,
                     app_config=refreshed_resolution.app_config,
+                    grammar_record=llamacpp_grammar_record,
                 )
                 refreshed_args["request"] = request
                 refreshed_model = refreshed_args.get("model")

--- a/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
@@ -38,6 +38,7 @@ async def create_chat_grammar(
     grammar: ChatGrammarCreate,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ChatGrammarResponse:
+    """Create a saved llama.cpp grammar for the current user."""
     service = ChatGrammarService(db)
     try:
         grammar_id = service.create_grammar(
@@ -75,6 +76,7 @@ async def list_chat_grammars(
     offset: int = Query(0, ge=0, description="Pagination offset"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ChatGrammarListResponse:
+    """List saved llama.cpp grammars visible to the current user."""
     try:
         service = ChatGrammarService(db)
         grammars = service.list_grammars(
@@ -105,6 +107,7 @@ async def get_chat_grammar(
     include_archived: bool = Query(False, description="Allow archived grammars to be returned"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ChatGrammarResponse:
+    """Fetch one saved llama.cpp grammar owned by the current user."""
     try:
         service = ChatGrammarService(db)
         grammar = service.get_grammar(grammar_id, include_archived=include_archived)
@@ -131,6 +134,7 @@ async def update_chat_grammar(
     update: ChatGrammarUpdate,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> ChatGrammarResponse:
+    """Update a saved llama.cpp grammar owned by the current user."""
     service = ChatGrammarService(db)
     try:
         current = service.get_grammar(grammar_id, include_archived=True)
@@ -170,6 +174,7 @@ async def delete_chat_grammar(
     hard_delete: bool = Query(False, description="Permanently delete instead of soft delete"),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> Response:
+    """Delete a saved llama.cpp grammar owned by the current user."""
     service = ChatGrammarService(db)
     try:
         deleted = service.delete_grammar(grammar_id, hard_delete=hard_delete)

--- a/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
+++ b/tldw_Server_API/app/api/v1/endpoints/chat_grammars.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.schemas.chat_grammar_schemas import (
+    ChatGrammarCreate,
+    ChatGrammarListResponse,
+    ChatGrammarResponse,
+    ChatGrammarUpdate,
+)
+from tldw_Server_API.app.core.Character_Chat.chat_grammar import ChatGrammarService
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    ConflictError,
+    InputError,
+)
+
+router = APIRouter()
+
+
+def _grammar_to_response(grammar_data: dict[str, Any]) -> ChatGrammarResponse:
+    return ChatGrammarResponse(**grammar_data)
+
+
+@router.post(
+    "/grammars",
+    response_model=ChatGrammarResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a saved chat grammar",
+    description="Create a user-scoped reusable GBNF grammar for llama.cpp chat sessions.",
+    tags=["chat-grammars"],
+)
+async def create_chat_grammar(
+    grammar: ChatGrammarCreate,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> ChatGrammarResponse:
+    service = ChatGrammarService(db)
+    try:
+        grammar_id = service.create_grammar(
+            name=grammar.name,
+            description=grammar.description,
+            grammar_text=grammar.grammar_text,
+        )
+        created = service.get_grammar(grammar_id, include_archived=True)
+    except ConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except InputError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Error creating chat grammar: {exc}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+    if not created:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Grammar created but could not be retrieved",
+        )
+    return _grammar_to_response(created)
+
+
+@router.get(
+    "/grammars",
+    response_model=ChatGrammarListResponse,
+    summary="List saved chat grammars",
+    description="List user-scoped saved GBNF grammars. Use include_archived to include archived items.",
+    tags=["chat-grammars"],
+)
+async def list_chat_grammars(
+    include_archived: bool = Query(False, description="Include archived saved grammars"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum grammars to return"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> ChatGrammarListResponse:
+    try:
+        service = ChatGrammarService(db)
+        grammars = service.list_grammars(
+            include_archived=include_archived,
+            limit=limit,
+            offset=offset,
+        )
+        total = service.count_grammars(include_archived=include_archived)
+    except Exception as exc:
+        logger.error(f"Error listing chat grammars: {exc}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+    return ChatGrammarListResponse(
+        items=[_grammar_to_response(grammar) for grammar in grammars],
+        total=total,
+    )
+
+
+@router.get(
+    "/grammars/{grammar_id}",
+    response_model=ChatGrammarResponse,
+    summary="Get a saved chat grammar",
+    description="Retrieve a saved GBNF grammar by identifier.",
+    tags=["chat-grammars"],
+)
+async def get_chat_grammar(
+    grammar_id: str,
+    include_archived: bool = Query(False, description="Allow archived grammars to be returned"),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> ChatGrammarResponse:
+    try:
+        service = ChatGrammarService(db)
+        grammar = service.get_grammar(grammar_id, include_archived=include_archived)
+    except InputError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Error getting chat grammar: {exc}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+    if not grammar:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grammar not found")
+    return _grammar_to_response(grammar)
+
+
+@router.patch(
+    "/grammars/{grammar_id}",
+    response_model=ChatGrammarResponse,
+    summary="Update a saved chat grammar",
+    description="Update grammar metadata or grammar text for a saved user-scoped grammar.",
+    tags=["chat-grammars"],
+)
+async def update_chat_grammar(
+    grammar_id: str,
+    update: ChatGrammarUpdate,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> ChatGrammarResponse:
+    service = ChatGrammarService(db)
+    try:
+        current = service.get_grammar(grammar_id, include_archived=True)
+        if not current:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grammar not found")
+
+        update_payload = update.model_dump(exclude_unset=True)
+        expected_version = update_payload.pop("version", None)
+        updated = service.update_grammar(
+            grammar_id,
+            update_payload,
+            expected_version=expected_version if expected_version is not None else current["version"],
+        )
+    except ConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except InputError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error updating chat grammar: {exc}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+    return _grammar_to_response(updated)
+
+
+@router.delete(
+    "/grammars/{grammar_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    summary="Delete a saved chat grammar",
+    description="Soft-delete a saved user-scoped grammar unless hard_delete=true is supplied.",
+    tags=["chat-grammars"],
+)
+async def delete_chat_grammar(
+    grammar_id: str,
+    hard_delete: bool = Query(False, description="Permanently delete instead of soft delete"),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> Response:
+    service = ChatGrammarService(db)
+    try:
+        deleted = service.delete_grammar(grammar_id, hard_delete=hard_delete)
+    except InputError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grammar not found")
+    except ConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Error deleting chat grammar: {exc}")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Grammar not found")
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/llm_providers.py
@@ -36,6 +36,7 @@ from tldw_Server_API.app.core.LLM_Calls.extra_body_compat_catalog import (
     get_model_extra_body_compat,
     get_provider_extra_body_compat,
 )
+from tldw_Server_API.app.core.LLM_Calls.llamacpp_request_extensions import resolve_llamacpp_runtime_caps
 from tldw_Server_API.app.core.LLM_Calls.tokenizer_resolver import (
     resolve_tokenizer_metadata,
     strict_token_counting_enabled as _strict_token_counting_enabled_shared,
@@ -1236,16 +1237,56 @@ def _should_probe_model_tokenizer(
 
 def _build_runtime_context(config_parser: Any) -> dict[str, Any]:
     strict_openai_compat = False
+    thinking_budget_request_key = ""
     try:
         if config_parser.has_section("Local-API") and config_parser.has_option("Local-API", "strict_openai_compat"):
             strict_openai_compat = _truthy(config_parser.get("Local-API", "strict_openai_compat", fallback="false"))
+        if config_parser.has_section("Local-API") and config_parser.has_option("Local-API", "llama_cpp_thinking_budget_param"):
+            thinking_budget_request_key = (
+                config_parser.get("Local-API", "llama_cpp_thinking_budget_param", fallback="") or ""
+            ).strip()
     except Exception:  # noqa: BLE001 - capability metadata should fail open
         strict_openai_compat = False
+        thinking_budget_request_key = ""
 
     env_override = os.getenv("LOCAL_LLM_STRICT_OPENAI_COMPAT")
     if env_override is not None:
         strict_openai_compat = _truthy(env_override)
-    return {"strict_openai_compat": strict_openai_compat}
+    thinking_budget_env = os.getenv("LLAMA_CPP_THINKING_BUDGET_PARAM")
+    if thinking_budget_env is not None:
+        thinking_budget_request_key = thinking_budget_env.strip()
+    return {
+        "strict_openai_compat": strict_openai_compat,
+        "thinking_budget_request_key": thinking_budget_request_key or None,
+    }
+
+
+def _resolve_llama_cpp_control_caps(runtime_context: dict[str, Any]) -> dict[str, Any]:
+    runtime_caps = resolve_llamacpp_runtime_caps(runtime_context=runtime_context)
+    strict_mode = bool(runtime_caps.get("strict_openai_compat"))
+    thinking_budget = runtime_caps.get("thinking_budget") or {}
+    request_key = str(thinking_budget.get("request_key") or "").strip()
+    return {
+        "grammar": {
+            "supported": not strict_mode,
+            "effective_reason": (
+                "disabled by strict_openai_compat runtime setting"
+                if strict_mode else "supported in current deployment"
+            ),
+            "source": "first_class+extra_body",
+        },
+        "thinking_budget": {
+            "supported": (not strict_mode) and bool(request_key),
+            "request_key": request_key or None,
+            "effective_reason": (
+                "disabled by strict_openai_compat runtime setting"
+                if strict_mode
+                else "no configured thinking-budget mapping for this deployment"
+                if not request_key else "supported in current deployment"
+            ),
+        },
+        "reserved_extra_body_keys": list(runtime_caps.get("reserved_extra_body_keys") or ["grammar"]),
+    }
 
 
 def _fallback_extra_body_compat() -> dict[str, Any]:
@@ -1627,6 +1668,7 @@ def get_configured_providers(
                 models_info = filtered
                 models = [mi['name'] for mi in models_info]
 
+            llama_cpp_controls = _resolve_llama_cpp_control_caps(runtime_context) if provider_name == "llama" else None
             strict_mode_effective = _strict_token_counting_enabled_shared(default=False)
             for model_index, model_info in enumerate(models_info):
                 model_name = str(model_info.get("name") or model_info.get("id") or "").strip()
@@ -1635,6 +1677,8 @@ def get_configured_providers(
                     model_name,
                     runtime_context,
                 )
+                if llama_cpp_controls is not None:
+                    model_info["llama_cpp_controls"] = dict(llama_cpp_controls)
                 should_probe_tokenizer, skip_reason = _should_probe_model_tokenizer(
                     provider_type=provider_info["type"],
                     model_info=model_info,
@@ -1691,6 +1735,8 @@ def get_configured_providers(
                 'extra_body_compat': _safe_provider_extra_body_compat(provider_name, runtime_context),
                 'tokenizers': tokenizers_by_model or None,
             }
+            if llama_cpp_controls is not None:
+                provider_data['llama_cpp_controls'] = llama_cpp_controls
 
             # Add endpoint for local providers
             if provider_info['type'] == 'local':

--- a/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
@@ -32,6 +32,7 @@ class ChatGrammarCreate(ChatGrammarBase):
 class ChatGrammarUpdate(BaseModel):
     """Request schema for updating a saved grammar."""
 
+    version: int | None = Field(None, ge=1, description="Optional optimistic-lock version")
     name: str | None = Field(None, min_length=1, max_length=200)
     description: str | None = Field(None, max_length=2000)
     grammar_text: str | None = Field(None, min_length=1, max_length=200_000)

--- a/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py
@@ -1,0 +1,77 @@
+"""
+Pydantic schemas for llama.cpp grammar-library API endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+ChatGrammarValidationStatus = Literal["unchecked", "valid", "invalid"]
+
+
+class ChatGrammarBase(BaseModel):
+    """Shared fields for stored chat grammars."""
+
+    name: str = Field(..., min_length=1, max_length=200, description="Display name for the saved grammar")
+    description: str | None = Field(None, max_length=2000, description="Optional user-authored description")
+    grammar_text: str = Field(
+        ...,
+        min_length=1,
+        max_length=200_000,
+        description="Inline GBNF grammar text stored for later reuse",
+    )
+
+
+class ChatGrammarCreate(ChatGrammarBase):
+    """Request schema for creating a saved grammar."""
+
+
+class ChatGrammarUpdate(BaseModel):
+    """Request schema for updating a saved grammar."""
+
+    name: str | None = Field(None, min_length=1, max_length=200)
+    description: str | None = Field(None, max_length=2000)
+    grammar_text: str | None = Field(None, min_length=1, max_length=200_000)
+    validation_status: ChatGrammarValidationStatus | None = Field(None)
+    validation_error: str | None = Field(None, max_length=4000)
+    last_validated_at: datetime | None = Field(None)
+    is_archived: bool | None = Field(None)
+
+    @model_validator(mode="after")
+    def validate_at_least_one_field(self) -> "ChatGrammarUpdate":
+        if (
+            self.name is None
+            and self.description is None
+            and self.grammar_text is None
+            and self.validation_status is None
+            and self.validation_error is None
+            and self.last_validated_at is None
+            and self.is_archived is None
+        ):
+            raise ValueError("At least one updatable field must be provided")
+        return self
+
+
+class ChatGrammarResponse(ChatGrammarBase):
+    """Response schema for a saved grammar."""
+
+    id: str = Field(..., description="Stable grammar identifier")
+    validation_status: ChatGrammarValidationStatus = Field(..., description="Current validation state")
+    validation_error: str | None = Field(None, description="Most recent validation error, if any")
+    last_validated_at: datetime | None = Field(None, description="When the grammar was last validated")
+    is_archived: bool = Field(False, description="Whether the grammar is archived from normal listings")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+    version: int = Field(..., description="Optimistic-lock version")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ChatGrammarListResponse(BaseModel):
+    """Response schema for listing saved grammars."""
+
+    items: list[ChatGrammarResponse] = Field(default_factory=list, description="Saved grammar records")
+    total: int = Field(..., description="Total number of matching saved grammars")

--- a/tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py
@@ -802,6 +802,31 @@ class ChatCompletionRequest(BaseModel):
         description="Provider-specific extra body content. For Bedrock guardrails, include"
         " 'amazon-bedrock-guardrailConfig': { 'tagSuffix': '...'} if needed.",
     )
+    thinking_budget_tokens: Optional[int] = Field(
+        None,
+        ge=0,
+        description="[llama.cpp extension] App-level thinking budget in tokens. Only valid when the resolved target provider is llama.cpp.",
+    )
+    grammar_mode: Optional[Literal["none", "library", "inline"]] = Field(
+        None,
+        description="[llama.cpp extension] How to resolve the outbound grammar payload.",
+    )
+    grammar_id: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=128,
+        description="[llama.cpp extension] Saved grammar identifier when grammar_mode='library'.",
+    )
+    grammar_inline: Optional[str] = Field(
+        None,
+        max_length=200_000,
+        description="[llama.cpp extension] Inline grammar when grammar_mode='inline'.",
+    )
+    grammar_override: Optional[str] = Field(
+        None,
+        max_length=200_000,
+        description="[llama.cpp extension] Optional per-request override applied on top of a saved grammar selection.",
+    )
 
     # --- Extended Parameters for chat_api_call ---
     minp: Optional[float] = Field(None, description="[Extension] Minimum probability threshold (provider specific).")
@@ -901,6 +926,14 @@ class ChatCompletionRequest(BaseModel):
         if top_logprobs is not None and not logprobs:
             raise ValueError("If top_logprobs is specified, logprobs must be set to true.")
         return values
+
+    @model_validator(mode="after")
+    def validate_llamacpp_grammar_fields(self) -> "ChatCompletionRequest":
+        if self.grammar_mode == "library" and not self.grammar_id:
+            raise ValueError("grammar_id is required when grammar_mode is 'library'")
+        if self.grammar_mode == "inline" and not self.grammar_inline:
+            raise ValueError("grammar_inline is required when grammar_mode is 'inline'")
+        return self
 
 
 #

--- a/tldw_Server_API/app/core/Character_Chat/chat_grammar.py
+++ b/tldw_Server_API/app/core/Character_Chat/chat_grammar.py
@@ -1,0 +1,167 @@
+"""
+User-scoped llama.cpp grammar-library service.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    CharactersRAGDBError,
+    ConflictError,
+    InputError,
+)
+
+_CHAT_GRAMMAR_NONCRITICAL_EXCEPTIONS = (
+    AssertionError,
+    AttributeError,
+    ConnectionError,
+    FileNotFoundError,
+    ImportError,
+    IndexError,
+    KeyError,
+    LookupError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    UnicodeDecodeError,
+    ValueError,
+    sqlite3.Error,
+)
+
+
+class ChatGrammarService:
+    """Request-scoped CRUD service for saved GBNF grammars."""
+
+    def __init__(self, db: CharactersRAGDB):
+        self.db = db
+        self.db.ensure_chat_grammars_table()
+
+    def create_grammar(
+        self,
+        *,
+        name: str,
+        description: str | None = None,
+        grammar_text: str,
+    ) -> str:
+        """Create a saved grammar and return its identifier."""
+        try:
+            return self.db.insert_chat_grammar(
+                {
+                    "name": name,
+                    "description": description,
+                    "grammar_text": grammar_text,
+                }
+            )
+        except ConflictError:
+            raise
+        except _CHAT_GRAMMAR_NONCRITICAL_EXCEPTIONS as exc:
+            logger.error(f"Error creating chat grammar: {exc}")
+            raise CharactersRAGDBError(f"Error creating chat grammar: {exc}") from exc
+
+    def list_grammars(
+        self,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List saved grammars for the current user."""
+        return self.db.list_chat_grammars(
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+            limit=limit,
+            offset=offset,
+        )
+
+    def count_grammars(
+        self,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> int:
+        """Count saved grammars for the current user."""
+        return self.db.count_chat_grammars(
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+
+    def get_grammar(
+        self,
+        grammar_id: str,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch a saved grammar by identifier."""
+        return self.db.get_chat_grammar(
+            grammar_id,
+            include_archived=include_archived,
+            include_deleted=include_deleted,
+        )
+
+    def update_grammar(
+        self,
+        grammar_id: str,
+        updates: dict[str, Any],
+        *,
+        expected_version: int | None = None,
+    ) -> dict[str, Any]:
+        """Update a saved grammar and return the refreshed record."""
+        if not updates:
+            raise InputError("No grammar updates were provided")
+        current = self.db.get_chat_grammar(grammar_id, include_archived=True, include_deleted=True)
+        if current is None or bool(current.get("deleted")):
+            raise InputError(f"Grammar {grammar_id} not found")
+        version = int(expected_version if expected_version is not None else current["version"])
+        self.db.update_chat_grammar(grammar_id, updates, expected_version=version)
+        updated = self.db.get_chat_grammar(grammar_id, include_archived=True, include_deleted=True)
+        if updated is None:
+            raise CharactersRAGDBError(f"Updated grammar {grammar_id} could not be reloaded")
+        return updated
+
+    def archive_grammar(
+        self,
+        grammar_id: str,
+        *,
+        expected_version: int | None = None,
+    ) -> dict[str, Any]:
+        """Archive a grammar without deleting its stored text."""
+        current = self.db.get_chat_grammar(grammar_id, include_archived=True, include_deleted=True)
+        if current is None or bool(current.get("deleted")):
+            raise InputError(f"Grammar {grammar_id} not found")
+        version = int(expected_version if expected_version is not None else current["version"])
+        self.db.archive_chat_grammar(grammar_id, expected_version=version)
+        archived = self.db.get_chat_grammar(grammar_id, include_archived=True, include_deleted=True)
+        if archived is None:
+            raise CharactersRAGDBError(f"Archived grammar {grammar_id} could not be reloaded")
+        return archived
+
+    def delete_grammar(
+        self,
+        grammar_id: str,
+        *,
+        expected_version: int | None = None,
+        hard_delete: bool = False,
+    ) -> bool:
+        """Delete a grammar, soft-delete by default."""
+        current = self.db.get_chat_grammar(grammar_id, include_archived=True, include_deleted=True)
+        if current is None:
+            raise InputError(f"Grammar {grammar_id} not found")
+        version = int(expected_version if expected_version is not None else current["version"])
+        return self.db.delete_chat_grammar(
+            grammar_id,
+            expected_version=version,
+            hard_delete=hard_delete,
+        )
+
+    def close(self) -> None:
+        """Compatibility no-op for test fixtures."""
+        return None

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -18,7 +18,7 @@ import os
 import re
 import time
 import uuid as _uuid
-from collections.abc import AsyncIterator, Awaitable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Iterator, Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -1403,6 +1403,7 @@ def build_call_params_from_request(
     templated_llm_payload: list[dict[str, Any]],
     final_system_message: str | None,
     app_config: dict[str, Any] | None = None,
+    grammar_record: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Construct the cleaned argument dictionary for chat_api_call.
 
@@ -1467,7 +1468,7 @@ def build_call_params_from_request(
     call_params["extra_body"] = resolve_llamacpp_request_extensions(
         request_fields=llamacpp_request_fields,
         provider=target_api_provider,
-        grammar_record=None,
+        grammar_record=grammar_record,
         runtime_caps=resolve_llamacpp_runtime_caps(app_config=app_config),
     )["extra_body"]
 

--- a/tldw_Server_API/app/core/Chat/chat_service.py
+++ b/tldw_Server_API/app/core/Chat/chat_service.py
@@ -77,6 +77,10 @@ from tldw_Server_API.app.core.LLM_Calls.openrouter_model_inventory import (
     clear_openrouter_model_cache as _clear_openrouter_model_cache_shared,
     discover_openrouter_models as _discover_openrouter_models_shared,
 )
+from tldw_Server_API.app.core.LLM_Calls.llamacpp_request_extensions import (
+    resolve_llamacpp_request_extensions,
+    resolve_llamacpp_runtime_caps,
+)
 from tldw_Server_API.app.core.LLM_Calls.streaming import wrap_sync_stream
 from tldw_Server_API.app.core.LLM_Calls.structured_generation import (
     StructuredGenerationCapabilityError,
@@ -1424,6 +1428,11 @@ def build_call_params_from_request(
             "persona_exemplar_budget_tokens",
             "persona_exemplar_strategy",
             "persona_debug",
+            "thinking_budget_tokens",
+            "grammar_mode",
+            "grammar_id",
+            "grammar_inline",
+            "grammar_override",
         },
     )
 
@@ -1446,6 +1455,21 @@ def build_call_params_from_request(
             )
             call_params["_structured_requested_response_format"] = dict(response_format)
             call_params["response_format"] = decision.response_format
+
+    llamacpp_request_fields = {
+        "thinking_budget_tokens": getattr(request_data, "thinking_budget_tokens", None),
+        "grammar_mode": getattr(request_data, "grammar_mode", None),
+        "grammar_id": getattr(request_data, "grammar_id", None),
+        "grammar_inline": getattr(request_data, "grammar_inline", None),
+        "grammar_override": getattr(request_data, "grammar_override", None),
+        "extra_body": getattr(request_data, "extra_body", None),
+    }
+    call_params["extra_body"] = resolve_llamacpp_request_extensions(
+        request_fields=llamacpp_request_fields,
+        provider=target_api_provider,
+        grammar_record=None,
+        runtime_caps=resolve_llamacpp_runtime_caps(app_config=app_config),
+    )["extra_body"]
 
     call_params.update(
         {

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -6241,7 +6241,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 """
                 CREATE TABLE IF NOT EXISTS chat_grammars (
                     id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL UNIQUE,
+                    user_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
                     description TEXT,
                     grammar_text TEXT NOT NULL,
                     validation_status TEXT NOT NULL DEFAULT 'unchecked',
@@ -6251,23 +6252,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     deleted BOOLEAN NOT NULL DEFAULT 0,
-                    version INTEGER NOT NULL DEFAULT 1
+                    version INTEGER NOT NULL DEFAULT 1,
+                    UNIQUE(user_id, name)
                 )
                 """,
                 script=False,
                 commit=True,
             )
-            self.execute_query(
-                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_name ON chat_grammars(name)",
-                script=False,
-                commit=True,
-            )
-            self.execute_query(
-                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_archived_deleted "
-                "ON chat_grammars(is_archived, deleted)",
-                script=False,
-                commit=True,
-            )
+            self._migrate_sqlite_chat_grammars_table()
+            self._ensure_chat_grammars_indexes()
             return
 
         if self.backend_type == BackendType.POSTGRESQL:
@@ -6275,7 +6268,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 """
                 CREATE TABLE IF NOT EXISTS chat_grammars (
                     id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL UNIQUE,
+                    user_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
                     description TEXT,
                     grammar_text TEXT NOT NULL,
                     validation_status TEXT NOT NULL DEFAULT 'unchecked',
@@ -6285,19 +6279,126 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
                     updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
                     deleted BOOLEAN NOT NULL DEFAULT FALSE,
-                    version INTEGER NOT NULL DEFAULT 1
+                    version INTEGER NOT NULL DEFAULT 1,
+                    CONSTRAINT uq_chat_grammars_user_name UNIQUE (user_id, name)
                 )
                 """
             )
-            self.backend.execute("CREATE INDEX IF NOT EXISTS idx_chat_grammars_name ON chat_grammars(name)")
-            self.backend.execute(
-                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_archived_deleted "
-                "ON chat_grammars(is_archived, deleted)"
-            )
+            self._migrate_postgres_chat_grammars_table()
+            self._ensure_chat_grammars_indexes()
             return
 
         raise NotImplementedError(
             f"chat_grammars table creation not supported for backend {self.backend_type.value}"
+        )
+
+    def _chat_grammar_owner_id(self) -> str:
+        """Return the effective owner identifier for grammar-library rows."""
+        owner_id = str(self.client_id or "").strip()
+        return owner_id or "unknown"
+
+    def _chat_grammar_column_names(self, conn: Any | None = None) -> set[str]:
+        """Return the current chat_grammars column names for the active backend."""
+        return {
+            str(column.get("name"))
+            for column in self.backend.get_table_info("chat_grammars", connection=conn)
+            if column.get("name")
+        }
+
+    def _ensure_chat_grammars_indexes(self) -> None:
+        """Create the owner-scoped lookup indexes used by grammar-library CRUD."""
+        index_statements = (
+            "CREATE INDEX IF NOT EXISTS idx_chat_grammars_user_name ON chat_grammars(user_id, name)",
+            "CREATE INDEX IF NOT EXISTS idx_chat_grammars_user_archived_deleted "
+            "ON chat_grammars(user_id, is_archived, deleted)",
+        )
+        for statement in index_statements:
+            if self.backend_type == BackendType.POSTGRESQL:
+                self.backend.execute(statement)
+            else:
+                self.execute_query(statement, script=False, commit=True)
+
+    def _migrate_sqlite_chat_grammars_table(self) -> None:
+        """Rebuild legacy SQLite chat_grammars tables so rows are owner-scoped."""
+        with self.transaction() as conn:
+            existing_cols = self._chat_grammar_column_names(conn)
+            if "user_id" in existing_cols:
+                return
+
+            owner_id = self._chat_grammar_owner_id()
+            conn.execute("ALTER TABLE chat_grammars RENAME TO chat_grammars_legacy")
+            conn.execute(
+                """
+                CREATE TABLE chat_grammars (
+                    id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    grammar_text TEXT NOT NULL,
+                    validation_status TEXT NOT NULL DEFAULT 'unchecked',
+                    validation_error TEXT,
+                    last_validated_at DATETIME,
+                    is_archived BOOLEAN NOT NULL DEFAULT 0,
+                    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    deleted BOOLEAN NOT NULL DEFAULT 0,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    UNIQUE(user_id, name)
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO chat_grammars (
+                    id,
+                    user_id,
+                    name,
+                    description,
+                    grammar_text,
+                    validation_status,
+                    validation_error,
+                    last_validated_at,
+                    is_archived,
+                    created_at,
+                    updated_at,
+                    deleted,
+                    version
+                )
+                SELECT
+                    id,
+                    ?,
+                    name,
+                    description,
+                    grammar_text,
+                    validation_status,
+                    validation_error,
+                    last_validated_at,
+                    is_archived,
+                    created_at,
+                    updated_at,
+                    deleted,
+                    version
+                FROM chat_grammars_legacy
+                """,
+                (owner_id,),
+            )
+            conn.execute("DROP TABLE chat_grammars_legacy")
+
+    def _migrate_postgres_chat_grammars_table(self) -> None:
+        """Backfill owner scoping for legacy PostgreSQL chat_grammars tables."""
+        owner_id = self._chat_grammar_owner_id()
+        existing_cols = self._chat_grammar_column_names()
+        if "user_id" not in existing_cols:
+            self.backend.execute("ALTER TABLE chat_grammars ADD COLUMN IF NOT EXISTS user_id TEXT")
+        self.backend.execute(
+            "UPDATE chat_grammars SET user_id = %s WHERE user_id IS NULL OR BTRIM(user_id) = ''",
+            (owner_id,),
+        )
+        self.backend.execute("ALTER TABLE chat_grammars ALTER COLUMN user_id SET NOT NULL")
+        self.backend.execute("ALTER TABLE chat_grammars DROP CONSTRAINT IF EXISTS chat_grammars_name_key")
+        self.backend.execute("ALTER TABLE chat_grammars DROP CONSTRAINT IF EXISTS uq_chat_grammars_user_name")
+        self.backend.execute(
+            "ALTER TABLE chat_grammars ADD CONSTRAINT uq_chat_grammars_user_name UNIQUE (user_id, name)"
         )
 
     def _coerce_chat_grammar_datetime(self, value: Any) -> datetime | None:
@@ -6318,6 +6419,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not row:
             return None
         item = dict(row)
+        item.pop("user_id", None)
         item["validation_status"] = str(item.get("validation_status") or "unchecked").strip().lower()
         item["is_archived"] = bool(item.get("is_archived", False))
         item["deleted"] = bool(item.get("deleted", False))
@@ -6337,8 +6439,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     ) -> list[dict[str, Any]]:
         """List saved grammars for the current user."""
         self._ensure_chat_grammars_table()
-        clauses: list[str] = []
-        params: list[Any] = []
+        clauses: list[str] = ["user_id = ?"]
+        params: list[Any] = [self._chat_grammar_owner_id()]
         if not include_deleted:
             clauses.append("deleted = ?")
             params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
@@ -6367,8 +6469,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     ) -> int:
         """Return the number of saved grammars for the current user."""
         self._ensure_chat_grammars_table()
-        clauses: list[str] = []
-        params: list[Any] = []
+        clauses: list[str] = ["user_id = ?"]
+        params: list[Any] = [self._chat_grammar_owner_id()]
         if not include_deleted:
             clauses.append("deleted = ?")
             params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
@@ -6397,8 +6499,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         grammar_id = str(grammar_id or "").strip()
         if not grammar_id:
             raise InputError("grammar_id is required.")  # noqa: TRY003
-        query = "SELECT * FROM chat_grammars WHERE id = ?"
-        params: list[Any] = [grammar_id]
+        query = "SELECT * FROM chat_grammars WHERE id = ? AND user_id = ?"
+        params: list[Any] = [grammar_id, self._chat_grammar_owner_id()]
         if not include_deleted:
             query += " AND deleted = ?"
             params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
@@ -6430,15 +6532,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         now = self._get_current_utc_timestamp_iso()
         grammar_id = str(grammar_data.get("id") or f"grammar_{self._generate_uuid().replace('-', '')}")
         bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+        owner_id = self._chat_grammar_owner_id()
 
         query = (
             "INSERT INTO chat_grammars ("
-            "id, name, description, grammar_text, validation_status, validation_error, "
+            "id, user_id, name, description, grammar_text, validation_status, validation_error, "
             "last_validated_at, is_archived, created_at, updated_at, deleted, version"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         params = (
             grammar_id,
+            owner_id,
             name,
             grammar_data.get("description"),
             grammar_text,
@@ -6457,7 +6561,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 conn.execute(prepared_query, prepared_params)
                 return grammar_id  # noqa: TRY300
         except sqlite3.IntegrityError as exc:
-            if "unique constraint failed: chat_grammars.name" in str(exc).lower():
+            lowered = str(exc).lower()
+            if "unique constraint failed: chat_grammars.user_id, chat_grammars.name" in lowered or (
+                "unique constraint failed: chat_grammars.name" in lowered
+            ):
                 raise ConflictError(  # noqa: TRY003
                     f"Grammar '{name}' already exists.",
                     entity="chat_grammars",
@@ -6547,17 +6654,23 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             params.append(None)
             set_parts.append("last_validated_at = ?")
 
+        owner_id = self._chat_grammar_owner_id()
         next_version = expected_version + 1
         set_parts.extend(["updated_at = ?", "version = ?"])
-        params.extend([now, next_version, grammar_id, expected_version])
+        params.extend([now, next_version, grammar_id, owner_id, expected_version])
         query = (
             f"UPDATE chat_grammars SET {', '.join(set_parts)} "  # nosec B608
-            "WHERE id = ? AND version = ? AND deleted = 0"
+            "WHERE id = ? AND user_id = ? AND version = ? AND deleted = 0"
         )
 
         try:
             with self.transaction() as conn:
-                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                lookup_query, lookup_params = self._prepare_backend_statement(
+                    "SELECT version FROM chat_grammars WHERE id = ? AND user_id = ? AND deleted = 0",
+                    (grammar_id, owner_id),
+                )
+                current_row = conn.execute(lookup_query, lookup_params).fetchone()
+                current_db_version = int(current_row["version"]) if current_row else None
                 if current_db_version != expected_version:
                     raise ConflictError(  # noqa: TRY003, TRY301
                         f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
@@ -6598,19 +6711,26 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         next_version = expected_version + 1
         query = (
             "UPDATE chat_grammars SET is_archived = ?, updated_at = ?, version = ? "
-            "WHERE id = ? AND version = ? AND deleted = 0"
+            "WHERE id = ? AND user_id = ? AND version = ? AND deleted = 0"
         )
+        owner_id = self._chat_grammar_owner_id()
         params = (
             True if self.backend_type == BackendType.POSTGRESQL else 1,
             now,
             next_version,
             grammar_id,
+            owner_id,
             expected_version,
         )
 
         try:
             with self.transaction() as conn:
-                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                lookup_query, lookup_params = self._prepare_backend_statement(
+                    "SELECT version FROM chat_grammars WHERE id = ? AND user_id = ? AND deleted = 0",
+                    (grammar_id, owner_id),
+                )
+                current_row = conn.execute(lookup_query, lookup_params).fetchone()
+                current_db_version = int(current_row["version"]) if current_row else None
                 if current_db_version != expected_version:
                     raise ConflictError(  # noqa: TRY003, TRY301
                         f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
@@ -6643,10 +6763,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """Delete a saved grammar using optimistic locking."""
         self._ensure_chat_grammars_table()
         now = self._get_current_utc_timestamp_iso()
+        owner_id = self._chat_grammar_owner_id()
 
         try:
             with self.transaction() as conn:
-                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                lookup_query, lookup_params = self._prepare_backend_statement(
+                    "SELECT version FROM chat_grammars WHERE id = ? AND user_id = ?",
+                    (grammar_id, owner_id),
+                )
+                current_row = conn.execute(lookup_query, lookup_params).fetchone()
+                current_db_version = int(current_row["version"]) if current_row else None
                 if current_db_version != expected_version:
                     raise ConflictError(  # noqa: TRY003, TRY301
                         f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
@@ -6656,18 +6782,19 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
                 if hard_delete:
                     prepared_query, prepared_params = self._prepare_backend_statement(
-                        "DELETE FROM chat_grammars WHERE id = ? AND version = ?",
-                        (grammar_id, expected_version),
+                        "DELETE FROM chat_grammars WHERE id = ? AND user_id = ? AND version = ?",
+                        (grammar_id, owner_id, expected_version),
                     )
                 else:
                     prepared_query, prepared_params = self._prepare_backend_statement(
                         "UPDATE chat_grammars SET deleted = ?, updated_at = ?, version = ? "
-                        "WHERE id = ? AND version = ? AND deleted = 0",
+                        "WHERE id = ? AND user_id = ? AND version = ? AND deleted = 0",
                         (
                             True if self.backend_type == BackendType.POSTGRESQL else 1,
                             now,
                             expected_version + 1,
                             grammar_id,
+                            owner_id,
                             expected_version,
                         ),
                     )

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -99,6 +99,7 @@ _ORDER_BY_EXPR_RE = re.compile(
     re.IGNORECASE,
 )
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CHAT_GRAMMAR_VALIDATION_STATUSES = frozenset({"unchecked", "valid", "invalid"})
 
 # --- Custom Exceptions ---
 class CharactersRAGDBError(Exception):
@@ -6224,6 +6225,464 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             raise
         except CharactersRAGDBError as exc:
             logger.error(f"Database error deleting skill '{name}': {exc}")
+            raise
+
+    # ----------------------
+    # Chat grammar library
+    # ----------------------
+    def ensure_chat_grammars_table(self) -> None:
+        """Ensure the chat_grammars table exists for the active backend."""
+        self._ensure_chat_grammars_table()
+
+    def _ensure_chat_grammars_table(self) -> None:
+        """Create the user-scoped grammar-library table and indexes when missing."""
+        if self.backend_type == BackendType.SQLITE:
+            self.execute_query(
+                """
+                CREATE TABLE IF NOT EXISTS chat_grammars (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT,
+                    grammar_text TEXT NOT NULL,
+                    validation_status TEXT NOT NULL DEFAULT 'unchecked',
+                    validation_error TEXT,
+                    last_validated_at DATETIME,
+                    is_archived BOOLEAN NOT NULL DEFAULT 0,
+                    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    deleted BOOLEAN NOT NULL DEFAULT 0,
+                    version INTEGER NOT NULL DEFAULT 1
+                )
+                """,
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_name ON chat_grammars(name)",
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_archived_deleted "
+                "ON chat_grammars(is_archived, deleted)",
+                script=False,
+                commit=True,
+            )
+            return
+
+        if self.backend_type == BackendType.POSTGRESQL:
+            self.backend.execute(
+                """
+                CREATE TABLE IF NOT EXISTS chat_grammars (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT,
+                    grammar_text TEXT NOT NULL,
+                    validation_status TEXT NOT NULL DEFAULT 'unchecked',
+                    validation_error TEXT,
+                    last_validated_at TIMESTAMP,
+                    is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+                    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                    deleted BOOLEAN NOT NULL DEFAULT FALSE,
+                    version INTEGER NOT NULL DEFAULT 1
+                )
+                """
+            )
+            self.backend.execute("CREATE INDEX IF NOT EXISTS idx_chat_grammars_name ON chat_grammars(name)")
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_chat_grammars_archived_deleted "
+                "ON chat_grammars(is_archived, deleted)"
+            )
+            return
+
+        raise NotImplementedError(
+            f"chat_grammars table creation not supported for backend {self.backend_type.value}"
+        )
+
+    def _coerce_chat_grammar_datetime(self, value: Any) -> datetime | None:
+        """Best-effort conversion of stored chat-grammar timestamps."""
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    def _chat_grammar_row_to_dict(self, row: Any) -> dict[str, Any] | None:
+        """Convert a chat_grammars row into a normalized dict."""
+        if not row:
+            return None
+        item = dict(row)
+        item["validation_status"] = str(item.get("validation_status") or "unchecked").strip().lower()
+        item["is_archived"] = bool(item.get("is_archived", False))
+        item["deleted"] = bool(item.get("deleted", False))
+        item["version"] = int(item.get("version") or 1)
+        item["created_at"] = self._coerce_chat_grammar_datetime(item.get("created_at"))
+        item["updated_at"] = self._coerce_chat_grammar_datetime(item.get("updated_at"))
+        item["last_validated_at"] = self._coerce_chat_grammar_datetime(item.get("last_validated_at"))
+        return item
+
+    def list_chat_grammars(
+        self,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List saved grammars for the current user."""
+        self._ensure_chat_grammars_table()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        if not include_archived:
+            clauses.append("is_archived = ?")
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query = (
+            "SELECT * FROM chat_grammars "  # nosec B608
+            f"{where_sql} "
+            "ORDER BY name ASC LIMIT ? OFFSET ?"
+        )
+        params.extend([limit, offset])
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            return [self._chat_grammar_row_to_dict(row) for row in cursor.fetchall() if row]
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error listing chat grammars: {exc}")
+            raise
+
+    def count_chat_grammars(
+        self,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> int:
+        """Return the number of saved grammars for the current user."""
+        self._ensure_chat_grammars_table()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if not include_deleted:
+            clauses.append("deleted = ?")
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        if not include_archived:
+            clauses.append("is_archived = ?")
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        query = f"SELECT COUNT(*) AS cnt FROM chat_grammars {where_sql}"  # nosec B608
+        try:
+            cursor = self.execute_query(query, tuple(params) if params else None)
+            row = cursor.fetchone()
+            return int(row["cnt"]) if row else 0
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error counting chat grammars: {exc}")
+            raise
+
+    def get_chat_grammar(
+        self,
+        grammar_id: str,
+        *,
+        include_archived: bool = False,
+        include_deleted: bool = False,
+    ) -> dict[str, Any] | None:
+        """Fetch a saved grammar by identifier."""
+        self._ensure_chat_grammars_table()
+        grammar_id = str(grammar_id or "").strip()
+        if not grammar_id:
+            raise InputError("grammar_id is required.")  # noqa: TRY003
+        query = "SELECT * FROM chat_grammars WHERE id = ?"
+        params: list[Any] = [grammar_id]
+        if not include_deleted:
+            query += " AND deleted = ?"
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        if not include_archived:
+            query += " AND is_archived = ?"
+            params.append(False if self.backend_type == BackendType.POSTGRESQL else 0)
+        try:
+            cursor = self.execute_query(query, tuple(params))
+            row = cursor.fetchone()
+            return self._chat_grammar_row_to_dict(row)
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error fetching chat grammar '{grammar_id}': {exc}")
+            raise
+
+    def insert_chat_grammar(self, grammar_data: dict[str, Any]) -> str:
+        """Insert a new saved grammar and return its identifier."""
+        self._ensure_chat_grammars_table()
+        name = str(grammar_data.get("name") or "").strip()
+        if not name:
+            raise InputError("Grammar name is required.")  # noqa: TRY003
+        grammar_text = str(grammar_data.get("grammar_text") or "")
+        if not grammar_text.strip():
+            raise InputError("grammar_text is required.")  # noqa: TRY003
+
+        validation_status = str(grammar_data.get("validation_status") or "unchecked").strip().lower()
+        if validation_status not in _CHAT_GRAMMAR_VALIDATION_STATUSES:
+            raise InputError("validation_status must be one of unchecked, valid, invalid.")  # noqa: TRY003
+
+        now = self._get_current_utc_timestamp_iso()
+        grammar_id = str(grammar_data.get("id") or f"grammar_{self._generate_uuid().replace('-', '')}")
+        bool_cast = bool if self.backend_type == BackendType.POSTGRESQL else int
+
+        query = (
+            "INSERT INTO chat_grammars ("
+            "id, name, description, grammar_text, validation_status, validation_error, "
+            "last_validated_at, is_archived, created_at, updated_at, deleted, version"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        params = (
+            grammar_id,
+            name,
+            grammar_data.get("description"),
+            grammar_text,
+            validation_status,
+            grammar_data.get("validation_error"),
+            grammar_data.get("last_validated_at"),
+            bool_cast(bool(grammar_data.get("is_archived", False))),
+            grammar_data.get("created_at") or now,
+            grammar_data.get("updated_at") or now,
+            bool_cast(bool(grammar_data.get("deleted", False))),
+            int(grammar_data.get("version", 1)),
+        )
+        try:
+            with self.transaction() as conn:
+                prepared_query, prepared_params = self._prepare_backend_statement(query, params)
+                conn.execute(prepared_query, prepared_params)
+                return grammar_id  # noqa: TRY300
+        except sqlite3.IntegrityError as exc:
+            if "unique constraint failed: chat_grammars.name" in str(exc).lower():
+                raise ConflictError(  # noqa: TRY003
+                    f"Grammar '{name}' already exists.",
+                    entity="chat_grammars",
+                    entity_id=name,
+                ) from exc
+            if "unique constraint failed: chat_grammars.id" in str(exc).lower():
+                raise ConflictError(  # noqa: TRY003
+                    "Grammar ID already exists.",
+                    entity="chat_grammars",
+                    entity_id=grammar_id,
+                ) from exc
+            raise CharactersRAGDBError(f"Database integrity error adding grammar '{name}': {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(  # noqa: TRY003
+                    f"Grammar '{name}' already exists.",
+                    entity="chat_grammars",
+                    entity_id=name,
+                ) from exc
+            raise CharactersRAGDBError(f"Database integrity error adding grammar '{name}': {exc}") from exc  # noqa: TRY003
+
+    def update_chat_grammar(
+        self,
+        grammar_id: str,
+        update_data: dict[str, Any],
+        *,
+        expected_version: int,
+    ) -> bool:
+        """Update a saved grammar using optimistic locking."""
+        if not update_data:
+            raise InputError(f"No data provided for grammar update '{grammar_id}'.")  # noqa: TRY003
+
+        self._ensure_chat_grammars_table()
+        now = self._get_current_utc_timestamp_iso()
+        allowed_fields = {
+            "name",
+            "description",
+            "grammar_text",
+            "validation_status",
+            "validation_error",
+            "last_validated_at",
+            "is_archived",
+        }
+
+        set_parts: list[str] = []
+        params: list[Any] = []
+        grammar_text_updated = False
+        for key, value in update_data.items():
+            if key not in allowed_fields:
+                continue
+            if key == "name":
+                normalized = str(value or "").strip()
+                if not normalized:
+                    raise InputError("Grammar name cannot be empty.")  # noqa: TRY003
+                params.append(normalized)
+                set_parts.append("name = ?")
+            elif key == "grammar_text":
+                normalized_text = str(value or "")
+                if not normalized_text.strip():
+                    raise InputError("grammar_text cannot be empty.")  # noqa: TRY003
+                params.append(normalized_text)
+                set_parts.append("grammar_text = ?")
+                grammar_text_updated = True
+            elif key == "validation_status":
+                normalized_status = str(value or "").strip().lower()
+                if normalized_status not in _CHAT_GRAMMAR_VALIDATION_STATUSES:
+                    raise InputError("validation_status must be one of unchecked, valid, invalid.")  # noqa: TRY003
+                params.append(normalized_status)
+                set_parts.append("validation_status = ?")
+            elif key == "is_archived":
+                params.append(bool(value) if self.backend_type == BackendType.POSTGRESQL else int(bool(value)))
+                set_parts.append("is_archived = ?")
+            else:
+                params.append(value)
+                set_parts.append(f"{key} = ?")
+
+        if not set_parts:
+            raise InputError(f"No supported data provided for grammar update '{grammar_id}'.")  # noqa: TRY003
+
+        if grammar_text_updated and "validation_status" not in update_data:
+            params.append("unchecked")
+            set_parts.append("validation_status = ?")
+        if grammar_text_updated and "validation_error" not in update_data:
+            params.append(None)
+            set_parts.append("validation_error = ?")
+        if grammar_text_updated and "last_validated_at" not in update_data:
+            params.append(None)
+            set_parts.append("last_validated_at = ?")
+
+        next_version = expected_version + 1
+        set_parts.extend(["updated_at = ?", "version = ?"])
+        params.extend([now, next_version, grammar_id, expected_version])
+        query = (
+            f"UPDATE chat_grammars SET {', '.join(set_parts)} "  # nosec B608
+            "WHERE id = ? AND version = ? AND deleted = 0"
+        )
+
+        try:
+            with self.transaction() as conn:
+                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                if current_db_version != expected_version:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+
+                prepared_query, prepared_params = self._prepare_backend_statement(query, tuple(params))
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Grammar '{grammar_id}' update affected 0 rows.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+                return True
+        except sqlite3.IntegrityError as exc:
+            if "unique constraint failed: chat_grammars.name" in str(exc).lower():
+                raise ConflictError(  # noqa: TRY003
+                    f"Grammar '{update_data.get('name')}' already exists.",
+                    entity="chat_grammars",
+                    entity_id=update_data.get("name"),
+                ) from exc
+            raise CharactersRAGDBError(f"Database error updating grammar '{grammar_id}': {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(  # noqa: TRY003
+                    f"Grammar '{update_data.get('name')}' already exists.",
+                    entity="chat_grammars",
+                    entity_id=update_data.get("name"),
+                ) from exc
+            raise CharactersRAGDBError(f"Database error updating grammar '{grammar_id}': {exc}") from exc  # noqa: TRY003
+
+    def archive_chat_grammar(self, grammar_id: str, *, expected_version: int) -> bool:
+        """Archive a saved grammar using optimistic locking."""
+        self._ensure_chat_grammars_table()
+        now = self._get_current_utc_timestamp_iso()
+        next_version = expected_version + 1
+        query = (
+            "UPDATE chat_grammars SET is_archived = ?, updated_at = ?, version = ? "
+            "WHERE id = ? AND version = ? AND deleted = 0"
+        )
+        params = (
+            True if self.backend_type == BackendType.POSTGRESQL else 1,
+            now,
+            next_version,
+            grammar_id,
+            expected_version,
+        )
+
+        try:
+            with self.transaction() as conn:
+                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                if current_db_version != expected_version:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+
+                prepared_query, prepared_params = self._prepare_backend_statement(query, params)
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Grammar '{grammar_id}' archive affected 0 rows.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+                return True
+        except ConflictError:
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error archiving grammar '{grammar_id}': {exc}")
+            raise
+
+    def delete_chat_grammar(
+        self,
+        grammar_id: str,
+        *,
+        expected_version: int,
+        hard_delete: bool = False,
+    ) -> bool:
+        """Delete a saved grammar using optimistic locking."""
+        self._ensure_chat_grammars_table()
+        now = self._get_current_utc_timestamp_iso()
+
+        try:
+            with self.transaction() as conn:
+                current_db_version = self._get_current_db_version(conn, "chat_grammars", "id", grammar_id)
+                if current_db_version != expected_version:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Version mismatch. Expected {expected_version}, found {current_db_version}. Please refresh and try again.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+
+                if hard_delete:
+                    prepared_query, prepared_params = self._prepare_backend_statement(
+                        "DELETE FROM chat_grammars WHERE id = ? AND version = ?",
+                        (grammar_id, expected_version),
+                    )
+                else:
+                    prepared_query, prepared_params = self._prepare_backend_statement(
+                        "UPDATE chat_grammars SET deleted = ?, updated_at = ?, version = ? "
+                        "WHERE id = ? AND version = ? AND deleted = 0",
+                        (
+                            True if self.backend_type == BackendType.POSTGRESQL else 1,
+                            now,
+                            expected_version + 1,
+                            grammar_id,
+                            expected_version,
+                        ),
+                    )
+                cursor = conn.execute(prepared_query, prepared_params)
+                if cursor.rowcount == 0:
+                    raise ConflictError(  # noqa: TRY003, TRY301
+                        f"Grammar '{grammar_id}' delete affected 0 rows.",
+                        entity="chat_grammars",
+                        entity_id=grammar_id,
+                    )
+                return True
+        except ConflictError:
+            raise
+        except CharactersRAGDBError as exc:
+            logger.error(f"Database error deleting grammar '{grammar_id}': {exc}")
             raise
 
     # ----------------------

--- a/tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py
+++ b/tldw_Server_API/app/core/LLM_Calls/extra_body_compat_catalog.py
@@ -112,6 +112,7 @@ def _normalize_model(model: str | None) -> str:
 def _default_runtime_context() -> dict[str, Any]:
     return {
         "strict_openai_compat": _coerce_bool(os.getenv("LOCAL_LLM_STRICT_OPENAI_COMPAT", False)),
+        "thinking_budget_request_key": (os.getenv("LLAMA_CPP_THINKING_BUDGET_PARAM") or "").strip() or None,
     }
 
 

--- a/tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py
+++ b/tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError
+
+
+_LLAMA_CPP_EXTENSION_FIELDS = (
+    "thinking_budget_tokens",
+    "grammar_mode",
+    "grammar_id",
+    "grammar_inline",
+    "grammar_override",
+)
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _has_llamacpp_extension_values(request_fields: Mapping[str, Any]) -> bool:
+    grammar_mode = request_fields.get("grammar_mode")
+    if grammar_mode not in (None, "", "none"):
+        return True
+    return any(request_fields.get(field) is not None for field in _LLAMA_CPP_EXTENSION_FIELDS if field != "grammar_mode")
+
+
+def resolve_llamacpp_runtime_caps(
+    *,
+    app_config: Mapping[str, Any] | None = None,
+    runtime_context: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    context = dict(runtime_context or {})
+    llama_settings = _as_mapping(_as_mapping(app_config).get("llama_api"))
+    local_api_settings = _as_mapping(_as_mapping(app_config).get("local_api"))
+
+    strict_override = context.get("strict_openai_compat")
+    strict_env = os.getenv("LOCAL_LLM_STRICT_OPENAI_COMPAT")
+    if strict_override is not None:
+        strict_mode = _coerce_bool(strict_override)
+    elif strict_env is not None:
+        strict_mode = _coerce_bool(strict_env)
+    else:
+        strict_mode = _coerce_bool(llama_settings.get("strict_openai_compat"))
+
+    request_key = str(
+        context.get("thinking_budget_request_key")
+        or os.getenv("LLAMA_CPP_THINKING_BUDGET_PARAM")
+        or llama_settings.get("llama_cpp_thinking_budget_param")
+        or llama_settings.get("thinking_budget_request_key")
+        or local_api_settings.get("llama_cpp_thinking_budget_param")
+        or ""
+    ).strip()
+
+    return {
+        "strict_openai_compat": strict_mode,
+        "thinking_budget": {
+            "supported": bool(request_key),
+            "request_key": request_key or None,
+        },
+        "reserved_extra_body_keys": ["grammar", *([request_key] if request_key else [])],
+    }
+
+
+def _resolve_grammar_text(
+    *,
+    request_fields: Mapping[str, Any],
+    grammar_record: Mapping[str, Any] | None,
+) -> str | None:
+    grammar_mode = request_fields.get("grammar_mode")
+    if grammar_mode == "library":
+        if not isinstance(grammar_record, Mapping):
+            raise ChatBadRequestError(provider="llama.cpp", message="Saved grammar could not be resolved")
+        grammar_text = request_fields.get("grammar_override") or grammar_record.get("grammar_text")
+        if not grammar_text:
+            raise ChatBadRequestError(provider="llama.cpp", message="Saved grammar is missing grammar text")
+        return str(grammar_text)
+    if grammar_mode == "inline":
+        grammar_text = request_fields.get("grammar_inline")
+        return str(grammar_text) if grammar_text is not None else None
+    return None
+
+
+def resolve_llamacpp_request_extensions(
+    *,
+    request_fields: Mapping[str, Any],
+    provider: str,
+    grammar_record: Mapping[str, Any] | None,
+    runtime_caps: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw_extra_body = request_fields.get("extra_body")
+    has_original_extra_body = isinstance(raw_extra_body, Mapping)
+    extra_body = dict(raw_extra_body) if has_original_extra_body else {}
+    has_extension_values = _has_llamacpp_extension_values(request_fields)
+
+    if provider != "llama.cpp":
+        if has_extension_values:
+            raise ChatBadRequestError(
+                provider=provider or None,
+                message="llama.cpp extension fields require the resolved target provider to be 'llama.cpp'",
+            )
+        return {"extra_body": extra_body if has_original_extra_body else None}
+
+    if runtime_caps.get("strict_openai_compat") and has_extension_values:
+        raise ChatBadRequestError(
+            provider=provider,
+            message="llama.cpp advanced controls are disabled by strict_openai_compat",
+        )
+
+    grammar_text = _resolve_grammar_text(request_fields=request_fields, grammar_record=grammar_record)
+    if grammar_text:
+        extra_body["grammar"] = grammar_text
+
+    thinking_budget_tokens = request_fields.get("thinking_budget_tokens")
+    if thinking_budget_tokens is not None:
+        thinking_caps = _as_mapping(runtime_caps.get("thinking_budget"))
+        request_key = str(
+            thinking_caps.get("request_key") or runtime_caps.get("thinking_budget_request_key") or ""
+        ).strip()
+        if not thinking_caps.get("supported") or not request_key:
+            raise ChatBadRequestError(
+                provider=provider,
+                message="thinking_budget_tokens is not supported by this deployment",
+            )
+        extra_body[request_key] = int(thinking_budget_tokens)
+
+    if extra_body or has_original_extra_body:
+        return {"extra_body": extra_body}
+    return {"extra_body": None}
+
+
+__all__ = [
+    "resolve_llamacpp_request_extensions",
+    "resolve_llamacpp_runtime_caps",
+]

--- a/tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py
+++ b/tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py
@@ -17,6 +17,7 @@ _LLAMA_CPP_EXTENSION_FIELDS = (
 
 
 def _coerce_bool(value: Any) -> bool:
+    """Normalize permissive truthy inputs used in llama.cpp runtime settings."""
     if isinstance(value, bool):
         return value
     if value is None:
@@ -29,10 +30,12 @@ def _coerce_bool(value: Any) -> bool:
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
+    """Return `value` as a mapping, falling back to an empty mapping."""
     return value if isinstance(value, Mapping) else {}
 
 
 def _has_llamacpp_extension_values(request_fields: Mapping[str, Any]) -> bool:
+    """Report whether a request carries any non-empty llama.cpp extension fields."""
     grammar_mode = request_fields.get("grammar_mode")
     if grammar_mode not in (None, "", "none"):
         return True
@@ -44,6 +47,12 @@ def resolve_llamacpp_runtime_caps(
     app_config: Mapping[str, Any] | None = None,
     runtime_context: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    """Resolve deployment-specific llama.cpp capability metadata.
+
+    The returned mapping captures whether strict OpenAI compatibility is active,
+    whether a per-request thinking-budget key is configured, and which raw
+    `extra_body` keys the UI should reserve for first-class llama.cpp controls.
+    """
     context = dict(runtime_context or {})
     llama_settings = _as_mapping(_as_mapping(app_config).get("llama_api"))
     local_api_settings = _as_mapping(_as_mapping(app_config).get("local_api"))
@@ -81,6 +90,7 @@ def _resolve_grammar_text(
     request_fields: Mapping[str, Any],
     grammar_record: Mapping[str, Any] | None,
 ) -> str | None:
+    """Choose the final grammar text for a llama.cpp request, if any."""
     grammar_mode = request_fields.get("grammar_mode")
     if grammar_mode == "library":
         if not isinstance(grammar_record, Mapping):
@@ -102,6 +112,12 @@ def resolve_llamacpp_request_extensions(
     grammar_record: Mapping[str, Any] | None,
     runtime_caps: Mapping[str, Any],
 ) -> dict[str, Any]:
+    """Translate app-level llama.cpp controls into provider `extra_body` fields.
+
+    This resolver applies provider guards, strict-compatibility checks, saved
+    grammar resolution, and thinking-budget mapping in one place so every chat
+    caller produces a consistent outbound llama.cpp payload.
+    """
     raw_extra_body = request_fields.get("extra_body")
     has_original_extra_body = isinstance(raw_extra_body, Mapping)
     extra_body = dict(raw_extra_body) if has_original_extra_body else {}

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for ChatGrammarService.
+
+Tests the llama.cpp grammar-library persistence service against the real
+per-user ChaChaNotes database.
+"""
+
+import pytest
+
+from tldw_Server_API.app.core.Character_Chat.chat_grammar import ChatGrammarService
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError
+
+
+class TestChatGrammarService:
+    """Test grammar-library CRUD operations."""
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_creates_and_reads_grammar(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        grammar_id = service.create_grammar(
+            name="JSON Root",
+            description="Simple test grammar",
+            grammar_text='root ::= "ok"',
+        )
+
+        grammar = service.get_grammar(grammar_id)
+
+        assert grammar is not None
+        assert grammar["id"] == grammar_id
+        assert grammar["name"] == "JSON Root"
+        assert grammar["validation_status"] == "unchecked"
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_archives_without_deleting_text(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        grammar_id = service.create_grammar(
+            name="Archive Me",
+            description="",
+            grammar_text='root ::= "x"',
+        )
+
+        service.archive_grammar(grammar_id)
+
+        grammar = service.get_grammar(grammar_id, include_archived=True)
+
+        assert grammar is not None
+        assert grammar["is_archived"] is True
+        assert grammar["grammar_text"] == 'root ::= "x"'
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_lists_active_grammars_by_default(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        active_id = service.create_grammar(
+            name="Active Grammar",
+            description="",
+            grammar_text='root ::= "active"',
+        )
+        archived_id = service.create_grammar(
+            name="Archived Grammar",
+            description="",
+            grammar_text='root ::= "archived"',
+        )
+        service.archive_grammar(archived_id)
+
+        grammars = service.list_grammars()
+
+        assert [grammar["id"] for grammar in grammars] == [active_id]
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_updates_grammar_and_bumps_version(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        grammar_id = service.create_grammar(
+            name="Versioned Grammar",
+            description="v1",
+            grammar_text='root ::= "v1"',
+        )
+        created = service.get_grammar(grammar_id)
+
+        updated = service.update_grammar(
+            grammar_id,
+            {
+                "description": "v2",
+                "grammar_text": 'root ::= "v2"',
+            },
+            expected_version=created["version"],
+        )
+
+        assert updated["description"] == "v2"
+        assert updated["grammar_text"] == 'root ::= "v2"'
+        assert updated["version"] == created["version"] + 1
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_rejects_stale_update_version(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        grammar_id = service.create_grammar(
+            name="Conflicted Grammar",
+            description="v1",
+            grammar_text='root ::= "v1"',
+        )
+        created = service.get_grammar(grammar_id)
+
+        service.update_grammar(
+            grammar_id,
+            {"description": "v2"},
+            expected_version=created["version"],
+        )
+
+        with pytest.raises(ConflictError, match="Version mismatch"):
+            service.update_grammar(
+                grammar_id,
+                {"description": "v3"},
+                expected_version=created["version"],
+            )
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_rejects_duplicate_names(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        service.create_grammar(
+            name="Duplicate Grammar",
+            description="first",
+            grammar_text='root ::= "first"',
+        )
+
+        with pytest.raises(ConflictError, match="already exists"):
+            service.create_grammar(
+                name="Duplicate Grammar",
+                description="second",
+                grammar_text='root ::= "second"',
+            )
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_soft_deletes_grammar(self, character_db):
+        service = ChatGrammarService(character_db)
+
+        grammar_id = service.create_grammar(
+            name="Delete Me",
+            description="",
+            grammar_text='root ::= "gone"',
+        )
+
+        service.delete_grammar(grammar_id)
+
+        assert service.get_grammar(grammar_id) is None
+        deleted = service.get_grammar(grammar_id, include_deleted=True, include_archived=True)
+        assert deleted is not None
+        assert deleted["deleted"] is True

--- a/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py
+++ b/tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py
@@ -8,7 +8,7 @@ per-user ChaChaNotes database.
 import pytest
 
 from tldw_Server_API.app.core.Character_Chat.chat_grammar import ChatGrammarService
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import ConflictError
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 
 
 class TestChatGrammarService:
@@ -150,3 +150,32 @@ class TestChatGrammarService:
         deleted = service.get_grammar(grammar_id, include_deleted=True, include_archived=True)
         assert deleted is not None
         assert deleted["deleted"] is True
+
+    @pytest.mark.unit
+    def test_chat_grammar_service_scopes_same_name_per_client_on_shared_db(self, tmp_path):
+        db_path = tmp_path / "shared_chacha.db"
+        db_user_a = CharactersRAGDB(db_path=str(db_path), client_id="user-a")
+        db_user_b = CharactersRAGDB(db_path=str(db_path), client_id="user-b")
+
+        try:
+            service_user_a = ChatGrammarService(db_user_a)
+            service_user_b = ChatGrammarService(db_user_b)
+
+            grammar_a = service_user_a.create_grammar(
+                name="Shared Grammar",
+                description="user a",
+                grammar_text='root ::= "a"',
+            )
+            grammar_b = service_user_b.create_grammar(
+                name="Shared Grammar",
+                description="user b",
+                grammar_text='root ::= "b"',
+            )
+
+            assert [item["id"] for item in service_user_a.list_grammars()] == [grammar_a]
+            assert [item["id"] for item in service_user_b.list_grammars()] == [grammar_b]
+            assert service_user_a.get_grammar(grammar_b, include_archived=True, include_deleted=True) is None
+            assert service_user_b.get_grammar(grammar_a, include_archived=True, include_deleted=True) is None
+        finally:
+            db_user_a.close_connection()
+            db_user_b.close_connection()

--- a/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.api.v1.endpoints import chat as chat_endpoints
+from tldw_Server_API.app.api.v1.endpoints import chat_grammars as chat_grammar_endpoints
+from tldw_Server_API.app.api.v1.schemas.chat_grammar_schemas import (
+    ChatGrammarCreate,
+    ChatGrammarUpdate,
+)
+from tldw_Server_API.app.core.Character_Chat.chat_grammar import ChatGrammarService
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture()
+def chacha_db(tmp_path):
+    db_path = tmp_path / "ChaChaNotes.db"
+    db = CharactersRAGDB(db_path=str(db_path), client_id="test-client")
+    try:
+        yield db
+    finally:
+        db.close_connection()
+
+
+def test_chat_grammar_router_exposes_expected_paths():
+    paths = {route.path for route in chat_grammar_endpoints.router.routes}
+    assert "/grammars" in paths
+    assert "/grammars/{grammar_id}" in paths
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_chat_grammars(chacha_db: CharactersRAGDB):
+    created = await chat_endpoints.create_chat_grammar(
+        ChatGrammarCreate(name="Root", description="desc", grammar_text='root ::= "ok"'),
+        db=chacha_db,
+    )
+    assert created.name == "Root"
+
+    listing = await chat_endpoints.list_chat_grammars(
+        include_archived=False,
+        limit=100,
+        offset=0,
+        db=chacha_db,
+    )
+    assert listing.total == 1
+    assert listing.items[0].id == created.id
+
+
+@pytest.mark.asyncio
+async def test_get_archived_grammar_requires_include_archived(chacha_db: CharactersRAGDB):
+    service = ChatGrammarService(chacha_db)
+    grammar_id = service.create_grammar(
+        name="Archived Grammar",
+        description="desc",
+        grammar_text='root ::= "archived"',
+    )
+    service.archive_grammar(grammar_id)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_endpoints.get_chat_grammar(grammar_id, include_archived=False, db=chacha_db)
+    assert excinfo.value.status_code == 404
+
+    archived = await chat_endpoints.get_chat_grammar(
+        grammar_id,
+        include_archived=True,
+        db=chacha_db,
+    )
+    assert archived.id == grammar_id
+    assert archived.is_archived is True
+
+
+@pytest.mark.asyncio
+async def test_update_chat_grammar_returns_refreshed_record(chacha_db: CharactersRAGDB):
+    created = await chat_endpoints.create_chat_grammar(
+        ChatGrammarCreate(
+            name="Versioned Grammar",
+            description="v1",
+            grammar_text='root ::= "v1"',
+        ),
+        db=chacha_db,
+    )
+
+    updated = await chat_endpoints.update_chat_grammar(
+        created.id,
+        ChatGrammarUpdate(description="v2", grammar_text='root ::= "v2"'),
+        db=chacha_db,
+    )
+
+    assert updated.description == "v2"
+    assert updated.grammar_text == 'root ::= "v2"'
+    assert updated.version == created.version + 1
+
+
+@pytest.mark.asyncio
+async def test_delete_chat_grammar_hides_record_from_default_reads(chacha_db: CharactersRAGDB):
+    created = await chat_endpoints.create_chat_grammar(
+        ChatGrammarCreate(
+            name="Delete Grammar",
+            description="desc",
+            grammar_text='root ::= "delete"',
+        ),
+        db=chacha_db,
+    )
+
+    response = await chat_endpoints.delete_chat_grammar(created.id, db=chacha_db)
+    assert response.status_code == 204
+
+    with pytest.raises(HTTPException) as excinfo:
+        await chat_endpoints.get_chat_grammar(created.id, include_archived=False, db=chacha_db)
+    assert excinfo.value.status_code == 404

--- a/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py
@@ -29,6 +29,19 @@ def test_chat_grammar_router_exposes_expected_paths():
     assert "/grammars/{grammar_id}" in paths
 
 
+def test_chat_grammar_route_handlers_have_docstrings():
+    handlers = (
+        chat_grammar_endpoints.create_chat_grammar,
+        chat_grammar_endpoints.list_chat_grammars,
+        chat_grammar_endpoints.get_chat_grammar,
+        chat_grammar_endpoints.update_chat_grammar,
+        chat_grammar_endpoints.delete_chat_grammar,
+    )
+
+    for handler in handlers:
+        assert handler.__doc__
+
+
 @pytest.mark.asyncio
 async def test_create_and_list_chat_grammars(chacha_db: CharactersRAGDB):
     created = await chat_endpoints.create_chat_grammar(

--- a/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
+++ b/tldw_Server_API/tests/Chat/unit/test_chat_request_schemas.py
@@ -180,6 +180,43 @@ def test_chat_completion_request_rejects_json_schema_without_schema_object():
         )
 
 
+@pytest.mark.unit
+def test_chat_completion_request_accepts_llamacpp_extension_fields():
+    req = ChatCompletionRequest(
+        model="llama.cpp/local-model",
+        messages=[ChatCompletionUserMessageParam(role="user", content="reply in JSON")],
+        grammar_mode="library",
+        grammar_id="grammar_123",
+        grammar_override='root ::= "ok"',
+        thinking_budget_tokens=128,
+    )
+    assert req.grammar_mode == "library"
+    assert req.grammar_id == "grammar_123"
+    assert req.thinking_budget_tokens == 128
+
+
+@pytest.mark.unit
+def test_chat_completion_request_rejects_llamacpp_library_mode_without_grammar_id():
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(
+            model="llama.cpp/local-model",
+            messages=[ChatCompletionUserMessageParam(role="user", content="x")],
+            grammar_mode="library",
+        )
+    assert "grammar_id is required" in str(exc_info.value)
+
+
+@pytest.mark.unit
+def test_chat_completion_request_rejects_llamacpp_inline_mode_without_grammar_inline():
+    with pytest.raises(ValidationError) as exc_info:
+        ChatCompletionRequest(
+            model="llama.cpp/local-model",
+            messages=[ChatCompletionUserMessageParam(role="user", content="x")],
+            grammar_mode="inline",
+        )
+    assert "grammar_inline is required" in str(exc_info.value)
+
+
 # --- Tests for FunctionDefinition Parameter Validation ---
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py
+++ b/tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py
@@ -92,3 +92,57 @@ def test_chat_completions_rejects_llamacpp_fields_for_resolved_non_llamacpp_prov
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid request."
+
+
+def test_chat_completions_refresh_params_reloads_saved_grammar_for_retry(
+    test_client,
+    auth_headers,
+    chacha_db,
+    monkeypatch,
+):
+    grammar_id = chacha_db.insert_chat_grammar(
+        {
+            "name": "Retry grammar",
+            "grammar_text": 'root ::= "retry"',
+        }
+    )
+
+    def override_get_db():
+        return chacha_db
+
+    lookup_count = {"calls": 0}
+    original_get_chat_grammar = chacha_db.get_chat_grammar
+    captured: dict[str, object] = {}
+
+    def counting_get_chat_grammar(*args, **kwargs):
+        lookup_count["calls"] += 1
+        return original_get_chat_grammar(*args, **kwargs)
+
+    async def _fake_execute_non_stream_call(**kwargs):
+        refreshed_args, _ = await kwargs["refresh_provider_params"]("llama.cpp")
+        captured["extra_body"] = refreshed_args.get("extra_body")
+        return _fake_chat_response(content="Retry payload refreshed.")
+
+    test_client.app.dependency_overrides[get_chacha_db_for_user] = override_get_db
+    monkeypatch.setattr(chacha_db, "get_chat_grammar", counting_get_chat_grammar)
+    monkeypatch.setattr(chat_endpoint_module, "execute_non_stream_call", _fake_execute_non_stream_call)
+    monkeypatch.setattr(chat_endpoint_module, "get_provider_manager", lambda: None)
+
+    try:
+        response = test_client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama.cpp/local-model",
+                "messages": [{"role": "user", "content": "Reply with retry"}],
+                "save_to_db": False,
+                "grammar_mode": "library",
+                "grammar_id": grammar_id,
+            },
+            headers=auth_headers,
+        )
+    finally:
+        test_client.app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+    assert response.status_code == 200
+    assert captured["extra_body"] == {"grammar": 'root ::= "retry"'}
+    assert lookup_count["calls"] == 2

--- a/tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py
+++ b/tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py
@@ -1,0 +1,94 @@
+"""Integration tests for llama.cpp chat-completions request extensions."""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import get_chacha_db_for_user
+from tldw_Server_API.app.api.v1.endpoints import chat as chat_endpoint_module
+
+
+pytestmark = pytest.mark.integration
+
+
+def _fake_chat_response(content: str = "Mocked response") -> dict:
+    return {
+        "id": "chatcmpl-mock",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "mock-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10},
+    }
+
+
+def test_chat_completions_resolves_saved_grammar_into_llamacpp_payload(
+    test_client,
+    auth_headers,
+    chacha_db,
+    monkeypatch,
+):
+    grammar_id = chacha_db.insert_chat_grammar(
+        {
+            "name": "JSON output grammar",
+            "grammar_text": 'root ::= "ok"',
+        }
+    )
+
+    def override_get_db():
+        return chacha_db
+
+    captured: dict[str, object] = {}
+
+    def _fake_provider_call(**kwargs):
+        captured.update(kwargs)
+        return _fake_chat_response(content="Grammar resolved.")
+
+    test_client.app.dependency_overrides[get_chacha_db_for_user] = override_get_db
+    monkeypatch.setattr(chat_endpoint_module, "perform_chat_api_call", _fake_provider_call)
+
+    try:
+        response = test_client.post(
+            "/api/v1/chat/completions",
+            json={
+                "model": "llama.cpp/local-model",
+                "messages": [{"role": "user", "content": "Reply with ok"}],
+                "save_to_db": False,
+                "grammar_mode": "library",
+                "grammar_id": grammar_id,
+            },
+            headers=auth_headers,
+        )
+    finally:
+        test_client.app.dependency_overrides.pop(get_chacha_db_for_user, None)
+
+    assert response.status_code == 200
+    assert captured["api_endpoint"] == "llama.cpp"
+    assert captured["extra_body"] == {"grammar": 'root ::= "ok"'}
+
+
+def test_chat_completions_rejects_llamacpp_fields_for_resolved_non_llamacpp_provider(
+    test_client,
+    auth_headers,
+):
+    response = test_client.post(
+        "/api/v1/chat/completions",
+        json={
+            "api_provider": "openai",
+            "model": "llama.cpp/local-model",
+            "messages": [{"role": "user", "content": "Reply with ok"}],
+            "save_to_db": False,
+            "grammar_mode": "inline",
+            "grammar_inline": 'root ::= "ok"',
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid request."

--- a/tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py
+++ b/tldw_Server_API/tests/Chat_NEW/unit/test_chat_schemas.py
@@ -212,6 +212,34 @@ class TestChatCompletionRequest:
         )
         assert request.stream is False
 
+    @pytest.mark.unit
+    def test_llamacpp_extension_fields_are_first_class_schema_fields(self):
+        """Test llama.cpp extension fields round-trip through the request schema."""
+        request = ChatCompletionRequest(
+            model="llama.cpp/local-model",
+            messages=[{"role": "user", "content": "test"}],
+            grammar_mode="library",
+            grammar_id="grammar_1",
+            grammar_override='root ::= "ok"',
+            thinking_budget_tokens=64,
+        )
+        dumped = request.model_dump()
+        assert dumped["grammar_mode"] == "library"
+        assert dumped["grammar_id"] == "grammar_1"
+        assert dumped["thinking_budget_tokens"] == 64
+
+    @pytest.mark.unit
+    def test_llamacpp_inline_mode_requires_inline_grammar(self):
+        """Test llama.cpp inline grammar mode validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            ChatCompletionRequest(
+                model="llama.cpp/local-model",
+                messages=[{"role": "user", "content": "test"}],
+                grammar_mode="inline",
+            )
+
+        assert "grammar_inline is required" in str(exc_info.value)
+
 # ========================================================================
 # Response Format Tests
 # ========================================================================

--- a/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py
+++ b/tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py
@@ -13,6 +13,16 @@ def _fake_config():
     return cfg
 
 
+def _fake_config_with_llama():
+    cfg = _fake_config()
+    cfg.set("Local-API", "llama_api_IP", "http://localhost:8001/v1/chat/completions")
+    return cfg
+
+
+def _provider_by_display_name(data: dict, display_name: str) -> dict:
+    return next(provider for provider in data.get("providers", []) if provider.get("display_name") == display_name)
+
+
 @pytest.fixture
 def llm_client():
     from fastapi import FastAPI
@@ -194,3 +204,70 @@ def test_llm_providers_includes_model_level_tokenizer_metadata(monkeypatch, llm_
     assert "kind" in tokenizers["gpt-4o-mini"]
     assert "source" in tokenizers["gpt-4o-mini"]
     assert "detokenize" in tokenizers["gpt-4o-mini"]
+
+
+def test_llm_providers_exposes_llama_cpp_controls_block(monkeypatch, llm_client):
+    import tldw_Server_API.app.core.config as core_config
+    import tldw_Server_API.app.api.v1.endpoints.llm_providers as llm_endpoints
+    import tldw_Server_API.app.core.LLM_Calls.adapter_registry as reg_mod
+
+    monkeypatch.setattr(core_config, "load_comprehensive_config", _fake_config_with_llama)
+    monkeypatch.setattr(llm_endpoints, "load_comprehensive_config", _fake_config_with_llama)
+
+    class _DummyReg:
+        def list_capabilities(self, include_disabled=True):
+            return []
+
+    monkeypatch.setattr(reg_mod, "get_registry", lambda: _DummyReg())
+
+    response = llm_client.get("/api/v1/llm/providers")
+    assert response.status_code == 200
+    llama = _provider_by_display_name(response.json(), "Llama.cpp")
+    controls = llama["llama_cpp_controls"]
+    assert controls["grammar"]["supported"] is True
+    assert "thinking_budget" in controls
+    assert controls["reserved_extra_body_keys"] == ["grammar"]
+
+
+def test_llm_providers_disables_thinking_budget_without_verified_mapping(monkeypatch, llm_client):
+    import tldw_Server_API.app.core.config as core_config
+    import tldw_Server_API.app.api.v1.endpoints.llm_providers as llm_endpoints
+    import tldw_Server_API.app.core.LLM_Calls.adapter_registry as reg_mod
+
+    monkeypatch.setattr(core_config, "load_comprehensive_config", _fake_config_with_llama)
+    monkeypatch.setattr(llm_endpoints, "load_comprehensive_config", _fake_config_with_llama)
+    monkeypatch.delenv("LLAMA_CPP_THINKING_BUDGET_PARAM", raising=False)
+
+    class _DummyReg:
+        def list_capabilities(self, include_disabled=True):
+            return []
+
+    monkeypatch.setattr(reg_mod, "get_registry", lambda: _DummyReg())
+
+    response = llm_client.get("/api/v1/llm/providers")
+    assert response.status_code == 200
+    controls = _provider_by_display_name(response.json(), "Llama.cpp")["llama_cpp_controls"]
+    assert controls["thinking_budget"]["supported"] is False
+    assert controls["thinking_budget"]["request_key"] is None
+
+
+def test_llm_providers_exposes_reserved_key_when_mapping_configured(monkeypatch, llm_client):
+    import tldw_Server_API.app.core.config as core_config
+    import tldw_Server_API.app.api.v1.endpoints.llm_providers as llm_endpoints
+    import tldw_Server_API.app.core.LLM_Calls.adapter_registry as reg_mod
+
+    monkeypatch.setattr(core_config, "load_comprehensive_config", _fake_config_with_llama)
+    monkeypatch.setattr(llm_endpoints, "load_comprehensive_config", _fake_config_with_llama)
+    monkeypatch.setenv("LLAMA_CPP_THINKING_BUDGET_PARAM", "reasoning_budget")
+
+    class _DummyReg:
+        def list_capabilities(self, include_disabled=True):
+            return []
+
+    monkeypatch.setattr(reg_mod, "get_registry", lambda: _DummyReg())
+
+    response = llm_client.get("/api/v1/llm/providers")
+    assert response.status_code == 200
+    controls = _provider_by_display_name(response.json(), "Llama.cpp")["llama_cpp_controls"]
+    assert controls["thinking_budget"]["request_key"] == "reasoning_budget"
+    assert "reasoning_budget" in controls["reserved_extra_body_keys"]

--- a/tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py
@@ -1,0 +1,87 @@
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import ChatCompletionRequest
+from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError
+from tldw_Server_API.app.core.Chat.chat_service import build_call_params_from_request
+from tldw_Server_API.app.core.LLM_Calls.llamacpp_request_extensions import (
+    resolve_llamacpp_request_extensions,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_resolver_merges_saved_grammar_into_extra_body() -> None:
+    payload = resolve_llamacpp_request_extensions(
+        request_fields={
+            "grammar_mode": "library",
+            "grammar_id": "grammar_1",
+            "grammar_override": None,
+            "thinking_budget_tokens": None,
+            "extra_body": {"mirostat": 2},
+        },
+        provider="llama.cpp",
+        grammar_record={"id": "grammar_1", "grammar_text": 'root ::= "ok"'},
+        runtime_caps={"strict_openai_compat": False, "thinking_budget": {"supported": False}},
+    )
+
+    assert payload["extra_body"]["grammar"] == 'root ::= "ok"'
+    assert payload["extra_body"]["mirostat"] == 2
+
+
+def test_resolver_overrides_conflicting_raw_extra_body_grammar() -> None:
+    payload = resolve_llamacpp_request_extensions(
+        request_fields={
+            "grammar_mode": "inline",
+            "grammar_inline": 'root ::= "inline"',
+            "extra_body": {"grammar": 'root ::= "raw"'},
+        },
+        provider="llama.cpp",
+        grammar_record=None,
+        runtime_caps={"strict_openai_compat": False, "thinking_budget": {"supported": False}},
+    )
+
+    assert payload["extra_body"]["grammar"] == 'root ::= "inline"'
+
+
+def test_build_call_params_merges_llamacpp_inline_grammar_into_extra_body() -> None:
+    request = ChatCompletionRequest(
+        model="llama.cpp/local-model",
+        messages=[{"role": "user", "content": "reply in JSON"}],
+        grammar_mode="inline",
+        grammar_inline='root ::= "inline"',
+        extra_body={"mirostat": 2},
+    )
+
+    params = build_call_params_from_request(
+        request_data=request,
+        target_api_provider="llama.cpp",
+        provider_api_key="test-key",
+        templated_llm_payload=[{"role": "user", "content": "reply in JSON"}],
+        final_system_message=None,
+        app_config={"llama_api": {"strict_openai_compat": False}},
+    )
+
+    assert params["extra_body"]["grammar"] == 'root ::= "inline"'
+    assert params["extra_body"]["mirostat"] == 2
+    assert "grammar_mode" not in params
+    assert "grammar_inline" not in params
+
+
+def test_build_call_params_rejects_llamacpp_fields_for_non_llamacpp_provider() -> None:
+    request = ChatCompletionRequest(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "reply in JSON"}],
+        grammar_mode="inline",
+        grammar_inline='root ::= "inline"',
+    )
+
+    with pytest.raises(ChatBadRequestError):
+        build_call_params_from_request(
+            request_data=request,
+            target_api_provider="openai",
+            provider_api_key="test-key",
+            templated_llm_payload=[{"role": "user", "content": "reply in JSON"}],
+            final_system_message=None,
+            app_config=None,
+        )

--- a/tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py
@@ -5,6 +5,7 @@ from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError
 from tldw_Server_API.app.core.Chat.chat_service import build_call_params_from_request
 from tldw_Server_API.app.core.LLM_Calls.llamacpp_request_extensions import (
     resolve_llamacpp_request_extensions,
+    resolve_llamacpp_runtime_caps,
 )
 
 
@@ -85,3 +86,8 @@ def test_build_call_params_rejects_llamacpp_fields_for_non_llamacpp_provider() -
             final_system_message=None,
             app_config=None,
         )
+
+
+def test_llamacpp_request_extension_helpers_have_docstrings() -> None:
+    assert resolve_llamacpp_runtime_caps.__doc__
+    assert resolve_llamacpp_request_extensions.__doc__

--- a/tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py
+++ b/tldw_Server_API/tests/LLM_Calls/test_llamacpp_strict_filter.py
@@ -1,7 +1,9 @@
 import pytest
 from unittest.mock import patch
 
+from tldw_Server_API.app.api.v1.schemas.chat_request_schemas import ChatCompletionRequest
 from tldw_Server_API.app.core.Chat.Chat_Deps import ChatBadRequestError
+from tldw_Server_API.app.core.Chat.chat_service import build_call_params_from_request
 from tldw_Server_API.app.core.Chat.chat_orchestrator import chat_api_call
 from tldw_Server_API.app.core.LLM_Calls.capability_registry import validate_payload
 
@@ -82,4 +84,25 @@ def test_llamacpp_tools_rejected_by_contract():
                 "messages": [{"role": "user", "content": "hi"}],
                 "tools": [{"type": "function", "function": {"name": "x", "parameters": {}}}],
             },
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.strict_mode
+def test_build_call_params_rejects_llamacpp_advanced_fields_in_strict_mode():
+    request = ChatCompletionRequest(
+        model="llama.cpp/local-model",
+        messages=[{"role": "user", "content": "hello"}],
+        grammar_mode="inline",
+        grammar_inline='root ::= "x"',
+    )
+
+    with pytest.raises(ChatBadRequestError):
+        build_call_params_from_request(
+            request_data=request,
+            target_api_provider="llama.cpp",
+            provider_api_key="test-key",
+            templated_llm_payload=[{"role": "user", "content": "hello"}],
+            final_system_message=None,
+            app_config={"llama_api": {"strict_openai_compat": True}},
         )


### PR DESCRIPTION
## Summary
- add first-class llama.cpp grammar request fields, request-extension resolution, provider capability metadata, and a user-scoped grammar library API
- persist llama.cpp grammar/thinking settings in shared chat UI state and add advanced controls plus a grammar library modal in the sidepanel/playground flows
- document the llama.cpp chat contract, provider metadata, integration modes, and raw `extra_body` conflict behavior

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Chat/unit/test_chat_grammar_endpoints.py tldw_Server_API/tests/Character_Chat_NEW/unit/test_chat_grammar_unit.py tldw_Server_API/tests/Chat_NEW/integration/test_chat_llamacpp_extensions_api.py tldw_Server_API/tests/LLM_Adapters/unit/test_llm_providers_capabilities_merge.py tldw_Server_API/tests/LLM_Calls/test_llamacpp_request_extensions.py`
- [x] `./node_modules/.bin/vitest run src/store/__tests__/model.llamacpp-controls.test.ts src/services/__tests__/model-settings.llamacpp-controls.test.ts src/components/Sidepanel/Chat/__tests__/ModelParamsPanel.llamacpp-controls.test.tsx src/services/__tests__/tldw-chat.message-sanitization.test.ts src/components/Option/Playground/__tests__/PlaygroundForm.llamacpp-controls.guard.test.ts src/components/Option/WorkspacePlayground/__tests__/WorkspacePlayground.stage9.persistence.test.tsx`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/chat.py tldw_Server_API/app/api/v1/endpoints/chat_grammars.py tldw_Server_API/app/api/v1/endpoints/llm_providers.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py tldw_Server_API/app/api/v1/schemas/chat_grammar_schemas.py tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/core/Character_Chat/chat_grammar.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/LLM_Calls/llamacpp_request_extensions.py -f json -o /tmp/bandit_llamacpp_grammar.json` (3 low-severity pre-existing `B101` findings in `ChaChaNotes_DB.py`)
