### PR TITLE
docs: add admin-ui prod readiness release handoff

### DIFF
--- a/.github/workflows/frontend-required.yml
+++ b/.github/workflows/frontend-required.yml
@@ -109,6 +109,11 @@ jobs:
         working-directory: admin-ui
         run: bun run lint
 
+      - name: Run admin-ui typecheck
+        if: needs.changes.outputs.admin_ui_changed == 'true'
+        working-directory: admin-ui
+        run: bun run typecheck
+
       - name: Run admin-ui unit tests
         if: needs.changes.outputs.admin_ui_changed == 'true'
         working-directory: admin-ui

--- a/Docs/Plans/2026-03-10-admin-ui-prod-readiness-reconciliation-design.md
+++ b/Docs/Plans/2026-03-10-admin-ui-prod-readiness-reconciliation-design.md
@@ -1,0 +1,199 @@
+# 2026-03-10 Admin UI Production Readiness Reconciliation Design
+
+## Goal
+
+Produce a current-state reconciliation of `admin-ui` that:
+
+1. Compares the live codebase against the existing review artifacts.
+2. Distinguishes resolved findings from still-open production risks.
+3. Surfaces newly relevant blockers that the older reviews did not capture.
+4. Produces an ordered remediation backlog suitable for implementation planning.
+
+## Scope
+
+This review is broader than an enterprise-only control-plane audit.
+
+It includes:
+
+- Security and privileged admin workflows
+- Build and release integrity
+- Contract correctness between frontend and backend
+- Operator UX for high-risk actions
+- Reliability and verification coverage
+- Maintainability and scale risks that materially affect production operations
+
+It does not include implementing fixes. This document defines the review shape and the decision framework for the reconciliation pass.
+
+## Prior Art To Reconcile
+
+The reconciliation uses these repo artifacts as the baseline to compare against current code:
+
+- `Docs/Plans/2026-02-27-admin-ui-review-findings.md`
+- `Docs/Plans/2026-03-07-admin-ui-enterprise-prod-readiness-review-findings.md`
+- `admin-ui/Release_Checklist.md`
+
+## Output Format
+
+The reconciliation findings document should be organized into four sections.
+
+### 1. Current Verdict
+
+A concise statement answering:
+
+- Is `admin-ui` production ready today?
+- If yes, for which use case?
+- If no, what category of risks currently block rollout?
+
+The verdict must be explicit and should distinguish between:
+
+- Internal production use
+- Enterprise-sensitive live-customer administration
+- General pre-production readiness
+
+### 2. Delta Matrix Against Prior Reviews
+
+Each notable prior finding must be mapped to one of these statuses:
+
+- `resolved`
+- `partially resolved`
+- `still open`
+- `superseded`
+
+Each matrix row should include:
+
+- Source review
+- Original finding summary
+- Current status
+- Current evidence
+- Why the status changed or did not change
+
+### 3. New Current-State Gaps
+
+This section captures issues that are significant today but were missing, underweighted, or reframed by later code changes. Examples include:
+
+- Truthfulness of lint/build/typecheck signals
+- CI or release-process blind spots
+- Lockfile or workspace-root drift
+- Missing smoke or E2E coverage for admin-critical paths
+- Refactor pressure from oversized modules
+
+### 4. Release Gate
+
+The review must end with a concrete prioritization:
+
+- `Must fix before production`
+- `Should fix soon after`
+- `Cleanup/debt`
+
+Each item must identify the likely owner:
+
+- `frontend`
+- `backend`
+- `both`
+
+## Decision Criteria
+
+The reconciliation uses these rules:
+
+1. Current code and current verification results override older documentation.
+2. Passing unit tests alone is not sufficient evidence for production readiness.
+3. “Production ready” requires credible signals across:
+   - Auth and session handling
+   - Privileged action protection
+   - Durable auditability
+   - Correct frontend/backend contracts
+   - Green CI gates
+   - Truthful build output
+   - Release hygiene
+4. A green build is downgraded as evidence if key validation is bypassed.
+5. Findings are prioritized by operational and security risk, not code neatness.
+
+## Evidence Model
+
+The review should use the following evidence sources, in this order:
+
+1. Existing review artifacts
+2. Current `admin-ui` implementation
+3. Current backend contracts and service behavior
+4. Current CI and release gates
+5. Local verification results
+
+### Required Verification Inputs
+
+The reconciliation should capture current results for:
+
+- `bun run lint`
+- `bun run test`
+- `bun run build`
+- `bunx tsc --noEmit`
+- `bun run test:a11y`
+
+If a command fails, the failure is part of the finding set, not a reason to omit the command.
+
+## Reconciliation Rules
+
+Use the following mapping logic:
+
+- `resolved`: the prior issue no longer materially applies based on current code and verification.
+- `partially resolved`: the architecture improved, but meaningful residual risk remains.
+- `still open`: the original problem still materially applies.
+- `superseded`: the original framing is no longer accurate because the implementation changed and the risk must be restated.
+
+If code comments or docs disagree with live verification, the live verification result wins.
+
+## Findings Taxonomy
+
+All reconciled findings should be grouped into these categories:
+
+1. `Security and control plane`
+2. `Build and release integrity`
+3. `Contract and correctness`
+4. `Operator UX and safety`
+5. `Reliability and coverage`
+6. `Maintainability and scale`
+
+Each finding should also receive a severity:
+
+- `Blocker`
+- `Major`
+- `Medium`
+- `Low`
+
+And each finding should include:
+
+- Current status versus older reviews
+- Evidence
+- Why it matters operationally
+- Recommended next action
+- Likely owner
+
+## Planned Execution Flow
+
+The review should proceed in this order:
+
+1. Collect the major findings from the February 27 and March 7 review docs.
+2. Inspect the current `admin-ui` code, supporting backend code, and release docs.
+3. Run the verification commands.
+4. Mark each prior finding as resolved, partially resolved, still open, or superseded.
+5. Add newly observed gaps not adequately covered by the old reviews.
+6. Produce a go/no-go style release gate.
+7. Translate the release gate into an implementation plan for remediation.
+
+## Completion Criteria
+
+The reconciliation is complete when:
+
+- Every major prior finding has a current status.
+- Every current blocker is backed by code or command evidence.
+- The final verdict is explicit.
+- The remediation list is ordered by risk.
+- The follow-on implementation plan is actionable without rediscovery work.
+
+## Initial Expectations
+
+Based on current inspection before the reconciliation document is written:
+
+- Several March control-plane findings are likely now `resolved` or `superseded`.
+- The app likely still falls short of a strict production bar because build integrity, type-safety signal quality, release hygiene, and maintainability risks remain active.
+
+The reconciliation document must validate or overturn these expectations with current evidence.

--- a/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
@@ -14,7 +14,7 @@
 **Goal:** Make `lint`, `build`, and the main plan-gated flows reflect the actual code quality instead of failing early on known issues or hiding type debt.
 **Success Criteria:** `bun run lint` passes, `bun run build` no longer fails on current ESLint issues, and the billing gate continues to behave correctly.
 **Tests:** `bunx vitest run components/__tests__/PlanGuard.test.tsx app/onboarding/__tests__/page.test.tsx app/plans/__tests__/page.test.tsx`, `bun run lint`, `bun run build`
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 1: Fix the current lint and build blockers
 
@@ -95,7 +95,7 @@ git commit -m "fix(admin-ui): clear plan guard lint blockers"
 **Goal:** Make `bunx tsc --noEmit` and `next build` trustworthy by fixing the current strict-type failures and removing `ignoreBuildErrors`.
 **Success Criteria:** `bunx tsc --noEmit` passes, `next.config.js` no longer suppresses build type errors, and `bun run build` passes without skipping type validation.
 **Tests:** `bunx tsc --noEmit`, targeted Vitest suites for touched files, `bun run build`
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 2: Restore test matcher typing and Next page-module compatibility
 

--- a/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
@@ -255,7 +255,7 @@ git commit -m "fix(admin-ui): restore truthful type-safe build gates"
 **Goal:** Add the missing browser-level and CI/release checks for the privileged admin paths that matter most in production.
 **Success Criteria:** Critical login and privileged user-management flows have browser smoke coverage, and the required frontend gate runs the same checks the release checklist requires.
 **Tests:** Playwright smoke specs, `bun run test:a11y`, updated frontend-required workflow green
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 4: Add browser smoke coverage for critical admin flows
 

--- a/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
@@ -410,7 +410,7 @@ git commit -m "ci(admin-ui): align frontend gate with production checks"
 **Goal:** Lower the probability that future production changes regress critical admin flows by extracting the highest-risk monoliths into smaller typed units.
 **Success Criteria:** The largest user-management pages and their helper state are split into section components or hooks with no behavior change.
 **Tests:** Existing page suites remain green; new extracted helpers have focused unit tests
-**Status:** Not Started
+**Status:** Complete
 
 ### Task 6: Decompose the highest-risk user-management modules after the gate is green
 

--- a/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-admin-ui-prod-readiness-remediation-implementation-plan.md
@@ -1,0 +1,493 @@
+# Admin UI Production Readiness Remediation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the remaining `admin-ui` production-readiness gaps so the app has truthful quality gates, credible privileged-flow verification, and a release process that matches the current control-plane risk.
+
+**Architecture:** Remediate in layers. First restore trustworthy local and CI signals by fixing the current lint/build blockers and clearing strict TypeScript failures. Then harden release confidence with browser smoke coverage and CI wiring. Finally reduce regression pressure in the largest modules after the production gate is restored.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript 5, Vitest, React Testing Library, Bun, GitHub Actions, Playwright using existing repo patterns from `apps/tldw-frontend/`.
+
+---
+
+## Stage 1: Restore Truthful Quality Gates
+**Goal:** Make `lint`, `build`, and the main plan-gated flows reflect the actual code quality instead of failing early on known issues or hiding type debt.
+**Success Criteria:** `bun run lint` passes, `bun run build` no longer fails on current ESLint issues, and the billing gate continues to behave correctly.
+**Tests:** `bunx vitest run components/__tests__/PlanGuard.test.tsx app/onboarding/__tests__/page.test.tsx app/plans/__tests__/page.test.tsx`, `bun run lint`, `bun run build`
+**Status:** Not Started
+
+### Task 1: Fix the current lint and build blockers
+
+**Files:**
+- Modify: `admin-ui/components/PlanGuard.tsx`
+- Modify: `admin-ui/components/__tests__/PlanGuard.test.tsx`
+- Modify: `admin-ui/app/onboarding/page.tsx`
+- Modify: `admin-ui/app/onboarding/__tests__/page.test.tsx`
+- Modify: `admin-ui/app/plans/page.tsx`
+
+**Step 1: Write the failing test**
+
+Add a regression case in `admin-ui/components/__tests__/PlanGuard.test.tsx` that proves the guard renders children immediately when billing is disabled and does not fetch an org subscription.
+
+```tsx
+it('renders children immediately when billing is disabled', async () => {
+  vi.mocked(isBillingEnabled).mockReturnValue(false);
+  const getOrgSubscription = vi.spyOn(api, 'getOrgSubscription');
+
+  render(<PlanGuard requiredPlan="pro"><div>Allowed</div></PlanGuard>);
+
+  expect(await screen.findByText('Allowed')).toBeInTheDocument();
+  expect(getOrgSubscription).not.toHaveBeenCalled();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run components/__tests__/PlanGuard.test.tsx -t "renders children immediately when billing is disabled"`
+
+Expected: FAIL if the current guard still depends on synchronous `setState` inside the effect.
+
+**Step 3: Write minimal implementation**
+
+Refactor `admin-ui/components/PlanGuard.tsx` so the non-billing path is derived before the effect, and keep the effect only for the async subscription fetch path.
+
+```tsx
+const billingEnabled = isBillingEnabled();
+const [allowed, setAllowed] = useState<boolean | null>(billingEnabled ? null : true);
+
+useEffect(() => {
+  if (!billingEnabled) return;
+  if (orgLoading || !selectedOrg) return;
+  // existing async subscription fetch
+}, [billingEnabled, orgLoading, requiredPlan, selectedOrg]);
+```
+
+Then remove the unused local bindings that currently fail ESLint:
+
+- `handleSubmit` in `admin-ui/app/onboarding/page.tsx`
+- `mockedCreateOnboardingSession` in `admin-ui/app/onboarding/__tests__/page.test.tsx`
+- `PlanTier` import in `admin-ui/app/plans/page.tsx`
+
+**Step 4: Run tests to verify behavior and lint**
+
+Run: `bunx vitest run components/__tests__/PlanGuard.test.tsx app/onboarding/__tests__/page.test.tsx app/plans/__tests__/page.test.tsx`
+
+Expected: PASS
+
+Run: `bun run lint`
+
+Expected: PASS with no `react-hooks/set-state-in-effect` or `no-unused-vars` failures.
+
+**Step 5: Run the build to verify the lint failure is gone**
+
+Run: `bun run build`
+
+Expected: BUILD proceeds past linting; any remaining failures should now be TypeScript or config-related only.
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/components/PlanGuard.tsx admin-ui/components/__tests__/PlanGuard.test.tsx admin-ui/app/onboarding/page.tsx admin-ui/app/onboarding/__tests__/page.test.tsx admin-ui/app/plans/page.tsx
+git commit -m "fix(admin-ui): clear plan guard lint blockers"
+```
+
+## Stage 2: Remove Hidden Type Debt And Re-enable Type Safety
+**Goal:** Make `bunx tsc --noEmit` and `next build` trustworthy by fixing the current strict-type failures and removing `ignoreBuildErrors`.
+**Success Criteria:** `bunx tsc --noEmit` passes, `next.config.js` no longer suppresses build type errors, and `bun run build` passes without skipping type validation.
+**Tests:** `bunx tsc --noEmit`, targeted Vitest suites for touched files, `bun run build`
+**Status:** Not Started
+
+### Task 2: Restore test matcher typing and Next page-module compatibility
+
+**Files:**
+- Modify: `admin-ui/tsconfig.json`
+- Create: `admin-ui/vitest.d.ts`
+- Modify: `admin-ui/app/monitoring/page.tsx`
+- Create: `admin-ui/app/monitoring/status-utils.ts`
+- Test: `admin-ui/app/monitoring/__tests__/page.test.tsx`
+
+**Step 1: Add the failing type gate**
+
+Run: `bunx tsc --noEmit`
+
+Expected: FAIL with matcher typing errors such as `toBeInTheDocument` and the `.next/types/app/monitoring/page.ts` export error for `normalizeHealthStatus`.
+
+**Step 2: Add the missing test matcher declaration**
+
+Create `admin-ui/vitest.d.ts` with the matcher imports used by the test suite.
+
+```ts
+/// <reference types="vitest/globals" />
+import '@testing-library/jest-dom/vitest';
+```
+
+Update `admin-ui/tsconfig.json` so the declaration file is included in typecheck.
+
+**Step 3: Move the exported page helper out of the App Router page module**
+
+Extract the exported status-normalization helper from `admin-ui/app/monitoring/page.tsx` into `admin-ui/app/monitoring/status-utils.ts`, then import it back into the page and tests.
+
+```ts
+export function normalizeHealthStatus(status?: string): SystemHealthStatus {
+  // existing normalization logic
+}
+```
+
+This keeps the App Router page module contract clean for Next-generated `.next/types`.
+
+**Step 4: Re-run the focused suite and typecheck**
+
+Run: `bunx vitest run admin-ui/app/monitoring/__tests__/page.test.tsx`
+
+Expected: PASS
+
+Run: `bunx tsc --noEmit`
+
+Expected: FAIL, but the matcher-type errors and `app/monitoring/page` export error should be gone.
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/tsconfig.json admin-ui/vitest.d.ts admin-ui/app/monitoring/page.tsx admin-ui/app/monitoring/status-utils.ts admin-ui/app/monitoring/__tests__/page.test.tsx
+git commit -m "fix(admin-ui): restore test and page-module typings"
+```
+
+### Task 3: Burn down the remaining strict TypeScript runtime errors
+
+**Files:**
+- Modify: `admin-ui/components/PermissionGuard.tsx`
+- Create: `admin-ui/components/__tests__/PermissionGuard.test.tsx`
+- Modify: `admin-ui/components/ErrorBoundary.tsx`
+- Create: `admin-ui/components/__tests__/ErrorBoundary.test.tsx`
+- Modify: `admin-ui/components/users/ApiKeyCreateForm.tsx`
+- Modify: `admin-ui/components/data-ops/MaintenanceSection.tsx`
+- Modify: `admin-ui/app/dependencies/page.tsx`
+- Modify: `admin-ui/lib/export.ts`
+- Modify: `admin-ui/lib/use-user-api-keys.ts`
+- Modify: `admin-ui/middleware.ts`
+
+**Step 1: Add focused regression tests around shared auth and error components**
+
+Create tests for the currently untested shared components:
+
+`admin-ui/components/__tests__/PermissionGuard.test.tsx`
+
+```tsx
+it('keeps the user in the permission context after a successful refresh', async () => {
+  vi.mocked(api.getCurrentUser).mockResolvedValue(mockUser);
+  vi.mocked(api.getUserEffectivePermissions).mockResolvedValue({ permissions: ['read:users'] });
+  render(<PermissionProvider><ProtectedChild /></PermissionProvider>);
+  expect(await screen.findByText('Protected')).toBeInTheDocument();
+});
+```
+
+`admin-ui/components/__tests__/ErrorBoundary.test.tsx`
+
+```tsx
+it('resets cleanly before retry exhaustion', async () => {
+  render(<ErrorBoundary><ThrowOnce /></ErrorBoundary>);
+  await user.click(screen.getByRole('button', { name: /try again/i }));
+  expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bunx vitest run components/__tests__/PermissionGuard.test.tsx components/__tests__/ErrorBoundary.test.tsx`
+
+Expected: FAIL until the type-safe implementations and tests are in place.
+
+**Step 3: Fix each current strict-type error without loosening compiler settings**
+
+Apply narrow, boring fixes only:
+
+- `admin-ui/components/PermissionGuard.tsx`
+  - Narrow `api.getCurrentUser()` and `api.getUserEffectivePermissions()` responses before writing them into state.
+- `admin-ui/components/ErrorBoundary.tsx`
+  - Return a fully populated `ErrorBoundaryState` shape from the functional `setState`.
+- `admin-ui/components/users/ApiKeyCreateForm.tsx`
+  - Align the `Resolver` and submit callback generic types with the actual form schema.
+- `admin-ui/components/data-ops/MaintenanceSection.tsx`
+  - Reconcile the `RotationStatus` union with the UI state that can legitimately be `"running"`.
+- `admin-ui/app/dependencies/page.tsx`
+  - Guard `Object.entries()` calls with a record-type check before iterating unknown API payloads.
+- `admin-ui/lib/export.ts`
+  - Add the correct `Record<string, unknown>` generic constraints and narrow date inputs before constructing `Date`.
+- `admin-ui/lib/use-user-api-keys.ts`
+  - Narrow the hook response before writing state.
+- `admin-ui/middleware.ts`
+  - Use an `ArrayBuffer`-compatible `BufferSource` input when verifying HMAC signatures.
+
+**Step 4: Re-run the relevant suites and the full typecheck**
+
+Run: `bunx vitest run components/__tests__/PermissionGuard.test.tsx components/__tests__/ErrorBoundary.test.tsx components/data-ops/MaintenanceSection.test.tsx app/dependencies/__tests__/page.test.tsx`
+
+Expected: PASS
+
+Run: `bunx tsc --noEmit`
+
+Expected: PASS
+
+**Step 5: Remove the build type bypass**
+
+Modify `admin-ui/next.config.js` to remove:
+
+```js
+typescript: {
+  ignoreBuildErrors: true,
+}
+```
+
+Then run:
+
+`bun run build`
+
+Expected: PASS without `Skipping validation of types`.
+
+**Step 6: Commit**
+
+```bash
+git add admin-ui/components/PermissionGuard.tsx admin-ui/components/__tests__/PermissionGuard.test.tsx admin-ui/components/ErrorBoundary.tsx admin-ui/components/__tests__/ErrorBoundary.test.tsx admin-ui/components/users/ApiKeyCreateForm.tsx admin-ui/components/data-ops/MaintenanceSection.tsx admin-ui/app/dependencies/page.tsx admin-ui/lib/export.ts admin-ui/lib/use-user-api-keys.ts admin-ui/middleware.ts admin-ui/next.config.js
+git commit -m "fix(admin-ui): restore truthful type-safe build gates"
+```
+
+## Stage 3: Increase Production Confidence Beyond Unit Tests
+**Goal:** Add the missing browser-level and CI/release checks for the privileged admin paths that matter most in production.
+**Success Criteria:** Critical login and privileged user-management flows have browser smoke coverage, and the required frontend gate runs the same checks the release checklist requires.
+**Tests:** Playwright smoke specs, `bun run test:a11y`, updated frontend-required workflow green
+**Status:** Not Started
+
+### Task 4: Add browser smoke coverage for critical admin flows
+
+**Files:**
+- Create: `admin-ui/playwright.config.ts`
+- Create: `admin-ui/tests/e2e/login-and-mfa.spec.ts`
+- Create: `admin-ui/tests/e2e/user-privileged-actions.spec.ts`
+- Modify: `admin-ui/package.json`
+- Reference: `apps/tldw-frontend/playwright.config.ts`
+
+**Step 1: Write the first failing smoke spec**
+
+Create a login smoke test that covers the hardened auth model:
+
+```ts
+test('supports password login and MFA challenge completion', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel(/username or email/i).fill('admin');
+  await page.getByLabel(/password/i).fill('AdminPass123!');
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await expect(page.getByLabel(/verification code/i)).toBeVisible();
+});
+```
+
+Create a privileged-action smoke test:
+
+```ts
+test('requires reason and reauthentication before reset password', async ({ page }) => {
+  await page.goto('/users/42');
+  await page.getByRole('button', { name: /reset password/i }).click();
+  await expect(page.getByLabel(/reason/i)).toBeVisible();
+  await expect(page.getByLabel(/current password/i)).toBeVisible();
+});
+```
+
+**Step 2: Run the new smoke tests to verify they fail**
+
+Run: `bunx playwright test tests/e2e/login-and-mfa.spec.ts tests/e2e/user-privileged-actions.spec.ts`
+
+Expected: FAIL until the harness, fixtures, and routes are correctly wired.
+
+**Step 3: Implement the minimal harness using existing repo conventions**
+
+- Reuse the shape of `apps/tldw-frontend/playwright.config.ts`.
+- Point the smoke suite at the local `admin-ui` dev or preview server.
+- Keep the suite intentionally small: auth, MFA, users detail, privileged action modal.
+- Add package scripts:
+
+```json
+"test:smoke": "playwright test"
+```
+
+**Step 4: Run smoke and accessibility checks**
+
+Run: `bunx playwright test tests/e2e/login-and-mfa.spec.ts tests/e2e/user-privileged-actions.spec.ts`
+
+Expected: PASS
+
+Run: `bun run test:a11y`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/playwright.config.ts admin-ui/tests/e2e/login-and-mfa.spec.ts admin-ui/tests/e2e/user-privileged-actions.spec.ts admin-ui/package.json
+git commit -m "test(admin-ui): add browser smoke coverage for privileged flows"
+```
+
+### Task 5: Align CI and release docs with the real production gate
+
+**Files:**
+- Modify: `.github/workflows/frontend-required.yml`
+- Modify: `admin-ui/package.json`
+- Modify: `admin-ui/README.md`
+- Modify: `admin-ui/Release_Checklist.md`
+- Modify: `admin-ui/next.config.js`
+
+**Step 1: Add the failing gate locally**
+
+Add explicit scripts if they do not already exist:
+
+```json
+"typecheck": "tsc --noEmit",
+"test:smoke": "playwright test"
+```
+
+Then run:
+
+- `bun run typecheck`
+- `bun run build`
+
+Expected: PASS locally before CI is updated.
+
+**Step 2: Update the required workflow**
+
+Extend `.github/workflows/frontend-required.yml` so `admin-ui_changed == true` runs:
+
+1. `bun run lint`
+2. `bun run typecheck`
+3. `bun run test`
+4. `bun run build`
+
+Keep browser smoke in the release checklist unless runtime fixtures are made CI-stable in the same PR.
+
+**Step 3: Update the operator-facing docs**
+
+Document the real production gate in:
+
+- `admin-ui/README.md`
+- `admin-ui/Release_Checklist.md`
+
+Required checklist items:
+
+- `bun run lint`
+- `bun run typecheck`
+- `bun run test`
+- `bun run test:a11y`
+- `bun run build`
+- `bun run test:smoke`
+
+Also set `outputFileTracingRoot` in `admin-ui/next.config.js` so Next resolves the workspace root deterministically instead of guessing from stray lockfiles.
+
+```js
+const path = require('path');
+
+module.exports = {
+  reactStrictMode: true,
+  outputFileTracingRoot: path.join(__dirname, '..'),
+};
+```
+
+**Step 4: Re-run the production gate**
+
+Run:
+
+- `bun run lint`
+- `bun run typecheck`
+- `bun run test`
+- `bun run build`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/frontend-required.yml admin-ui/package.json admin-ui/README.md admin-ui/Release_Checklist.md admin-ui/next.config.js
+git commit -m "ci(admin-ui): align frontend gate with production checks"
+```
+
+## Stage 4: Reduce Regression Surface In Oversized Modules
+**Goal:** Lower the probability that future production changes regress critical admin flows by extracting the highest-risk monoliths into smaller typed units.
+**Success Criteria:** The largest user-management pages and their helper state are split into section components or hooks with no behavior change.
+**Tests:** Existing page suites remain green; new extracted helpers have focused unit tests
+**Status:** Not Started
+
+### Task 6: Decompose the highest-risk user-management modules after the gate is green
+
+**Files:**
+- Modify: `admin-ui/app/users/[id]/page.tsx`
+- Create: `admin-ui/app/users/[id]/components/UserProfileCard.tsx`
+- Create: `admin-ui/app/users/[id]/components/UserSecurityCard.tsx`
+- Create: `admin-ui/app/users/[id]/components/UserMembershipDialogs.tsx`
+- Create: `admin-ui/app/users/[id]/hooks/use-user-security.ts`
+- Modify: `admin-ui/app/users/[id]/__tests__/page.test.tsx`
+- Modify: `admin-ui/app/users/page.tsx`
+- Create: `admin-ui/app/users/components/UserBulkActions.tsx`
+- Create: `admin-ui/app/users/hooks/use-user-filters.ts`
+- Modify: `admin-ui/app/users/__tests__/page.test.tsx`
+
+**Step 1: Write a no-behavior-change extraction test**
+
+Add assertions in the existing users page suites that anchor the highest-risk behaviors before extraction:
+
+- reset password still requires privileged confirmation
+- revoke-all sessions still works
+- saved views still round-trip correctly
+
+**Step 2: Run the targeted suites to freeze current behavior**
+
+Run: `bunx vitest run app/users/[id]/__tests__/page.test.tsx app/users/__tests__/page.test.tsx`
+
+Expected: PASS
+
+**Step 3: Extract by concern, not by visual fragment**
+
+Start with the detail page security flows:
+
+- `UserSecurityCard.tsx`
+- `use-user-security.ts`
+
+Then extract the membership dialogs and bulk-action logic. Keep API calls in one place and pass typed props down instead of duplicating fetch logic.
+
+**Step 4: Re-run the suites after each extraction slice**
+
+Run after each slice:
+
+`bunx vitest run app/users/[id]/__tests__/page.test.tsx app/users/__tests__/page.test.tsx`
+
+Expected: PASS after every extraction.
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/users/[id]/page.tsx admin-ui/app/users/[id]/components admin-ui/app/users/[id]/hooks admin-ui/app/users/[id]/__tests__/page.test.tsx admin-ui/app/users/page.tsx admin-ui/app/users/components admin-ui/app/users/hooks admin-ui/app/users/__tests__/page.test.tsx
+git commit -m "refactor(admin-ui): split user management monoliths"
+```
+
+## Verification Checklist For The Full Remediation Series
+
+Run from `admin-ui/` unless noted otherwise:
+
+1. `bun run lint`
+2. `bun run typecheck`
+3. `bun run test`
+4. `bun run test:a11y`
+5. `bun run build`
+6. `bun run test:smoke`
+7. From repo root: `python -m bandit -r admin-ui -f json -o /tmp/bandit_admin_ui.json` if the final change set adds Python-touching automation or backend helpers adjacent to `admin-ui`; otherwise skip and document why it is not applicable.
+
+## Recommended Commit Sequence
+
+1. `fix(admin-ui): clear plan guard lint blockers`
+2. `fix(admin-ui): restore test and page-module typings`
+3. `fix(admin-ui): restore truthful type-safe build gates`
+4. `test(admin-ui): add browser smoke coverage for privileged flows`
+5. `ci(admin-ui): align frontend gate with production checks`
+6. `refactor(admin-ui): split user management monoliths`
+
+## Notes For The Implementer
+
+- Do not widen TypeScript types or disable rules to make the gate green.
+- Keep `admin-ui` on Bun as the canonical package manager.
+- Reuse repo Playwright patterns instead of creating a second browser-test style.
+- Treat the Stage 4 refactor as post-gate work; do not mix it into the same PR as the gate restoration unless the branch stays small and reviewable.

--- a/Docs/Plans/2026-03-10-companion-explicit-capture-roadmap-design.md
+++ b/Docs/Plans/2026-03-10-companion-explicit-capture-roadmap-design.md
@@ -1,0 +1,430 @@
+# Companion Explicit-Capture Roadmap Design
+
+Date: 2026-03-10
+Status: Approved
+
+## Summary
+
+This design reviews the Echo concept described in the external article and repo, compares it against the existing `tldw_server` persona and adjacent systems, and proposes a local-first roadmap that stays inside explicit-capture boundaries.
+
+The recommendation is to build a `Companion` product layer on top of the existing persona, personalization, collections, notifications, and jobs infrastructure rather than copying Echo's ambient desktop-monitoring model.
+
+## Reviewed Sources
+
+- Medium article: <https://kotrotsos.medium.com/claude-desktop-has-a-hidden-feature-6322a22ab625>
+- `claude_echo` repo: <https://github.com/Kotrotsos/claude_echo>
+- Echo notes: <https://raw.githubusercontent.com/Kotrotsos/claude_echo/main/docs/09-ECHO-FEATURE.md>
+
+## Investigated Internal Context
+
+- Persona design and APIs:
+  - `Docs/Design/Personas.md`
+  - `Docs/Product/Persona_Agent_Design.md`
+  - `tldw_Server_API/app/api/v1/endpoints/persona.py`
+  - `tldw_Server_API/app/api/v1/schemas/persona.py`
+  - `tldw_Server_API/app/core/Persona/memory_integration.py`
+  - `tldw_Server_API/app/core/Persona/policy_evaluator.py`
+  - `tldw_Server_API/app/core/Persona/session_manager.py`
+- Persona WebUI:
+  - `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+  - `Docs/Plans/2026-03-08-persona-garden-design.md`
+- Personalization:
+  - `Docs/Product/Personalization_Design.md`
+  - `tldw_Server_API/app/core/DB_Management/Personalization_DB.py`
+  - `tldw_Server_API/app/services/personalization_consolidation.py`
+- Notifications and reminders:
+  - `Docs/API-related/Reminder_Notifications_API.md`
+- Self-monitoring:
+  - `Docs/Design/Guardian_Self_Monitoring.md`
+- Collections, reading, extension, and digests:
+  - `Docs/Product/Completed/Content_Collections_PRD.md`
+  - `tldw_Server_API/app/core/Collections/reading_digest_jobs.py`
+  - `tldw_Server_API/app/services/reading_digest_scheduler.py`
+
+## Problem Statement
+
+The external Echo material suggests a useful product pattern:
+
+- maintain an activity timeline
+- derive knowledge from activity
+- support a dedicated companion conversation surface
+- generate reflections, goals, and proactive notifications
+
+`tldw_server` already has much of the upper-layer substrate for this pattern, but it does not yet have a first-class unified activity model for explicit user captures and actions. Without that shared activity layer, the existing persona, personalization, notifications, and reading/watchlist systems remain useful but fragmented.
+
+## Scope Decision
+
+Approved scope:
+
+- local-first
+- explicit capture only
+- broader roadmap across persona plus adjacent systems
+
+Explicitly out of scope for this design:
+
+- passive desktop monitoring
+- ambient screen capture
+- arbitrary window observation
+- hidden or non-provenanced behavioral inference from non-explicit OS activity
+
+## What Echo Does
+
+Based on the external material, Echo appears to combine:
+
+- a capture engine with configurable cadence and privacy controls
+- an activity feed
+- a knowledge base derived from observed behavior
+- reflections and behavioral goals
+- proactive notifications
+- a dedicated conversational interface
+- dashboard, tray, and bubble surfaces
+
+The most relevant product pattern is not the screen capture itself. It is the stack above capture: activity normalization, derived knowledge, coaching/reflection, and a conversational companion.
+
+## Current tldw_server Overlap
+
+### Strong overlap
+
+- Persona already provides:
+  - catalog, session, and session history endpoints
+  - live WS streaming
+  - tool-plan confirmation
+  - policy and scope rules
+  - persona state docs and restore history
+  - persona memory retrieval and persistence hooks
+- Personalization already provides:
+  - per-user profile/preferences
+  - per-user usage events
+  - semantic memories
+  - topic profiles
+  - proactive preference fields and quiet hours
+- Notifications and reminders already provide:
+  - inbox model
+  - SSE stream
+  - reminders
+  - Jobs bridge patterns for user-facing background outcomes
+- Collections already provide:
+  - explicit reading capture
+  - watchlists
+  - notes/highlights substrate
+  - scheduled digests and suggestion logic
+- Self-monitoring already provides:
+  - awareness-rule concepts
+  - escalation and cooldown ideas
+  - notification-oriented reflective workflows
+
+### Partial overlap
+
+- reflections and suggestions exist as design direction across personalization, digests, and self-monitoring, but are not yet unified
+- extension capture surfaces exist, but not as a generalized companion-ingestion adapter
+
+### Main gap
+
+The biggest missing primitive is a unified explicit-capture activity ledger that can power:
+
+- activity timeline UX
+- knowledge derivation
+- reflection generation
+- goal progress tracking
+- proactive suggestions with provenance
+
+## Recommended Product Direction
+
+Recommended approach: `Persona-first companion`
+
+Use the existing persona system as the interactive companion surface and build the missing activity/knowledge/reflection layer around it.
+
+Rejected alternatives:
+
+- `Personalization-first life log`
+  - cleaner from a data-model perspective, but delays value and duplicates existing persona surface area
+- `Digest/monitoring-first coach`
+  - useful for scheduled summaries, but weaker for conversational continuity and less aligned with current persona investment
+
+## Product Model
+
+Use only one new top-level user-facing workspace:
+
+- `Companion`
+
+`Persona Garden` remains separate and continues to own:
+
+- persona profile editing
+- persona state docs
+- scope rules
+- policy rules
+- live persona sessions
+
+`Companion` owns:
+
+- Activity
+- Knowledge
+- Reflections
+- Goals
+- Conversations
+
+This keeps persona configuration distinct from the user-facing companion experience.
+
+## Recommended Roadmap
+
+### Phase 1: Explicit Activity Ledger
+
+Create a first-class explicit activity model for:
+
+- reading-item saves
+- reading status changes
+- highlights and note edits
+- watchlist item additions
+- persona session summaries
+- important persona tool outcomes
+- reminder completions
+- optional manual user check-ins
+- extension-driven explicit captures such as page summary, save selection, and ask-about-page
+
+This phase is the core missing primitive.
+
+### Phase 2: Activity-Derived Knowledge
+
+Derive compact, user-editable knowledge from the activity ledger:
+
+- active topics
+- recurring projects
+- repeated research themes
+- stale or unfinished reading queues
+- source/domain focus areas
+- working preferences inferred from explicit behavior
+
+This phase should extend the personalization domain rather than create an unrelated memory system.
+
+### Phase 3: Reflections, Digests, and Goals
+
+Add inspectable, user-visible outputs:
+
+- daily/weekly reflections
+- saved-but-unrevisited suggestions
+- backlog summaries
+- project-focused summaries
+- lightweight goals tied to explicit activity
+- reminders and follow-ups
+
+These are user-facing and should run on the Jobs backend, with APScheduler only used to enqueue recurring work.
+
+### Phase 4: Companion Workspace
+
+Expose the system through a dedicated workspace:
+
+- activity timeline
+- knowledge cards
+- goals
+- reflection history
+- conversations with the companion persona
+- notification/inbox integration
+- provenance details for every suggestion or reflection
+
+## Feature Mapping
+
+### Adopt soon
+
+- activity timeline
+- knowledge base from activity
+- reflections
+- behavioral goals tied to explicit events
+- prompt/profile customization through persona profiles, state docs, and prompt library
+
+### Adopt later
+
+- proactive notifications
+- dedicated companion dashboard
+- browser-side quick capture actions for companion workflows
+
+### Do not copy directly
+
+- ambient screen capture
+- always-visible floating bubble
+- separate auth/product key model
+- Slack-style ambient communication monitoring
+
+## Architecture
+
+### Core principle
+
+Do not create a second parallel event system unless the existing personalization schema proves insufficient.
+
+Default architecture:
+
+- extend the personalization domain to hold the normalized explicit-capture activity ledger
+- let persona consume that context
+- keep persona state/memory separate from per-user companion knowledge
+
+### Proposed layers
+
+- `Companion Activity Adapter Layer`
+  - normalizes events from reading, highlights, notes, watchlists, reminders, and persona sessions
+- `Personalization Activity Store`
+  - stores normalized explicit activity events inside the personalization domain
+- `Companion Consolidation`
+  - derives knowledge cards, reflection inputs, and goal-progress signals
+- `Companion Orchestrator`
+  - prepares companion context for persona conversations and dashboard views
+- `Companion Workspace`
+  - renders Activity, Knowledge, Reflections, Goals, and Conversations
+
+### Ownership rules
+
+- Companion knowledge is per-user, source-linked, and editable.
+- Persona memory/state is per-persona, scoped, and not silently rewritten by companion inference.
+- Persona may read companion context during responses.
+- Companion reflections/goals may reference persona sessions, but they do not mutate persona state docs automatically.
+
+## Data Contract
+
+Every normalized activity event should include at minimum:
+
+- `event_type`
+- `source_type`
+- `source_id`
+- `surface`
+- `timestamp`
+- `tags`
+- `provenance`
+- `dedupe_key`
+
+Derived outputs should carry evidence links back to their source events/items.
+
+## Provenance Requirements
+
+Provenance is mandatory.
+
+Every reflection, suggestion, and goal-progress explanation must expose:
+
+- which source records were used
+- why they were selected
+- when they were captured
+- how many signals were involved
+
+This must be part of the API contract, not just UI copy.
+
+## Jobs and Scheduling
+
+User-visible durable work should use Jobs:
+
+- scheduled reflections
+- proactive summaries
+- goal progress evaluations
+- companion digest generation
+
+Recurring schedules should use APScheduler only to enqueue Jobs, following existing reading-digest and reminders patterns.
+
+## Notification Policy
+
+To avoid notification fatigue:
+
+- respect quiet hours and proactive preferences already present in personalization
+- enforce minimum evidence thresholds for proactive outputs
+- cap proactive reflection frequency
+- rank notifications before delivery
+- make all proactive outputs inspectable in the inbox and companion workspace
+
+## Relationship To Existing Systems
+
+### Persona
+
+Use persona as the conversation/action surface, not as the single storage layer for companion state.
+
+### Personalization
+
+Extend personalization for activity events and user-level derived knowledge. Avoid creating a separate user-modeling database unless forced by schema limitations.
+
+### Collections
+
+Use reading/watchlists/highlights/notes as primary explicit-capture inputs for the activity ledger.
+
+### Self-Monitoring
+
+Reuse notification, escalation, cooldown, and awareness ideas where useful, but keep productivity goals separate from guardian/self-monitoring rule models.
+
+### Notifications
+
+Use existing inbox/SSE/reminder infrastructure for delivery and acknowledgement flows.
+
+## Purge and Export Semantics
+
+Because this system models user behavior, purge/export semantics are part of v1:
+
+- derived knowledge, reflections, and goals must be purgeable
+- derivations should be reconstructible from source records where possible
+- the system should prefer references and compact summaries over large duplicated content copies
+
+## Testing Strategy
+
+### Unit
+
+- event normalization
+- dedupe behavior
+- consolidation logic
+- provenance assembly
+- goal-progress calculations
+- notification ranking/throttling
+
+### Integration
+
+- reading save/highlight/note to activity event
+- watchlist additions to activity event
+- persona session/tool outcome to activity event
+- reflection job to notification output
+- persona companion retrieval with activity and derived knowledge context
+
+### UX/behavioral
+
+- provenance visibility
+- quiet-hours enforcement
+- opt-in and opt-out behavior
+- purge behavior
+- web and extension parity for explicit capture entry points
+
+## Risks
+
+### Risk: duplicate storage semantics
+
+Mitigation:
+
+- keep source systems canonical
+- store activity rows as references plus compact metadata
+- keep derivations compact and rebuildable
+
+### Risk: persona sprawl
+
+Mitigation:
+
+- keep `Companion` separate from `Persona Garden`
+- do not overload persona endpoints with every companion concern
+
+### Risk: noisy proactive output
+
+Mitigation:
+
+- add evidence thresholds
+- rank and throttle suggestions
+- make every suggestion inspectable and dismissible
+
+### Risk: privacy confusion
+
+Mitigation:
+
+- use strict explicit-capture language everywhere
+- avoid ambient-monitoring language and product claims
+
+## Suggested v1 Deliverables
+
+1. Extend personalization event capture with a normalized explicit activity envelope.
+2. Build activity adapters for reading, highlights, notes, watchlists, reminders, and persona sessions.
+3. Add companion derivation logic for knowledge cards and reflections.
+4. Create Jobs-backed reflection generation and delivery.
+5. Add a `Companion` workspace with Activity, Knowledge, Reflections, Goals, and Conversations.
+6. Wire persona companion retrieval to the per-user companion knowledge layer.
+
+## Final Recommendation
+
+The best path for `tldw_server` is not to imitate Echo's hidden ambient-capture model.
+
+The best path is to turn the repo's existing persona, personalization, collections, notifications, and jobs infrastructure into a transparent, local-first `Companion` built from explicit user captures and actions. That produces most of Echo's useful value while staying consistent with `tldw_server`'s architecture, privacy posture, and existing product direction.

