### PR TITLE
feat: add MCP Hub tool permissions management

### DIFF
--- a/Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-design.md
+++ b/Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-design.md
@@ -1,0 +1,344 @@
+# MCP Hub Capability Registry And Guided Editor Design
+
+Date: 2026-03-09
+Status: Approved for planning
+
+## Summary
+
+The next MCP Hub PR should add a derived tool capability registry and use it to drive two existing MCP Hub surfaces:
+
+- the Catalog tab
+- the profile and assignment editors in simple mode
+
+This PR is the bridge between the policy engine that already exists and a policy authoring experience that ordinary users can actually use. The registry is derived from MCP tool definitions and normalization rules at startup. It is not user-authored in this phase.
+
+## Why This Is The Next PR
+
+The first MCP Hub tool-governance PR shipped:
+
+- durable policy storage
+- CRUD APIs for profiles, assignments, and approvals
+- effective policy resolution
+- runtime approvals
+- persona-side approval prompts and policy summary
+
+What is still missing is the machine-readable tool metadata and guided editor model that the original governance design depends on. The current UI is still document-first and hardcodes capabilities. The current catalog is still just a scope/list surface.
+
+Without a registry-backed editor, MCP Hub still asks users to think in terms of raw allowlists and policy blobs instead of the capability-based controls the product goal calls for.
+
+## Goals
+
+- Add a canonical, derived registry of MCP tool governance metadata.
+- Use the same registry DTO for the Catalog tab and the simple-mode policy editor.
+- Replace hardcoded UI capability lists with registry-backed grouped controls.
+- Ship structured preset generation for the core built-in profiles.
+- Keep runtime behavior aligned with what the editor actually promises today.
+
+## Non-Goals
+
+- Adding a user-editable capability registry.
+- Full path-bounded or resource-bounded enforcement for every tool.
+- Override CRUD and explainability provenance UI.
+- Credential binding management or external-server precedence cleanup.
+- Reworking runtime temporary elevation semantics.
+
+## Current Constraints
+
+- Tool metadata exists today, but it is inconsistent and partial. Tool definitions can carry `metadata`, and runtime code already uses heuristic checks such as `metadata.category` and name-based write detection.
+- Runtime enforcement is still centered on `allowed_tools` pattern matching and approval mode logic, not full capability family enforcement.
+- The MCP Hub editors currently rely on hardcoded capability lists and freeform allow/deny text.
+- The current Catalog tab does not expose the metadata needed to support a guided authoring flow.
+
+These constraints mean the next PR must improve authoring and classification without pretending that every proposed future capability constraint is already enforceable.
+
+## Core Decisions
+
+### 1. The first registry is derived, not administered
+
+The registry must be generated from MCP tool definitions plus server-side normalization rules.
+
+Reasons:
+
+- avoids a second source of truth
+- keeps metadata close to tool definitions
+- makes the catalog/editor reflect real server state
+- prevents an admin UI from drifting away from runtime behavior
+
+If a tool definition is missing metadata, the registry should classify it conservatively rather than invent confidence.
+
+### 2. The registry must expose one canonical DTO
+
+The registry output should be the single normalized shape consumed by:
+
+- MCP Hub catalog enrichment
+- simple-mode profile editing
+- simple-mode assignment editing
+- approval sensitivity decisions where applicable
+
+This avoids having the catalog and editor each invent their own metadata interpretation layer.
+
+### 3. The editor must support safe dual-mode authoring
+
+The new simple mode should sit alongside the current advanced/document mode.
+
+Rules:
+
+- simple mode edits should generate policy documents from structured controls
+- advanced mode should continue to expose raw allow/deny document editing
+- if a stored policy contains fields that simple mode cannot faithfully round-trip, the UI should show an `advanced fields present` warning and avoid destructive rewrites
+
+This is necessary to keep backward compatibility with the first PR and with power-user manual policy documents.
+
+### 4. The PR must not over-promise enforcement
+
+The simple editor should only expose controls that map cleanly to runtime behavior that exists today or can be added safely in the same PR.
+
+That means this PR should support:
+
+- tool group and tool-level allowlists
+- broad capability toggles used for profile generation
+- sensitivity-aware approval configuration
+- read/write/process/network/credential classifications for UX and audit
+
+It should not claim per-path or per-resource guarantees that the runtime cannot yet enforce.
+
+## Registry Data Model
+
+The registry is a derived read model, not a persistent policy object in this phase.
+
+### Registry entry
+
+Each tool registry entry should include:
+
+- `tool_name`
+- `display_name`
+- `module`
+- `category`
+- `risk_class`
+- `capabilities`
+- `mutates_state`
+- `uses_filesystem`
+- `uses_processes`
+- `uses_network`
+- `uses_credentials`
+- `supports_arguments_preview`
+- `path_boundable`
+- `metadata_source`
+- `metadata_warnings`
+
+### Field semantics
+
+- `category`
+  - coarse existing classification such as `read`, `search`, `management`, `ingestion`, `execution`
+- `risk_class`
+  - normalized class used by the UI and approval logic
+  - recommended values: `low`, `medium`, `high`, `unclassified`
+- `capabilities`
+  - normalized capability family list, such as `filesystem.read`, `process.execute`, `network.external`
+- `metadata_source`
+  - shows whether the entry came from explicit tool metadata, heuristics, or fallback normalization
+- `metadata_warnings`
+  - non-fatal notes used to highlight tools that require review because their metadata is incomplete or inferred
+
+### Conservative fallback
+
+If metadata is incomplete:
+
+- default `risk_class` to `unclassified`
+- mark `metadata_source` as `heuristic` or `fallback`
+- attach warnings
+- avoid placing the tool in low-risk presets unless explicitly allowed by normalization rules
+
+## Registry Derivation Rules
+
+Registry derivation should follow this order:
+
+1. Read explicit tool metadata from the MCP tool definition.
+2. Normalize known metadata keys to the canonical registry fields.
+3. Apply module-specific normalization rules for built-in tools where metadata is known to be incomplete.
+4. Apply conservative heuristics as a final fallback.
+5. Emit warnings when heuristics were required.
+
+### Example normalization
+
+- `metadata.category = "ingestion"` implies:
+  - `mutates_state = true`
+  - `risk_class` at least `medium`
+- shell/command execution tools imply:
+  - `capabilities` includes `process.execute`
+  - `uses_processes = true`
+  - `risk_class = high`
+- external service tools imply:
+  - `uses_network = true`
+  - `capabilities` includes `network.external`
+- secret-bearing tools imply:
+  - `uses_credentials = true`
+  - `capabilities` includes `credentials.use`
+
+## Backend Changes
+
+### New registry service
+
+Add a dedicated service that:
+
+- enumerates the effective MCP tool definitions
+- normalizes them into registry entries
+- groups them by module
+- exposes filtering helpers for presets and editor surfaces
+
+This should be implemented as a read service, not a persistence layer.
+
+### New MCP Hub API surface
+
+Expose registry-backed read endpoints through MCP Hub:
+
+- list registry entries
+- list modules/groups
+- return registry metadata for a specific tool
+- optionally return derived preset templates built from the registry
+
+### Catalog enrichment
+
+The existing catalog read path should include registry metadata so the Catalog tab can show:
+
+- module/group
+- risk badge
+- capability tags
+- metadata warnings
+
+## Guided Editor Design
+
+### Simple mode
+
+Simple mode should present grouped controls such as:
+
+- file reading
+- file writing
+- destructive file actions
+- command execution
+- external service access
+- credential usage
+- tool groups/modules
+
+The controls generate a policy document from registry-backed mappings. This replaces the current hardcoded capability set as the default authoring path.
+
+### Advanced mode
+
+Advanced mode remains available for:
+
+- raw capability list editing
+- raw allow/deny pattern editing
+- unsupported legacy fields
+
+### Round-trip safety
+
+If the stored policy document includes fields or patterns that the simple editor cannot preserve exactly:
+
+- show a warning
+- keep advanced mode as the source of truth
+- do not silently flatten or discard advanced data
+
+## Presets
+
+Presets should remain normal profiles, but their generation should be registry-backed.
+
+Recommended built-ins:
+
+- `No Additional MCP Restrictions`
+- `Read Only`
+- `Read Current Folder`
+- `RW Current Folder`
+- `External Services`
+
+Important note:
+
+`No Security` is a misleading label because platform ceilings, RBAC, and auth scopes still apply. The preset should be renamed to avoid implying that all restrictions are gone.
+
+## Runtime Alignment
+
+This PR should align the editor and runtime where feasible, but it should not attempt to solve full capability enforcement.
+
+Scope for runtime alignment in this PR:
+
+- use registry risk class to support `ask_on_sensitive_actions`
+- keep `allowed_tools` pattern enforcement as the actual execution gate
+- ensure preset generation produces patterns and capabilities consistent with the current enforcement model
+
+Out of scope:
+
+- universal per-path enforcement
+- universal per-credential binding enforcement
+- per-argument sandboxing for every tool type
+
+## Testing Requirements
+
+### Backend
+
+- registry normalization tests for built-in tools
+- fallback classification tests for incomplete metadata
+- API tests for enriched registry/catalog responses
+- resolver/protocol parity tests for registry-backed preset output
+
+### Frontend
+
+- simple-mode profile generation tests
+- simple-mode assignment generation tests
+- advanced-fields-present guard tests
+- catalog rendering tests for risk badges and warnings
+
+## Risks And Mitigations
+
+### Risk: metadata drift between tools and registry
+
+Mitigation:
+
+- derive the registry at runtime from tool definitions
+- keep normalization rules server-side and tested
+
+### Risk: simple mode corrupts advanced policies
+
+Mitigation:
+
+- add explicit non-round-trippable detection
+- keep advanced mode as fallback
+
+### Risk: external tool metadata is weak or malformed
+
+Mitigation:
+
+- conservative classification
+- `unclassified` risk class
+- warning badges in the catalog and editor
+
+### Risk: the UI exposes controls the runtime cannot enforce
+
+Mitigation:
+
+- limit simple-mode controls to what maps cleanly to current runtime behavior
+- defer path-bounded and credential-bounded controls to later PRs
+
+## Recommended Rollout
+
+### Phase 1
+
+- add derived registry service
+- add registry read APIs
+- enrich Catalog tab
+
+### Phase 2
+
+- add guided simple mode for profiles
+- add guided simple mode for assignments
+- keep advanced mode available
+
+### Phase 3
+
+- switch presets to registry-backed generation
+- align approval sensitivity decisions with registry risk classes
+
+## Follow-Up PRs After This One
+
+- Policy overrides and effective-policy provenance
+- Credential bindings and external-server precedence
+- Path-bounded capability enforcement
+- More explicit grant-authority visualization in the UI

--- a/Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-implementation-plan.md
+++ b/Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-implementation-plan.md
@@ -1,0 +1,446 @@
+# MCP Hub Capability Registry And Guided Editor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a derived MCP Hub tool capability registry, enrich the Catalog tab with registry metadata, and ship a registry-backed guided policy editor without introducing a second source of truth for tool metadata.
+
+**Architecture:** Build a server-side registry read service that normalizes MCP tool definitions into a canonical DTO, expose it through MCP Hub APIs, and use that DTO in both the Catalog tab and new simple-mode policy authoring. Keep advanced/manual policy editing intact and add round-trip guards so unsupported policy shapes are not silently flattened.
+
+**Tech Stack:** FastAPI, Pydantic, existing MCP Unified tool-definition metadata, React, Ant Design, Vitest, pytest
+
+---
+
+### Task 1: Add the failing backend tests for the derived registry
+
+**Files:**
+- Create: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+
+**Step 1: Write the failing registry normalization tests**
+
+Add tests that cover:
+
+- explicit metadata normalization for a built-in tool
+- conservative fallback for a tool with incomplete metadata
+- module grouping output
+- risk class derivation for execution and management tools
+
+Include concrete assertions for:
+
+- `tool_name`
+- `module`
+- `risk_class`
+- `capabilities`
+- `metadata_source`
+- `metadata_warnings`
+
+**Step 2: Run the backend registry tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py -v
+```
+
+Expected:
+
+- failure because the registry service does not exist yet
+
+**Step 3: Write the failing API tests for registry-backed catalog output**
+
+Extend the MCP Hub policy API tests to assert that catalog/registry endpoints return normalized metadata fields used by the UI.
+
+**Step 4: Run the API tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -k registry -v
+```
+
+Expected:
+
+- failure because the endpoint/schema additions do not exist yet
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "test: add MCP Hub tool registry coverage"
+```
+
+### Task 2: Implement the derived registry service and schemas
+
+**Files:**
+- Create: `tldw_Server_API/app/services/mcp_hub_tool_registry.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/modules/base.py`
+
+**Step 1: Implement minimal registry service**
+
+Add a read service that:
+
+- enumerates MCP tool definitions
+- normalizes tool metadata into a canonical DTO
+- applies conservative fallback classification
+- groups entries by module
+
+**Step 2: Add registry response schemas**
+
+Add Pydantic models for:
+
+- registry entry
+- registry module group
+- registry listing response
+
+**Step 3: Normalize existing tool metadata instead of inventing a new store**
+
+Use existing tool definition metadata and helper heuristics from MCP Unified base code. Only add normalization helpers required to make the registry output stable and explicit.
+
+**Step 4: Run the registry tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py -v
+```
+
+Expected:
+
+- pass
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/mcp_hub_tool_registry.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/core/MCP_unified/modules/base.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py
+git commit -m "feat: add MCP Hub tool capability registry"
+```
+
+### Task 3: Expose registry-backed MCP Hub APIs and enrich catalog output
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py`
+- Modify: `tldw_Server_API/app/services/mcp_hub_service.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+
+**Step 1: Add read endpoints for registry data**
+
+Add endpoints for:
+
+- listing registry entries
+- listing grouped modules
+- returning enriched catalog data used by MCP Hub
+
+Do not add write endpoints for registry editing.
+
+**Step 2: Keep the DTO shared**
+
+Make sure the Catalog tab and the upcoming simple-mode editor can both use the same response shape without separate transformation logic.
+
+**Step 3: Run focused API tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -v
+```
+
+Expected:
+
+- pass
+
+**Step 4: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/services/mcp_hub_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "feat: expose MCP Hub tool registry APIs"
+```
+
+### Task 4: Add failing frontend tests for the guided editor and enriched catalog
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/mcp-hub.ts`
+
+**Step 1: Add failing catalog tests**
+
+Write tests asserting the Catalog tab renders:
+
+- module labels
+- risk badges
+- capability tags
+- warning state for unclassified tools
+
+**Step 2: Add failing simple-mode editor tests**
+
+Write tests asserting:
+
+- simple-mode controls generate the expected policy document
+- built-in presets use registry-backed mappings
+- advanced-fields-present blocks destructive simple-mode rewriting
+
+**Step 3: Run the frontend tests to verify they fail**
+
+Run from `apps/packages/ui`:
+
+```bash
+bunx vitest run src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+```
+
+Expected:
+
+- failures because the registry-backed UI and DTOs are not implemented yet
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx apps/packages/ui/src/services/tldw/mcp-hub.ts
+git commit -m "test: add guided MCP Hub editor coverage"
+```
+
+### Task 5: Implement registry-backed Catalog tab and shared frontend DTOs
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/mcp-hub.ts`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/index.tsx`
+
+**Step 1: Add typed client support for registry endpoints**
+
+Define client types for registry entries and module groups. Add API functions for fetching enriched catalog data.
+
+**Step 2: Replace the current thin catalog rendering**
+
+Update the Catalog tab to render:
+
+- module/group organization
+- risk badge
+- capability chips
+- warnings for inferred or incomplete metadata
+
+**Step 3: Run catalog tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
+```
+
+Expected:
+
+- pass
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/mcp-hub.ts apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx apps/packages/ui/src/components/Option/MCPHub/index.tsx
+git commit -m "feat: enrich MCP Hub catalog with registry metadata"
+```
+
+### Task 6: Implement guided simple mode for permission profiles
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/policyHelpers.ts`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx`
+
+**Step 1: Replace hardcoded capability-only authoring with shared simple-mode helpers**
+
+Add helpers that:
+
+- map simple-mode toggles to policy documents
+- generate built-in preset payloads from registry metadata
+- detect advanced-only policy fields that cannot round-trip safely
+
+**Step 2: Update the profile editor**
+
+Add:
+
+- simple mode as the default
+- advanced mode as an opt-in
+- warning state when advanced fields are present
+
+Do not remove raw editing support.
+
+**Step 3: Run the profile editor tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
+```
+
+Expected:
+
+- pass
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/MCPHub/policyHelpers.ts apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
+git commit -m "feat: add guided MCP Hub profile editor"
+```
+
+### Task 7: Implement guided simple mode for policy assignments
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/mcp-hub.ts`
+
+**Step 1: Reuse the same simple-mode generation model in assignments**
+
+Assignments should support:
+
+- referencing a profile
+- manual simple-mode configuration
+- advanced/manual fallback when needed
+
+**Step 2: Keep effective preview intact**
+
+Do not rebuild the effective preview into provenance mode yet. This PR only needs the guided editor.
+
+**Step 3: Run the assignment tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+```
+
+Expected:
+
+- pass
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx apps/packages/ui/src/services/tldw/mcp-hub.ts
+git commit -m "feat: add guided MCP Hub assignment editor"
+```
+
+### Task 8: Align runtime sensitivity checks with the registry where safe
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/mcp_hub_approval_service.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/protocol.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_approval_service.py`
+- Modify: `tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py`
+
+**Step 1: Replace ad hoc sensitivity decisions only where the registry already has stable data**
+
+Use registry-backed `risk_class` and normalized capability hints to support `ask_on_sensitive_actions`.
+
+Do not replace existing `allowed_tools` execution gates.
+
+**Step 2: Add parity tests**
+
+Add tests proving:
+
+- sensitive tools trigger approval based on registry risk class
+- unknown/unclassified tools fail conservatively where intended
+
+**Step 3: Run the focused backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_approval_service.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -v
+```
+
+Expected:
+
+- pass
+
+**Step 4: Commit**
+
+```bash
+git add tldw_Server_API/app/services/mcp_hub_approval_service.py tldw_Server_API/app/core/MCP_unified/protocol.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_approval_service.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py
+git commit -m "feat: align MCP approvals with tool registry risk"
+```
+
+### Task 9: Run full verification and security validation
+
+**Files:**
+- No new files
+
+**Step 1: Run the backend verification suite**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_approval_service.py tldw_Server_API/app/core/MCP_unified/tests/test_protocol_allowed_tools.py -v
+```
+
+Expected:
+
+- all tests pass
+
+**Step 2: Run the focused frontend verification suite**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+```
+
+Expected:
+
+- all tests pass
+
+**Step 3: Run Bandit on touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/mcp_hub_tool_registry.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/services/mcp_hub_approval_service.py tldw_Server_API/app/core/MCP_unified/protocol.py -f json -o /tmp/bandit_mcp_hub_registry.json
+```
+
+Expected:
+
+- zero new findings in touched code
+
+**Step 4: Commit the final verification-only changes if needed**
+
+```bash
+git add <any updated test snapshots or touched files>
+git commit -m "test: verify MCP Hub registry-guided editor flow"
+```
+
+### Task 10: Update docs and PR summary
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-design.md`
+- Modify: `README.md` or relevant MCP Hub docs only if the implementation changes user-visible setup
+
+**Step 1: Update design doc status notes**
+
+Record any implementation deviations needed to stay aligned with runtime enforcement reality.
+
+**Step 2: Prepare PR summary**
+
+Summarize:
+
+- new registry service
+- catalog enrichment
+- guided editor
+- runtime sensitivity alignment
+- known deferred items
+
+**Step 3: Commit docs**
+
+```bash
+git add Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-design.md README.md
+git commit -m "docs: summarize MCP Hub capability registry rollout"
+```
+
+---
+
+Plan complete and saved to `Docs/Plans/2026-03-09-mcp-hub-capability-registry-guided-editor-implementation-plan.md`. Two execution options:
+
+1. Subagent-Driven (this session) - I dispatch fresh subagent per task, review between tasks, fast iteration
+2. Parallel Session (separate) - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/Docs/Plans/2026-03-09-mcp-hub-tool-permissions-design.md
+++ b/Docs/Plans/2026-03-09-mcp-hub-tool-permissions-design.md
@@ -259,7 +259,7 @@ Without this registry, the system would only be able to approximate the promised
 
 Presets should be implemented as normal profiles shipped by the system:
 
-- `No Security`
+- `No Additional MCP Restrictions`
 - `Read Only`
 - `Read In Current Folder`
 - `RW Current Folder`

