### PR TITLE
feat: add macOS sandbox runtimes

### DIFF
--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -1,0 +1,87 @@
+# macOS Sandbox Runtime Operator Notes
+
+## Scope
+
+These notes cover the current macOS runtime scaffolding for the sandbox subsystem:
+
+- `vz_linux`
+- `vz_macos`
+- `seatbelt`
+
+This is not a guide for shipping real guest execution yet. The current implementation exposes runtime identities, policy admission, discovery metadata, helper/image-store contracts, and fake-backed runner paths.
+
+## Host Assumptions
+
+- Target host platform: Apple silicon macOS
+- The VM-oriented runtimes assume Apple `Virtualization.framework`
+- `vz_linux` and `vz_macos` preflights fail closed when the host is not macOS or not Apple silicon
+
+## Trust-Level Policy
+
+- `untrusted`:
+  - must use a VM runtime
+  - `seatbelt` is rejected
+- `standard`:
+  - allowed on VM runtimes
+  - allowed on `seatbelt` only when `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED=1`
+- `trusted`:
+  - allowed on all current runtime identities
+
+## Helper And Template Readiness
+
+The VM scaffolding is controlled by explicit readiness signals.
+
+Required env flags today:
+
+- `TLDW_SANDBOX_MACOS_HELPER_READY=1`
+- `TLDW_SANDBOX_VZ_LINUX_AVAILABLE=1`
+- `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY=1`
+- `TLDW_SANDBOX_VZ_MACOS_AVAILABLE=1`
+- `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY=1`
+
+The helper contract lives under `tldw_Server_API/app/core/Sandbox/macos_virtualization/`.
+
+The intended production shape is a native signed helper or service that owns `Virtualization.framework` lifecycle operations. The current Python-side helper client is a contract stub with fake transport in test mode.
+
+## Template Preparation Flow
+
+Current image handling is manifest-driven rather than real APFS cloning.
+
+Expected operator flow later:
+
+1. Prepare a sealed template image per runtime family.
+2. Register the template in the sandbox image store.
+3. Create run-scoped clone manifests from that template.
+4. Hand clone metadata to the native helper for VM boot.
+5. Destroy the run-scoped clone state after completion.
+
+Today, the image store implements template registration plus deterministic run-clone manifests only.
+
+## Networking
+
+- `deny_all` is the intended strict baseline for the new macOS runtimes.
+- `strict_allowlist_not_supported` is still the expected result for:
+  - `vz_linux`
+  - `vz_macos`
+  - `seatbelt`
+- Warm-session optimization is not implemented yet and should not be assumed by operators.
+
+## Discovery And ACP
+
+`/api/v1/sandbox/runtimes` now exposes:
+
+- runtime availability
+- preflight reasons
+- supported trust levels
+- enforcement readiness
+- host facts
+
+ACP sandbox session creation now performs runtime preflight validation before calling the sandbox service, and converts failures into `ACPResponseError` instead of leaking raw sandbox exceptions.
+
+## Current Limits
+
+- No real `vz_linux` or `vz_macos` guest command execution yet
+- No real seatbelt profile generation or hardened-runtime helper process
+- No APFS clone execution path yet
+- No allowlist networking for the new macOS runtimes
+- No warm-session VM reuse yet

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -35,9 +35,14 @@ Required env flags today:
 
 - `TLDW_SANDBOX_MACOS_HELPER_READY=1`
 - `TLDW_SANDBOX_VZ_LINUX_AVAILABLE=1`
+- `TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC=1`
 - `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY=1`
 - `TLDW_SANDBOX_VZ_MACOS_AVAILABLE=1`
+- `TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC=1`
 - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY=1`
+
+Without the fake execution flag, the VZ runtimes stay unavailable and expose
+`real_execution_not_implemented` in preflight/discovery.
 
 The helper contract lives under `tldw_Server_API/app/core/Sandbox/macos_virtualization/`.
 
@@ -81,7 +86,7 @@ ACP sandbox session creation now performs runtime preflight validation before ca
 ## Current Limits
 
 - No real `vz_linux` or `vz_macos` guest command execution yet
-- No real seatbelt profile generation or hardened-runtime helper process
+- `seatbelt` fake execution uses `TLDW_SANDBOX_SEATBELT_FAKE_EXEC=1`; real seatbelt execution is still absent
 - No APFS clone execution path yet
 - No allowlist networking for the new macOS runtimes
 - No warm-session VM reuse yet

--- a/apps/macos_virtualization_helper/README.md
+++ b/apps/macos_virtualization_helper/README.md
@@ -1,0 +1,19 @@
+# macOS Virtualization Helper
+
+This directory reserves the native control-plane helper for the sandbox
+`vz_linux` and `vz_macos` runtimes.
+
+Current status:
+
+- No native helper binary is implemented yet.
+- The Python-side contract lives under
+  `tldw_Server_API/app/core/Sandbox/macos_virtualization/`.
+- In `TEST_MODE`, the helper client returns fake success responses so the
+  sandbox runtime layers can be developed and tested without a real helper.
+
+Planned responsibilities for the native helper:
+
+- validate host and entitlement readiness
+- create and boot VMs via Apple's `Virtualization.framework`
+- manage guest control channels
+- report structured lifecycle state back to the Python sandbox service

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -16,6 +16,8 @@ TrustLevelType = Literal["trusted", "standard", "untrusted"]
 class SandboxRuntimeInfo(BaseModel):
     name: RuntimeType
     available: bool = Field(description="Whether this runtime is detected/usable on host")
+    reasons: list[str] | None = Field(default=None, description="Preflight reasons when the runtime is unavailable or constrained")
+    supported_trust_levels: list[TrustLevelType] | None = Field(default=None, description="Trust levels supported by this runtime under current host policy")
     default_images: list[str] = Field(default_factory=list)
     max_cpu: float | None = Field(default=None, description="Max CPU (cores) per run")
     max_mem_mb: int | None = Field(default=None, description="Max memory (MB) per run")
@@ -31,7 +33,7 @@ class SandboxRuntimeInfo(BaseModel):
     strict_deny_all_supported: bool | None = Field(default=None, description="Whether strict deny-all network enforcement is supported")
     strict_allowlist_supported: bool | None = Field(default=None, description="Whether strict allowlist network enforcement is supported")
     enforcement_ready: dict[str, bool] | None = Field(default=None, description="Runtime enforcement readiness by network policy mode")
-    host: dict[str, str] | None = Field(default=None, description="Runtime host capability facts for troubleshooting")
+    host: dict[str, str | bool] | None = Field(default=None, description="Runtime host capability facts for troubleshooting")
     store_mode: str | None = Field(default=None, description="Current store backend mode (memory|sqlite|cluster)")
     notes: str | None = None
 

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -9,7 +9,7 @@ try:
 except ImportError:  # pragma: no cover - pydantic v1 fallback
     from pydantic import root_validator as model_validator  # type: ignore
 
-RuntimeType = Literal["docker", "firecracker", "lima"]
+RuntimeType = Literal["docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"]
 TrustLevelType = Literal["trusted", "standard", "untrusted"]
 
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -28,7 +28,9 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import dete
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage, ACPResponseError
 from tldw_Server_API.app.core.Agent_Client_Protocol.stream_client import ACPStreamClient
 from tldw_Server_API.app.core.config import settings as app_settings
-from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType, SessionSpec
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType, SessionSpec, TrustLevel
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import collect_runtime_preflights
 from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.testing import is_truthy
@@ -385,6 +387,38 @@ class ACPSandboxRunnerManager:
             f"ACP lima strict policy requirements not satisfied: {', '.join(reasons) if reasons else 'unknown'}"
         )
 
+    def _configured_runtime(self) -> RuntimeType:
+        runtime_raw = str(self.config.runtime or "").strip().lower()
+        try:
+            return RuntimeType(runtime_raw)
+        except ValueError as exc:
+            raise ACPResponseError(f"Unsupported ACP sandbox runtime: {runtime_raw or 'unknown'}") from exc
+
+    def _validate_runtime_requirements(self, runtime: RuntimeType) -> None:
+        self._validate_lima_strict_runtime_requirements()
+        network_policy = str(self.config.network_policy or "deny_all").strip().lower() or "deny_all"
+        preflight = collect_runtime_preflights(network_policy=network_policy).get(runtime)
+        if preflight is None:
+            return
+        if not preflight.available:
+            reasons = list(preflight.reasons or [])
+            raise ACPResponseError(
+                f"ACP {runtime.value} runtime requirements not satisfied: "
+                f"{', '.join(reasons) if reasons else 'unknown'}"
+            )
+        try:
+            SandboxPolicy._require_trust_level_supported(
+                runtime,
+                TrustLevel.standard,
+                runtime_preflights={runtime: preflight},
+            )
+        except SandboxPolicy.PolicyUnsupported as exc:
+            reasons = list(getattr(exc, "reasons", []) or [])
+            detail = ", ".join(reasons) if reasons else getattr(exc, "requirement", "unsupported")
+            raise ACPResponseError(
+                f"ACP {runtime.value} runtime requirements not satisfied: {detail}"
+            ) from exc
+
     # -------------------------------------------------------------------------
     # Session lifecycle
     # -------------------------------------------------------------------------
@@ -434,7 +468,8 @@ class ACPSandboxRunnerManager:
             execute_enabled = False
         if not execute_enabled:
             raise ACPResponseError("SANDBOX_ENABLE_EXECUTION must be enabled for ACP sandbox sessions")
-        self._validate_lima_strict_runtime_requirements()
+        runtime = self._configured_runtime()
+        self._validate_runtime_requirements(runtime)
 
         sandbox_service = sandbox_ep._service  # type: ignore[attr-defined]
 
@@ -448,9 +483,10 @@ class ACPSandboxRunnerManager:
         try:
             # Create sandbox session
             sess_spec = SessionSpec(
-                runtime=RuntimeType(self.config.runtime),
+                runtime=runtime,
                 base_image=self.config.base_image,
                 network_policy=self.config.network_policy or "deny_all",
+                trust_level=TrustLevel.standard,
                 persona_id=persona_id,
                 workspace_id=workspace_id,
                 workspace_group_id=workspace_group_id,
@@ -497,7 +533,7 @@ class ACPSandboxRunnerManager:
 
             run_spec = RunSpec(
                 session_id=sandbox_session.id,
-                runtime=RuntimeType(self.config.runtime),
+                runtime=runtime,
                 base_image=self.config.base_image,
                 command=["/usr/local/bin/tldw-acp-entrypoint"],
                 env=env,
@@ -505,6 +541,7 @@ class ACPSandboxRunnerManager:
                 run_as_root=bool(self.config.run_as_root),
                 read_only_root=bool(self.config.read_only_root),
                 network_policy=self.config.network_policy or "deny_all",
+                trust_level=TrustLevel.standard,
                 port_mappings=port_mappings,
                 persona_id=persona_id,
                 workspace_id=workspace_id,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -30,7 +30,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stream_client import ACPStre
 from tldw_Server_API.app.core.config import settings as app_settings
 from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType, SessionSpec, TrustLevel
 from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
-from tldw_Server_API.app.core.Sandbox.runtime_capabilities import collect_runtime_preflights
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
 from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.testing import is_truthy
@@ -370,7 +370,11 @@ class ACPSandboxRunnerManager:
         for sess in sessions:
             await self.close_session(sess.session_id)
 
-    def _validate_lima_strict_runtime_requirements(self) -> None:
+    def _validate_lima_strict_runtime_requirements(
+        self,
+        *,
+        preflight: RuntimePreflightResult | None = None,
+    ) -> None:
         runtime = str(self.config.runtime or "").strip().lower()
         if runtime != RuntimeType.lima.value:
             return
@@ -379,7 +383,7 @@ class ACPSandboxRunnerManager:
             raise ACPResponseError(
                 "ACP lima strict policy requires network_policy to be deny_all or allowlist"
             )
-        preflight = LimaRunner().preflight(network_policy=network_policy)
+        preflight = preflight or LimaRunner().preflight(network_policy=network_policy)
         if preflight.available:
             return
         reasons = list(preflight.reasons or [])
@@ -395,9 +399,11 @@ class ACPSandboxRunnerManager:
             raise ACPResponseError(f"Unsupported ACP sandbox runtime: {runtime_raw or 'unknown'}") from exc
 
     def _validate_runtime_requirements(self, runtime: RuntimeType) -> None:
-        self._validate_lima_strict_runtime_requirements()
         network_policy = str(self.config.network_policy or "deny_all").strip().lower() or "deny_all"
-        preflight = collect_runtime_preflights(network_policy=network_policy).get(runtime)
+        runtime_preflights = collect_runtime_preflights(network_policy=network_policy)
+        preflight = runtime_preflights.get(runtime)
+        if runtime == RuntimeType.lima:
+            self._validate_lima_strict_runtime_requirements(preflight=preflight)
         if preflight is None:
             return
         if not preflight.available:

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/sandbox_module.py
@@ -48,7 +48,10 @@ class SandboxModule(BaseModule):
                 "inputSchema": {
                     "type": "object",
                     "properties": {
-                        "runtime": {"type": "string", "enum": ["docker", "firecracker", "lima"]},
+                        "runtime": {
+                            "type": "string",
+                            "enum": ["docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"],
+                        },
                         "session_id": {"type": "string"},
                         "base_image": {"type": "string"},
                         "command": {"type": "array", "items": {"type": "string"}},
@@ -242,7 +245,7 @@ class SandboxModule(BaseModule):
 
     def _coerce_runtime(self, value: Any) -> SbxRuntimeType | None:
         runtime_raw = (str(value).strip().lower() if value is not None else "")
-        if runtime_raw in ("docker", "firecracker", "lima"):
+        if runtime_raw in ("docker", "firecracker", "lima", "vz_linux", "vz_macos", "seatbelt"):
             return SbxRuntimeType(runtime_raw)
         return None
 
@@ -298,8 +301,15 @@ class SandboxModule(BaseModule):
         if (isinstance(sess, str) and sess) and (isinstance(img, str) and img):
             raise ValueError("Provide only one of session_id or base_image, not both")
         rt = arguments.get("runtime")
-        if rt is not None and str(rt).lower() not in {"docker", "firecracker", "lima"}:
-            raise ValueError("runtime must be docker|firecracker|lima when provided")
+        if rt is not None and str(rt).lower() not in {
+            "docker",
+            "firecracker",
+            "lima",
+            "vz_linux",
+            "vz_macos",
+            "seatbelt",
+        }:
+            raise ValueError("runtime must be docker|firecracker|lima|vz_linux|vz_macos|seatbelt when provided")
         if arguments.get("timeout_sec") is not None:
             try:
                 ts = int(arguments.get("timeout_sec"))

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -46,7 +46,7 @@ Trust-level rules:
 Current limitations:
 
 - Real `Virtualization.framework` execution is not implemented yet.
-- `vz_linux` and `vz_macos` require helper and template readiness env wiring to pass preflight.
+- `vz_linux` and `vz_macos` require helper/template readiness plus `*_FAKE_EXEC=1`; otherwise discovery reports `real_execution_not_implemented`.
 - Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, or `seatbelt`.
 - Warm session VM reuse is not implemented yet.
 - `seatbelt` is intentionally conservative and should not be treated as equivalent to a VM boundary.
@@ -70,8 +70,11 @@ Selected configuration knobs:
 - macOS scaffolding:
   - `TLDW_SANDBOX_MACOS_HELPER_READY`
   - `TLDW_SANDBOX_VZ_LINUX_AVAILABLE`
+  - `TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC`
   - `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY`
   - `TLDW_SANDBOX_VZ_MACOS_AVAILABLE`
+  - `TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC`
   - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY`
   - `TLDW_SANDBOX_SEATBELT_AVAILABLE`
