### PR TITLE
fix(media-review): render previewed item in reading pane + section nav regression test

### DIFF
--- a/Docs/Plans/2026-03-09-pr-840-review-followup-implementation-plan.md
+++ b/Docs/Plans/2026-03-09-pr-840-review-followup-implementation-plan.md
@@ -1,0 +1,114 @@
+# PR 840 Review Follow-Up Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve the remaining actionable review feedback on PR #840 by syncing the branch with its current `dev` base, fixing any real remaining UI issue, and re-running focused verification.
+
+**Architecture:** First update the branch against the current PR base so stale sandbox/admin review comments disappear from the diff if they have already landed on `dev`. Then use TDD on the remaining reading-pane navigation behavior, keeping the fix local to the media-review components and tests. Finish with targeted UI verification and scope-limited security checks only if backend files change during conflict resolution.
+
+**Tech Stack:** Git, React, TypeScript, Vitest, Testing Library, Python Bandit (conditional)
+
+---
+
+### Task 1: Capture Current Review Scope
+
+**Files:**
+- Create: `Docs/Plans/2026-03-09-pr-840-review-followup-implementation-plan.md`
+- Inspect: `apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx`
+- Inspect: `apps/packages/ui/src/components/Review/ContentRenderer.tsx`
+- Inspect: `apps/packages/ui/src/components/Review/SectionNavigator.tsx`
+
+**Step 1: Confirm the branch and review-comment inventory**
+
+Run: `git status --short --branch && git log --oneline --decorate -5`
+Expected: clean PR worktree on `feat/media-review-three-panel-redesign` with the two existing review-fix commits visible.
+
+**Step 2: Read the current reading-pane section navigation implementation**
+
+Run: `sed -n '720,820p' apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx`
+Expected: current implementation uses text/heading lookup and `scrollIntoView`, not character offsets.
+
+**Step 3: Record the only still-actionable behavior to verify**
+
+Behavior: selecting a section from `SectionNavigator` should scroll to the rendered heading/timestamp anchor in the reading pane.
+
+### Task 2: Sync the PR Branch with Current `dev`
+
+**Files:**
+- Modify: merge state on current branch only
+
+**Step 1: Merge the latest `dev` into the PR branch**
+
+Run: `git merge origin/dev`
+Expected: merge commit created cleanly, or conflicts reported in files that overlap with this PR.
+
+**Step 2: Resolve conflicts minimally**
+
+Rule: keep the media-review redesign behavior from this branch, accept `dev` for unrelated sandbox/admin/docs files unless the PR still requires branch-specific edits.
+
+**Step 3: Verify the post-merge diff**
+
+Run: `git diff --stat origin/dev...HEAD`
+Expected: only files that still belong to the PR remain in the diff; stale sandbox/admin-only diffs should disappear if they were already merged to `dev`.
+
+### Task 3: Add the Failing Regression Test First
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx`
+- Modify: `apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx`
+- Optional Modify: `apps/packages/ui/src/components/Review/ContentRenderer.tsx`
+
+**Step 1: Write a failing test for section navigation**
+
+Test behavior:
+- Render a reading pane with markdown headings or transcript sections.
+- Open the section navigator.
+- Select a section.
+- Assert the corresponding rendered element receives `scrollIntoView`.
+
+**Step 2: Run only that test and watch it fail**
+
+Run: `source .venv/bin/activate && bunx vitest run apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx -t "section navigator scrolls to rendered anchors"`
+Expected: FAIL for the new test before implementation changes.
+
+### Task 4: Implement the Minimal Fix
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx`
+- Optional Modify: `apps/packages/ui/src/components/Review/ContentRenderer.tsx`
+
+**Step 1: Implement stable anchor lookup for section navigation**
+
+Preferred approach:
+- Use actual rendered DOM anchors or deterministic query targets.
+- Avoid character-offset-to-pixel math.
+- Keep the fix scoped to the reading pane/content renderer.
+
+**Step 2: Re-run the targeted test**
+
+Run: `source .venv/bin/activate && bunx vitest run apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx -t "section navigator scrolls to rendered anchors"`
+Expected: PASS.
+
+### Task 5: Verify Review Fixes End-to-End
+
+**Files:**
+- Verify: `apps/packages/ui/src/components/Review/hooks/useMediaReviewActions.tsx`
+- Verify: `apps/packages/ui/src/components/Review/hooks/useMediaReviewKeyboard.ts`
+- Verify: `apps/packages/ui/src/components/Review/hooks/useSyncedScroll.ts`
+- Verify: `apps/packages/ui/src/components/Review/interaction-context.ts`
+- Verify: `apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx`
+
+**Step 1: Run focused media-review tests**
+
+Run: `source .venv/bin/activate && bunx vitest run apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage1.selectionLimit.test.tsx apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage6.keyboard-scope.test.tsx apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx apps/packages/ui/src/components/Review/__tests__/ComparisonSplit.test.tsx`
+Expected: all targeted tests pass.
+
+**Step 2: Run Bandit only if backend files changed during merge/conflict resolution**
+
+Run: `source .venv/bin/activate && python -m bandit -r <touched_backend_paths> -f json -o /tmp/bandit_pr840_review_followup.json`
+Expected: no new findings in touched backend scope.
+
+**Step 3: Inspect final diff**
+
+Run: `git status --short && git diff --stat`
+Expected: only intentional PR review-follow-up changes remain.