--- a/Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-design.md
+++ b/Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-design.md
@@ -1,0 +1,266 @@
+# MCP Hub Assignment Overrides And Provenance Design
+
+Date: 2026-03-10
+Status: Approved for planning
+
+## Summary
+
+The next MCP Hub checkpoint should add assignment-bound overrides and effective-policy provenance.
+
+This work does not introduce standalone overrides. An override may only exist as a single 1:1 record attached to an existing `mcp_policy_assignment`. The MCP Hub UI remains centered on `Assignments`, and the resolver returns both the effective policy and enough provenance to explain how that result was built.
+
+## Why This Is The Next Slice
+
+The capability-registry and guided-editor checkpoint now gives MCP Hub:
+
+- derived tool metadata
+- a registry-backed catalog
+- guided editing for profiles and assignments
+
+What is still missing is a clear way to express "base policy here, targeted delta here" and then explain the result back to the user. Today the assignment inline policy and the effective preview are still too flat for that. The schema already reserves `mcp_policy_overrides`, but the repo, service, API, resolver, and UI do not expose it.
+
+## Goals
+
+- Add a single optional override record per policy assignment.
+- Keep overrides attached only to assignments, never standalone.
+- Extend the resolver to apply overrides after profile and inline assignment policy.
+- Return compact field-level provenance in effective-policy responses.
+- Add MCP Hub assignment UI for create, edit, disable, and delete override.
+- Show override presence in assignment lists and persona policy summary.
+
+## Non-Goals
+
+- Standalone overrides.
+- Multiple overrides per assignment.
+- A top-level `Overrides` tab.
+- Element-by-element diff visualization for array fields.
+- Credential bindings or external-server precedence work.
+- Path-scoped enforcement redesign.
+
+## Reviewed Constraints And Corrections
+
+### 1. Override semantics must match current resolver merge behavior
+
+The current resolver unions list fields such as:
+
+- `allowed_tools`
+- `denied_tools`
+- `tool_names`
+- `tool_patterns`
+- `capabilities`
+
+This checkpoint should not invent a second merge model only for overrides. Override application should reuse the same policy merge semantics that assignments already use. Provenance must label these fields as `merged`, not `replaced`, unless the field is actually overwritten.
+
+### 2. Provenance should stay field-level
+
+The first provenance version should explain policy assembly by field, not by exact per-item diff set algebra.
+
+Good example:
+
+- `field = allowed_tools`
+- `values = ["remote.fetch"]`
+- `source_kind = assignment_override`
+- `effect = merged`
+
+This is enough to explain behavior without creating a noisy diff engine.
+
+### 3. Grant-authority checks must evaluate broadened effective access
+
+Override writes cannot be validated only against the override document in isolation.
+
+The server must:
+
+1. resolve the effective assignment state without override
+2. simulate application of the proposed override
+3. detect whether the effective result broadens capabilities or tool reach
+4. require grant authority for the broadened delta
+
+This prevents a seemingly small override document from widening the effective result in ways a local document-only validator would miss.
+
+### 4. One-to-one must be enforced explicitly
+
+The reserved `mcp_policy_overrides` table exists in bootstrap, but this checkpoint must verify and enforce 1:1 behavior on `assignment_id` in both SQLite and Postgres migration paths.
+
+### 5. Deletion behavior must be explicit
+
+Deleting an assignment should delete its override through service/repo behavior, not only by hoping DB cascade behavior is consistent across backends and migration states.
+
+## Data Model
+
+### PolicyAssignment
+
+The existing assignment remains the contextual anchor and may include:
+
+- `target_type`
+- `target_id`
+- `owner_scope_type`
+- `owner_scope_id`
+- `profile_id`
+- `inline_policy_document`
+- `approval_policy_id`
+- `is_active`
+
+### PolicyOverride
+
+Add repo/service/API support for a separate record:
+
+- `id`
+- `assignment_id` (unique)
+- `override_policy_document`
+- `is_active`
+- `created_by`
+- `updated_by`
+- `created_at`
+- `updated_at`
+
+Rules:
+
+- override cannot exist without an assignment
+- only one override row may exist per assignment
+- inactive overrides are skipped by the resolver
+- deleting an assignment removes the override
+
+## Effective Policy Resolution
+
+Resolution remains deterministic and assignment-anchored.
+
+For a single assignment:
+
+1. start with referenced profile policy, if present and active
+2. merge assignment inline policy
+3. merge assignment override policy, if present and active
+
+Across contexts, keep the current order:
+
+1. `default`
+2. `group`
+3. `persona`
+
+So the final chain is:
+
+1. default profile
+2. default inline
+3. default override
+4. group profile
+5. group inline
+6. group override
+7. persona profile
+8. persona inline
+9. persona override
+
+## Provenance Model
+
+Keep the existing high-level `sources` array for compatibility, but add a compact `provenance` array on effective-policy responses.
+
+Each provenance entry should include:
+
+- `field`
+- `values`
+- `source_kind`
+  - `profile`
+  - `assignment_inline`
+  - `assignment_override`
+- `assignment_id`
+- `profile_id`
+- `override_id`
+- `effect`
+  - `added`
+  - `merged`
+  - `replaced`
+
+Field-level guidance:
+
+- list fields use `merged`
+- scalar replacement uses `replaced`
+- first introduction of a previously-empty field may use `added`
+
+## Backend API Shape
+
+Keep overrides nested under assignments instead of creating a top-level collection.
+
+Add:
+
+- `GET /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `PUT /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `DELETE /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+
+Also extend assignment list responses with lightweight summary fields:
+
+- `has_override`
+- `override_active`
+- `override_id`
+- `override_updated_at`
+
+This lets the UI show override state without a second fetch per row.
+
+## UI Design
+
+### Assignments Tab
+
+Keep `Assignments` as the main editing surface.
+
+Each assignment row should show:
+
+- whether an override exists
+- whether the override is active
+- quick entry into edit mode
+
+The assignment editor should show distinct sections:
+
+- `Base Assignment Policy`
+- `Assignment Override`
+- `Effective Policy Preview`
+
+Use the existing `PolicyDocumentEditor` for both base policy and override policy, but with explicit labels and helper text so users know which layer they are editing.
+
+### Effective Preview
+
+The effective preview should show:
+
+- effective capabilities
+- allowed tools
+- denied tools
+- approval mode
+- provenance entries grouped by field
+
+The first version should emphasize readability over diff exhaustiveness.
+
+### Persona Summary
+
+The persona summary should remain compact and add:
+
+- override present or not
+- override active or not
+- linked profile name if available
+
+It should not attempt to show the full provenance stream.
+
+## Testing Strategy
+
+### Backend
+
+- unit tests for override repo CRUD and uniqueness
+- service tests for assignment deletion cleaning up override
+- resolver tests for merge order and provenance output
+- grant-authority tests for broadened override writes
+- API tests for nested override routes and assignment summary fields
+
+### Frontend
+
+- assignment editor tests for create/edit/delete override
+- effective preview tests for provenance rendering
+- helper tests for merge semantics and advanced-field preservation
+- persona summary tests for override presence badge
+
+## Rollout
+
+1. add repo and migration enforcement for 1:1 overrides
+2. add service and nested API routes
+3. extend resolver output with provenance
+4. wire assignment UI to nested override CRUD
+5. add compact persona summary indicator
+6. verify with targeted pytest, Vitest, and Bandit
+
+## Recommendation
+
+Implement this as one focused checkpoint after the capability-registry work. Keep it assignment-bound, explainability-first, and consistent with existing merge semantics. Do not broaden scope into standalone overrides or a full policy diff engine.

--- a/Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-implementation-plan.md
@@ -1,0 +1,449 @@
+# MCP Hub Assignment Overrides And Provenance Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a single assignment-bound override record, nested override APIs, effective-policy provenance, and MCP Hub assignment UI that clearly separates base policy from override policy.
+
+**Architecture:** Extend the existing MCP Hub assignment model with a 1:1 `mcp_policy_overrides` record keyed by `assignment_id`, expose it through nested assignment endpoints, and update the resolver to compute `profile -> assignment inline -> assignment override` with field-level provenance. Reuse the current `PolicyDocumentEditor` for both layers and keep assignment list responses lightweight by including override summary fields.
+
+**Tech Stack:** FastAPI, existing AuthNZ repo/service stack, SQLite/Postgres migrations, React, Ant Design, Vitest, pytest, Bandit
+
+---
+
+### Task 1: Add the failing backend tests for override storage and nested APIs
+
+**Files:**
+- Create: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+- Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py`
+
+**Step 1: Write the failing repo/service-facing tests**
+
+Add tests for:
+
+- creating one override for an assignment
+- rejecting a second override for the same assignment
+- deleting an assignment removes its override
+- inactive overrides are ignored
+
+**Step 2: Run the new override tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py -v
+```
+
+Expected: FAIL because override repo/service support does not exist yet.
+
+**Step 3: Extend API tests for nested override routes**
+
+Add failing tests for:
+
+- `GET /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `PUT /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `DELETE /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+
+Also add assertions that assignment list rows include:
+
+- `has_override`
+- `override_active`
+
+**Step 4: Run the focused API tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -k override -v
+```
+
+Expected: FAIL because the nested override routes and response fields do not exist yet.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "test: add MCP Hub assignment override coverage"
+```
+
+### Task 2: Implement repo support and enforce the 1:1 override model
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py`
+- Modify: `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- Modify: `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- Test: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py`
+
+**Step 1: Add repo CRUD for policy overrides**
+
+Implement methods to:
+
+- get override by assignment id
+- upsert override by assignment id
+- delete override by assignment id
+
+Normalize `override_policy_document_json` the same way other MCP Hub policy blobs are normalized.
+
+**Step 2: Add or verify unique enforcement on `assignment_id`**
+
+Ensure both SQLite and Postgres schema paths enforce a unique `assignment_id` for `mcp_policy_overrides`.
+
+**Step 3: Add assignment summary enrichment in repo list/get paths**
+
+When listing assignments, include:
+
+- `has_override`
+- `override_id`
+- `override_active`
+- `override_updated_at`
+
+Prefer a compact join or follow-up fetch that does not change assignment semantics.
+
+**Step 4: Run the override repo tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py tldw_Server_API/app/core/AuthNZ/migrations.py tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
+git commit -m "feat: add MCP Hub policy override storage"
+```
+
+### Task 3: Add service and nested API endpoints for assignment overrides
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/mcp_hub_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+
+**Step 1: Add service methods for assignment-bound overrides**
+
+Implement:
+
+- get assignment override
+- upsert assignment override
+- delete assignment override
+
+On assignment delete, explicitly remove the override or ensure coordinated cleanup and audit emission.
+
+**Step 2: Add nested override request and response schemas**
+
+Add models for:
+
+- override upsert request
+- override response
+- assignment override summary fields
+
+**Step 3: Add nested routes under assignments**
+
+Implement:
+
+- `GET /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `PUT /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+- `DELETE /api/v1/mcp/hub/policy-assignments/{assignment_id}/override`
+
+Apply the same mutation and grant-authority patterns already used in MCP Hub.
+
+**Step 4: Run the focused API tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -k override -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/mcp_hub_service.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "feat: add nested MCP Hub override APIs"
+```
+
+### Task 4: Extend the resolver with assignment override application and provenance
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/mcp_hub_policy_resolver.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+
+**Step 1: Add failing provenance assertions**
+
+Write tests that expect:
+
+- merge order `profile -> inline -> override`
+- provenance entries for fields contributed by profile, inline policy, and override
+- `effect = merged` for list fields
+- `effect = replaced` for overwritten scalar fields
+
+**Step 2: Run the resolver tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py -k provenance -v
+```
+
+Expected: FAIL because provenance is not emitted yet.
+
+**Step 3: Implement provenance in the resolver**
+
+Extend resolver output with a compact `provenance` array. Keep the existing `sources` array unchanged.
+
+Do not build a per-item diff engine. Emit field-level provenance only.
+
+**Step 4: Reuse current merge semantics**
+
+Apply the override using the same merge logic as the rest of the resolver so behavior stays deterministic and unsurprising.
+
+**Step 5: Run the override and API suites**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -v
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/services/mcp_hub_policy_resolver.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "feat: add MCP Hub policy provenance"
+```
+
+### Task 5: Enforce broadened-access checks for override writes
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py`
+- Modify: `tldw_Server_API/app/services/mcp_hub_policy_resolver.py`
+- Modify: `tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py`
+
+**Step 1: Add the failing grant-authority tests**
+
+Cover this case:
+
+- base assignment is restrictive
+- proposed override broadens effective access
+- write is rejected without matching grant authority
+- write succeeds when grant authority is present
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -k grant -v
+```
+
+Expected: FAIL for the new override-specific broadened-access cases.
+
+**Step 3: Implement effective-base comparison**
+
+Before accepting override writes:
+
+1. resolve effective assignment state without override
+2. simulate merge with the proposed override
+3. compute broadened capability/tool reach
+4. apply grant-authority checks to the broadened delta
+
+Keep the implementation simple and deterministic. Do not attempt deep semantic analysis beyond current MCP Hub policy fields.
+
+**Step 4: Run the focused API suite**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/services/mcp_hub_policy_resolver.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+git commit -m "feat: validate broadened MCP Hub overrides"
+```
+
+### Task 6: Add failing frontend tests for override editing and provenance preview
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/mcp-hub.ts`
+
+**Step 1: Add failing assignment-tab tests**
+
+Cover:
+
+- assignment rows show override presence
+- editor loads base policy and override separately
+- effective preview renders provenance
+
+**Step 2: Add failing persona-summary tests**
+
+Cover:
+
+- summary shows override-active state
+- summary remains compact and does not attempt full provenance output
+
+**Step 3: Run the focused frontend tests to verify they fail**
+
+Run from `apps/packages/ui`:
+
+```bash
+./node_modules/.bin/vitest run src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+```
+
+Expected: FAIL because override DTOs and rendering do not exist yet.
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx apps/packages/ui/src/services/tldw/mcp-hub.ts
+git commit -m "test: add MCP Hub override UI coverage"
+```
+
+### Task 7: Implement assignment override UI and effective-policy explainability
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/mcp-hub.ts`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx`
+- Modify: `apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx`
+
+**Step 1: Add typed client support for overrides and provenance**
+
+Extend client DTOs and request helpers for:
+
+- assignment override CRUD
+- assignment override summary fields
+- effective-policy provenance
+
+**Step 2: Update the assignments UI**
+
+Add:
+
+- override presence badges in list rows
+- separate `Base Assignment Policy` and `Assignment Override` cards
+- explicit helper text so users know which layer they are editing
+
+**Step 3: Add effective-preview provenance rendering**
+
+Show compact field-level provenance grouped under the effective preview.
+
+Keep the display readable. Do not render a noisy diff table.
+
+**Step 4: Update the persona summary**
+
+Add a compact override-active indicator and keep the rest of the summary lightweight.
+
+**Step 5: Run the focused UI suite**
+
+Run:
+
+```bash
+cd apps/packages/ui && ./node_modules/.bin/vitest run src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/mcp-hub.ts apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+git commit -m "feat: add MCP Hub override editing and provenance UI"
+```
+
+### Task 8: Run verification and security checks on the full touched scope
+
+**Files:**
+- Verify: `tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py`
+- Verify: `tldw_Server_API/app/services/mcp_hub_service.py`
+- Verify: `tldw_Server_API/app/services/mcp_hub_policy_resolver.py`
+- Verify: `tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py`
+- Verify: `tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py`
+- Verify: `apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx`
+- Verify: `apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx`
+
+**Step 1: Run backend verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -v
+```
+
+Expected: PASS.
+
+**Step 2: Run frontend verification**
+
+Run:
+
+```bash
+cd apps/packages/ui && ./node_modules/.bin/vitest run src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Run Bandit on touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py tldw_Server_API/app/services/mcp_hub_service.py tldw_Server_API/app/services/mcp_hub_policy_resolver.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py -f json -o /tmp/bandit_mcp_hub_overrides.json
+```
+
+Expected: JSON written with no new findings in touched code.
+
+**Step 4: Commit**
+
+```bash
+git add .
+git commit -m "test: verify MCP Hub override and provenance slice"
+```
+
+### Task 9: Prepare the checkpoint for review
+
+**Files:**
+- Review: `Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-design.md`
+- Review: `Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-implementation-plan.md`
+
+**Step 1: Review the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD~1..HEAD
+```
+
+Expected: clean worktree and a focused override/provenance diff.
+
+**Step 2: Summarize remaining follow-up work**
+
+Document what is still out of scope:
+
+- credential bindings
+- path-scoped enforcement
+- richer diff visualization
+
+**Step 3: Commit any final doc adjustments**
+
+```bash
+git add Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-design.md Docs/Plans/2026-03-10-mcp-hub-assignment-overrides-provenance-implementation-plan.md
+git commit -m "docs: finalize MCP Hub override implementation plan"
+```

--- a/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx
@@ -5,16 +5,17 @@ import {
   createPermissionProfile,
   deletePermissionProfile,
   listPermissionProfiles,
+  listToolRegistry,
+  listToolRegistryModules,
   updatePermissionProfile,
-  type McpHubPermissionProfile
+  type McpHubPermissionPolicyDocument,
+  type McpHubPermissionProfile,
+  type McpHubToolRegistryEntry,
+  type McpHubToolRegistryModule
 } from "@/services/tldw/mcp-hub"
 
-import {
-  buildPolicyDocument,
-  MCP_HUB_CAPABILITY_OPTIONS,
-  MCP_HUB_PROFILE_MODE_OPTIONS,
-  MCP_HUB_SCOPE_OPTIONS
-} from "./policyHelpers"
+import { MCP_HUB_PROFILE_MODE_OPTIONS, MCP_HUB_SCOPE_OPTIONS } from "./policyHelpers"
+import { PolicyDocumentEditor } from "./PolicyDocumentEditor"
 
 export const PermissionProfilesTab = () => {
   const [profiles, setProfiles] = useState<McpHubPermissionProfile[]>([])
@@ -27,10 +28,10 @@ export const PermissionProfilesTab = () => {
   const [description, setDescription] = useState("")
   const [ownerScopeType, setOwnerScopeType] = useState<"global" | "org" | "team" | "user">("global")
   const [mode, setMode] = useState<"custom" | "preset">("custom")
-  const [capabilities, setCapabilities] = useState<string[]>([])
-  const [allowedToolsText, setAllowedToolsText] = useState("")
-  const [deniedToolsText, setDeniedToolsText] = useState("")
+  const [policyDocument, setPolicyDocument] = useState<McpHubPermissionPolicyDocument>({})
   const [isActive, setIsActive] = useState(true)
+  const [registryEntries, setRegistryEntries] = useState<McpHubToolRegistryEntry[]>([])
+  const [registryModules, setRegistryModules] = useState<McpHubToolRegistryModule[]>([])
 
   const canSave = useMemo(() => name.trim().length > 0 && !saving, [name, saving])
 
@@ -52,6 +53,28 @@ export const PermissionProfilesTab = () => {
     void loadProfiles()
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+    const loadRegistry = async () => {
+      try {
+        const [entries, modules] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
+        if (!cancelled) {
+          setRegistryEntries(Array.isArray(entries) ? entries : [])
+          setRegistryModules(Array.isArray(modules) ? modules : [])
+        }
+      } catch {
+        if (!cancelled) {
+          setRegistryEntries([])
+          setRegistryModules([])
+        }
+      }
+    }
+    void loadRegistry()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   const resetForm = () => {
     setCreateOpen(false)
     setEditingId(null)
@@ -59,9 +82,7 @@ export const PermissionProfilesTab = () => {
     setDescription("")
     setOwnerScopeType("global")
     setMode("custom")
-    setCapabilities([])
-    setAllowedToolsText("")
-    setDeniedToolsText("")
+    setPolicyDocument({})
     setIsActive(true)
   }
 
@@ -72,9 +93,7 @@ export const PermissionProfilesTab = () => {
     setDescription(String(profile.description || ""))
     setOwnerScopeType(profile.owner_scope_type)
     setMode(profile.mode)
-    setCapabilities(Array.isArray(profile.policy_document.capabilities) ? profile.policy_document.capabilities : [])
-    setAllowedToolsText(Array.isArray(profile.policy_document.allowed_tools) ? profile.policy_document.allowed_tools.join("\n") : "")
-    setDeniedToolsText(Array.isArray(profile.policy_document.denied_tools) ? profile.policy_document.denied_tools.join("\n") : "")
+    setPolicyDocument(profile.policy_document || {})
     setIsActive(profile.is_active)
   }
 
@@ -88,11 +107,7 @@ export const PermissionProfilesTab = () => {
         description: description.trim() || null,
         owner_scope_type: ownerScopeType,
         mode,
-        policy_document: buildPolicyDocument({
-          capabilities,
-          allowedToolsText,
-          deniedToolsText
-        }),
+        policy_document: policyDocument,
         is_active: isActive
       }
       if (editingId) {
@@ -129,7 +144,7 @@ export const PermissionProfilesTab = () => {
   return (
     <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
       <Typography.Text type="secondary">
-        Reusable tool-access profiles define capabilities, tool allowlists, and baseline restrictions.
+        Reusable tool-access profiles define capabilities, exact tool allowlists, and baseline restrictions.
       </Typography.Text>
       {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
@@ -147,7 +162,7 @@ export const PermissionProfilesTab = () => {
                 aria-label="Profile Name"
                 value={name}
                 onChange={(event) => setName(event.target.value)}
-                placeholder="Process Exec"
+                placeholder="Read Only"
               />
             </Space>
             <Space orientation="vertical" style={{ width: "100%" }}>
@@ -157,7 +172,7 @@ export const PermissionProfilesTab = () => {
                 aria-label="Description"
                 value={description}
                 onChange={(event) => setDescription(event.target.value)}
-                placeholder="Allows tool execution for shell workflows"
+                placeholder="Restricts this persona to low-risk read flows"
               />
             </Space>
             <Space>
@@ -192,48 +207,15 @@ export const PermissionProfilesTab = () => {
                 </select>
               </Space>
             </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <Typography.Text strong>Capabilities</Typography.Text>
-              <Space wrap>
-                {MCP_HUB_CAPABILITY_OPTIONS.map((capability) => (
-                  <Checkbox
-                    key={capability}
-                    checked={capabilities.includes(capability)}
-                    onChange={(event) => {
-                      setCapabilities((prev) =>
-                        event.target.checked
-                          ? [...prev, capability]
-                          : prev.filter((entry) => entry !== capability)
-                      )
-                    }}
-                  >
-                    {capability}
-                  </Checkbox>
-                ))}
-              </Space>
-            </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <label htmlFor="mcp-permission-profile-allowed-tools">Allowed Tools</label>
-              <textarea
-                id="mcp-permission-profile-allowed-tools"
-                aria-label="Allowed Tools"
-                value={allowedToolsText}
-                onChange={(event) => setAllowedToolsText(event.target.value)}
-                placeholder={"Bash(git *)\nnotes.search"}
-                rows={4}
-              />
-            </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <label htmlFor="mcp-permission-profile-denied-tools">Denied Tools</label>
-              <textarea
-                id="mcp-permission-profile-denied-tools"
-                aria-label="Denied Tools"
-                value={deniedToolsText}
-                onChange={(event) => setDeniedToolsText(event.target.value)}
-                placeholder={"Bash(rm *)\nBash(sudo *)"}
-                rows={4}
-              />
-            </Space>
+
+            <PolicyDocumentEditor
+              formId="mcp-permission-profile"
+              policy={policyDocument}
+              onChange={setPolicyDocument}
+              registryEntries={registryEntries}
+              registryModules={registryModules}
+            />
+
             <Checkbox checked={isActive} onChange={(event) => setIsActive(event.target.checked)}>
               Active
             </Checkbox>

--- a/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PermissionProfilesTab.tsx
@@ -4,9 +4,8 @@ import { Alert, Button, Card, Checkbox, Empty, List, Space, Tag, Typography } fr
 import {
   createPermissionProfile,
   deletePermissionProfile,
+  getToolRegistrySummary,
   listPermissionProfiles,
-  listToolRegistry,
-  listToolRegistryModules,
   updatePermissionProfile,
   type McpHubPermissionPolicyDocument,
   type McpHubPermissionProfile,
@@ -57,10 +56,10 @@ export const PermissionProfilesTab = () => {
     let cancelled = false
     const loadRegistry = async () => {
       try {
-        const [entries, modules] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
+        const summary = await getToolRegistrySummary()
         if (!cancelled) {
-          setRegistryEntries(Array.isArray(entries) ? entries : [])
-          setRegistryModules(Array.isArray(modules) ? modules : [])
+          setRegistryEntries(Array.isArray(summary?.entries) ? summary.entries : [])
+          setRegistryModules(Array.isArray(summary?.modules) ? summary.modules : [])
         }
       } catch {
         if (!cancelled) {

--- a/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
@@ -65,6 +65,9 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
               <Tag key={capability}>{capability}</Tag>
             ))}
             {policy.approval_mode ? <Tag color="gold">{policy.approval_mode}</Tag> : null}
+            {policy.provenance.some((entry) => entry.source_kind === "assignment_override") ? (
+              <Tag color="cyan">Override active</Tag>
+            ) : null}
           </Space>
           <Space wrap>
             {policy.allowed_tools.map((tool) => (

--- a/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
@@ -3,25 +3,35 @@ import { Alert, Button, Card, Checkbox, Empty, List, Space, Tag, Typography } fr
 
 import {
   createPolicyAssignment,
+  deletePolicyAssignmentOverride,
   deletePolicyAssignment,
   getEffectivePolicy,
+  getPolicyAssignmentOverride,
   listApprovalPolicies,
   listPermissionProfiles,
   listPolicyAssignments,
   listToolRegistry,
   listToolRegistryModules,
+  upsertPolicyAssignmentOverride,
   updatePolicyAssignment,
   type McpHubApprovalPolicy,
   type McpHubEffectivePolicy,
   type McpHubPermissionPolicyDocument,
   type McpHubPermissionProfile,
   type McpHubPolicyAssignment,
+  type McpHubPolicyOverride,
   type McpHubToolRegistryEntry,
   type McpHubToolRegistryModule
 } from "@/services/tldw/mcp-hub"
 
 import { MCP_HUB_SCOPE_OPTIONS, MCP_HUB_TARGET_OPTIONS } from "./policyHelpers"
 import { PolicyDocumentEditor } from "./PolicyDocumentEditor"
+
+const PROVENANCE_LABELS = {
+  profile: "profile",
+  assignment_inline: "assignment",
+  assignment_override: "assignment override"
+} as const
 
 export const PolicyAssignmentsTab = () => {
   const [assignments, setAssignments] = useState<McpHubPolicyAssignment[]>([])
@@ -40,6 +50,13 @@ export const PolicyAssignmentsTab = () => {
   const [approvalPolicyId, setApprovalPolicyId] = useState<string>("")
   const [policyDocument, setPolicyDocument] = useState<McpHubPermissionPolicyDocument>({})
   const [isActive, setIsActive] = useState(true)
+  const [overridePolicyDocument, setOverridePolicyDocument] = useState<McpHubPermissionPolicyDocument>(
+    {}
+  )
+  const [overrideIsActive, setOverrideIsActive] = useState(true)
+  const [overrideExists, setOverrideExists] = useState(false)
+  const [overrideLoading, setOverrideLoading] = useState(false)
+  const [overrideSaving, setOverrideSaving] = useState(false)
   const [registryEntries, setRegistryEntries] = useState<McpHubToolRegistryEntry[]>([])
   const [registryModules, setRegistryModules] = useState<McpHubToolRegistryModule[]>([])
 
@@ -119,6 +136,28 @@ export const PolicyAssignmentsTab = () => {
     setApprovalPolicyId("")
     setPolicyDocument({})
     setIsActive(true)
+    setOverridePolicyDocument({})
+    setOverrideIsActive(true)
+    setOverrideExists(false)
+    setOverrideLoading(false)
+    setOverrideSaving(false)
+  }
+
+  const loadOverride = async (assignmentId: number) => {
+    setOverrideLoading(true)
+    try {
+      const row = await getPolicyAssignmentOverride(assignmentId)
+      const overrideRow = row as McpHubPolicyOverride
+      setOverridePolicyDocument(overrideRow.override_policy_document || {})
+      setOverrideIsActive(Boolean(overrideRow.is_active))
+      setOverrideExists(true)
+    } catch {
+      setOverridePolicyDocument({})
+      setOverrideIsActive(true)
+      setOverrideExists(false)
+    } finally {
+      setOverrideLoading(false)
+    }
   }
 
   const openForEdit = (assignment: McpHubPolicyAssignment) => {
@@ -131,6 +170,12 @@ export const PolicyAssignmentsTab = () => {
     setApprovalPolicyId(assignment.approval_policy_id ? String(assignment.approval_policy_id) : "")
     setPolicyDocument(assignment.inline_policy_document || {})
     setIsActive(assignment.is_active)
+    setOverridePolicyDocument({})
+    setOverrideIsActive(assignment.has_override ? Boolean(assignment.override_active) : true)
+    setOverrideExists(Boolean(assignment.has_override))
+    if (assignment.has_override) {
+      void loadOverride(assignment.id)
+    }
   }
 
   const handleSave = async () => {
@@ -173,6 +218,41 @@ export const PolicyAssignmentsTab = () => {
       await loadAll()
     } catch {
       setErrorMessage("Failed to delete policy assignment.")
+    }
+  }
+
+  const handleSaveOverride = async () => {
+    if (!editingId) return
+    setOverrideSaving(true)
+    setErrorMessage(null)
+    try {
+      await upsertPolicyAssignmentOverride(editingId, {
+        override_policy_document: overridePolicyDocument,
+        is_active: overrideIsActive
+      })
+      setOverrideExists(true)
+      await loadAll()
+    } catch {
+      setErrorMessage("Failed to save assignment override.")
+    } finally {
+      setOverrideSaving(false)
+    }
+  }
+
+  const handleDeleteOverride = async () => {
+    if (!editingId) return
+    if (typeof window !== "undefined" && !window.confirm("Delete this assignment override?")) {
+      return
+    }
+    setErrorMessage(null)
+    try {
+      await deletePolicyAssignmentOverride(editingId)
+      setOverridePolicyDocument({})
+      setOverrideIsActive(true)
+      setOverrideExists(false)
+      await loadAll()
+    } catch {
+      setErrorMessage("Failed to delete assignment override.")
     }
   }
 
@@ -270,13 +350,72 @@ export const PolicyAssignmentsTab = () => {
               </Space>
             </Space>
 
-            <PolicyDocumentEditor
-              formId="mcp-assignment"
-              policy={policyDocument}
-              onChange={setPolicyDocument}
-              registryEntries={registryEntries}
-              registryModules={registryModules}
-            />
+            <Card size="small" title="Base Assignment Policy">
+              <PolicyDocumentEditor
+                formId="mcp-assignment"
+                policy={policyDocument}
+                onChange={setPolicyDocument}
+                registryEntries={registryEntries}
+                registryModules={registryModules}
+              />
+            </Card>
+
+            {editingId ? (
+              <Card
+                size="small"
+                title="Assignment Override"
+                extra={
+                  overrideExists ? (
+                    <Tag color={overrideIsActive ? "cyan" : "default"}>
+                      {overrideIsActive ? "override active" : "override inactive"}
+                    </Tag>
+                  ) : (
+                    <Tag>no override yet</Tag>
+                  )
+                }
+              >
+                <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+                  <Typography.Text type="secondary">
+                    Use one explicit override document for this assignment when it needs to differ from
+                    the base profile plus assignment policy.
+                  </Typography.Text>
+                  {overrideLoading ? (
+                    <Typography.Text type="secondary">Loading override...</Typography.Text>
+                  ) : (
+                    <PolicyDocumentEditor
+                      formId="mcp-assignment-override"
+                      policy={overridePolicyDocument}
+                      onChange={setOverridePolicyDocument}
+                      registryEntries={registryEntries}
+                      registryModules={registryModules}
+                    />
+                  )}
+                  <Checkbox
+                    checked={overrideIsActive}
+                    onChange={(event) => setOverrideIsActive(event.target.checked)}
+                  >
+                    Override Active
+                  </Checkbox>
+                  <Space>
+                    <Button
+                      type="primary"
+                      onClick={() => void handleSaveOverride()}
+                      loading={overrideSaving}
+                      disabled={overrideLoading}
+                    >
+                      Save Override
+                    </Button>
+                    <Button
+                      danger
+                      onClick={() => void handleDeleteOverride()}
+                      disabled={!overrideExists || overrideLoading}
+                    >
+                      Delete Override
+                    </Button>
+                  </Space>
+                </Space>
+              </Card>
+            ) : null}
 
             <Checkbox checked={isActive} onChange={(event) => setIsActive(event.target.checked)}>
               Active
@@ -312,6 +451,16 @@ export const PolicyAssignmentsTab = () => {
                 <Tag color="gold">{effectivePolicy.approval_mode}</Tag>
               ) : null}
             </Space>
+            {effectivePolicy.provenance.length > 0 ? (
+              <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+                <Typography.Text strong>Why This Applies</Typography.Text>
+                {effectivePolicy.provenance.map((entry, index) => (
+                  <Typography.Text key={`${entry.assignment_id}-${entry.field}-${entry.source_kind}-${index}`}>
+                    {`${entry.field} from ${PROVENANCE_LABELS[entry.source_kind]} (${entry.effect})`}
+                  </Typography.Text>
+                ))}
+              </Space>
+            ) : null}
           </Space>
         ) : (
           <Empty description="No effective policy preview available yet" />
@@ -335,6 +484,11 @@ export const PolicyAssignmentsTab = () => {
                   <Tag color="gold">{`approval ${assignment.approval_policy_id}`}</Tag>
                 ) : null}
                 {assignment.is_active ? <Tag color="green">active</Tag> : <Tag>inactive</Tag>}
+                {assignment.has_override ? (
+                  <Tag color={assignment.override_active ? "cyan" : "default"}>
+                    {assignment.override_active ? "override active" : "override inactive"}
+                  </Tag>
+                ) : null}
                 <Button size="small" onClick={() => openForEdit(assignment)}>
                   Edit
                 </Button>

--- a/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
@@ -5,13 +5,12 @@ import {
   createPolicyAssignment,
   deletePolicyAssignmentOverride,
   deletePolicyAssignment,
+  getToolRegistrySummary,
   getEffectivePolicy,
   getPolicyAssignmentOverride,
   listApprovalPolicies,
   listPermissionProfiles,
   listPolicyAssignments,
-  listToolRegistry,
-  listToolRegistryModules,
   upsertPolicyAssignmentOverride,
   updatePolicyAssignment,
   type McpHubApprovalPolicy,
@@ -108,10 +107,10 @@ export const PolicyAssignmentsTab = () => {
     let cancelled = false
     const loadRegistry = async () => {
       try {
-        const [entries, modules] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
+        const summary = await getToolRegistrySummary()
         if (!cancelled) {
-          setRegistryEntries(Array.isArray(entries) ? entries : [])
-          setRegistryModules(Array.isArray(modules) ? modules : [])
+          setRegistryEntries(Array.isArray(summary?.entries) ? summary.entries : [])
+          setRegistryModules(Array.isArray(summary?.modules) ? summary.modules : [])
         }
       } catch {
         if (!cancelled) {

--- a/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PolicyAssignmentsTab.tsx
@@ -8,19 +8,20 @@ import {
   listApprovalPolicies,
   listPermissionProfiles,
   listPolicyAssignments,
+  listToolRegistry,
+  listToolRegistryModules,
   updatePolicyAssignment,
   type McpHubApprovalPolicy,
   type McpHubEffectivePolicy,
+  type McpHubPermissionPolicyDocument,
   type McpHubPermissionProfile,
-  type McpHubPolicyAssignment
+  type McpHubPolicyAssignment,
+  type McpHubToolRegistryEntry,
+  type McpHubToolRegistryModule
 } from "@/services/tldw/mcp-hub"
 
-import {
-  buildPolicyDocument,
-  MCP_HUB_CAPABILITY_OPTIONS,
-  MCP_HUB_SCOPE_OPTIONS,
-  MCP_HUB_TARGET_OPTIONS
-} from "./policyHelpers"
+import { MCP_HUB_SCOPE_OPTIONS, MCP_HUB_TARGET_OPTIONS } from "./policyHelpers"
+import { PolicyDocumentEditor } from "./PolicyDocumentEditor"
 
 export const PolicyAssignmentsTab = () => {
   const [assignments, setAssignments] = useState<McpHubPolicyAssignment[]>([])
@@ -37,16 +38,15 @@ export const PolicyAssignmentsTab = () => {
   const [ownerScopeType, setOwnerScopeType] = useState<"global" | "org" | "team" | "user">("user")
   const [profileId, setProfileId] = useState<string>("")
   const [approvalPolicyId, setApprovalPolicyId] = useState<string>("")
-  const [capabilities, setCapabilities] = useState<string[]>([])
-  const [allowedToolsText, setAllowedToolsText] = useState("")
-  const [deniedToolsText, setDeniedToolsText] = useState("")
+  const [policyDocument, setPolicyDocument] = useState<McpHubPermissionPolicyDocument>({})
   const [isActive, setIsActive] = useState(true)
+  const [registryEntries, setRegistryEntries] = useState<McpHubToolRegistryEntry[]>([])
+  const [registryModules, setRegistryModules] = useState<McpHubToolRegistryModule[]>([])
 
-  const canSave = useMemo(() => !saving && (targetType === "default" || targetId.trim().length > 0), [
-    saving,
-    targetId,
-    targetType
-  ])
+  const canSave = useMemo(
+    () => !saving && (targetType === "default" || targetId.trim().length > 0),
+    [saving, targetId, targetType]
+  )
 
   const loadAll = async () => {
     setLoading(true)
@@ -61,8 +61,12 @@ export const PolicyAssignmentsTab = () => {
       setProfiles(Array.isArray(profileRows) ? profileRows : [])
       setApprovalPolicies(Array.isArray(approvalRows) ? approvalRows : [])
 
-      const firstPersonaAssignment = assignmentRows.find((row) => row.target_type === "persona" && row.target_id)
-      const firstGroupAssignment = assignmentRows.find((row) => row.target_type === "group" && row.target_id)
+      const firstPersonaAssignment = assignmentRows.find(
+        (row) => row.target_type === "persona" && row.target_id
+      )
+      const firstGroupAssignment = assignmentRows.find(
+        (row) => row.target_type === "group" && row.target_id
+      )
       const preview = await getEffectivePolicy({
         persona_id: firstPersonaAssignment?.target_id ?? null,
         group_id: firstGroupAssignment?.target_id ?? null
@@ -83,6 +87,28 @@ export const PolicyAssignmentsTab = () => {
     void loadAll()
   }, [])
 
+  useEffect(() => {
+    let cancelled = false
+    const loadRegistry = async () => {
+      try {
+        const [entries, modules] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
+        if (!cancelled) {
+          setRegistryEntries(Array.isArray(entries) ? entries : [])
+          setRegistryModules(Array.isArray(modules) ? modules : [])
+        }
+      } catch {
+        if (!cancelled) {
+          setRegistryEntries([])
+          setRegistryModules([])
+        }
+      }
+    }
+    void loadRegistry()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
   const resetForm = () => {
     setCreateOpen(false)
     setEditingId(null)
@@ -91,9 +117,7 @@ export const PolicyAssignmentsTab = () => {
     setOwnerScopeType("user")
     setProfileId("")
     setApprovalPolicyId("")
-    setCapabilities([])
-    setAllowedToolsText("")
-    setDeniedToolsText("")
+    setPolicyDocument({})
     setIsActive(true)
   }
 
@@ -105,21 +129,7 @@ export const PolicyAssignmentsTab = () => {
     setOwnerScopeType(assignment.owner_scope_type)
     setProfileId(assignment.profile_id ? String(assignment.profile_id) : "")
     setApprovalPolicyId(assignment.approval_policy_id ? String(assignment.approval_policy_id) : "")
-    setCapabilities(
-      Array.isArray(assignment.inline_policy_document.capabilities)
-        ? assignment.inline_policy_document.capabilities
-        : []
-    )
-    setAllowedToolsText(
-      Array.isArray(assignment.inline_policy_document.allowed_tools)
-        ? assignment.inline_policy_document.allowed_tools.join("\n")
-        : ""
-    )
-    setDeniedToolsText(
-      Array.isArray(assignment.inline_policy_document.denied_tools)
-        ? assignment.inline_policy_document.denied_tools.join("\n")
-        : ""
-    )
+    setPolicyDocument(assignment.inline_policy_document || {})
     setIsActive(assignment.is_active)
   }
 
@@ -134,11 +144,7 @@ export const PolicyAssignmentsTab = () => {
         owner_scope_type: ownerScopeType,
         profile_id: profileId ? Number(profileId) : null,
         approval_policy_id: approvalPolicyId ? Number(approvalPolicyId) : null,
-        inline_policy_document: buildPolicyDocument({
-          capabilities,
-          allowedToolsText,
-          deniedToolsText
-        }),
+        inline_policy_document: policyDocument,
         is_active: isActive
       }
       if (editingId) {
@@ -173,7 +179,8 @@ export const PolicyAssignmentsTab = () => {
   return (
     <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
       <Typography.Text type="secondary">
-        Assign profiles to default, group, or persona targets, then layer in manual overrides where needed.
+        Assign profiles to default, group, or persona targets, then layer in exact tool overrides where
+        needed.
       </Typography.Text>
       {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
@@ -262,46 +269,15 @@ export const PolicyAssignmentsTab = () => {
                 </select>
               </Space>
             </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <Typography.Text strong>Inline Capabilities</Typography.Text>
-              <Space wrap>
-                {MCP_HUB_CAPABILITY_OPTIONS.map((capability) => (
-                  <Checkbox
-                    key={capability}
-                    checked={capabilities.includes(capability)}
-                    onChange={(event) => {
-                      setCapabilities((prev) =>
-                        event.target.checked
-                          ? [...prev, capability]
-                          : prev.filter((entry) => entry !== capability)
-                      )
-                    }}
-                  >
-                    {capability}
-                  </Checkbox>
-                ))}
-              </Space>
-            </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <label htmlFor="mcp-assignment-allowed-tools">Allowed Tools</label>
-              <textarea
-                id="mcp-assignment-allowed-tools"
-                aria-label="Allowed Tools"
-                value={allowedToolsText}
-                onChange={(event) => setAllowedToolsText(event.target.value)}
-                rows={3}
-              />
-            </Space>
-            <Space orientation="vertical" style={{ width: "100%" }}>
-              <label htmlFor="mcp-assignment-denied-tools">Denied Tools</label>
-              <textarea
-                id="mcp-assignment-denied-tools"
-                aria-label="Denied Tools"
-                value={deniedToolsText}
-                onChange={(event) => setDeniedToolsText(event.target.value)}
-                rows={3}
-              />
-            </Space>
+
+            <PolicyDocumentEditor
+              formId="mcp-assignment"
+              policy={policyDocument}
+              onChange={setPolicyDocument}
+              registryEntries={registryEntries}
+              registryModules={registryModules}
+            />
+
             <Checkbox checked={isActive} onChange={(event) => setIsActive(event.target.checked)}>
               Active
             </Checkbox>
@@ -369,6 +345,11 @@ export const PolicyAssignmentsTab = () => {
               <Space wrap>
                 {(assignment.inline_policy_document.capabilities || []).map((capability) => (
                   <Tag key={capability}>{capability}</Tag>
+                ))}
+                {(assignment.inline_policy_document.allowed_tools || []).map((tool) => (
+                  <Tag key={tool} color="green">
+                    {tool}
+                  </Tag>
                 ))}
               </Space>
             </Space>

--- a/apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useMemo, useState } from "react"
+import { Alert, Button, Card, Checkbox, Empty, Space, Tag, Typography } from "antd"
+
+import type {
+  McpHubPermissionPolicyDocument,
+  McpHubToolRegistryEntry,
+  McpHubToolRegistryModule
+} from "@/services/tldw/mcp-hub"
+
+import {
+  buildSimplePolicyDocument,
+  createPresetSelection,
+  getAdvancedPolicyKeys,
+  getDerivedCapabilities,
+  getKnownRegistryCapabilities,
+  getPolicyAllowedToolSelection,
+  getToolEntriesByModule,
+  joinList,
+  parseLineList
+} from "./policyHelpers"
+
+type EditorMode = "simple" | "advanced"
+
+type PolicyDocumentEditorProps = {
+  formId: string
+  policy: McpHubPermissionPolicyDocument
+  onChange: (next: McpHubPermissionPolicyDocument) => void
+  registryEntries: McpHubToolRegistryEntry[]
+  registryModules: McpHubToolRegistryModule[]
+}
+
+const PRESET_OPTIONS = [
+  { key: "none", label: "No Additional Restrictions" },
+  { key: "read_only", label: "Read Only" },
+  { key: "write_manage", label: "Write And Manage" },
+  { key: "process_execution", label: "Process Execution" },
+  { key: "external_services", label: "External Services" }
+] as const
+
+export const PolicyDocumentEditor = ({
+  formId,
+  policy,
+  onChange,
+  registryEntries,
+  registryModules
+}: PolicyDocumentEditorProps) => {
+  const [editorMode, setEditorMode] = useState<EditorMode>("simple")
+  const [advancedText, setAdvancedText] = useState("{}")
+  const [advancedError, setAdvancedError] = useState<string | null>(null)
+
+  const modules = useMemo(
+    () => getToolEntriesByModule(registryEntries, registryModules),
+    [registryEntries, registryModules]
+  )
+  const knownCapabilities = useMemo(() => getKnownRegistryCapabilities(registryEntries), [registryEntries])
+  const selection = useMemo(
+    () => getPolicyAllowedToolSelection(policy.allowed_tools, registryEntries),
+    [policy.allowed_tools, registryEntries]
+  )
+  const derivedCapabilities = useMemo(
+    () => getDerivedCapabilities(selection.selectedTools, registryEntries, policy.capabilities),
+    [policy.capabilities, registryEntries, selection.selectedTools]
+  )
+  const advancedKeys = useMemo(() => getAdvancedPolicyKeys(policy), [policy])
+  const deniedToolsText = useMemo(() => joinList(policy.denied_tools), [policy.denied_tools])
+
+  useEffect(() => {
+    setAdvancedText(JSON.stringify(policy, null, 2))
+    setAdvancedError(null)
+  }, [policy])
+
+  const applySimpleSelection = (selectedTools: string[], deniedToolsValue: string) => {
+    onChange(
+      buildSimplePolicyDocument({
+        currentPolicy: policy,
+        selectedTools,
+        deniedTools: parseLineList(deniedToolsValue),
+        registryEntries
+      })
+    )
+  }
+
+  const handlePreset = (presetId: (typeof PRESET_OPTIONS)[number]["key"]) => {
+    const preset = createPresetSelection(presetId, registryEntries)
+    applySimpleSelection(preset.selectedTools, deniedToolsText)
+  }
+
+  const toggleTool = (toolName: string, checked: boolean) => {
+    const next = new Set(selection.selectedTools)
+    if (checked) next.add(toolName)
+    else next.delete(toolName)
+    applySimpleSelection(Array.from(next), deniedToolsText)
+  }
+
+  const toggleModule = (toolNames: string[], checked: boolean) => {
+    const next = new Set(selection.selectedTools)
+    for (const toolName of toolNames) {
+      if (checked) next.add(toolName)
+      else next.delete(toolName)
+    }
+    applySimpleSelection(Array.from(next), deniedToolsText)
+  }
+
+  const handleDeniedToolsChange = (value: string) => {
+    applySimpleSelection(selection.selectedTools, value)
+  }
+
+  const handleAdvancedChange = (value: string) => {
+    setAdvancedText(value)
+    try {
+      const parsed = JSON.parse(value) as McpHubPermissionPolicyDocument
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("Policy JSON must decode to an object")
+      }
+      setAdvancedError(null)
+      onChange(parsed)
+    } catch {
+      setAdvancedError("Policy JSON must be valid before it can be saved.")
+    }
+  }
+
+  return (
+    <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+      <Space wrap>
+        <Button
+          type={editorMode === "simple" ? "primary" : "default"}
+          onClick={() => setEditorMode("simple")}
+        >
+          Guided
+        </Button>
+        <Button
+          type={editorMode === "advanced" ? "primary" : "default"}
+          onClick={() => setEditorMode("advanced")}
+        >
+          Advanced JSON
+        </Button>
+      </Space>
+
+      {editorMode === "simple" ? (
+        <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+          {advancedKeys.length > 0 || selection.preservedPatterns.length > 0 ? (
+            <Alert
+              type="warning"
+              showIcon
+              message="Advanced policy fields are present and will be preserved."
+              description={[
+                advancedKeys.length > 0 ? `Advanced keys: ${advancedKeys.join(", ")}` : null,
+                selection.preservedPatterns.length > 0
+                  ? `Non-registry allow rules: ${selection.preservedPatterns.join(", ")}`
+                  : null
+              ]
+                .filter(Boolean)
+                .join(" ")}
+            />
+          ) : null}
+
+          <Card size="small" title="Presets">
+            <Space wrap>
+              {PRESET_OPTIONS.map((preset) => (
+                <Button key={preset.key} size="small" onClick={() => handlePreset(preset.key)}>
+                  {preset.label}
+                </Button>
+              ))}
+            </Space>
+          </Card>
+
+          <Card size="small" title="Derived Capabilities">
+            {derivedCapabilities.length > 0 ? (
+              <Space wrap>
+                {derivedCapabilities.map((capability) => (
+                  <Tag key={capability} color={knownCapabilities.includes(capability) ? "blue" : "default"}>
+                    {capability}
+                  </Tag>
+                ))}
+              </Space>
+            ) : (
+              <Typography.Text type="secondary">
+                No additional capability metadata will be written. With no allowed tools selected, the
+                resulting policy does not add MCP Hub allowlist restrictions.
+              </Typography.Text>
+            )}
+          </Card>
+
+          <Card size="small" title="Allowed Modules And Tools">
+            {modules.length > 0 ? (
+              <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+                {modules.map((moduleGroup) => {
+                  const moduleToolNames = moduleGroup.tools.map((tool) => tool.tool_name)
+                  const allSelected =
+                    moduleToolNames.length > 0 &&
+                    moduleToolNames.every((toolName) => selection.selectedTools.includes(toolName))
+                  return (
+                    <Card
+                      key={moduleGroup.module}
+                      size="small"
+                      title={
+                        <Space wrap>
+                          <Checkbox
+                            checked={allSelected}
+                            onChange={(event) => toggleModule(moduleToolNames, event.target.checked)}
+                          >
+                            {moduleGroup.display_name}
+                          </Checkbox>
+                          <Tag>{`${moduleGroup.tool_count} tools`}</Tag>
+                          {Object.entries(moduleGroup.risk_summary)
+                            .filter(([, count]) => Number(count) > 0)
+                            .map(([riskClass, count]) => (
+                              <Tag key={`${moduleGroup.module}-${riskClass}`}>{`${riskClass}:${count}`}</Tag>
+                            ))}
+                        </Space>
+                      }
+                    >
+                      <Space wrap>
+                        {moduleGroup.tools.map((tool) => (
+                          <Checkbox
+                            key={tool.tool_name}
+                            checked={selection.selectedTools.includes(tool.tool_name)}
+                            onChange={(event) => toggleTool(tool.tool_name, event.target.checked)}
+                          >
+                            <Space size={4}>
+                              <span>{tool.display_name}</span>
+                              <Tag>{tool.category}</Tag>
+                              <Tag color={tool.risk_class === "high" ? "red" : tool.risk_class === "medium" ? "gold" : "green"}>
+                                {tool.risk_class}
+                              </Tag>
+                            </Space>
+                          </Checkbox>
+                        ))}
+                      </Space>
+                    </Card>
+                  )
+                })}
+              </Space>
+            ) : (
+              <Empty description="No registry metadata available yet" />
+            )}
+          </Card>
+
+          <Space orientation="vertical" style={{ width: "100%" }}>
+            <label htmlFor={`${formId}-denied-tools`}>Denied Tools</label>
+            <textarea
+              id={`${formId}-denied-tools`}
+              aria-label="Denied Tools"
+              value={deniedToolsText}
+              onChange={(event) => handleDeniedToolsChange(event.target.value)}
+              rows={4}
+            />
+          </Space>
+        </Space>
+      ) : (
+        <Space orientation="vertical" style={{ width: "100%" }}>
+          {advancedError ? <Alert type="error" showIcon message={advancedError} /> : null}
+          <label htmlFor={`${formId}-advanced-policy`}>Policy JSON</label>
+          <textarea
+            id={`${formId}-advanced-policy`}
+            aria-label="Policy JSON"
+            value={advancedText}
+            onChange={(event) => handleAdvancedChange(event.target.value)}
+            rows={16}
+          />
+        </Space>
+      )}
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PolicyDocumentEditor.tsx
@@ -142,7 +142,7 @@ export const PolicyDocumentEditor = ({
             <Alert
               type="warning"
               showIcon
-              message="Advanced policy fields are present and will be preserved."
+              title="Advanced policy fields are present and will be preserved."
               description={[
                 advancedKeys.length > 0 ? `Advanced keys: ${advancedKeys.join(", ")}` : null,
                 selection.preservedPatterns.length > 0
@@ -249,7 +249,7 @@ export const PolicyDocumentEditor = ({
         </Space>
       ) : (
         <Space orientation="vertical" style={{ width: "100%" }}>
-          {advancedError ? <Alert type="error" showIcon message={advancedError} /> : null}
+          {advancedError ? <Alert type="error" showIcon title={advancedError} /> : null}
           <label htmlFor={`${formId}-advanced-policy`}>Policy JSON</label>
           <textarea
             id={`${formId}-advanced-policy`}

--- a/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
@@ -1,25 +1,21 @@
-import { useEffect, useState } from "react"
-import { Alert, Card, Empty, List, Space, Typography } from "antd"
+import { useEffect, useMemo, useState } from "react"
+import { Alert, Card, Empty, Space, Tag, Typography } from "antd"
 
 import {
-  fetchMcpToolCatalogs,
-  fetchMcpToolCatalogsViaDiscovery,
-  type McpToolCatalog
-} from "@/services/tldw/mcp"
+  listToolRegistry,
+  listToolRegistryModules,
+  type McpHubToolRegistryEntry,
+  type McpHubToolRegistryModule
+} from "@/services/tldw/mcp-hub"
 
-type CatalogScope = "global" | "org" | "team"
-
-const SCOPE_LABELS: Record<CatalogScope, string> = {
-  global: "Global",
-  org: "Org",
-  team: "Team"
-}
+import { getToolEntriesByModule } from "./policyHelpers"
 
 export const ToolCatalogsTab = () => {
-  const [scope, setScope] = useState<CatalogScope>("global")
-  const [catalogs, setCatalogs] = useState<McpToolCatalog[]>([])
+  const [entries, setEntries] = useState<McpHubToolRegistryEntry[]>([])
+  const [modules, setModules] = useState<McpHubToolRegistryModule[]>([])
   const [loading, setLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const groupedModules = useMemo(() => getToolEntriesByModule(entries, modules), [entries, modules])
 
   useEffect(() => {
     let cancelled = false
@@ -27,19 +23,16 @@ export const ToolCatalogsTab = () => {
       setLoading(true)
       setErrorMessage(null)
       try {
-        const discovered = await fetchMcpToolCatalogsViaDiscovery(scope)
-        if (!cancelled && discovered.length > 0) {
-          setCatalogs(discovered)
-          return
-        }
-        const fallback = await fetchMcpToolCatalogs()
+        const [entryRows, moduleRows] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
         if (!cancelled) {
-          setCatalogs(fallback)
+          setEntries(Array.isArray(entryRows) ? entryRows : [])
+          setModules(Array.isArray(moduleRows) ? moduleRows : [])
         }
       } catch {
         if (!cancelled) {
-          setCatalogs([])
-          setErrorMessage("Failed to load tool catalogs.")
+          setEntries([])
+          setModules([])
+          setErrorMessage("Failed to load tool registry metadata.")
         }
       } finally {
         if (!cancelled) {
@@ -51,46 +44,80 @@ export const ToolCatalogsTab = () => {
     return () => {
       cancelled = true
     }
-  }, [scope])
+  }, [])
 
   return (
     <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
       <Typography.Text type="secondary">
-        Tool catalogs control which MCP tools are exposed by scope.
+        Registry-backed tool metadata powers both the catalog view and the guided policy editor.
       </Typography.Text>
       {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
 
-      <Space>
-        <label htmlFor="mcp-catalog-scope">Scope</label>
-        <select
-          id="mcp-catalog-scope"
-          aria-label="Scope"
-          value={scope}
-          onChange={(event) => setScope(event.target.value as CatalogScope)}
-        >
-          <option value="global">Global</option>
-          <option value="org">Org</option>
-          <option value="team">Team</option>
-        </select>
-      </Space>
-
-      <Card title={`${SCOPE_LABELS[scope]} Catalogs`}>
-        <List
-          loading={loading}
-          dataSource={catalogs}
-          locale={{ emptyText: <Empty description="No catalogs available" /> }}
-          renderItem={(catalog) => (
-            <List.Item>
-              <Space orientation="vertical" size={2}>
-                <Typography.Text strong>{catalog.name}</Typography.Text>
-                <Typography.Text type="secondary">
-                  {catalog.description || "No description"}
-                </Typography.Text>
+      {groupedModules.length > 0 ? (
+        groupedModules.map((module) => (
+          <Card
+            key={module.module}
+            title={
+              <Space wrap>
+                <Typography.Text strong>{module.display_name}</Typography.Text>
+                <Tag>{`${module.tool_count} tools`}</Tag>
+                {Object.entries(module.risk_summary)
+                  .filter(([, count]) => Number(count) > 0)
+                  .map(([riskClass, count]) => (
+                    <Tag key={`${module.module}-${riskClass}`}>{`${riskClass}:${count}`}</Tag>
+                  ))}
               </Space>
-            </List.Item>
-          )}
-        />
-      </Card>
+            }
+            loading={loading}
+          >
+            <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+              {module.metadata_warnings.length > 0 ? (
+                <Alert type="warning" showIcon message={module.metadata_warnings.join(" ")} />
+              ) : null}
+              {module.tools.map((tool) => (
+                <Card key={tool.tool_name} size="small">
+                  <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+                    <Space wrap>
+                      <Typography.Text strong>{tool.display_name}</Typography.Text>
+                      <Tag>{tool.category}</Tag>
+                      <Tag
+                        color={
+                          tool.risk_class === "high"
+                            ? "red"
+                            : tool.risk_class === "medium"
+                              ? "gold"
+                              : "green"
+                        }
+                      >
+                        {tool.risk_class}
+                      </Tag>
+                      <Tag>{tool.metadata_source}</Tag>
+                      {tool.mutates_state ? <Tag color="volcano">mutates</Tag> : null}
+                      {tool.uses_network ? <Tag color="purple">network</Tag> : null}
+                      {tool.uses_processes ? <Tag color="magenta">process</Tag> : null}
+                    </Space>
+                    <Typography.Text type="secondary">
+                      {tool.description || "No description"}
+                    </Typography.Text>
+                    <Space wrap>
+                      {tool.capabilities.map((capability) => (
+                        <Tag key={`${tool.tool_name}-${capability}`}>{capability}</Tag>
+                      ))}
+                    </Space>
+                    {tool.metadata_warnings.length > 0 ? (
+                      <Alert type="warning" showIcon message={tool.metadata_warnings.join(" ")} />
+                    ) : null}
+                  </Space>
+                </Card>
+              ))}
+            </Space>
+          </Card>
+        ))
+      ) : (
+        <Card loading={loading}>
+          <Empty description="No registry metadata available yet" />
+        </Card>
+      )}
     </Space>
   )
 }

--- a/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/ToolCatalogsTab.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { Alert, Card, Empty, Space, Tag, Typography } from "antd"
 
 import {
-  listToolRegistry,
-  listToolRegistryModules,
+  getToolRegistrySummary,
   type McpHubToolRegistryEntry,
   type McpHubToolRegistryModule
 } from "@/services/tldw/mcp-hub"
@@ -23,10 +22,10 @@ export const ToolCatalogsTab = () => {
       setLoading(true)
       setErrorMessage(null)
       try {
-        const [entryRows, moduleRows] = await Promise.all([listToolRegistry(), listToolRegistryModules()])
+        const summary = await getToolRegistrySummary()
         if (!cancelled) {
-          setEntries(Array.isArray(entryRows) ? entryRows : [])
-          setModules(Array.isArray(moduleRows) ? moduleRows : [])
+          setEntries(Array.isArray(summary?.entries) ? summary.entries : [])
+          setModules(Array.isArray(summary?.modules) ? summary.modules : [])
         }
       } catch {
         if (!cancelled) {

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
@@ -5,12 +5,16 @@ import userEvent from "@testing-library/user-event"
 
 const mocks = vi.hoisted(() => ({
   listPermissionProfiles: vi.fn(),
-  createPermissionProfile: vi.fn()
+  createPermissionProfile: vi.fn(),
+  listToolRegistry: vi.fn(),
+  listToolRegistryModules: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
   listPermissionProfiles: (...args: unknown[]) => mocks.listPermissionProfiles(...args),
-  createPermissionProfile: (...args: unknown[]) => mocks.createPermissionProfile(...args)
+  createPermissionProfile: (...args: unknown[]) => mocks.createPermissionProfile(...args),
+  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
+  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
 }))
 
 import { PermissionProfilesTab } from "../PermissionProfilesTab"
@@ -43,6 +47,34 @@ describe("PermissionProfilesTab", () => {
       },
       is_active: true
     })
+    mocks.listToolRegistry.mockResolvedValue([
+      {
+        tool_name: "notes.search",
+        display_name: "notes.search",
+        module: "notes",
+        category: "search",
+        risk_class: "low",
+        capabilities: ["filesystem.read"],
+        mutates_state: false,
+        uses_filesystem: false,
+        uses_processes: false,
+        uses_network: false,
+        uses_credentials: false,
+        supports_arguments_preview: true,
+        path_boundable: false,
+        metadata_source: "explicit",
+        metadata_warnings: []
+      }
+    ])
+    mocks.listToolRegistryModules.mockResolvedValue([
+      {
+        module: "notes",
+        display_name: "notes",
+        tool_count: 1,
+        risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
+        metadata_warnings: []
+      }
+    ])
   })
 
   it("renders saved permission profiles and opens the create form", async () => {
@@ -54,6 +86,7 @@ describe("PermissionProfilesTab", () => {
 
     await user.click(screen.getByRole("button", { name: /new profile/i }))
     expect(screen.getByLabelText(/profile name/i)).toBeTruthy()
-    expect(screen.getByLabelText(/allowed tools/i)).toBeTruthy()
+    expect(screen.getByText(/allowed modules and tools/i)).toBeTruthy()
+    expect(screen.getByText(/no additional restrictions/i)).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PermissionProfilesTab.test.tsx
@@ -6,15 +6,13 @@ import userEvent from "@testing-library/user-event"
 const mocks = vi.hoisted(() => ({
   listPermissionProfiles: vi.fn(),
   createPermissionProfile: vi.fn(),
-  listToolRegistry: vi.fn(),
-  listToolRegistryModules: vi.fn()
+  getToolRegistrySummary: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
   listPermissionProfiles: (...args: unknown[]) => mocks.listPermissionProfiles(...args),
   createPermissionProfile: (...args: unknown[]) => mocks.createPermissionProfile(...args),
-  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
-  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
+  getToolRegistrySummary: (...args: unknown[]) => mocks.getToolRegistrySummary(...args)
 }))
 
 import { PermissionProfilesTab } from "../PermissionProfilesTab"
@@ -47,34 +45,36 @@ describe("PermissionProfilesTab", () => {
       },
       is_active: true
     })
-    mocks.listToolRegistry.mockResolvedValue([
-      {
-        tool_name: "notes.search",
-        display_name: "notes.search",
-        module: "notes",
-        category: "search",
-        risk_class: "low",
-        capabilities: ["filesystem.read"],
-        mutates_state: false,
-        uses_filesystem: false,
-        uses_processes: false,
-        uses_network: false,
-        uses_credentials: false,
-        supports_arguments_preview: true,
-        path_boundable: false,
-        metadata_source: "explicit",
-        metadata_warnings: []
-      }
-    ])
-    mocks.listToolRegistryModules.mockResolvedValue([
-      {
-        module: "notes",
-        display_name: "notes",
-        tool_count: 1,
-        risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
-        metadata_warnings: []
-      }
-    ])
+    mocks.getToolRegistrySummary.mockResolvedValue({
+      entries: [
+        {
+          tool_name: "notes.search",
+          display_name: "notes.search",
+          module: "notes",
+          category: "search",
+          risk_class: "low",
+          capabilities: ["filesystem.read"],
+          mutates_state: false,
+          uses_filesystem: false,
+          uses_processes: false,
+          uses_network: false,
+          uses_credentials: false,
+          supports_arguments_preview: true,
+          path_boundable: false,
+          metadata_source: "explicit",
+          metadata_warnings: []
+        }
+      ],
+      modules: [
+        {
+          module: "notes",
+          display_name: "notes",
+          tool_count: 1,
+          risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
+          metadata_warnings: []
+        }
+      ]
+    })
   })
 
   it("renders saved permission profiles and opens the create form", async () => {

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
@@ -23,7 +23,18 @@ describe("PersonaPolicySummary", () => {
       approval_policy_id: 17,
       approval_mode: "ask_outside_profile",
       policy_document: {},
-      sources: []
+      sources: [],
+      provenance: [
+        {
+          field: "allowed_tools",
+          value: ["Bash(git *)"],
+          source_kind: "assignment_override",
+          assignment_id: 11,
+          profile_id: 5,
+          override_id: 31,
+          effect: "merged"
+        }
+      ]
     })
   })
 
@@ -33,6 +44,7 @@ describe("PersonaPolicySummary", () => {
     expect(await screen.findByText("process.execute")).toBeTruthy()
     expect(screen.getByText("Bash(git *)")).toBeTruthy()
     expect(screen.getByText("Bash(rm *)")).toBeTruthy()
+    expect(screen.getByText("Override active")).toBeTruthy()
     expect(screen.getByRole("link", { name: /open mcp hub/i })).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
@@ -8,7 +8,9 @@ const mocks = vi.hoisted(() => ({
   createPolicyAssignment: vi.fn(),
   listPermissionProfiles: vi.fn(),
   listApprovalPolicies: vi.fn(),
-  getEffectivePolicy: vi.fn()
+  getEffectivePolicy: vi.fn(),
+  listToolRegistry: vi.fn(),
+  listToolRegistryModules: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
@@ -16,7 +18,9 @@ vi.mock("@/services/tldw/mcp-hub", () => ({
   createPolicyAssignment: (...args: unknown[]) => mocks.createPolicyAssignment(...args),
   listPermissionProfiles: (...args: unknown[]) => mocks.listPermissionProfiles(...args),
   listApprovalPolicies: (...args: unknown[]) => mocks.listApprovalPolicies(...args),
-  getEffectivePolicy: (...args: unknown[]) => mocks.getEffectivePolicy(...args)
+  getEffectivePolicy: (...args: unknown[]) => mocks.getEffectivePolicy(...args),
+  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
+  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
 }))
 
 import { PolicyAssignmentsTab } from "../PolicyAssignmentsTab"
@@ -80,6 +84,34 @@ describe("PolicyAssignmentsTab", () => {
       policy_document: {},
       sources: []
     })
+    mocks.listToolRegistry.mockResolvedValue([
+      {
+        tool_name: "sandbox.run",
+        display_name: "sandbox.run",
+        module: "sandbox",
+        category: "execution",
+        risk_class: "high",
+        capabilities: ["process.execute"],
+        mutates_state: true,
+        uses_filesystem: true,
+        uses_processes: true,
+        uses_network: false,
+        uses_credentials: false,
+        supports_arguments_preview: true,
+        path_boundable: false,
+        metadata_source: "heuristic",
+        metadata_warnings: []
+      }
+    ])
+    mocks.listToolRegistryModules.mockResolvedValue([
+      {
+        module: "sandbox",
+        display_name: "sandbox",
+        tool_count: 1,
+        risk_summary: { low: 0, medium: 0, high: 1, unclassified: 0 },
+        metadata_warnings: []
+      }
+    ])
   })
 
   it("loads assignments and shows the current effective preview", async () => {
@@ -92,5 +124,6 @@ describe("PolicyAssignmentsTab", () => {
 
     await user.click(screen.getByRole("button", { name: /new assignment/i }))
     expect(screen.getByLabelText(/target type/i)).toBeTruthy()
+    expect(screen.getByText(/allowed modules and tools/i)).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
@@ -13,8 +13,7 @@ const mocks = vi.hoisted(() => ({
   listPermissionProfiles: vi.fn(),
   listApprovalPolicies: vi.fn(),
   getEffectivePolicy: vi.fn(),
-  listToolRegistry: vi.fn(),
-  listToolRegistryModules: vi.fn()
+  getToolRegistrySummary: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
@@ -27,8 +26,7 @@ vi.mock("@/services/tldw/mcp-hub", () => ({
   listPermissionProfiles: (...args: unknown[]) => mocks.listPermissionProfiles(...args),
   listApprovalPolicies: (...args: unknown[]) => mocks.listApprovalPolicies(...args),
   getEffectivePolicy: (...args: unknown[]) => mocks.getEffectivePolicy(...args),
-  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
-  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
+  getToolRegistrySummary: (...args: unknown[]) => mocks.getToolRegistrySummary(...args)
 }))
 
 import { PolicyAssignmentsTab } from "../PolicyAssignmentsTab"
@@ -143,34 +141,36 @@ describe("PolicyAssignmentsTab", () => {
         }
       ]
     })
-    mocks.listToolRegistry.mockResolvedValue([
-      {
-        tool_name: "sandbox.run",
-        display_name: "sandbox.run",
-        module: "sandbox",
-        category: "execution",
-        risk_class: "high",
-        capabilities: ["process.execute"],
-        mutates_state: true,
-        uses_filesystem: true,
-        uses_processes: true,
-        uses_network: false,
-        uses_credentials: false,
-        supports_arguments_preview: true,
-        path_boundable: false,
-        metadata_source: "heuristic",
-        metadata_warnings: []
-      }
-    ])
-    mocks.listToolRegistryModules.mockResolvedValue([
-      {
-        module: "sandbox",
-        display_name: "sandbox",
-        tool_count: 1,
-        risk_summary: { low: 0, medium: 0, high: 1, unclassified: 0 },
-        metadata_warnings: []
-      }
-    ])
+    mocks.getToolRegistrySummary.mockResolvedValue({
+      entries: [
+        {
+          tool_name: "sandbox.run",
+          display_name: "sandbox.run",
+          module: "sandbox",
+          category: "execution",
+          risk_class: "high",
+          capabilities: ["process.execute"],
+          mutates_state: true,
+          uses_filesystem: true,
+          uses_processes: true,
+          uses_network: false,
+          uses_credentials: false,
+          supports_arguments_preview: true,
+          path_boundable: false,
+          metadata_source: "heuristic",
+          metadata_warnings: []
+        }
+      ],
+      modules: [
+        {
+          module: "sandbox",
+          display_name: "sandbox",
+          tool_count: 1,
+          risk_summary: { low: 0, medium: 0, high: 1, unclassified: 0 },
+          metadata_warnings: []
+        }
+      ]
+    })
   })
 
   it("loads assignments and shows the current effective preview", async () => {

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PolicyAssignmentsTab.test.tsx
@@ -6,6 +6,10 @@ import userEvent from "@testing-library/user-event"
 const mocks = vi.hoisted(() => ({
   listPolicyAssignments: vi.fn(),
   createPolicyAssignment: vi.fn(),
+  updatePolicyAssignment: vi.fn(),
+  getPolicyAssignmentOverride: vi.fn(),
+  upsertPolicyAssignmentOverride: vi.fn(),
+  deletePolicyAssignmentOverride: vi.fn(),
   listPermissionProfiles: vi.fn(),
   listApprovalPolicies: vi.fn(),
   getEffectivePolicy: vi.fn(),
@@ -16,6 +20,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/services/tldw/mcp-hub", () => ({
   listPolicyAssignments: (...args: unknown[]) => mocks.listPolicyAssignments(...args),
   createPolicyAssignment: (...args: unknown[]) => mocks.createPolicyAssignment(...args),
+  updatePolicyAssignment: (...args: unknown[]) => mocks.updatePolicyAssignment(...args),
+  getPolicyAssignmentOverride: (...args: unknown[]) => mocks.getPolicyAssignmentOverride(...args),
+  upsertPolicyAssignmentOverride: (...args: unknown[]) => mocks.upsertPolicyAssignmentOverride(...args),
+  deletePolicyAssignmentOverride: (...args: unknown[]) => mocks.deletePolicyAssignmentOverride(...args),
   listPermissionProfiles: (...args: unknown[]) => mocks.listPermissionProfiles(...args),
   listApprovalPolicies: (...args: unknown[]) => mocks.listApprovalPolicies(...args),
   getEffectivePolicy: (...args: unknown[]) => mocks.getEffectivePolicy(...args),
@@ -40,7 +48,11 @@ describe("PolicyAssignmentsTab", () => {
           capabilities: ["network.external"]
         },
         approval_policy_id: 17,
-        is_active: true
+        is_active: true,
+        has_override: true,
+        override_id: 31,
+        override_active: true,
+        override_updated_at: "2026-03-09T21:00:00Z"
       }
     ])
     mocks.createPolicyAssignment.mockResolvedValue({
@@ -54,6 +66,42 @@ describe("PolicyAssignmentsTab", () => {
       approval_policy_id: null,
       is_active: true
     })
+    mocks.updatePolicyAssignment.mockResolvedValue({
+      id: 11,
+      target_type: "persona",
+      target_id: "researcher",
+      owner_scope_type: "user",
+      owner_scope_id: 7,
+      profile_id: 5,
+      inline_policy_document: {
+        capabilities: ["network.external"]
+      },
+      approval_policy_id: 17,
+      is_active: true,
+      has_override: true,
+      override_id: 31,
+      override_active: true,
+      override_updated_at: "2026-03-09T21:00:00Z"
+    })
+    mocks.getPolicyAssignmentOverride.mockResolvedValue({
+      id: 31,
+      assignment_id: 11,
+      override_policy_document: {
+        allowed_tools: ["remote.fetch"],
+        approval_mode: "ask_outside_profile"
+      },
+      is_active: true
+    })
+    mocks.upsertPolicyAssignmentOverride.mockResolvedValue({
+      id: 31,
+      assignment_id: 11,
+      override_policy_document: {
+        allowed_tools: ["remote.fetch"],
+        approval_mode: "ask_outside_profile"
+      },
+      is_active: true
+    })
+    mocks.deletePolicyAssignmentOverride.mockResolvedValue({ ok: true })
     mocks.listPermissionProfiles.mockResolvedValue([
       {
         id: 5,
@@ -82,7 +130,18 @@ describe("PolicyAssignmentsTab", () => {
       approval_policy_id: 17,
       approval_mode: "ask_outside_profile",
       policy_document: {},
-      sources: []
+      sources: [],
+      provenance: [
+        {
+          field: "allowed_tools",
+          value: ["remote.fetch"],
+          source_kind: "assignment_override",
+          assignment_id: 11,
+          profile_id: 5,
+          override_id: 31,
+          effect: "merged"
+        }
+      ]
     })
     mocks.listToolRegistry.mockResolvedValue([
       {
@@ -121,9 +180,35 @@ describe("PolicyAssignmentsTab", () => {
     expect(await screen.findByText("researcher")).toBeTruthy()
     expect(await screen.findByText("process.execute")).toBeTruthy()
     expect(screen.getByText("Bash(git *)")).toBeTruthy()
+    expect(screen.getByText("override active")).toBeTruthy()
+    expect(screen.getByText("Why This Applies")).toBeTruthy()
+    expect(screen.getByText(/allowed_tools/i)).toBeTruthy()
+    expect(screen.getByText(/assignment override/i)).toBeTruthy()
 
     await user.click(screen.getByRole("button", { name: /new assignment/i }))
     expect(screen.getByLabelText(/target type/i)).toBeTruthy()
     expect(screen.getByText(/allowed modules and tools/i)).toBeTruthy()
+  })
+
+  it("loads the assignment override editor and saves the override independently", async () => {
+    const user = userEvent.setup()
+    render(<PolicyAssignmentsTab />)
+
+    await screen.findByText("researcher")
+    await user.click(screen.getByRole("button", { name: "Edit" }))
+
+    expect(await screen.findByText("Assignment Override")).toBeTruthy()
+    expect(screen.getByText("Base Assignment Policy")).toBeTruthy()
+    expect(mocks.getPolicyAssignmentOverride).toHaveBeenCalledWith(11)
+
+    await user.click(screen.getByRole("button", { name: /save override/i }))
+
+    expect(mocks.upsertPolicyAssignmentOverride).toHaveBeenCalledWith(11, {
+      override_policy_document: {
+        allowed_tools: ["remote.fetch"],
+        approval_mode: "ask_outside_profile"
+      },
+      is_active: true
+    })
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
@@ -3,13 +3,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
 
 const mocks = vi.hoisted(() => ({
-  listToolRegistry: vi.fn(),
-  listToolRegistryModules: vi.fn()
+  getToolRegistrySummary: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
-  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
-  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
+  getToolRegistrySummary: (...args: unknown[]) => mocks.getToolRegistrySummary(...args)
 }))
 
 import { ToolCatalogsTab } from "../ToolCatalogsTab"
@@ -17,34 +15,36 @@ import { ToolCatalogsTab } from "../ToolCatalogsTab"
 describe("ToolCatalogsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.listToolRegistry.mockResolvedValue([
-      {
-        tool_name: "notes.search",
-        display_name: "notes.search",
-        module: "notes",
-        category: "search",
-        risk_class: "low",
-        capabilities: ["filesystem.read"],
-        mutates_state: false,
-        uses_filesystem: false,
-        uses_processes: false,
-        uses_network: false,
-        uses_credentials: false,
-        supports_arguments_preview: true,
-        path_boundable: false,
-        metadata_source: "explicit",
-        metadata_warnings: []
-      }
-    ])
-    mocks.listToolRegistryModules.mockResolvedValue([
-      {
-        module: "notes",
-        display_name: "notes",
-        tool_count: 1,
-        risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
-        metadata_warnings: []
-      }
-    ])
+    mocks.getToolRegistrySummary.mockResolvedValue({
+      entries: [
+        {
+          tool_name: "notes.search",
+          display_name: "notes.search",
+          module: "notes",
+          category: "search",
+          risk_class: "low",
+          capabilities: ["filesystem.read"],
+          mutates_state: false,
+          uses_filesystem: false,
+          uses_processes: false,
+          uses_network: false,
+          uses_credentials: false,
+          supports_arguments_preview: true,
+          path_boundable: false,
+          metadata_source: "explicit",
+          metadata_warnings: []
+        }
+      ],
+      modules: [
+        {
+          module: "notes",
+          display_name: "notes",
+          tool_count: 1,
+          risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
+          metadata_warnings: []
+        }
+      ]
+    })
   })
 
   it("renders registry-backed module and tool metadata", async () => {

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/ToolCatalogsTab.test.tsx
@@ -1,17 +1,15 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { render, screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 
 const mocks = vi.hoisted(() => ({
-  fetchMcpToolCatalogsViaDiscovery: vi.fn(),
-  fetchMcpToolCatalogs: vi.fn()
+  listToolRegistry: vi.fn(),
+  listToolRegistryModules: vi.fn()
 }))
 
-vi.mock("@/services/tldw/mcp", () => ({
-  fetchMcpToolCatalogsViaDiscovery: (...args: unknown[]) =>
-    mocks.fetchMcpToolCatalogsViaDiscovery(...args),
-  fetchMcpToolCatalogs: (...args: unknown[]) => mocks.fetchMcpToolCatalogs(...args)
+vi.mock("@/services/tldw/mcp-hub", () => ({
+  listToolRegistry: (...args: unknown[]) => mocks.listToolRegistry(...args),
+  listToolRegistryModules: (...args: unknown[]) => mocks.listToolRegistryModules(...args)
 }))
 
 import { ToolCatalogsTab } from "../ToolCatalogsTab"
@@ -19,17 +17,41 @@ import { ToolCatalogsTab } from "../ToolCatalogsTab"
 describe("ToolCatalogsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.fetchMcpToolCatalogsViaDiscovery.mockImplementation(async (scope: string) => [
-      { id: 1, name: `${scope}-catalog`, description: `${scope} catalog` }
+    mocks.listToolRegistry.mockResolvedValue([
+      {
+        tool_name: "notes.search",
+        display_name: "notes.search",
+        module: "notes",
+        category: "search",
+        risk_class: "low",
+        capabilities: ["filesystem.read"],
+        mutates_state: false,
+        uses_filesystem: false,
+        uses_processes: false,
+        uses_network: false,
+        uses_credentials: false,
+        supports_arguments_preview: true,
+        path_boundable: false,
+        metadata_source: "explicit",
+        metadata_warnings: []
+      }
     ])
-    mocks.fetchMcpToolCatalogs.mockResolvedValue([])
+    mocks.listToolRegistryModules.mockResolvedValue([
+      {
+        module: "notes",
+        display_name: "notes",
+        tool_count: 1,
+        risk_summary: { low: 1, medium: 0, high: 0, unclassified: 0 },
+        metadata_warnings: []
+      }
+    ])
   })
 
-  it("switches scope and calls proper catalog loader", async () => {
-    const user = userEvent.setup()
+  it("renders registry-backed module and tool metadata", async () => {
     render(<ToolCatalogsTab />)
 
-    await user.selectOptions(screen.getByLabelText(/scope/i), "org")
-    expect(await screen.findByText(/org catalogs/i)).toBeTruthy()
+    expect(await screen.findByText("notes")).toBeTruthy()
+    expect(screen.getByText("notes.search")).toBeTruthy()
+    expect(screen.getByText("filesystem.read")).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/policyHelpers.test.ts
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/policyHelpers.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import type { McpHubToolRegistryEntry } from "@/services/tldw/mcp-hub"
+
+import {
+  buildSimplePolicyDocument,
+  createPresetSelection,
+  getDerivedCapabilities,
+  getPolicyAllowedToolSelection
+} from "../policyHelpers"
+
+const TOOL_REGISTRY: McpHubToolRegistryEntry[] = [
+  {
+    tool_name: "notes.search",
+    display_name: "notes.search",
+    module: "notes",
+    category: "search",
+    risk_class: "low",
+    capabilities: ["filesystem.read"],
+    mutates_state: false,
+    uses_filesystem: false,
+    uses_processes: false,
+    uses_network: false,
+    uses_credentials: false,
+    supports_arguments_preview: true,
+    path_boundable: false,
+    metadata_source: "explicit",
+    metadata_warnings: []
+  },
+  {
+    tool_name: "sandbox.run",
+    display_name: "sandbox.run",
+    module: "sandbox",
+    category: "execution",
+    risk_class: "high",
+    capabilities: ["process.execute"],
+    mutates_state: true,
+    uses_filesystem: true,
+    uses_processes: true,
+    uses_network: false,
+    uses_credentials: false,
+    supports_arguments_preview: true,
+    path_boundable: false,
+    metadata_source: "heuristic",
+    metadata_warnings: []
+  },
+  {
+    tool_name: "remote.fetch",
+    display_name: "remote.fetch",
+    module: "remote",
+    category: "retrieval",
+    risk_class: "medium",
+    capabilities: ["network.external"],
+    mutates_state: false,
+    uses_filesystem: false,
+    uses_processes: false,
+    uses_network: true,
+    uses_credentials: true,
+    supports_arguments_preview: true,
+    path_boundable: false,
+    metadata_source: "heuristic",
+    metadata_warnings: []
+  }
+]
+
+describe("policyHelpers", () => {
+  it("builds simple policy documents with exact allowed tools and preserved advanced fields", () => {
+    const next = buildSimplePolicyDocument({
+      currentPolicy: {
+        allowed_tools: ["notes.search", "Bash(git *)"],
+        denied_tools: ["sandbox.run"],
+        capabilities: ["filesystem.read", "mcp.server.connect"],
+        approval_mode: "ask_every_time"
+      },
+      selectedTools: ["notes.search", "remote.fetch"],
+      deniedTools: ["sandbox.run"],
+      registryEntries: TOOL_REGISTRY
+    })
+
+    expect(next.allowed_tools).toEqual(["Bash(git *)", "notes.search", "remote.fetch"])
+    expect(next.denied_tools).toEqual(["sandbox.run"])
+    expect(next.capabilities).toEqual(["filesystem.read", "mcp.server.connect", "network.external"])
+    expect(next.approval_mode).toEqual("ask_every_time")
+  })
+
+  it("derives read-only presets from registry metadata and preserves pattern separation", () => {
+    const preset = createPresetSelection("read_only", TOOL_REGISTRY)
+    const selection = getPolicyAllowedToolSelection(["notes.search", "Bash(git *)"], TOOL_REGISTRY)
+    const capabilities = getDerivedCapabilities(preset.selectedTools, TOOL_REGISTRY, [])
+
+    expect(preset.selectedTools).toEqual(["notes.search"])
+    expect(selection.selectedTools).toEqual(["notes.search"])
+    expect(selection.preservedPatterns).toEqual(["Bash(git *)"])
+    expect(capabilities).toEqual(["filesystem.read"])
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/policyHelpers.ts
+++ b/apps/packages/ui/src/components/Option/MCPHub/policyHelpers.ts
@@ -4,7 +4,9 @@ import type {
   McpHubAssignmentTargetType,
   McpHubPermissionPolicyDocument,
   McpHubProfileMode,
-  McpHubScopeType
+  McpHubScopeType,
+  McpHubToolRegistryEntry,
+  McpHubToolRegistryModule
 } from "@/services/tldw/mcp-hub"
 
 export const MCP_HUB_SCOPE_OPTIONS: Array<{ label: string; value: McpHubScopeType }> = [
@@ -42,17 +44,6 @@ export const MCP_HUB_APPROVAL_DURATION_OPTIONS: Array<{
   { label: "Conversation", value: "conversation" }
 ]
 
-export const MCP_HUB_CAPABILITY_OPTIONS = [
-  "filesystem.read",
-  "filesystem.write",
-  "filesystem.delete",
-  "process.execute",
-  "network.external",
-  "credentials.use",
-  "mcp.server.connect",
-  "tool.invoke"
-]
-
 export const parseLineList = (value: string): string[] =>
   value
     .split(/\r?\n/)
@@ -68,21 +59,118 @@ export const parseCommaList = (value: string): string[] =>
 export const joinList = (values: string[] | undefined | null, separator = "\n"): string =>
   Array.isArray(values) ? values.filter(Boolean).join(separator) : ""
 
-export const toggleStringValue = (values: string[], nextValue: string, checked: boolean): string[] => {
-  const next = new Set(values)
-  if (checked) next.add(nextValue)
-  else next.delete(nextValue)
-  return Array.from(next)
+const SIMPLE_POLICY_KEYS = new Set(["allowed_tools", "denied_tools", "capabilities"])
+
+const unique = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
+
+export const getKnownRegistryCapabilities = (entries: McpHubToolRegistryEntry[]): string[] =>
+  unique(entries.flatMap((entry) => entry.capabilities || [])).sort()
+
+export const getToolEntriesByModule = (
+  entries: McpHubToolRegistryEntry[],
+  modules: McpHubToolRegistryModule[]
+): Array<McpHubToolRegistryModule & { tools: McpHubToolRegistryEntry[] }> => {
+  const byModule = new Map<string, McpHubToolRegistryEntry[]>()
+  for (const entry of entries) {
+    const existing = byModule.get(entry.module) || []
+    existing.push(entry)
+    byModule.set(entry.module, existing)
+  }
+  return modules.map((module) => ({
+    ...module,
+    tools: [...(byModule.get(module.module) || [])].sort((left, right) =>
+      left.display_name.localeCompare(right.display_name)
+    )
+  }))
 }
 
-export const buildPolicyDocument = (input: {
-  capabilities: string[]
-  allowedToolsText: string
-  deniedToolsText: string
-}): McpHubPermissionPolicyDocument => {
-  return {
-    capabilities: input.capabilities,
-    allowed_tools: parseLineList(input.allowedToolsText),
-    denied_tools: parseLineList(input.deniedToolsText)
+export const getPolicyAllowedToolSelection = (
+  allowedTools: string[] | undefined,
+  entries: McpHubToolRegistryEntry[]
+): { selectedTools: string[]; preservedPatterns: string[] } => {
+  const knownTools = new Set(entries.map((entry) => entry.tool_name))
+  const selectedTools: string[] = []
+  const preservedPatterns: string[] = []
+
+  for (const toolName of allowedTools || []) {
+    if (knownTools.has(toolName)) selectedTools.push(toolName)
+    else preservedPatterns.push(toolName)
   }
+
+  return { selectedTools: unique(selectedTools), preservedPatterns: unique(preservedPatterns) }
+}
+
+export const getAdvancedPolicyKeys = (policy: McpHubPermissionPolicyDocument): string[] =>
+  Object.keys(policy || {}).filter((key) => !SIMPLE_POLICY_KEYS.has(key))
+
+export const getDerivedCapabilities = (
+  selectedTools: string[],
+  entries: McpHubToolRegistryEntry[],
+  existingCapabilities: string[] | undefined
+): string[] => {
+  const entryMap = new Map(entries.map((entry) => [entry.tool_name, entry]))
+  const derived = unique(
+    selectedTools.flatMap((toolName) => entryMap.get(toolName)?.capabilities || [])
+  )
+  const knownCapabilities = new Set(getKnownRegistryCapabilities(entries))
+  const preserved = (existingCapabilities || []).filter((capability) => !knownCapabilities.has(capability))
+  return unique([...preserved, ...derived]).sort()
+}
+
+export const buildSimplePolicyDocument = (input: {
+  currentPolicy: McpHubPermissionPolicyDocument
+  selectedTools: string[]
+  deniedTools: string[]
+  registryEntries: McpHubToolRegistryEntry[]
+}): McpHubPermissionPolicyDocument => {
+  const nextPolicy: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(input.currentPolicy || {})) {
+    if (!SIMPLE_POLICY_KEYS.has(key)) {
+      nextPolicy[key] = value
+    }
+  }
+
+  const selection = getPolicyAllowedToolSelection(input.currentPolicy.allowed_tools, input.registryEntries)
+  const allowedTools = unique([...input.selectedTools, ...selection.preservedPatterns]).sort()
+  const capabilities = getDerivedCapabilities(
+    input.selectedTools,
+    input.registryEntries,
+    input.currentPolicy.capabilities
+  )
+
+  nextPolicy.allowed_tools = allowedTools
+  nextPolicy.denied_tools = unique(input.deniedTools).sort()
+  nextPolicy.capabilities = capabilities
+
+  return nextPolicy as McpHubPermissionPolicyDocument
+}
+
+export const createPresetSelection = (
+  presetId: "none" | "read_only" | "write_manage" | "process_execution" | "external_services",
+  entries: McpHubToolRegistryEntry[]
+): { selectedTools: string[] } => {
+  if (presetId === "none") {
+    return { selectedTools: [] }
+  }
+
+  const selectedTools = entries
+    .filter((entry) => {
+      if (presetId === "read_only") {
+        return !entry.mutates_state && !entry.uses_processes && !entry.uses_network && !entry.uses_credentials
+      }
+      if (presetId === "write_manage") {
+        return entry.mutates_state && !entry.uses_processes && !entry.uses_network && !entry.uses_credentials
+      }
+      if (presetId === "process_execution") {
+        return entry.uses_processes || entry.category === "execution"
+      }
+      if (presetId === "external_services") {
+        return entry.uses_network || entry.uses_credentials
+      }
+      return false
+    })
+    .map((entry) => entry.tool_name)
+    .sort()
+
+  return { selectedTools }
 }

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -101,6 +101,10 @@ export type McpHubPolicyAssignment = {
   inline_policy_document: McpHubPermissionPolicyDocument
   approval_policy_id?: number | null
   is_active: boolean
+  has_override?: boolean
+  override_id?: number | null
+  override_active?: boolean
+  override_updated_at?: string | null
   created_by?: number | null
   updated_by?: number | null
   created_at?: string | null
@@ -189,6 +193,22 @@ export type McpHubApprovalDecisionResponse = {
   created_at?: string | null
 }
 
+export type McpHubPolicyOverride = {
+  id: number
+  assignment_id: number
+  override_policy_document: McpHubPermissionPolicyDocument
+  is_active: boolean
+  created_by?: number | null
+  updated_by?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type McpHubPolicyOverrideUpsertInput = {
+  override_policy_document?: McpHubPermissionPolicyDocument
+  is_active?: boolean
+}
+
 export type McpHubEffectivePolicySource = {
   assignment_id: number
   target_type: McpHubAssignmentTargetType
@@ -196,6 +216,16 @@ export type McpHubEffectivePolicySource = {
   owner_scope_type: McpHubScopeType
   owner_scope_id?: number | null
   profile_id?: number | null
+}
+
+export type McpHubEffectivePolicyProvenance = {
+  field: string
+  value: unknown
+  source_kind: "profile" | "assignment_inline" | "assignment_override"
+  assignment_id: number
+  profile_id?: number | null
+  override_id?: number | null
+  effect: "merged" | "replaced"
 }
 
 export type McpHubEffectivePolicy = {
@@ -207,6 +237,7 @@ export type McpHubEffectivePolicy = {
   approval_mode?: McpHubApprovalMode | null
   policy_document: Record<string, unknown>
   sources: McpHubEffectivePolicySource[]
+  provenance: McpHubEffectivePolicyProvenance[]
 }
 
 export type McpHubToolRegistryEntry = {
@@ -487,6 +518,35 @@ export const deletePolicyAssignment = async (
 ): Promise<{ ok: boolean }> => {
   return await bgRequestClient<{ ok: boolean }>({
     path: `/api/v1/mcp/hub/policy-assignments/${assignmentId}`,
+    method: "DELETE"
+  })
+}
+
+export const getPolicyAssignmentOverride = async (
+  assignmentId: number
+): Promise<McpHubPolicyOverride> => {
+  return await bgRequestClient<McpHubPolicyOverride>({
+    path: `/api/v1/mcp/hub/policy-assignments/${assignmentId}/override`,
+    method: "GET"
+  })
+}
+
+export const upsertPolicyAssignmentOverride = async (
+  assignmentId: number,
+  payload: McpHubPolicyOverrideUpsertInput
+): Promise<McpHubPolicyOverride> => {
+  return await bgRequestClient<McpHubPolicyOverride>({
+    path: `/api/v1/mcp/hub/policy-assignments/${assignmentId}/override`,
+    method: "PUT",
+    body: payload
+  })
+}
+
+export const deletePolicyAssignmentOverride = async (
+  assignmentId: number
+): Promise<{ ok: boolean }> => {
+  return await bgRequestClient<{ ok: boolean }>({
+    path: `/api/v1/mcp/hub/policy-assignments/${assignmentId}/override`,
     method: "DELETE"
   })
 }

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -268,6 +268,11 @@ export type McpHubToolRegistryModule = {
   metadata_warnings: string[]
 }
 
+export type McpHubToolRegistrySummary = {
+  entries: McpHubToolRegistryEntry[]
+  modules: McpHubToolRegistryModule[]
+}
+
 export type McpHubExternalServer = {
   id: string
   name: string
@@ -443,6 +448,13 @@ export const listToolRegistry = async (): Promise<McpHubToolRegistryEntry[]> => 
 export const listToolRegistryModules = async (): Promise<McpHubToolRegistryModule[]> => {
   return await bgRequestClient<McpHubToolRegistryModule[]>({
     path: "/api/v1/mcp/hub/tool-registry/modules",
+    method: "GET"
+  })
+}
+
+export const getToolRegistrySummary = async (): Promise<McpHubToolRegistrySummary> => {
+  return await bgRequestClient<McpHubToolRegistrySummary>({
+    path: "/api/v1/mcp/hub/tool-registry/summary",
     method: "GET"
   })
 }

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -12,6 +12,8 @@ export type McpHubApprovalMode =
   | "temporary_elevation_allowed"
 export type McpHubApprovalDecision = "approved" | "denied"
 export type McpHubApprovalDuration = "once" | "session" | "conversation"
+export type McpHubToolRiskClass = "low" | "medium" | "high" | "unclassified"
+export type McpHubToolMetadataSource = "explicit" | "heuristic" | "fallback"
 
 export type McpHubProfile = {
   id: number
@@ -207,6 +209,34 @@ export type McpHubEffectivePolicy = {
   sources: McpHubEffectivePolicySource[]
 }
 
+export type McpHubToolRegistryEntry = {
+  tool_name: string
+  display_name: string
+  description?: string | null
+  module: string
+  module_display_name?: string | null
+  category: string
+  risk_class: McpHubToolRiskClass
+  capabilities: string[]
+  mutates_state: boolean
+  uses_filesystem: boolean
+  uses_processes: boolean
+  uses_network: boolean
+  uses_credentials: boolean
+  supports_arguments_preview: boolean
+  path_boundable: boolean
+  metadata_source: McpHubToolMetadataSource
+  metadata_warnings: string[]
+}
+
+export type McpHubToolRegistryModule = {
+  module: string
+  display_name: string
+  tool_count: number
+  risk_summary: Record<string, number>
+  metadata_warnings: string[]
+}
+
 export type McpHubExternalServer = {
   id: string
   name: string
@@ -368,6 +398,20 @@ export const listPermissionProfiles = async (params: {
       owner_scope_type: params.owner_scope_type,
       owner_scope_id: params.owner_scope_id
     }),
+    method: "GET"
+  })
+}
+
+export const listToolRegistry = async (): Promise<McpHubToolRegistryEntry[]> => {
+  return await bgRequestClient<McpHubToolRegistryEntry[]>({
+    path: "/api/v1/mcp/hub/tool-registry",
+    method: "GET"
+  })
+}
+
+export const listToolRegistryModules = async (): Promise<McpHubToolRegistryModule[]> => {
+  return await bgRequestClient<McpHubToolRegistryModule[]>({
+    path: "/api/v1/mcp/hub/tool-registry/modules",
     method: "GET"
   })
 }

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -31,6 +32,8 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     PolicyAssignmentCreateRequest,
     PolicyAssignmentResponse,
     PolicyAssignmentUpdateRequest,
+    PolicyOverrideResponse,
+    PolicyOverrideUpsertRequest,
     ToolRegistryEntryResponse,
     ToolRegistryModuleResponse,
 )
@@ -58,6 +61,7 @@ _CAPABILITY_GRANT_PERMISSIONS = {
     "tool.invoke": "grant.tool.invoke",
 }
 _TOOL_GRANT_KEYS = ("allowed_tools", "tool_patterns", "tool_names")
+_UNION_POLICY_KEYS = frozenset({"allowed_tools", "denied_tools", "tool_names", "tool_patterns", "capabilities"})
 _SUPPORTED_APPROVAL_DURATIONS = frozenset({"once", "session", "conversation"})
 _DEFAULT_SCOPED_APPROVAL_TTL_MINUTES = 480
 
@@ -162,6 +166,98 @@ def _require_grant_authority(principal: AuthPrincipal, policy_document: dict[str
             status_code=403,
             detail=f"Grant authority required: {', '.join(missing)}",
         )
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if key in _UNION_POLICY_KEYS:
+            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
+            continue
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _merge_policy_documents(
+                dict(merged.get(key) or {}),
+                dict(value or {}),
+            )
+            continue
+        merged[key] = deepcopy(value)
+    return merged
+
+
+def _tool_grant_entries(policy_document: dict[str, Any]) -> set[str]:
+    entries: set[str] = set()
+    for key in _TOOL_GRANT_KEYS:
+        entries.update(_as_str_list(policy_document.get(key)))
+    return entries
+
+
+def _grant_authority_delta(base_policy_document: dict[str, Any], merged_policy_document: dict[str, Any]) -> dict[str, Any]:
+    base_capabilities = {entry.lower() for entry in _as_str_list(base_policy_document.get("capabilities"))}
+    merged_capabilities = {entry.lower() for entry in _as_str_list(merged_policy_document.get("capabilities"))}
+    next_document: dict[str, Any] = {}
+
+    extra_capabilities = sorted(merged_capabilities - base_capabilities)
+    if extra_capabilities:
+        next_document["capabilities"] = extra_capabilities
+
+    base_tools = _tool_grant_entries(base_policy_document)
+    merged_tools = _tool_grant_entries(merged_policy_document)
+    extra_tools = sorted(merged_tools - base_tools)
+    if extra_tools:
+        next_document["allowed_tools"] = extra_tools
+
+    return next_document
+
+
+def _grant_authority_snapshot(principal: AuthPrincipal, delta_document: dict[str, Any]) -> dict[str, Any]:
+    granted_permissions = sorted(
+        {
+            str(permission).strip().lower()
+            for permission in (principal.permissions or [])
+            if str(permission).strip()
+        }
+    )
+    required_permissions = sorted(
+        {
+            required
+            for capability in {
+                str(capability).strip().lower()
+                for capability in _as_str_list(delta_document.get("capabilities"))
+            }
+            if (required := _CAPABILITY_GRANT_PERMISSIONS.get(capability))
+        }
+    )
+    if _tool_grant_entries(delta_document):
+        required_permissions.append(_CAPABILITY_GRANT_PERMISSIONS["tool.invoke"])
+    return {
+        "required_permissions": _unique(required_permissions),
+        "granted_permissions": granted_permissions,
+    }
 
 
 def _collect_scope_ids(values: list[int] | None, active_id: int | None) -> list[int]:
@@ -323,6 +419,23 @@ def _policy_assignment_row_to_response(row: dict[str, Any]) -> PolicyAssignmentR
         inline_policy_document=_load_json_object(row.get("inline_policy_document")),
         approval_policy_id=row.get("approval_policy_id"),
         is_active=bool(row.get("is_active")),
+        has_override=bool(row.get("has_override")),
+        override_id=row.get("override_id"),
+        override_active=bool(row.get("override_active")),
+        override_updated_at=row.get("override_updated_at"),
+        created_by=row.get("created_by"),
+        updated_by=row.get("updated_by"),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+def _policy_override_row_to_response(row: dict[str, Any]) -> PolicyOverrideResponse:
+    return PolicyOverrideResponse(
+        id=int(row.get("id")),
+        assignment_id=int(row.get("assignment_id")),
+        override_policy_document=_load_json_object(row.get("override_policy_document")),
+        is_active=bool(row.get("is_active")),
         created_by=row.get("created_by"),
         updated_by=row.get("updated_by"),
         created_at=row.get("created_at"),
@@ -439,6 +552,44 @@ def _approval_decision_lifetime(
         ttl_minutes = _approval_ttl_minutes(rules, normalized_duration)
         return False, datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)
     raise HTTPException(status_code=422, detail=f"Unsupported approval duration '{normalized_duration}'")
+
+
+async def _get_visible_policy_assignment_or_404(
+    *,
+    assignment_id: int,
+    principal: AuthPrincipal,
+    svc: McpHubService,
+) -> dict[str, Any]:
+    assignment = await svc.get_policy_assignment(assignment_id)
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="mcp_policy_assignment not found")
+    _resolve_visible_scope_filters(
+        principal=principal,
+        owner_scope_type=str(assignment.get("owner_scope_type") or "global"),
+        owner_scope_id=assignment.get("owner_scope_id"),
+    )
+    return assignment
+
+
+async def _assignment_base_policy_document(
+    *,
+    svc: McpHubService,
+    assignment: dict[str, Any],
+) -> tuple[int | None, dict[str, Any]]:
+    base_document: dict[str, Any] = {}
+    profile_id = assignment.get("profile_id")
+    if profile_id is not None:
+        profile_row = await svc.get_permission_profile(int(profile_id))
+        if profile_row and bool(profile_row.get("is_active", True)):
+            base_document = _merge_policy_documents(
+                base_document,
+                _load_json_object(profile_row.get("policy_document")),
+            )
+    base_document = _merge_policy_documents(
+        base_document,
+        _load_json_object(assignment.get("inline_policy_document")),
+    )
+    return (int(profile_id) if profile_id is not None else None, base_document)
 
 
 @router.get("/tool-registry", response_model=list[ToolRegistryEntryResponse])
@@ -639,6 +790,91 @@ async def delete_policy_assignment(
             raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
     except ResourceNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return MCPHubDeleteResponse(ok=True)
+
+
+@router.get(
+    "/policy-assignments/{assignment_id}/override",
+    response_model=PolicyOverrideResponse,
+)
+async def get_policy_assignment_override(
+    assignment_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> PolicyOverrideResponse:
+    """Fetch the single override attached to a policy assignment."""
+    await _get_visible_policy_assignment_or_404(
+        assignment_id=assignment_id,
+        principal=principal,
+        svc=svc,
+    )
+    row = await svc.get_policy_override(assignment_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="mcp_policy_override not found")
+    return _policy_override_row_to_response(row)
+
+
+@router.put(
+    "/policy-assignments/{assignment_id}/override",
+    response_model=PolicyOverrideResponse,
+)
+async def upsert_policy_assignment_override(
+    assignment_id: int,
+    payload: PolicyOverrideUpsertRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> PolicyOverrideResponse:
+    """Create or replace the single override attached to a policy assignment."""
+    _require_mutation_permission(principal)
+    assignment = await _get_visible_policy_assignment_or_404(
+        assignment_id=assignment_id,
+        principal=principal,
+        svc=svc,
+    )
+    profile_id, base_document = await _assignment_base_policy_document(
+        svc=svc,
+        assignment=assignment,
+    )
+    merged_document = _merge_policy_documents(base_document, payload.override_policy_document)
+    delta_document = _grant_authority_delta(base_document, merged_document)
+    if delta_document:
+        _require_grant_authority(principal, delta_document)
+    row = await svc.upsert_policy_override(
+        assignment_id,
+        override_policy_document=payload.override_policy_document,
+        is_active=payload.is_active,
+        broadens_access=bool(delta_document),
+        grant_authority_snapshot={
+            **_grant_authority_snapshot(principal, delta_document),
+            "assignment_id": assignment_id,
+            "profile_id": profile_id,
+        },
+        actor_id=principal.user_id,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="mcp_policy_assignment not found")
+    return _policy_override_row_to_response(row)
+
+
+@router.delete(
+    "/policy-assignments/{assignment_id}/override",
+    response_model=MCPHubDeleteResponse,
+)
+async def delete_policy_assignment_override(
+    assignment_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+) -> MCPHubDeleteResponse:
+    """Delete the override attached to a policy assignment."""
+    _require_mutation_permission(principal)
+    await _get_visible_policy_assignment_or_404(
+        assignment_id=assignment_id,
+        principal=principal,
+        svc=svc,
+    )
+    deleted = await svc.delete_policy_override(assignment_id, actor_id=principal.user_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="mcp_policy_override not found")
     return MCPHubDeleteResponse(ok=True)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -36,6 +36,7 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     PolicyOverrideUpsertRequest,
     ToolRegistryEntryResponse,
     ToolRegistryModuleResponse,
+    ToolRegistrySummaryResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
@@ -144,7 +145,7 @@ def _require_grant_authority(principal: AuthPrincipal, policy_document: dict[str
     if "*" in granted:
         return
 
-    raw_capabilities = policy_document.get("capabilities") or []
+    raw_capabilities = _as_str_list(policy_document.get("capabilities"))
     capabilities = {
         str(capability).strip().lower()
         for capability in raw_capabilities
@@ -153,7 +154,7 @@ def _require_grant_authority(principal: AuthPrincipal, policy_document: dict[str
     if any(
         str(entry).strip()
         for key in _TOOL_GRANT_KEYS
-        for entry in (policy_document.get(key) or [])
+        for entry in _as_str_list(policy_document.get(key))
     ):
         capabilities.add("tool.invoke")
     missing = [
@@ -169,6 +170,7 @@ def _require_grant_authority(principal: AuthPrincipal, policy_document: dict[str
 
 
 def _as_str_list(value: Any) -> list[str]:
+    """Normalize a loose scalar-or-sequence value into a cleaned string list."""
     if isinstance(value, str):
         cleaned = value.strip()
         return [cleaned] if cleaned else []
@@ -183,6 +185,7 @@ def _as_str_list(value: Any) -> list[str]:
 
 
 def _unique(items: list[str]) -> list[str]:
+    """Preserve order while removing duplicate string values."""
     seen: set[str] = set()
     out: list[str] = []
     for item in items:
@@ -194,6 +197,7 @@ def _unique(items: list[str]) -> list[str]:
 
 
 def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge overlay policy fields into a base document using union semantics for allowlists."""
     merged = deepcopy(base)
     for key, value in overlay.items():
         if key in _UNION_POLICY_KEYS:
@@ -210,6 +214,7 @@ def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> di
 
 
 def _tool_grant_entries(policy_document: dict[str, Any]) -> set[str]:
+    """Collect every tool-grant entry across the supported allowlist keys."""
     entries: set[str] = set()
     for key in _TOOL_GRANT_KEYS:
         entries.update(_as_str_list(policy_document.get(key)))
@@ -217,6 +222,7 @@ def _tool_grant_entries(policy_document: dict[str, Any]) -> set[str]:
 
 
 def _grant_authority_delta(base_policy_document: dict[str, Any], merged_policy_document: dict[str, Any]) -> dict[str, Any]:
+    """Extract the broadened-access delta that requires explicit grant authority."""
     base_capabilities = {entry.lower() for entry in _as_str_list(base_policy_document.get("capabilities"))}
     merged_capabilities = {entry.lower() for entry in _as_str_list(merged_policy_document.get("capabilities"))}
     next_document: dict[str, Any] = {}
@@ -235,6 +241,7 @@ def _grant_authority_delta(base_policy_document: dict[str, Any], merged_policy_d
 
 
 def _grant_authority_snapshot(principal: AuthPrincipal, delta_document: dict[str, Any]) -> dict[str, Any]:
+    """Capture granted and required permissions for an override broadening audit record."""
     granted_permissions = sorted(
         {
             str(permission).strip().lower()
@@ -560,9 +567,10 @@ async def _get_visible_policy_assignment_or_404(
     principal: AuthPrincipal,
     svc: McpHubService,
 ) -> dict[str, Any]:
+    """Fetch a policy assignment and ensure the principal can access its owner scope."""
     assignment = await svc.get_policy_assignment(assignment_id)
     if assignment is None:
-        raise HTTPException(status_code=404, detail="mcp_policy_assignment not found")
+        raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
     _resolve_visible_scope_filters(
         principal=principal,
         owner_scope_type=str(assignment.get("owner_scope_type") or "global"),
@@ -576,6 +584,7 @@ async def _assignment_base_policy_document(
     svc: McpHubService,
     assignment: dict[str, Any],
 ) -> tuple[int | None, dict[str, Any]]:
+    """Resolve the merged profile-plus-inline base policy for an assignment."""
     base_document: dict[str, Any] = {}
     profile_id = assignment.get("profile_id")
     if profile_id is not None:
@@ -608,6 +617,19 @@ async def list_tool_registry_modules(
 ) -> list[ToolRegistryModuleResponse]:
     """List grouped MCP tool metadata summaries by module."""
     return [ToolRegistryModuleResponse.model_validate(row) for row in await registry.list_modules()]
+
+
+@router.get("/tool-registry/summary", response_model=ToolRegistrySummaryResponse)
+async def get_tool_registry_summary(
+    _principal: AuthPrincipal = Depends(get_auth_principal),
+    registry: McpHubToolRegistryService = Depends(get_mcp_hub_tool_registry_dep),
+) -> ToolRegistrySummaryResponse:
+    """Return tool entries and module summaries from a single registry enumeration."""
+    summary = await registry.get_summary()
+    return ToolRegistrySummaryResponse(
+        entries=[ToolRegistryEntryResponse.model_validate(row) for row in summary.get("entries", [])],
+        modules=[ToolRegistryModuleResponse.model_validate(row) for row in summary.get("modules", [])],
+    )
 
 
 @router.post("/permission-profiles", response_model=PermissionProfileResponse, status_code=201)
@@ -803,14 +825,17 @@ async def get_policy_assignment_override(
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> PolicyOverrideResponse:
     """Fetch the single override attached to a policy assignment."""
-    await _get_visible_policy_assignment_or_404(
-        assignment_id=assignment_id,
-        principal=principal,
-        svc=svc,
-    )
-    row = await svc.get_policy_override(assignment_id)
-    if not row:
-        raise HTTPException(status_code=404, detail="mcp_policy_override not found")
+    try:
+        await _get_visible_policy_assignment_or_404(
+            assignment_id=assignment_id,
+            principal=principal,
+            svc=svc,
+        )
+        row = await svc.get_policy_override(assignment_id)
+        if not row:
+            raise ResourceNotFoundError("mcp_policy_override", identifier=str(assignment_id))
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return _policy_override_row_to_response(row)
 
 
@@ -826,33 +851,36 @@ async def upsert_policy_assignment_override(
 ) -> PolicyOverrideResponse:
     """Create or replace the single override attached to a policy assignment."""
     _require_mutation_permission(principal)
-    assignment = await _get_visible_policy_assignment_or_404(
-        assignment_id=assignment_id,
-        principal=principal,
-        svc=svc,
-    )
-    profile_id, base_document = await _assignment_base_policy_document(
-        svc=svc,
-        assignment=assignment,
-    )
-    merged_document = _merge_policy_documents(base_document, payload.override_policy_document)
-    delta_document = _grant_authority_delta(base_document, merged_document)
-    if delta_document:
-        _require_grant_authority(principal, delta_document)
-    row = await svc.upsert_policy_override(
-        assignment_id,
-        override_policy_document=payload.override_policy_document,
-        is_active=payload.is_active,
-        broadens_access=bool(delta_document),
-        grant_authority_snapshot={
-            **_grant_authority_snapshot(principal, delta_document),
-            "assignment_id": assignment_id,
-            "profile_id": profile_id,
-        },
-        actor_id=principal.user_id,
-    )
-    if not row:
-        raise HTTPException(status_code=404, detail="mcp_policy_assignment not found")
+    try:
+        assignment = await _get_visible_policy_assignment_or_404(
+            assignment_id=assignment_id,
+            principal=principal,
+            svc=svc,
+        )
+        profile_id, base_document = await _assignment_base_policy_document(
+            svc=svc,
+            assignment=assignment,
+        )
+        merged_document = _merge_policy_documents(base_document, payload.override_policy_document)
+        delta_document = _grant_authority_delta(base_document, merged_document)
+        if delta_document:
+            _require_grant_authority(principal, delta_document)
+        row = await svc.upsert_policy_override(
+            assignment_id,
+            override_policy_document=payload.override_policy_document,
+            is_active=payload.is_active,
+            broadens_access=bool(delta_document),
+            grant_authority_snapshot={
+                **_grant_authority_snapshot(principal, delta_document),
+                "assignment_id": assignment_id,
+                "profile_id": profile_id,
+            },
+            actor_id=principal.user_id,
+        )
+        if not row:
+            raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return _policy_override_row_to_response(row)
 
 
@@ -867,14 +895,17 @@ async def delete_policy_assignment_override(
 ) -> MCPHubDeleteResponse:
     """Delete the override attached to a policy assignment."""
     _require_mutation_permission(principal)
-    await _get_visible_policy_assignment_or_404(
-        assignment_id=assignment_id,
-        principal=principal,
-        svc=svc,
-    )
-    deleted = await svc.delete_policy_override(assignment_id, actor_id=principal.user_id)
-    if not deleted:
-        raise HTTPException(status_code=404, detail="mcp_policy_override not found")
+    try:
+        await _get_visible_policy_assignment_or_404(
+            assignment_id=assignment_id,
+            principal=principal,
+            svc=svc,
+        )
+        deleted = await svc.delete_policy_override(assignment_id, actor_id=principal.user_id)
+        if not deleted:
+            raise ResourceNotFoundError("mcp_policy_override", identifier=str(assignment_id))
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return MCPHubDeleteResponse(ok=True)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -31,6 +31,8 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     PolicyAssignmentCreateRequest,
     PolicyAssignmentResponse,
     PolicyAssignmentUpdateRequest,
+    ToolRegistryEntryResponse,
+    ToolRegistryModuleResponse,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
@@ -39,6 +41,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
 from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError, McpHubService
+from tldw_Server_API.app.services.mcp_hub_tool_registry import McpHubToolRegistryService
 
 router = APIRouter(prefix="/mcp/hub", tags=["mcp-hub"], dependencies=[Depends(check_rate_limit)])
 
@@ -70,6 +73,11 @@ async def get_mcp_hub_service() -> McpHubService:
 async def get_mcp_hub_policy_resolver_dep() -> McpHubPolicyResolver:
     """Resolve MCP Hub policy resolver for effective policy previews."""
     return await get_mcp_hub_policy_resolver()
+
+
+async def get_mcp_hub_tool_registry_dep() -> McpHubToolRegistryService:
+    """Resolve the derived MCP Hub tool registry service."""
+    return McpHubToolRegistryService()
 
 
 def _load_json_object(raw: Any) -> dict[str, Any]:
@@ -431,6 +439,24 @@ def _approval_decision_lifetime(
         ttl_minutes = _approval_ttl_minutes(rules, normalized_duration)
         return False, datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)
     raise HTTPException(status_code=422, detail=f"Unsupported approval duration '{normalized_duration}'")
+
+
+@router.get("/tool-registry", response_model=list[ToolRegistryEntryResponse])
+async def list_tool_registry(
+    _principal: AuthPrincipal = Depends(get_auth_principal),
+    registry: McpHubToolRegistryService = Depends(get_mcp_hub_tool_registry_dep),
+) -> list[ToolRegistryEntryResponse]:
+    """List normalized MCP tool metadata derived from the live module registry."""
+    return [ToolRegistryEntryResponse.model_validate(row) for row in await registry.list_entries()]
+
+
+@router.get("/tool-registry/modules", response_model=list[ToolRegistryModuleResponse])
+async def list_tool_registry_modules(
+    _principal: AuthPrincipal = Depends(get_auth_principal),
+    registry: McpHubToolRegistryService = Depends(get_mcp_hub_tool_registry_dep),
+) -> list[ToolRegistryModuleResponse]:
+    """List grouped MCP tool metadata summaries by module."""
+    return [ToolRegistryModuleResponse.model_validate(row) for row in await registry.list_modules()]
 
 
 @router.post("/permission-profiles", response_model=PermissionProfileResponse, status_code=201)

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -267,6 +267,11 @@ class ToolRegistryModuleResponse(BaseModel):
     metadata_warnings: list[str] = Field(default_factory=list)
 
 
+class ToolRegistrySummaryResponse(BaseModel):
+    entries: list[ToolRegistryEntryResponse] = Field(default_factory=list)
+    modules: list[ToolRegistryModuleResponse] = Field(default_factory=list)
+
+
 class ExternalServerCreateRequest(BaseModel):
     server_id: str = Field(..., min_length=1, max_length=128)
     name: str = Field(..., min_length=1, max_length=200)

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field
 ScopeType = Literal["global", "org", "team", "user"]
 ProfileMode = Literal["preset", "custom"]
 AssignmentTargetType = Literal["default", "group", "persona"]
+PolicyProvenanceSourceKind = Literal["profile", "assignment_inline", "assignment_override"]
+PolicyProvenanceEffect = Literal["merged", "replaced"]
 ApprovalMode = Literal[
     "allow_silently",
     "ask_every_time",
@@ -120,6 +122,26 @@ class PolicyAssignmentResponse(BaseModel):
     inline_policy_document: dict[str, Any] = Field(default_factory=dict)
     approval_policy_id: int | None = None
     is_active: bool
+    has_override: bool = False
+    override_id: int | None = None
+    override_active: bool = False
+    override_updated_at: datetime | str | None = None
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class PolicyOverrideUpsertRequest(BaseModel):
+    override_policy_document: dict[str, Any] = Field(default_factory=dict)
+    is_active: bool = True
+
+
+class PolicyOverrideResponse(BaseModel):
+    id: int
+    assignment_id: int
+    override_policy_document: dict[str, Any] = Field(default_factory=dict)
+    is_active: bool
     created_by: int | None = None
     updated_by: int | None = None
     created_at: datetime | str | None = None
@@ -195,6 +217,16 @@ class EffectivePolicySourceResponse(BaseModel):
     profile_id: int | None = None
 
 
+class EffectivePolicyProvenanceResponse(BaseModel):
+    field: str
+    value: Any
+    source_kind: PolicyProvenanceSourceKind
+    assignment_id: int
+    profile_id: int | None = None
+    override_id: int | None = None
+    effect: PolicyProvenanceEffect
+
+
 class EffectivePolicyResponse(BaseModel):
     enabled: bool
     allowed_tools: list[str] = Field(default_factory=list)
@@ -204,6 +236,7 @@ class EffectivePolicyResponse(BaseModel):
     approval_mode: ApprovalMode | None = None
     policy_document: dict[str, Any] = Field(default_factory=dict)
     sources: list[EffectivePolicySourceResponse] = Field(default_factory=list)
+    provenance: list[EffectivePolicyProvenanceResponse] = Field(default_factory=list)
 
 
 class ToolRegistryEntryResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -17,6 +17,8 @@ ApprovalMode = Literal[
 ]
 ApprovalDecision = Literal["approved", "denied"]
 ApprovalDuration = Literal["once", "session", "conversation"]
+ToolRiskClass = Literal["low", "medium", "high", "unclassified"]
+ToolMetadataSource = Literal["explicit", "heuristic", "fallback"]
 
 
 class ACPProfileCreateRequest(BaseModel):
@@ -202,6 +204,34 @@ class EffectivePolicyResponse(BaseModel):
     approval_mode: ApprovalMode | None = None
     policy_document: dict[str, Any] = Field(default_factory=dict)
     sources: list[EffectivePolicySourceResponse] = Field(default_factory=list)
+
+
+class ToolRegistryEntryResponse(BaseModel):
+    tool_name: str
+    display_name: str
+    description: str | None = None
+    module: str
+    module_display_name: str | None = None
+    category: str
+    risk_class: ToolRiskClass
+    capabilities: list[str] = Field(default_factory=list)
+    mutates_state: bool = False
+    uses_filesystem: bool = False
+    uses_processes: bool = False
+    uses_network: bool = False
+    uses_credentials: bool = False
+    supports_arguments_preview: bool = False
+    path_boundable: bool = False
+    metadata_source: ToolMetadataSource
+    metadata_warnings: list[str] = Field(default_factory=list)
+
+
+class ToolRegistryModuleResponse(BaseModel):
+    module: str
+    display_name: str
+    tool_count: int
+    risk_summary: dict[str, int] = Field(default_factory=dict)
+    metadata_warnings: list[str] = Field(default_factory=list)
 
 
 class ExternalServerCreateRequest(BaseModel):

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -1482,8 +1482,9 @@ def migration_056_create_mcp_hub_policy_tables(conn: sqlite3.Connection) -> None
         """
         CREATE TABLE IF NOT EXISTS mcp_policy_overrides (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            assignment_id INTEGER NOT NULL,
+            assignment_id INTEGER NOT NULL UNIQUE,
             override_document_json TEXT NOT NULL DEFAULT '{}',
+            is_active INTEGER DEFAULT 1,
             broadens_access INTEGER DEFAULT 0,
             grant_authority_snapshot_json TEXT NOT NULL DEFAULT '{}',
             created_by INTEGER,
@@ -1495,7 +1496,7 @@ def migration_056_create_mcp_hub_policy_tables(conn: sqlite3.Connection) -> None
         """
     )
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_mcp_policy_overrides_assignment "
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_policy_overrides_assignment "
         "ON mcp_policy_overrides(assignment_id)"
     )
 
@@ -1610,6 +1611,21 @@ def migration_057_add_consumable_mcp_approval_decision_columns(conn: sqlite3.Con
 
     conn.commit()
     logger.info("Migration 057: Added MCP approval decision consumption columns")
+
+
+def migration_058_harden_mcp_policy_override_schema(conn: sqlite3.Connection) -> None:
+    """Add override activity tracking and enforce a 1:1 assignment override mapping."""
+
+    cols = {str(row[1]) for row in conn.execute("PRAGMA table_info(mcp_policy_overrides)").fetchall()}
+    if "is_active" not in cols:
+        conn.execute("ALTER TABLE mcp_policy_overrides ADD COLUMN is_active INTEGER DEFAULT 1")
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_policy_overrides_assignment "
+        "ON mcp_policy_overrides(assignment_id)"
+    )
+
+    conn.commit()
+    logger.info("Migration 058: Hardened MCP policy override schema")
 
 
 def rollback_053_drop_byok_oauth_state(conn: sqlite3.Connection) -> None:
@@ -3054,6 +3070,11 @@ def get_authnz_migrations() -> list[Migration]:
             57,
             "Add consumable MCP approval decision columns",
             migration_057_add_consumable_mcp_approval_decision_columns,
+        ),
+        Migration(
+            58,
+            "Harden MCP policy override schema",
+            migration_058_harden_mcp_policy_override_schema,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -198,8 +198,9 @@ _CREATE_MCP_HUB_TABLES = [
         """
         CREATE TABLE IF NOT EXISTS mcp_policy_overrides (
             id SERIAL PRIMARY KEY,
-            assignment_id INTEGER NOT NULL REFERENCES mcp_policy_assignments(id) ON DELETE CASCADE,
+            assignment_id INTEGER NOT NULL UNIQUE REFERENCES mcp_policy_assignments(id) ON DELETE CASCADE,
             override_document_json TEXT NOT NULL DEFAULT '{}',
+            is_active BOOLEAN DEFAULT TRUE,
             broadens_access BOOLEAN DEFAULT FALSE,
             grant_authority_snapshot_json TEXT NOT NULL DEFAULT '{}',
             created_by INTEGER NULL,
@@ -211,7 +212,12 @@ _CREATE_MCP_HUB_TABLES = [
         (),
     ),
     (
-        "CREATE INDEX IF NOT EXISTS idx_mcp_policy_overrides_assignment "
+        "ALTER TABLE mcp_policy_overrides "
+        "ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT TRUE",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_policy_overrides_assignment "
         "ON mcp_policy_overrides(assignment_id)",
         (),
     ),

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -177,6 +177,23 @@ class McpHubRepo:
         out = dict(row)
         out["is_active"] = _to_bool(out.get("is_active"))
         out["inline_policy_document"] = _load_json_dict(out.pop("inline_policy_document_json", None))
+        out["has_override"] = _to_bool(out.get("has_override"))
+        out["override_active"] = _to_bool(out.get("override_active"))
+        if out.get("override_id") is None:
+            out["override_active"] = False
+        return out
+
+    @staticmethod
+    def _normalize_policy_override_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["is_active"] = _to_bool(out.get("is_active"))
+        out["broadens_access"] = _to_bool(out.get("broadens_access"))
+        out["override_policy_document"] = _load_json_dict(out.pop("override_document_json", None))
+        out["grant_authority_snapshot"] = _load_json_dict(
+            out.pop("grant_authority_snapshot_json", None)
+        )
         return out
 
     @staticmethod
@@ -626,11 +643,16 @@ class McpHubRepo:
     async def get_policy_assignment(self, assignment_id: int) -> dict[str, Any] | None:
         row = await self.db_pool.fetchone(
             """
-            SELECT id, target_type, target_id, owner_scope_type, owner_scope_id, profile_id,
-                   inline_policy_document_json, approval_policy_id, is_active,
-                   created_by, updated_by, created_at, updated_at
-            FROM mcp_policy_assignments
-            WHERE id = ?
+            SELECT a.id, a.target_type, a.target_id, a.owner_scope_type, a.owner_scope_id, a.profile_id,
+                   a.inline_policy_document_json, a.approval_policy_id, a.is_active,
+                   a.created_by, a.updated_by, a.created_at, a.updated_at,
+                   o.id AS override_id,
+                   CASE WHEN o.id IS NULL THEN 0 ELSE 1 END AS has_override,
+                   COALESCE(o.is_active, 0) AS override_active,
+                   o.updated_at AS override_updated_at
+            FROM mcp_policy_assignments AS a
+            LEFT JOIN mcp_policy_overrides AS o ON o.assignment_id = a.id
+            WHERE a.id = ?
             """,
             (int(assignment_id),),
         )
@@ -658,15 +680,20 @@ class McpHubRepo:
         normalized_target_id = str(target_id).strip() if target_id is not None else None
         rows = await self.db_pool.fetchall(
             """
-            SELECT id, target_type, target_id, owner_scope_type, owner_scope_id, profile_id,
-                   inline_policy_document_json, approval_policy_id, is_active,
-                   created_by, updated_by, created_at, updated_at
-            FROM mcp_policy_assignments
-            WHERE (? IS NULL OR owner_scope_type = ?)
-              AND (? IS NULL OR owner_scope_id = ?)
-              AND (? IS NULL OR target_type = ?)
-              AND (? IS NULL OR target_id = ?)
-            ORDER BY target_type, target_id, id
+            SELECT a.id, a.target_type, a.target_id, a.owner_scope_type, a.owner_scope_id, a.profile_id,
+                   a.inline_policy_document_json, a.approval_policy_id, a.is_active,
+                   a.created_by, a.updated_by, a.created_at, a.updated_at,
+                   o.id AS override_id,
+                   CASE WHEN o.id IS NULL THEN 0 ELSE 1 END AS has_override,
+                   COALESCE(o.is_active, 0) AS override_active,
+                   o.updated_at AS override_updated_at
+            FROM mcp_policy_assignments AS a
+            LEFT JOIN mcp_policy_overrides AS o ON o.assignment_id = a.id
+            WHERE (? IS NULL OR a.owner_scope_type = ?)
+              AND (? IS NULL OR a.owner_scope_id = ?)
+              AND (? IS NULL OR a.target_type = ?)
+              AND (? IS NULL OR a.target_id = ?)
+            ORDER BY a.target_type, a.target_id, a.id
             """,
             (
                 normalized_scope_type,
@@ -769,6 +796,75 @@ class McpHubRepo:
     async def delete_policy_assignment(self, assignment_id: int) -> bool:
         cursor = await self.db_pool.execute(
             "DELETE FROM mcp_policy_assignments WHERE id = ?",
+            (int(assignment_id),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)
+
+    async def get_policy_override_by_assignment(self, assignment_id: int) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, assignment_id, override_document_json, is_active, broadens_access,
+                   grant_authority_snapshot_json, created_by, updated_by, created_at, updated_at
+            FROM mcp_policy_overrides
+            WHERE assignment_id = ?
+            """,
+            (int(assignment_id),),
+        )
+        return self._normalize_policy_override_row(self._row_to_dict(row) if row else None)
+
+    async def upsert_policy_override(
+        self,
+        assignment_id: int,
+        *,
+        override_policy_document: dict[str, Any],
+        broadens_access: bool,
+        grant_authority_snapshot: dict[str, Any],
+        actor_id: int | None,
+        is_active: bool = True,
+    ) -> dict[str, Any] | None:
+        assignment = await self.get_policy_assignment(int(assignment_id))
+        if assignment is None:
+            return None
+
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
+        broadens_value: bool | int = (
+            broadens_access if getattr(self.db_pool, "pool", None) is not None else int(broadens_access)
+        )
+
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_policy_overrides (
+                assignment_id, override_document_json, is_active, broadens_access,
+                grant_authority_snapshot_json, created_by, updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(assignment_id) DO UPDATE SET
+                override_document_json = excluded.override_document_json,
+                is_active = excluded.is_active,
+                broadens_access = excluded.broadens_access,
+                grant_authority_snapshot_json = excluded.grant_authority_snapshot_json,
+                updated_by = excluded.updated_by,
+                updated_at = excluded.updated_at
+            """,
+            (
+                int(assignment_id),
+                json.dumps(override_policy_document or {}),
+                active_value,
+                broadens_value,
+                json.dumps(grant_authority_snapshot or {}),
+                actor_id,
+                actor_id,
+                ts,
+                ts,
+            ),
+        )
+        return await self.get_policy_override_by_assignment(int(assignment_id))
+
+    async def delete_policy_override_by_assignment(self, assignment_id: int) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_policy_overrides WHERE assignment_id = ?",
             (int(assignment_id),),
         )
         rowcount = getattr(cursor, "rowcount", 0)

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -109,6 +109,30 @@ def _allowed_tool_patterns(policy_document: dict[str, Any]) -> list[str]:
     return _unique(patterns)
 
 
+def _provenance_entries(
+    *,
+    layer_document: dict[str, Any],
+    source_kind: str,
+    assignment_id: int,
+    profile_id: int | None,
+    override_id: int | None,
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for field, value in layer_document.items():
+        entries.append(
+            {
+                "field": str(field),
+                "value": deepcopy(value),
+                "source_kind": source_kind,
+                "assignment_id": assignment_id,
+                "profile_id": profile_id,
+                "override_id": override_id,
+                "effect": "merged" if field in _UNION_LIST_KEYS else "replaced",
+            }
+        )
+    return entries
+
+
 class McpHubPolicyResolver:
     """Resolve effective MCP Hub policy for a runtime request context."""
 
@@ -143,32 +167,70 @@ class McpHubPolicyResolver:
         sources: list[dict[str, Any]] = []
         profile_cache: dict[int, dict[str, Any] | None] = {}
         resolved_approval_policy_id: int | None = None
+        provenance: list[dict[str, Any]] = []
 
         for assignment in assignments:
             assignment_document: dict[str, Any] = {}
             profile_id = assignment.get("profile_id")
+            profile_key: int | None = int(profile_id) if profile_id is not None else None
+            assignment_id = int(assignment.get("id"))
             if profile_id is not None:
-                profile_key = int(profile_id)
                 if profile_key not in profile_cache:
                     profile_cache[profile_key] = await self.repo.get_permission_profile(profile_key)
                 profile_row = profile_cache.get(profile_key) or {}
                 if bool(profile_row.get("is_active", True)):
+                    profile_document = _as_dict(profile_row.get("policy_document"))
                     assignment_document = _merge_policy_documents(
                         assignment_document,
-                        _as_dict(profile_row.get("policy_document")),
+                        profile_document,
+                    )
+                    provenance.extend(
+                        _provenance_entries(
+                            layer_document=profile_document,
+                            source_kind="profile",
+                            assignment_id=assignment_id,
+                            profile_id=profile_key,
+                            override_id=None,
+                        )
                     )
 
+            inline_policy_document = _as_dict(assignment.get("inline_policy_document"))
             assignment_document = _merge_policy_documents(
                 assignment_document,
-                _as_dict(assignment.get("inline_policy_document")),
+                inline_policy_document,
             )
+            provenance.extend(
+                _provenance_entries(
+                    layer_document=inline_policy_document,
+                    source_kind="assignment_inline",
+                    assignment_id=assignment_id,
+                    profile_id=profile_key,
+                    override_id=None,
+                )
+            )
+            override_row = await self.repo.get_policy_override_by_assignment(assignment_id)
+            if override_row and bool(override_row.get("is_active", True)):
+                override_document = _as_dict(override_row.get("override_policy_document"))
+                assignment_document = _merge_policy_documents(
+                    assignment_document,
+                    override_document,
+                )
+                provenance.extend(
+                    _provenance_entries(
+                        layer_document=override_document,
+                        source_kind="assignment_override",
+                        assignment_id=assignment_id,
+                        profile_id=profile_key,
+                        override_id=int(override_row.get("id")),
+                    )
+                )
             merged_policy_document = _merge_policy_documents(merged_policy_document, assignment_document)
             approval_policy_id = assignment.get("approval_policy_id")
             if approval_policy_id is not None:
                 resolved_approval_policy_id = int(approval_policy_id)
             sources.append(
                 {
-                    "assignment_id": int(assignment.get("id")),
+                    "assignment_id": assignment_id,
                     "target_type": str(assignment.get("target_type") or "default"),
                     "target_id": assignment.get("target_id"),
                     "owner_scope_type": str(assignment.get("owner_scope_type") or "global"),
@@ -186,6 +248,7 @@ class McpHubPolicyResolver:
             "approval_mode": str(merged_policy_document.get("approval_mode") or "").strip() or None,
             "policy_document": merged_policy_document,
             "sources": sources,
+            "provenance": provenance,
         }
 
     async def _load_applicable_assignments(
@@ -237,6 +300,7 @@ class McpHubPolicyResolver:
             "approval_mode": None,
             "policy_document": {},
             "sources": [],
+            "provenance": [],
         }
 
 

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -123,6 +123,10 @@ class McpHubService:
             owner_scope_id=owner_scope_id,
         )
 
+    async def get_permission_profile(self, profile_id: int) -> dict[str, Any] | None:
+        """Fetch a single permission profile by id."""
+        return await self.repo.get_permission_profile(profile_id)
+
     async def update_permission_profile(
         self,
         profile_id: int,
@@ -211,6 +215,10 @@ class McpHubService:
             target_id=target_id,
         )
 
+    async def get_policy_assignment(self, assignment_id: int) -> dict[str, Any] | None:
+        """Fetch a single policy assignment by id."""
+        return await self.repo.get_policy_assignment(assignment_id)
+
     async def update_policy_assignment(
         self,
         assignment_id: int,
@@ -236,6 +244,18 @@ class McpHubService:
         return row
 
     async def delete_policy_assignment(self, assignment_id: int, *, actor_id: int | None) -> bool:
+        existing_override = await self.repo.get_policy_override_by_assignment(assignment_id)
+        if existing_override:
+            await self.repo.delete_policy_override_by_assignment(assignment_id)
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.policy_override.delete",
+                    actor_id=actor_id,
+                    resource_type="mcp_policy_override",
+                    resource_id=str(existing_override.get("id") or ""),
+                    metadata={"assignment_id": assignment_id},
+                )
+            )
         deleted = await self.repo.delete_policy_assignment(assignment_id)
         if deleted:
             await _await_if_needed(
@@ -245,6 +265,59 @@ class McpHubService:
                     resource_type="mcp_policy_assignment",
                     resource_id=str(assignment_id),
                     metadata=None,
+                )
+            )
+        return deleted
+
+    async def get_policy_override(self, assignment_id: int) -> dict[str, Any] | None:
+        """Fetch a single assignment-bound override by assignment id."""
+        return await self.repo.get_policy_override_by_assignment(assignment_id)
+
+    async def upsert_policy_override(
+        self,
+        assignment_id: int,
+        *,
+        override_policy_document: dict[str, Any],
+        is_active: bool,
+        broadens_access: bool,
+        grant_authority_snapshot: dict[str, Any],
+        actor_id: int | None,
+    ) -> dict[str, Any] | None:
+        row = await self.repo.upsert_policy_override(
+            assignment_id,
+            override_policy_document=override_policy_document,
+            is_active=is_active,
+            broadens_access=broadens_access,
+            grant_authority_snapshot=grant_authority_snapshot,
+            actor_id=actor_id,
+        )
+        if row:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.policy_override.upsert",
+                    actor_id=actor_id,
+                    resource_type="mcp_policy_override",
+                    resource_id=str(row.get("id") or ""),
+                    metadata={
+                        "assignment_id": assignment_id,
+                        "broadens_access": bool(row.get("broadens_access")),
+                        "is_active": bool(row.get("is_active")),
+                    },
+                )
+            )
+        return row
+
+    async def delete_policy_override(self, assignment_id: int, *, actor_id: int | None) -> bool:
+        existing = await self.repo.get_policy_override_by_assignment(assignment_id)
+        deleted = await self.repo.delete_policy_override_by_assignment(assignment_id)
+        if deleted:
+            await _await_if_needed(
+                emit_mcp_hub_audit(
+                    action="mcp_hub.policy_override.delete",
+                    actor_id=actor_id,
+                    resource_type="mcp_policy_override",
+                    resource_id=str((existing or {}).get("id") or ""),
+                    metadata={"assignment_id": assignment_id},
                 )
             )
         return deleted

--- a/tldw_Server_API/app/services/mcp_hub_tool_registry.py
+++ b/tldw_Server_API/app/services/mcp_hub_tool_registry.py
@@ -95,7 +95,10 @@ _STRONG_EXPLICIT_KEYS = frozenset(
     }
 )
 _CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("execution", ("bash", "command", "execute", "exec", "process", "run", "sandbox", "shell")),
+    (
+        "execution",
+        ("bash", "command", "execute", "exec", "process", "run", "sandbox", "shell"),
+    ),
     ("management", ("create", "delete", "import", "remove", "update", "write")),
     ("ingestion", ("ingest", "upload")),
     ("search", ("find", "list", "query", "search")),
@@ -155,6 +158,7 @@ class McpHubToolRegistryService:
         self._module_registry = module_registry or get_module_registry()
 
     async def list_entries(self) -> list[dict[str, Any]]:
+        """Return normalized tool metadata entries for every live MCP tool."""
         modules = await self._module_registry.get_all_modules()
         entries: list[dict[str, Any]] = []
 
@@ -172,9 +176,23 @@ class McpHubToolRegistryService:
         return entries
 
     async def list_modules(self) -> list[dict[str, Any]]:
+        """Return module-level summaries derived from the normalized tool registry."""
+        return self._module_rows_from_entries(await self.list_entries())
+
+    async def get_summary(self) -> dict[str, list[dict[str, Any]]]:
+        """Return tool entries and module summaries from a single registry enumeration."""
+        entries = await self.list_entries()
+        return {
+            "entries": entries,
+            "modules": self._module_rows_from_entries(entries),
+        }
+
+    @staticmethod
+    def _module_rows_from_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Build module summary rows from pre-normalized tool entries."""
         module_rows: dict[str, dict[str, Any]] = {}
 
-        for entry in await self.list_entries():
+        for entry in entries:
             module_key = entry["module"]
             row = module_rows.setdefault(
                 module_key,
@@ -299,4 +317,3 @@ class McpHubToolRegistryService:
         if risk_class == "unclassified":
             warnings.append("Tool risk class requires manual review")
         return _unique(warnings)
-

--- a/tldw_Server_API/app/services/mcp_hub_tool_registry.py
+++ b/tldw_Server_API/app/services/mcp_hub_tool_registry.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.MCP_unified.modules.registry import ModuleRegistry, get_module_registry
+
+_KNOWN_RISK_CLASSES = ("low", "medium", "high", "unclassified")
+_KNOWN_METADATA_SOURCES = ("explicit", "heuristic", "fallback")
+_CATEGORY_DEFAULTS: dict[str, dict[str, Any]] = {
+    "execution": {
+        "risk_class": "high",
+        "capabilities": ["process.execute"],
+        "mutates_state": True,
+        "uses_filesystem": True,
+        "uses_processes": True,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": False,
+    },
+    "governance": {
+        "risk_class": "medium",
+        "capabilities": [],
+        "mutates_state": False,
+        "uses_filesystem": False,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": False,
+    },
+    "ingestion": {
+        "risk_class": "high",
+        "capabilities": ["filesystem.write"],
+        "mutates_state": True,
+        "uses_filesystem": True,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": True,
+    },
+    "management": {
+        "risk_class": "high",
+        "capabilities": ["filesystem.write"],
+        "mutates_state": True,
+        "uses_filesystem": True,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": True,
+    },
+    "retrieval": {
+        "risk_class": "low",
+        "capabilities": ["filesystem.read"],
+        "mutates_state": False,
+        "uses_filesystem": False,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": False,
+    },
+    "search": {
+        "risk_class": "low",
+        "capabilities": ["filesystem.read"],
+        "mutates_state": False,
+        "uses_filesystem": False,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": False,
+    },
+    "unclassified": {
+        "risk_class": "unclassified",
+        "capabilities": [],
+        "mutates_state": False,
+        "uses_filesystem": False,
+        "uses_processes": False,
+        "uses_network": False,
+        "uses_credentials": False,
+        "path_boundable": False,
+    },
+}
+_STRONG_EXPLICIT_KEYS = frozenset(
+    {
+        "capabilities",
+        "mutates_state",
+        "path_boundable",
+        "risk_class",
+        "supports_arguments_preview",
+        "uses_credentials",
+        "uses_filesystem",
+        "uses_network",
+        "uses_processes",
+    }
+)
+_CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("execution", ("bash", "command", "execute", "exec", "process", "run", "sandbox", "shell")),
+    ("management", ("create", "delete", "import", "remove", "update", "write")),
+    ("ingestion", ("ingest", "upload")),
+    ("search", ("find", "list", "query", "search")),
+    ("retrieval", ("fetch", "get", "read", "retrieve", "view")),
+)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _as_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _default_risk_summary() -> dict[str, int]:
+    return {risk_class: 0 for risk_class in _KNOWN_RISK_CLASSES}
+
+
+class McpHubToolRegistryService:
+    """Derive MCP Hub tool metadata from the live module registry."""
+
+    def __init__(self, module_registry: ModuleRegistry | None = None):
+        self._module_registry = module_registry or get_module_registry()
+
+    async def list_entries(self) -> list[dict[str, Any]]:
+        modules = await self._module_registry.get_all_modules()
+        entries: list[dict[str, Any]] = []
+
+        for module_id, module in sorted(modules.items(), key=lambda item: item[0]):
+            try:
+                tools = await module.get_tools()
+            except Exception as exc:  # noqa: BLE001 - derived registry should fail open
+                logger.warning("Skipping MCP Hub tool registry load for module {}: {}", module_id, exc)
+                continue
+
+            for tool_def in tools or []:
+                entries.append(self._normalize_tool_entry(module_id=module_id, module=module, tool_def=tool_def))
+
+        entries.sort(key=lambda entry: (entry["module"], entry["tool_name"]))
+        return entries
+
+    async def list_modules(self) -> list[dict[str, Any]]:
+        module_rows: dict[str, dict[str, Any]] = {}
+
+        for entry in await self.list_entries():
+            module_key = entry["module"]
+            row = module_rows.setdefault(
+                module_key,
+                {
+                    "module": module_key,
+                    "display_name": entry.get("module_display_name") or module_key,
+                    "tool_count": 0,
+                    "risk_summary": _default_risk_summary(),
+                    "metadata_warnings": [],
+                },
+            )
+            row["tool_count"] += 1
+            risk_class = str(entry.get("risk_class") or "unclassified")
+            if risk_class not in row["risk_summary"]:
+                row["risk_summary"][risk_class] = 0
+            row["risk_summary"][risk_class] += 1
+            row["metadata_warnings"] = _unique(
+                list(row["metadata_warnings"]) + _as_str_list(entry.get("metadata_warnings"))
+            )
+
+        return [module_rows[module_key] for module_key in sorted(module_rows)]
+
+    def _normalize_tool_entry(
+        self,
+        *,
+        module_id: str,
+        module: Any,
+        tool_def: dict[str, Any],
+    ) -> dict[str, Any]:
+        metadata = _as_dict(tool_def.get("metadata"))
+        tool_name = str(tool_def.get("name") or "").strip()
+        display_name = str(metadata.get("display_name") or tool_name or module_id)
+        category, category_source = self._resolve_category(tool_name=tool_name, metadata=metadata)
+        defaults = dict(_CATEGORY_DEFAULTS.get(category, _CATEGORY_DEFAULTS["unclassified"]))
+
+        risk_class = str(metadata.get("risk_class") or defaults["risk_class"]).strip().lower() or "unclassified"
+        if risk_class not in _KNOWN_RISK_CLASSES:
+            risk_class = "unclassified"
+
+        capabilities = _unique(
+            _as_str_list(metadata.get("capabilities")) or list(defaults.get("capabilities") or [])
+        )
+        mutates_state = self._resolve_bool(metadata, "mutates_state", defaults["mutates_state"])
+        uses_filesystem = self._resolve_bool(metadata, "uses_filesystem", defaults["uses_filesystem"])
+        uses_processes = self._resolve_bool(metadata, "uses_processes", defaults["uses_processes"])
+        uses_network = self._resolve_bool(metadata, "uses_network", defaults["uses_network"])
+        uses_credentials = self._resolve_bool(metadata, "uses_credentials", defaults["uses_credentials"])
+        path_boundable = self._resolve_bool(metadata, "path_boundable", defaults["path_boundable"])
+        supports_arguments_preview = self._resolve_bool(
+            metadata,
+            "supports_arguments_preview",
+            bool(_as_dict(tool_def.get("inputSchema"))),
+        )
+
+        if metadata.get("readOnlyHint") is True and "filesystem.read" not in capabilities:
+            capabilities = _unique(capabilities + ["filesystem.read"])
+
+        metadata_source = self._resolve_metadata_source(metadata=metadata, category_source=category_source)
+        metadata_warnings = self._metadata_warnings(
+            metadata_source=metadata_source,
+            category_source=category_source,
+            risk_class=risk_class,
+        )
+
+        return {
+            "tool_name": tool_name,
+            "display_name": display_name,
+            "description": str(tool_def.get("description") or ""),
+            "module": module_id,
+            "module_display_name": str(getattr(module, "name", None) or module_id),
+            "category": category,
+            "risk_class": risk_class,
+            "capabilities": capabilities,
+            "mutates_state": mutates_state,
+            "uses_filesystem": uses_filesystem,
+            "uses_processes": uses_processes,
+            "uses_network": uses_network,
+            "uses_credentials": uses_credentials,
+            "supports_arguments_preview": supports_arguments_preview,
+            "path_boundable": path_boundable,
+            "metadata_source": metadata_source,
+            "metadata_warnings": metadata_warnings,
+        }
+
+    @staticmethod
+    def _resolve_bool(metadata: dict[str, Any], key: str, default: bool) -> bool:
+        value = _as_bool(metadata.get(key))
+        return default if value is None else value
+
+    def _resolve_category(self, *, tool_name: str, metadata: dict[str, Any]) -> tuple[str, str]:
+        category = str(metadata.get("category") or "").strip().lower()
+        if category:
+            if category in _CATEGORY_DEFAULTS:
+                return category, "metadata"
+            return "unclassified", "metadata"
+
+        lowered = tool_name.lower()
+        for inferred_category, keywords in _CATEGORY_KEYWORDS:
+            if any(keyword in lowered for keyword in keywords):
+                return inferred_category, "heuristic"
+        return "unclassified", "fallback"
+
+    def _resolve_metadata_source(self, *, metadata: dict[str, Any], category_source: str) -> str:
+        if any(key in metadata for key in _STRONG_EXPLICIT_KEYS):
+            return "explicit"
+        if metadata or category_source == "heuristic":
+            return "heuristic"
+        return "fallback"
+
+    @staticmethod
+    def _metadata_warnings(
+        *,
+        metadata_source: str,
+        category_source: str,
+        risk_class: str,
+    ) -> list[str]:
+        warnings: list[str] = []
+        if metadata_source == "heuristic" and category_source in {"metadata", "heuristic"}:
+            warnings.append("Derived metadata from tool category")
+        if metadata_source == "fallback":
+            warnings.append("Tool metadata missing; classified conservatively")
+        if risk_class == "unclassified":
+            warnings.append("Tool risk class requires manual review")
+        return _unique(warnings)
+

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
@@ -55,3 +55,15 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
     column_names = {str(row["column_name"]) for row in column_rows}
     assert "consume_on_match" in column_names
     assert "consumed_at" in column_names
+
+    override_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_policy_overrides'
+          AND column_name IN ('is_active')
+        """
+    )
+    override_column_names = {str(row["column_name"]) for row in override_column_rows}
+    assert "is_active" in override_column_names

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py
@@ -41,3 +41,7 @@ async def test_mcp_hub_tables_exist_after_authnz_migrations_sqlite(tmp_path, mon
     column_names = {str(row["name"]) for row in columns}
     assert "consume_on_match" in column_names
     assert "consumed_at" in column_names
+
+    override_columns = await pool.fetchall("PRAGMA table_info(mcp_policy_overrides)")
+    override_column_names = {str(row["name"]) for row in override_columns}
+    assert "is_active" in override_column_names

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -267,11 +267,73 @@ class _FakePolicyResolver:
         }
 
 
+class _FakeToolRegistryService:
+    def __init__(self) -> None:
+        self.entries = [
+            {
+                "tool_name": "notes.search",
+                "display_name": "notes.search",
+                "module": "notes",
+                "category": "search",
+                "risk_class": "low",
+                "capabilities": ["filesystem.read"],
+                "mutates_state": False,
+                "uses_filesystem": False,
+                "uses_processes": False,
+                "uses_network": False,
+                "uses_credentials": False,
+                "supports_arguments_preview": True,
+                "path_boundable": False,
+                "metadata_source": "explicit",
+                "metadata_warnings": [],
+            },
+            {
+                "tool_name": "sandbox.run",
+                "display_name": "sandbox.run",
+                "module": "sandbox",
+                "category": "execution",
+                "risk_class": "high",
+                "capabilities": ["process.execute"],
+                "mutates_state": True,
+                "uses_filesystem": True,
+                "uses_processes": True,
+                "uses_network": False,
+                "uses_credentials": False,
+                "supports_arguments_preview": True,
+                "path_boundable": False,
+                "metadata_source": "heuristic",
+                "metadata_warnings": ["Derived from tool category"],
+            },
+        ]
+
+    async def list_entries(self):
+        return list(self.entries)
+
+    async def list_modules(self):
+        return [
+            {
+                "module": "notes",
+                "display_name": "notes",
+                "tool_count": 1,
+                "risk_summary": {"low": 1, "medium": 0, "high": 0, "unclassified": 0},
+                "metadata_warnings": [],
+            },
+            {
+                "module": "sandbox",
+                "display_name": "sandbox",
+                "tool_count": 1,
+                "risk_summary": {"low": 0, "medium": 0, "high": 1, "unclassified": 0},
+                "metadata_warnings": ["Derived metadata present"],
+            },
+        ]
+
+
 def _build_app(
     principal: AuthPrincipal,
     service: _FakePolicyService | None = None,
     resolver: _FakePolicyResolver | None = None,
     *,
+    tool_registry: _FakeToolRegistryService | None = None,
     rate_limit_calls: list[str] | None = None,
 ) -> FastAPI:
     app = FastAPI()
@@ -285,6 +347,10 @@ def _build_app(
     app.dependency_overrides[mcp_hub_management.get_mcp_hub_policy_resolver_dep] = (
         lambda: resolver or _FakePolicyResolver()
     )
+    if hasattr(mcp_hub_management, "get_mcp_hub_tool_registry_dep"):
+        app.dependency_overrides[mcp_hub_management.get_mcp_hub_tool_registry_dep] = (
+            lambda: tool_registry or _FakeToolRegistryService()
+        )
     if rate_limit_calls is not None:
         async def _fake_check_rate_limit(_request: Request) -> None:
             rate_limit_calls.append("called")
@@ -605,6 +671,48 @@ def test_get_effective_policy_returns_resolved_payload() -> None:
     assert payload["allowed_tools"] == ["Bash(git *)"]
     assert payload["approval_mode"] == "ask_outside_profile"
     assert payload["sources"][0]["target_id"] == "researcher"
+
+
+def test_list_tool_registry_returns_normalized_entries() -> None:
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[],
+        ),
+        tool_registry=_FakeToolRegistryService(),
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/tool-registry")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload) == 2
+    assert payload[0]["tool_name"] == "notes.search"
+    assert payload[0]["risk_class"] == "low"
+    assert payload[1]["tool_name"] == "sandbox.run"
+    assert payload[1]["metadata_warnings"] == ["Derived from tool category"]
+
+
+def test_list_tool_registry_modules_returns_grouped_summary() -> None:
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[],
+        ),
+        tool_registry=_FakeToolRegistryService(),
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/tool-registry/modules")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload) == 2
+    assert payload[0]["module"] == "notes"
+    assert payload[0]["tool_count"] == 1
+    assert payload[1]["module"] == "sandbox"
+    assert payload[1]["risk_summary"]["high"] == 1
 
 
 def test_list_permission_profiles_returns_visible_rows() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -62,12 +62,30 @@ class _FakePolicyService:
                 "inline_policy_document": {"capabilities": ["process.execute"]},
                 "approval_policy_id": None,
                 "is_active": True,
+                "has_override": True,
+                "override_id": 31,
+                "override_active": True,
+                "override_updated_at": datetime.now(timezone.utc).isoformat(),
                 "created_by": 7,
                 "updated_by": 7,
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
         ]
+        self.policy_overrides = {
+            11: {
+                "id": 31,
+                "assignment_id": 11,
+                "override_policy_document": {"allowed_tools": ["remote.fetch"]},
+                "is_active": True,
+                "broadens_access": True,
+                "grant_authority_snapshot": {"permissions": ["grant.tool.invoke"]},
+                "created_by": 7,
+                "updated_by": 7,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        }
         self.approval_policies = [
             {
                 "id": 17,
@@ -88,6 +106,12 @@ class _FakePolicyService:
 
     async def list_permission_profiles(self, **_kwargs):
         return list(self.permission_profiles)
+
+    async def get_permission_profile(self, profile_id: int):
+        for profile in self.permission_profiles:
+            if int(profile.get("id") or 0) == int(profile_id):
+                return dict(profile)
+        return None
 
     async def create_permission_profile(self, **kwargs):
         profile = {
@@ -131,6 +155,12 @@ class _FakePolicyService:
     async def list_policy_assignments(self, **_kwargs):
         return list(self.policy_assignments)
 
+    async def get_policy_assignment(self, assignment_id: int):
+        for assignment in self.policy_assignments:
+            if int(assignment.get("id") or 0) == int(assignment_id):
+                return dict(assignment)
+        return None
+
     async def create_policy_assignment(self, **kwargs):
         assignment = {
             "id": 11,
@@ -142,6 +172,10 @@ class _FakePolicyService:
             "inline_policy_document": kwargs["inline_policy_document"],
             "approval_policy_id": kwargs.get("approval_policy_id"),
             "is_active": kwargs.get("is_active", True),
+            "has_override": False,
+            "override_id": None,
+            "override_active": False,
+            "override_updated_at": None,
             "created_by": kwargs.get("actor_id"),
             "updated_by": kwargs.get("actor_id"),
             "created_at": datetime.now(timezone.utc).isoformat(),
@@ -167,11 +201,65 @@ class _FakePolicyService:
         if kwargs.get("is_active") is not None:
             assignment["is_active"] = kwargs["is_active"]
         assignment["updated_by"] = kwargs.get("actor_id")
+        override = self.policy_overrides.get(assignment_id)
+        assignment["has_override"] = override is not None
+        assignment["override_id"] = override["id"] if override else None
+        assignment["override_active"] = bool(override and override.get("is_active"))
+        assignment["override_updated_at"] = override.get("updated_at") if override else None
         self.policy_assignments = [assignment]
         return assignment
 
     async def delete_policy_assignment(self, assignment_id: int, *, actor_id: int | None):
+        self.policy_overrides.pop(assignment_id, None)
         return assignment_id == 11 and actor_id == 7
+
+    async def get_policy_override(self, assignment_id: int):
+        return dict(self.policy_overrides[assignment_id]) if assignment_id in self.policy_overrides else None
+
+    async def upsert_policy_override(self, assignment_id: int, **kwargs):
+        if assignment_id != 11:
+            return None
+        existing = self.policy_overrides.get(assignment_id)
+        override_id = existing["id"] if existing else 31
+        row = {
+            "id": override_id,
+            "assignment_id": assignment_id,
+            "override_policy_document": kwargs["override_policy_document"],
+            "is_active": kwargs.get("is_active", True),
+            "broadens_access": kwargs.get("broadens_access", False),
+            "grant_authority_snapshot": kwargs.get("grant_authority_snapshot", {}),
+            "created_by": (existing or {}).get("created_by", kwargs.get("actor_id")),
+            "updated_by": kwargs.get("actor_id"),
+            "created_at": (existing or {}).get("created_at", datetime.now(timezone.utc).isoformat()),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self.policy_overrides[assignment_id] = row
+        self.policy_assignments = [
+            {
+                **assignment,
+                "has_override": int(assignment.get("id") or 0) == assignment_id,
+                "override_id": override_id if int(assignment.get("id") or 0) == assignment_id else None,
+                "override_active": bool(row.get("is_active")) if int(assignment.get("id") or 0) == assignment_id else False,
+                "override_updated_at": row["updated_at"] if int(assignment.get("id") or 0) == assignment_id else None,
+            }
+            for assignment in self.policy_assignments
+        ]
+        return dict(row)
+
+    async def delete_policy_override(self, assignment_id: int, *, actor_id: int | None):
+        deleted = assignment_id in self.policy_overrides and actor_id == 7
+        self.policy_overrides.pop(assignment_id, None)
+        self.policy_assignments = [
+            {
+                **assignment,
+                "has_override": False if int(assignment.get("id") or 0) == assignment_id else assignment.get("has_override", False),
+                "override_id": None if int(assignment.get("id") or 0) == assignment_id else assignment.get("override_id"),
+                "override_active": False if int(assignment.get("id") or 0) == assignment_id else assignment.get("override_active", False),
+                "override_updated_at": None if int(assignment.get("id") or 0) == assignment_id else assignment.get("override_updated_at"),
+            }
+            for assignment in self.policy_assignments
+        ]
+        return deleted
 
     async def list_approval_policies(self, **_kwargs):
         return list(self.approval_policies)
@@ -262,6 +350,26 @@ class _FakePolicyResolver:
                     "owner_scope_type": "user",
                     "owner_scope_id": user_id,
                     "profile_id": 5
+                }
+            ],
+            "provenance": [
+                {
+                    "field": "allowed_tools",
+                    "value": ["Bash(git *)"],
+                    "source_kind": "assignment_inline",
+                    "assignment_id": 11,
+                    "profile_id": 5,
+                    "override_id": None,
+                    "effect": "merged"
+                },
+                {
+                    "field": "allowed_tools",
+                    "value": ["remote.fetch"],
+                    "source_kind": "assignment_override",
+                    "assignment_id": 11,
+                    "profile_id": 5,
+                    "override_id": 31,
+                    "effect": "merged"
                 }
             ]
         }
@@ -671,6 +779,98 @@ def test_get_effective_policy_returns_resolved_payload() -> None:
     assert payload["allowed_tools"] == ["Bash(git *)"]
     assert payload["approval_mode"] == "ask_outside_profile"
     assert payload["sources"][0]["target_id"] == "researcher"
+    assert payload["provenance"][1]["source_kind"] == "assignment_override"
+
+
+def test_list_policy_assignments_includes_override_summary_fields() -> None:
+    app = _build_app(
+        _make_principal(
+            permissions=[SYSTEM_CONFIGURE, "grant.process.execute", "grant.tool.invoke"],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/policy-assignments")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload[0]["has_override"] is True
+    assert payload[0]["override_active"] is True
+    assert payload[0]["override_id"] == 31
+
+
+def test_get_policy_assignment_override_returns_payload() -> None:
+    app = _build_app(
+        _make_principal(
+            permissions=[SYSTEM_CONFIGURE, "grant.process.execute", "grant.tool.invoke"],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/policy-assignments/11/override")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["assignment_id"] == 11
+    assert payload["override_policy_document"]["allowed_tools"] == ["remote.fetch"]
+    assert payload["is_active"] is True
+
+
+def test_put_policy_assignment_override_returns_payload() -> None:
+    app = _build_app(
+        _make_principal(
+            permissions=[SYSTEM_CONFIGURE, "grant.process.execute", "grant.tool.invoke"],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/mcp/hub/policy-assignments/11/override",
+            json={
+                "override_policy_document": {"allowed_tools": ["remote.fetch"]},
+                "is_active": True,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["assignment_id"] == 11
+    assert payload["override_policy_document"]["allowed_tools"] == ["remote.fetch"]
+    assert payload["is_active"] is True
+
+
+def test_put_policy_assignment_override_requires_grant_authority_for_broadened_delta() -> None:
+    app = _build_app(
+        _make_principal(
+            permissions=[SYSTEM_CONFIGURE],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/mcp/hub/policy-assignments/11/override",
+            json={
+                "override_policy_document": {"allowed_tools": ["remote.fetch"]},
+                "is_active": True,
+            },
+        )
+
+    assert resp.status_code == 403
+    assert "grant.tool.invoke" in resp.json()["detail"]
+
+
+def test_delete_policy_assignment_override_returns_ok() -> None:
+    app = _build_app(
+        _make_principal(
+            permissions=[SYSTEM_CONFIGURE, "grant.process.execute", "grant.tool.invoke"],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.delete("/api/v1/mcp/hub/policy-assignments/11/override")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
 
 
 def test_list_tool_registry_returns_normalized_entries() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -377,6 +377,7 @@ class _FakePolicyResolver:
 
 class _FakeToolRegistryService:
     def __init__(self) -> None:
+        self.list_entries_calls = 0
         self.entries = [
             {
                 "tool_name": "notes.search",
@@ -415,25 +416,33 @@ class _FakeToolRegistryService:
         ]
 
     async def list_entries(self):
+        self.list_entries_calls += 1
         return list(self.entries)
 
     async def list_modules(self):
-        return [
-            {
-                "module": "notes",
-                "display_name": "notes",
-                "tool_count": 1,
-                "risk_summary": {"low": 1, "medium": 0, "high": 0, "unclassified": 0},
-                "metadata_warnings": [],
-            },
-            {
-                "module": "sandbox",
-                "display_name": "sandbox",
-                "tool_count": 1,
-                "risk_summary": {"low": 0, "medium": 0, "high": 1, "unclassified": 0},
-                "metadata_warnings": ["Derived metadata present"],
-            },
-        ]
+        return (await self.get_summary())["modules"]
+
+    async def get_summary(self):
+        entries = await self.list_entries()
+        return {
+            "entries": entries,
+            "modules": [
+                {
+                    "module": "notes",
+                    "display_name": "notes",
+                    "tool_count": 1,
+                    "risk_summary": {"low": 1, "medium": 0, "high": 0, "unclassified": 0},
+                    "metadata_warnings": [],
+                },
+                {
+                    "module": "sandbox",
+                    "display_name": "sandbox",
+                    "tool_count": 1,
+                    "risk_summary": {"low": 0, "medium": 0, "high": 1, "unclassified": 0},
+                    "metadata_warnings": ["Derived metadata present"],
+                },
+            ],
+        }
 
 
 def _build_app(
@@ -484,6 +493,31 @@ def test_create_permission_profile_requires_grant_authority_for_capabilities() -
                 "owner_scope_id": 7,
                 "mode": "custom",
                 "policy_document": {"capabilities": ["process.execute"]},
+                "is_active": True,
+            },
+        )
+
+    assert resp.status_code == 403
+    assert "grant.process.execute" in resp.json()["detail"]
+
+
+def test_create_permission_profile_rejects_string_capability_without_grant_authority() -> None:
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[SYSTEM_CONFIGURE],
+        )
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/permission-profiles",
+            json={
+                "name": "Process Exec",
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "mode": "custom",
+                "policy_document": {"capabilities": "process.execute"},
                 "is_active": True,
             },
         )
@@ -913,6 +947,26 @@ def test_list_tool_registry_modules_returns_grouped_summary() -> None:
     assert payload[0]["tool_count"] == 1
     assert payload[1]["module"] == "sandbox"
     assert payload[1]["risk_summary"]["high"] == 1
+
+
+def test_get_tool_registry_summary_returns_entries_and_modules_from_one_scan() -> None:
+    registry = _FakeToolRegistryService()
+    app = _build_app(
+        _make_principal(
+            roles=[],
+            permissions=[],
+        ),
+        tool_registry=registry,
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/tool-registry/summary")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert len(payload["entries"]) == 2
+    assert len(payload["modules"]) == 2
+    assert registry.list_entries_calls == 1
 
 
 def test_list_permission_profiles_returns_visible_rows() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py
@@ -105,7 +105,7 @@ class _FakePolicyService:
         self.approval_decisions = []
 
     async def list_permission_profiles(self, **_kwargs):
-        return list(self.permission_profiles)
+        return self.permission_profiles
 
     async def get_permission_profile(self, profile_id: int):
         for profile in self.permission_profiles:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+async def _make_repo(tmp_path, monkeypatch):
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_repo_policy_override_is_one_to_one_and_enriches_assignment_summary(
+    tmp_path, monkeypatch
+) -> None:
+    repo = await _make_repo(tmp_path, monkeypatch)
+
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=None,
+        inline_policy_document={"approval_mode": "ask_every_time"},
+        approval_policy_id=None,
+        actor_id=7,
+        is_active=True,
+    )
+
+    created = await repo.upsert_policy_override(
+        assignment_id=int(assignment["id"]),
+        override_policy_document={
+            "allowed_tools": ["remote.fetch"],
+            "approval_mode": "ask_outside_profile",
+        },
+        broadens_access=True,
+        grant_authority_snapshot={"permissions": ["grant.tool.invoke"]},
+        actor_id=7,
+        is_active=True,
+    )
+
+    updated = await repo.upsert_policy_override(
+        assignment_id=int(assignment["id"]),
+        override_policy_document={"denied_tools": ["sandbox.run"]},
+        broadens_access=False,
+        grant_authority_snapshot={"permissions": []},
+        actor_id=8,
+        is_active=False,
+    )
+
+    assert int(updated["id"]) == int(created["id"])
+    assert updated["override_policy_document"] == {"denied_tools": ["sandbox.run"]}
+    assert updated["is_active"] is False
+
+    listed = await repo.list_policy_assignments(owner_scope_type="user", owner_scope_id=7)
+    assert len(listed) == 1
+    assert listed[0]["has_override"] is True
+    assert int(listed[0]["override_id"]) == int(created["id"])
+    assert listed[0]["override_active"] is False
+    assert listed[0]["override_updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_repo_delete_policy_assignment_removes_override(tmp_path, monkeypatch) -> None:
+    repo = await _make_repo(tmp_path, monkeypatch)
+
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=None,
+        inline_policy_document={},
+        approval_policy_id=None,
+        actor_id=7,
+        is_active=True,
+    )
+    await repo.upsert_policy_override(
+        assignment_id=int(assignment["id"]),
+        override_policy_document={"allowed_tools": ["remote.fetch"]},
+        broadens_access=True,
+        grant_authority_snapshot={"permissions": ["grant.tool.invoke"]},
+        actor_id=7,
+        is_active=True,
+    )
+
+    deleted = await repo.delete_policy_assignment(int(assignment["id"]))
+
+    assert deleted is True
+    assert await repo.get_policy_override_by_assignment(int(assignment["id"])) is None
+
+
+class _ResolverRepo:
+    def __init__(self, *, override_active: bool) -> None:
+        self.profiles = {
+            1: {
+                "id": 1,
+                "name": "Base Research",
+                "is_active": True,
+                "policy_document": {
+                    "allowed_tools": ["notes.search"],
+                    "capabilities": ["filesystem.read"],
+                },
+            }
+        }
+        self.assignments = [
+            {
+                "id": 12,
+                "target_type": "persona",
+                "target_id": "researcher",
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "profile_id": 1,
+                "inline_policy_document": {
+                    "allowed_tools": ["Bash(git *)"],
+                    "approval_mode": "ask_every_time",
+                },
+                "approval_policy_id": None,
+                "is_active": True,
+            }
+        ]
+        self.overrides = {
+            12: {
+                "id": 101,
+                "assignment_id": 12,
+                "override_policy_document": {
+                    "allowed_tools": ["remote.fetch"],
+                    "approval_mode": "ask_outside_profile",
+                },
+                "is_active": override_active,
+            }
+        }
+
+    async def list_policy_assignments(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> list[dict]:
+        rows = list(self.assignments)
+        if owner_scope_type is not None:
+            rows = [row for row in rows if row["owner_scope_type"] == owner_scope_type]
+        if owner_scope_id is not None:
+            rows = [row for row in rows if row["owner_scope_id"] == owner_scope_id]
+        if target_type is not None:
+            rows = [row for row in rows if row["target_type"] == target_type]
+        if target_id is not None:
+            rows = [row for row in rows if row["target_id"] == target_id]
+        return rows
+
+    async def get_permission_profile(self, profile_id: int) -> dict | None:
+        return self.profiles.get(profile_id)
+
+    async def get_policy_override_by_assignment(self, assignment_id: int) -> dict | None:
+        return self.overrides.get(assignment_id)
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_applies_assignment_override_and_emits_provenance() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    resolver = McpHubPolicyResolver(repo=_ResolverRepo(override_active=True))
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True, "persona_id": "researcher"},
+    )
+
+    assert policy["enabled"] is True
+    assert policy["allowed_tools"] == ["notes.search", "Bash(git *)", "remote.fetch"]
+    assert policy["capabilities"] == ["filesystem.read"]
+    assert policy["approval_mode"] == "ask_outside_profile"
+    assert policy["sources"] == [
+        {
+            "assignment_id": 12,
+            "target_type": "persona",
+            "target_id": "researcher",
+            "owner_scope_type": "user",
+            "owner_scope_id": 7,
+            "profile_id": 1,
+        }
+    ]
+    assert policy["provenance"] == [
+        {
+            "field": "allowed_tools",
+            "value": ["notes.search"],
+            "source_kind": "profile",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": None,
+            "effect": "merged",
+        },
+        {
+            "field": "capabilities",
+            "value": ["filesystem.read"],
+            "source_kind": "profile",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": None,
+            "effect": "merged",
+        },
+        {
+            "field": "allowed_tools",
+            "value": ["Bash(git *)"],
+            "source_kind": "assignment_inline",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": None,
+            "effect": "merged",
+        },
+        {
+            "field": "approval_mode",
+            "value": "ask_every_time",
+            "source_kind": "assignment_inline",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": None,
+            "effect": "replaced",
+        },
+        {
+            "field": "allowed_tools",
+            "value": ["remote.fetch"],
+            "source_kind": "assignment_override",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": 101,
+            "effect": "merged",
+        },
+        {
+            "field": "approval_mode",
+            "value": "ask_outside_profile",
+            "source_kind": "assignment_override",
+            "assignment_id": 12,
+            "profile_id": 1,
+            "override_id": 101,
+            "effect": "replaced",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_ignores_inactive_assignment_override() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    resolver = McpHubPolicyResolver(repo=_ResolverRepo(override_active=False))
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True, "persona_id": "researcher"},
+    )
+
+    assert policy["enabled"] is True
+    assert policy["allowed_tools"] == ["notes.search", "Bash(git *)"]
+    assert policy["approval_mode"] == "ask_every_time"
+    assert not any(
+        entry["source_kind"] == "assignment_override" for entry in policy["provenance"]
+    )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -81,6 +81,9 @@ class _FakeRepo:
     async def get_permission_profile(self, profile_id: int) -> dict | None:
         return self.profiles.get(profile_id)
 
+    async def get_policy_override_by_assignment(self, assignment_id: int) -> dict | None:
+        return None
+
 
 @pytest.mark.asyncio
 async def test_policy_resolver_merges_default_group_and_persona_targets() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_tool_registry.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.modules.base import BaseModule, ModuleConfig, create_tool_definition
+from tldw_Server_API.app.core.MCP_unified.modules.registry import get_module_registry, register_module, reset_module_registry
+from tldw_Server_API.app.services.mcp_hub_tool_registry import McpHubToolRegistryService
+
+
+class _RegistryProbeModule(BaseModule):
+    async def on_initialize(self) -> None:
+        return None
+
+    async def on_shutdown(self) -> None:
+        return None
+
+    async def check_health(self) -> dict[str, bool]:
+        return {"ok": True}
+
+    async def get_tools(self) -> list[dict[str, Any]]:
+        return [
+            create_tool_definition(
+                name="probe.explicit",
+                description="Explicitly annotated read tool.",
+                parameters={"properties": {}, "required": []},
+                metadata={
+                    "category": "search",
+                    "risk_class": "low",
+                    "capabilities": ["filesystem.read"],
+                    "readOnlyHint": True,
+                },
+            ),
+            create_tool_definition(
+                name="probe.execute",
+                description="Execution tool derived from category.",
+                parameters={"properties": {}, "required": []},
+                metadata={"category": "execution"},
+            ),
+            create_tool_definition(
+                name="probe.unknown",
+                description="Tool with no explicit metadata.",
+                parameters={"properties": {}, "required": []},
+            ),
+        ]
+
+    async def execute_tool(self, tool_name: str, arguments: dict[str, Any], context: Any | None = None) -> Any:
+        return {"tool": tool_name, "arguments": arguments}
+
+
+@pytest.fixture(autouse=True)
+async def _reset_registry() -> None:
+    await reset_module_registry()
+    yield
+    await reset_module_registry()
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_normalizes_explicit_and_fallback_metadata() -> None:
+    await register_module("probe", _RegistryProbeModule, ModuleConfig(name="probe", description="Probe module"))
+
+    service = McpHubToolRegistryService(module_registry=get_module_registry())
+    entries = await service.list_entries()
+    by_name = {entry["tool_name"]: entry for entry in entries}
+
+    explicit = by_name["probe.explicit"]
+    assert explicit["module"] == "probe"
+    assert explicit["category"] == "search"
+    assert explicit["risk_class"] == "low"
+    assert explicit["capabilities"] == ["filesystem.read"]
+    assert explicit["metadata_source"] == "explicit"
+    assert explicit["metadata_warnings"] == []
+
+    unknown = by_name["probe.unknown"]
+    assert unknown["module"] == "probe"
+    assert unknown["risk_class"] == "unclassified"
+    assert unknown["metadata_source"] in {"heuristic", "fallback"}
+    assert unknown["metadata_warnings"]
+
+
+@pytest.mark.asyncio
+async def test_tool_registry_derives_execution_risk_and_groups_modules() -> None:
+    await register_module("probe", _RegistryProbeModule, ModuleConfig(name="probe", description="Probe module"))
+
+    service = McpHubToolRegistryService(module_registry=get_module_registry())
+    groups = await service.list_modules()
+    entries = await service.list_entries()
+    by_name = {entry["tool_name"]: entry for entry in entries}
+
+    execute = by_name["probe.execute"]
+    assert execute["module"] == "probe"
+    assert execute["category"] == "execution"
+    assert execute["risk_class"] == "high"
+    assert "process.execute" in execute["capabilities"]
+
+    assert len(groups) == 1
+    assert groups[0]["module"] == "probe"
+    assert groups[0]["tool_count"] == 3
+    assert groups[0]["risk_summary"]["high"] == 1
+


### PR DESCRIPTION
## Summary
- add the MCP Hub tool-permissions foundation, runtime approval flow, and registry-backed guided editor
- add assignment-bound overrides with nested override APIs, effective-policy provenance, and MCP Hub assignment UI support
- add persona-side effective policy summaries and runtime approval prompts backed by MCP Hub

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_migrations.py tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_api.py -v
- [x] ./apps/packages/ui/node_modules/.bin/vitest run apps/packages/ui/src/components/Option/MCPHub/__tests__
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py tldw_Server_API/app/core/AuthNZ/migrations.py tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py tldw_Server_API/app/services/mcp_hub_service.py tldw_Server_API/app/services/mcp_hub_policy_resolver.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py -f json -o /tmp/bandit_mcp_hub_override_provenance.json

## Notes
- Opened from a fresh branch because the previous tracked remote branch had unrelated divergence and could not be safely updated without force-push.
- This PR supersedes #848.