+  - `TLDW_SANDBOX_SEATBELT_FAKE_EXEC`
   - `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED`

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -1,53 +1,77 @@
 # Sandbox
 
-## 1. Descriptive of Current Feature Set
+## Current Feature Set
 
-- Purpose: An isolated execution scaffold with sessions, queued runs, idempotency, and artifact streaming.
+- Purpose: isolated execution with sessions, queued runs, idempotency, artifact streaming, and capability-driven runtime admission.
+- Core runtimes:
+  - `docker`
+  - `firecracker`
+  - `lima`
+  - `vz_linux`
+  - `vz_macos`
+  - `seatbelt`
 - Capabilities:
-  - Create/destroy sessions; upload files to session
-  - Queue runs with TTL and capacity limits; cancelation support
-  - Stream run events via WebSocket; secure artifact download URLs
-- Inputs/Outputs:
-  - Inputs: JSON payloads for sessions/runs; file uploads; WS control frames
-  - Outputs: run statuses, artifacts, stream frames, health states
-- Related Endpoints:
-  - `tldw_Server_API/app/api/v1/endpoints/sandbox.py:82` (router + endpoints: health, sessions, runs, stream, admin)
-- Related Models:
-  - `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py:1`
+  - Create and destroy sessions
+  - Queue runs with TTL and capacity limits
+  - Stream run events over WebSocket
+  - Serve guarded artifact download URLs
+  - Expose runtime discovery with preflight reasons, host facts, and supported trust levels
 
-## 2. Technical Details of Features
+## Runtime Model
 
-- Architecture & Data Flow:
-  - `SandboxOrchestrator` manages sessions, runs, idempotency storage via `store`; queue pruning by TTL
-- Key Classes/Functions:
-  - Orchestrator: `core/Sandbox/orchestrator.py:1`; Policy/config in `core/Sandbox/policy.py`; store/cache/streams modules
-- Dependencies:
-  - Internal: Metrics counters; Audit logging; feature flags
-- Data Models & DB:
-  - In-memory store by default (pluggable via `store`)
-- Configuration:
-  - Queue: `SANDBOX_QUEUE_MAX_LENGTH`, `SANDBOX_QUEUE_TTL_SEC`, `SANDBOX_QUEUE_ESTIMATED_WAIT_PER_RUN_SEC`
-  - Idempotency TTL: `SANDBOX_IDEMPOTENCY_TTL_SEC`
-- Concurrency & Performance:
-  - Lock-guarded maps; minimal O(1) operations; histograms for durations
-- Error Handling:
-  - Idempotency conflict surfaces original id and created_at; safe streaming cleanup on exceptions
-- Security:
-  - Artifact path guard to prevent traversal; route class wrapper for download URLs
+- `docker`: general-purpose default runtime with existing interactive support.
+- `firecracker`: VM-oriented Linux isolation path.
+- `lima`: strict macOS-host VM path with explicit deny-all readiness checks.
+- `vz_linux`: Apple `Virtualization.framework` Linux guest scaffold on Apple silicon macOS hosts.
+- `vz_macos`: Apple `Virtualization.framework` macOS guest scaffold on Apple silicon macOS hosts.
+- `seatbelt`: host-local process isolation scaffold for conservative macOS trusted workflows.
 
-## 3. Developer-Related/Relevant Information for Contributors
+Trust-level rules:
 