--- a/Docs/Plans/2026-03-10-macos-sandbox-runtimes-design.md
+++ b/Docs/Plans/2026-03-10-macos-sandbox-runtimes-design.md
@@ -1,0 +1,297 @@
+# macOS Sandbox Runtimes Design
+
+Date: 2026-03-10
+Status: Approved for planning
+Scope: `tldw_Server_API/app/core/Sandbox/` and related REST/MCP/ACP runtime contracts
+
+## 1. Summary
+
+This design adds first-class macOS-focused sandbox runtimes for Apple silicon hosts:
+
+- `vz_linux`: Linux guest VMs backed by Apple's `Virtualization.framework`
+- `vz_macos`: macOS guest VMs backed by Apple's `Virtualization.framework`
+- `seatbelt`: host-local restricted process execution for lower-trust cases
+
+The primary security rule is simple:
+
+- `untrusted` execution requires a full VM runtime
+- `seatbelt` is never accepted for `untrusted`
+- runtime admission stays capability-driven and fail-closed
+
+The provisioning baseline is per-run ephemeral VMs created from sealed templates plus APFS copy-on-write cloning. Warm sessions are a later optimization and should reuse the same template/control-plane model rather than introduce a weaker path.
+
+## 2. User-Confirmed Decisions
+
+1. The feature should support both macOS-native guest execution and Linux guests on macOS hosts.
+2. Apple silicon is the target host platform for the serious VM path.
+3. API/runtime exposure should use separate runtimes rather than hiding behavior behind a generic macOS selector.
+4. Per-run ephemeral VMs are the security baseline.
+5. Warm reusable sessions may be added later as an optimization.
+6. `untrusted` runs must use a full VM boundary, not seatbelt-only isolation.
+
+## 3. Problem
+
+The sandbox subsystem already has a capability-driven runtime seam and partial Lima support, but macOS support is still limited:
+
+- macOS-specific enforcement is mostly a stub today.
+- There is no first-class runtime for Apple `Virtualization.framework`.
+- Host-local restricted execution is not modeled as a distinct runtime with clear trust limits.
+- Fast macOS-specific provisioning via APFS copy-on-write cloning is not yet represented in the runtime lifecycle.
+
+Without explicit runtime contracts, it is too easy to blur together:
+
+- Linux-on-macOS execution versus macOS-on-macOS execution
+- VM isolation versus host-local restrictions
+- per-run ephemeral isolation versus long-lived session reuse
+
+That would weaken policy semantics and make the API misleading.
+
+## 4. Goals and Non-Goals
+
+### Goals
+
+1. Add first-class runtime types for `vz_linux`, `vz_macos`, and `seatbelt`.
+2. Preserve fail-closed policy admission across REST, MCP, and ACP.
+3. Make `untrusted` execution require a VM runtime on macOS hosts.
+4. Use sealed templates and APFS clone-based provisioning for fast ephemeral VM startup.
+5. Design warm sessions as an optimization layer on top of the same VM image/control-plane architecture.
+6. Keep host/runtime capability reporting explicit and descriptive.
+
+### Non-Goals
+
+1. Achieving parity on Intel Macs in the first phase.
+2. Treating seatbelt as equivalent to a VM boundary.
+3. Implementing broad allowlist networking on day one.
+4. Committing the implementation to Python-only runtime control if a native helper is the more defensible choice.
+
+## 5. Selected Architecture
+
+### 5.1 Runtime taxonomy
+
+Add new `RuntimeType` values:
+
+- `vz_linux`
+- `vz_macos`
+- `seatbelt`
+
+These are first-class runtime values, not aliases for `lima`.
+
+### 5.2 Trust-level rules
+
+- `vz_linux`
+  - allowed for `trusted`, `standard`, `untrusted`
+- `vz_macos`
+  - allowed for `trusted`, `standard`, `untrusted`
+- `seatbelt`
+  - allowed for `trusted`
+  - optionally allowed for `standard` only if explicitly enabled and the host policy is proven sufficient
+  - rejected for `untrusted`
+
+Phase 1 should bias conservative: if there is any doubt about `seatbelt` support for `standard`, ship it as `trusted`-only first.
+
+### 5.3 Capability-driven admission
+
+Extend runtime capability and preflight reporting to include:
+
+- host OS and version
+- Apple silicon requirement
+- helper readiness
+- template image readiness
+- trust-level support per runtime
+- support for `ephemeral_run_vm`
+- support for `warm_session_vm`
+- network policy readiness (`deny_all`, `allowlist`)
+- filesystem isolation guarantees
+
+The existing capability/preflight seam under `runtime_capabilities.py` is the right integration point.
+
+## 6. Control Plane Design
+
+### 6.1 Native helper requirement
+
+The VM control plane should not assume Python is the production-quality interface to Apple's virtualization APIs.
+
+The recommended model is a small native macOS helper, likely Swift-based, responsible for:
+
+- template validation
+- VM creation and boot
+- guest agent transport setup
+- suspend/resume support
+- structured lifecycle status reporting
+
+This helper should be treated as a constrained local control plane, similar in spirit to the privileged-helper direction already identified in the Lima design work.
+
+### 6.2 Hardened runtime clarification
+
+`hardened runtime` should be treated as a property of the signed native helper binary and its launch model, not as a per-request toggle on arbitrary subprocesses.
+
+That means the design should not promise "limited per-process isolation via seatbelt and the hardened runtime" as though both are runtime flags. The correct contract is:
+
+- a signed helper/launcher may operate under hardened-runtime constraints
+- the `seatbelt` runtime applies generated host policy to a launched process tree
+
+### 6.3 Guest command transport
+
+The VM runtimes should not depend on guest networking just to execute commands. Prefer a non-network control channel such as:
+
+- virtio socket / vsock style transport where available
+- serial/control socket fallback
+
+This keeps `deny_all` practical and avoids turning command transport into a hidden network dependency.
+
+## 7. Provisioning Model
+
+### 7.1 Image store
+
+Introduce an image/template store with:
+
+- sealed template manifests
+- versioned template metadata
+- template readiness checks
+- APFS clone lifecycle management
+- garbage collection and usage accounting
+
+### 7.2 APFS clone assumptions
+
+The design should be explicit about the unit of cloning.
+
+Do not describe provisioning as "clone the whole VM bundle" unless the implementation chooses a bundle format that is actually safe and efficient to clone as a unit. Instead, define a concrete clone strategy such as:
+
+- clone the disk image file(s) as the fast path
+- keep mutable run metadata outside the sealed template
+- maintain a manifest describing which files are cloned, generated, or immutable
+
+This avoids overstating what APFS copy-on-write cloning gives us.
+
+### 7.3 Ephemeral run baseline
+
+Per-run ephemeral VMs are the baseline path:
+
+1. Select runtime and validate policy.
+2. Validate host/helper/template readiness.
+3. Create a run-scoped clone from the template.
+4. Create the run bundle and workspace attachment.
+5. Boot the VM and wait for guest agent readiness.
+6. Execute the command, stream logs, capture artifacts.
+7. Destroy run state and revoke resources in `finally`.
+
+## 8. Warm Sessions
+
+Warm sessions are a later optimization, not the baseline security contract.
+
+The preferred design is not "keep every VM running forever." Instead:
+
+- support resumable VM sessions using save/restore or suspend/resume where the platform makes that practical
+- keep the same trust/runtime restrictions as the ephemeral path
+- ensure session resumption never bypasses authoritative preflight and policy checks
+
+This reduces always-on resource cost and fits better with the desired fast provisioning model.
+
+## 9. Networking and Filesystem Policy
+
+### 9.1 Networking
+
+Phase 1 network target:
+
+- strict `deny_all` for `vz_linux`
+- strict `deny_all` for `vz_macos`
+- no promise of strict allowlist until it is provable and verified
+
+`seatbelt` should only advertise the network guarantees that can actually be enforced and verified on the host. If those guarantees are not sufficient for the requested trust level, admission must fail closed.
+
+### 9.2 Filesystem
+
+- VM templates remain immutable.
+- Only the run workspace is writable.
+- Artifacts continue to flow through the existing artifact-root safety model.
+- Snapshot/restore export should be conservative until clone lifecycle auditing is complete.
+
+## 10. Error Semantics
+
+Reuse and extend the existing taxonomy:
+
+1. `runtime_unavailable`
+   - unsupported host
+   - helper missing
+   - Apple silicon missing
+   - template image missing
+2. `policy_unsupported`
+   - runtime exists but requested trust level or network mode is not allowed
+3. `permission_denied_host_enforcement`
+   - required helper capability or host control surface is not available
+4. `runtime_execution_failed`
+   - VM boot, guest handshake, or command path failed after admission
+
+Structured error details should include:
+
+- runtime
+- host facts
+- trust level
+- required capabilities
+- missing capabilities
+- template/helper readiness reasons
+
+## 11. Testing Strategy
+
+### Unit tests
+
+1. Runtime enum and schema acceptance for `vz_linux`, `vz_macos`, `seatbelt`
+2. Trust-level admission rules, especially `seatbelt` rejection for `untrusted`
+3. Preflight reason mapping for:
+   - non-Apple-silicon host
+   - helper missing
+   - template missing
+   - unsupported macOS version
+4. No-fallback behavior for all new runtimes
+
+### Fake integration tests
+
+1. Per-run clone lifecycle success and failure
+2. Cleanup on boot failure, cancelation, and timeout
+3. Warm-session resume contract without real platform dependencies
+4. Artifact and workspace isolation invariants
+
+### macOS-gated integration tests
+
+1. Apple silicon only
+2. Feature-flagged and opt-in
+3. Validate real helper handshake and real preflight
+4. Prefer targeted smoke coverage over trying to run the full VM matrix in every CI environment
+
+## 12. Rollout Recommendation
+
+1. Add runtime enums, capability contracts, and fail-closed admission.
+2. Add `seatbelt` as a lower-trust runtime with explicit restrictions.
+3. Add `vz_linux` ephemeral VM support backed by sealed templates and APFS clone provisioning.
+4. Add `vz_macos` ephemeral VM support after the control plane and image store are proven.
+5. Add warm sessions using suspend/resume or save/restore semantics.
+6. Add stricter allowlist networking only after deny-all and lifecycle cleanup are stable.
+
+`vz_linux` should ship before `vz_macos`. It delivers immediate macOS host support while keeping the operational model simpler than macOS guest virtualization.
+
+## 13. Key Risks and Improvements Identified During Review
+
+1. The original design was too vague about the VM control plane.
+   Improvement: require a native helper abstraction early instead of assuming Python can own production lifecycle management.
+
+2. The original design blurred hardened runtime semantics.
+   Improvement: model hardened runtime as a signed-helper property, not a run-level toggle.
+
+3. The original warm-session idea risked becoming "resident VMs forever."
+   Improvement: prefer suspend/resume or save/restore semantics over permanently running sessions.
+
+4. The original APFS clone language was too hand-wavy.
+   Improvement: define a concrete clone unit and manifest-driven template layout before promising "fast provisioning."
+
+5. `seatbelt` support for `standard` is easy to over-claim.
+   Improvement: ship conservative trust gating first, then expand only if the guarantees are demonstrably sufficient.
+
+## 14. References
+
+- Apple `Virtualization.framework`: https://developer.apple.com/documentation/virtualization
+- WWDC 2023, "Create macOS or Linux virtual machines": https://developer.apple.com/videos/play/wwdc2023/10007/
+- WWDC 2023, "Bring your virtual machine to life": https://developer.apple.com/videos/play/wwdc2023/10086/
+- Apple App Sandbox overview: https://developer.apple.com/documentation/security/app_sandbox
+- Apple Hardened Runtime overview: https://developer.apple.com/documentation/security/hardened_runtime
+- Agent Safehouse overview: https://agent-safehouse.dev/docs/overview
+- Agent Safehouse policy architecture: https://agent-safehouse.dev/docs/policy-architecture