--- a/apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
+++ b/apps/packages/ui/src/components/Review/MediaReviewReadingPane.tsx
@@ -910,6 +910,13 @@ export const MediaReviewReadingPane: React.FC<MediaReviewReadingPaneProps> = ({ 
                 </div>
               )}
             </div>
+          ) : showPreviewMode && previewedDetail ? (
+            <div
+              ref={viewerParentRef}
+              className="relative flex-1 min-h-0 overflow-auto"
+            >
+              {renderCard(previewedDetail, 0)}
+            </div>
           ) : (
             <>
               <div

--- a/apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx
+++ b/apps/packages/ui/src/components/Review/__tests__/MediaReviewPage.stage7.three-panel.test.tsx
@@ -350,12 +350,19 @@ vi.mock("@/components/Common/Markdown", () => ({
 vi.mock("@/components/Review/ContentRenderer", () => ({
   ContentRenderer: ({
     content,
-    headingAnchorIds = []
+    headingAnchorIds: explicitIds
   }: {
     content: string
     headingAnchorIds?: string[]
   }) => {
     const React = require('react') as typeof import('react')
+
+    // Auto-generate heading anchor IDs from content (mirrors real ContentRenderer behavior)
+    const autoIds: string[] = []
+    content.split('\n').forEach((line, i) => {
+      if (/^#{1,6}\s+/.test(line)) autoIds.push(`section-${i}`)
+    })
+    const anchorIds = explicitIds && explicitIds.length > 0 ? explicitIds : autoIds
     let headingIndex = 0
 
     return (
@@ -364,7 +371,7 @@ vi.mock("@/components/Review/ContentRenderer", () => ({
           const headingMatch = line.match(/^(#{1,6})\s+(.+)$/)
           if (headingMatch) {
             const level = Math.min(headingMatch[1].length, 6)
-            const anchorId = headingAnchorIds[headingIndex]
+            const anchorId = anchorIds[headingIndex]
             headingIndex += 1
             return React.createElement(`h${level}`, {
               key: `${line}-${index}`,
@@ -740,6 +747,63 @@ describe('MediaReviewPage stage7 three-panel layout', () => {
 
     await waitFor(() => {
       expect(screen.getByText('1 / 30 selected')).toBeInTheDocument()
+    })
+  })
+
+  it('section navigator scrolls to rendered anchors', async () => {
+    const headingContent = '## Introduction\nSome intro text.\n## Methods\nMethodology here.\n## Results\nFindings.'
+
+    mocks.bgRequest.mockImplementation(async (request: { path?: string }) => {
+      const path = String(request?.path || '')
+      const idMatch = path.match(/\/api\/v1\/media\/([^?]+)/)
+      const id = idMatch ? Number(idMatch[1]) : 1
+      return {
+        id,
+        title: `Item ${id}`,
+        type: 'pdf',
+        content: headingContent
+      }
+    })
+
+    render(<MediaReviewPage />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('resizable-panels')).toBeInTheDocument()
+    })
+
+    // Preview Item 1 to load its content into the reading pane
+    fireEvent.click(getResultRowByTitle('Item 1'))
+
+    // Wait for the content to appear in the reading pane via ContentRenderer
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-content-renderer')).toBeInTheDocument()
+    })
+
+    // Verify anchors rendered by mock ContentRenderer
+    const rendererEl = screen.getByTestId('mock-content-renderer')
+    const h2s = rendererEl.querySelectorAll('h2')
+    expect(h2s.length).toBe(3)
+    const anchorAttrs = Array.from(h2s).map(h => h.getAttribute('data-section-anchor'))
+    expect(anchorAttrs).toEqual(['section-0', 'section-2', 'section-4'])
+
+    // Mock scrollIntoView on all heading elements
+    h2s.forEach((h) => {
+      h.scrollIntoView = vi.fn()
+    })
+
+    // The SectionNavigator should appear (3 sections detected from headings)
+    const sectionButton = screen.getByTestId('section-navigator')
+    expect(sectionButton).toBeInTheDocument()
+
+    // The mock Dropdown renders section items as buttons — click the "Methods" section
+    const methodsButton = screen.getByRole('button', { name: /Methods/ })
+    fireEvent.click(methodsButton)
+
+    // scrollSectionIntoView should find the heading with data-section-anchor="section-2"
+    await waitFor(() => {
+      const anchoredHeading = document.querySelector('[data-section-anchor="section-2"]')
+      expect(anchoredHeading).toBeTruthy()
+      expect(anchoredHeading!.scrollIntoView).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fix reading pane preview mode: previewed item content was not rendered because the card area used `viewerItems` (selected items list, empty when no selection) instead of `effectiveItems`. Added a dedicated preview-mode branch that renders `previewedDetail` directly.
- Add regression test for section navigator scroll-to-anchor behavior: renders markdown headings, clicks a section, asserts `scrollIntoView` is called on the correct `data-section-anchor` element.
- Update ContentRenderer mock to auto-generate `data-section-anchor` attributes from heading lines (mirrors real ContentRenderer behavior).

## Test plan
- [x] New test: "section navigator scrolls to rendered anchors" — red before fix, green after
- [x] All 27 Review test files pass (163 tests)
- [ ] Manual: navigate to /media-multi, click a result row without selecting — verify content appears in reading pane
- [ ] Manual: with heading content visible, click Sections dropdown and select a heading — verify scroll to that heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)