-- Folder Structure:
-  - `Sandbox/` with `models.py`, `orchestrator.py`, `service.py`, `store.py`, `streams.py`, `policy.py`, runner stubs
-- Extension Points:
-  - Implement durable stores and real runners (docker/firecracker runners are stubs here)
-- Coding Patterns:
-  - Keep API thin; push logic into orchestrator/service; add metrics/audit labels consistently
-- Tests:
-  - (Scaffold) Add end-to-end tests using WS and queue limits as the module matures
-- Local Dev Tips:
-  - Use `/api/v1/sandbox/health` and `/api/v1/sandbox/runs` for quick validation; enable synthetic test frames in config when available
-- Pitfalls & Gotchas:
-  - Queue backpressure and TTL pruning; large artifact payloads
-- Roadmap/TODOs:
-  - Pluggable backends for store and runners; per-tenant quotas
+- `untrusted` requires a VM runtime.
+- `seatbelt` is rejected for `untrusted`.
+- `seatbelt` defaults to `trusted` only; `standard` requires `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED=1`.
+- `vz_linux` and `vz_macos` advertise `trusted`, `standard`, and `untrusted`.
+
+## Technical Notes
+
+- `SandboxOrchestrator` owns session/run lifecycle, queueing, idempotency, and artifact storage.
+- `SandboxService` is the integration point for policy admission, runtime preflights, execution dispatch, and runtime discovery.
+- Runtime capability snapshots are collected in `runtime_capabilities.py`.
+- macOS scaffolding currently includes:
+  - fake-backed helper contract in `macos_virtualization/`
+  - manifest/image-store contract in `image_store.py`
+  - fake-backed runners for `vz_linux`, `vz_macos`, and `seatbelt`
+
+Current limitations:
+
+- Real `Virtualization.framework` execution is not implemented yet.
+- `vz_linux` and `vz_macos` require helper and template readiness env wiring to pass preflight.
+- Strict allowlist networking is not implemented for `vz_linux`, `vz_macos`, or `seatbelt`.
+- Warm session VM reuse is not implemented yet.
+- `seatbelt` is intentionally conservative and should not be treated as equivalent to a VM boundary.
+
+## Operations And Development
+
+- Main API surface: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Main schemas: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- ACP integration: `tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py`
+- Recommended validation endpoints:
+  - `/api/v1/sandbox/health`
+  - `/api/v1/sandbox/runtimes`
+  - `/api/v1/sandbox/runs`
+
+Selected configuration knobs:
+
+- Queue and idempotency:
+  - `SANDBOX_QUEUE_MAX_LENGTH`
+  - `SANDBOX_QUEUE_TTL_SEC`
+  - `SANDBOX_IDEMPOTENCY_TTL_SEC`
+- macOS scaffolding:
+  - `TLDW_SANDBOX_MACOS_HELPER_READY`
+  - `TLDW_SANDBOX_VZ_LINUX_AVAILABLE`
+  - `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY`
+  - `TLDW_SANDBOX_VZ_MACOS_AVAILABLE`
+  - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY`
+  - `TLDW_SANDBOX_SEATBELT_AVAILABLE`
+  - `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED`

--- a/tldw_Server_API/app/core/Sandbox/image_store.py
+++ b/tldw_Server_API/app/core/Sandbox/image_store.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class CloneItem:
+    source_path: str
+    target_path: str
+    mode: str
+
+
+@dataclass(slots=True)
+class TemplateRecord:
+    template_id: str
+    runtime: str
+    template_name: str
+    disk_paths: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class RunCloneManifest:
+    template_id: str
+    run_id: str
+    clone_items: list[CloneItem] = field(default_factory=list)
+
+
+class SandboxImageStore:
+    """Manifest-oriented VM template store.
+
+    The initial implementation is intentionally lightweight: it records template
+    metadata and returns deterministic clone manifests without performing APFS
+    cloning yet.
+    """
+
+    def __init__(self, root_path: str | Path) -> None:
+        self.root_path = Path(root_path)
+        self._templates: dict[str, TemplateRecord] = {}
+
+    def register_template(
+        self,
+        *,
+        runtime: str,
+        template_name: str,
+        disk_paths: list[str],
+    ) -> str:
+        runtime_name = str(runtime).strip()
+        normalized_name = str(template_name).strip()
+        template_id = f"{runtime_name}:{normalized_name}"
+        self._templates[template_id] = TemplateRecord(
+            template_id=template_id,
+            runtime=runtime_name,
+            template_name=normalized_name,
+            disk_paths=[str(path) for path in disk_paths],
+        )
+        return template_id
+
+    def prepare_run_clone(self, *, template_id: str, run_id: str) -> RunCloneManifest:
+        template = self._templates[template_id]
+        run_root = self.root_path / "runs" / str(run_id)
+        clone_items = [
+            CloneItem(
+                source_path=str(source_path),
+                target_path=str(run_root / Path(source_path).name),
+                mode="clone",
+            )
+            for source_path in template.disk_paths
+        ]
+        return RunCloneManifest(
+            template_id=template.template_id,
+            run_id=str(run_id),
+            clone_items=clone_items,
+        )

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/__init__.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/__init__.py
@@ -1,7 +1,11 @@
-from .helper_client import MacOSVirtualizationHelperClient
+from .helper_client import (
+    MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperUnavailable,
+)
 from .models import HelperVMReply
 
 __all__ = [
     "HelperVMReply",
     "MacOSVirtualizationHelperClient",
+    "MacOSVirtualizationHelperUnavailable",
 ]

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/__init__.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/__init__.py
@@ -1,0 +1,7 @@
+from .helper_client import MacOSVirtualizationHelperClient
+from .models import HelperVMReply
+
+__all__ = [
+    "HelperVMReply",
+    "MacOSVirtualizationHelperClient",
+]

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from tldw_Server_API.app.core.testing import is_truthy
+
+from .models import HelperVMReply
+
+
+class MacOSVirtualizationHelperClient:
+    """Client stub for the future native macOS virtualization helper."""
+
+    def create_vm(self, request: dict[str, Any]) -> HelperVMReply:
+        if is_truthy(os.getenv("TEST_MODE")):
+            vm_name = str(request.get("vm_name") or "").strip() or "vm-test"
+            runtime = str(request.get("runtime") or "").strip()
+            return HelperVMReply(
+                vm_id=vm_name,
+                state="created",
+                details={"runtime": runtime or None, "transport": "fake"},
+            )
+        raise RuntimeError("macos_virtualization_helper_unavailable")

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py
@@ -8,6 +8,10 @@ from tldw_Server_API.app.core.testing import is_truthy
 from .models import HelperVMReply
 
 
+class MacOSVirtualizationHelperUnavailable(RuntimeError):
+    """Raised when the native macOS virtualization helper cannot service a request."""
+
+
 class MacOSVirtualizationHelperClient:
     """Client stub for the future native macOS virtualization helper."""
 
@@ -20,4 +24,4 @@ class MacOSVirtualizationHelperClient:
                 state="created",
                 details={"runtime": runtime or None, "transport": "fake"},
             )
-        raise RuntimeError("macos_virtualization_helper_unavailable")
+        raise MacOSVirtualizationHelperUnavailable("macos_virtualization_helper_unavailable")

--- a/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_virtualization/models.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class HelperVMReply:
+    vm_id: str
+    state: str
+    details: dict[str, Any] = field(default_factory=dict)

--- a/tldw_Server_API/app/core/Sandbox/models.py
+++ b/tldw_Server_API/app/core/Sandbox/models.py
@@ -9,6 +9,9 @@ class RuntimeType(str, Enum):
     docker = "docker"
     firecracker = "firecracker"
     lima = "lima"
+    vz_linux = "vz_linux"
+    vz_macos = "vz_macos"
+    seatbelt = "seatbelt"
 
 
 class TrustLevel(str, Enum):

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -212,6 +212,12 @@ class SandboxPolicy:
             for level in (preflight.supported_trust_levels or [])
             if str(level).strip()
         }
+        if runtime == RuntimeType.seatbelt and trust == TrustLevel.standard and "standard" not in supported:
+            raise SandboxPolicy.PolicyUnsupported(
+                runtime,
+                requirement="standard_not_enabled",
+                reasons=["seatbelt_standard_disabled"],
+            )
         if supported and trust.value not in supported:
             raise SandboxPolicy.PolicyUnsupported(
                 runtime,

--- a/tldw_Server_API/app/core/Sandbox/policy.py
+++ b/tldw_Server_API/app/core/Sandbox/policy.py
@@ -186,6 +186,39 @@ class SandboxPolicy:
             return
         raise SandboxPolicy.RuntimeUnavailable(runtime, reasons=list(preflight.reasons or []))
 
+    @staticmethod
+    def _require_trust_level_supported(
+        runtime: RuntimeType,
+        trust: TrustLevel,
+        *,
+        runtime_preflights: Mapping[RuntimeType, RuntimePreflightResult] | None = None,
+    ) -> None:
+        if runtime == RuntimeType.seatbelt and trust == TrustLevel.untrusted:
+            raise SandboxPolicy.PolicyUnsupported(
+                runtime,
+                requirement="untrusted_requires_vm_runtime",
+                reasons=["trust_level_requires_vm_runtime"],
+            )
+
+        if runtime_preflights is None:
+            return
+
+        preflight = runtime_preflights.get(runtime)
+        if preflight is None:
+            return
+
+        supported = {
+            str(level).strip().lower()
+            for level in (preflight.supported_trust_levels or [])
+            if str(level).strip()
+        }
+        if supported and trust.value not in supported:
+            raise SandboxPolicy.PolicyUnsupported(
+                runtime,
+                requirement=f"trust_level:{trust.value}",
+                reasons=["trust_level_not_supported"],
+            )
+
     def select_runtime(
         self,
         requested: RuntimeType | None,
@@ -226,6 +259,11 @@ class SandboxPolicy:
 
         # Apply trust-level profile constraints
         trust = spec.trust_level or TrustLevel.standard
+        self._require_trust_level_supported(
+            spec.runtime,
+            trust,
+            runtime_preflights=runtime_preflights,
+        )
         profile = TRUST_PROFILES.get(trust, TRUST_PROFILES[TrustLevel.standard])
 
         if not spec.network_policy:
@@ -280,6 +318,11 @@ class SandboxPolicy:
 
         # Apply trust-level profile constraints
         trust = spec.trust_level or TrustLevel.standard
+        self._require_trust_level_supported(
+            spec.runtime,
+            trust,
+            runtime_preflights=runtime_preflights,
+        )
         profile = TRUST_PROFILES.get(trust, TRUST_PROFILES[TrustLevel.standard])
 
         if not spec.network_policy:

--- a/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import contextlib
 import os
 import sys
 from datetime import datetime
+
+from loguru import logger
 
 from tldw_Server_API.app.core.testing import is_truthy
 
@@ -12,21 +13,19 @@ from ..runtime_capabilities import RuntimePreflightResult
 from ..streams import get_hub
 from .vz_common import vz_host_facts
 
-_SEATBELT_NONCRITICAL_EXCEPTIONS = (
-    AttributeError,
-    OSError,
-    PermissionError,
-    RuntimeError,
-    TypeError,
-    ValueError,
-)
-
 
 def _truthy(value: str | None) -> bool:
     return is_truthy(value)
 
 
 class SeatbeltRunner:
+    """Host-local macOS runner for seatbelt-scoped trusted workloads.
+
+    This runner only supports discovery and a fake execution path today.
+    `untrusted` is never allowed, `standard` requires explicit opt-in, and real
+    seatbelt execution is still pending.
+    """
+
     runtime_type = RuntimeType.seatbelt
 
     def _version(self) -> str | None:
@@ -67,9 +66,20 @@ class SeatbeltRunner:
 
     def _run_fake(self, run_id: str) -> RunStatus:
         now = datetime.utcnow()
-        with contextlib.suppress(_SEATBELT_NONCRITICAL_EXCEPTIONS):
-            get_hub().publish_event(run_id, "start", {"ts": now.isoformat(), "runtime": self.runtime_type.value})
-            get_hub().publish_event(run_id, "end", {"exit_code": 0})
+        hub = get_hub()
+        for event, payload in (
+            ("start", {"ts": now.isoformat(), "runtime": self.runtime_type.value}),
+            ("end", {"exit_code": 0}),
+        ):
+            try:
+                hub.publish_event(run_id, event, payload)
+            except (AttributeError, OSError, PermissionError, RuntimeError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "seatbelt fake execution failed to publish {} event for run {}: {}",
+                    event,
+                    run_id,
+                    exc,
+                )
         return RunStatus(
             id="",
             phase=RunPhase.completed,

--- a/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from datetime import datetime
+
+from tldw_Server_API.app.core.testing import is_truthy
+
+from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
+from ..runtime_capabilities import RuntimePreflightResult
+from ..streams import get_hub
+from .vz_common import vz_host_facts
+
+_SEATBELT_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+
+def _truthy(value: str | None) -> bool:
+    return is_truthy(value)
+
+
+class SeatbeltRunner:
+    runtime_type = RuntimeType.seatbelt
+
+    def _version(self) -> str | None:
+        raw = str(os.getenv("TLDW_SANDBOX_SEATBELT_VERSION") or "").strip()
+        return raw or None
+
+    def _supported_trust_levels(self) -> list[str]:
+        levels = ["trusted"]
+        if _truthy(os.getenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED")):
+            levels.append("standard")
+        return levels
+
+    def preflight(self, network_policy: str | None = None) -> RuntimePreflightResult:
+        host = vz_host_facts()
+        reasons: list[str] = []
+
+        if sys.platform != "darwin":
+            reasons.append("macos_required")
+        if not bool(host.get("apple_silicon")):
+            reasons.append("apple_silicon_required")
+
+        availability_override = os.getenv("TLDW_SANDBOX_SEATBELT_AVAILABLE")
+        if availability_override is not None and not _truthy(availability_override):
+            reasons.append("seatbelt_unavailable")
+
+        if str(network_policy or "deny_all").strip().lower() == "allowlist":
+            reasons.append("strict_allowlist_not_supported")
+
+        available = not reasons
+        return RuntimePreflightResult(
+            runtime=self.runtime_type,
+            available=available,
+            reasons=reasons,
+            supported_trust_levels=self._supported_trust_levels(),
+            host={str(k): v for k, v in host.items()},
+            enforcement_ready={"deny_all": False, "allowlist": False},
+        )
+
+    def _run_fake(self, run_id: str) -> RunStatus:
+        now = datetime.utcnow()
+        with contextlib.suppress(_SEATBELT_NONCRITICAL_EXCEPTIONS):
+            get_hub().publish_event(run_id, "start", {"ts": now.isoformat(), "runtime": self.runtime_type.value})
+            get_hub().publish_event(run_id, "end", {"exit_code": 0})
+        return RunStatus(
+            id="",
+            phase=RunPhase.completed,
+            started_at=now,
+            finished_at=now,
+            exit_code=0,
+            message="seatbelt fake execution",
+            runtime_version=self._version(),
+        )
+
+    @classmethod
+    def cancel_run(cls, _run_id: str) -> bool:
+        return False
+
+    def start_run(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        session_workspace: str | None = None,
+    ) -> RunStatus:
+        del spec
+        del session_workspace
+        if _truthy(os.getenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC")):
+            return self._run_fake(run_id)
+        raise RuntimeError("seatbelt_real_execution_not_implemented")

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_common.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_common.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import contextlib
+import os
+import platform
+import sys
+from datetime import datetime
+
+from tldw_Server_API.app.core.testing import is_truthy
+
+from ..models import RunPhase, RunSpec, RunStatus, RuntimeType
+from ..runtime_capabilities import RuntimePreflightResult
+from ..streams import get_hub
+
+_VZ_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    OSError,
+    PermissionError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+_APPLE_SILICON_ARCHES = {"arm64", "aarch64"}
+
+
+def _truthy(value: str | None) -> bool:
+    return is_truthy(value)
+
+
+def vz_host_facts() -> dict[str, str | bool]:
+    arch = str(platform.machine() or "").strip().lower()
+    return {
+        "os": sys.platform,
+        "arch": arch,
+        "apple_silicon": bool(sys.platform == "darwin" and arch in _APPLE_SILICON_ARCHES),
+    }
+
+
+class VZBaseRunner:
+    runtime_type: RuntimeType
+    fake_exec_env_key: str
+    available_env_key: str
+    version_env_key: str
+    template_ready_env_key: str
+    template_missing_reason: str
+
+    def _helper_ready(self) -> bool:
+        return _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
+
+    def _template_ready(self) -> bool:
+        return _truthy(os.getenv(self.template_ready_env_key))
+
+    def _version(self) -> str | None:
+        raw = str(os.getenv(self.version_env_key) or "").strip()
+        return raw or None
+
+    def preflight(self, network_policy: str | None = None) -> RuntimePreflightResult:
+        host = vz_host_facts()
+        reasons: list[str] = []
+
+        if sys.platform != "darwin":
+            reasons.append("macos_required")
+        if not bool(host.get("apple_silicon")):
+            reasons.append("apple_silicon_required")
+
+        availability_override = os.getenv(self.available_env_key)
+        if availability_override is not None and not _truthy(availability_override):
+            reasons.append(f"{self.runtime_type.value}_unavailable")
+
+        if not self._helper_ready():
+            reasons.append("macos_helper_missing")
+        if not self._template_ready():
+            reasons.append(self.template_missing_reason)
+
+        if str(network_policy or "deny_all").strip().lower() == "allowlist":
+            reasons.append("strict_allowlist_not_supported")
+
+        available = not reasons
+        return RuntimePreflightResult(
+            runtime=self.runtime_type,
+            available=available,
+            reasons=reasons,
+            host={str(k): v for k, v in host.items()},
+            enforcement_ready={"deny_all": available, "allowlist": False},
+        )
+
+    def _run_fake(self, run_id: str, message: str) -> RunStatus:
+        now = datetime.utcnow()
+        with contextlib.suppress(_VZ_NONCRITICAL_EXCEPTIONS):
+            get_hub().publish_event(run_id, "start", {"ts": now.isoformat(), "runtime": self.runtime_type.value})
+            get_hub().publish_event(run_id, "end", {"exit_code": 0})
+        return RunStatus(
+            id="",
+            phase=RunPhase.completed,
+            started_at=now,
+            finished_at=now,
+            exit_code=0,
+            message=message,
+            runtime_version=self._version(),
+        )
+
+    @classmethod
+    def cancel_run(cls, _run_id: str) -> bool:
+        return False
+
+    def start_run(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        session_workspace: str | None = None,
+    ) -> RunStatus:
+        del spec
+        del session_workspace
+        if _truthy(os.getenv(self.fake_exec_env_key)):
+            return self._run_fake(run_id, message=f"{self.runtime_type.value} fake execution")
+        raise RuntimeError(f"{self.runtime_type.value}_real_execution_not_implemented")

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_common.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_common.py
@@ -45,6 +45,9 @@ class VZBaseRunner:
     template_ready_env_key: str
     template_missing_reason: str
 
+    def _execution_ready(self) -> bool:
+        return _truthy(os.getenv(self.fake_exec_env_key))
+
     def _helper_ready(self) -> bool:
         return _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
 
@@ -72,6 +75,8 @@ class VZBaseRunner:
             reasons.append("macos_helper_missing")
         if not self._template_ready():
             reasons.append(self.template_missing_reason)
+        if not self._execution_ready():
+            reasons.append("real_execution_not_implemented")
 
         if str(network_policy or "deny_all").strip().lower() == "allowlist":
             reasons.append("strict_allowlist_not_supported")

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_linux_runner.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ..models import RuntimeType
+from .vz_common import VZBaseRunner
+
+
+class VZLinuxRunner(VZBaseRunner):
+    runtime_type = RuntimeType.vz_linux
+    fake_exec_env_key = "TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC"
+    available_env_key = "TLDW_SANDBOX_VZ_LINUX_AVAILABLE"
+    version_env_key = "TLDW_SANDBOX_VZ_LINUX_VERSION"
+    template_ready_env_key = "TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY"
+    template_missing_reason = "vz_linux_template_missing"

--- a/tldw_Server_API/app/core/Sandbox/runners/vz_macos_runner.py
+++ b/tldw_Server_API/app/core/Sandbox/runners/vz_macos_runner.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from ..models import RuntimeType
+from .vz_common import VZBaseRunner
+
+
+class VZMacOSRunner(VZBaseRunner):
+    runtime_type = RuntimeType.vz_macos
+    fake_exec_env_key = "TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC"
+    available_env_key = "TLDW_SANDBOX_VZ_MACOS_AVAILABLE"
+    version_env_key = "TLDW_SANDBOX_VZ_MACOS_VERSION"
+    template_ready_env_key = "TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY"
+    template_missing_reason = "macos_template_missing"

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -42,6 +42,7 @@ def collect_runtime_preflights(
     from .runners.docker_runner import docker_available
     from .runners.firecracker_runner import firecracker_available
     from .runners.lima_runner import LimaRunner
+    from .runners.vz_linux_runner import VZLinuxRunner
 
     requested_policy = str(network_policy or "deny_all").strip().lower() or "deny_all"
 
@@ -60,4 +61,5 @@ def collect_runtime_preflights(
             reasons=[] if firecracker_ok else ["firecracker_unavailable"],
         ),
         RuntimeType.lima: LimaRunner().preflight(network_policy=requested_policy),
+        RuntimeType.vz_linux: VZLinuxRunner().preflight(network_policy=requested_policy),
     }

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -43,6 +43,7 @@ def collect_runtime_preflights(
     from .runners.firecracker_runner import firecracker_available
     from .runners.lima_runner import LimaRunner
     from .runners.vz_linux_runner import VZLinuxRunner
+    from .runners.vz_macos_runner import VZMacOSRunner
 
     requested_policy = str(network_policy or "deny_all").strip().lower() or "deny_all"
 
@@ -62,4 +63,5 @@ def collect_runtime_preflights(
         ),
         RuntimeType.lima: LimaRunner().preflight(network_policy=requested_policy),
         RuntimeType.vz_linux: VZLinuxRunner().preflight(network_policy=requested_policy),
+        RuntimeType.vz_macos: VZMacOSRunner().preflight(network_policy=requested_policy),
     }

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -24,6 +24,9 @@ class RuntimePreflightResult:
     runtime: RuntimeType
     available: bool
     reasons: list[str] = field(default_factory=list)
+    supported_trust_levels: list[str] = field(
+        default_factory=lambda: ["trusted", "standard", "untrusted"]
+    )
     host: dict[str, Any] = field(default_factory=dict)
     enforcement_ready: dict[str, bool] = field(
         default_factory=lambda: {"deny_all": False, "allowlist": False}

--- a/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
+++ b/tldw_Server_API/app/core/Sandbox/runtime_capabilities.py
@@ -42,6 +42,7 @@ def collect_runtime_preflights(
     from .runners.docker_runner import docker_available
     from .runners.firecracker_runner import firecracker_available
     from .runners.lima_runner import LimaRunner
+    from .runners.seatbelt_runner import SeatbeltRunner
     from .runners.vz_linux_runner import VZLinuxRunner
     from .runners.vz_macos_runner import VZMacOSRunner
 
@@ -62,6 +63,7 @@ def collect_runtime_preflights(
             reasons=[] if firecracker_ok else ["firecracker_unavailable"],
         ),
         RuntimeType.lima: LimaRunner().preflight(network_policy=requested_policy),
+        RuntimeType.seatbelt: SeatbeltRunner().preflight(network_policy=requested_policy),
         RuntimeType.vz_linux: VZLinuxRunner().preflight(network_policy=requested_policy),
         RuntimeType.vz_macos: VZMacOSRunner().preflight(network_policy=requested_policy),
     }

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -31,6 +31,7 @@ from .models import (
     RuntimeType,
     Session,
     SessionSpec,
+    TrustLevel,
 )
 from .orchestrator import SandboxOrchestrator, SessionActiveRunsConflict
 from .policy import SandboxPolicy, SandboxPolicyConfig, compute_policy_hash
@@ -38,6 +39,7 @@ from .runtime_capabilities import RuntimePreflightResult, collect_runtime_prefli
 from .runners.docker_runner import DockerRunner, docker_available
 from .runners.firecracker_runner import FirecrackerRunner, firecracker_available, firecracker_real_enabled
 from .runners.lima_runner import LimaRunner, lima_available
+from .runners.seatbelt_runner import SeatbeltRunner
 from .runners.vz_linux_runner import VZLinuxRunner
 from .runners.vz_macos_runner import VZMacOSRunner
 from .snapshots import SnapshotManager
@@ -228,6 +230,22 @@ class SandboxService:
             raise SandboxPolicy.RuntimeUnavailable(RuntimeType.vz_macos, reasons=list(preflight.reasons or []))
         return VZMacOSRunner().start_run(run_id, spec, workspace_path)
 
+    def _start_seatbelt_run_with_execution_preflight(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        workspace_path: str | None,
+    ) -> RunStatus:
+        preflight = SeatbeltRunner().preflight(network_policy=spec.network_policy)
+        if not preflight.available:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.seatbelt, reasons=list(preflight.reasons or []))
+        self.policy._require_trust_level_supported(
+            RuntimeType.seatbelt,
+            spec.trust_level or TrustLevel.standard,
+            runtime_preflights={RuntimeType.seatbelt: preflight},
+        )
+        return SeatbeltRunner().start_run(run_id, spec, workspace_path)
+
     def _effective_claim_lease_seconds(self) -> int:
         try:
             raw = os.getenv("SANDBOX_RUN_CLAIM_LEASE_SEC")
@@ -254,6 +272,12 @@ class SandboxService:
                 RuntimeType.lima: RuntimePreflightResult(
                     runtime=RuntimeType.lima,
                     available=bool(lima_available()),
+                ),
+                RuntimeType.seatbelt: RuntimePreflightResult(
+                    runtime=RuntimeType.seatbelt,
+                    available=False,
+                    reasons=["seatbelt_unavailable"],
+                    supported_trust_levels=["trusted"],
                 ),
                 RuntimeType.vz_linux: RuntimePreflightResult(
                     runtime=RuntimeType.vz_linux,
@@ -1400,6 +1424,38 @@ class SandboxService:
                 self._orch.update_run(status.id, status)
             except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                 self._mark_run_failed(status, reason="vz_macos_failed")
+        elif execute_enabled and spec.runtime == RuntimeType.seatbelt:
+            try:
+                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+                admitted = self._admit_run_starting(status.id)
+                if admitted is None:
+                    existing = self._orch.get_run(status.id)
+                    return existing or status
+                if admitted.phase != RunPhase.starting:
+                    return admitted
+                self._apply_admitted_status(status, admitted)
+                try:
+                    real = self._run_with_claim_lease(
+                        status.id,
+                        lambda: self._start_seatbelt_run_with_execution_preflight(status.id, spec, ws),
+                    )
+                except (SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported):
+                    status.phase = RunPhase.failed
+                    status.message = "seatbelt_policy_failed"
+                    status.finished_at = datetime.utcnow()
+                    self._orch.update_run(status.id, status)
+                    return status
+                real.id = status.id
+                status.phase = real.phase
+                status.exit_code = real.exit_code
+                status.started_at = real.started_at
+                status.finished_at = real.finished_at
+                status.message = real.message
+                status.image_digest = real.image_digest
+                status.runtime_version = real.runtime_version
+                self._orch.update_run(status.id, status)
+            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+                self._mark_run_failed(status, reason="seatbelt_failed")
         else:
             # Stub artifacts even without execution
             artifacts: dict[str, bytes] = {}
@@ -1451,6 +1507,8 @@ class SandboxService:
                 cancelled = DockerRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.lima:
                 cancelled = LimaRunner.cancel_run(run_id)
+            elif st.runtime == RuntimeType.seatbelt:
+                cancelled = SeatbeltRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.vz_linux:
                 cancelled = VZLinuxRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.vz_macos:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -627,6 +627,50 @@ class SandboxService:
         with contextlib.suppress(_SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS):
             get_hub().publish_event(status.id, "end", {"exit_code": None, "reason": reason})
 
+    def _execute_single_runtime_scaffold(
+        self,
+        *,
+        status: RunStatus,
+        spec: RunSpec,
+        workspace_path: str | None,
+        start_run_fn,
+        policy_failed_reason: str,
+        failed_reason: str,
+        policy_exceptions: tuple[type[BaseException], ...],
+    ) -> RunStatus:
+        try:
+            admitted = self._admit_run_starting(status.id)
+            if admitted is None:
+                existing = self._orch.get_run(status.id)
+                return existing or status
+            if admitted.phase != RunPhase.starting:
+                return admitted
+            self._apply_admitted_status(status, admitted)
+            try:
+                real = self._run_with_claim_lease(
+                    status.id,
+                    lambda: start_run_fn(status.id, spec, workspace_path),
+                )
+            except policy_exceptions:
+                status.phase = RunPhase.failed
+                status.message = policy_failed_reason
+                status.finished_at = datetime.utcnow()
+                self._orch.update_run(status.id, status)
+                return status
+            real.id = status.id
+            status.phase = real.phase
+            status.exit_code = real.exit_code
+            status.started_at = real.started_at
+            status.finished_at = real.finished_at
+            status.message = real.message
+            status.image_digest = real.image_digest
+            status.runtime_version = real.runtime_version
+            self._orch.update_run(status.id, status)
+            return status
+        except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+            self._mark_run_failed(status, reason=failed_reason)
+            return status
+
     def feature_discovery(self) -> list[dict]:
         images = [
             "python:3.11-slim",
@@ -1430,101 +1474,38 @@ class SandboxService:
                 except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                     pass
         elif execute_enabled and spec.runtime == RuntimeType.vz_linux:
-            try:
-                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
-                admitted = self._admit_run_starting(status.id)
-                if admitted is None:
-                    existing = self._orch.get_run(status.id)
-                    return existing or status
-                if admitted.phase != RunPhase.starting:
-                    return admitted
-                self._apply_admitted_status(status, admitted)
-                try:
-                    real = self._run_with_claim_lease(
-                        status.id,
-                        lambda: self._start_vz_linux_run_with_execution_preflight(status.id, spec, ws),
-                    )
-                except SandboxPolicy.RuntimeUnavailable:
-                    status.phase = RunPhase.failed
-                    status.message = "vz_linux_policy_failed"
-                    status.finished_at = datetime.utcnow()
-                    self._orch.update_run(status.id, status)
-                    return status
-                real.id = status.id
-                status.phase = real.phase
-                status.exit_code = real.exit_code
-                status.started_at = real.started_at
-                status.finished_at = real.finished_at
-                status.message = real.message
-                status.image_digest = real.image_digest
-                status.runtime_version = real.runtime_version
-                self._orch.update_run(status.id, status)
-            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
-                self._mark_run_failed(status, reason="vz_linux_failed")
+            ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+            return self._execute_single_runtime_scaffold(
+                status=status,
+                spec=spec,
+                workspace_path=ws,
+                start_run_fn=self._start_vz_linux_run_with_execution_preflight,
+                policy_failed_reason="vz_linux_policy_failed",
+                failed_reason="vz_linux_failed",
+                policy_exceptions=(SandboxPolicy.RuntimeUnavailable,),
+            )
         elif execute_enabled and spec.runtime == RuntimeType.vz_macos:
-            try:
-                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
-                admitted = self._admit_run_starting(status.id)
-                if admitted is None:
-                    existing = self._orch.get_run(status.id)
-                    return existing or status
-                if admitted.phase != RunPhase.starting:
-                    return admitted
-                self._apply_admitted_status(status, admitted)
-                try:
-                    real = self._run_with_claim_lease(
-                        status.id,
-                        lambda: self._start_vz_macos_run_with_execution_preflight(status.id, spec, ws),
-                    )
-                except SandboxPolicy.RuntimeUnavailable:
-                    status.phase = RunPhase.failed
-                    status.message = "vz_macos_policy_failed"
-                    status.finished_at = datetime.utcnow()
-                    self._orch.update_run(status.id, status)
-                    return status
-                real.id = status.id
-                status.phase = real.phase
-                status.exit_code = real.exit_code
-                status.started_at = real.started_at
-                status.finished_at = real.finished_at
-                status.message = real.message
-                status.image_digest = real.image_digest
-                status.runtime_version = real.runtime_version
-                self._orch.update_run(status.id, status)
-            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
-                self._mark_run_failed(status, reason="vz_macos_failed")
+            ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+            return self._execute_single_runtime_scaffold(
+                status=status,
+                spec=spec,
+                workspace_path=ws,
+                start_run_fn=self._start_vz_macos_run_with_execution_preflight,
+                policy_failed_reason="vz_macos_policy_failed",
+                failed_reason="vz_macos_failed",
+                policy_exceptions=(SandboxPolicy.RuntimeUnavailable,),
+            )
         elif execute_enabled and spec.runtime == RuntimeType.seatbelt:
-            try:
-                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
-                admitted = self._admit_run_starting(status.id)
-                if admitted is None:
-                    existing = self._orch.get_run(status.id)
-                    return existing or status
-                if admitted.phase != RunPhase.starting:
-                    return admitted
-                self._apply_admitted_status(status, admitted)
-                try:
-                    real = self._run_with_claim_lease(
-                        status.id,
-                        lambda: self._start_seatbelt_run_with_execution_preflight(status.id, spec, ws),
-                    )
-                except (SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported):
-                    status.phase = RunPhase.failed
-                    status.message = "seatbelt_policy_failed"
-                    status.finished_at = datetime.utcnow()
-                    self._orch.update_run(status.id, status)
-                    return status
-                real.id = status.id
-                status.phase = real.phase
-                status.exit_code = real.exit_code
-                status.started_at = real.started_at
-                status.finished_at = real.finished_at
-                status.message = real.message
-                status.image_digest = real.image_digest
-                status.runtime_version = real.runtime_version
-                self._orch.update_run(status.id, status)
-            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
-                self._mark_run_failed(status, reason="seatbelt_failed")
+            ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+            return self._execute_single_runtime_scaffold(
+                status=status,
+                spec=spec,
+                workspace_path=ws,
+                start_run_fn=self._start_seatbelt_run_with_execution_preflight,
+                policy_failed_reason="seatbelt_policy_failed",
+                failed_reason="seatbelt_failed",
+                policy_exceptions=(SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported),
+            )
         else:
             # Stub artifacts even without execution
             artifacts: dict[str, bytes] = {}

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -39,6 +39,7 @@ from .runners.docker_runner import DockerRunner, docker_available
 from .runners.firecracker_runner import FirecrackerRunner, firecracker_available, firecracker_real_enabled
 from .runners.lima_runner import LimaRunner, lima_available
 from .runners.vz_linux_runner import VZLinuxRunner
+from .runners.vz_macos_runner import VZMacOSRunner
 from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
@@ -216,6 +217,17 @@ class SandboxService:
             raise SandboxPolicy.RuntimeUnavailable(RuntimeType.vz_linux, reasons=list(preflight.reasons or []))
         return VZLinuxRunner().start_run(run_id, spec, workspace_path)
 
+    def _start_vz_macos_run_with_execution_preflight(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        workspace_path: str | None,
+    ) -> RunStatus:
+        preflight = VZMacOSRunner().preflight(network_policy=spec.network_policy)
+        if not preflight.available:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.vz_macos, reasons=list(preflight.reasons or []))
+        return VZMacOSRunner().start_run(run_id, spec, workspace_path)
+
     def _effective_claim_lease_seconds(self) -> int:
         try:
             raw = os.getenv("SANDBOX_RUN_CLAIM_LEASE_SEC")
@@ -247,6 +259,11 @@ class SandboxService:
                     runtime=RuntimeType.vz_linux,
                     available=False,
                     reasons=["vz_linux_unavailable"],
+                ),
+                RuntimeType.vz_macos: RuntimePreflightResult(
+                    runtime=RuntimeType.vz_macos,
+                    available=False,
+                    reasons=["vz_macos_unavailable"],
                 ),
             }
 
@@ -1351,6 +1368,38 @@ class SandboxService:
                 self._orch.update_run(status.id, status)
             except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                 self._mark_run_failed(status, reason="vz_linux_failed")
+        elif execute_enabled and spec.runtime == RuntimeType.vz_macos:
+            try:
+                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+                admitted = self._admit_run_starting(status.id)
+                if admitted is None:
+                    existing = self._orch.get_run(status.id)
+                    return existing or status
+                if admitted.phase != RunPhase.starting:
+                    return admitted
+                self._apply_admitted_status(status, admitted)
+                try:
+                    real = self._run_with_claim_lease(
+                        status.id,
+                        lambda: self._start_vz_macos_run_with_execution_preflight(status.id, spec, ws),
+                    )
+                except SandboxPolicy.RuntimeUnavailable:
+                    status.phase = RunPhase.failed
+                    status.message = "vz_macos_policy_failed"
+                    status.finished_at = datetime.utcnow()
+                    self._orch.update_run(status.id, status)
+                    return status
+                real.id = status.id
+                status.phase = real.phase
+                status.exit_code = real.exit_code
+                status.started_at = real.started_at
+                status.finished_at = real.finished_at
+                status.message = real.message
+                status.image_digest = real.image_digest
+                status.runtime_version = real.runtime_version
+                self._orch.update_run(status.id, status)
+            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+                self._mark_run_failed(status, reason="vz_macos_failed")
         else:
             # Stub artifacts even without execution
             artifacts: dict[str, bytes] = {}
@@ -1404,6 +1453,8 @@ class SandboxService:
                 cancelled = LimaRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.vz_linux:
                 cancelled = VZLinuxRunner.cancel_run(run_id)
+            elif st.runtime == RuntimeType.vz_macos:
+                cancelled = VZMacOSRunner.cancel_run(run_id)
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"cancel_run failed: {e}")
             cancelled = False

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -689,10 +689,25 @@ class SandboxService:
         docker_preflight = runtime_preflights.get(RuntimeType.docker)
         firecracker_preflight = runtime_preflights.get(RuntimeType.firecracker)
         lima_preflight = runtime_preflights.get(RuntimeType.lima)
+        vz_linux_preflight = runtime_preflights.get(RuntimeType.vz_linux)
+        vz_macos_preflight = runtime_preflights.get(RuntimeType.vz_macos)
+        seatbelt_preflight = runtime_preflights.get(RuntimeType.seatbelt)
         lima_enforcement_ready = dict((lima_preflight.enforcement_ready if lima_preflight else {}) or {})
         # Allowlist enforcement is not implemented for Lima runtime execution.
         lima_enforcement_ready["allowlist"] = False
         lima_host = dict((lima_preflight.host if lima_preflight else {}) or {})
+
+        def _preflight_fields(preflight: RuntimePreflightResult | None) -> dict[str, object]:
+            enforcement_ready = dict((preflight.enforcement_ready if preflight else {}) or {})
+            return {
+                "available": bool(preflight.available) if preflight is not None else False,
+                "reasons": list((preflight.reasons if preflight else []) or []),
+                "supported_trust_levels": list((preflight.supported_trust_levels if preflight else []) or []),
+                "strict_deny_all_supported": bool(enforcement_ready.get("deny_all")),
+                "strict_allowlist_supported": bool(enforcement_ready.get("allowlist")),
+                "enforcement_ready": enforcement_ready,
+                "host": dict((preflight.host if preflight else {}) or {}),
+            }
 
         return [
             {
@@ -783,6 +798,60 @@ class SandboxService:
                 "host": lima_host,
                 "store_mode": store_mode,
                 "notes": "Full VM isolation via Lima; recommended for macOS",
+            },
+            {
+                "name": "vz_linux",
+                "default_images": ["ubuntu-24.04"],
+                "max_cpu": max_cpu,
+                "max_mem_mb": max_mem_mb,
+                "max_upload_mb": max_upload_mb,
+                "max_log_bytes": max_log_bytes,
+                "queue_max_length": queue_max_length,
+                "queue_ttl_sec": queue_ttl_sec,
+                "workspace_cap_mb": workspace_cap_mb,
+                "artifact_ttl_hours": artifact_ttl_hours,
+                "supported_spec_versions": supported_spec_versions,
+                "interactive_supported": False,
+                "egress_allowlist_supported": False,
+                "store_mode": store_mode,
+                "notes": "Linux guest VM via Virtualization.framework on Apple silicon hosts",
+                **_preflight_fields(vz_linux_preflight),
+            },
+            {
+                "name": "vz_macos",
+                "default_images": ["macos-15"],
+                "max_cpu": max_cpu,
+                "max_mem_mb": max_mem_mb,
+                "max_upload_mb": max_upload_mb,
+                "max_log_bytes": max_log_bytes,
+                "queue_max_length": queue_max_length,
+                "queue_ttl_sec": queue_ttl_sec,
+                "workspace_cap_mb": workspace_cap_mb,
+                "artifact_ttl_hours": artifact_ttl_hours,
+                "supported_spec_versions": supported_spec_versions,
+                "interactive_supported": False,
+                "egress_allowlist_supported": False,
+                "store_mode": store_mode,
+                "notes": "macOS guest VM via Virtualization.framework on Apple silicon hosts",
+                **_preflight_fields(vz_macos_preflight),
+            },
+            {
+                "name": "seatbelt",
+                "default_images": ["host-local"],
+                "max_cpu": max_cpu,
+                "max_mem_mb": max_mem_mb,
+                "max_upload_mb": max_upload_mb,
+                "max_log_bytes": max_log_bytes,
+                "queue_max_length": queue_max_length,
+                "queue_ttl_sec": queue_ttl_sec,
+                "workspace_cap_mb": workspace_cap_mb,
+                "artifact_ttl_hours": artifact_ttl_hours,
+                "supported_spec_versions": supported_spec_versions,
+                "interactive_supported": False,
+                "egress_allowlist_supported": False,
+                "store_mode": store_mode,
+                "notes": "Host-local seatbelt process isolation for trusted workflows on macOS",
+                **_preflight_fields(seatbelt_preflight),
             },
         ]
 

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -38,6 +38,7 @@ from .runtime_capabilities import RuntimePreflightResult, collect_runtime_prefli
 from .runners.docker_runner import DockerRunner, docker_available
 from .runners.firecracker_runner import FirecrackerRunner, firecracker_available, firecracker_real_enabled
 from .runners.lima_runner import LimaRunner, lima_available
+from .runners.vz_linux_runner import VZLinuxRunner
 from .snapshots import SnapshotManager
 from .store import get_store_mode
 from .streams import get_hub
@@ -204,6 +205,17 @@ class SandboxService:
         self._validate_lima_policy(runtime=spec.runtime, network_policy=spec.network_policy)
         return LimaRunner().start_run(run_id, spec, workspace_path)
 
+    def _start_vz_linux_run_with_execution_preflight(
+        self,
+        run_id: str,
+        spec: RunSpec,
+        workspace_path: str | None,
+    ) -> RunStatus:
+        preflight = VZLinuxRunner().preflight(network_policy=spec.network_policy)
+        if not preflight.available:
+            raise SandboxPolicy.RuntimeUnavailable(RuntimeType.vz_linux, reasons=list(preflight.reasons or []))
+        return VZLinuxRunner().start_run(run_id, spec, workspace_path)
+
     def _effective_claim_lease_seconds(self) -> int:
         try:
             raw = os.getenv("SANDBOX_RUN_CLAIM_LEASE_SEC")
@@ -230,6 +242,11 @@ class SandboxService:
                 RuntimeType.lima: RuntimePreflightResult(
                     runtime=RuntimeType.lima,
                     available=bool(lima_available()),
+                ),
+                RuntimeType.vz_linux: RuntimePreflightResult(
+                    runtime=RuntimeType.vz_linux,
+                    available=False,
+                    reasons=["vz_linux_unavailable"],
                 ),
             }
 
@@ -1302,6 +1319,38 @@ class SandboxService:
                         get_hub().publish_event(status.id, "end", {"exit_code": status.exit_code, "reason": "lima_failed"})
                 except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
                     pass
+        elif execute_enabled and spec.runtime == RuntimeType.vz_linux:
+            try:
+                ws = self._orch.get_session_workspace_path(spec.session_id) if spec.session_id else None
+                admitted = self._admit_run_starting(status.id)
+                if admitted is None:
+                    existing = self._orch.get_run(status.id)
+                    return existing or status
+                if admitted.phase != RunPhase.starting:
+                    return admitted
+                self._apply_admitted_status(status, admitted)
+                try:
+                    real = self._run_with_claim_lease(
+                        status.id,
+                        lambda: self._start_vz_linux_run_with_execution_preflight(status.id, spec, ws),
+                    )
+                except SandboxPolicy.RuntimeUnavailable:
+                    status.phase = RunPhase.failed
+                    status.message = "vz_linux_policy_failed"
+                    status.finished_at = datetime.utcnow()
+                    self._orch.update_run(status.id, status)
+                    return status
+                real.id = status.id
+                status.phase = real.phase
+                status.exit_code = real.exit_code
+                status.started_at = real.started_at
+                status.finished_at = real.finished_at
+                status.message = real.message
+                status.image_digest = real.image_digest
+                status.runtime_version = real.runtime_version
+                self._orch.update_run(status.id, status)
+            except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS:
+                self._mark_run_failed(status, reason="vz_linux_failed")
         else:
             # Stub artifacts even without execution
             artifacts: dict[str, bytes] = {}
@@ -1353,6 +1402,8 @@ class SandboxService:
                 cancelled = DockerRunner.cancel_run(run_id)
             elif st.runtime == RuntimeType.lima:
                 cancelled = LimaRunner.cancel_run(run_id)
+            elif st.runtime == RuntimeType.vz_linux:
+                cancelled = VZLinuxRunner.cancel_run(run_id)
         except _SANDBOX_SERVICE_NONCRITICAL_EXCEPTIONS as e:
             logger.debug(f"cancel_run failed: {e}")
             cancelled = False

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -141,6 +141,45 @@ async def test_create_session_requires_authenticated_user_id() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_create_session_rejects_unavailable_vz_macos_runtime(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="vz_macos",
+            network_policy="deny_all",
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_AVAILABLE", "0")
+
+    with pytest.raises(ACPResponseError, match="vz_macos"):
+        await manager.create_session(cwd="/workspace", user_id=7)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_session_rejects_seatbelt_without_standard_opt_in(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="seatbelt",
+            network_policy="deny_all",
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    monkeypatch.setenv("SANDBOX_BACKGROUND_EXECUTION", "1")
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
+
+    with pytest.raises(ACPResponseError, match="seatbelt_standard_disabled"):
+        await manager.create_session(cwd="/workspace", user_id=7)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_session_propagates_non_root_read_only_and_internal_ssh_port(monkeypatch) -> None:
     manager = ACPSandboxRunnerManager(
         ACPSandboxConfig(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -13,6 +13,9 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_runner_client import
     _is_self_referential_agent_command,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
+from tldw_Server_API.app.core.Sandbox.models import RuntimeType
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult
+from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 
 
 @pytest.mark.unit
@@ -176,6 +179,36 @@ async def test_create_session_rejects_seatbelt_without_standard_opt_in(monkeypat
 
     with pytest.raises(ACPResponseError, match="seatbelt_standard_disabled"):
         await manager.create_session(cwd="/workspace", user_id=7)
+
+
+@pytest.mark.unit
+def test_validate_runtime_requirements_uses_single_lima_preflight(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            runtime="lima",
+            network_policy="deny_all",
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    calls = {"count": 0}
+
+    def _fake_preflight(self, network_policy: str | None = None):
+        del self, network_policy
+        calls["count"] += 1
+        return RuntimePreflightResult(
+            runtime=RuntimeType.lima,
+            available=True,
+            reasons=[],
+            host={"os": "darwin"},
+            enforcement_ready={"deny_all": True, "allowlist": True},
+        )
+
+    monkeypatch.setattr(LimaRunner, "preflight", _fake_preflight)
+
+    manager._validate_runtime_requirements(RuntimeType.lima)
+
+    assert calls["count"] == 1
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
+++ b/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
@@ -115,3 +115,30 @@ def test_firecracker_not_available_when_real_disabled(monkeypatch) -> None:
         fc = next((rt for rt in data.get("runtimes", []) if rt.get("name") == "firecracker"), None)
         assert fc is not None
         assert fc.get("available") is False
+
+
+def test_runtimes_discovery_includes_macos_runtime_capabilities(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
+    clear_config_cache()
+
+    with TestClient(app) as client:
+        r = client.get("/api/v1/sandbox/runtimes")
+        assert r.status_code == 200
+        data = r.json()
+        runtimes = {item["name"]: item for item in data["runtimes"]}
+        assert "vz_linux" in runtimes
+        assert "vz_macos" in runtimes
+        assert "seatbelt" in runtimes
+        assert "supported_trust_levels" in runtimes["vz_linux"]
+        assert "standard" in runtimes["vz_linux"]["supported_trust_levels"]
+        assert "supported_trust_levels" in runtimes["seatbelt"]
+        assert runtimes["seatbelt"]["supported_trust_levels"] == ["trusted"]
+        assert isinstance(runtimes["vz_macos"].get("host"), dict)

--- a/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
     MacOSVirtualizationHelperClient,
+    MacOSVirtualizationHelperUnavailable,
 )
 
 
@@ -13,3 +16,12 @@ def test_helper_client_uses_fake_transport_in_test_mode(monkeypatch) -> None:
 
     assert reply.vm_id == "run-123"
     assert reply.state == "created"
+
+
+def test_helper_client_raises_custom_exception_when_helper_unavailable(monkeypatch) -> None:
+    monkeypatch.delenv("TEST_MODE", raising=False)
+
+    client = MacOSVirtualizationHelperClient()
+
+    with pytest.raises(MacOSVirtualizationHelperUnavailable, match="macos_virtualization_helper_unavailable"):
+        client.create_vm({"runtime": "vz_linux", "vm_name": "run-123"})

--- a/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_helper_client.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.macos_virtualization.helper_client import (
+    MacOSVirtualizationHelperClient,
+)
+
+
+def test_helper_client_uses_fake_transport_in_test_mode(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+
+    client = MacOSVirtualizationHelperClient()
+    reply = client.create_vm({"runtime": "vz_linux", "vm_name": "run-123"})
+
+    assert reply.vm_id == "run-123"
+    assert reply.state == "created"

--- a/tldw_Server_API/tests/sandbox/test_macos_image_store.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_image_store.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tldw_Server_API.app.core.Sandbox.image_store import SandboxImageStore
+
+
+def test_image_store_returns_run_clone_manifest_for_template(tmp_path: Path) -> None:
+    store = SandboxImageStore(root_path=tmp_path)
+    template_id = store.register_template(
+        runtime="vz_linux",
+        template_name="ubuntu-24.04",
+        disk_paths=["/templates/ubuntu-24.04.img"],
+    )
+
+    manifest = store.prepare_run_clone(template_id=template_id, run_id="run-123")
+
+    assert manifest.template_id == template_id
+    assert manifest.run_id == "run-123"
+    assert manifest.clone_items[0].source_path.endswith(".img")
+    assert manifest.clone_items[0].mode == "clone"

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py
@@ -58,3 +58,30 @@ def test_runtime_preflight_trust_levels_are_enforced() -> None:
 
     assert exc.value.runtime == RuntimeType.vz_linux
     assert "trust_level_not_supported" in exc.value.reasons
+
+
+def test_seatbelt_standard_requires_explicit_opt_in() -> None:
+    policy = SandboxPolicy()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.seatbelt,
+        base_image=None,
+        command=["echo", "ok"],
+        trust_level=TrustLevel.standard,
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=True,
+            runtime_preflights={
+                RuntimeType.seatbelt: RuntimePreflightResult(
+                    runtime=RuntimeType.seatbelt,
+                    available=True,
+                    supported_trust_levels=["trusted"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.seatbelt
+    assert "seatbelt_standard_disabled" in exc.value.reasons

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.models import RunSpec, RuntimeType, TrustLevel
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def test_seatbelt_rejected_for_untrusted_runs(monkeypatch) -> None:
+    monkeypatch.setenv("SANDBOX_ENABLE_EXECUTION", "0")
+
+    svc = SandboxService()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.seatbelt,
+        base_image="python:3.11-slim",
+        command=["echo", "ok"],
+        trust_level=TrustLevel.untrusted,
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        svc.start_run_scaffold(
+            user_id="1",
+            spec=spec,
+            spec_version="1.0",
+            idem_key=None,
+            raw_body={},
+        )
+
+    assert exc.value.runtime == RuntimeType.seatbelt
+    assert "trust_level_requires_vm_runtime" in exc.value.reasons
+
+
+def test_runtime_preflight_trust_levels_are_enforced() -> None:
+    policy = SandboxPolicy()
+    spec = RunSpec(
+        session_id=None,
+        runtime=RuntimeType.vz_linux,
+        base_image="ubuntu-24.04",
+        command=["echo", "ok"],
+        trust_level=TrustLevel.untrusted,
+    )
+
+    with pytest.raises(SandboxPolicy.PolicyUnsupported) as exc:
+        policy.apply_to_run(
+            spec,
+            firecracker_available=True,
+            runtime_preflights={
+                RuntimeType.vz_linux: RuntimePreflightResult(
+                    runtime=RuntimeType.vz_linux,
+                    available=True,
+                    supported_trust_levels=["trusted", "standard"],
+                )
+            },
+        )
+
+    assert exc.value.runtime == RuntimeType.vz_linux
+    assert "trust_level_not_supported" in exc.value.reasons

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_service_dispatch.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_service_dispatch.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RunStatus, RuntimeType, TrustLevel
+from tldw_Server_API.app.core.Sandbox.policy import SandboxPolicy
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def test_execute_single_runtime_scaffold_marks_policy_failures(monkeypatch) -> None:
+    svc = SandboxService()
+    status = RunStatus(id="run-1", phase=RunPhase.queued, runtime=RuntimeType.seatbelt)
+    admitted = RunStatus(id="run-1", phase=RunPhase.starting, runtime=RuntimeType.seatbelt)
+    updates: list[tuple[str, RunStatus]] = []
+
+    def _fake_apply(target: RunStatus, source: RunStatus) -> None:
+        target.phase = source.phase
+
+    monkeypatch.setattr(svc, "_admit_run_starting", lambda run_id: admitted)
+    monkeypatch.setattr(svc, "_apply_admitted_status", _fake_apply)
+    monkeypatch.setattr(svc, "_run_with_claim_lease", lambda run_id, fn: fn())
+    monkeypatch.setattr(svc._orch, "update_run", lambda run_id, state: updates.append((run_id, state)))
+
+    def _raise_policy(run_id: str, spec: RunSpec, workspace_path: str | None):
+        del run_id, spec, workspace_path
+        raise SandboxPolicy.PolicyUnsupported(
+            RuntimeType.seatbelt,
+            requirement="standard",
+            reasons=["seatbelt_standard_disabled"],
+        )
+
+    result = svc._execute_single_runtime_scaffold(
+        status=status,
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.seatbelt,
+            base_image="host-local",
+            command=["echo", "ok"],
+            trust_level=TrustLevel.standard,
+        ),
+        workspace_path=None,
+        start_run_fn=_raise_policy,
+        policy_failed_reason="seatbelt_policy_failed",
+        failed_reason="seatbelt_failed",
+        policy_exceptions=(SandboxPolicy.RuntimeUnavailable, SandboxPolicy.PolicyUnsupported),
+    )
+
+    assert result.phase == RunPhase.failed
+    assert result.message == "seatbelt_policy_failed"
+    assert updates[-1][0] == "run-1"

--- a/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import SandboxRunCreateRequest
+from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
+from tldw_Server_API.app.core.MCP_unified.modules.implementations.sandbox_module import SandboxModule
+
+
+def test_run_schema_accepts_vz_linux_runtime() -> None:
+    body = {
+        "spec_version": "1.0",
+        "runtime": "vz_linux",
+        "base_image": "ubuntu-24.04",
+        "command": ["echo", "ok"],
+    }
+
+    model = SandboxRunCreateRequest.model_validate(body)
+
+    assert model.runtime == "vz_linux"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_schema_lists_new_macos_runtimes() -> None:
+    module = SandboxModule(ModuleConfig(name="sandbox"))
+
+    tools = await module.get_tools()
+    tool = next(item for item in tools if item["name"] == "sandbox.run")
+
+    assert tool["inputSchema"]["properties"]["runtime"]["enum"] == [
+        "docker",
+        "firecracker",
+        "lima",
+        "vz_linux",
+        "vz_macos",
+        "seatbelt",
+    ]

--- a/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
@@ -79,3 +79,24 @@ def test_firecracker_unavailable_without_docker_has_empty_suggestions(monkeypatc
         d = j.get("error", {}).get("details", {})
         assert d.get("runtime") == "firecracker"
         assert d.get("suggested") == []
+
+
+def test_vz_linux_unavailable_returns_503_without_fallback_suggestions(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "0")
+
+    with TestClient(app) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "vz_linux",
+            "base_image": "ubuntu-24.04",
+            "command": ["echo", "ok"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        d = j.get("error", {}).get("details", {})
+        assert d.get("runtime") == "vz_linux"
+        assert d.get("available") is False
+        assert d.get("suggested") == []

--- a/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
@@ -100,3 +100,24 @@ def test_vz_linux_unavailable_returns_503_without_fallback_suggestions(monkeypat
         assert d.get("runtime") == "vz_linux"
         assert d.get("available") is False
         assert d.get("suggested") == []
+
+
+def test_vz_macos_unavailable_returns_503_without_fallback_suggestions(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_AVAILABLE", "0")
+
+    with TestClient(app) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "vz_macos",
+            "base_image": "macos-15",
+            "command": ["echo", "ok"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        d = j.get("error", {}).get("details", {})
+        assert d.get("runtime") == "vz_macos"
+        assert d.get("available") is False
+        assert d.get("suggested") == []

--- a/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
+++ b/tldw_Server_API/tests/sandbox/test_runtime_unavailable.py
@@ -121,3 +121,24 @@ def test_vz_macos_unavailable_returns_503_without_fallback_suggestions(monkeypat
         assert d.get("runtime") == "vz_macos"
         assert d.get("available") is False
         assert d.get("suggested") == []
+
+
+def test_seatbelt_unavailable_returns_503_without_fallback_suggestions(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("ROUTES_ENABLE", "sandbox")
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "0")
+
+    with TestClient(app) as client:
+        body = {
+            "spec_version": "1.0",
+            "runtime": "seatbelt",
+            "base_image": "host-local",
+            "command": ["echo", "ok"],
+        }
+        r = client.post("/api/v1/sandbox/runs", json=body)
+        assert r.status_code == 503
+        j = r.json()
+        d = j.get("error", {}).get("details", {})
+        assert d.get("runtime") == "seatbelt"
+        assert d.get("available") is False
+        assert d.get("suggested") == []

--- a/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+import tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner as seatbelt_module
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType, TrustLevel
 from tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner import SeatbeltRunner
 
@@ -42,3 +45,38 @@ def test_seatbelt_fake_run_completes(monkeypatch) -> None:
 
     assert status.phase == RunPhase.completed
     assert status.exit_code == 0
+
+
+def test_seatbelt_runner_docstring_covers_constraints() -> None:
+    doc = SeatbeltRunner.__doc__ or ""
+
+    assert "trusted" in doc
+    assert "fake" in doc
+
+
+def test_seatbelt_fake_run_logs_publish_failures(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC", "1")
+
+    class _BrokenHub:
+        def publish_event(self, run_id: str, event: str, data: dict | None = None) -> None:
+            del run_id, event, data
+            raise OSError("hub down")
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr(seatbelt_module, "get_hub", lambda: _BrokenHub())
+    monkeypatch.setattr(seatbelt_module, "logger", mock_logger, raising=False)
+
+    status = SeatbeltRunner().start_run(
+        run_id="run-seatbelt-log-1",
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.seatbelt,
+            base_image=None,
+            command=["echo", "ok"],
+            network_policy="deny_all",
+            trust_level=TrustLevel.trusted,
+        ),
+    )
+
+    assert status.phase == RunPhase.completed
+    mock_logger.warning.assert_called()

--- a/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_seatbelt_runner.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType, TrustLevel
+from tldw_Server_API.app.core.Sandbox.runners.seatbelt_runner import SeatbeltRunner
+
+
+def test_seatbelt_preflight_defaults_to_trusted_only(monkeypatch) -> None:
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
+
+    result = SeatbeltRunner().preflight(network_policy="deny_all")
+
+    assert "trusted" in result.supported_trust_levels
+    assert "standard" not in result.supported_trust_levels
+    assert "untrusted" not in result.supported_trust_levels
+
+
+def test_seatbelt_preflight_allows_standard_when_explicitly_enabled(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", "1")
+
+    result = SeatbeltRunner().preflight(network_policy="deny_all")
+
+    assert "trusted" in result.supported_trust_levels
+    assert "standard" in result.supported_trust_levels
+    assert "untrusted" not in result.supported_trust_levels
+
+
+def test_seatbelt_fake_run_completes(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_FAKE_EXEC", "1")
+
+    runner = SeatbeltRunner()
+    status = runner.start_run(
+        run_id="run-seatbelt-1",
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.seatbelt,
+            base_image=None,
+            command=["echo", "ok"],
+            network_policy="deny_all",
+            trust_level=TrustLevel.trusted,
+        ),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner import VZLinuxRunner
 
@@ -21,3 +22,18 @@ def test_vz_linux_fake_run_completes(monkeypatch) -> None:
 
     assert status.phase == RunPhase.completed
     assert status.exit_code == 0
+
+
+def test_vz_linux_preflight_requires_execution_readiness(monkeypatch) -> None:
+    monkeypatch.setattr(vz_common.sys, "platform", "darwin")
+    monkeypatch.setattr(vz_common.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_EXEC_READY", raising=False)
+
+    result = VZLinuxRunner().preflight(network_policy="deny_all")
+
+    assert result.available is False
+    assert "real_execution_not_implemented" in result.reasons

--- a/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_linux_runner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner import VZLinuxRunner
+
+
+def test_vz_linux_fake_run_completes(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", "1")
+
+    runner = VZLinuxRunner()
+    status = runner.start_run(
+        run_id="run-123",
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.vz_linux,
+            base_image="ubuntu-24.04",
+            command=["echo", "ok"],
+            network_policy="deny_all",
+        ),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0

--- a/tldw_Server_API/tests/sandbox/test_vz_macos_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_macos_runner.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
+from tldw_Server_API.app.core.Sandbox.runners.vz_macos_runner import VZMacOSRunner
+
+
+def test_vz_macos_preflight_requires_template_and_helper(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "0")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", "0")
+
+    result = VZMacOSRunner().preflight(network_policy="deny_all")
+
+    assert result.available is False
+    assert "macos_helper_missing" in result.reasons
+    assert "macos_template_missing" in result.reasons
+
+
+def test_vz_macos_fake_run_completes(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC", "1")
+
+    runner = VZMacOSRunner()
+    status = runner.start_run(
+        run_id="run-456",
+        spec=RunSpec(
+            session_id=None,
+            runtime=RuntimeType.vz_macos,
+            base_image="macos-15",
+            command=["echo", "ok"],
+            network_policy="deny_all",
+        ),
+    )
+
+    assert status.phase == RunPhase.completed
+    assert status.exit_code == 0

--- a/tldw_Server_API/tests/sandbox/test_vz_macos_runner.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_macos_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import tldw_Server_API.app.core.Sandbox.runners.vz_common as vz_common
 from tldw_Server_API.app.core.Sandbox.models import RunPhase, RunSpec, RuntimeType
 from tldw_Server_API.app.core.Sandbox.runners.vz_macos_runner import VZMacOSRunner
 
@@ -34,3 +35,18 @@ def test_vz_macos_fake_run_completes(monkeypatch) -> None:
 
     assert status.phase == RunPhase.completed
     assert status.exit_code == 0
+
+
+def test_vz_macos_preflight_requires_execution_readiness(monkeypatch) -> None:
+    monkeypatch.setattr(vz_common.sys, "platform", "darwin")
+    monkeypatch.setattr(vz_common.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_EXEC_READY", raising=False)
+
+    result = VZMacOSRunner().preflight(network_policy="deny_all")
+
+    assert result.available is False
+    assert "real_execution_not_implemented" in result.reasons

--- a/tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner import VZLinuxRunner
+from tldw_Server_API.app.core.Sandbox.runners.vz_macos_runner import VZMacOSRunner
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+def test_vz_linux_preflight_smoke_on_real_host() -> None:
+    result = VZLinuxRunner().preflight(network_policy="deny_all")
+
+    assert isinstance(result.available, bool)
+    assert isinstance(result.host, dict)
+    assert "os" in result.host
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+def test_vz_macos_preflight_smoke_on_real_host() -> None:
+    result = VZMacOSRunner().preflight(network_policy="deny_all")
+
+    assert isinstance(result.available, bool)
+    assert isinstance(result.host, dict)
+    assert "os" in result.host


### PR DESCRIPTION
## Summary
- add first-class macOS sandbox runtimes for `vz_linux`, `vz_macos`, and `seatbelt` with trust-level admission and preflight discovery
- add Virtualization helper and image-store contracts plus service and ACP integration for macOS runtime selection
- add operator notes and targeted sandbox/ACP coverage for runtime discovery, unavailable-runtime errors, and host-gated smoke checks

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_macos_runtime_surface_contract.py tldw_Server_API/tests/sandbox/test_macos_runtime_admission.py tldw_Server_API/tests/sandbox/test_macos_helper_client.py tldw_Server_API/tests/sandbox/test_macos_image_store.py tldw_Server_API/tests/sandbox/test_vz_linux_runner.py tldw_Server_API/tests/sandbox/test_vz_macos_runner.py tldw_Server_API/tests/sandbox/test_seatbelt_runner.py tldw_Server_API/tests/sandbox/test_runtime_unavailable.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py -q`