--- a/Docs/Plans/2026-03-10-prompt-schema-foundation-design.md
+++ b/Docs/Plans/2026-03-10-prompt-schema-foundation-design.md
@@ -1,0 +1,498 @@
+# Prompt Schema Foundation Design
+
+Date: 2026-03-10
+Status: Approved
+Scope: shared structured prompt definition and assembly for Prompt Studio and the regular Prompts workspace, with server-side assembly, live preview, and legacy compatibility rendering
+
+## 1. Summary
+
+Add a shared prompt-schema foundation so prompts are authored as ordered, reusable blocks with declared variables instead of as a single raw insert string. The backend becomes the source of truth for validation and assembly, producing both canonical role-based messages and derived legacy `system_prompt` and `user_prompt` snapshots for older consumers.
+
+The design applies to both Prompt Studio and the regular Prompts workspace. Both surfaces edit the same canonical prompt definition, while execution and preview always flow through a shared server-side assembly service.
+
+Implementation scope for v1 is:
+
+- ordered blocks plus variable substitution only
+- no conditionals, loops, or mini-DSL
+- server-side assembly as the runtime contract
+- canonical role-based message output plus legacy compatibility rendering
+- coexistence with legacy prompts through explicit format/version markers and conversion tooling
+
+## 2. User-Approved Decisions
+
+1. The feature should be a shared foundation for Prompt Studio and the regular Prompts UI.
+2. The schema should own the runtime assembly contract, not just authoring convenience.
+3. The first version should support ordered sections and variables only.
+4. The canonical runtime output should be role-based messages, with a compatibility renderer for legacy `system_prompt` and `user_prompt` consumers.
+
+## 3. Review-Driven Revisions
+
+This design was revised after review to address the highest-risk gaps in the first draft:
+
+1. Add explicit `prompt_format` and `prompt_schema_version` fields so schema-backed prompts and legacy prompts cannot silently drift into mixed editing modes.
+2. Prevent dual-authoring. Once a prompt is `structured`, raw `system_prompt` and `user_prompt` remain preview/export fields only.
+3. Preserve search and indexing by storing or regenerating a derived searchable snapshot from structured content.
+4. Define provider compatibility rules for collapsing canonical role-based messages into older `system_message + user prompt` execution paths.
+5. Standardize on one variable engine for schema-backed prompts. v1 uses strict placeholder substitution only, not Jinja or arbitrary templating logic.
+6. Keep Prompt Studio signatures separate from prompt variables. Signatures remain I/O contracts; variables remain prompt input definitions.
+7. Version local sync payloads and conflict hashes in the regular Prompts workspace so structured prompts sync correctly through Dexie and Prompt Studio sync helpers.
+8. Define fixed insertion behavior for `few_shot_examples` and `modules_config` during v1 so preview and runtime remain aligned before those concepts become first-class block types.
+
+## 4. Current State
+
+### 4.1 Backend
+
+- The regular Prompts API stores `system_prompt` and `user_prompt` directly in `Prompts_DB`.
+- The regular Prompts API exposes regex-based variable extraction and rendering in `tldw_Server_API/app/api/v1/endpoints/prompts.py`.
+- Prompt Studio stores versioned prompts with `system_prompt`, `user_prompt`, `few_shot_examples`, `modules_config`, and optional `signature_id` in `PromptStudioDatabase`.
+- Prompt Studio execution in `tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py` still assembles prompts via direct string replacement rather than a reusable prompt-definition contract.
+- There is also a Jinja-based safe template renderer in `tldw_Server_API/app/core/Chat/prompt_template_manager.py`, creating multiple overlapping rendering paths.
+
+### 4.2 Frontend
+
+- The regular Prompts workspace centers on raw `system_prompt` and `user_prompt` editing in `apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx` and related editors.
+- Prompt Studio prompt editing in `apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx` is also text-first, with JSON textareas for advanced fields.
+- Variable support in the UI is currently limited to simple `{{variable}}` extraction/highlighting utilities.
+- The regular Prompts workspace keeps local prompt records in Dexie and syncs with Prompt Studio using hashes over raw prompt text in `apps/packages/ui/src/services/prompt-sync.ts`.
+
+### 4.3 Gaps
+
+- No shared canonical prompt-definition model exists across both prompt systems.
+- No single backend assembly service guarantees preview and execution parity.
+- Search/indexing assumes raw prompt text fields rather than structured blocks.
+- Existing sync and conflict logic treats `system_prompt` and `user_prompt` as the primary source of truth.
+- Prompt Studio signatures are adjacent to prompt composition, but do not solve prompt block authoring or runtime assembly.
+
+## 5. Goals and Non-Goals
+
+### 5.1 Goals
+
+- Provide a shared prompt-definition model for Prompt Studio and the regular Prompts workspace.
+- Let users author prompts as ordered named blocks with reusable variables.
+- Move validation and assembly to the backend so preview, sync, and execution share one source of truth.
+- Produce canonical role-based messages and derived legacy prompt snapshots from the same definition.
+- Preserve current search, sync, and interoperability expectations through explicit compatibility projections.
+- Support a safe migration path from legacy prompts to structured prompts.
+
+### 5.2 Non-Goals
+
+- No conditionals, loops, branching logic, or DSL in v1.
+- No arbitrary Jinja execution for schema-backed prompts.
+- No requirement that `few_shot_examples` and `modules_config` become first-class user-editable blocks in the first implementation pass.
+- No breaking removal of legacy prompt APIs during the first rollout.
+- No attempt to unify every prompt-like feature in the codebase at once, such as character cards or unrelated document-generator prompt storage.
+
+## 6. Proposed Architecture
+
+### 6.1 Shared Prompt Definition Domain Model
+
+Introduce a new shared prompt-schema package under:
+
+`tldw_Server_API/app/core/Prompt_Management/structured_prompts/`
+
+Core types:
+
+- `PromptDefinition`
+- `PromptVariableDefinition`
+- `PromptBlock`
+- `PromptAssemblyResult`
+- `PromptLegacySnapshot`
+- `PromptPreviewResult`
+
+Suggested canonical shape:
+
+```json
+{
+  "schema_version": 1,
+  "format": "structured",
+  "variables": [
+    {
+      "name": "topic",
+      "label": "Topic",
+      "description": "User-provided topic or source text",
+      "required": true,
+      "default_value": null,
+      "input_type": "textarea",
+      "options": null,
+      "max_length": 20000
+    }
+  ],
+  "blocks": [
+    {
+      "id": "identity",
+      "name": "Identity",
+      "role": "system",
+      "kind": "identity",
+      "content": "You are a precise research assistant.",
+      "enabled": true,
+      "order": 10,
+      "is_template": false
+    },
+    {
+      "id": "task",
+      "name": "Task",
+      "role": "user",
+      "kind": "task",
+      "content": "Analyze the following topic:\n\n{{topic}}",
+      "enabled": true,
+      "order": 20,
+      "is_template": true
+    }
+  ],
+  "assembly_config": {
+    "legacy_system_roles": ["system", "developer"],
+    "legacy_user_roles": ["user"],
+    "block_separator": "\n\n"
+  }
+}
+```
+
+### 6.2 Prompt Format Contract
+
+Add explicit format metadata to both prompt systems:
+
+- `prompt_format`: `legacy | structured`
+- `prompt_schema_version`: integer, nullable for legacy
+
+Rules:
+
+- Legacy prompts can still be stored and executed as raw fields.
+- Structured prompts must use `prompt_definition_json` as their source of truth.
+- Raw fields on structured prompts are derived compatibility snapshots, not editable peers.
+- Conversion from legacy to structured is explicit and one-way for authoring purposes.
+
+This prevents ambiguous writes from current text-first UIs, sync helpers, or background jobs.
+
+### 6.3 Shared Server-Side Assembly Service
+
+Create a reusable service with four responsibilities:
+
+1. `validate_definition(definition)`
+2. `assemble_messages(definition, variables, extras)`
+3. `render_legacy_snapshot(assembly_result)`
+4. `preview_definition(definition, sample_variables, extras)`
+
+Inputs:
+
+- prompt definition
+- variable values
+- optional assembly extras for few-shot examples, module expansion, and signature-aware hints
+
+Outputs:
+
+- canonical ordered role-based messages
+- variable resolution metadata
+- warnings and validation errors
+- derived legacy `system_prompt` and `user_prompt`
+- derived searchable text snapshot
+
+The same service must be used for:
+
+- Prompt Studio execution
+- Prompt Studio preview
+- regular Prompts preview
+- compatibility rendering for old consumers
+
+### 6.4 Compatibility Rendering Rules
+
+Canonical messages are the source of truth. Legacy projections are derived using explicit rules:
+
+- all `system` and `developer` blocks collapse into the legacy `system_prompt`
+- all `user` blocks collapse into the legacy `user_prompt`
+- `assistant` blocks are preserved in canonical messages, but legacy rendering folds them into the user snapshot using labeled transcript formatting if needed
+- block order is preserved within each compatibility rendering group
+
+This protects canonical fidelity while preserving older execution paths that only support one system string and one user string.
+
+### 6.5 Variable Engine
+
+Schema-backed prompts must use one strict substitution engine.
+
+V1 rules:
+
+- placeholder syntax is `{{variable_name}}`
+- names allow letters, digits, and underscores only
+- no expressions
+- no filters
+- no conditionals
+- missing required variables are execution errors
+- optional variables without values render as empty strings unless a default value exists
+
+This intentionally replaces the current mix of regex substitution, manual replacement, and Jinja rendering for structured prompts.
+
+### 6.6 Signatures vs Variables
+
+Prompt Studio signatures remain separate from prompt blocks.
+
+- prompt variables define what values can be injected into blocks
+- Prompt Studio signatures define structured input/output expectations for testing, evaluation, and optional output parsing
+
+Integration rule:
+
+- Prompt Studio can map signature input fields to prompt variables
+- Prompt Studio can use signature output schemas after execution
+- signatures do not become block definitions or block-editing contracts
+
+### 6.7 Few-Shot Examples and Modules in V1
+
+`few_shot_examples` and `modules_config` already exist in Prompt Studio and cannot be ignored during rollout.
+
+V1 approach:
+
+- keep storage shape stable for these fields initially
+- treat them as assembler inputs, not free-floating runtime side channels
+- insert few-shot examples into canonical message output at a fixed point before the final task/user block
+- expand supported module configs into generated system/developer guidance at a fixed point before user blocks
+- show both in preview so runtime and UI stay aligned
+
+Later phases may migrate both concepts into first-class block kinds once the core schema foundation is stable.
+
+### 6.8 Search and Indexing
+
+Structured content must remain searchable.
+
+Add a derived snapshot field or deterministic derived text computation for:
+
+- regular Prompts search and FTS
+- Prompt Studio list/search UX
+- conflict detection and compact preview text
+
+Suggested derived text shape:
+
+- prompt name
+- joined enabled block names
+- joined enabled block content
+- rendered few-shot/module summaries where applicable
+
+This avoids regressing search while keeping the canonical source structured.
+
+### 6.9 Local Sync and Conflict Detection
+
+The regular Prompts workspace currently syncs and detects conflicts using raw prompt text.
+
+Add:
+
+- `structuredPromptDefinition` to Dexie prompt records
+- `promptFormat`
+- `promptSchemaVersion`
+- `syncPayloadVersion`
+- canonical conflict hash computed from the structured definition plus derived compatibility fields
+
+This allows offline editing and sync to remain coherent once structured prompts are introduced.
+
+## 7. Data Model and Storage
+
+### 7.1 Regular Prompts Database
+
+Extend the `Prompts` table with:
+
+- `prompt_format TEXT NOT NULL DEFAULT 'legacy'`
+- `prompt_schema_version INTEGER`
+- `prompt_definition_json TEXT`
+- `rendered_legacy_system_prompt TEXT` or reuse existing `system_prompt` as derived snapshot
+- `rendered_legacy_user_prompt TEXT` or reuse existing `user_prompt` as derived snapshot
+- `searchable_prompt_text TEXT` if needed for FTS refresh or preview caching
+
+Migration requirements:
+
+- existing rows default to `legacy`
+- structured rows require valid `prompt_definition_json`
+- FTS refresh logic must include structured derived content
+
+### 7.2 Prompt Studio Database
+
+Extend `prompt_studio_prompts` with:
+
+- `prompt_format`
+- `prompt_schema_version`
+- `prompt_definition_json`
+- optional derived search/preview snapshot fields if query performance requires them
+
+Versioning rule:
+
+- each new prompt version stores the full prompt definition snapshot
+- compatibility fields are persisted as derived values for older consumers and search ergonomics
+
+### 7.3 API Models
+
+Add shared request/response support for:
+
+- prompt definition payloads
+- validation results
+- preview/assembly responses
+- conversion requests from legacy to structured
+
+Regular Prompts and Prompt Studio should expose the same core schema shape, even if the surrounding metadata differs.
+
+## 8. UX and Interaction Model
+
+### 8.1 Shared Editor Pattern
+
+Use the same mental model in both prompt surfaces:
+
+- left rail: ordered block list
+- center pane: selected block editor
+- right rail: preview and variables
+
+Primary actions:
+
+- add block from starter presets
+- reorder blocks
+- enable or disable blocks
+- duplicate blocks
+- define and edit variables
+- preview final canonical messages
+- preview derived legacy prompt
+- fill sample values to verify render output
+
+### 8.2 Prompt Studio
+
+Prompt Studio gets the structured editor first.
+
+Additional behavior:
+
+- test cases map onto prompt variables
+- execution preview uses the shared backend assembler
+- evaluation and optimization operate on the structured definition snapshot, not raw prompt fields
+- signatures remain visible as structured I/O contracts, separate from the block editor
+
+### 8.3 Regular Prompts Workspace
+
+Regular prompts should support:
+
+- quick-create legacy mode for small cases
+- convert-to-structured action
+- structured editor and preview for converted or newly structured prompts
+- sync-aware UX that shows whether a prompt is legacy or structured
+
+### 8.4 Starter Presets
+
+Starter block presets should mirror practical prompt-authoring patterns:
+
+- identity
+- core instructions
+- constraints
+- style rules
+- task
+- context
+- output format
+- examples
+
+This lines up with current OpenAI guidance to separate instructions, examples, context, and formatting rather than pushing everything into one undifferentiated prompt. See:
+
+- [Prompting](https://platform.openai.com/docs/guides/prompting)
+- [Prompt engineering strategies](https://platform.openai.com/docs/guides/prompt-engineering/strategies-to-improve-reliability)
+- [Text generation](https://platform.openai.com/docs/guides/text?api-mode=responses)
+
+## 9. Validation and Error Handling
+
+Validation levels:
+
+### 9.1 Definition Validation
+
+- invalid or duplicate variable names
+- invalid block roles
+- duplicate block ids
+- missing required fields
+- unsupported schema version
+
+### 9.2 Assembly Validation
+
+- unresolved required variables
+- block content length overflow
+- assembled prompt/message size overflow
+- invalid assistant-only prompt shapes when a target execution path cannot support them
+
+### 9.3 UX Warnings
+
+- empty enabled blocks
+- unused declared variables
+- unresolved optional variables
+- blocks omitted from legacy rendering
+
+Execution should fail with descriptive errors for invalid structured prompts. Preview should surface warnings without mutating stored state.
+
+## 10. Migration and Rollout
+
+### 10.1 Prompt States
+
+Every prompt is either:
+
+- `legacy`
+- `structured`
+
+No hybrid editable mode exists.
+
+### 10.2 Conversion
+
+Add conversion tooling:
+
+- wrap existing `system_prompt` into a default system block
+- wrap existing `user_prompt` into a default task/user block
+- extract existing `{{variables}}` into variable definitions where possible
+- carry over Prompt Studio few-shot examples and modules as assembler extras
+
+### 10.3 Rollout Order
+
+1. Backend schema types, validation, assembly, and preview endpoints
+2. Prompt Studio structured editor
+3. Prompt Studio execution/evaluation integration through the shared assembler
+4. Regular Prompts structured editor and conversion flow
+5. Dexie/local sync and conflict-hash migration
+6. Search/indexing hardening and compatibility cleanup
+
+This rollout limits breakage by moving server-side truth and Prompt Studio runtime first, then updating the more locally stateful regular Prompts workspace.
+
+## 11. Testing Strategy
+
+### 11.1 Backend Unit Tests
+
+- prompt definition validation
+- variable substitution
+- canonical message assembly
+- legacy compatibility rendering
+- few-shot/module insertion behavior
+- structured-to-legacy conversion
+
+### 11.2 Backend Integration Tests
+
+- regular Prompts CRUD with structured definitions
+- Prompt Studio CRUD with structured definitions
+- preview endpoints
+- Prompt Studio execution using assembled messages
+- sync-safe round trips of derived compatibility fields
+
+### 11.3 Frontend Tests
+
+- block reorder and enable/disable behavior
+- variable editor validation
+- live preview updates
+- conversion flows
+- legacy versus structured display states
+- sync conflict behavior for structured prompts
+
+### 11.4 Regression Focus
+
+- preview must match execution assembly
+- search must continue to find structured prompts
+- regular Prompt sync must not collapse structured prompts back into raw-only records
+- Prompt Studio signatures must continue to work independently of the block editor
+
+## 12. Risks and Open Questions
+
+1. Legacy compatibility rendering for assistant/example blocks can become lossy. The design accepts this for older consumers and preserves fidelity in canonical message output.
+2. Search/indexing cost may rise if derived snapshots are regenerated too often. Implementation should prefer deterministic regeneration on write rather than on every read.
+3. The regular Prompts workspace has more local/offline state complexity than Prompt Studio. That is why rollout should update Prompt Studio first.
+4. Prompt-like features outside these two surfaces may later benefit from the same schema foundation, but they are intentionally out of scope for the first pass.
+
+## 13. References
+
+- `tldw_Server_API/app/api/v1/endpoints/prompts.py`
+- `tldw_Server_API/app/core/DB_Management/Prompts_DB.py`
+- `tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py`
+- `tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py`
+- `tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py`
+- `apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx`
+- `apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx`
+- `apps/packages/ui/src/services/prompt-sync.ts`
+- `apps/packages/ui/src/db/dexie/types.ts`

--- a/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
@@ -10,6 +10,8 @@
 
 **Implementation scope note:** v1 supports ordered blocks plus variables only. Do not introduce conditionals, loops, Jinja execution, or a general prompt DSL while executing this plan.
 
+**Migration discipline note:** Do not edit historical Prompt Studio migrations once this work starts. Add new additive migrations for schema changes and let fresh databases reach the new shape by applying the full ordered migration chain.
+
 ---
 
 ### Task 1: Create the Shared Structured Prompt Domain Models and Validator
@@ -125,6 +127,30 @@ def test_assembler_returns_canonical_messages_and_legacy_snapshot():
     assert result.legacy.user_prompt == "Summarize SQLite FTS"
 ```
 
+```python
+def test_assembler_inserts_few_shot_examples_and_modules_at_fixed_points():
+    definition = make_definition(...)
+
+    result = assemble_prompt_definition(
+        definition,
+        {"topic": "SQLite FTS"},
+        extras={
+            "few_shot_examples": [
+                {
+                    "inputs": {"topic": "Indexes"},
+                    "outputs": {"answer": "Use the covering index."},
+                }
+            ],
+            "modules_config": [
+                {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+            ],
+        },
+    )
+
+    assert any(message["role"] == "assistant" for message in result.messages)
+    assert "concise" in result.legacy.system_prompt
+```
+
 **Step 2: Run test to verify it fails**
 
 Run:
@@ -158,7 +184,7 @@ source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py -v
 ```
 
-Expected: PASS, including missing-variable and compatibility-rendering tests.
+Expected: PASS, including missing-variable, compatibility-rendering, and extras insertion tests.
 
 **Step 5: Commit**
 
@@ -250,7 +276,6 @@ git commit -m "feat: add structured prompt support to prompts api"
 ### Task 4: Extend Prompt Studio Versioned Prompts for Structured Definitions
 
 **Files:**
-- Modify: `tldw_Server_API/app/core/DB_Management/migrations/001_prompt_studio_schema.sql`
 - Create: `tldw_Server_API/app/core/DB_Management/migrations/005_prompt_studio_structured_prompts.sql`
 - Modify: `tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py`
 - Modify: `tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py`
@@ -310,6 +335,8 @@ Add migration-backed support in Prompt Studio for:
 - storing the full structured definition snapshot per version
 - returning derived compatibility fields in responses
 
+Use the new `005_prompt_studio_structured_prompts.sql` migration for additive schema changes. Do not back-edit `001_prompt_studio_schema.sql`, because fresh databases should converge by applying the ordered migration chain rather than by maintaining two incompatible sources of schema truth.
+
 Do not break legacy Prompt Studio prompts or current history/revert behavior.
 
 **Step 4: Run test to verify it passes**
@@ -326,8 +353,7 @@ Expected: PASS for create, update, history, revert, and list coverage.
 **Step 5: Commit**
 
 ```bash
-git add tldw_Server_API/app/core/DB_Management/migrations/001_prompt_studio_schema.sql \
-        tldw_Server_API/app/core/DB_Management/migrations/005_prompt_studio_structured_prompts.sql \
+git add tldw_Server_API/app/core/DB_Management/migrations/005_prompt_studio_structured_prompts.sql \
         tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py \
         tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py \
         tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py \
@@ -364,6 +390,29 @@ def test_preview_endpoint_matches_assembled_messages(client, auth_headers):
     assert body["legacy"]["user_prompt"] == "Summarize Prompt engineering"
 ```
 
+```python
+def test_preview_endpoint_reflects_few_shot_examples_and_modules(client, auth_headers):
+    response = client.post(
+        "/api/v1/prompts/preview",
+        json={
+            "prompt_definition": make_prompt_definition_payload(),
+            "variables": {"topic": "Prompt engineering"},
+            "few_shot_examples": [
+                {"inputs": {"topic": "Caching"}, "outputs": {"answer": "Use prompt caching."}}
+            ],
+            "modules_config": [
+                {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+            ],
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "concise" in body["legacy"]["system_prompt"]
+    assert any(message["role"] == "assistant" for message in body["messages"])
+```
+
 **Step 2: Run test to verify it fails**
 
 Run:
@@ -391,6 +440,8 @@ async def convert_prompt_to_structured(...):
 ```
 
 Add preview and conversion endpoints for both APIs. Preview must always call the shared assembler. Conversion must wrap legacy `system_prompt` and `user_prompt` into default blocks and infer variables from existing placeholders where possible.
+
+Preview endpoints must also accept and render existing Prompt Studio `few_shot_examples` and `modules_config` payloads through the same assembler extras path used by runtime execution.
 
 **Step 4: Run test to verify it passes**
 
@@ -453,14 +504,20 @@ Expected: FAIL because `PromptExecutor` still performs direct string substitutio
 
 ```python
 if prompt.get("prompt_format") == "structured":
-    assembled = assemble_prompt_definition(...)
+    assembled = assemble_prompt_definition(
+        ...,
+        extras={
+            "few_shot_examples": prompt.get("few_shot_examples"),
+            "modules_config": prompt.get("modules_config"),
+        },
+    )
     messages = assembled.messages
     legacy = assembled.legacy
 else:
     ...
 ```
 
-Use canonical assembled messages for execution metadata and provider calls. Keep compatibility rendering only as an adapter for providers that still rely on `system_message + user prompt`.
+Use canonical assembled messages for execution metadata and provider calls. Pass existing `few_shot_examples` and `modules_config` through assembler extras so preview and execution stay aligned for Prompt Studio prompts that already depend on those fields. Keep compatibility rendering only as an adapter for providers that still rely on `system_message + user prompt`.
 
 **Step 4: Run test to verify it passes**
 
@@ -707,6 +764,7 @@ git commit -m "feat: add structured prompt conversion to prompts workspace"
 - Modify: `Docs/Published/API-related/Prompt_Studio_API.md`
 - Modify: `Docs/Plans/2026-03-10-prompt-schema-foundation-design.md`
 - Create: `tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py`
+- Create: `tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py`
 
 **Step 1: Write the failing test**
 
@@ -740,6 +798,14 @@ def build_structured_prompt_searchable_text(definition: dict[str, Any]) -> str:
 
 Update search/index refresh logic to derive searchable text from enabled blocks and persisted compatibility fields. Then run Bandit on touched backend paths before closing the work.
 
+Final verification must include:
+
+- regular Prompts structured API coverage
+- Prompt Studio structured versioning and execution coverage
+- Prompt Studio preview/execution parity for few-shot examples and modules
+- Dexie sync tests for structured prompts
+- UI editor coverage for Prompt Studio and the regular Prompts workspace
+
 **Step 4: Run verification to verify it passes**
 
 Run:
@@ -747,14 +813,23 @@ Run:
 ```bash
 source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py -v
+python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py -v
 python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py -v
 python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py -v
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py -v
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py -v
+python -m pytest tldw_Server_API/tests/prompt_studio/test_prompt_preview_api.py -v
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py -v
 python -m bandit -r tldw_Server_API/app/core/Prompt_Management/structured_prompts tldw_Server_API/app/api/v1/endpoints/prompts.py tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py -f json -o /tmp/bandit_prompt_schema_foundation.json
+bunx vitest run apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/StructuredPromptEditor.test.tsx
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
 ```
 
 Expected:
 
 - pytest PASS on the structured prompt suites
+- vitest PASS on the structured prompt UI and sync suites
 - Bandit completes without new high-signal findings in touched code
 
 **Step 5: Commit**
@@ -764,6 +839,7 @@ git add tldw_Server_API/app/core/DB_Management/Prompts_DB.py \
         tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py \
         Docs/Published/API-related/Prompt_Studio_API.md \
         Docs/Plans/2026-03-10-prompt-schema-foundation-design.md \
-        tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py
+        tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py \
+        tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py
 git commit -m "feat: finalize structured prompt search and verification"
 ```

--- a/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
@@ -1,0 +1,769 @@
+# Prompt Schema Foundation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a shared structured prompt-definition foundation for Prompt Studio and the regular Prompts workspace, with server-side validation and assembly, legacy compatibility rendering, and phased UI adoption.
+
+**Architecture:** Add a new backend `structured_prompts` package that owns the canonical prompt-definition model, validation, assembly, compatibility rendering, and preview output. Extend both prompt persistence layers to store explicit `legacy` versus `structured` formats, then wire Prompt Studio and the regular Prompts workspace to consume the shared backend contract rather than editing or executing raw prompt strings as the source of truth.
+
+**Tech Stack:** FastAPI, Pydantic v2, Loguru, SQLite-backed prompt stores and migrations, existing Prompt Studio services, Dexie, React, Ant Design, TanStack Query, Vitest, pytest, Bandit.
+
+**Implementation scope note:** v1 supports ordered blocks plus variables only. Do not introduce conditionals, loops, Jinja execution, or a general prompt DSL while executing this plan.
+
+---
+
+### Task 1: Create the Shared Structured Prompt Domain Models and Validator
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py`
+- Create: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py`
+- Create: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py`
+- Create: `tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_validator_rejects_duplicate_variable_names():
+    definition = {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {"name": "topic", "required": True, "input_type": "textarea"},
+            {"name": "topic", "required": False, "input_type": "text"},
+        ],
+        "blocks": [],
+    }
+
+    errors = validate_prompt_definition(definition)
+
+    assert errors[0].code == "duplicate_variable_name"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py::test_validator_rejects_duplicate_variable_names -v
+```
+
+Expected: FAIL with import errors because the structured prompt package does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+class PromptVariableDefinition(BaseModel):
+    name: str
+    required: bool = False
+    input_type: str = "text"
+
+
+class PromptBlock(BaseModel):
+    id: str
+    name: str
+    role: Literal["system", "developer", "user", "assistant"]
+    content: str
+    enabled: bool = True
+    order: int
+    is_template: bool = False
+
+
+def validate_prompt_definition(definition: dict[str, Any]) -> list[ValidationIssue]:
+    ...
+```
+
+Keep validation strict and boring. Reject duplicate variable names, invalid roles, duplicate block ids, and unsupported schema versions.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py -v
+```
+
+Expected: PASS for validation coverage.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py \
+        tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py \
+        tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py \
+        tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py
+git commit -m "feat: add structured prompt models and validator"
+```
+
+### Task 2: Build the Shared Prompt Assembler and Legacy Renderer
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/assembler.py`
+- Create: `tldw_Server_API/app/core/Prompt_Management/structured_prompts/legacy_renderer.py`
+- Create: `tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_assembler_returns_canonical_messages_and_legacy_snapshot():
+    definition = make_definition(
+        blocks=[
+            {"id": "sys", "name": "Identity", "role": "system", "content": "You are precise.", "order": 10},
+            {"id": "task", "name": "Task", "role": "user", "content": "Summarize {{topic}}", "order": 20, "is_template": True},
+        ],
+        variables=[{"name": "topic", "required": True, "input_type": "text"}],
+    )
+
+    result = assemble_prompt_definition(definition, {"topic": "SQLite FTS"})
+
+    assert result.messages == [
+        {"role": "system", "content": "You are precise."},
+        {"role": "user", "content": "Summarize SQLite FTS"},
+    ]
+    assert result.legacy.system_prompt == "You are precise."
+    assert result.legacy.user_prompt == "Summarize SQLite FTS"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py::test_assembler_returns_canonical_messages_and_legacy_snapshot -v
+```
+
+Expected: FAIL because no assembler exists yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+def assemble_prompt_definition(definition: PromptDefinition, variables: dict[str, Any], extras: dict[str, Any] | None = None) -> PromptAssemblyResult:
+    ...
+
+
+def render_legacy_snapshot(messages: list[dict[str, str]]) -> PromptLegacySnapshot:
+    ...
+```
+
+Use one strict `{{variable}}` substitution engine. Do not call Jinja for structured prompts. Preserve block order, collapse `system` and `developer` into legacy system output, and collapse `user` blocks into legacy user output.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py -v
+```
+
+Expected: PASS, including missing-variable and compatibility-rendering tests.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Prompt_Management/structured_prompts/assembler.py \
+        tldw_Server_API/app/core/Prompt_Management/structured_prompts/legacy_renderer.py \
+        tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py
+git commit -m "feat: add structured prompt assembler and legacy renderer"
+```
+
+### Task 3: Extend the Regular Prompts Persistence Layer for Structured Prompts
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Prompts_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/prompts_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/prompts.py`
+- Create: `tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_create_structured_prompt_persists_definition_and_format(client, auth_headers):
+    payload = {
+        "name": "Structured Summarizer",
+        "prompt_format": "structured",
+        "prompt_schema_version": 1,
+        "prompt_definition": make_prompt_definition_payload(),
+        "keywords": ["summary"],
+    }
+
+    response = client.post("/api/v1/prompts", json=payload, headers=auth_headers)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["prompt_format"] == "structured"
+    assert body["prompt_definition"]["schema_version"] == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py::test_create_structured_prompt_persists_definition_and_format -v
+```
+
+Expected: FAIL because the API and DB schema do not accept structured prompt fields.
+
+**Step 3: Write minimal implementation**
+
+```python
+class PromptCreate(PromptBase):
+    prompt_format: Literal["legacy", "structured"] = "legacy"
+    prompt_schema_version: int | None = None
+    prompt_definition: dict[str, Any] | None = None
+```
+
+Extend the `Prompts` table and stored payload logic so structured prompts persist:
+
+- `prompt_format`
+- `prompt_schema_version`
+- `prompt_definition_json`
+- derived compatibility/system-user snapshots
+
+Update read/write and export paths without breaking legacy rows.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py -v
+```
+
+Expected: PASS for create, get, list, update, and conversion coverage.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Prompts_DB.py \
+        tldw_Server_API/app/api/v1/schemas/prompts_schemas.py \
+        tldw_Server_API/app/api/v1/endpoints/prompts.py \
+        tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
+git commit -m "feat: add structured prompt support to prompts api"
+```
+
+### Task 4: Extend Prompt Studio Versioned Prompts for Structured Definitions
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/migrations/001_prompt_studio_schema.sql`
+- Create: `tldw_Server_API/app/core/DB_Management/migrations/005_prompt_studio_structured_prompts.sql`
+- Modify: `tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py`
+- Create: `tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_prompt_studio_update_creates_new_structured_prompt_version(prompt_studio_db):
+    created = prompt_studio_db.create_prompt(
+        project_id=1,
+        name="Structured Evaluator",
+        version_number=1,
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=make_prompt_definition_payload(),
+        client_id="test-client",
+    )
+
+    updated = prompt_studio_db.update_prompt(
+        created["id"],
+        {
+            "change_description": "Adjust instructions",
+            "prompt_definition": make_prompt_definition_payload(task_text="Evaluate {{input}} carefully."),
+        },
+    )
+
+    assert updated["version_number"] == 2
+    assert updated["prompt_definition"]["blocks"][1]["content"] == "Evaluate {{input}} carefully."
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py::test_prompt_studio_update_creates_new_structured_prompt_version -v
+```
+
+Expected: FAIL because Prompt Studio does not version structured prompt definitions yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+class PromptBase(BaseModel):
+    ...
+    prompt_format: Literal["legacy", "structured"] = "legacy"
+    prompt_schema_version: int | None = None
+    prompt_definition: dict[str, Any] | None = None
+```
+
+Add migration-backed support in Prompt Studio for:
+
+- storing prompt format/version
+- storing the full structured definition snapshot per version
+- returning derived compatibility fields in responses
+
+Do not break legacy Prompt Studio prompts or current history/revert behavior.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py -v
+```
+
+Expected: PASS for create, update, history, revert, and list coverage.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/migrations/001_prompt_studio_schema.sql \
+        tldw_Server_API/app/core/DB_Management/migrations/005_prompt_studio_structured_prompts.sql \
+        tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py \
+        tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py \
+        tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py \
+        tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py
+git commit -m "feat: add structured prompt versions to prompt studio"
+```
+
+### Task 5: Add Shared Preview and Conversion Endpoints
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/prompts.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/prompts_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py`
+- Create: `tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompt_preview_api.py`
+- Create: `tldw_Server_API/tests/prompt_studio/test_prompt_preview_api.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_preview_endpoint_matches_assembled_messages(client, auth_headers):
+    response = client.post(
+        "/api/v1/prompts/preview",
+        json={
+            "prompt_definition": make_prompt_definition_payload(),
+            "variables": {"topic": "Prompt engineering"},
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["messages"][1]["content"] == "Summarize Prompt engineering"
+    assert body["legacy"]["user_prompt"] == "Summarize Prompt engineering"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompt_preview_api.py \
+  tldw_Server_API/tests/prompt_studio/test_prompt_preview_api.py -v
+```
+
+Expected: FAIL because preview and conversion endpoints do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```python
+@router.post("/preview")
+async def preview_prompt(...):
+    return preview_prompt_definition(...)
+
+
+@router.post("/convert-to-structured")
+async def convert_prompt_to_structured(...):
+    ...
+```
+
+Add preview and conversion endpoints for both APIs. Preview must always call the shared assembler. Conversion must wrap legacy `system_prompt` and `user_prompt` into default blocks and infer variables from existing placeholders where possible.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompt_preview_api.py \
+  tldw_Server_API/tests/prompt_studio/test_prompt_preview_api.py -v
+```
+
+Expected: PASS with parity between preview messages and derived legacy snapshots.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/prompts.py \
+        tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py \
+        tldw_Server_API/app/api/v1/schemas/prompts_schemas.py \
+        tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py \
+        tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompt_preview_api.py \
+        tldw_Server_API/tests/prompt_studio/test_prompt_preview_api.py
+git commit -m "feat: add structured prompt preview and conversion endpoints"
+```
+
+### Task 6: Route Prompt Studio Execution Through the Shared Assembler
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py`
+- Modify: `tldw_Server_API/app/core/Prompt_Management/prompt_studio/test_runner.py`
+- Modify: `tldw_Server_API/app/core/Prompt_Management/prompt_studio/evaluation_manager.py`
+- Create: `tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py`
+
+**Step 1: Write the failing test**
+
+```python
+async def test_prompt_executor_uses_structured_assembly_for_prompt_studio(db):
+    prompt = create_structured_prompt_in_db(db)
+    executor = PromptExecutor(db)
+
+    result = await executor.execute(prompt["id"], {"topic": "retrieval"}, provider="openai", model="gpt-4o-mini")
+
+    assert result["success"] is True
+    assert result["metadata"]["assembled_messages"][1]["content"] == "Summarize retrieval"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py::test_prompt_executor_uses_structured_assembly_for_prompt_studio -v
+```
+
+Expected: FAIL because `PromptExecutor` still performs direct string substitution and ignores the new prompt definition.
+
+**Step 3: Write minimal implementation**
+
+```python
+if prompt.get("prompt_format") == "structured":
+    assembled = assemble_prompt_definition(...)
+    messages = assembled.messages
+    legacy = assembled.legacy
+else:
+    ...
+```
+
+Use canonical assembled messages for execution metadata and provider calls. Keep compatibility rendering only as an adapter for providers that still rely on `system_message + user prompt`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py -v
+```
+
+Expected: PASS, including preview-versus-execution parity tests.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py \
+        tldw_Server_API/app/core/Prompt_Management/prompt_studio/test_runner.py \
+        tldw_Server_API/app/core/Prompt_Management/prompt_studio/evaluation_manager.py \
+        tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py
+git commit -m "feat: route prompt studio execution through structured assembly"
+```
+
+### Task 7: Add Structured Prompt Types to Dexie and Sync Plumbing
+
+**Files:**
+- Modify: `apps/packages/ui/src/db/dexie/types.ts`
+- Modify: `apps/packages/ui/src/db/dexie/helpers.ts`
+- Modify: `apps/packages/ui/src/services/prompt-sync.ts`
+- Modify: `apps/packages/ui/src/services/prompt-studio.ts`
+- Create: `apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+it("preserves structured prompt definitions when syncing from workspace to studio", async () => {
+  const local = makeLocalPrompt({
+    promptFormat: "structured",
+    promptSchemaVersion: 1,
+    structuredPromptDefinition: makeStructuredPromptDefinition(),
+  })
+
+  const payload = localToServerPayload(local, 42)
+
+  expect(payload.prompt_format).toBe("structured")
+  expect(payload.prompt_definition?.schema_version).toBe(1)
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
+```
+
+Expected: FAIL because local prompt types and sync payloads do not know about structured prompts.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export type Prompt = {
+  ...
+  promptFormat?: "legacy" | "structured"
+  promptSchemaVersion?: number | null
+  structuredPromptDefinition?: StructuredPromptDefinition | null
+  syncPayloadVersion?: number | null
+}
+```
+
+Update sync hashing and conflict detection to hash canonical structured content when present. Keep legacy hashing for legacy prompts.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
+```
+
+Expected: PASS for local-to-server, server-to-local, and conflict-hash coverage.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/db/dexie/types.ts \
+        apps/packages/ui/src/db/dexie/helpers.ts \
+        apps/packages/ui/src/services/prompt-sync.ts \
+        apps/packages/ui/src/services/prompt-studio.ts \
+        apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
+git commit -m "feat: add structured prompt sync plumbing"
+```
+
+### Task 8: Build the Structured Prompt Studio Editor and Preview
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/Structured/BlockListPanel.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/Structured/BlockEditorPanel.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/Structured/VariableEditorPanel.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/Structured/AssemblyPreviewPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/__tests__/StructuredPromptEditor.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it("renders reordered blocks in preview order", async () => {
+  render(<StructuredPromptEditor initialDefinition={makeDefinition()} />)
+
+  await dragBlock("Task", "Identity")
+
+  expect(screen.getByTestId("assembly-preview")).toHaveTextContent("Task")
+  expect(screen.getByTestId("assembly-preview")).toHaveTextContent("Identity")
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/StructuredPromptEditor.test.tsx
+```
+
+Expected: FAIL because the structured editor components do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function StructuredPromptEditor(...) {
+  return (
+    <>
+      <BlockListPanel ... />
+      <BlockEditorPanel ... />
+      <VariableEditorPanel ... />
+      <AssemblyPreviewPanel ... />
+    </>
+  )
+}
+```
+
+Start with Prompt Studio only. Use the shared preview endpoint for the right-hand preview instead of local assembly logic.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/StructuredPromptEditor.test.tsx
+```
+
+Expected: PASS for reorder, enable/disable, variable editing, and preview updates.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx \
+        apps/packages/ui/src/components/Option/Prompt/Structured/BlockListPanel.tsx \
+        apps/packages/ui/src/components/Option/Prompt/Structured/BlockEditorPanel.tsx \
+        apps/packages/ui/src/components/Option/Prompt/Structured/VariableEditorPanel.tsx \
+        apps/packages/ui/src/components/Option/Prompt/Structured/AssemblyPreviewPanel.tsx \
+        apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx \
+        apps/packages/ui/src/components/Option/Prompt/__tests__/StructuredPromptEditor.test.tsx
+git commit -m "feat: add structured prompt editor to prompt studio"
+```
+
+### Task 9: Add Conversion and Structured Editing to the Regular Prompts Workspace
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Prompt/index.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx`
+- Modify: `apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx`
+- Create: `apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it("converts a legacy prompt into a structured prompt and locks raw fields", async () => {
+  render(<PromptDrawer open mode="edit" initialValues={makeLegacyPrompt()} ... />)
+
+  await user.click(screen.getByRole("button", { name: /convert to structured/i }))
+
+  expect(screen.getByText(/structured prompt/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/system prompt/i)).toBeDisabled()
+  expect(screen.getByLabelText(/user prompt/i)).toBeDisabled()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+```
+
+Expected: FAIL because the regular prompt UI has no structured conversion or lockout behavior yet.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+if (promptFormat === "structured") {
+  return <StructuredPromptEditor ... />
+}
+```
+
+Add:
+
+- explicit format state
+- convert-to-structured action
+- raw-field lockout for structured prompts
+- sync-aware persistence of the structured definition
+
+Do not remove legacy mode from the regular Prompts workspace in this phase.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+```
+
+Expected: PASS for conversion, structured editing, and raw-field lockout behavior.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx \
+        apps/packages/ui/src/components/Option/Prompt/index.tsx \
+        apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx \
+        apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx \
+        apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+git commit -m "feat: add structured prompt conversion to prompts workspace"
+```
+
+### Task 10: Harden Search, Security, and Verification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Prompts_DB.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py`
+- Modify: `Docs/Published/API-related/Prompt_Studio_API.md`
+- Modify: `Docs/Plans/2026-03-10-prompt-schema-foundation-design.md`
+- Create: `tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py`
+
+**Step 1: Write the failing test**
+
+```python
+def test_structured_prompt_search_indexes_block_content(client, auth_headers):
+    create_structured_prompt(client, auth_headers, name="Classifier", block_content="Classify {{text}} by sentiment")
+
+    response = client.get("/api/v1/prompts?search_query=sentiment", headers=auth_headers)
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["name"] == "Classifier"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py -v
+```
+
+Expected: FAIL because FTS/search does not yet index structured content.
+
+**Step 3: Write minimal implementation**
+
+```python
+def build_structured_prompt_searchable_text(definition: dict[str, Any]) -> str:
+    ...
+```
+
+Update search/index refresh logic to derive searchable text from enabled blocks and persisted compatibility fields. Then run Bandit on touched backend paths before closing the work.
+
+**Step 4: Run verification to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py -v
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py -v
+python -m pytest tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py -v
+python -m bandit -r tldw_Server_API/app/core/Prompt_Management/structured_prompts tldw_Server_API/app/api/v1/endpoints/prompts.py tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py -f json -o /tmp/bandit_prompt_schema_foundation.json
+```
+
+Expected:
+
+- pytest PASS on the structured prompt suites
+- Bandit completes without new high-signal findings in touched code
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Prompts_DB.py \
+        tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py \
+        Docs/Published/API-related/Prompt_Studio_API.md \
+        Docs/Plans/2026-03-10-prompt-schema-foundation-design.md \
+        tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py
+git commit -m "feat: finalize structured prompt search and verification"
+```

--- a/Docs/Plans/2026-03-10-vllm-managed-instances-design.md
+++ b/Docs/Plans/2026-03-10-vllm-managed-instances-design.md
@@ -1,0 +1,467 @@
+# Managed vLLM Instances Design
+
+Date: 2026-03-10
+Status: Approved
+Scope: managed `vllm` lifecycle, multi-instance routing, local and remote orchestration, chat/embeddings/multimodal inference via existing OpenAI-compatible provider path
+
+## 1. Summary
+
+Add first-class managed `vLLM` instances to `tldw_server` so operators can:
+
+- define multiple structured `vLLM` instance specs
+- launch and stop `vLLM` servers locally or on remote hosts
+- monitor readiness and health over time
+- route chat, embeddings, and multimodal requests to a selected managed instance
+
+The design keeps inference on the existing OpenAI-compatible `vllm` provider adapter, but moves lifecycle management into a dedicated control plane with durable instance storage, request-scoped routing, pluggable executors, and job-backed lifecycle operations.
+
+## 2. User-Approved Decisions
+
+1. `tldw_server` should own `vLLM` process lifecycle.
+2. `vLLM` should run as an external process, not as an in-process runtime inside `tldw_server`.
+3. Launch configuration should use structured settings, not a raw operator-provided command string.
+4. The design must account for embeddings and multimodal models from day one.
+5. Remote orchestration is in scope.
+6. Multiple managed `vLLM` instances are required.
+7. Remote control should support SSH first and leave room for a future agent-based path.
+
+## 3. Review-Driven Revisions
+
+This design was revised after review to address the highest-risk gaps:
+
+1. Instance specs and runtime metadata must be durable across `tldw_server` restarts.
+2. Request routing must be request-scoped and must not mutate global `vllm_api_IP` or related shared config.
+3. The executor contract must define direct reachability requirements for inference, especially for future agent mode.
+4. Capability handling for embeddings and multimodal models must distinguish operator declarations from active probes.
+5. SSH lifecycle management must rely on a stable remote launcher contract, not ad hoc shell backgrounding.
+6. Long-running lifecycle operations should be Jobs-backed rather than purely synchronous admin requests.
+7. `extra_args` must remain constrained and argv-based, not raw shell text.
+
+## 4. Current State
+
+### 4.1 Existing Capabilities
+
+- `vLLM` already exists as a chat provider in `tldw_Server_API/app/core/LLM_Calls/providers/local_adapters.py`.
+- The current `vllm` adapter is OpenAI-compatible HTTP and already supports the core request path used by chat.
+- Configuration already includes legacy single-endpoint keys such as `vllm_api_IP`, `vllm_model`, sampling defaults, retries, and timeouts.
+- The provider registry already exposes `vllm` as a first-class provider name.
+- The codebase already has two relevant lifecycle patterns:
+  - `llama.cpp`: older singleton process management in `app/core/Local_LLM`
+  - `mlx`: newer provider-specific lifecycle endpoints with a dedicated runtime registry
+
+### 4.2 Gaps
+
+- There is no multi-instance `vLLM` registry.
+- There is no durable managed runtime model for `vLLM`.
+- The existing `vllm` integration assumes a single configured endpoint rather than per-request instance selection.
+- There is no local or SSH-backed `vLLM` command builder/supervisor.
+- There is no admin API for creating, starting, stopping, probing, or selecting managed `vLLM` instances.
+- There is no capability contract for embeddings or multimodal `vLLM` instances.
+
+## 5. Goals And Non-Goals
+
+### 5.1 Goals
+
+- Add durable multi-instance `vLLM` management to `tldw_server`.
+- Support both local-host and SSH-managed `vLLM` execution in v1.
+- Reuse the existing OpenAI-compatible `vllm` inference adapter rather than inventing a separate inference stack.
+- Support routing for chat, embeddings, and multimodal requests from day one.
+- Provide explicit admin APIs and UI-ready status models for lifecycle operations.
+- Make lifecycle operations operationally safe through structured command building, health checks, and auditable status.
+
+### 5.2 Non-Goals
+
+- No generic managed-runtime framework for every local backend in this phase.
+- No promise of inference proxying through a future agent in v1.
+- No arbitrary shell command execution for `vLLM` management.
+- No automatic inference that every `vLLM` model supports embeddings or every multimodal mode from `/v1/models` alone.
+- No hidden mutation of process/global config to swap active `vLLM` endpoints mid-request.
+
+## 6. Proposed Architecture
+
+### 6.1 Durable Instance Registry
+
+Introduce a dedicated `VLLMInstanceRegistry` backed by durable storage.
+
+Each instance record stores:
+
+- identity: `instance_id`, display name, description, tags
+- execution mode: `local`, `ssh`, `agent`
+- launch spec: structured `vLLM` settings and constrained `extra_args`
+- routing policy: enabled, default-route eligibility, optional future tenant/org policy
+- capability metadata:
+  - `declared_capabilities`
+  - `probed_capabilities`
+  - `effective_capabilities`
+- observed runtime state:
+  - `desired_state`
+  - `observed_state`
+  - last known `base_url`
+  - pid/remote pid or executor handle metadata
+  - last health check
+  - last probe summary
+  - last error
+
+The registry is the source of truth for instance configuration. In-memory executor/session state is only a cache of current observation.
+
+### 6.2 Request-Scoped Routing
+
+Managed `vLLM` must not depend on mutating global settings such as `vllm_api_IP`.
+
+Instead, add a request-scoped routing layer:
+
+- request may specify `provider="vllm"` and `provider_instance_id`
+- if omitted, routing may fall back to one configured managed default instance
+- routing resolves a specific instance, endpoint, model, and capability envelope for the current request only
+
+This resolution must feed the existing `vllm` HTTP adapter as per-request override data.
+
+Result:
+
+- multiple concurrent requests can safely target different `vLLM` instances
+- no cross-request leakage occurs
+- backward compatibility remains possible through a managed default route
+
+### 6.3 Split Lifecycle From Inference
+
+Keep the existing `vllm` adapter for inference transport and request formatting.
+
+Add a new control-plane package for lifecycle management, for example:
+
+`tldw_Server_API/app/core/VLLM_Management/`
+
+Core responsibilities:
+
+1. instance CRUD and state management
+2. structured command building
+3. launch/stop/restart/probe orchestration
+4. health reconciliation
+5. request-time instance resolution
+
+This avoids mixing external process supervision logic into the OpenAI-compatible chat adapter.
+
+### 6.4 Executor Abstraction
+
+Define a common executor interface implemented by:
+
+- `LocalExecutor`
+- `SSHExecutor`
+- `AgentExecutor` placeholder
+
+Each executor must provide:
+
+- `start(instance_spec) -> lifecycle_result`
+- `stop(instance_spec, handle) -> stop_result`
+- `restart(instance_spec, handle) -> lifecycle_result`
+- `probe(instance_spec) -> probe_result`
+- `resolve_logs(instance_spec, handle) -> log_metadata`
+
+Every lifecycle result must include:
+
+- resolved `base_url`
+- executor lifecycle handle
+- log metadata
+- pid/remote pid metadata when known
+- a normalized readiness/health contract
+
+This keeps `local`, `ssh`, and future `agent` execution on the same state machine.
+
+### 6.5 SSH Remote Launcher Contract
+
+SSH mode should not use a fragile pattern like:
+
+- `ssh host "vllm serve ... &"`
+
+Instead, define a stable remote launcher contract:
+
+- install or provide a small remote launcher script
+- pass structured argv and metadata to that launcher
+- launcher starts `vllm`, writes pid/log/status metadata, and returns a normalized handle
+- stop/status operations use the same launcher contract
+
+Benefits:
+
+- stable pid tracking
+- safer quoting and argument handling
+- better orphan cleanup
+- predictable log collection and restart behavior
+
+### 6.6 Reachability Rule
+
+Phase 1 inference requires direct reachability from `tldw_server` to the managed `vLLM` HTTP endpoint.
+
+That means:
+
+- local instances must expose a reachable local URL
+- SSH-managed instances must expose a reachable remote URL to `tldw_server`
+- future agent-managed instances are only inference-capable in v1 if they also expose a directly reachable URL
+
+If future agent-managed instances do not expose direct reachability, the architecture must add inference proxying instead of pretending the current adapter path still works.
+
+### 6.7 Reconciler
+
+Add a background `VLLMReconciler` service that:
+
+- loads persisted instance specs on startup
+- probes existing known endpoints
+- updates observed state to `healthy`, `unhealthy`, `stopped`, `failed`, or `unknown`
+- reapplies monitoring and optional restart policy
+
+The reconciler should not blindly relaunch every instance on startup. Persisted `desired_state` and observed results must drive behavior.
+
+## 7. Launch Specification
+
+### 7.1 Structured Settings
+
+The launch spec should support structured `vLLM` settings such as:
+
+- `model`
+- `served_model_name`
+- `host`
+- `port`
+- `dtype`
+- `quantization`
+- `tensor_parallel_size`
+- `pipeline_parallel_size`
+- `gpu_memory_utilization`
+- `max_model_len`
+- `max_num_seqs`
+- `trust_remote_code`
+- `chat_template`
+- `limit_mm_per_prompt`
+- `api_key`
+- `download_dir`
+- `revision`
+- `tokenizer`
+- `tokenizer_mode`
+
+The exact list should track the supported `vllm serve` surface selected for the release, but the public API should remain structured and typed.
+
+### 7.2 Constrained Extra Args
+
+Allow `extra_args` only as a constrained list of validated pass-through flags.
+
+Rules:
+
+1. `extra_args` must be stored and processed as argv tokens, not raw shell text.
+2. shell concatenation is forbidden.
+3. dangerous/conflicting flags should be rejected.
+4. first-class structured fields win over conflicting pass-through args.
+
+This provides an escape hatch without turning the feature into arbitrary command execution.
+
+## 8. Capability Model
+
+### 8.1 Capability Sources
+
+Track three capability layers:
+
+- `declared_capabilities`
+  - operator says this instance is intended for chat, embeddings, vision, audio, or tool use
+- `probed_capabilities`
+  - health and lightweight runtime probes can confirm support or availability
+- `effective_capabilities`
+  - routing is allowed to use only what survives policy and probe validation
+
+### 8.2 Why This Split Is Required
+
+`/v1/models` alone is not enough to prove embeddings or multimodal support.
+
+Therefore:
+
+- some capabilities can be probed
+- some capabilities must be operator-declared
+- some capabilities should remain “unknown” until explicitly validated
+
+Routing should reject requests that require unsupported or unverified capabilities rather than silently failing deeper in the stack.
+
+## 9. Lifecycle Operations And Jobs
+
+Lifecycle operations can take long enough to exceed normal request budgets.
+
+Use Jobs for:
+
+- start
+- restart
+- likely probe
+- possibly stop when remote cleanup is slow
+
+Reasoning:
+
+- model startup can be slow
+- SSH reachability can hang or degrade
+- readiness and capability checks can take time
+- job-backed operations provide better operator visibility and retry behavior
+
+The instance API should return job metadata and current state summaries instead of forcing long synchronous waits.
+
+This follows the repository guidance that new user-visible/admin-visible operational work should default to Jobs.
+
+## 10. API Surface
+
+### 10.1 Instance CRUD
+
+- `POST /api/v1/llm/providers/vllm/instances`
+- `GET /api/v1/llm/providers/vllm/instances`
+- `GET /api/v1/llm/providers/vllm/instances/{instance_id}`
+- `PATCH /api/v1/llm/providers/vllm/instances/{instance_id}`
+- `DELETE /api/v1/llm/providers/vllm/instances/{instance_id}`
+
+### 10.2 Lifecycle
+
+- `POST /api/v1/llm/providers/vllm/instances/{instance_id}/start`
+- `POST /api/v1/llm/providers/vllm/instances/{instance_id}/stop`
+- `POST /api/v1/llm/providers/vllm/instances/{instance_id}/restart`
+- `POST /api/v1/llm/providers/vllm/instances/{instance_id}/probe`
+
+These endpoints should enqueue Jobs and return:
+
+- instance identifier
+- requested action
+- job identifier
+- current observed state snapshot
+
+### 10.3 Default Routing
+
+- `POST /api/v1/llm/providers/vllm/default`
+
+This endpoint sets or clears the managed default `vLLM` instance used when a request targets `provider="vllm"` without `provider_instance_id`.
+
+### 10.4 Request Contract Extension
+
+Prefer a generic request field:
+
+- `provider_instance_id`
+
+instead of a `vllm`-specific selector.
+
+Initial behavior:
+
+- meaningful for `provider="vllm"`
+- ignored or rejected for providers that do not support managed instances
+
+This avoids schema churn if other providers gain managed-instance routing later.
+
+## 11. Data Model
+
+### 11.1 Persistent Instance Record
+
+Suggested durable fields:
+
+- `instance_id`
+- `name`
+- `description`
+- `tags`
+- `execution_mode`
+- `launch_spec_json`
+- `routing_policy_json`
+- `declared_capabilities_json`
+- `desired_state`
+- `observed_state`
+- `last_known_base_url`
+- `last_probe_at`
+- `last_probe_summary_json`
+- `last_error`
+- `executor_metadata_json`
+- `created_at`
+- `updated_at`
+
+### 11.2 Runtime Observation Fields
+
+Observation-only metadata may include:
+
+- local pid
+- remote pid
+- launcher handle id
+- log path or log locator
+- last health latency
+- recent readiness failure reason
+
+These should be persisted where useful for operator debugging, but must be treated as observed state rather than configuration truth.
+
+## 12. Error Handling
+
+The control plane should produce explicit, instance-scoped failures for:
+
+- invalid launch configuration
+- unknown instance id
+- conflicting route/default selection
+- unreachable SSH host
+- failed remote launcher handshake
+- port already in use
+- readiness timeout
+- direct endpoint not reachable from `tldw_server`
+- capability mismatch for embeddings or multimodal requests
+- unhealthy or failed target instance
+
+Inference-side routing errors should clearly distinguish:
+
+- instance not found
+- instance not healthy
+- instance not reachable
+- instance lacks required capability
+
+## 13. Security
+
+- Management endpoints remain admin-only.
+- Secrets must be stored or referenced securely and redacted from logs and status payloads.
+- Command building must remain argv-based and never fall back to raw shell command strings.
+- SSH mode should prefer stored connection profiles or secret references rather than inline credentials.
+- `extra_args` must be constrained and validated.
+- Future agent mode must use explicit host registration and authenticated control-plane requests.
+
+## 14. Validation And Testing
+
+### 14.1 Unit Tests
+
+- instance registry CRUD and state transitions
+- command builder flag mapping and conflict resolution
+- constrained `extra_args` validation
+- request-scoped instance resolution
+- effective capability computation
+- executor contract normalization
+
+### 14.2 Integration Tests
+
+- create/list/update/delete instance APIs
+- start/restart/stop/probe endpoints returning Jobs metadata
+- default-instance routing
+- explicit `provider_instance_id` routing
+- unhealthy-instance rejection paths
+- SSH executor mocking with remote launcher contract validation
+
+### 14.3 Contract Tests
+
+- chat requests routed through a managed `vLLM` instance
+- embeddings requests routed only to effective embeddings-capable instances
+- multimodal requests routed only to effective multimodal-capable instances
+- concurrent requests targeting different managed `vLLM` instances without global-config leakage
+
+## 15. Rollout Plan
+
+### Phase 1
+
+- durable instance registry
+- local and SSH executors
+- structured command builder
+- Jobs-backed lifecycle endpoints
+- request-scoped routing into the existing `vllm` adapter
+- direct-reachability enforcement
+
+### Phase 2
+
+- agent executor implementation
+- richer capability probing
+- improved logs/metrics surface
+- optional restart policies and more advanced routing controls
+
+## 16. Recommended Next Step
+
+Write an implementation plan that stages the work in this order:
+
+1. persistent instance model and registry
+2. request-scoped routing and adapter integration
+3. local executor and local lifecycle APIs
+4. SSH executor with remote launcher contract
+5. Jobs-backed orchestration and reconciler
+6. capability enforcement, tests, and docs

--- a/Docs/Product/WebUI/PR_RELEASE_NOTES_ADMIN_UI_PROD_READINESS_2026_03_10.md
+++ b/Docs/Product/WebUI/PR_RELEASE_NOTES_ADMIN_UI_PROD_READINESS_2026_03_10.md
@@ -1,0 +1,96 @@
+# PR / Release Notes: Admin UI Production Readiness Remediation
+
+Date: 2026-03-10  
+Scope: `admin-ui` production-readiness remediation handoff and release-note summary
+
+## PR Summary
+
+This follow-up PR captures the release-note and operational handoff for the completed `admin-ui` production-readiness remediation series already present on `dev`.
+
+The underlying remediation work restored truthful build gates, aligned CI with the real frontend release bar, added browser smoke coverage for privileged flows, and reduced regression risk in the highest-risk user-management pages.
+
+## Remediation Scope
+
+The completed series addressed four areas:
+
+1. Truthful quality gates
+   - removed hidden build/type bypasses
+   - restored lint/build/typecheck as meaningful release signals
+
+2. Type safety and runtime correctness
+   - fixed remaining `admin-ui` type errors
+   - cleaned up runtime typing mismatches in critical pages and helpers
+
+3. Production confidence
+   - added Playwright smoke coverage for login/MFA and privileged user actions
+   - aligned the frontend-required gate with actual release checks
+   - updated release and README documentation to match the real gate
+
+4. Regression-surface reduction
+   - split oversized `/users` and `/users/[id]` pages into smaller typed components and hooks
+   - anchored the refactor with page-level regression coverage and focused helper tests
+
+## Commit Series
+
+Primary commits in the remediation sequence:
+
+- `056cade96` `docs: add admin-ui prod readiness reconciliation design`
+- `fd0bd1173` `docs: add admin-ui prod readiness remediation plan`
+- `90a3cd5ce` `fix(admin-ui): clear plan guard lint blockers`
+- `2e577a6e0` `fix(admin-ui): scope runtime typecheck and clean monitoring export`
+- `2462023ec` `fix(admin-ui): restore truthful type-safe build gates`
+- `78dadeda4` `test(admin-ui): add smoke coverage and align production gate`
+- `02d70a347` `refactor(admin-ui): split user management monoliths`
+
+## Validation Evidence
+
+Verified on the completed `admin-ui` branch:
+
+```bash
+cd admin-ui && bun run lint
+cd admin-ui && bun run test
+cd admin-ui && bun run build
+cd admin-ui && bun run typecheck
+cd admin-ui && bun run test:a11y
+cd admin-ui && bun run test:smoke
+```
+
+Observed outcomes:
+
+- `bun run test`: `113` files passed, `436` tests passed
+- `bun run test:a11y`: `7` files passed, `37` tests passed
+- `bun run test:smoke`: `2` Playwright smoke tests passed
+
+Note: the smoke suite requires permission to bind `127.0.0.1:3001` for the temporary Next dev server.
+
+## Operational Handoff
+
+Release owners should treat this series as a production-hardening package for the admin control plane.
+
+Before shipping:
+
+- ensure the backend environment exposes the auth, MFA, session, and audit endpoints expected by `admin-ui`
+- keep the `frontend-required` workflow enforcing lint, typecheck, unit tests, build, and smoke coverage for `admin-ui` changes
+- preserve the Bun-based commands in release documentation and CI
+
+After shipping:
+
+- monitor login/MFA success rates and admin privileged-action failures
+- watch for schema drift between `admin-ui` and backend admin endpoints
+- keep future changes to `/users` and `/users/[id]` covered by the extracted helper/page tests
+
+## User-Facing Release Notes Snippet
+
+### Admin Console Production Hardening
+
+The admin console now ships with stronger build validation, improved privileged-flow coverage, and a safer user-management surface. Login/MFA and sensitive user actions have dedicated smoke coverage, and the most complex user-management screens were refactored into smaller tested units to reduce regression risk.
+
+## Known Limitations
+
+1. This PR is a handoff artifact; the code remediation itself is already present on `dev`.
+2. Browser smoke coverage is intentionally narrow and targets the highest-risk privileged flows rather than every admin route.
+3. Production rollout still depends on backend endpoint compatibility and deployment hygiene outside `admin-ui` itself.
+
+## Go / No-Go
+
+Go for the `admin-ui` remediation scope covered by this series, assuming standard backend and deployment release checks remain green.

--- a/admin-ui/README.md
+++ b/admin-ui/README.md
@@ -58,6 +58,24 @@ bun run dev
 
 Open `http://localhost:3001`.
 
+## Quality Gate
+
+Run the production gate from `admin-ui/` before cutting a release or merging risky admin changes:
+
+```bash
+bun run lint
+bun run typecheck
+bun run test
+bun run test:a11y
+bun run build
+bun run test:smoke
+```
+
+`test:smoke` starts a local Next server by default, stubs the critical `/api/auth/*` and `/api/proxy/*`
+calls in-browser, and verifies the hardened password+MFA login path plus privileged user actions.
+It does not require a live backend. To point the smoke suite at an already running server, set
+`TLDW_ADMIN_UI_AUTOSTART=false` and `TLDW_ADMIN_UI_URL=http://127.0.0.1:3001`.
+
 ## Authentication
 
 - **Single-user mode**: API key login remains supported, but the validated key is moved into an

--- a/admin-ui/Release_Checklist.md
+++ b/admin-ui/Release_Checklist.md
@@ -35,6 +35,7 @@ This checklist covers release readiness for the admin UI (Next.js). Treat it as 
 
 - [ ] Run `bun install` from `admin-ui/`.
 - [ ] Run `bun run lint` and address warnings.
+- [ ] Run `bun run typecheck` and fix all TypeScript errors.
 - [ ] Run `bun run build` and confirm the build completes without errors.
 - [ ] Start the production build (`bun run start`) and confirm pages load correctly.
 
@@ -43,9 +44,12 @@ This checklist covers release readiness for the admin UI (Next.js). Treat it as 
 ## 5. Test Matrix (Frontend)
 
 - [ ] Run unit tests (`bun run test` or `bunx vitest run`).
+- [ ] Run accessibility coverage (`bun run test:a11y`).
+- [ ] Run browser smoke coverage (`bun run test:smoke`).
 - [ ] Confirm React Testing Library coverage for new UI flows and error states.
 - [ ] If snapshots are used, review and update them intentionally.
 - [ ] Verify key pages (dashboard, monitoring, auth/config views) render without console errors.
+- [ ] Verify the smoke suite still covers password login, MFA completion, and privileged user actions.
 
 ---
 

--- a/admin-ui/app/dependencies/page.tsx
+++ b/admin-ui/app/dependencies/page.tsx
@@ -100,8 +100,9 @@ const toProviderList = (payload: unknown): Provider[] => {
     return providers;
   }
 
-  if (asRecord(rawProviders)) {
-    Object.entries(rawProviders).forEach(([providerName, providerValue]) => {
+  const rawProvidersRecord = asRecord(rawProviders);
+  if (rawProvidersRecord) {
+    Object.entries(rawProvidersRecord).forEach(([providerName, providerValue]) => {
       const parsed = parseProvider(providerName, providerValue);
       if (parsed) providers.push(parsed);
     });

--- a/admin-ui/app/incidents/page.tsx
+++ b/admin-ui/app/incidents/page.tsx
@@ -32,7 +32,7 @@ import {
 import { useUrlPagination } from '@/lib/use-url-state';
 import { usePagedResource } from '@/lib/use-paged-resource';
 import type { IncidentItem } from '@/types/incidents';
-import { RefreshCw, Trash2 } from 'lucide-react';
+import { AlertTriangle, RefreshCw, Trash2 } from 'lucide-react';
 
 const STATUSES = ['open', 'investigating', 'mitigating', 'resolved'] as const;
 const SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;

--- a/admin-ui/app/jobs/page.tsx
+++ b/admin-ui/app/jobs/page.tsx
@@ -1521,7 +1521,7 @@ export default function JobsPage() {
                         Attachments ({jobAttachments.length})
                       </Label>
                       <div className="rounded-md border">
-                        <Table caption={`Job attachments table with ${selectedJobAttachments.length} rows.`}>
+                        <Table caption={`Job attachments table with ${jobAttachments.length} rows.`}>
                           <TableHeader>
                             <TableRow>
                               <TableHead>Name</TableHead>

--- a/admin-ui/app/monitoring/__tests__/page.test.tsx
+++ b/admin-ui/app/monitoring/__tests__/page.test.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import MonitoringPage, { normalizeHealthStatus } from '../page';
+import MonitoringPage from '../page';
+import { normalizeHealthStatus } from '../status-utils';
 import { api } from '@/lib/api-client';
 import { formatAxeViolations, getCriticalAndSeriousAxeViolations } from '@/test-utils/axe';
 

--- a/admin-ui/app/monitoring/components/MetricsChart.tsx
+++ b/admin-ui/app/monitoring/components/MetricsChart.tsx
@@ -123,8 +123,8 @@ export default function MetricsChart({
                     border: '1px solid hsl(var(--border))',
                     borderRadius: '8px',
                   }}
-                  formatter={(value: unknown, _name: string, item: { dataKey?: string | number }) => {
-                    const key = String(item.dataKey ?? '');
+                  formatter={(value, name, item) => {
+                    const key = String(item?.dataKey ?? name ?? '');
                     if (['cpu', 'memory', 'diskUsage'].includes(key)) {
                       const percent = typeof value === 'number' && Number.isFinite(value) ? value.toFixed(1) : value;
                       return [`${percent}%`, SERIES_DEFINITIONS.find((series) => series.key === key)?.label ?? key];
@@ -153,4 +153,3 @@ export default function MetricsChart({
     </Card>
   );
 }
-

--- a/admin-ui/app/monitoring/components/NotificationsPanel.tsx
+++ b/admin-ui/app/monitoring/components/NotificationsPanel.tsx
@@ -74,7 +74,9 @@ const NotificationsPanelShell = ({
         <Button
           variant="outline"
           size="sm"
-          onClick={onTest}
+          onClick={() => {
+            void onTest();
+          }}
           disabled={loading || saving || enabledChannels === 0}
         >
           <Send className="mr-2 h-4 w-4" />

--- a/admin-ui/app/monitoring/components/TimeRangeControls.tsx
+++ b/admin-ui/app/monitoring/components/TimeRangeControls.tsx
@@ -14,10 +14,10 @@ type TimeRangeControlsProps = {
   customRangeStart: string;
   customRangeEnd: string;
   rangeValidationError: string;
-  onSelectTimeRange: (value: MonitoringTimeRangeOption) => Promise<void> | void;
+  onSelectTimeRange: (value: MonitoringTimeRangeOption) => Promise<boolean> | boolean | void;
   onCustomRangeStartChange: (value: string) => void;
   onCustomRangeEndChange: (value: string) => void;
-  onApplyCustomRange: () => Promise<void> | void;
+  onApplyCustomRange: () => Promise<boolean> | boolean | void;
 };
 
 export default function TimeRangeControls({

--- a/admin-ui/app/monitoring/load-state-utils.ts
+++ b/admin-ui/app/monitoring/load-state-utils.ts
@@ -183,9 +183,9 @@ export const resolveMonitoringLoadState = ({
     ? normalizeWatchlistsPayload(settledResults.watchlistsData.value)
     : null;
 
-  const alertsDataFulfilled = settledResults.alertsData.status === 'fulfilled';
-  const normalizedAlerts = alertsDataFulfilled
-    ? normalizeMonitoringAlertsPayload(settledResults.alertsData.value)
+  const alertsResult = settledResults.alertsData;
+  const normalizedAlerts = alertsResult.status === 'fulfilled'
+    ? normalizeMonitoringAlertsPayload(alertsResult.value)
     : null;
 
   const alerts = normalizedAlerts

--- a/admin-ui/app/monitoring/page.tsx
+++ b/admin-ui/app/monitoring/page.tsx
@@ -2,19 +2,12 @@
 
 import { PermissionGuard } from '@/components/PermissionGuard';
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
-import {
-  normalizeMonitoringHealthStatus,
-} from '@/lib/monitoring-health';
 import MonitoringFeedbackBanners from './components/MonitoringFeedbackBanners';
 import MonitoringManagementPanels from './components/MonitoringManagementPanels';
 import MonitoringMetricsSection from './components/MonitoringMetricsSection';
 import MonitoringPageHeader from './components/MonitoringPageHeader';
+import { normalizeHealthStatus } from './status-utils';
 import { useMonitoringPageController } from './use-monitoring-page-controller';
-import type { SystemHealthStatus } from './types';
-
-export const normalizeHealthStatus = (status?: string): SystemHealthStatus => {
-  return normalizeMonitoringHealthStatus(status);
-};
 
 export default function MonitoringPage() {
   const {

--- a/admin-ui/app/monitoring/page.tsx
+++ b/admin-ui/app/monitoring/page.tsx
@@ -6,7 +6,6 @@ import MonitoringFeedbackBanners from './components/MonitoringFeedbackBanners';
 import MonitoringManagementPanels from './components/MonitoringManagementPanels';
 import MonitoringMetricsSection from './components/MonitoringMetricsSection';
 import MonitoringPageHeader from './components/MonitoringPageHeader';
-import { normalizeHealthStatus } from './status-utils';
 import { useMonitoringPageController } from './use-monitoring-page-controller';
 
 export default function MonitoringPage() {

--- a/admin-ui/app/monitoring/status-utils.ts
+++ b/admin-ui/app/monitoring/status-utils.ts
@@ -1,0 +1,5 @@
+import { normalizeMonitoringHealthStatus } from '@/lib/monitoring-health';
+import type { SystemHealthStatus } from './types';
+
+export const normalizeHealthStatus = (status?: string): SystemHealthStatus =>
+  normalizeMonitoringHealthStatus(status);

--- a/admin-ui/app/monitoring/use-monitoring-data-loader.ts
+++ b/admin-ui/app/monitoring/use-monitoring-data-loader.ts
@@ -29,7 +29,7 @@ type UseMonitoringDataLoaderArgs = {
     timeRange: MonitoringTimeRangeOption,
     customRangeStart?: string,
     customRangeEnd?: string
-  ) => Promise<void> | void;
+  ) => Promise<boolean> | boolean | void;
   markMonitoringDataUpdated: () => void;
   setLoading: (value: boolean) => void;
   setError: (value: string) => void;

--- a/admin-ui/app/monitoring/use-monitoring-metrics-history.ts
+++ b/admin-ui/app/monitoring/use-monitoring-metrics-history.ts
@@ -62,8 +62,8 @@ export const useMonitoringMetricsHistory = ({
 
   const loadMetricsHistoryForRange = useCallback(async (
     selectedRange: MonitoringTimeRangeOption,
-    customStart: string,
-    customEnd: string
+    customStart = customRangeStart,
+    customEnd = customRangeEnd
   ): Promise<boolean> => {
     const resolvedRange = resolveMonitoringRangeParams(selectedRange, customStart, customEnd);
     if (!resolvedRange.ok) {
@@ -119,7 +119,7 @@ export const useMonitoringMetricsHistory = ({
       }
       return false;
     }
-  }, [apiClient]);
+  }, [apiClient, customRangeEnd, customRangeStart]);
 
   useEffect(() => {
     void loadMetricsHistoryForRange(timeRange, customRangeStart, customRangeEnd);

--- a/admin-ui/app/monitoring/use-monitoring-metrics-section-props.ts
+++ b/admin-ui/app/monitoring/use-monitoring-metrics-section-props.ts
@@ -18,10 +18,10 @@ type UseMonitoringMetricsSectionPropsArgs = {
   customRangeStart: string;
   customRangeEnd: string;
   rangeValidationError: string;
-  onSelectTimeRange: (value: MonitoringTimeRangeOption) => Promise<void> | void;
+  onSelectTimeRange: (value: MonitoringTimeRangeOption) => Promise<boolean> | boolean | void;
   onCustomRangeStartChange: (value: string) => void;
   onCustomRangeEndChange: (value: string) => void;
-  onApplyCustomRange: () => Promise<void> | void;
+  onApplyCustomRange: () => Promise<boolean> | boolean | void;
   metricsHistory: MetricsHistoryPoint[];
   rangeLabel: string;
   seriesVisibility: MonitoringMetricsSeriesVisibility;

--- a/admin-ui/app/onboarding/__tests__/page.test.tsx
+++ b/admin-ui/app/onboarding/__tests__/page.test.tsx
@@ -71,7 +71,6 @@ import { api } from '@/lib/api-client';
 import { isBillingEnabled } from '@/lib/billing';
 
 const mockedGetPlans = api.getPlans as ReturnType<typeof vi.fn>;
-const mockedCreateOnboardingSession = api.createOnboardingSession as ReturnType<typeof vi.fn>;
 const mockedIsBillingEnabled = isBillingEnabled as ReturnType<typeof vi.fn>;
 
 describe('OnboardingPage', () => {

--- a/admin-ui/app/onboarding/page.tsx
+++ b/admin-ui/app/onboarding/page.tsx
@@ -79,7 +79,6 @@ function OnboardingPageContent() {
 
   const {
     register,
-    handleSubmit,
     getValues,
     trigger,
     formState: { errors },

--- a/admin-ui/app/organizations/[id]/page.tsx
+++ b/admin-ui/app/organizations/[id]/page.tsx
@@ -252,7 +252,7 @@ export default function OrganizationDetailPage() {
       const result = await api.createOrgInvite(orgId, {
         email: inviteEmail,
         role: inviteRole,
-      });
+      }) as { invite_url?: string; link?: string };
       setInviteLink(result.invite_url || result.link || 'Invite created - check email');
       setSuccess('Invite created successfully');
       setInviteEmail('');

--- a/admin-ui/app/page.tsx
+++ b/admin-ui/app/page.tsx
@@ -231,13 +231,18 @@ export default function DashboardPage() {
       setSecurityHealthError('');
 
       const orgParams = selectedOrg ? { org_id: String(selectedOrg.id) } : undefined;
-      const auditParams = selectedOrg ? { limit: '10', org_id: String(selectedOrg.id) } : { limit: '10' };
-      const usageDailyParams = selectedOrg
-        ? { limit: '200', org_id: String(selectedOrg.id) }
-        : { limit: '200' };
-      const llmUsageSummaryParams = selectedOrg
-        ? { group_by: 'day', org_id: String(selectedOrg.id) }
-        : { group_by: 'day' };
+      const auditParams: Record<string, string> = {
+        limit: '10',
+        ...(selectedOrg ? { org_id: String(selectedOrg.id) } : {}),
+      };
+      const usageDailyParams: Record<string, string> = {
+        limit: '200',
+        ...(selectedOrg ? { org_id: String(selectedOrg.id) } : {}),
+      };
+      const llmUsageSummaryParams: Record<string, string> = {
+        group_by: 'day',
+        ...(selectedOrg ? { org_id: String(selectedOrg.id) } : {}),
+      };
       const activityQuery = getDashboardActivityQuery(activityRange);
 
       // Fetch all dashboard data in parallel

--- a/admin-ui/app/plans/page.tsx
+++ b/admin-ui/app/plans/page.tsx
@@ -17,7 +17,7 @@ import { Form, FormInput, FormSelect } from '@/components/ui/form';
 import { CreditCard, Plus, Pencil, Trash2 } from 'lucide-react';
 import { api } from '@/lib/api-client';
 import { isBillingEnabled } from '@/lib/billing';
-import { Plan, PlanTier } from '@/types';
+import { Plan } from '@/types';
 
 const planSchema = z.object({
   name: z.string().min(1, 'Plan name is required'),

--- a/admin-ui/app/plans/page.tsx
+++ b/admin-ui/app/plans/page.tsx
@@ -19,9 +19,11 @@ import { api } from '@/lib/api-client';
 import { isBillingEnabled } from '@/lib/billing';
 import { Plan } from '@/types';
 
+const PLAN_TIERS = ['free', 'pro', 'enterprise'] as const;
+
 const planSchema = z.object({
   name: z.string().min(1, 'Plan name is required'),
-  tier: z.enum(['free', 'pro', 'enterprise'], { required_error: 'Tier is required' }),
+  tier: z.enum(PLAN_TIERS),
   monthly_price_cents: z.coerce.number().int().min(0, 'Price must be non-negative'),
   included_token_credits: z.coerce.number().int().min(0, 'Must be non-negative'),
   overage_rate_per_1k_tokens_cents: z.coerce.number().int().min(0, 'Must be non-negative'),
@@ -29,7 +31,8 @@ const planSchema = z.object({
   stripe_price_id: z.string().optional(),
 });
 
-type PlanFormData = z.infer<typeof planSchema>;
+type PlanFormInput = z.input<typeof planSchema>;
+type PlanFormData = z.output<typeof planSchema>;
 
 const tierOptions = [
   { value: 'free', label: 'Free' },
@@ -51,7 +54,7 @@ export default function PlansPage() {
   const [editingPlan, setEditingPlan] = useState<Plan | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
-  const form = useForm<PlanFormData>({
+  const form = useForm<PlanFormInput, unknown, PlanFormData>({
     resolver: zodResolver(planSchema),
     defaultValues: {
       name: '',

--- a/admin-ui/app/providers/page.tsx
+++ b/admin-ui/app/providers/page.tsx
@@ -663,6 +663,7 @@ export default function ProvidersPage() {
       apiKey: '',
       clearApiKey: false,
       isSaving: false,
+      isDeleting: false,
     });
   };
 
@@ -739,7 +740,7 @@ export default function ProvidersPage() {
       message: `Remove override for ${formatProviderName(overrideDialog.provider.name)}?`,
       confirmText: 'Remove',
       variant: 'danger',
-      icon: 'trash',
+      icon: 'delete',
     });
     if (!confirmed) return;
     try {
@@ -768,7 +769,7 @@ export default function ProvidersPage() {
         provider: provider.name,
         model: overrideDefaultModel || provider.default_model || undefined,
         use_override: true,
-      });
+      }) as { model?: string | null };
       toastSuccess(
         'Connectivity check OK',
         `${formatProviderName(provider.name)} (${response?.model || 'default'})`

--- a/admin-ui/app/resource-governor/page.tsx
+++ b/admin-ui/app/resource-governor/page.tsx
@@ -152,9 +152,10 @@ const policyFormSchema = z
     });
   });
 
-type PolicyFormData = z.infer<typeof policyFormSchema>;
+type PolicyFormInput = z.input<typeof policyFormSchema>;
+type PolicyFormData = z.output<typeof policyFormSchema>;
 
-const defaultPolicyFormValues: PolicyFormData = {
+const defaultPolicyFormValues: PolicyFormInput = {
   name: '',
   scope: 'global',
   scope_id: '',
@@ -247,7 +248,7 @@ export default function ResourceGovernorPage() {
   const [rateLimitEventsError, setRateLimitEventsError] = useState('');
   const [rateLimitEventsSource, setRateLimitEventsSource] = useState<RateLimitEventsSource>('unavailable');
 
-  const policyForm = useForm<PolicyFormData>({
+  const policyForm = useForm<PolicyFormInput, unknown, PolicyFormData>({
     resolver: zodResolver(policyFormSchema),
     defaultValues: defaultPolicyFormValues,
   });
@@ -538,11 +539,13 @@ export default function ResourceGovernorPage() {
     if (!isValid) return;
 
     const formData = policyForm.getValues();
+    const scopeId = formData.scope_id?.trim() ?? '';
+    const description = formData.description?.trim() ?? '';
     const simulatedPolicy: ResourcePolicy = {
       id: editingPolicy?.id,
       name: formData.name.trim(),
       scope: formData.scope,
-      scope_id: formData.scope === 'global' ? null : formData.scope_id.trim(),
+      scope_id: formData.scope === 'global' ? null : scopeId,
       resource_type: formData.resource_type,
       enabled: formData.enabled,
       priority: parseOptionalInt(formData.priority) ?? 0,
@@ -551,7 +554,7 @@ export default function ResourceGovernorPage() {
       max_requests_per_day: parseOptionalInt(formData.max_requests_per_day),
       max_tokens_per_request: parseOptionalInt(formData.max_tokens_per_request),
       max_concurrent_requests: parseOptionalInt(formData.max_concurrent_requests),
-      description: formData.description.trim() || null,
+      description: description || null,
     };
 
     try {

--- a/admin-ui/app/security/page.tsx
+++ b/admin-ui/app/security/page.tsx
@@ -156,7 +156,7 @@ const countAgedActiveKeys = (keys: ApiKeyMetadataLike[]) => {
 };
 
 const buildRiskBreakdown = (context: SecurityRiskBreakdownContext): SecurityRiskBreakdown => {
-  const factors: SecurityRiskFactor[] = [
+  const baseFactors = [
     {
       key: 'users_without_mfa',
       label: 'Users without MFA',
@@ -205,7 +205,9 @@ const buildRiskBreakdown = (context: SecurityRiskBreakdownContext): SecurityRisk
       remediationHref: '/monitoring',
       remediationLabel: 'Open monitoring alerts',
     },
-  ].map((factor) => ({
+  ] satisfies SecurityRiskFactor[];
+
+  const factors: SecurityRiskFactor[] = baseFactors.map((factor) => ({
     ...factor,
     severity: getRiskFactorSeverity(factor.contribution),
   }));

--- a/admin-ui/app/teams/[id]/page.tsx
+++ b/admin-ui/app/teams/[id]/page.tsx
@@ -23,7 +23,7 @@ export default function TeamDetailPage() {
   const params = useParams();
   const router = useRouter();
   const confirm = useConfirm();
-  const teamId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const teamId = typeof params.id === 'string' ? params.id : params.id?.[0] ?? '';
 
   const [team, setTeam] = useState<Team | null>(null);
   const [members, setMembers] = useState<TeamMember[]>([]);

--- a/admin-ui/app/usage/page.tsx
+++ b/admin-ui/app/usage/page.tsx
@@ -432,8 +432,8 @@ export default function UsagePage() {
   }, [activeTab]);
 
   return (
-    <PermissionGuard requiredRole="admin" fallbackToDashboard>
-      <ResponsiveLayout title="Usage" subtitle="Router analytics status dashboard">
+    <PermissionGuard role="admin">
+      <ResponsiveLayout>
         <div className="space-y-6" data-testid="usage-router-analytics-page">
           <div className="rounded-lg border bg-card p-4">
             <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">

--- a/admin-ui/app/users/[id]/__tests__/page.test.tsx
+++ b/admin-ui/app/users/[id]/__tests__/page.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/lib/api-client', () => {
       getUserTeamMemberships: vi.fn(),
       getUserMfaStatus: vi.fn(),
       getUserSessions: vi.fn(),
+      revokeAllUserSessions: vi.fn(),
       getAuditLogs: vi.fn(),
       getUserEffectivePermissions: vi.fn(),
       getUserPermissionOverrides: vi.fn(),
@@ -88,6 +89,7 @@ type ApiMock = {
   getUserTeamMemberships: ReturnType<typeof vi.fn>;
   getUserMfaStatus: ReturnType<typeof vi.fn>;
   getUserSessions: ReturnType<typeof vi.fn>;
+  revokeAllUserSessions: ReturnType<typeof vi.fn>;
   getAuditLogs: ReturnType<typeof vi.fn>;
   getUserEffectivePermissions: ReturnType<typeof vi.fn>;
   getUserPermissionOverrides: ReturnType<typeof vi.fn>;
@@ -148,6 +150,7 @@ beforeEach(() => {
     method: null,
   });
   apiMock.getUserSessions.mockResolvedValue([]);
+  apiMock.revokeAllUserSessions.mockResolvedValue({});
   apiMock.getAuditLogs.mockResolvedValue({
     entries: [
       {
@@ -245,6 +248,48 @@ describe('UserDetailPage password reset', () => {
     );
     expect(screen.queryByText('Temporary password (shown once)')).not.toBeInTheDocument();
     expect(screen.queryByText('TempP@ssw0rd123')).not.toBeInTheDocument();
+  });
+
+  it('revokes all sessions after privileged confirmation', async () => {
+    const user = userEvent.setup();
+    apiMock.getUserSessions
+      .mockResolvedValueOnce([
+        {
+          id: 5001,
+          ip_address: '127.0.0.1',
+          user_agent: 'Chrome on macOS',
+          created_at: '2026-03-10T00:00:00Z',
+          last_activity: '2026-03-10T00:30:00Z',
+          expires_at: '2026-03-10T02:00:00Z',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    render(<UserDetailPage />);
+
+    const revokeAllButton = await screen.findByRole('button', { name: 'Revoke all' });
+    await user.click(revokeAllButton);
+
+    await waitFor(() => {
+      expect(privilegedActionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Revoke All Sessions' })
+      );
+    });
+    await waitFor(() => {
+      expect(apiMock.revokeAllUserSessions).toHaveBeenCalledWith('42', {
+        reason: 'Customer requested this change',
+        admin_password: 'AdminPass123!',
+      });
+    });
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        'Sessions revoked',
+        'All sessions have been revoked.'
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('No active sessions found.')).toBeInTheDocument();
+    });
   });
 
   it('only exposes backend-supported platform roles in the role selector', async () => {

--- a/admin-ui/app/users/[id]/components/UserMembershipDialogs.tsx
+++ b/admin-ui/app/users/[id]/components/UserMembershipDialogs.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { OrgMembership, TeamMembership } from '@/types';
+
+interface UserMembershipDialogsProps {
+  showOrgMembershipsDialog: boolean;
+  showTeamMembershipsDialog: boolean;
+  orgMemberships: OrgMembership[];
+  teamMemberships: TeamMembership[];
+  orgMembershipsLoading: boolean;
+  teamMembershipsLoading: boolean;
+  orgMembershipsError: string;
+  teamMembershipsError: string;
+  onOpenOrgMembershipsChange: (open: boolean) => void;
+  onOpenTeamMembershipsChange: (open: boolean) => void;
+}
+
+export function UserMembershipDialogs({
+  showOrgMembershipsDialog,
+  showTeamMembershipsDialog,
+  orgMemberships,
+  teamMemberships,
+  orgMembershipsLoading,
+  teamMembershipsLoading,
+  orgMembershipsError,
+  teamMembershipsError,
+  onOpenOrgMembershipsChange,
+  onOpenTeamMembershipsChange,
+}: UserMembershipDialogsProps) {
+  return (
+    <>
+      <Dialog open={showOrgMembershipsDialog} onOpenChange={onOpenOrgMembershipsChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>User Organizations</DialogTitle>
+            <DialogDescription>
+              Organizations this user belongs to and their role in each organization.
+            </DialogDescription>
+          </DialogHeader>
+          {orgMembershipsError && (
+            <Alert variant="destructive">
+              <AlertDescription>{orgMembershipsError}</AlertDescription>
+            </Alert>
+          )}
+          {orgMembershipsLoading ? (
+            <div className="text-sm text-muted-foreground">Loading organizations...</div>
+          ) : orgMemberships.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No organization memberships found.</div>
+          ) : (
+            <div className="max-h-80 overflow-y-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Organization</TableHead>
+                    <TableHead>Role</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {orgMemberships.map((membership) => (
+                    <TableRow key={membership.org_id}>
+                      <TableCell className="text-sm">
+                        {membership.org_name || `Organization ${membership.org_id}`}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{membership.role}</Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenOrgMembershipsChange(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showTeamMembershipsDialog} onOpenChange={onOpenTeamMembershipsChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>User Teams</DialogTitle>
+            <DialogDescription>
+              Team memberships with organization context and assigned role.
+            </DialogDescription>
+          </DialogHeader>
+          {teamMembershipsError && (
+            <Alert variant="destructive">
+              <AlertDescription>{teamMembershipsError}</AlertDescription>
+            </Alert>
+          )}
+          {teamMembershipsLoading ? (
+            <div className="text-sm text-muted-foreground">Loading teams...</div>
+          ) : teamMemberships.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No team memberships found.</div>
+          ) : (
+            <div className="max-h-80 overflow-y-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Team</TableHead>
+                    <TableHead>Organization</TableHead>
+                    <TableHead>Role</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {teamMemberships.map((membership) => (
+                    <TableRow key={`${membership.org_id}-${membership.team_id}`}>
+                      <TableCell className="text-sm">
+                        {membership.team_name || `Team ${membership.team_id}`}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {membership.org_name || `Organization ${membership.org_id}`}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">{membership.role}</Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenTeamMembershipsChange(false)}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/admin-ui/app/users/[id]/components/UserProfileCard.tsx
+++ b/admin-ui/app/users/[id]/components/UserProfileCard.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatDateTime } from '@/lib/format';
+import type { User } from '@/types';
+
+export type UserProfileFormData = {
+  username: string;
+  email: string;
+  role: string;
+  is_active: boolean;
+  storage_quota_mb: number;
+};
+
+export type UserProfileRoleOption = {
+  value: string;
+  label: string;
+};
+
+interface UserProfileCardProps {
+  user: User;
+  formData: UserProfileFormData;
+  roleOptions: readonly UserProfileRoleOption[];
+  isAuthorized: boolean;
+  saving: boolean;
+  isValidRole: (role: string) => boolean;
+  onFormDataChange: (next: UserProfileFormData) => void;
+  onSave: () => void;
+}
+
+const formatDate = (dateStr?: string) => formatDateTime(dateStr, { fallback: 'Never' });
+
+const formatStorage = (usedMb: number, quotaMb: number) => {
+  const percentage = quotaMb > 0 ? (usedMb / quotaMb) * 100 : 0;
+  return {
+    used: usedMb.toFixed(1),
+    quota: quotaMb,
+    percentage: Math.min(percentage, 100).toFixed(1),
+  };
+};
+
+export function UserProfileCard({
+  user,
+  formData,
+  roleOptions,
+  isAuthorized,
+  saving,
+  isValidRole,
+  onFormDataChange,
+  onSave,
+}: UserProfileCardProps) {
+  const storage = formatStorage(user.storage_used_mb || 0, user.storage_quota_mb || 0);
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>User Information</CardTitle>
+          <CardDescription>View and edit user details</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>User ID</Label>
+              <Input value={user.id} disabled />
+            </div>
+            <div className="space-y-2">
+              <Label>UUID</Label>
+              <Input value={user.uuid} disabled className="font-mono text-xs" />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="username">Username</Label>
+            <Input
+              id="username"
+              value={formData.username}
+              disabled={!isAuthorized}
+              onChange={(event) =>
+                onFormDataChange({ ...formData, username: event.target.value })
+              }
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={formData.email}
+              disabled={!isAuthorized}
+              onChange={(event) =>
+                onFormDataChange({ ...formData, email: event.target.value })
+              }
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="role">Role</Label>
+            <Select
+              id="role"
+              value={formData.role}
+              disabled={!isAuthorized}
+              onChange={(event) => {
+                const nextRole = event.target.value;
+                if (isValidRole(nextRole)) {
+                  onFormDataChange({ ...formData, role: nextRole });
+                }
+              }}
+            >
+              {!isValidRole(formData.role) && formData.role ? (
+                <option value={formData.role}>
+                  Unsupported ({formData.role})
+                </option>
+              ) : null}
+              {roleOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+            {!isValidRole(formData.role) && formData.role ? (
+              <p className="text-xs text-muted-foreground">
+                This account uses an unsupported role value. It will be preserved unless you explicitly choose a supported replacement.
+              </p>
+            ) : null}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_active"
+              checked={formData.is_active}
+              disabled={!isAuthorized}
+              onChange={(event) =>
+                onFormDataChange({ ...formData, is_active: event.target.checked })
+              }
+              className="h-4 w-4 rounded border-primary"
+            />
+            <Label htmlFor="is_active">Active</Label>
+          </div>
+
+          <Button onClick={onSave} disabled={saving || !isAuthorized} loading={saving} loadingText="Saving...">
+            <Save className="mr-2 h-4 w-4" />
+            Save Changes
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Storage & Activity</CardTitle>
+          <CardDescription>Usage statistics and timestamps</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <Label>Storage Usage</Label>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span>{storage.used} MB used</span>
+                <span>{storage.quota} MB quota</span>
+              </div>
+              <div
+                className="h-3 w-full rounded-full bg-gray-200"
+                role="progressbar"
+                aria-valuenow={parseFloat(storage.percentage)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`Storage usage: ${storage.percentage}%${
+                  parseFloat(storage.percentage) > 90 ? ', critical' :
+                  parseFloat(storage.percentage) > 70 ? ', warning' : ''
+                }`}
+              >
+                <div
+                  className={`h-3 rounded-full transition-all ${
+                    parseFloat(storage.percentage) > 90 ? 'bg-red-500' :
+                    parseFloat(storage.percentage) > 70 ? 'bg-yellow-500' :
+                    'bg-green-500'
+                  }`}
+                  style={{ width: `${storage.percentage}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {storage.percentage}% of quota used
+              </p>
+            </div>
+
+            <div className="pt-2">
+              <Label htmlFor="storage_quota">Storage Quota (MB)</Label>
+              <Input
+                id="storage_quota"
+                type="number"
+                min="0"
+                value={formData.storage_quota_mb}
+                disabled={!isAuthorized}
+                onChange={(event) => {
+                  const nextValue = parseInt(event.target.value, 10);
+                  onFormDataChange({
+                    ...formData,
+                    storage_quota_mb: Number.isNaN(nextValue)
+                      ? formData.storage_quota_mb
+                      : nextValue,
+                  });
+                }}
+                className="mt-1"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-3 border-t pt-4">
+            <div className="flex justify-between">
+              <span className="text-sm text-muted-foreground">Created</span>
+              <span className="text-sm">{formatDate(user.created_at)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm text-muted-foreground">Updated</span>
+              <span className="text-sm">{formatDate(user.updated_at)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm text-muted-foreground">Last Login</span>
+              <span className="text-sm">{formatDate(user.last_login)}</span>
+            </div>
+          </div>
+
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Email Verified</span>
+              <Badge variant={user.is_verified ? 'default' : 'secondary'}>
+                {user.is_verified ? 'Verified' : 'Not Verified'}
+              </Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/admin-ui/app/users/[id]/components/UserSecurityCard.tsx
+++ b/admin-ui/app/users/[id]/components/UserSecurityCard.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { Clock, Monitor, RefreshCw, Shield, Trash2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatDateTime } from '@/lib/format';
+import type { LoginHistoryEntry, MfaStatus, UserSession } from '../hooks/use-user-security';
+
+interface UserSecurityCardProps {
+  isAuthorized: boolean;
+  securityLoading: boolean;
+  securityError: string;
+  mfaStatus: MfaStatus | null;
+  sessions: UserSession[];
+  loginHistory: LoginHistoryEntry[];
+  loginHistoryLoading: boolean;
+  loginHistoryError: string;
+  forcePasswordChangeOnNextLogin: boolean;
+  passwordResetLoading: boolean;
+  resetPasswordValue: string;
+  onForcePasswordChangeOnNextLogin: (next: boolean) => void;
+  onResetPasswordValueChange: (value: string) => void;
+  onResetPassword: () => void;
+  onDisableMfa: () => void;
+  onRefreshSecurity: () => void;
+  onRevokeAllSessions: () => void;
+  onRevokeSession: (session: UserSession) => void;
+  onRefreshLoginHistory: () => void;
+}
+
+const formatDate = (dateStr?: string) => formatDateTime(dateStr, { fallback: 'Never' });
+
+export function UserSecurityCard({
+  isAuthorized,
+  securityLoading,
+  securityError,
+  mfaStatus,
+  sessions,
+  loginHistory,
+  loginHistoryLoading,
+  loginHistoryError,
+  forcePasswordChangeOnNextLogin,
+  passwordResetLoading,
+  resetPasswordValue,
+  onForcePasswordChangeOnNextLogin,
+  onResetPasswordValueChange,
+  onResetPassword,
+  onDisableMfa,
+  onRefreshSecurity,
+  onRevokeAllSessions,
+  onRevokeSession,
+  onRefreshLoginHistory,
+}: UserSecurityCardProps) {
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader>
+        <CardTitle>Security Controls</CardTitle>
+        <CardDescription>MFA status and active sessions</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {securityError && (
+          <Alert variant="destructive">
+            <AlertDescription>{securityError}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-3 rounded-lg border p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-1">
+              <div className="font-medium">Password reset</div>
+              <p className="text-sm text-muted-foreground">
+                Generate a temporary password for this user.
+              </p>
+            </div>
+            <Button
+              onClick={onResetPassword}
+              disabled={!isAuthorized || passwordResetLoading}
+              loading={passwordResetLoading}
+              loadingText="Resetting..."
+            >
+              Reset Password
+            </Button>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="temporary-password">Temporary Password to Set</Label>
+            <Input
+              id="temporary-password"
+              type="password"
+              autoComplete="new-password"
+              value={resetPasswordValue}
+              onChange={(event) => onResetPasswordValueChange(event.target.value)}
+              disabled={!isAuthorized || passwordResetLoading}
+              minLength={10}
+              placeholder="Enter a temporary password to share securely"
+            />
+            <p className="text-xs text-muted-foreground">
+              Set the temporary password yourself so it never needs to be returned to the browser.
+            </p>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={forcePasswordChangeOnNextLogin}
+              onChange={(event) => onForcePasswordChangeOnNextLogin(event.target.checked)}
+              disabled={!isAuthorized || passwordResetLoading}
+              className="h-4 w-4 rounded border-primary"
+            />
+            Force Password Change on Next Login
+          </label>
+        </div>
+
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">Multi-factor authentication</span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              <Badge variant={mfaStatus?.enabled ? 'default' : 'secondary'}>
+                {mfaStatus?.enabled ? 'Enabled' : 'Disabled'}
+              </Badge>
+              {mfaStatus?.method ? <span className="text-xs">Method: {mfaStatus.method}</span> : null}
+              <span className="text-xs">
+                Backup codes: {mfaStatus?.has_backup_codes ? 'Set' : 'Not set'}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              MFA enrollment is managed by the user from their profile.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            onClick={onDisableMfa}
+            disabled={!mfaStatus?.enabled || !isAuthorized}
+          >
+            Disable MFA
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Monitor className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">Active sessions</span>
+              <Badge variant="outline">{sessions.length}</Badge>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={onRefreshSecurity} disabled={securityLoading}>
+                <RefreshCw className={`mr-2 h-4 w-4 ${securityLoading ? 'animate-spin' : ''}`} />
+                Refresh
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onRevokeAllSessions}
+                disabled={!sessions.length || !isAuthorized}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Revoke all
+              </Button>
+            </div>
+          </div>
+
+          {securityLoading ? (
+            <div className="text-sm text-muted-foreground">Loading sessions...</div>
+          ) : sessions.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No active sessions found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Session</TableHead>
+                    <TableHead>IP Address</TableHead>
+                    <TableHead>Last Activity</TableHead>
+                    <TableHead>Expires</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sessions.map((session) => (
+                    <TableRow key={session.id}>
+                      <TableCell>
+                        <div className="text-sm font-mono">{session.id}</div>
+                        <div className="max-w-[240px] truncate text-xs text-muted-foreground">
+                          {session.user_agent || 'Unknown device'}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm font-mono">
+                        {session.ip_address || '—'}
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {formatDate(session.last_activity || session.created_at)}
+                      </TableCell>
+                      <TableCell className="text-sm">
+                        {formatDate(session.expires_at || '')}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => onRevokeSession(session)}
+                          disabled={!isAuthorized}
+                        >
+                          Revoke
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3 border-t pt-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Clock className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">Login History</span>
+              <Badge variant="outline">{loginHistory.length}</Badge>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRefreshLoginHistory}
+              disabled={loginHistoryLoading}
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${loginHistoryLoading ? 'animate-spin' : ''}`} />
+              Refresh
+            </Button>
+          </div>
+
+          {loginHistoryError && (
+            <Alert variant="destructive">
+              <AlertDescription>{loginHistoryError}</AlertDescription>
+            </Alert>
+          )}
+
+          {loginHistoryLoading ? (
+            <div className="text-sm text-muted-foreground">Loading login history...</div>
+          ) : loginHistory.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No recent login attempts found.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Timestamp</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>IP Address</TableHead>
+                    <TableHead>User Agent</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {loginHistory.map((entry) => (
+                    <TableRow key={entry.id}>
+                      <TableCell className="text-sm">{formatDate(entry.timestamp)}</TableCell>
+                      <TableCell>
+                        <Badge variant={entry.status === 'success' ? 'default' : 'destructive'}>
+                          {entry.status === 'success' ? 'Success' : 'Failure'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-sm font-mono">{entry.ipAddress || '—'}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {entry.userAgent || 'Unknown client'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/admin-ui/app/users/[id]/hooks/use-user-security.ts
+++ b/admin-ui/app/users/[id]/hooks/use-user-security.ts
@@ -1,0 +1,332 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { PrivilegedActionOptions, PrivilegedActionResult } from '@/components/ui/privileged-action-dialog';
+import { api } from '@/lib/api-client';
+import type { AuditLog } from '@/types';
+
+export type MfaStatus = {
+  enabled: boolean;
+  has_secret: boolean;
+  has_backup_codes: boolean;
+  method?: string | null;
+};
+
+export type UserSession = {
+  id: number;
+  ip_address?: string | null;
+  user_agent?: string | null;
+  created_at: string;
+  last_activity?: string | null;
+  expires_at?: string | null;
+};
+
+type PasswordResetResponse = {
+  force_password_change?: boolean;
+  message?: string;
+};
+
+type LoginHistoryStatus = 'success' | 'failure';
+
+export type LoginHistoryEntry = {
+  id: string;
+  timestamp: string;
+  ipAddress?: string;
+  userAgent?: string;
+  status: LoginHistoryStatus;
+};
+
+interface UseUserSecurityOptions {
+  userId: string;
+  user: {
+    username?: string | null;
+    email?: string | null;
+    metadata?: Record<string, unknown>;
+  } | null;
+  requirePasswordReauth: boolean;
+  promptPrivilegedAction: (options: PrivilegedActionOptions) => Promise<PrivilegedActionResult | null>;
+  onUserRefresh: () => void;
+  showError: (title: string, message: string) => void;
+  toastSuccess: (title: string, message: string) => void;
+}
+
+const getLoginAttemptStatus = (entry: AuditLog): LoginHistoryStatus => {
+  const details = entry.details ?? {};
+  const raw = entry.raw ?? {};
+  const successValue = details.success ?? raw.success;
+  if (typeof successValue === 'boolean') {
+    return successValue ? 'success' : 'failure';
+  }
+
+  const statusText = String(details.status ?? details.result ?? raw.status ?? '').toLowerCase();
+  if (statusText.includes('fail') || statusText.includes('error') || statusText.includes('denied')) {
+    return 'failure';
+  }
+  if (statusText.includes('success') || statusText.includes('ok')) {
+    return 'success';
+  }
+
+  const actionText = String(entry.action ?? raw.action ?? '').toLowerCase();
+  if (actionText.includes('fail') || actionText.includes('denied')) {
+    return 'failure';
+  }
+  return 'success';
+};
+
+const toLoginHistoryEntry = (entry: AuditLog, index: number): LoginHistoryEntry => {
+  const details = entry.details ?? {};
+  const raw = entry.raw ?? {};
+  const ipValue = entry.ip_address
+    ?? (typeof details.ip_address === 'string' ? details.ip_address : undefined)
+    ?? (typeof details.ip === 'string' ? details.ip : undefined)
+    ?? (typeof raw.ip_address === 'string' ? raw.ip_address : undefined)
+    ?? (typeof raw.ip === 'string' ? raw.ip : undefined);
+  const detailsUserAgent = details.user_agent;
+  const detailsUserAgentAlt = details.userAgent;
+  const rawUserAgent = raw.user_agent;
+  const rawUserAgentAlt = raw.userAgent;
+  const userAgentValue = (typeof detailsUserAgent === 'string' ? detailsUserAgent : undefined)
+    ?? (typeof detailsUserAgentAlt === 'string' ? detailsUserAgentAlt : undefined)
+    ?? (typeof rawUserAgent === 'string' ? rawUserAgent : undefined)
+    ?? (typeof rawUserAgentAlt === 'string' ? rawUserAgentAlt : undefined);
+
+  return {
+    id: entry.id || `${entry.timestamp}-${index}`,
+    timestamp: entry.timestamp,
+    ipAddress: ipValue,
+    userAgent: userAgentValue,
+    status: getLoginAttemptStatus(entry),
+  };
+};
+
+const getUserLabel = (user: UseUserSecurityOptions['user']): string =>
+  user?.username || user?.email || 'this user';
+
+export function useUserSecurity({
+  userId,
+  user,
+  requirePasswordReauth,
+  promptPrivilegedAction,
+  onUserRefresh,
+  showError,
+  toastSuccess,
+}: UseUserSecurityOptions) {
+  const [securityLoading, setSecurityLoading] = useState(false);
+  const [securityError, setSecurityError] = useState('');
+  const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
+  const [sessions, setSessions] = useState<UserSession[]>([]);
+  const [loginHistory, setLoginHistory] = useState<LoginHistoryEntry[]>([]);
+  const [loginHistoryLoading, setLoginHistoryLoading] = useState(false);
+  const [loginHistoryError, setLoginHistoryError] = useState('');
+  const [forcePasswordChangeOnNextLogin, setForcePasswordChangeOnNextLogin] = useState(true);
+  const [passwordResetLoading, setPasswordResetLoading] = useState(false);
+  const [resetPasswordValue, setResetPasswordValue] = useState('');
+
+  useEffect(() => {
+    const forceChange =
+      typeof user?.metadata?.force_password_change === 'boolean'
+        ? user.metadata.force_password_change
+        : true;
+    setForcePasswordChangeOnNextLogin(forceChange);
+  }, [user?.metadata?.force_password_change]);
+
+  const loadSecurity = useCallback(async () => {
+    if (!userId) return;
+    try {
+      setSecurityLoading(true);
+      setSecurityError('');
+      const [mfaResult, sessionsResult] = await Promise.allSettled([
+        api.getUserMfaStatus(userId),
+        api.getUserSessions(userId),
+      ]);
+
+      if (mfaResult.status === 'fulfilled') {
+        setMfaStatus(mfaResult.value as MfaStatus);
+      } else {
+        setMfaStatus(null);
+      }
+
+      if (sessionsResult.status === 'fulfilled') {
+        setSessions(Array.isArray(sessionsResult.value) ? (sessionsResult.value as UserSession[]) : []);
+      } else {
+        setSessions([]);
+      }
+
+      if (mfaResult.status === 'rejected' || sessionsResult.status === 'rejected') {
+        setSecurityError('Failed to load security controls.');
+      }
+    } catch (error) {
+      console.error('Failed to load security controls:', error);
+      setSecurityError('Failed to load security controls.');
+      setMfaStatus(null);
+      setSessions([]);
+    } finally {
+      setSecurityLoading(false);
+    }
+  }, [userId]);
+
+  const loadLoginHistory = useCallback(async () => {
+    if (!userId) return;
+    try {
+      setLoginHistoryLoading(true);
+      setLoginHistoryError('');
+      const response = await api.getAuditLogs({
+        user_id: String(userId),
+        action: 'login',
+        limit: '20',
+        offset: '0',
+      });
+      const entries = Array.isArray(response?.entries)
+        ? (response.entries as AuditLog[])
+        : [];
+      const mapped = entries.map((entry, index) => toLoginHistoryEntry(entry, index));
+      mapped.sort((a, b) => {
+        const aTime = Date.parse(a.timestamp || '');
+        const bTime = Date.parse(b.timestamp || '');
+        return (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0);
+      });
+      setLoginHistory(mapped.slice(0, 20));
+    } catch (error) {
+      console.error('Failed to load login history:', error);
+      setLoginHistory([]);
+      setLoginHistoryError('Failed to load login history.');
+    } finally {
+      setLoginHistoryLoading(false);
+    }
+  }, [userId]);
+
+  const handleDisableMfa = useCallback(async () => {
+    if (!mfaStatus?.enabled) return;
+    const approval = await promptPrivilegedAction({
+      title: 'Disable MFA',
+      message: `Disable MFA for ${getUserLabel(user)}?`,
+      confirmText: 'Disable MFA',
+      requirePassword: requirePasswordReauth,
+    });
+    if (!approval) return;
+
+    try {
+      await api.disableUserMfa(userId, {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
+      toastSuccess('MFA disabled', 'Multi-factor authentication has been turned off.');
+      void loadSecurity();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to disable MFA';
+      showError('Disable MFA failed', message);
+    }
+  }, [loadSecurity, mfaStatus?.enabled, promptPrivilegedAction, requirePasswordReauth, showError, toastSuccess, user, userId]);
+
+  const handleRevokeSession = useCallback(async (session: UserSession) => {
+    const approval = await promptPrivilegedAction({
+      title: 'Revoke Session',
+      message: 'Revoke this session? The user will be signed out on that device.',
+      confirmText: 'Revoke',
+      requirePassword: requirePasswordReauth,
+    });
+    if (!approval) return;
+
+    try {
+      await api.revokeUserSession(userId, session.id.toString(), {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
+      toastSuccess('Session revoked', 'The session has been revoked.');
+      void loadSecurity();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to revoke session';
+      showError('Revoke failed', message);
+    }
+  }, [loadSecurity, promptPrivilegedAction, requirePasswordReauth, showError, toastSuccess, userId]);
+
+  const handleRevokeAllSessions = useCallback(async () => {
+    const approval = await promptPrivilegedAction({
+      title: 'Revoke All Sessions',
+      message: 'Revoke all active sessions for this user? They will be signed out everywhere.',
+      confirmText: 'Revoke all',
+      requirePassword: requirePasswordReauth,
+    });
+    if (!approval) return;
+
+    try {
+      await api.revokeAllUserSessions(userId, {
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      });
+      toastSuccess('Sessions revoked', 'All sessions have been revoked.');
+      void loadSecurity();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to revoke sessions';
+      showError('Revoke failed', message);
+    }
+  }, [loadSecurity, promptPrivilegedAction, requirePasswordReauth, showError, toastSuccess, userId]);
+
+  const handleResetPassword = useCallback(async () => {
+    const normalizedTemporaryPassword = resetPasswordValue.trim();
+    if (normalizedTemporaryPassword.length < 10) {
+      showError('Password reset failed', 'Enter a temporary password with at least 10 characters.');
+      return;
+    }
+
+    const approval = await promptPrivilegedAction({
+      title: 'Reset Password',
+      message: `Reset password for ${getUserLabel(user)}?`,
+      confirmText: 'Reset password',
+      requirePassword: requirePasswordReauth,
+    });
+    if (!approval) return;
+
+    try {
+      setPasswordResetLoading(true);
+      await api.resetUserPassword(userId, {
+        temporary_password: normalizedTemporaryPassword,
+        force_password_change: forcePasswordChangeOnNextLogin,
+        reason: approval.reason,
+        admin_password: approval.adminPassword,
+      }) as PasswordResetResponse;
+      setResetPasswordValue('');
+      toastSuccess(
+        'Password reset',
+        'Temporary password updated. Share it with the user through an approved secure channel.'
+      );
+      onUserRefresh();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to reset password';
+      showError('Password reset failed', message);
+    } finally {
+      setPasswordResetLoading(false);
+    }
+  }, [
+    forcePasswordChangeOnNextLogin,
+    onUserRefresh,
+    promptPrivilegedAction,
+    requirePasswordReauth,
+    resetPasswordValue,
+    showError,
+    toastSuccess,
+    user,
+    userId,
+  ]);
+
+  return {
+    securityLoading,
+    securityError,
+    mfaStatus,
+    sessions,
+    loginHistory,
+    loginHistoryLoading,
+    loginHistoryError,
+    forcePasswordChangeOnNextLogin,
+    passwordResetLoading,
+    resetPasswordValue,
+    setForcePasswordChangeOnNextLogin,
+    setResetPasswordValue,
+    loadSecurity,
+    loadLoginHistory,
+    handleDisableMfa,
+    handleRevokeSession,
+    handleRevokeAllSessions,
+    handleResetPassword,
+  };
+}

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { PermissionGuard } from '@/components/PermissionGuard';
 import { ResponsiveLayout } from '@/components/ResponsiveLayout';
@@ -29,7 +29,7 @@ import {
   validateRateLimitInputs,
 } from '@/lib/rate-limits';
 import { canEditFromMemberships } from '@/lib/permissions';
-import { User, Permission, AuditLog } from '@/types';
+import { User, Permission, AuditLog, OrgMembership, TeamMembership } from '@/types';
 import Link from 'next/link';
 
 type UserRateLimits = {
@@ -59,7 +59,7 @@ type EffectivePermission = {
   id: number;
   name: string;
   source: EffectivePermissionSource;
-  sourceLabel?: string;
+  sourceLabel: string;
 };
 
 const roleOptions = [
@@ -108,20 +108,6 @@ type LoginHistoryEntry = {
   ipAddress?: string;
   userAgent?: string;
   status: LoginHistoryStatus;
-};
-
-type OrgMembership = {
-  org_id: number;
-  role: string;
-  org_name?: string;
-};
-
-type TeamMembership = {
-  team_id: number;
-  org_id: number;
-  role: string;
-  team_name?: string;
-  org_name?: string;
 };
 
 type RateLimitRecord = {
@@ -328,7 +314,7 @@ const normalizeEffectivePermissionList = (
 export default function UserDetailPage() {
   const params = useParams();
   const router = useRouter();
-  const userId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const userId = typeof params.id === 'string' ? params.id : params.id?.[0] ?? '';
   const confirm = useConfirm();
   const promptPrivilegedAction = usePrivilegedActionDialog();
   const { success: toastSuccess, error: showError } = useToast();
@@ -532,22 +518,13 @@ export default function UserDetailPage() {
       setOrgMembershipsLoading(true);
       setOrgMembershipsError('');
       const response = await api.getUserOrgMemberships(userId);
-      const items = Array.isArray(response) ? response : [];
-      const normalized = items
-        .map((item) => {
-          if (!item || typeof item !== 'object') return null;
-          const record = item as Record<string, unknown>;
-          const orgId = Number(record.org_id);
-          const role = String(record.role ?? '').trim();
-          const orgName = record.org_name;
-          if (!Number.isFinite(orgId) || !role) return null;
-          return {
-            org_id: orgId,
-            role,
-            org_name: typeof orgName === 'string' ? orgName : undefined,
-          };
-        })
-        .filter((entry): entry is OrgMembership => entry !== null);
+      const normalized = response
+        .filter((item) => Number.isFinite(item.org_id) && typeof item.role === 'string' && item.role.trim().length > 0)
+        .map((item) => ({
+          org_id: item.org_id,
+          role: item.role.trim(),
+          org_name: typeof item.org_name === 'string' ? item.org_name : undefined,
+        }));
       setOrgMemberships(normalized);
     } catch (err: unknown) {
       console.error('Failed to load user organizations:', err);
@@ -564,26 +541,21 @@ export default function UserDetailPage() {
       setTeamMembershipsLoading(true);
       setTeamMembershipsError('');
       const response = await api.getUserTeamMemberships(userId);
-      const items = Array.isArray(response) ? response : [];
-      const normalized = items
-        .map((item) => {
-          if (!item || typeof item !== 'object') return null;
-          const record = item as Record<string, unknown>;
-          const teamId = Number(record.team_id);
-          const orgId = Number(record.org_id);
-          const role = String(record.role ?? '').trim();
-          const teamName = record.team_name;
-          const orgName = record.org_name;
-          if (!Number.isFinite(teamId) || !Number.isFinite(orgId) || !role) return null;
-          return {
-            team_id: teamId,
-            org_id: orgId,
-            role,
-            team_name: typeof teamName === 'string' ? teamName : undefined,
-            org_name: typeof orgName === 'string' ? orgName : undefined,
-          };
-        })
-        .filter((entry): entry is TeamMembership => entry !== null);
+      const normalized = response
+        .filter(
+          (item) =>
+            Number.isFinite(item.team_id)
+            && Number.isFinite(item.org_id)
+            && typeof item.role === 'string'
+            && item.role.trim().length > 0
+        )
+        .map((item) => ({
+          team_id: item.team_id,
+          org_id: item.org_id,
+          role: item.role.trim(),
+          team_name: typeof item.team_name === 'string' ? item.team_name : undefined,
+          org_name: typeof item.org_name === 'string' ? item.org_name : undefined,
+        }));
       setTeamMemberships(normalized);
     } catch (err: unknown) {
       console.error('Failed to load user teams:', err);
@@ -1004,7 +976,7 @@ export default function UserDetailPage() {
     };
   };
 
-  let content: JSX.Element = <></>;
+  let content: ReactNode = null;
 
   if (loading) {
     content = (

--- a/admin-ui/app/users/[id]/page.tsx
+++ b/admin-ui/app/users/[id]/page.tsx
@@ -9,18 +9,15 @@ import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { useConfirm } from '@/components/ui/confirm-dialog';
 import { usePrivilegedActionDialog } from '@/components/ui/privileged-action-dialog';
 import { useToast } from '@/components/ui/toast';
-import { ArrowLeft, Key, Save, Building2, Users, Shield, Monitor, RefreshCw, Trash2, Clock, ShieldCheck, Plus, X } from 'lucide-react';
+import { ArrowLeft, Key, Building2, Users, Trash2, Clock, ShieldCheck, Plus, X } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api, ApiError } from '@/lib/api-client';
 import { isSingleUserMode } from '@/lib/auth';
-import { formatDateTime } from '@/lib/format';
 import { parseOptionalInt } from '@/lib/number';
 import {
   deriveLimitPerMinute,
@@ -29,7 +26,14 @@ import {
   validateRateLimitInputs,
 } from '@/lib/rate-limits';
 import { canEditFromMemberships } from '@/lib/permissions';
-import { User, Permission, AuditLog, OrgMembership, TeamMembership } from '@/types';
+import { User, Permission, OrgMembership, TeamMembership } from '@/types';
+import {
+  UserProfileCard,
+  type UserProfileFormData,
+} from './components/UserProfileCard';
+import { UserSecurityCard } from './components/UserSecurityCard';
+import { UserMembershipDialogs } from './components/UserMembershipDialogs';
+import { useUserSecurity } from './hooks/use-user-security';
 import Link from 'next/link';
 
 type UserRateLimits = {
@@ -70,45 +74,7 @@ const roleOptions = [
 
 type UserRole = (typeof roleOptions)[number]['value'];
 
-type UserFormData = {
-  username: string;
-  email: string;
-  role: string;
-  is_active: boolean;
-  storage_quota_mb: number;
-};
-
 const isValidRole = (role: string): role is UserRole => roleOptions.some((option) => option.value === role);
-type MfaStatus = {
-  enabled: boolean;
-  has_secret: boolean;
-  has_backup_codes: boolean;
-  method?: string | null;
-};
-
-type UserSession = {
-  id: number;
-  ip_address?: string | null;
-  user_agent?: string | null;
-  created_at: string;
-  last_activity?: string | null;
-  expires_at?: string | null;
-};
-
-type PasswordResetResponse = {
-  force_password_change?: boolean;
-  message?: string;
-};
-
-type LoginHistoryStatus = 'success' | 'failure';
-
-type LoginHistoryEntry = {
-  id: string;
-  timestamp: string;
-  ipAddress?: string;
-  userAgent?: string;
-  status: LoginHistoryStatus;
-};
 
 type RateLimitRecord = {
   resource?: string;
@@ -168,57 +134,6 @@ const isForbiddenError = (err: unknown): boolean => {
     return /not authorized|forbidden|permission/i.test(err.message);
   }
   return false;
-};
-
-const formatDate = (dateStr?: string) => formatDateTime(dateStr, { fallback: 'Never' });
-
-const getLoginAttemptStatus = (entry: AuditLog): LoginHistoryStatus => {
-  const details = entry.details ?? {};
-  const raw = entry.raw ?? {};
-  const successValue = details.success ?? raw.success;
-  if (typeof successValue === 'boolean') {
-    return successValue ? 'success' : 'failure';
-  }
-
-  const statusText = String(details.status ?? details.result ?? raw.status ?? '').toLowerCase();
-  if (statusText.includes('fail') || statusText.includes('error') || statusText.includes('denied')) {
-    return 'failure';
-  }
-  if (statusText.includes('success') || statusText.includes('ok')) {
-    return 'success';
-  }
-
-  const actionText = String(entry.action ?? raw.action ?? '').toLowerCase();
-  if (actionText.includes('fail') || actionText.includes('denied')) {
-    return 'failure';
-  }
-  return 'success';
-};
-
-const toLoginHistoryEntry = (entry: AuditLog, index: number): LoginHistoryEntry => {
-  const details = entry.details ?? {};
-  const raw = entry.raw ?? {};
-  const ipValue = entry.ip_address
-    ?? (typeof details.ip_address === 'string' ? details.ip_address : undefined)
-    ?? (typeof details.ip === 'string' ? details.ip : undefined)
-    ?? (typeof raw.ip_address === 'string' ? raw.ip_address : undefined)
-    ?? (typeof raw.ip === 'string' ? raw.ip : undefined);
-  const detailsUserAgent = details['user_agent'];
-  const detailsUserAgentAlt = details['userAgent'];
-  const rawUserAgent = raw['user_agent'];
-  const rawUserAgentAlt = raw['userAgent'];
-  const userAgentValue = (typeof detailsUserAgent === 'string' ? detailsUserAgent : undefined)
-    ?? (typeof detailsUserAgentAlt === 'string' ? detailsUserAgentAlt : undefined)
-    ?? (typeof rawUserAgent === 'string' ? rawUserAgent : undefined)
-    ?? (typeof rawUserAgentAlt === 'string' ? rawUserAgentAlt : undefined);
-
-  return {
-    id: entry.id || `${entry.timestamp}-${index}`,
-    timestamp: entry.timestamp,
-    ipAddress: ipValue,
-    userAgent: userAgentValue,
-    status: getLoginAttemptStatus(entry),
-  };
 };
 
 const normalizePermissionOverrideList = (value: unknown): PermissionOverride[] => {
@@ -326,13 +241,6 @@ export default function UserDetailPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [isAuthorized, setIsAuthorized] = useState(true);
-  const [securityLoading, setSecurityLoading] = useState(false);
-  const [securityError, setSecurityError] = useState('');
-  const [mfaStatus, setMfaStatus] = useState<MfaStatus | null>(null);
-  const [sessions, setSessions] = useState<UserSession[]>([]);
-  const [loginHistory, setLoginHistory] = useState<LoginHistoryEntry[]>([]);
-  const [loginHistoryLoading, setLoginHistoryLoading] = useState(false);
-  const [loginHistoryError, setLoginHistoryError] = useState('');
   const [showOrgMembershipsDialog, setShowOrgMembershipsDialog] = useState(false);
   const [showTeamMembershipsDialog, setShowTeamMembershipsDialog] = useState(false);
   const [orgMemberships, setOrgMemberships] = useState<OrgMembership[]>([]);
@@ -341,11 +249,8 @@ export default function UserDetailPage() {
   const [teamMembershipsLoading, setTeamMembershipsLoading] = useState(false);
   const [orgMembershipsError, setOrgMembershipsError] = useState('');
   const [teamMembershipsError, setTeamMembershipsError] = useState('');
-  const [forcePasswordChangeOnNextLogin, setForcePasswordChangeOnNextLogin] = useState(true);
-  const [passwordResetLoading, setPasswordResetLoading] = useState(false);
-  const [resetPasswordValue, setResetPasswordValue] = useState('');
 
-  const [formData, setFormData] = useState<UserFormData>({
+  const [formData, setFormData] = useState<UserProfileFormData>({
     username: '',
     email: '',
     role: 'user',
@@ -403,11 +308,6 @@ export default function UserDetailPage() {
       });
       const normalizedRateLimits = normalizeRateLimits(userValue.rate_limits);
       applyRateLimits(normalizedRateLimits);
-      const forceChange =
-        typeof userValue.metadata?.force_password_change === 'boolean'
-          ? userValue.metadata.force_password_change
-          : true;
-      setForcePasswordChangeOnNextLogin(forceChange);
 
       try {
         const currentUser = await api.getCurrentUser();
@@ -446,71 +346,16 @@ export default function UserDetailPage() {
       setLoading(false);
     }
   }, [applyRateLimits, userId]);
-
-  const loadSecurity = useCallback(async () => {
-    if (!userId) return;
-    try {
-      setSecurityLoading(true);
-      setSecurityError('');
-      const [mfaResult, sessionsResult] = await Promise.allSettled([
-        api.getUserMfaStatus(userId),
-        api.getUserSessions(userId),
-      ]);
-
-      if (mfaResult.status === 'fulfilled') {
-        setMfaStatus(mfaResult.value as MfaStatus);
-      } else {
-        setMfaStatus(null);
-      }
-
-      if (sessionsResult.status === 'fulfilled') {
-        setSessions(Array.isArray(sessionsResult.value) ? (sessionsResult.value as UserSession[]) : []);
-      } else {
-        setSessions([]);
-      }
-
-      if (mfaResult.status === 'rejected' || sessionsResult.status === 'rejected') {
-        setSecurityError('Failed to load security controls.');
-      }
-    } catch (err: unknown) {
-      console.error('Failed to load security controls:', err);
-      setSecurityError('Failed to load security controls.');
-      setMfaStatus(null);
-      setSessions([]);
-    } finally {
-      setSecurityLoading(false);
-    }
-  }, [userId]);
-
-  const loadLoginHistory = useCallback(async () => {
-    if (!userId) return;
-    try {
-      setLoginHistoryLoading(true);
-      setLoginHistoryError('');
-      const response = await api.getAuditLogs({
-        user_id: String(userId),
-        action: 'login',
-        limit: '20',
-        offset: '0',
-      });
-      const entries = Array.isArray(response?.entries)
-        ? (response.entries as AuditLog[])
-        : [];
-      const mapped = entries.map((entry, index) => toLoginHistoryEntry(entry, index));
-      mapped.sort((a, b) => {
-        const aTime = Date.parse(a.timestamp || '');
-        const bTime = Date.parse(b.timestamp || '');
-        return (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0);
-      });
-      setLoginHistory(mapped.slice(0, 20));
-    } catch (err: unknown) {
-      console.error('Failed to load login history:', err);
-      setLoginHistory([]);
-      setLoginHistoryError('Failed to load login history.');
-    } finally {
-      setLoginHistoryLoading(false);
-    }
-  }, [userId]);
+  const userSecurity = useUserSecurity({
+    userId,
+    user,
+    requirePasswordReauth,
+    promptPrivilegedAction,
+    onUserRefresh: loadUser,
+    showError,
+    toastSuccess,
+  });
+  const { loadSecurity, loadLoginHistory } = userSecurity;
 
   const loadOrgMemberships = useCallback(async () => {
     if (!userId) return;
@@ -633,7 +478,7 @@ export default function UserDetailPage() {
       void loadPermissions();
       void loadLoginHistory();
     }
-  }, [user, isAuthorized, loadLoginHistory, loadSecurity, loadPermissions]);
+  }, [user, isAuthorized, loadLoginHistory, loadPermissions, loadSecurity]);
 
   const handleSave = async () => {
     if (!isAuthorized) {
@@ -705,110 +550,6 @@ export default function UserDetailPage() {
       }
     } finally {
       setSaving(false);
-    }
-  };
-
-  const handleDisableMfa = async () => {
-    if (!mfaStatus?.enabled) return;
-    const approval = await promptPrivilegedAction({
-      title: 'Disable MFA',
-      message: `Disable MFA for ${user?.username || user?.email || 'this user'}?`,
-      confirmText: 'Disable MFA',
-      requirePassword: requirePasswordReauth,
-    });
-    if (!approval) return;
-
-    try {
-      await api.disableUserMfa(userId, {
-        reason: approval.reason,
-        admin_password: approval.adminPassword,
-      });
-      toastSuccess('MFA disabled', 'Multi-factor authentication has been turned off.');
-      void loadSecurity();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to disable MFA';
-      showError('Disable MFA failed', message);
-    }
-  };
-
-  const handleRevokeSession = async (session: UserSession) => {
-    const approval = await promptPrivilegedAction({
-      title: 'Revoke Session',
-      message: 'Revoke this session? The user will be signed out on that device.',
-      confirmText: 'Revoke',
-      requirePassword: requirePasswordReauth,
-    });
-    if (!approval) return;
-
-    try {
-      await api.revokeUserSession(userId, session.id.toString(), {
-        reason: approval.reason,
-        admin_password: approval.adminPassword,
-      });
-      toastSuccess('Session revoked', 'The session has been revoked.');
-      void loadSecurity();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to revoke session';
-      showError('Revoke failed', message);
-    }
-  };
-
-  const handleRevokeAllSessions = async () => {
-    const approval = await promptPrivilegedAction({
-      title: 'Revoke All Sessions',
-      message: 'Revoke all active sessions for this user? They will be signed out everywhere.',
-      confirmText: 'Revoke all',
-      requirePassword: requirePasswordReauth,
-    });
-    if (!approval) return;
-
-    try {
-      await api.revokeAllUserSessions(userId, {
-        reason: approval.reason,
-        admin_password: approval.adminPassword,
-      });
-      toastSuccess('Sessions revoked', 'All sessions have been revoked.');
-      void loadSecurity();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to revoke sessions';
-      showError('Revoke failed', message);
-    }
-  };
-
-  const handleResetPassword = async () => {
-    const normalizedTemporaryPassword = resetPasswordValue.trim();
-    if (normalizedTemporaryPassword.length < 10) {
-      showError('Password reset failed', 'Enter a temporary password with at least 10 characters.');
-      return;
-    }
-
-    const approval = await promptPrivilegedAction({
-      title: 'Reset Password',
-      message: `Reset password for ${user?.username || user?.email || 'this user'}?`,
-      confirmText: 'Reset password',
-      requirePassword: requirePasswordReauth,
-    });
-    if (!approval) return;
-
-    try {
-      setPasswordResetLoading(true);
-      await api.resetUserPassword(userId, {
-        temporary_password: normalizedTemporaryPassword,
-        force_password_change: forcePasswordChangeOnNextLogin,
-        reason: approval.reason,
-        admin_password: approval.adminPassword,
-      }) as PasswordResetResponse;
-      setResetPasswordValue('');
-      toastSuccess(
-        'Password reset',
-        'Temporary password updated. Share it with the user through an approved secure channel.'
-      );
-      void loadUser();
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to reset password';
-      showError('Password reset failed', message);
-    } finally {
-      setPasswordResetLoading(false);
     }
   };
 
@@ -967,15 +708,6 @@ export default function UserDetailPage() {
     }
   };
 
-  const formatStorage = (usedMb: number, quotaMb: number) => {
-    const percentage = quotaMb > 0 ? (usedMb / quotaMb) * 100 : 0;
-    return {
-      used: usedMb.toFixed(1),
-      quota: quotaMb,
-      percentage: Math.min(percentage, 100).toFixed(1),
-    };
-  };
-
   let content: ReactNode = null;
 
   if (loading) {
@@ -1011,7 +743,6 @@ export default function UserDetailPage() {
       );
     }
   } else {
-    const storage = formatStorage(user.storage_used_mb || 0, user.storage_quota_mb || 0);
     content = (
       <div className="p-4 lg:p-8">
             {/* Header */}
@@ -1055,402 +786,38 @@ export default function UserDetailPage() {
             )}
 
             <div className="grid gap-6 lg:grid-cols-2">
-              {/* User Info Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>User Information</CardTitle>
-                  <CardDescription>View and edit user details</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div className="space-y-2">
-                      <Label>User ID</Label>
-                      <Input value={user.id} disabled />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>UUID</Label>
-                      <Input value={user.uuid} disabled className="font-mono text-xs" />
-                    </div>
-                  </div>
+              <UserProfileCard
+                user={user}
+                formData={formData}
+                roleOptions={roleOptions}
+                isAuthorized={isAuthorized}
+                saving={saving}
+                isValidRole={isValidRole}
+                onFormDataChange={setFormData}
+                onSave={handleSave}
+              />
 
-                  <div className="space-y-2">
-                    <Label htmlFor="username">Username</Label>
-                    <Input
-                      id="username"
-                      value={formData.username}
-                      disabled={!isAuthorized}
-                      onChange={(e) => setFormData({ ...formData, username: e.target.value })}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      value={formData.email}
-                      disabled={!isAuthorized}
-                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="role">Role</Label>
-                    <Select
-                      id="role"
-                      value={formData.role}
-                      disabled={!isAuthorized}
-                      onChange={(e) => {
-                        const nextRole = e.target.value;
-                        if (isValidRole(nextRole)) {
-                          setFormData({ ...formData, role: nextRole });
-                        }
-                      }}
-                    >
-                      {!isValidRole(formData.role) && formData.role ? (
-                        <option value={formData.role}>
-                          Unsupported ({formData.role})
-                        </option>
-                      ) : null}
-                      {roleOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </Select>
-                    {!isValidRole(formData.role) && formData.role ? (
-                      <p className="text-xs text-muted-foreground">
-                        This account uses an unsupported role value. It will be preserved unless you explicitly choose a supported replacement.
-                      </p>
-                    ) : null}
-                  </div>
-
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id="is_active"
-                      checked={formData.is_active}
-                      disabled={!isAuthorized}
-                      onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
-                      className="h-4 w-4 rounded border-primary"
-                    />
-                    <Label htmlFor="is_active">Active</Label>
-                  </div>
-
-                  <Button onClick={handleSave} disabled={saving || !isAuthorized} loading={saving} loadingText="Saving...">
-                    <Save className="mr-2 h-4 w-4" />
-                    Save Changes
-                  </Button>
-                </CardContent>
-              </Card>
-
-              {/* Storage & Activity Card */}
-              <Card>
-                <CardHeader>
-                  <CardTitle>Storage & Activity</CardTitle>
-                  <CardDescription>Usage statistics and timestamps</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  {/* Storage Usage */}
-                  <div className="space-y-2">
-                    <Label>Storage Usage</Label>
-                    <div className="space-y-2">
-                      <div className="flex justify-between text-sm">
-                        <span>{storage.used} MB used</span>
-                        <span>{storage.quota} MB quota</span>
-                      </div>
-                      <div
-                        className="w-full bg-gray-200 rounded-full h-3"
-                        role="progressbar"
-                        aria-valuenow={parseFloat(storage.percentage)}
-                        aria-valuemin={0}
-                        aria-valuemax={100}
-                        aria-label={`Storage usage: ${storage.percentage}%${
-                          parseFloat(storage.percentage) > 90 ? ', critical' :
-                          parseFloat(storage.percentage) > 70 ? ', warning' : ''
-                        }`}
-                      >
-                        <div
-                          className={`h-3 rounded-full transition-all ${
-                            parseFloat(storage.percentage) > 90 ? 'bg-red-500' :
-                            parseFloat(storage.percentage) > 70 ? 'bg-yellow-500' :
-                            'bg-green-500'
-                          }`}
-                          style={{ width: `${storage.percentage}%` }}
-                        />
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {storage.percentage}% of quota used
-                      </p>
-                    </div>
-
-                    <div className="pt-2">
-                      <Label htmlFor="storage_quota">Storage Quota (MB)</Label>
-                      <Input
-                        id="storage_quota"
-                        type="number"
-                        min="0"
-                        value={formData.storage_quota_mb}
-                        disabled={!isAuthorized}
-                        onChange={(e) => {
-                          const val = parseInt(e.target.value, 10);
-                          setFormData({
-                            ...formData,
-                            storage_quota_mb: Number.isNaN(val) ? formData.storage_quota_mb : val,
-                          });
-                        }}
-                        className="mt-1"
-                      />
-                    </div>
-                  </div>
-
-                  {/* Timestamps */}
-                  <div className="space-y-3 pt-4 border-t">
-                    <div className="flex justify-between">
-                      <span className="text-sm text-muted-foreground">Created</span>
-                      <span className="text-sm">{formatDate(user.created_at)}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-sm text-muted-foreground">Updated</span>
-                      <span className="text-sm">{formatDate(user.updated_at)}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-sm text-muted-foreground">Last Login</span>
-                      <span className="text-sm">{formatDate(user.last_login)}</span>
-                    </div>
-                  </div>
-
-                  {/* Verification Status */}
-                  <div className="pt-4 border-t">
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm text-muted-foreground">Email Verified</span>
-                      <Badge variant={user.is_verified ? 'default' : 'secondary'}>
-                        {user.is_verified ? 'Verified' : 'Not Verified'}
-                      </Badge>
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Security Controls */}
-              <Card className="lg:col-span-2">
-                <CardHeader>
-                  <CardTitle>Security Controls</CardTitle>
-                  <CardDescription>MFA status and active sessions</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                  {securityError && (
-                    <Alert variant="destructive">
-                      <AlertDescription>{securityError}</AlertDescription>
-                    </Alert>
-                  )}
-
-                  <div className="rounded-lg border p-4 space-y-3">
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div className="space-y-1">
-                        <div className="font-medium">Password reset</div>
-                        <p className="text-sm text-muted-foreground">
-                          Generate a temporary password for this user.
-                        </p>
-                      </div>
-                      <Button
-                        onClick={handleResetPassword}
-                        disabled={!isAuthorized || passwordResetLoading}
-                        loading={passwordResetLoading}
-                        loadingText="Resetting..."
-                      >
-                        Reset Password
-                      </Button>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="temporary-password">Temporary Password to Set</Label>
-                      <Input
-                        id="temporary-password"
-                        type="password"
-                        autoComplete="new-password"
-                        value={resetPasswordValue}
-                        onChange={(event) => setResetPasswordValue(event.target.value)}
-                        disabled={!isAuthorized || passwordResetLoading}
-                        minLength={10}
-                        placeholder="Enter a temporary password to share securely"
-                      />
-                      <p className="text-xs text-muted-foreground">
-                        Set the temporary password yourself so it never needs to be returned to the browser.
-                      </p>
-                    </div>
-                    <label className="flex items-center gap-2 text-sm">
-                      <input
-                        type="checkbox"
-                        checked={forcePasswordChangeOnNextLogin}
-                        onChange={(event) => setForcePasswordChangeOnNextLogin(event.target.checked)}
-                        disabled={!isAuthorized || passwordResetLoading}
-                        className="h-4 w-4 rounded border-primary"
-                      />
-                      Force Password Change on Next Login
-                    </label>
-                  </div>
-
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <Shield className="h-4 w-4 text-muted-foreground" />
-                        <span className="font-medium">Multi-factor authentication</span>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                        <Badge variant={mfaStatus?.enabled ? 'default' : 'secondary'}>
-                          {mfaStatus?.enabled ? 'Enabled' : 'Disabled'}
-                        </Badge>
-                        {mfaStatus?.method && <span className="text-xs">Method: {mfaStatus.method}</span>}
-                        <span className="text-xs">
-                          Backup codes: {mfaStatus?.has_backup_codes ? 'Set' : 'Not set'}
-                        </span>
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        MFA enrollment is managed by the user from their profile.
-                      </p>
-                    </div>
-                    <Button
-                      variant="outline"
-                      onClick={handleDisableMfa}
-                      disabled={!mfaStatus?.enabled || !isAuthorized}
-                    >
-                      Disable MFA
-                    </Button>
-                  </div>
-
-                  <div className="space-y-3">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div className="flex items-center gap-2">
-                        <Monitor className="h-4 w-4 text-muted-foreground" />
-                        <span className="font-medium">Active sessions</span>
-                        <Badge variant="outline">{sessions.length}</Badge>
-                      </div>
-                      <div className="flex gap-2">
-                        <Button variant="outline" size="sm" onClick={loadSecurity} disabled={securityLoading}>
-                          <RefreshCw className={`mr-2 h-4 w-4 ${securityLoading ? 'animate-spin' : ''}`} />
-                          Refresh
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={handleRevokeAllSessions}
-                          disabled={!sessions.length || !isAuthorized}
-                        >
-                          <Trash2 className="mr-2 h-4 w-4" />
-                          Revoke all
-                        </Button>
-                      </div>
-                    </div>
-
-                    {securityLoading ? (
-                      <div className="text-sm text-muted-foreground">Loading sessions...</div>
-                    ) : sessions.length === 0 ? (
-                      <div className="text-sm text-muted-foreground">No active sessions found.</div>
-                    ) : (
-                      <div className="overflow-x-auto">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>Session</TableHead>
-                              <TableHead>IP Address</TableHead>
-                              <TableHead>Last Activity</TableHead>
-                              <TableHead>Expires</TableHead>
-                              <TableHead className="text-right">Actions</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {sessions.map((session) => (
-                              <TableRow key={session.id}>
-                                <TableCell>
-                                  <div className="text-sm font-mono">{session.id}</div>
-                                  <div className="text-xs text-muted-foreground truncate max-w-[240px]">
-                                    {session.user_agent || 'Unknown device'}
-                                  </div>
-                                </TableCell>
-                                <TableCell className="text-sm font-mono">
-                                  {session.ip_address || '—'}
-                                </TableCell>
-                                <TableCell className="text-sm">{formatDate(session.last_activity || session.created_at)}</TableCell>
-                                <TableCell className="text-sm">{formatDate(session.expires_at || '')}</TableCell>
-                                <TableCell className="text-right">
-                                  <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={() => handleRevokeSession(session)}
-                                    disabled={!isAuthorized}
-                                  >
-                                    Revoke
-                                  </Button>
-                                </TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="space-y-3 border-t pt-4">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div className="flex items-center gap-2">
-                        <Clock className="h-4 w-4 text-muted-foreground" />
-                        <span className="font-medium">Login History</span>
-                        <Badge variant="outline">{loginHistory.length}</Badge>
-                      </div>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={loadLoginHistory}
-                        disabled={loginHistoryLoading}
-                      >
-                        <RefreshCw className={`mr-2 h-4 w-4 ${loginHistoryLoading ? 'animate-spin' : ''}`} />
-                        Refresh
-                      </Button>
-                    </div>
-
-                    {loginHistoryError && (
-                      <Alert variant="destructive">
-                        <AlertDescription>{loginHistoryError}</AlertDescription>
-                      </Alert>
-                    )}
-
-                    {loginHistoryLoading ? (
-                      <div className="text-sm text-muted-foreground">Loading login history...</div>
-                    ) : loginHistory.length === 0 ? (
-                      <div className="text-sm text-muted-foreground">No recent login attempts found.</div>
-                    ) : (
-                      <div className="overflow-x-auto">
-                        <Table>
-                          <TableHeader>
-                            <TableRow>
-                              <TableHead>Timestamp</TableHead>
-                              <TableHead>Status</TableHead>
-                              <TableHead>IP Address</TableHead>
-                              <TableHead>User Agent</TableHead>
-                            </TableRow>
-                          </TableHeader>
-                          <TableBody>
-                            {loginHistory.map((entry) => (
-                              <TableRow key={entry.id}>
-                                <TableCell className="text-sm">{formatDate(entry.timestamp)}</TableCell>
-                                <TableCell>
-                                  <Badge variant={entry.status === 'success' ? 'default' : 'destructive'}>
-                                    {entry.status === 'success' ? 'Success' : 'Failure'}
-                                  </Badge>
-                                </TableCell>
-                                <TableCell className="text-sm font-mono">{entry.ipAddress || '—'}</TableCell>
-                                <TableCell className="text-xs text-muted-foreground">
-                                  {entry.userAgent || 'Unknown client'}
-                                </TableCell>
-                              </TableRow>
-                            ))}
-                          </TableBody>
-                        </Table>
-                      </div>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
+              <UserSecurityCard
+                isAuthorized={isAuthorized}
+                securityLoading={userSecurity.securityLoading}
+                securityError={userSecurity.securityError}
+                mfaStatus={userSecurity.mfaStatus}
+                sessions={userSecurity.sessions}
+                loginHistory={userSecurity.loginHistory}
+                loginHistoryLoading={userSecurity.loginHistoryLoading}
+                loginHistoryError={userSecurity.loginHistoryError}
+                forcePasswordChangeOnNextLogin={userSecurity.forcePasswordChangeOnNextLogin}
+                passwordResetLoading={userSecurity.passwordResetLoading}
+                resetPasswordValue={userSecurity.resetPasswordValue}
+                onForcePasswordChangeOnNextLogin={userSecurity.setForcePasswordChangeOnNextLogin}
+                onResetPasswordValueChange={userSecurity.setResetPasswordValue}
+                onResetPassword={userSecurity.handleResetPassword}
+                onDisableMfa={userSecurity.handleDisableMfa}
+                onRefreshSecurity={loadSecurity}
+                onRevokeAllSessions={userSecurity.handleRevokeAllSessions}
+                onRevokeSession={userSecurity.handleRevokeSession}
+                onRefreshLoginHistory={loadLoginHistory}
+              />
 
               {/* Rate Limits */}
               <Card>
@@ -1703,107 +1070,18 @@ export default function UserDetailPage() {
                 </CardContent>
               </Card>
 
-              <Dialog open={showOrgMembershipsDialog} onOpenChange={setShowOrgMembershipsDialog}>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>User Organizations</DialogTitle>
-                    <DialogDescription>
-                      Organizations this user belongs to and their role in each organization.
-                    </DialogDescription>
-                  </DialogHeader>
-                  {orgMembershipsError && (
-                    <Alert variant="destructive">
-                      <AlertDescription>{orgMembershipsError}</AlertDescription>
-                    </Alert>
-                  )}
-                  {orgMembershipsLoading ? (
-                    <div className="text-sm text-muted-foreground">Loading organizations...</div>
-                  ) : orgMemberships.length === 0 ? (
-                    <div className="text-sm text-muted-foreground">No organization memberships found.</div>
-                  ) : (
-                    <div className="max-h-80 overflow-y-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Organization</TableHead>
-                            <TableHead>Role</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {orgMemberships.map((membership) => (
-                            <TableRow key={membership.org_id}>
-                              <TableCell className="text-sm">
-                                {membership.org_name || `Organization ${membership.org_id}`}
-                              </TableCell>
-                              <TableCell>
-                                <Badge variant="outline">{membership.role}</Badge>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-                  <DialogFooter>
-                    <Button variant="outline" onClick={() => setShowOrgMembershipsDialog(false)}>
-                      Close
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-
-              <Dialog open={showTeamMembershipsDialog} onOpenChange={setShowTeamMembershipsDialog}>
-                <DialogContent>
-                  <DialogHeader>
-                    <DialogTitle>User Teams</DialogTitle>
-                    <DialogDescription>
-                      Team memberships with organization context and assigned role.
-                    </DialogDescription>
-                  </DialogHeader>
-                  {teamMembershipsError && (
-                    <Alert variant="destructive">
-                      <AlertDescription>{teamMembershipsError}</AlertDescription>
-                    </Alert>
-                  )}
-                  {teamMembershipsLoading ? (
-                    <div className="text-sm text-muted-foreground">Loading teams...</div>
-                  ) : teamMemberships.length === 0 ? (
-                    <div className="text-sm text-muted-foreground">No team memberships found.</div>
-                  ) : (
-                    <div className="max-h-80 overflow-y-auto">
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Team</TableHead>
-                            <TableHead>Organization</TableHead>
-                            <TableHead>Role</TableHead>
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {teamMemberships.map((membership) => (
-                            <TableRow key={`${membership.org_id}-${membership.team_id}`}>
-                              <TableCell className="text-sm">
-                                {membership.team_name || `Team ${membership.team_id}`}
-                              </TableCell>
-                              <TableCell className="text-sm text-muted-foreground">
-                                {membership.org_name || `Organization ${membership.org_id}`}
-                              </TableCell>
-                              <TableCell>
-                                <Badge variant="outline">{membership.role}</Badge>
-                              </TableCell>
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </div>
-                  )}
-                  <DialogFooter>
-                    <Button variant="outline" onClick={() => setShowTeamMembershipsDialog(false)}>
-                      Close
-                    </Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+              <UserMembershipDialogs
+                showOrgMembershipsDialog={showOrgMembershipsDialog}
+                showTeamMembershipsDialog={showTeamMembershipsDialog}
+                orgMemberships={orgMemberships}
+                teamMemberships={teamMemberships}
+                orgMembershipsLoading={orgMembershipsLoading}
+                teamMembershipsLoading={teamMembershipsLoading}
+                orgMembershipsError={orgMembershipsError}
+                teamMembershipsError={teamMembershipsError}
+                onOpenOrgMembershipsChange={setShowOrgMembershipsDialog}
+                onOpenTeamMembershipsChange={setShowTeamMembershipsDialog}
+              />
             </div>
           </div>
     );

--- a/admin-ui/app/users/__tests__/page.test.tsx
+++ b/admin-ui/app/users/__tests__/page.test.tsx
@@ -341,4 +341,48 @@ describe('UsersPage', () => {
       });
     });
   });
+
+  it('round-trips a saved view through save, apply, and delete', async () => {
+    const user = userEvent.setup();
+    render(<UsersPage />);
+
+    const searchInput = screen.getByLabelText(/search users by username, email, or role/i) as HTMLInputElement;
+
+    await screen.findByText('Bob');
+    await user.type(searchInput, 'bob');
+    await user.click(screen.getByRole('button', { name: 'Save view' }));
+    await user.type(screen.getByLabelText('View name'), 'Bob only');
+    await user.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Save view' }));
+
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith('Saved view', 'Bob only has been added.');
+    });
+    expect(window.localStorage.getItem('admin_users_saved_views')).toContain('Bob only');
+
+    await user.clear(searchInput);
+    await waitFor(() => {
+      expect(searchInput.value).toBe('');
+    });
+
+    await user.selectOptions(
+      screen.getByLabelText('Saved views'),
+      await screen.findByRole('option', { name: 'Bob only' })
+    );
+
+    await waitFor(() => {
+      expect(searchInput.value).toBe('bob');
+    });
+    expect(await screen.findByText('Bob')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Delete view' }));
+
+    await waitFor(() => {
+      expect(confirmMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Delete saved view' })
+      );
+    });
+    await waitFor(() => {
+      expect(window.localStorage.getItem('admin_users_saved_views') ?? '').not.toContain('Bob only');
+    });
+  });
 });

--- a/admin-ui/app/users/components/UserBulkActions.test.tsx
+++ b/admin-ui/app/users/components/UserBulkActions.test.tsx
@@ -1,0 +1,69 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { UserBulkActions } from './UserBulkActions';
+
+const noop = () => {};
+
+describe('UserBulkActions', () => {
+  it('renders nothing when no users are selected', () => {
+    const { container } = render(
+      <UserBulkActions
+        selectedCount={0}
+        bulkRole="user"
+        bulkRoleOptions={['user', 'admin']}
+        bulkBusy={false}
+        bulkAction={null}
+        onBulkRoleChange={noop}
+        onAssignRole={noop}
+        onActivate={noop}
+        onDeactivate={noop}
+        onRequireMfa={noop}
+        onClearMfa={noop}
+        onDelete={noop}
+        onClearSelection={noop}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('delegates role selection and bulk action clicks', async () => {
+    const user = userEvent.setup();
+    const onBulkRoleChange = vi.fn();
+    const onAssignRole = vi.fn();
+    const onActivate = vi.fn();
+    const onClearSelection = vi.fn();
+
+    render(
+      <UserBulkActions
+        selectedCount={2}
+        bulkRole="user"
+        bulkRoleOptions={['user', 'admin']}
+        bulkBusy={false}
+        bulkAction={null}
+        onBulkRoleChange={onBulkRoleChange}
+        onAssignRole={onAssignRole}
+        onActivate={onActivate}
+        onDeactivate={noop}
+        onRequireMfa={noop}
+        onClearMfa={noop}
+        onDelete={noop}
+        onClearSelection={onClearSelection}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText('Bulk role selection'), 'admin');
+    expect(onBulkRoleChange).toHaveBeenCalledWith('admin');
+
+    await user.click(screen.getByRole('button', { name: 'Assign Role' }));
+    expect(onAssignRole).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Activate' }));
+    expect(onActivate).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', { name: 'Clear selection' }));
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/admin-ui/app/users/components/UserBulkActions.tsx
+++ b/admin-ui/app/users/components/UserBulkActions.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { ShieldCheck, ShieldOff, Trash2, UserCheck, UserX } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+
+interface UserBulkActionsProps {
+  selectedCount: number;
+  bulkRole: string;
+  bulkRoleOptions: string[];
+  bulkBusy: boolean;
+  bulkAction: string | null;
+  onBulkRoleChange: (value: string) => void;
+  onAssignRole: () => void;
+  onActivate: () => void;
+  onDeactivate: () => void;
+  onRequireMfa: () => void;
+  onClearMfa: () => void;
+  onDelete: () => void;
+  onClearSelection: () => void;
+}
+
+export function UserBulkActions({
+  selectedCount,
+  bulkRole,
+  bulkRoleOptions,
+  bulkBusy,
+  bulkAction,
+  onBulkRoleChange,
+  onAssignRole,
+  onActivate,
+  onDeactivate,
+  onRequireMfa,
+  onClearMfa,
+  onDelete,
+  onClearSelection,
+}: UserBulkActionsProps) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div className="mb-4 flex flex-col gap-3 rounded-md border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline">{selectedCount} selected</Badge>
+        <span className="text-sm text-muted-foreground">
+          Bulk actions apply to selected users.
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Select
+          value={bulkRole}
+          onChange={(event) => onBulkRoleChange(event.target.value)}
+          className="min-w-[160px]"
+          aria-label="Bulk role selection"
+          disabled={bulkBusy}
+        >
+          {bulkRoleOptions.map((role) => (
+            <option key={role} value={role}>
+              {role}
+            </option>
+          ))}
+        </Select>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onAssignRole}
+          loading={bulkAction === 'assign-role'}
+          loadingText="Assigning..."
+          disabled={bulkBusy && bulkAction !== 'assign-role'}
+        >
+          Assign Role
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onActivate}
+          loading={bulkAction === 'activate'}
+          loadingText="Activating..."
+          disabled={bulkBusy && bulkAction !== 'activate'}
+        >
+          <UserCheck className="mr-2 h-4 w-4" />
+          Activate
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDeactivate}
+          loading={bulkAction === 'deactivate'}
+          loadingText="Deactivating..."
+          disabled={bulkBusy && bulkAction !== 'deactivate'}
+        >
+          <UserX className="mr-2 h-4 w-4" />
+          Deactivate
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRequireMfa}
+          loading={bulkAction === 'mfa-require'}
+          loadingText="Applying..."
+          disabled={bulkBusy && bulkAction !== 'mfa-require'}
+        >
+          <ShieldCheck className="mr-2 h-4 w-4" />
+          Require MFA
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onClearMfa}
+          loading={bulkAction === 'mfa-clear'}
+          loadingText="Clearing..."
+          disabled={bulkBusy && bulkAction !== 'mfa-clear'}
+        >
+          <ShieldOff className="mr-2 h-4 w-4" />
+          Clear MFA
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDelete}
+          loading={bulkAction === 'delete'}
+          loadingText="Deleting..."
+          disabled={bulkBusy && bulkAction !== 'delete'}
+        >
+          <Trash2 className="mr-2 h-4 w-4 text-destructive" />
+          Delete
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClearSelection}
+          disabled={bulkBusy}
+        >
+          Clear selection
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/app/users/hooks/use-user-filters.test.tsx
+++ b/admin-ui/app/users/hooks/use-user-filters.test.tsx
@@ -1,0 +1,76 @@
+/* @vitest-environment jsdom */
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUserFilters } from './use-user-filters';
+
+vi.mock('@/lib/use-url-state', async () => {
+  const React = await import('react');
+  return {
+    useUrlState: (_key: string, options?: { defaultValue?: unknown }) => {
+      const [value, setValue] = React.useState(options?.defaultValue);
+      return [value, setValue];
+    },
+  };
+});
+
+describe('useUserFilters', () => {
+  const resetPagination = vi.fn();
+
+  beforeEach(() => {
+    localStorage.clear();
+    resetPagination.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('persists, reapplies, and removes saved views', async () => {
+    const { result } = renderHook(() => useUserFilters({ resetPagination }));
+
+    act(() => {
+      result.current.handleSearchChange('bob');
+    });
+
+    expect(resetPagination).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.setSaveViewName('Bob only');
+    });
+
+    let savedViewId = '';
+    act(() => {
+      const saveResult = result.current.saveCurrentView();
+      expect(saveResult.ok).toBe(true);
+      if (saveResult.ok) {
+        savedViewId = saveResult.view.id;
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.savedViews).toHaveLength(1);
+      expect(result.current.activeViewId).toBe(savedViewId);
+    });
+    expect(localStorage.getItem('admin_users_saved_views')).toContain('Bob only');
+
+    act(() => {
+      result.current.handleSearchChange('');
+      result.current.handleApplySavedView(savedViewId);
+    });
+
+    await waitFor(() => {
+      expect(result.current.searchQuery).toBe('bob');
+    });
+
+    act(() => {
+      const removed = result.current.removeSavedView(savedViewId);
+      expect(removed).toMatchObject({ name: 'Bob only', query: 'bob' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.savedViews).toHaveLength(0);
+      expect(result.current.activeViewId).toBe('');
+    });
+    expect(localStorage.getItem('admin_users_saved_views')).toBe('[]');
+  });
+});

--- a/admin-ui/app/users/hooks/use-user-filters.ts
+++ b/admin-ui/app/users/hooks/use-user-filters.ts
@@ -1,0 +1,202 @@
+'use client';
+
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
+import { useUrlState } from '@/lib/use-url-state';
+
+export type SavedUserView = {
+  id: string;
+  name: string;
+  query: string;
+};
+
+export type UserStatusFilter = 'all' | 'active' | 'inactive';
+export type UserVerifiedFilter = 'all' | 'verified' | 'unverified';
+export type UserMfaFilter = 'all' | 'enabled' | 'disabled';
+
+const SAVED_VIEWS_STORAGE_KEY = 'admin_users_saved_views';
+const savedViewsListeners = new Set<() => void>();
+let cachedSavedViewsRaw: string | null = null;
+let cachedSavedViews: SavedUserView[] = [];
+
+const readSavedViews = (): SavedUserView[] => {
+  if (typeof window === 'undefined') return [];
+  let stored: string | null = null;
+  try {
+    stored = window.localStorage.getItem(SAVED_VIEWS_STORAGE_KEY);
+    if (stored === cachedSavedViewsRaw) {
+      return cachedSavedViews;
+    }
+    if (!stored) {
+      cachedSavedViewsRaw = null;
+      cachedSavedViews = [];
+      return cachedSavedViews;
+    }
+    const parsed = JSON.parse(stored);
+    cachedSavedViewsRaw = stored;
+    cachedSavedViews = Array.isArray(parsed) ? (parsed as SavedUserView[]) : [];
+    return cachedSavedViews;
+  } catch (error) {
+    console.warn('Failed to load saved user views:', error);
+    cachedSavedViewsRaw = stored;
+    cachedSavedViews = [];
+    return cachedSavedViews;
+  }
+};
+
+const emitSavedViewsChange = () => {
+  savedViewsListeners.forEach((listener) => listener());
+};
+
+const subscribeToSavedViews = (listener: () => void) => {
+  savedViewsListeners.add(listener);
+
+  if (typeof window === 'undefined') {
+    return () => {
+      savedViewsListeners.delete(listener);
+    };
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === null || event.key === SAVED_VIEWS_STORAGE_KEY) {
+      listener();
+    }
+  };
+
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    savedViewsListeners.delete(listener);
+    window.removeEventListener('storage', handleStorage);
+  };
+};
+
+interface UseUserFiltersOptions {
+  resetPagination: () => void;
+}
+
+export function useUserFilters({ resetPagination }: UseUserFiltersOptions) {
+  const [showSaveViewDialog, setShowSaveViewDialog] = useState(false);
+  const [saveViewName, setSaveViewName] = useState('');
+  const [saveViewError, setSaveViewError] = useState('');
+  const [searchQuery, setSearchQuery] = useUrlState<string>('q', { defaultValue: '' });
+  const [statusFilter, setStatusFilter] = useUrlState<UserStatusFilter>('status', { defaultValue: 'all' });
+  const [verifiedFilter, setVerifiedFilter] = useUrlState<UserVerifiedFilter>('verified', { defaultValue: 'all' });
+  const [mfaFilter, setMfaFilter] = useUrlState<UserMfaFilter>('mfa', { defaultValue: 'all' });
+  const savedViews = useSyncExternalStore(subscribeToSavedViews, readSavedViews, () => []);
+
+  const persistSavedViews = useCallback((views: SavedUserView[]) => {
+    if (typeof window === 'undefined') return;
+    try {
+      const serialized = JSON.stringify(views);
+      cachedSavedViewsRaw = serialized;
+      cachedSavedViews = views;
+      window.localStorage.setItem(SAVED_VIEWS_STORAGE_KEY, serialized);
+      emitSavedViewsChange();
+    } catch (error) {
+      console.warn('Failed to persist saved user views:', error);
+    }
+  }, []);
+
+  const activeViewId = useMemo(() => {
+    const match = savedViews.find((view) => view.query === (searchQuery || ''));
+    return match ? match.id : '';
+  }, [savedViews, searchQuery]);
+
+  const hasActiveFilters = (statusFilter || 'all') !== 'all'
+    || (verifiedFilter || 'all') !== 'all'
+    || (mfaFilter || 'all') !== 'all';
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchQuery(value || undefined);
+    resetPagination();
+  }, [resetPagination, setSearchQuery]);
+
+  const handleStatusFilterChange = useCallback((value: UserStatusFilter) => {
+    setStatusFilter(value === 'all' ? undefined : value);
+    resetPagination();
+  }, [resetPagination, setStatusFilter]);
+
+  const handleVerifiedFilterChange = useCallback((value: UserVerifiedFilter) => {
+    setVerifiedFilter(value === 'all' ? undefined : value);
+    resetPagination();
+  }, [resetPagination, setVerifiedFilter]);
+
+  const handleMfaFilterChange = useCallback((value: UserMfaFilter) => {
+    setMfaFilter(value === 'all' ? undefined : value);
+    resetPagination();
+  }, [resetPagination, setMfaFilter]);
+
+  const handleClearFilters = useCallback(() => {
+    setStatusFilter(undefined);
+    setVerifiedFilter(undefined);
+    setMfaFilter(undefined);
+    resetPagination();
+  }, [resetPagination, setMfaFilter, setStatusFilter, setVerifiedFilter]);
+
+  const handleApplySavedView = useCallback((viewId: string) => {
+    if (!viewId) {
+      setSearchQuery(undefined);
+      resetPagination();
+      return;
+    }
+    const view = savedViews.find((item) => item.id === viewId);
+    if (!view) return;
+    setSearchQuery(view.query || undefined);
+    resetPagination();
+  }, [resetPagination, savedViews, setSearchQuery]);
+
+  const clearSaveViewForm = useCallback(() => {
+    setSaveViewError('');
+    setSaveViewName('');
+  }, []);
+
+  const saveCurrentView = useCallback(() => {
+    const name = saveViewName.trim();
+    if (!name) {
+      setSaveViewError('Provide a name for this view.');
+      return { ok: false as const };
+    }
+
+    const nextView: SavedUserView = {
+      id: `${Date.now()}`,
+      name,
+      query: searchQuery || '',
+    };
+    persistSavedViews([nextView, ...savedViews]);
+    clearSaveViewForm();
+    setShowSaveViewDialog(false);
+    return { ok: true as const, view: nextView };
+  }, [clearSaveViewForm, persistSavedViews, saveViewName, savedViews, searchQuery]);
+
+  const removeSavedView = useCallback((viewId: string) => {
+    const view = savedViews.find((item) => item.id === viewId);
+    if (!view) return null;
+    const next = savedViews.filter((item) => item.id !== viewId);
+    persistSavedViews(next);
+    return view;
+  }, [persistSavedViews, savedViews]);
+
+  return {
+    savedViews,
+    showSaveViewDialog,
+    saveViewName,
+    saveViewError,
+    searchQuery,
+    statusFilter,
+    verifiedFilter,
+    mfaFilter,
+    activeViewId,
+    hasActiveFilters,
+    setShowSaveViewDialog,
+    setSaveViewName,
+    clearSaveViewForm,
+    handleSearchChange,
+    handleStatusFilterChange,
+    handleVerifiedFilterChange,
+    handleMfaFilterChange,
+    handleClearFilters,
+    handleApplySavedView,
+    saveCurrentView,
+    removeSavedView,
+  };
+}

--- a/admin-ui/app/users/page.tsx
+++ b/admin-ui/app/users/page.tsx
@@ -30,8 +30,6 @@ import {
   UserX,
   BookmarkPlus,
   BookmarkX,
-  ShieldCheck,
-  ShieldOff,
 } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
 import { api } from '@/lib/api-client';
@@ -40,22 +38,20 @@ import { Organization, User } from '@/types';
 import { ExportMenu } from '@/components/ui/export-menu';
 import { exportUsers, ExportFormat } from '@/lib/export';
 import { Skeleton, TableSkeleton } from '@/components/ui/skeleton';
-import { useUrlState, useUrlPagination } from '@/lib/use-url-state';
+import { useUrlPagination } from '@/lib/use-url-state';
 import { useConfirm } from '@/components/ui/confirm-dialog';
 import { usePrivilegedActionDialog } from '@/components/ui/privileged-action-dialog';
 import { useToast } from '@/components/ui/toast';
 import { useOrgContext } from '@/components/OrgContextSwitcher';
 import { useResourceState } from '@/lib/use-resource-state';
+import { UserBulkActions } from './components/UserBulkActions';
+import {
+  useUserFilters,
+  type UserMfaFilter,
+  type UserStatusFilter,
+  type UserVerifiedFilter,
+} from './hooks/use-user-filters';
 
-type SavedUserView = {
-  id: string;
-  name: string;
-  query: string;
-};
-
-type UserStatusFilter = 'all' | 'active' | 'inactive';
-type UserVerifiedFilter = 'all' | 'verified' | 'unverified';
-type UserMfaFilter = 'all' | 'enabled' | 'disabled';
 type BulkActionType =
   | 'activate'
   | 'deactivate'
@@ -64,8 +60,6 @@ type BulkActionType =
   | 'mfa-require'
   | 'mfa-clear'
   | null;
-
-const SAVED_VIEWS_STORAGE_KEY = 'admin_users_saved_views';
 
 const createUserSchema = z.object({
   username: z.string().min(1, 'Username is required'),
@@ -177,10 +171,6 @@ function UsersPageContent() {
   const [createUserError, setCreateUserError] = useState('');
   const [creatingUser, setCreatingUser] = useState(false);
   const [deletingUserIds, setDeletingUserIds] = useState<Set<number>>(new Set());
-  const [savedViews, setSavedViews] = useState<SavedUserView[]>([]);
-  const [showSaveViewDialog, setShowSaveViewDialog] = useState(false);
-  const [saveViewName, setSaveViewName] = useState('');
-  const [saveViewError, setSaveViewError] = useState('');
   const [mfaByUserId, setMfaByUserId] = useState<Record<number, boolean>>({});
   const [mfaLoading, setMfaLoading] = useState(false);
   const [orgInvites, setOrgInvites] = useState<OrgInviteRecord[]>([]);
@@ -199,31 +189,31 @@ function UsersPageContent() {
   });
 
   // URL state for search + filters
-  const [searchQuery, setSearchQuery] = useUrlState<string>('q', { defaultValue: '' });
-  const [statusFilter, setStatusFilter] = useUrlState<UserStatusFilter>('status', { defaultValue: 'all' });
-  const [verifiedFilter, setVerifiedFilter] = useUrlState<UserVerifiedFilter>('verified', { defaultValue: 'all' });
-  const [mfaFilter, setMfaFilter] = useUrlState<UserMfaFilter>('mfa', { defaultValue: 'all' });
-  const activeViewId = useMemo(() => {
-    const match = savedViews.find((view) => view.query === (searchQuery || ''));
-    return match ? match.id : '';
-  }, [savedViews, searchQuery]);
-
   // URL state for pagination
   const { page: currentPage, pageSize, setPage: setCurrentPage, setPageSize, resetPagination } = useUrlPagination();
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    try {
-      const stored = window.localStorage.getItem(SAVED_VIEWS_STORAGE_KEY);
-      if (!stored) return;
-      const parsed = JSON.parse(stored);
-      if (Array.isArray(parsed)) {
-        setSavedViews(parsed as SavedUserView[]);
-      }
-    } catch (err) {
-      console.warn('Failed to load saved user views:', err);
-    }
-  }, []);
+  const {
+    savedViews,
+    showSaveViewDialog,
+    saveViewName,
+    saveViewError,
+    searchQuery,
+    statusFilter,
+    verifiedFilter,
+    mfaFilter,
+    activeViewId,
+    hasActiveFilters,
+    setShowSaveViewDialog,
+    setSaveViewName,
+    clearSaveViewForm,
+    handleSearchChange,
+    handleStatusFilterChange,
+    handleVerifiedFilterChange,
+    handleMfaFilterChange,
+    handleClearFilters,
+    handleApplySavedView,
+    saveCurrentView,
+    removeSavedView,
+  } = useUserFilters({ resetPagination });
 
   useEffect(() => {
     if (!showCreateUserDialog) {
@@ -231,16 +221,6 @@ function UsersPageContent() {
       setCreateUserError('');
     }
   }, [createUserForm, showCreateUserDialog]);
-
-  const persistSavedViews = useCallback((views: SavedUserView[]) => {
-    setSavedViews(views);
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage.setItem(SAVED_VIEWS_STORAGE_KEY, JSON.stringify(views));
-    } catch (err) {
-      console.warn('Failed to persist saved user views:', err);
-    }
-  }, []);
 
   const loadUsersResource = useCallback(async () => {
     const params: Record<string, string> = { limit: '200' };
@@ -488,9 +468,6 @@ function UsersPageContent() {
     && selectableUsers.every((user) => selectedUserIds.has(user.id));
   const selectedCount = selectedUserIds.size;
   const bulkBusy = bulkAction !== null;
-  const hasActiveFilters = (statusFilter || 'all') !== 'all'
-    || (verifiedFilter || 'all') !== 'all'
-    || (mfaFilter || 'all') !== 'all';
   const bulkRoleOptions = useMemo(() => {
     const roleSet = new Set<string>(['user', 'admin', 'service']);
     users.forEach((user) => {
@@ -514,33 +491,6 @@ function UsersPageContent() {
 
   const handlePageSizeChange = (size: number) => {
     setPageSize(size);
-    resetPagination();
-  };
-
-  const handleSearchChange = (value: string) => {
-    setSearchQuery(value || undefined);
-    resetPagination();
-  };
-
-  const handleStatusFilterChange = (value: UserStatusFilter) => {
-    setStatusFilter(value === 'all' ? undefined : value);
-    resetPagination();
-  };
-
-  const handleVerifiedFilterChange = (value: UserVerifiedFilter) => {
-    setVerifiedFilter(value === 'all' ? undefined : value);
-    resetPagination();
-  };
-
-  const handleMfaFilterChange = (value: UserMfaFilter) => {
-    setMfaFilter(value === 'all' ? undefined : value);
-    resetPagination();
-  };
-
-  const handleClearFilters = () => {
-    setStatusFilter(undefined);
-    setVerifiedFilter(undefined);
-    setMfaFilter(undefined);
     resetPagination();
   };
 
@@ -788,35 +738,10 @@ function UsersPageContent() {
     exportUsers(filteredUsers, format);
   };
 
-  const handleApplySavedView = (viewId: string) => {
-    if (!viewId) {
-      setSearchQuery(undefined);
-      resetPagination();
-      return;
-    }
-    const view = savedViews.find((item) => item.id === viewId);
-    if (!view) return;
-    setSearchQuery(view.query || undefined);
-    resetPagination();
-  };
-
   const handleSaveView = () => {
-    const name = saveViewName.trim();
-    if (!name) {
-      setSaveViewError('Provide a name for this view.');
-      return;
-    }
-    const query = searchQuery || '';
-    const newView: SavedUserView = {
-      id: `${Date.now()}`,
-      name,
-      query,
-    };
-    persistSavedViews([newView, ...savedViews]);
-    setSaveViewName('');
-    setSaveViewError('');
-    setShowSaveViewDialog(false);
-    success('Saved view', `${name} has been added.`);
+    const result = saveCurrentView();
+    if (!result.ok) return;
+    success('Saved view', `${result.view.name} has been added.`);
   };
 
   const handleDeleteView = async () => {
@@ -831,9 +756,9 @@ function UsersPageContent() {
       icon: 'delete',
     });
     if (!confirmed) return;
-    const next = savedViews.filter((item) => item.id !== activeViewId);
-    persistSavedViews(next);
-    success('Saved view removed', `"${view.name}" deleted.`);
+    const removedView = removeSavedView(activeViewId);
+    if (!removedView) return;
+    success('Saved view removed', `"${removedView.name}" deleted.`);
   };
 
   const handleCreateUserSubmit = createUserForm.handleSubmit(async (data) => {
@@ -1064,8 +989,7 @@ function UsersPageContent() {
                       <Dialog open={showSaveViewDialog} onOpenChange={(open) => {
                         setShowSaveViewDialog(open);
                         if (!open) {
-                          setSaveViewError('');
-                          setSaveViewName('');
+                          clearSaveViewForm();
                         }
                       }}>
                         <DialogTrigger asChild>
@@ -1257,104 +1181,21 @@ function UsersPageContent() {
                 </CardDescription>
               </CardHeader>
               <CardContent>
-                {selectedCount > 0 && (
-                  <div className="mb-4 flex flex-col gap-3 rounded-md border bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Badge variant="outline">{selectedCount} selected</Badge>
-                      <span className="text-sm text-muted-foreground">
-                        Bulk actions apply to selected users.
-                      </span>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      <Select
-                        value={bulkRole}
-                        onChange={(event) => setBulkRole(event.target.value)}
-                        className="min-w-[160px]"
-                        aria-label="Bulk role selection"
-                        disabled={bulkBusy}
-                      >
-                        {bulkRoleOptions.map((role) => (
-                          <option key={role} value={role}>
-                            {role}
-                          </option>
-                        ))}
-                      </Select>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleBulkAssignRole}
-                        loading={bulkAction === 'assign-role'}
-                        loadingText="Assigning..."
-                        disabled={bulkBusy && bulkAction !== 'assign-role'}
-                      >
-                        Assign Role
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleBulkToggleActive(true)}
-                        loading={bulkAction === 'activate'}
-                        loadingText="Activating..."
-                        disabled={bulkBusy && bulkAction !== 'activate'}
-                      >
-                        <UserCheck className="mr-2 h-4 w-4" />
-                        Activate
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleBulkToggleActive(false)}
-                        loading={bulkAction === 'deactivate'}
-                        loadingText="Deactivating..."
-                        disabled={bulkBusy && bulkAction !== 'deactivate'}
-                      >
-                        <UserX className="mr-2 h-4 w-4" />
-                        Deactivate
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleBulkSetMfaRequirement(true)}
-                        loading={bulkAction === 'mfa-require'}
-                        loadingText="Applying..."
-                        disabled={bulkBusy && bulkAction !== 'mfa-require'}
-                      >
-                        <ShieldCheck className="mr-2 h-4 w-4" />
-                        Require MFA
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleBulkSetMfaRequirement(false)}
-                        loading={bulkAction === 'mfa-clear'}
-                        loadingText="Clearing..."
-                        disabled={bulkBusy && bulkAction !== 'mfa-clear'}
-                      >
-                        <ShieldOff className="mr-2 h-4 w-4" />
-                        Clear MFA
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleBulkDelete}
-                        loading={bulkAction === 'delete'}
-                        loadingText="Deleting..."
-                        disabled={bulkBusy && bulkAction !== 'delete'}
-                      >
-                        <Trash2 className="mr-2 h-4 w-4 text-destructive" />
-                        Delete
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleClearSelection}
-                        disabled={bulkBusy}
-                      >
-                        Clear selection
-                      </Button>
-                    </div>
-                  </div>
-                )}
+                <UserBulkActions
+                  selectedCount={selectedCount}
+                  bulkRole={bulkRole}
+                  bulkRoleOptions={bulkRoleOptions}
+                  bulkBusy={bulkBusy}
+                  bulkAction={bulkAction}
+                  onBulkRoleChange={setBulkRole}
+                  onAssignRole={handleBulkAssignRole}
+                  onActivate={() => handleBulkToggleActive(true)}
+                  onDeactivate={() => handleBulkToggleActive(false)}
+                  onRequireMfa={() => handleBulkSetMfaRequirement(true)}
+                  onClearMfa={() => handleBulkSetMfaRequirement(false)}
+                  onDelete={handleBulkDelete}
+                  onClearSelection={handleClearSelection}
+                />
                 {loading ? (
                   <div className="py-4">
                     <TableSkeleton rows={5} columns={9} />
@@ -1373,7 +1214,7 @@ function UsersPageContent() {
                         ? {
                             label: 'Clear filters',
                             onClick: () => {
-                              setSearchQuery(undefined);
+                              handleSearchChange('');
                               handleClearFilters();
                             },
                           }

--- a/admin-ui/app/voice-commands/[id]/page.tsx
+++ b/admin-ui/app/voice-commands/[id]/page.tsx
@@ -45,7 +45,8 @@ const editCommandSchema = z.object({
   requires_confirmation: z.boolean().default(false),
 });
 
-type EditCommandFormData = z.infer<typeof editCommandSchema>;
+type EditCommandFormInput = z.input<typeof editCommandSchema>;
+type EditCommandFormData = z.output<typeof editCommandSchema>;
 
 export default function VoiceCommandDetailPage({
   params,
@@ -67,7 +68,7 @@ export default function VoiceCommandDetailPage({
   const [testInput, setTestInput] = useState('');
   const [testResult, setTestResult] = useState<VoiceCommandMatchResult | null>(null);
 
-  const form = useForm<EditCommandFormData>({
+  const form = useForm<EditCommandFormInput, unknown, EditCommandFormData>({
     resolver: zodResolver(editCommandSchema),
     defaultValues: {
       name: '',

--- a/admin-ui/app/voice-commands/components/TopCommandsChart.tsx
+++ b/admin-ui/app/voice-commands/components/TopCommandsChart.tsx
@@ -73,12 +73,14 @@ export function TopCommandsChart({ data, isLoading }: TopCommandsChartProps) {
                     border: '1px solid hsl(var(--border))',
                     borderRadius: '8px',
                   }}
-                  formatter={(value: number, name: string) => {
-                    if (name === 'invocations') return [value, 'Invocations'];
-                    return [value, name];
+                  formatter={(value, name) => {
+                    const safeValue = typeof value === 'number' ? value : 0;
+                    const safeName = typeof name === 'string' ? name : 'Invocations';
+                    if (safeName === 'invocations') return [safeValue, 'Invocations'];
+                    return [safeValue, safeName];
                   }}
-                  labelFormatter={(label: string, payload: unknown[]) => {
-                    const item = payload?.[0] as { payload?: { fullName: string } } | undefined;
+                  labelFormatter={(label, payload) => {
+                    const item = payload?.[0] as { payload?: { fullName?: string } } | undefined;
                     return item?.payload?.fullName || label;
                   }}
                 />

--- a/admin-ui/app/voice-commands/page.tsx
+++ b/admin-ui/app/voice-commands/page.tsx
@@ -47,7 +47,8 @@ const createCommandSchema = z.object({
   requires_confirmation: z.boolean().default(false),
 });
 
-type CreateCommandFormData = z.infer<typeof createCommandSchema>;
+type CreateCommandFormInput = z.input<typeof createCommandSchema>;
+type CreateCommandFormData = z.output<typeof createCommandSchema>;
 
 function VoiceCommandsPageContent() {
   const confirm = useConfirm();
@@ -63,7 +64,7 @@ function VoiceCommandsPageContent() {
   const [showDetailedAnalytics, setShowDetailedAnalytics] = useState(false);
   const [analyticsLoading, setAnalyticsLoading] = useState(false);
 
-  const createForm = useForm<CreateCommandFormData>({
+  const createForm = useForm<CreateCommandFormInput, unknown, CreateCommandFormData>({
     resolver: zodResolver(createCommandSchema),
     defaultValues: {
       name: '',

--- a/admin-ui/bun.lock
+++ b/admin-ui/bun.lock
@@ -34,6 +34,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -288,6 +289,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -815,7 +818,7 @@
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1078,6 +1081,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1383,7 +1390,11 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "sharp/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001750", "", {}, "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ=="],
 

--- a/admin-ui/components/ErrorBoundary.tsx
+++ b/admin-ui/components/ErrorBoundary.tsx
@@ -65,6 +65,8 @@ class ErrorBoundaryBase extends Component<ErrorBoundaryProps, ErrorBoundaryState
       const nextCount = prev.retryCount + 1;
       if (nextCount >= prev.maxRetries) {
         return {
+          ...prev,
+          hasError: true,
           retryCount: nextCount,
           retriesExhausted: true,
         };
@@ -75,6 +77,7 @@ class ErrorBoundaryBase extends Component<ErrorBoundaryProps, ErrorBoundaryState
         errorInfo: null,
         showDetails: false,
         retryCount: nextCount,
+        maxRetries: prev.maxRetries,
         retriesExhausted: false,
       };
     });

--- a/admin-ui/components/PlanGuard.tsx
+++ b/admin-ui/components/PlanGuard.tsx
@@ -18,11 +18,11 @@ interface PlanGuardProps {
 
 export function PlanGuard({ requiredPlan, featureName, fallback, children }: PlanGuardProps) {
   const { selectedOrg, loading: orgLoading } = useOrgContext();
+  const billingEnabled = isBillingEnabled();
   const [allowed, setAllowed] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!isBillingEnabled()) {
-      setAllowed(true);
+    if (!billingEnabled) {
       return;
     }
     if (orgLoading || !selectedOrg) return;
@@ -40,7 +40,11 @@ export function PlanGuard({ requiredPlan, featureName, fallback, children }: Pla
         if (!cancelled) setAllowed(false);
       });
     return () => { cancelled = true; };
-  }, [selectedOrg, orgLoading, requiredPlan]);
+  }, [billingEnabled, selectedOrg, orgLoading, requiredPlan]);
+
+  if (!billingEnabled) {
+    return <>{children}</>;
+  }
 
   if (allowed === null) return null; // loading
   if (allowed) return <>{children}</>;

--- a/admin-ui/components/__tests__/PlanGuard.test.tsx
+++ b/admin-ui/components/__tests__/PlanGuard.test.tsx
@@ -35,6 +35,7 @@ describe('PlanGuard', () => {
     mockUseOrgContext.mockReturnValue({ selectedOrg: null, loading: false });
     render(<PlanGuard requiredPlan="pro"><div>Protected Content</div></PlanGuard>);
     expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    expect(mockGetOrgSubscription).not.toHaveBeenCalled();
   });
 
   it('renders children when org has required plan', async () => {

--- a/admin-ui/components/data-ops/MaintenanceSection.tsx
+++ b/admin-ui/components/data-ops/MaintenanceSection.tsx
@@ -273,11 +273,8 @@ export function MaintenanceSection({ refreshSignal }: MaintenanceSectionProps) {
       try {
         const currentUser = await api.getCurrentUser();
         if (cancelled) return;
-        const record = currentUser && typeof currentUser === 'object'
-          ? currentUser as Record<string, unknown>
-          : {};
-        const usernameCandidate = typeof record.username === 'string' ? record.username : '';
-        const emailCandidate = typeof record.email === 'string' ? record.email : '';
+        const usernameCandidate = currentUser.username?.trim() ?? '';
+        const emailCandidate = currentUser.email?.trim() ?? '';
         const nextInitiator = usernameCandidate || emailCandidate || 'admin';
         setRotationInitiator(nextInitiator);
       } catch {
@@ -339,12 +336,13 @@ export function MaintenanceSection({ refreshSignal }: MaintenanceSectionProps) {
     if (previousStatus === 'running' && currentStatus && currentStatus !== 'running' && rotationState) {
       const completedAt = rotationState.completed_at ?? new Date().toISOString();
       setRotationHistory((previous) => {
+        const completedStatus = rotationState.status === 'complete' ? 'complete' : 'failed';
         const nextEntry: RotationHistoryEntry = {
           rotation_id: rotationState.rotation_id,
           completed_at: completedAt,
           records_affected: rotationState.records_processed,
           initiated_by: rotationState.initiated_by,
-          status: rotationState.status,
+          status: completedStatus,
         };
         const deduped = previous.filter((entry) => entry.rotation_id !== nextEntry.rotation_id);
         return [nextEntry, ...deduped].slice(0, 10);

--- a/admin-ui/components/users/ApiKeyCreateForm.tsx
+++ b/admin-ui/components/users/ApiKeyCreateForm.tsx
@@ -15,7 +15,8 @@ const apiKeySchema = z.object({
   ),
 });
 
-export type ApiKeyFormData = z.infer<typeof apiKeySchema>;
+type ApiKeyFormInput = z.input<typeof apiKeySchema>;
+export type ApiKeyFormData = z.output<typeof apiKeySchema>;
 
 type ApiKeyCreateFormProps = {
   onSubmit: (data: ApiKeyFormData) => Promise<void> | void;
@@ -23,7 +24,7 @@ type ApiKeyCreateFormProps = {
   isSubmitting?: boolean;
 };
 
-const defaultValues: ApiKeyFormData = {
+const defaultValues: ApiKeyFormInput = {
   name: '',
   scope: 'read',
   expires_days: 90,
@@ -34,7 +35,7 @@ export const ApiKeyCreateForm = ({
   onCancel,
   isSubmitting = false,
 }: ApiKeyCreateFormProps) => {
-  const form = useForm<ApiKeyFormData>({
+  const form = useForm<ApiKeyFormInput, unknown, ApiKeyFormData>({
     resolver: zodResolver(apiKeySchema),
     defaultValues,
   });

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -3,17 +3,36 @@
 import { ApiError, requestJson, requestText } from './http';
 import { normalizeListResponse, normalizePagedResponse } from './normalize';
 import type {
+  ApiKey,
+  ApiKeyMutationResponse,
   AuditLog,
   BackupsResponse,
+  EffectivePermissionsResponse,
   FeatureRegistryEntry,
   IncidentsResponse,
   Invoice,
+  OrgMember,
+  Organization,
+  OrgMembership,
   OrgUsageSummary,
   Plan,
+  ProviderSecret,
   RegistrationCode,
   RetentionPoliciesResponse,
+  SecurityAlertStatus,
+  SecurityHealthData,
   Subscription,
+  Team,
+  TeamMembership,
+  User,
   UserWithKeyCount,
+  VoiceAnalyticsSummary,
+  VoiceCommand,
+  VoiceCommandListResponse,
+  VoiceCommandUsage,
+  VoiceSession,
+  VoiceSessionListResponse,
+  WatchlistSettings,
 } from '@/types';
 export { ApiError };
 
@@ -151,11 +170,11 @@ export const api = {
     method: 'POST',
     body: JSON.stringify(data),
   }),
-  getUser: (userId: string) => requestJson(`/admin/users/${userId}`),
-  getUserOrgMemberships: (userId: string) => requestJson(`/admin/users/${userId}/org-memberships`),
-  getUserTeamMemberships: (userId: string) => requestJson(`/admin/users/${userId}/team-memberships`),
+  getUser: (userId: string) => requestJson<User>(`/admin/users/${userId}`),
+  getUserOrgMemberships: (userId: string) => requestJson<OrgMembership[]>(`/admin/users/${userId}/org-memberships`),
+  getUserTeamMemberships: (userId: string) => requestJson<TeamMembership[]>(`/admin/users/${userId}/team-memberships`),
   getUserEffectivePermissions: (userId: string) =>
-    requestJson(`/admin/users/${userId}/effective-permissions`),
+    requestJson<EffectivePermissionsResponse>(`/admin/users/${userId}/effective-permissions`),
   getUserSessions: (userId: string) => requestJson(`/admin/users/${userId}/sessions`),
   revokeUserSession: (userId: string, sessionId: string, data: { reason: string; admin_password?: string | null }) =>
     requestJson(`/admin/users/${userId}/sessions/${sessionId}`, {
@@ -193,7 +212,7 @@ export const api = {
     method: 'DELETE',
     body: JSON.stringify(data),
   }),
-  getCurrentUser: () => requestJson('/users/me'),
+  getCurrentUser: () => requestJson<User>('/users/me'),
 
   // ============================================
   // Registration Codes
@@ -229,13 +248,13 @@ export const api = {
       query.set('include_revoked', String(params.include_revoked));
     }
     const suffix = query.toString() ? `?${query.toString()}` : '';
-    return requestJson(`/admin/users/${userId}/api-keys${suffix}`);
+    return requestJson<ApiKey[]>(`/admin/users/${userId}/api-keys${suffix}`);
   },
-  createApiKey: (userId: string, data: Record<string, unknown>) => requestJson(`/admin/users/${userId}/api-keys`, {
+  createApiKey: (userId: string, data: Record<string, unknown>) => requestJson<ApiKeyMutationResponse>(`/admin/users/${userId}/api-keys`, {
     method: 'POST',
     body: JSON.stringify(data),
   }),
-  rotateApiKey: (userId: string, keyId: string) => requestJson(`/admin/users/${userId}/api-keys/${keyId}/rotate`, {
+  rotateApiKey: (userId: string, keyId: string) => requestJson<ApiKeyMutationResponse>(`/admin/users/${userId}/api-keys/${keyId}/rotate`, {
     method: 'POST',
   }),
   revokeApiKey: (userId: string, keyId: string) => requestJson(`/admin/users/${userId}/api-keys/${keyId}`, {
@@ -250,7 +269,7 @@ export const api = {
     const queryParams = params ? new URLSearchParams(params).toString() : '';
     return requestJson(`/admin/orgs${queryParams ? `?${queryParams}` : ''}`);
   },
-  getOrganization: (orgId: string) => requestJson(`/orgs/${orgId}`),
+  getOrganization: (orgId: string) => requestJson<Organization>(`/orgs/${orgId}`),
   createOrganization: (data: Record<string, unknown>) => requestJson('/admin/orgs', {
     method: 'POST',
     body: JSON.stringify(data),
@@ -262,7 +281,7 @@ export const api = {
   deleteOrganization: (orgId: string) => requestJson(`/orgs/${orgId}`, {
     method: 'DELETE',
   }),
-  getOrgMembers: (orgId: string) => requestJson(`/admin/orgs/${orgId}/members`),
+  getOrgMembers: (orgId: string) => requestJson<OrgMember[]>(`/admin/orgs/${orgId}/members`),
   addOrgMember: (orgId: string, data: Record<string, unknown>) => requestJson(`/admin/orgs/${orgId}/members`, {
     method: 'POST',
     body: JSON.stringify(data),
@@ -287,7 +306,7 @@ export const api = {
   // Teams
   // ============================================
   getTeam,
-  getTeams: (orgId: string) => requestJson(`/admin/orgs/${orgId}/teams`),
+  getTeams: (orgId: string) => requestJson<Team[]>(`/admin/orgs/${orgId}/teams`),
   createTeam: (orgId: string, data: Record<string, unknown>) => requestJson(`/admin/orgs/${orgId}/teams`, {
     method: 'POST',
     body: JSON.stringify(data),
@@ -366,7 +385,7 @@ export const api = {
   deleteUserByokKey: (userId: string, provider: string) => requestJson(`/admin/users/${userId}/byok-keys/${provider}`, {
     method: 'DELETE',
   }),
-  getOrgByokKeys: (orgId: string) => requestJson(`/admin/orgs/${orgId}/byok-keys`),
+  getOrgByokKeys: (orgId: string) => requestJson<ProviderSecret[]>(`/admin/orgs/${orgId}/byok-keys`),
   createOrgByokKey: (orgId: string, data: Record<string, unknown>) => requestJson(`/admin/orgs/${orgId}/byok-keys`, {
     method: 'POST',
     body: JSON.stringify(data),
@@ -832,8 +851,8 @@ export const api = {
   // ============================================
   // Security Health
   // ============================================
-  getSecurityHealth: () => requestJson('/health/security'),
-  getSecurityAlertStatus: () => requestJson('/admin/security/alert-status'),
+  getSecurityHealth: () => requestJson<SecurityHealthData>('/health/security'),
+  getSecurityAlertStatus: () => requestJson<SecurityAlertStatus>('/admin/security/alert-status'),
 
   // ============================================
   // Virtual API Keys
@@ -927,7 +946,7 @@ export const api = {
   // Organization Watchlist Settings
   // ============================================
   getOrgWatchlistSettings: (orgId: string) =>
-    requestJson(`/admin/orgs/${encodeURIComponent(orgId)}/watchlists/settings`),
+    requestJson<WatchlistSettings>(`/admin/orgs/${encodeURIComponent(orgId)}/watchlists/settings`),
   updateOrgWatchlistSettings: (orgId: string, data: Record<string, unknown>) =>
     requestJson(`/admin/orgs/${encodeURIComponent(orgId)}/watchlists/settings`, {
       method: 'PATCH',
@@ -1021,17 +1040,17 @@ export const api = {
   // ============================================
   getVoiceCommands: async (params?: Record<string, string>) => {
     const queryParams = params ? new URLSearchParams(params).toString() : '';
-    return requestJson(`/voice/commands${queryParams ? `?${queryParams}` : ''}`);
+    return requestJson<VoiceCommandListResponse | VoiceCommand[]>(`/voice/commands${queryParams ? `?${queryParams}` : ''}`);
   },
   getVoiceCommand: (commandId: string, signal?: AbortSignal) =>
-    requestJson(`/voice/commands/${encodeURIComponent(commandId)}`, { signal }),
+    requestJson<VoiceCommand>(`/voice/commands/${encodeURIComponent(commandId)}`, { signal }),
   createVoiceCommand: (data: Record<string, unknown>) =>
-    requestJson('/voice/commands', {
+    requestJson<VoiceCommand>('/voice/commands', {
       method: 'POST',
       body: JSON.stringify(data),
     }),
   updateVoiceCommand: (commandId: string, data: Record<string, unknown>) =>
-    requestJson(`/voice/commands/${encodeURIComponent(commandId)}`, {
+    requestJson<VoiceCommand>(`/voice/commands/${encodeURIComponent(commandId)}`, {
       method: 'PUT',
       body: JSON.stringify(data),
     }),
@@ -1040,7 +1059,7 @@ export const api = {
       method: 'DELETE',
     }),
   toggleVoiceCommand: (commandId: string, enabled: boolean) =>
-    requestJson(`/voice/commands/${encodeURIComponent(commandId)}/toggle`, {
+    requestJson<VoiceCommand>(`/voice/commands/${encodeURIComponent(commandId)}/toggle`, {
       method: 'POST',
       body: JSON.stringify({ enabled }),
     }),
@@ -1048,10 +1067,10 @@ export const api = {
   // Voice Sessions
   getVoiceSessions: (params?: Record<string, string>) => {
     const queryParams = params ? new URLSearchParams(params).toString() : '';
-    return requestJson(`/voice/sessions${queryParams ? `?${queryParams}` : ''}`);
+    return requestJson<VoiceSessionListResponse | VoiceSession[]>(`/voice/sessions${queryParams ? `?${queryParams}` : ''}`);
   },
   getVoiceSession: (sessionId: string) =>
-    requestJson(`/voice/sessions/${encodeURIComponent(sessionId)}`),
+    requestJson<VoiceSession>(`/voice/sessions/${encodeURIComponent(sessionId)}`),
   deleteVoiceSession: (sessionId: string) =>
     requestJson(`/voice/sessions/${encodeURIComponent(sessionId)}`, {
       method: 'DELETE',
@@ -1064,7 +1083,7 @@ export const api = {
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => [k, String(v)])
     ).toString() : '';
-    return requestJson(`/voice/analytics${queryParams ? `?${queryParams}` : ''}`);
+    return requestJson<VoiceAnalyticsSummary>(`/voice/analytics${queryParams ? `?${queryParams}` : ''}`);
   },
   getVoiceCommandUsage: (commandId: string, params?: { days?: number }, signal?: AbortSignal) => {
     const queryParams = params ? new URLSearchParams(
@@ -1072,7 +1091,7 @@ export const api = {
         .filter(([, v]) => v !== undefined)
         .map(([k, v]) => [k, String(v)])
     ).toString() : '';
-    return requestJson(`/voice/commands/${encodeURIComponent(commandId)}/usage${queryParams ? `?${queryParams}` : ''}`, { signal });
+    return requestJson<VoiceCommandUsage>(`/voice/commands/${encodeURIComponent(commandId)}/usage${queryParams ? `?${queryParams}` : ''}`, { signal });
   },
 
   // Voice Workflow Templates

--- a/admin-ui/lib/export.ts
+++ b/admin-ui/lib/export.ts
@@ -50,10 +50,21 @@ function getNestedValue(obj: Record<string, unknown> | null | undefined, path: s
   }, obj);
 }
 
+function toIsoDateString(value: unknown, fallback = ''): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? fallback : date.toISOString();
+  }
+  return fallback;
+}
+
 /**
  * Convert data array to CSV string
  */
-function toCSV<T>(data: T[], columns: ExportOptions<T>['columns']): string {
+function toCSV<T extends Record<string, unknown>>(data: T[], columns: ExportOptions<T>['columns']): string {
   if (!columns || columns.length === 0) {
     // Auto-generate columns from first item
     if (data.length === 0) return '';
@@ -98,7 +109,7 @@ function downloadFile(content: string, filename: string, mimeType: string): void
 /**
  * Export data to CSV or JSON file
  */
-export function exportData<T>(options: ExportOptions<T>): void {
+export function exportData<T extends Record<string, unknown>>(options: ExportOptions<T>): void {
   const { data, filename, format, columns } = options;
   const timestamp = new Date().toISOString().split('T')[0];
 
@@ -120,7 +131,7 @@ export function exportAuditLogs<T extends object>(logs: T[], format: ExportForma
     filename: 'audit-logs',
     format,
     columns: [
-      { key: 'timestamp', header: 'Timestamp', transform: (v) => v ? new Date(v).toISOString() : '' },
+      { key: 'timestamp', header: 'Timestamp', transform: (v) => toIsoDateString(v) },
       { key: 'user_id', header: 'User ID' },
       { key: 'action', header: 'Action' },
       { key: 'resource', header: 'Resource' },
@@ -134,9 +145,9 @@ export function exportAuditLogs<T extends object>(logs: T[], format: ExportForma
 /**
  * Pre-configured export for users
  */
-export function exportUsers(users: Array<Record<string, unknown>>, format: ExportFormat = 'csv'): void {
+export function exportUsers<T extends object>(users: T[], format: ExportFormat = 'csv'): void {
   exportData({
-    data: users,
+    data: users as Record<string, unknown>[],
     filename: 'users',
     format,
     columns: [
@@ -148,8 +159,8 @@ export function exportUsers(users: Array<Record<string, unknown>>, format: Expor
       { key: 'is_verified', header: 'Verified', transform: (v) => v ? 'Yes' : 'No' },
       { key: 'storage_used_mb', header: 'Storage Used (MB)' },
       { key: 'storage_quota_mb', header: 'Storage Quota (MB)' },
-      { key: 'created_at', header: 'Created At', transform: (v) => v ? new Date(v).toISOString() : '' },
-      { key: 'last_login', header: 'Last Login', transform: (v) => v ? new Date(v).toISOString() : '' },
+      { key: 'created_at', header: 'Created At', transform: (v) => toIsoDateString(v) },
+      { key: 'last_login', header: 'Last Login', transform: (v) => toIsoDateString(v) },
     ],
   });
 }
@@ -157,9 +168,9 @@ export function exportUsers(users: Array<Record<string, unknown>>, format: Expor
 /**
  * Pre-configured export for API keys
  */
-export function exportApiKeys(keys: Array<Record<string, unknown>>, format: ExportFormat = 'csv'): void {
+export function exportApiKeys<T extends object>(keys: T[], format: ExportFormat = 'csv'): void {
   exportData({
-    data: keys,
+    data: keys as Record<string, unknown>[],
     filename: 'api-keys',
     format,
     columns: [
@@ -168,9 +179,9 @@ export function exportApiKeys(keys: Array<Record<string, unknown>>, format: Expo
       { key: 'prefix', header: 'Key Prefix' },
       { key: 'user_id', header: 'User ID' },
       { key: 'is_active', header: 'Active', transform: (v) => v ? 'Yes' : 'No' },
-      { key: 'created_at', header: 'Created At', transform: (v) => v ? new Date(v).toISOString() : '' },
-      { key: 'expires_at', header: 'Expires At', transform: (v) => v ? new Date(v).toISOString() : 'Never' },
-      { key: 'last_used_at', header: 'Last Used', transform: (v) => v ? new Date(v).toISOString() : 'Never' },
+      { key: 'created_at', header: 'Created At', transform: (v) => toIsoDateString(v) },
+      { key: 'expires_at', header: 'Expires At', transform: (v) => toIsoDateString(v, 'Never') },
+      { key: 'last_used_at', header: 'Last Used', transform: (v) => toIsoDateString(v, 'Never') },
     ],
   });
 }

--- a/admin-ui/middleware.ts
+++ b/admin-ui/middleware.ts
@@ -173,6 +173,7 @@ const verifyJwtLocally = async (
 
   const data = new TextEncoder().encode(`${headerSegment}.${payloadSegment}`);
   const signature = base64UrlToUint8Array(signatureSegment);
+  const signatureBuffer = new Uint8Array(signature).buffer;
   const secrets = [secret, secondarySecret].filter((value): value is string => !!value);
   let signatureValid = false;
 
@@ -184,7 +185,7 @@ const verifyJwtLocally = async (
       false,
       ['verify']
     );
-    if (await subtle.verify('HMAC', key, signature, data)) {
+    if (await subtle.verify('HMAC', key, signatureBuffer, data)) {
       signatureValid = true;
       break;
     }

--- a/admin-ui/next.config.js
+++ b/admin-ui/next.config.js
@@ -1,11 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  // Skip TypeScript errors during build - stricter type checking after zod update
-  // requires refactoring Promise.allSettled patterns throughout the codebase.
-  typescript: {
-    ignoreBuildErrors: true,
-  },
 }
 
 module.exports = nextConfig

--- a/admin-ui/next.config.js
+++ b/admin-ui/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: `${__dirname}/..`,
 }
 
 module.exports = nextConfig

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start -p 3001",
     "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "test:smoke": "playwright test",
     "test:a11y": "vitest run app/__tests__/dashboard.a11y.test.tsx app/users/__tests__/page.test.tsx app/monitoring/__tests__/page.test.tsx app/audit/__tests__/page.test.tsx app/data-ops/__tests__/page.a11y.test.tsx app/__tests__/dark-mode-contrast.test.ts app/__tests__/icon-button-audit.test.ts",
     "lint": "BROWSERSLIST_IGNORE_OLD_DATA=1 BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA=1 eslint ."
   },
@@ -46,6 +48,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const rawBaseUrl = process.env.TLDW_ADMIN_UI_URL || 'http://127.0.0.1:3001';
+const baseURL = rawBaseUrl.replace('localhost', '127.0.0.1');
+const webCommand = process.env.TLDW_ADMIN_UI_CMD || 'bun run dev -- --hostname 127.0.0.1';
+const shouldAutoStart = process.env.TLDW_ADMIN_UI_AUTOSTART !== 'false';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  timeout: 60_000,
+  expect: {
+    timeout: 15_000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'line',
+  outputDir: '/tmp/tldw-admin-playwright',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  webServer: shouldAutoStart
+    ? {
+        command: webCommand,
+        url: baseURL,
+        reuseExistingServer: true,
+        timeout: 120_000,
+        env: {
+          ...process.env,
+          JWT_ALGORITHM: process.env.JWT_ALGORITHM || 'HS256',
+          JWT_SECRET_KEY: process.env.JWT_SECRET_KEY || 'playwright-test-secret',
+          NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:5999',
+          NEXT_TELEMETRY_DISABLED: '1',
+        },
+      }
+    : undefined,
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/admin-ui/tests/e2e/login-and-mfa.spec.ts
+++ b/admin-ui/tests/e2e/login-and-mfa.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+import { installAdminApiRoutes, installLoginRoutes } from './smoke-helpers';
+
+test('supports password login and MFA challenge completion', async ({ page }) => {
+  await installAdminApiRoutes(page);
+  await installLoginRoutes(page);
+
+  await page.goto('/login?redirectTo=%2Fusers%2F42');
+  await page.getByLabel(/username or email/i).fill('admin');
+  await page.getByLabel(/^password$/i).fill('AdminPass123!');
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  await expect(page.getByLabel(/verification code/i)).toBeVisible();
+  await page.getByLabel(/verification code/i).fill('123456');
+  await page.getByRole('button', { name: /verify mfa/i }).click();
+
+  await expect(page).toHaveURL(/\/users\/42$/);
+  await expect(page.getByRole('button', { name: 'Reset Password' })).toBeVisible();
+});

--- a/admin-ui/tests/e2e/smoke-helpers.ts
+++ b/admin-ui/tests/e2e/smoke-helpers.ts
@@ -1,0 +1,243 @@
+import { createHmac } from 'node:crypto';
+import type { Page, Route } from '@playwright/test';
+
+type AdminUserRecord = {
+  id: number;
+  uuid: string;
+  username: string;
+  email: string;
+  role: string;
+  is_active: boolean;
+  is_verified: boolean;
+  storage_quota_mb: number;
+  storage_used_mb: number;
+  created_at: string;
+  updated_at: string;
+  last_login?: string;
+  metadata?: Record<string, unknown>;
+};
+
+const origin = (process.env.TLDW_ADMIN_UI_URL || 'http://127.0.0.1:3001').replace('localhost', '127.0.0.1');
+const jwtSecret = process.env.JWT_SECRET_KEY || 'playwright-test-secret';
+
+export const adminUser: AdminUserRecord = {
+  id: 1,
+  uuid: 'admin-user-1',
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin',
+  is_active: true,
+  is_verified: true,
+  storage_quota_mb: 4096,
+  storage_used_mb: 256,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  last_login: '2026-03-10T01:00:00Z',
+};
+
+export const targetUser: AdminUserRecord = {
+  id: 42,
+  uuid: 'managed-user-42',
+  username: 'managed-user',
+  email: 'managed@example.com',
+  role: 'user',
+  is_active: true,
+  is_verified: true,
+  storage_quota_mb: 1024,
+  storage_used_mb: 64,
+  created_at: '2026-01-03T00:00:00Z',
+  updated_at: '2026-03-09T12:00:00Z',
+  metadata: {
+    force_password_change: true,
+  },
+};
+
+const jsonHeaders = {
+  'access-control-allow-origin': '*',
+  'content-type': 'application/json',
+};
+
+const toJsonResponse = async (route: Route, payload: unknown, status = 200) => {
+  await route.fulfill({
+    status,
+    headers: jsonHeaders,
+    body: JSON.stringify(payload),
+  });
+};
+
+const toBase64Url = (value: string): string => Buffer.from(value).toString('base64url');
+
+const createJwt = (payload: Record<string, unknown>): string => {
+  const header = toBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = toBase64Url(JSON.stringify(payload));
+  const signature = createHmac('sha256', jwtSecret)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+
+  return `${header}.${body}.${signature}`;
+};
+
+export const setAuthenticatedSession = async (page: Page) => {
+  const now = Math.floor(Date.now() / 1000);
+  const accessToken = createJwt({
+    sub: String(adminUser.id),
+    role: adminUser.role,
+    iat: now,
+    exp: now + 3600,
+  });
+
+  await page.context().addCookies([
+    {
+      name: 'access_token',
+      value: accessToken,
+      url: origin,
+      httpOnly: true,
+      sameSite: 'Lax',
+    },
+    {
+      name: 'admin_session',
+      value: '1',
+      url: origin,
+      sameSite: 'Lax',
+    },
+    {
+      name: 'admin_auth_mode',
+      value: 'jwt',
+      url: origin,
+      sameSite: 'Lax',
+    },
+  ]);
+};
+
+export const installAdminApiRoutes = async (page: Page) => {
+  await page.route('**/api/proxy/**', async (route) => {
+    const url = new URL(route.request().url());
+    const path = `${url.pathname}${url.search}`;
+
+    if (path === '/api/proxy/users/me') {
+      await toJsonResponse(route, adminUser);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/orgs') {
+      await toJsonResponse(route, [{ id: 100, name: 'Acme Org', slug: 'acme-org' }]);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/1/effective-permissions') {
+      await toJsonResponse(route, {
+        permissions: ['read:users', 'write:users', 'read:orgs', 'write:orgs'],
+      });
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42') {
+      await toJsonResponse(route, targetUser);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/1/org-memberships') {
+      await toJsonResponse(route, [{ org_id: 100, role: 'owner', org_name: 'Acme Org' }]);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/org-memberships') {
+      await toJsonResponse(route, [{ org_id: 100, role: 'member', org_name: 'Acme Org' }]);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/mfa') {
+      await toJsonResponse(route, {
+        enabled: true,
+        has_secret: true,
+        has_backup_codes: true,
+        method: 'totp',
+      });
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/sessions') {
+      await toJsonResponse(route, []);
+      return;
+    }
+
+    if (path.startsWith('/api/proxy/admin/audit-log?')) {
+      await toJsonResponse(route, {
+        entries: [
+          {
+            id: 'audit-1',
+            timestamp: '2026-03-10T01:00:00Z',
+            user_id: 42,
+            action: 'login',
+            resource: 'auth',
+            ip_address: '127.0.0.1',
+            details: {
+              success: true,
+              user_agent: 'Playwright',
+            },
+          },
+        ],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      });
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/effective-permissions') {
+      await toJsonResponse(route, {
+        permissions: ['reports.read', 'admin.impersonate'],
+      });
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/overrides') {
+      await toJsonResponse(route, { overrides: [] });
+      return;
+    }
+
+    if (path === '/api/proxy/admin/permissions') {
+      await toJsonResponse(route, []);
+      return;
+    }
+
+    if (path === '/api/proxy/admin/users/42/rate-limits') {
+      await toJsonResponse(route, {});
+      return;
+    }
+
+    await toJsonResponse(route, { detail: `Unhandled smoke stub: ${path}` }, 404);
+  });
+};
+
+export const installLoginRoutes = async (page: Page) => {
+  await page.route('**/api/auth/login', async (route) => {
+    const body = new URLSearchParams(route.request().postData() || '');
+    if (body.get('username') !== 'admin' || body.get('password') !== 'AdminPass123!') {
+      await toJsonResponse(route, { detail: 'Invalid username or password.' }, 401);
+      return;
+    }
+
+    await toJsonResponse(route, {
+      mfa_required: true,
+      session_token: 'mfa-session-token',
+      expires_in: 300,
+      message: 'Enter your verification code to continue.',
+    });
+  });
+
+  await page.route('**/api/auth/mfa/login', async (route) => {
+    const raw = route.request().postData() || '{}';
+    const body = JSON.parse(raw) as { session_token?: string; mfa_token?: string };
+    if (body.session_token !== 'mfa-session-token' || body.mfa_token !== '123456') {
+      await toJsonResponse(route, { detail: 'Invalid verification code.' }, 401);
+      return;
+    }
+
+    await setAuthenticatedSession(page);
+    await toJsonResponse(route, {
+      token_type: 'bearer',
+      expires_in: 3600,
+    });
+  });
+};

--- a/admin-ui/tests/e2e/user-privileged-actions.spec.ts
+++ b/admin-ui/tests/e2e/user-privileged-actions.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { installAdminApiRoutes, setAuthenticatedSession } from './smoke-helpers';
+
+test('requires reason and reauthentication before reset password', async ({ page }) => {
+  await installAdminApiRoutes(page);
+  await setAuthenticatedSession(page);
+
+  await page.goto('/users/42');
+  await page.getByLabel(/temporary password to set/i).fill('TempP@ssw0rd123');
+  await page.getByRole('button', { name: /reset password/i }).click();
+
+  await expect(page.getByLabel(/reason/i)).toBeVisible();
+  await expect(page.getByLabel(/current password/i)).toBeVisible();
+});

--- a/admin-ui/tsconfig.json
+++ b/admin-ui/tsconfig.json
@@ -31,6 +31,12 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/__tests__/**",
+    "vitest.config.ts",
+    "vitest.setup.ts",
+    "vitest.d.ts"
   ]
 }

--- a/admin-ui/types/index.ts
+++ b/admin-ui/types/index.ts
@@ -81,6 +81,20 @@ export interface TeamMember {
   user?: User;
 }
 
+export interface OrgMembership {
+  org_id: number;
+  role: string;
+  org_name?: string;
+}
+
+export interface TeamMembership {
+  team_id: number;
+  org_id: number;
+  role: string;
+  team_name?: string;
+  org_name?: string;
+}
+
 export interface ApiKey {
   id: string;
   user_id: number;
@@ -91,6 +105,12 @@ export interface ApiKey {
   expires_at?: string;
   revoked_at?: string;
   last_used_at?: string;
+}
+
+export interface ApiKeyMutationResponse {
+  key?: string;
+  id?: string;
+  key_prefix?: string;
 }
 
 export interface Role {
@@ -190,6 +210,25 @@ export type SecurityHealthData = {
   last_security_scan?: string;
 };
 
+export interface SecurityAlertStatus {
+  total_alerts?: number;
+  critical_alerts?: number;
+  warning_alerts?: number;
+  unacknowledged?: number;
+  recent_alerts?: {
+    id: string;
+    severity: string;
+    message: string;
+    timestamp: string;
+    source?: string;
+  }[];
+}
+
+export interface EffectivePermissionsResponse {
+  user_id: number;
+  permissions: string[];
+}
+
 export interface AuthContextType {
   user: User | null;
   login: (username: string, password: string) => Promise<boolean>;
@@ -222,6 +261,18 @@ export interface VoiceSession {
   created_at: string;
   last_activity: string;
   turn_count: number;
+}
+
+export interface VoiceCommandListResponse {
+  commands?: VoiceCommand[];
+  items?: VoiceCommand[];
+  total?: number;
+}
+
+export interface VoiceSessionListResponse {
+  sessions?: VoiceSession[];
+  items?: VoiceSession[];
+  total?: number;
 }
 
 export interface VoiceCommandUsage {

--- a/admin-ui/vitest.config.ts
+++ b/admin-ui/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 import path from 'path';
 
 export default defineConfig({
@@ -12,6 +12,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'tests/e2e/**'],
     setupFiles: ['./vitest.setup.ts'],
   },
 });


### PR DESCRIPTION
## Summary
- add a release-note and operational handoff document for the completed admin-ui production-readiness remediation series
- capture the remediation commit sequence, validation evidence, release guidance, and go/no-go note in `Docs/Product/WebUI/PR_RELEASE_NOTES_ADMIN_UI_PROD_READINESS_2026_03_10.md`
- provide a user-facing release-notes snippet for the admin console hardening work already present on `dev`

## Test Plan
- docs-only follow-up on top of the verified remediation branch
- existing remediation verification captured in the handoff doc:
  - `cd admin-ui && bun run lint`
  - `cd admin-ui && bun run test`
  - `cd admin-ui && bun run build`
  - `cd admin-ui && bun run typecheck`
  - `cd admin-ui && bun run test:a11y`
  - `cd admin-ui && bun run test:smoke`
