### PR TITLE
feat: add macOS sandbox admin diagnostics

### DIFF
--- a/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md
+++ b/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md
@@ -19,7 +19,7 @@ The design stays conservative:
 - diagnostics are operator-facing, not client-facing
 - detailed host paths and remediation hints remain admin-only
 - readiness distinguishes `host not ready` from `policy unsupported`
-- probe logic should become the single source of truth for macOS runtime readiness rather than drifting separately inside each runner and API surface
+- diagnostics should share low-level facts with the existing runner preflight path instead of inventing a second runtime-readiness engine
 
 ## 2. User-Confirmed Decisions
 
@@ -82,6 +82,8 @@ These probes should consume the same config and environment knobs already used b
 
 That keeps the endpoint safe for operators, tests, and future health checks.
 
+For runtime-level availability and reasons, phase 1 should prefer existing runner preflight contracts over a new parallel interpretation layer. In practice, the diagnostics module should derive runtime entries from the same runner preflight results already used by admission and feature discovery, then layer on extra operator metadata such as helper/template configuration detail.
+
 ### 5.2 Admin diagnostics endpoint
 
 Add an admin-only endpoint under the existing sandbox router:
@@ -128,6 +130,8 @@ This section answers whether the machine is even a valid target for the macOS ru
 
 This section must separate “not configured” from “configured incorrectly” and “configured but not ready.” That distinction matters for operator remediation and test assertions.
 
+Because the current scaffold only has boolean readiness flags, phase 1 should treat `path` and `transport` as optional fields. If no explicit helper-path configuration exists yet, `path` may be `null`, `configured` should be `false`, and `transport` should remain `null` except for known cases such as `fake` in test mode.
+
 ### 6.3 `templates`
 
 Return one entry per template-backed runtime, initially at least:
@@ -143,6 +147,8 @@ Each entry should include:
 - `reasons`
 
 The design intentionally avoids promising a richer image-store contract in this slice. The goal is readiness proof, not full template management.
+
+Like helper metadata, `source` should be optional in phase 1. If the runtime only exposes template readiness booleans today, diagnostics may return `source=null` until an explicit operator-facing template source contract exists.
 
 ### 6.4 `runtimes`
 
@@ -164,7 +170,7 @@ This section is the derived operator view. It should explain the runtime’s cur
 
 ## 7. Readiness Semantics
 
-The diagnostics layer should use explicit derived states:
+The diagnostics layer should use explicit derived states internally:
 
 - `ready`
 - `degraded`
@@ -186,6 +192,8 @@ Examples:
 - `vz_linux` may have a valid host and template but still report `execution_mode=none` until real execution is implemented
 
 This distinction should survive into tests and user-visible remediation text.
+
+Phase 1 does not have to expose a separate `status` field if that would widen the schema unnecessarily. Booleans plus reason codes are acceptable as the stable contract, as long as internal derivation still distinguishes these cases consistently.
 
 ## 8. Security and Data Exposure
 
@@ -211,7 +219,7 @@ Land the diagnostics layer first as a standalone module and admin endpoint.
 
 ### 9.2 Reuse in runtime discovery
 
-After the probe contract is trustworthy, refactor runtime discovery and preflight collection to reuse shared helpers where practical. The goal is to reduce duplicate readiness rules without forcing a risky “big bang” refactor into one patch.
+After the probe contract is trustworthy, refactor diagnostics and runtime discovery to share the same runner preflight inputs where practical. The goal is to reduce duplicate readiness rules without forcing a risky “big bang” refactor into one patch.
 
 ### 9.3 Execution-time truth remains authoritative
 
@@ -243,6 +251,7 @@ Diagnostics help operators understand readiness, but they do not replace authori
 2. Helper probe distinguishes missing path, non-executable helper, and ready helper.
 3. Template probe distinguishes configured versus ready template state per runtime.
 4. Runtime status derivation separates host-readiness failures from policy-limit failures.
+5. Admin runtime diagnostics stay aligned with the same runner preflight reasons used by `/api/v1/sandbox/runtimes`.
 
 ### API tests
 

--- a/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md
+++ b/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md
@@ -1,0 +1,264 @@
+# macOS Sandbox Admin Diagnostics Design
+
+Date: 2026-03-10
+Status: Approved for planning
+Scope: `tldw_Server_API/app/core/Sandbox/` diagnostics, sandbox admin API, and runtime discovery reuse
+
+## 1. Summary
+
+This design adds a dedicated admin-only macOS diagnostics surface for sandbox runtime readiness while keeping `GET /api/v1/sandbox/runtimes` concise.
+
+The selected direction is:
+
+- a shared, side-effect-free diagnostics probe layer
+- a new admin endpoint for detailed macOS host/helper/template/runtime posture
+- summarized reuse of the same probe results in `/api/v1/sandbox/runtimes`
+
+The design stays conservative:
+
+- diagnostics are operator-facing, not client-facing
+- detailed host paths and remediation hints remain admin-only
+- readiness distinguishes `host not ready` from `policy unsupported`
+- probe logic should become the single source of truth for macOS runtime readiness rather than drifting separately inside each runner and API surface
+
+## 2. User-Confirmed Decisions
+
+1. The next macOS sandbox milestone should optimize for production-grade host readiness and operator tooling first.
+2. The first slice in that milestone is host diagnostics and preflight proof.
+3. The proof should surface first through a dedicated admin diagnostics endpoint, while `/sandbox/runtimes` stays summarized.
+
+## 3. Problem
+
+The merged macOS sandbox runtime scaffolds expose runtime identities and preflight-based availability, but there is not yet a clear operator surface for answering basic readiness questions such as:
+
+- Is this host actually supported for `vz_linux` or `vz_macos`?
+- Is the native helper configured, present, executable, and ready?
+- Are the required templates configured and ready per runtime?
+- Is the runtime unavailable because of host posture, missing assets, or trust-policy restrictions?
+
+Today that information is either not exposed, partially duplicated across preflight code, or too coarse for operators who need to bring up Apple silicon hosts reliably.
+
+Without a dedicated diagnostics layer:
+
+- `/sandbox/runtimes` risks expanding into an operator dump instead of a client discovery contract
+- readiness rules will drift between runners, service discovery, and any future helper/image-store tooling
+- support triage will be slower because detailed reasons and remediation steps are missing
+
+## 4. Goals and Non-Goals
+
+### Goals
+
+1. Add a reusable macOS diagnostics module that evaluates host, helper, template, and runtime readiness.
+2. Expose a new admin-only endpoint with structured diagnostics and remediation hints.
+3. Keep `/api/v1/sandbox/runtimes` concise while reusing the same probe results where possible.
+4. Distinguish `policy unsupported` from `host not ready` in a way operators and tests can rely on.
+5. Keep the first diagnostics slice side-effect free and safe to call repeatedly.
+
+### Non-Goals
+
+1. Implementing real VM execution or real seatbelt command execution in this slice.
+2. Replacing runtime-specific execution-time preflight checks with a one-time startup cache.
+3. Exposing detailed local filesystem paths or helper posture to non-admin callers.
+4. Building a full operator CLI or janitor workflow in the same change.
+
+## 5. Selected Architecture
+
+### 5.1 Shared diagnostics probe layer
+
+Add a new sandbox-core module, likely `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`, with pure or near-pure probe functions:
+
+- `probe_host()`
+- `probe_helper()`
+- `probe_templates()`
+- `probe_runtime_statuses()`
+- `collect_macos_diagnostics()`
+
+These probes should consume the same config and environment knobs already used by the macOS runners, but they should avoid changing system state. The first release should not:
+
+- start the helper
+- mutate templates
+- create clones
+- boot VMs
+
+That keeps the endpoint safe for operators, tests, and future health checks.
+
+### 5.2 Admin diagnostics endpoint
+
+Add an admin-only endpoint under the existing sandbox router:
+
+- `GET /api/v1/sandbox/admin/macos-diagnostics`
+
+It should use the same admin auth pattern already present on sandbox admin endpoints (`require_roles("admin")`) and return a strongly typed Pydantic response model rather than a raw dict.
+
+### 5.3 Shared reuse with `/sandbox/runtimes`
+
+`GET /api/v1/sandbox/runtimes` should remain a discovery contract, not a full operator report. It may reuse probe results internally, but it should keep returning summarized runtime entries:
+
+- `available`
+- `reasons`
+- `supported_trust_levels`
+- existing enforcement and host summary fields already exposed today
+
+The public route should not include the full helper/template posture or detailed remediation hints.
+
+## 6. Diagnostics Payload
+
+The admin endpoint should return four top-level sections.
+
+### 6.1 `host`
+
+- `os`
+- `arch`
+- `apple_silicon`
+- `macos_version`
+- `supported`
+- `reasons`
+
+This section answers whether the machine is even a valid target for the macOS runtime family.
+
+### 6.2 `helper`
+
+- `configured`
+- `path`
+- `exists`
+- `executable`
+- `ready`
+- `transport`
+- `reasons`
+
+This section must separate “not configured” from “configured incorrectly” and “configured but not ready.” That distinction matters for operator remediation and test assertions.
+
+### 6.3 `templates`
+
+Return one entry per template-backed runtime, initially at least:
+
+- `vz_linux`
+- `vz_macos`
+
+Each entry should include:
+
+- `configured`
+- `ready`
+- `source`
+- `reasons`
+
+The design intentionally avoids promising a richer image-store contract in this slice. The goal is readiness proof, not full template management.
+
+### 6.4 `runtimes`
+
+Return entries for:
+
+- `vz_linux`
+- `vz_macos`
+- `seatbelt`
+
+Each runtime entry should include:
+
+- `available`
+- `supported_trust_levels`
+- `reasons`
+- `execution_mode` with `fake`, `real`, or `none`
+- `remediation`
+
+This section is the derived operator view. It should explain the runtime’s current usability after combining host facts, helper readiness, template readiness, and policy limits.
+
+## 7. Readiness Semantics
+
+The diagnostics layer should use explicit derived states:
+
+- `ready`
+- `degraded`
+- `unavailable`
+
+But the more important contract is the distinction between two different failure classes:
+
+1. `host not ready`
+   - unsupported OS/arch
+   - helper missing or not executable
+   - template missing
+   - execution mode not actually wired
+2. `policy unsupported`
+   - runtime may be host-ready, but the requested or allowed trust level is narrower than the operator expects
+
+Examples:
+
+- `seatbelt` may be host-ready while still rejecting `standard` or `untrusted`
+- `vz_linux` may have a valid host and template but still report `execution_mode=none` until real execution is implemented
+
+This distinction should survive into tests and user-visible remediation text.
+
+## 8. Security and Data Exposure
+
+The admin endpoint should be treated as privileged because it can expose:
+
+- helper paths
+- template source paths
+- detailed host posture
+- remediation hints that reveal local setup assumptions
+
+Design constraints:
+
+1. Keep it behind existing sandbox admin authorization.
+2. Keep `/sandbox/runtimes` summarized.
+3. Prefer machine-readable reason codes plus short remediation text instead of raw exception dumps.
+4. Do not expose secrets, tokens, or environment variable values directly.
+
+## 9. Integration Strategy
+
+### 9.1 First integration target
+
+Land the diagnostics layer first as a standalone module and admin endpoint.
+
+### 9.2 Reuse in runtime discovery
+
+After the probe contract is trustworthy, refactor runtime discovery and preflight collection to reuse shared helpers where practical. The goal is to reduce duplicate readiness rules without forcing a risky “big bang” refactor into one patch.
+
+### 9.3 Execution-time truth remains authoritative
+
+Diagnostics help operators understand readiness, but they do not replace authoritative execution-time checks in the runners and service layer. The system should still fail closed if runtime state changes after a successful diagnostic call.
+
+## 10. Potential Problems and Improvements Identified During Review
+
+1. Probe duplication risk
+   - If diagnostics invent their own readiness logic instead of sharing runner config/rules, they will drift quickly.
+   - Improvement: centralize helper/template fact gathering and have runners consume the same low-level helpers over time.
+
+2. Over-eager helper probing
+   - A “ready” check that launches processes, performs writes, or mutates state would make the endpoint unsafe and flaky.
+   - Improvement: keep probes read-only in this slice, and add richer handshake checks only when the helper protocol is stable.
+
+3. Overloading `/sandbox/runtimes`
+   - Putting the full diagnostics payload into the public discovery route would weaken the API contract and leak operator internals.
+   - Improvement: keep the admin endpoint detailed and the public route intentionally shallow.
+
+4. Startup-cache trap
+   - A startup-only readiness cache would hide transient local changes and produce stale operator data.
+   - Improvement: compute diagnostics on demand first; add caching only if the probes become expensive and cache invalidation is well defined.
+
+## 11. Testing Strategy
+
+### Unit tests
+
+1. Host probe returns correct support state for macOS versus non-macOS and Apple silicon versus non-Apple silicon.
+2. Helper probe distinguishes missing path, non-executable helper, and ready helper.
+3. Template probe distinguishes configured versus ready template state per runtime.
+4. Runtime status derivation separates host-readiness failures from policy-limit failures.
+
+### API tests
+
+1. Admin-only access is enforced on `/api/v1/sandbox/admin/macos-diagnostics`.
+2. Response schema contains the expected top-level sections and detailed runtime entries.
+3. `/api/v1/sandbox/runtimes` remains summarized and does not expose admin-only helper/template detail.
+
+### Host-gated smoke tests
+
+1. On Apple silicon macOS test hosts, verify the real host probe and any real version parsing.
+2. Keep these tests gated so the main suite remains deterministic on non-macOS CI.
+
+## 12. Acceptance Criteria
+
+1. A new admin-only macOS diagnostics endpoint returns structured host/helper/template/runtime readiness data.
+2. `/api/v1/sandbox/runtimes` remains summarized and does not become the operator diagnostics surface.
+3. Readiness semantics clearly distinguish host/setup failures from policy restrictions.
+4. The first diagnostics slice is side-effect free and safe to call repeatedly.
+5. Tests cover probe behavior, admin authorization, and the summarized discovery contract.

--- a/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-implementation-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an admin-only macOS sandbox diagnostics endpoint backed by a shared probe layer, while keeping `/api/v1/sandbox/runtimes` summarized and aligned with the same readiness logic.
 
-**Architecture:** Add a new `macos_diagnostics.py` probe module in the sandbox core to compute host/helper/template/runtime readiness from existing config and env signals. Expose that payload through `SandboxService` and a new admin route, then reuse only the runtime summary subset inside `feature_discovery()` so the public discovery contract stays shallow.
+**Architecture:** Add a new `macos_diagnostics.py` probe module in the sandbox core to compute host/helper/template/runtime readiness from existing config and env signals. Derive the runtime subsection from the same runner preflight path already used by admission and feature discovery, then layer on extra operator metadata such as optional helper/template source details. Expose that payload through `SandboxService` and a new admin route while keeping `/api/v1/sandbox/runtimes` shallow.
 
 **Tech Stack:** FastAPI, Pydantic, pytest, existing sandbox runtime preflight code, Loguru, Bandit
 
@@ -33,16 +33,23 @@ from tldw_Server_API.app.core.Sandbox.macos_diagnostics import collect_macos_dia
 def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypatch) -> None:
     monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.macos_diagnostics.sys.platform", "darwin")
     monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.macos_diagnostics.platform.machine", lambda: "arm64")
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_PATH", raising=False)
     monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", raising=False)
     monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
     monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", raising=False)
 
     data = collect_macos_diagnostics()
 
     assert data["host"]["supported"] is True
+    assert data["helper"]["configured"] is False
+    assert data["helper"]["path"] is None
     assert data["helper"]["ready"] is False
+    assert data["templates"]["vz_linux"]["configured"] is False
+    assert data["templates"]["vz_linux"]["source"] is None
     assert data["templates"]["vz_linux"]["ready"] is False
     assert "macos_helper_missing" in data["runtimes"]["vz_linux"]["reasons"]
+    assert data["runtimes"]["vz_linux"]["execution_mode"] == "none"
 
 
 def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypatch) -> None:
@@ -53,6 +60,16 @@ def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypa
 
     assert data["runtimes"]["seatbelt"]["supported_trust_levels"] == ["trusted"]
     assert data["runtimes"]["seatbelt"]["available"] in (True, False)
+
+
+def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_PATH", "/tmp/macos-helper")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
+
+    data = collect_macos_diagnostics()
+
+    assert data["helper"]["path"] == "/tmp/macos-helper"
+    assert data["templates"]["vz_linux"]["source"] == "/tmp/vz-linux.img"
 ```
 
 **Step 2: Run the tests to verify they fail**
@@ -91,7 +108,13 @@ def collect_macos_diagnostics() -> dict[str, object]:
     host = probe_host()
     helper = probe_helper()
     templates = probe_templates()
-    runtimes = probe_runtime_statuses(host=host, helper=helper, templates=templates)
+    runtime_preflights = collect_runtime_preflights(network_policy="deny_all")
+    runtimes = probe_runtime_statuses(
+        runtime_preflights=runtime_preflights,
+        host=host,
+        helper=helper,
+        templates=templates,
+    )
     return {
         "host": host,
         "helper": helper,
@@ -99,6 +122,14 @@ def collect_macos_diagnostics() -> dict[str, object]:
         "runtimes": runtimes,
     }
 ```
+
+Add a minimal diagnostics-only metadata contract for operator detail:
+
+- `TLDW_SANDBOX_MACOS_HELPER_PATH`
+- `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE`
+- `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_SOURCE`
+
+These keys should be optional. When they are absent, the diagnostics payload should return `path=None` / `source=None` rather than inventing fake filesystem locations.
 
 Keep this slice read-only:
 
@@ -298,15 +329,14 @@ git add tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/tests/sa
 git commit -m "feat: add sandbox admin macOS diagnostics endpoint"
 ```
 
-### Task 4: Reuse the Probe Results in `/sandbox/runtimes` Without Leaking Admin Detail
+### Task 4: Keep `/sandbox/runtimes` Summarized and Aligned With Shared Preflight Inputs
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/Sandbox/service.py`
-- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
 - Modify: `tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py`
 - Check: `tldw_Server_API/tests/sandbox/test_lima_feature_discovery_capabilities.py`
 
-**Step 1: Write the failing summary-contract tests**
+**Step 1: Write the failing alignment and summary-contract tests**
 
 Add a new test to `test_feature_discovery_flags.py`:
 
@@ -329,7 +359,23 @@ def test_runtimes_discovery_keeps_macos_diagnostics_summarized(monkeypatch) -> N
     assert isinstance(vz_linux.get("host"), dict)
 ```
 
-Also add a test that derived runtime reasons still reflect the shared diagnostics inputs rather than a second, divergent code path.
+Also add a test that the admin diagnostics runtime subsection stays aligned with the same preflight facts used by feature discovery:
+
+```python
+def test_macos_diagnostics_runtime_reasons_align_with_feature_discovery(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "0")
+    clear_config_cache()
+
+    svc = SandboxService()
+    diagnostics = svc.macos_diagnostics()
+    discovery = {item["name"]: item for item in svc.feature_discovery()}
+
+    assert diagnostics["runtimes"]["vz_linux"]["reasons"] == discovery["vz_linux"]["reasons"]
+    assert diagnostics["runtimes"]["vz_macos"]["reasons"] == discovery["vz_macos"]["reasons"]
+    assert diagnostics["runtimes"]["seatbelt"]["supported_trust_levels"] == discovery["seatbelt"]["supported_trust_levels"]
+```
 
 **Step 2: Run the discovery tests to verify they fail**
 
@@ -339,19 +385,11 @@ Run:
 python -m pytest tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py -q
 ```
 
-Expected: FAIL because `feature_discovery()` still derives its macOS status independently.
+Expected: FAIL if the new diagnostics runtime section is derived from a parallel logic path instead of the same preflight inputs.
 
-**Step 3: Refactor `feature_discovery()` to reuse shared diagnostics**
+**Step 3: Refactor only as needed to keep both views aligned**
 
-Keep Docker, Firecracker, and Lima behavior intact. Only refactor the macOS-specific runtime entries to read from the shared diagnostics contract or shared low-level helpers.
-
-Use a small helper inside `service.py` if needed:
-
-```python
-def _macos_runtime_summary(self) -> dict[str, dict[str, object]]:
-    diagnostics = self.macos_diagnostics()
-    return diagnostics["runtimes"]
-```
+Keep Docker, Firecracker, and Lima behavior intact. The important requirement is that macOS runtime diagnostics and `/sandbox/runtimes` must reflect the same underlying preflight reasons and supported trust levels. If `feature_discovery()` already uses the shared preflight path, do not add an unnecessary second abstraction just to satisfy the task wording.
 
 Preserve the public summary boundary:
 
@@ -371,7 +409,7 @@ Expected: PASS.
 **Step 5: Commit**
 
 ```bash
-git add tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
+git add tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
 git commit -m "feat: reuse macOS diagnostics in runtime discovery"
 ```
 
@@ -383,7 +421,7 @@ git commit -m "feat: reuse macOS diagnostics in runtime discovery"
 - Modify: `tldw_Server_API/app/core/Sandbox/README.md`
 - Check: `Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md`
 
-**Step 1: Write the failing host-gated smoke test**
+**Step 1: Add the host-gated diagnostics smoke test**
 
 Extend `test_vz_runtime_macos_host_gated.py` with a diagnostics smoke test:
 
@@ -398,7 +436,7 @@ def test_collect_macos_diagnostics_smoke_on_real_host() -> None:
     assert isinstance(data["host"].get("macos_version"), (str, type(None)))
 ```
 
-**Step 2: Run the smoke test to verify it fails**
+**Step 2: Run the smoke test**
 
 Run:
 
@@ -406,7 +444,7 @@ Run:
 python -m pytest tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py -q
 ```
 
-Expected: FAIL on missing import or missing `macos_version` field before the final probe contract is complete.
+Expected: PASS once the diagnostics contract is in place. Treat this as host-gated verification rather than a forced red phase.
 
 **Step 3: Finish the last implementation bits and update the docs**
 

--- a/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-implementation-plan.md
@@ -1,0 +1,466 @@
+# macOS Sandbox Admin Diagnostics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add an admin-only macOS sandbox diagnostics endpoint backed by a shared probe layer, while keeping `/api/v1/sandbox/runtimes` summarized and aligned with the same readiness logic.
+
+**Architecture:** Add a new `macos_diagnostics.py` probe module in the sandbox core to compute host/helper/template/runtime readiness from existing config and env signals. Expose that payload through `SandboxService` and a new admin route, then reuse only the runtime summary subset inside `feature_discovery()` so the public discovery contract stays shallow.
+
+**Tech Stack:** FastAPI, Pydantic, pytest, existing sandbox runtime preflight code, Loguru, Bandit
+
+**Environment note:** Before any `python` or `pytest` command in this plan, activate the project virtual environment. In a linked worktree, use the shared repo virtualenv from the main checkout rather than assuming the worktree has its own `.venv`.
+
+---
+
+### Task 1: Build the Shared macOS Diagnostics Probe Layer
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Sandbox/macos_diagnostics.py`
+- Check: `tldw_Server_API/app/core/Sandbox/runners/vz_common.py`
+- Check: `tldw_Server_API/app/core/Sandbox/runners/seatbelt_runner.py`
+- Check: `tldw_Server_API/app/core/Sandbox/macos_virtualization/helper_client.py`
+- Check: `tldw_Server_API/app/core/Sandbox/image_store.py`
+- Test: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+
+**Step 1: Write the failing probe tests**
+
+Create `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py` with focused unit tests for host, helper, template, and derived runtime status behavior:
+
+```python
+from tldw_Server_API.app.core.Sandbox.macos_diagnostics import collect_macos_diagnostics
+
+
+def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypatch) -> None:
+    monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.macos_diagnostics.sys.platform", "darwin")
+    monkeypatch.setattr("tldw_Server_API.app.core.Sandbox.macos_diagnostics.platform.machine", lambda: "arm64")
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", raising=False)
+
+    data = collect_macos_diagnostics()
+
+    assert data["host"]["supported"] is True
+    assert data["helper"]["ready"] is False
+    assert data["templates"]["vz_linux"]["ready"] is False
+    assert "macos_helper_missing" in data["runtimes"]["vz_linux"]["reasons"]
+
+
+def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypatch) -> None:
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
+
+    data = collect_macos_diagnostics()
+
+    assert data["runtimes"]["seatbelt"]["supported_trust_levels"] == ["trusted"]
+    assert data["runtimes"]["seatbelt"]["available"] in (True, False)
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: FAIL because `macos_diagnostics.py` does not exist yet.
+
+**Step 3: Write the minimal diagnostics implementation**
+
+Implement a side-effect-free probe module that returns one top-level payload with `host`, `helper`, `templates`, and `runtimes`.
+
+Start with simple helpers like:
+
+```python
+def probe_host() -> dict[str, object]:
+    facts = vz_host_facts()
+    reasons: list[str] = []
+    if facts["os"] != "darwin":
+        reasons.append("macos_required")
+    if not facts["apple_silicon"]:
+        reasons.append("apple_silicon_required")
+    return {
+        **facts,
+        "macos_version": platform.mac_ver()[0] or None,
+        "supported": not reasons,
+        "reasons": reasons,
+    }
+
+
+def collect_macos_diagnostics() -> dict[str, object]:
+    host = probe_host()
+    helper = probe_helper()
+    templates = probe_templates()
+    runtimes = probe_runtime_statuses(host=host, helper=helper, templates=templates)
+    return {
+        "host": host,
+        "helper": helper,
+        "templates": templates,
+        "runtimes": runtimes,
+    }
+```
+
+Keep this slice read-only:
+
+- do not start the helper
+- do not create templates or clones
+- do not boot VMs
+
+**Step 4: Run the probe tests again**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+git commit -m "feat: add macOS sandbox diagnostics probes"
+```
+
+### Task 2: Add Service Accessors and Typed Admin Response Models
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py`
+- Check: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Test: `tldw_Server_API/tests/sandbox/test_macos_diagnostics.py`
+
+**Step 1: Extend the failing tests for service and schema coverage**
+
+Add tests that prove the service exposes diagnostics and the admin schema accepts the payload:
+
+```python
+from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import SandboxAdminMacOSDiagnosticsResponse
+from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+
+def test_service_macos_diagnostics_returns_probe_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Sandbox.service.collect_macos_diagnostics",
+        lambda: {"host": {}, "helper": {}, "templates": {}, "runtimes": {}},
+    )
+    svc = SandboxService()
+    assert svc.macos_diagnostics() == {"host": {}, "helper": {}, "templates": {}, "runtimes": {}}
+
+
+def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
+    payload = {
+        "host": {"os": "darwin", "arch": "arm64", "apple_silicon": True, "macos_version": "15.0", "supported": True, "reasons": []},
+        "helper": {"configured": True, "path": "/tmp/helper", "exists": True, "executable": True, "ready": True, "transport": "fake", "reasons": []},
+        "templates": {"vz_linux": {"configured": True, "ready": True, "source": "/tmp/vz-linux.img", "reasons": []}},
+        "runtimes": {"vz_linux": {"available": True, "supported_trust_levels": ["trusted", "standard", "untrusted"], "reasons": [], "execution_mode": "fake", "remediation": None}},
+    }
+    model = SandboxAdminMacOSDiagnosticsResponse.model_validate(payload)
+    assert model.host.supported is True
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: FAIL because the service accessor and admin response models do not exist yet.
+
+**Step 3: Add the service method and Pydantic models**
+
+In `service.py`, add a small pass-through:
+
+```python
+from .macos_diagnostics import collect_macos_diagnostics
+
+
+def macos_diagnostics(self) -> dict[str, object]:
+    return collect_macos_diagnostics()
+```
+
+In `sandbox_schemas.py`, add explicit admin models for:
+
+- host status
+- helper status
+- template status
+- runtime diagnostics entry
+- top-level admin response
+
+Keep these separate from `SandboxRuntimeInfo`. The admin model is richer and should not silently widen the public discovery schema.
+
+**Step 4: Run the tests again**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+git commit -m "feat: add macOS sandbox diagnostics service contract"
+```
+
+### Task 3: Add the Admin Diagnostics Endpoint and RBAC Coverage
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/sandbox.py`
+- Create: `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_admin_rbac.py`
+- Modify: `tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py`
+
+**Step 1: Write the failing endpoint and authorization tests**
+
+Create `tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py`:
+
+```python
+def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sandbox_mod._service,
+        "macos_diagnostics",
+        lambda: {
+            "host": {"os": "darwin", "arch": "arm64", "apple_silicon": True, "macos_version": "15.0", "supported": True, "reasons": []},
+            "helper": {"configured": False, "path": None, "exists": False, "executable": False, "ready": False, "transport": None, "reasons": ["macos_helper_missing"]},
+            "templates": {},
+            "runtimes": {},
+        },
+        raising=False,
+    )
+    with TestClient(_build_app_with_overrides(_make_principal(roles=[ROLE_ADMIN], is_admin=True))) as client:
+        resp = client.get("/api/v1/sandbox/admin/macos-diagnostics")
+    assert resp.status_code == 200
+    assert set(resp.json().keys()) == {"host", "helper", "templates", "runtimes"}
+```
+
+Extend `test_admin_rbac.py` and `test_sandbox_admin_permissions_claims.py` to include:
+
+```python
+"/api/v1/sandbox/admin/macos-diagnostics"
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_rbac.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py -q
+```
+
+Expected: FAIL with 404 or missing response model wiring.
+
+**Step 3: Implement the route**
+
+Add a new admin route in `sandbox.py` using the same auth pattern as the existing admin endpoints:
+
+```python
+@router.get(
+    "/admin/macos-diagnostics",
+    response_model=SandboxAdminMacOSDiagnosticsResponse,
+    summary="Admin: macOS sandbox diagnostics",
+)
+async def admin_macos_diagnostics(
+    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    current_user: User = Depends(get_request_user),
+) -> SandboxAdminMacOSDiagnosticsResponse:
+    return SandboxAdminMacOSDiagnosticsResponse.model_validate(_service.macos_diagnostics())
+```
+
+Do not bypass the shared service or return raw untyped dicts from the route.
+
+**Step 4: Run the endpoint and RBAC tests again**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_rbac.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_rbac.py tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py
+git commit -m "feat: add sandbox admin macOS diagnostics endpoint"
+```
+
+### Task 4: Reuse the Probe Results in `/sandbox/runtimes` Without Leaking Admin Detail
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Sandbox/service.py`
+- Modify: `tldw_Server_API/app/core/Sandbox/runtime_capabilities.py`
+- Modify: `tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py`
+- Check: `tldw_Server_API/tests/sandbox/test_lima_feature_discovery_capabilities.py`
+
+**Step 1: Write the failing summary-contract tests**
+
+Add a new test to `test_feature_discovery_flags.py`:
+
+```python
+def test_runtimes_discovery_keeps_macos_diagnostics_summarized(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", "1")
+    clear_config_cache()
+
+    with TestClient(app) as client:
+        data = client.get("/api/v1/sandbox/runtimes").json()
+        vz_linux = next(item for item in data["runtimes"] if item["name"] == "vz_linux")
+
+    assert "helper" not in vz_linux
+    assert "templates" not in vz_linux
+    assert "supported_trust_levels" in vz_linux
+    assert isinstance(vz_linux.get("host"), dict)
+```
+
+Also add a test that derived runtime reasons still reflect the shared diagnostics inputs rather than a second, divergent code path.
+
+**Step 2: Run the discovery tests to verify they fail**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py -q
+```
+
+Expected: FAIL because `feature_discovery()` still derives its macOS status independently.
+
+**Step 3: Refactor `feature_discovery()` to reuse shared diagnostics**
+
+Keep Docker, Firecracker, and Lima behavior intact. Only refactor the macOS-specific runtime entries to read from the shared diagnostics contract or shared low-level helpers.
+
+Use a small helper inside `service.py` if needed:
+
+```python
+def _macos_runtime_summary(self) -> dict[str, dict[str, object]]:
+    diagnostics = self.macos_diagnostics()
+    return diagnostics["runtimes"]
+```
+
+Preserve the public summary boundary:
+
+- keep `available`, `reasons`, `supported_trust_levels`, `host`, and current capability booleans
+- do not expose `helper`, `templates`, or admin remediation detail in `/sandbox/runtimes`
+
+**Step 4: Run the discovery tests again**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/core/Sandbox/runtime_capabilities.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
+git commit -m "feat: reuse macOS diagnostics in runtime discovery"
+```
+
+### Task 5: Add Host-Gated Proof, Update Operator Docs, and Run Final Verification
+
+**Files:**
+- Modify: `tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py`
+- Modify: `Docs/Sandbox/macos-runtime-operator-notes.md`
+- Modify: `tldw_Server_API/app/core/Sandbox/README.md`
+- Check: `Docs/Plans/2026-03-10-macos-sandbox-admin-diagnostics-design.md`
+
+**Step 1: Write the failing host-gated smoke test**
+
+Extend `test_vz_runtime_macos_host_gated.py` with a diagnostics smoke test:
+
+```python
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+def test_collect_macos_diagnostics_smoke_on_real_host() -> None:
+    data = collect_macos_diagnostics()
+    assert "host" in data
+    assert "helper" in data
+    assert "templates" in data
+    assert "runtimes" in data
+    assert isinstance(data["host"].get("macos_version"), (str, type(None)))
+```
+
+**Step 2: Run the smoke test to verify it fails**
+
+Run:
+
+```bash
+python -m pytest tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py -q
+```
+
+Expected: FAIL on missing import or missing `macos_version` field before the final probe contract is complete.
+
+**Step 3: Finish the last implementation bits and update the docs**
+
+If the smoke test exposes any missing version/platform fields, fix them in `macos_diagnostics.py`.
+
+Then update the operator docs so they mention:
+
+- the new admin endpoint: `/api/v1/sandbox/admin/macos-diagnostics`
+- the difference between admin diagnostics and `/api/v1/sandbox/runtimes`
+- the current env-driven readiness signals and fake-exec limits
+
+Keep the docs aligned with the current scaffolded state. Do not imply real guest execution exists yet.
+
+**Step 4: Run the full targeted verification and Bandit**
+
+Run:
+
+```bash
+python -m pytest \
+  tldw_Server_API/tests/sandbox/test_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py \
+  tldw_Server_API/tests/sandbox/test_admin_rbac.py \
+  tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py \
+  tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py \
+  tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py -q
+```
+
+Expected: PASS.
+
+Run:
+
+```bash
+python -m bandit -r \
+  tldw_Server_API/app/core/Sandbox/macos_diagnostics.py \
+  tldw_Server_API/app/core/Sandbox/service.py \
+  tldw_Server_API/app/api/v1/endpoints/sandbox.py \
+  tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py \
+  -f json -o /tmp/bandit_macos_admin_diagnostics.json
+```
+
+Expected: `0` new findings in touched code.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py Docs/Sandbox/macos-runtime-operator-notes.md tldw_Server_API/app/core/Sandbox/README.md
+git commit -m "docs: add macOS sandbox diagnostics operator guidance"
+```
+
+## Final review checklist
+
+- The admin endpoint is admin-only and typed with dedicated Pydantic models.
+- `/api/v1/sandbox/runtimes` stays summarized.
+- Host/setup failures are distinguishable from policy restrictions.
+- The probe layer is read-only in this slice.
+- Targeted pytest coverage passes.
+- Bandit reports no new findings in touched code.

--- a/Docs/Sandbox/macos-runtime-operator-notes.md
+++ b/Docs/Sandbox/macos-runtime-operator-notes.md
@@ -81,6 +81,18 @@ Today, the image store implements template registration plus deterministic run-c
 - enforcement readiness
 - host facts
 
+`/api/v1/sandbox/admin/macos-diagnostics` is the operator-focused companion surface.
+It is admin-only and returns:
+
+- detailed host readiness, including macOS version
+- helper readiness, with optional configured path and transport metadata
+- template readiness for `vz_linux` and `vz_macos`, with optional template source metadata
+- per-runtime execution mode and remediation hints
+
+Use the admin endpoint when you are validating host setup or trying to explain why a
+runtime is unavailable. Use `/api/v1/sandbox/runtimes` for client-facing discovery;
+that payload stays summarized and does not expose helper/template internals.
+
 ACP sandbox session creation now performs runtime preflight validation before calling the sandbox service, and converts failures into `ACPResponseError` instead of leaking raw sandbox exceptions.
 
 ## Current Limits
@@ -90,3 +102,11 @@ ACP sandbox session creation now performs runtime preflight validation before ca
 - No APFS clone execution path yet
 - No allowlist networking for the new macOS runtimes
 - No warm-session VM reuse yet
+
+Current diagnostics are still env-driven scaffolding:
+
+- helper readiness is gated by `TLDW_SANDBOX_MACOS_HELPER_READY`
+- helper path metadata is optional and comes from `TLDW_SANDBOX_MACOS_HELPER_PATH`
+- template readiness is gated by `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY` and `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY`
+- template source metadata is optional and comes from `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE` and `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_SOURCE`
+- `execution_mode=fake` depends on the corresponding `*_FAKE_EXEC=1` flag

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -2227,11 +2227,11 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
     summary="Admin: macOS sandbox diagnostics",
 )
 async def admin_macos_diagnostics(
-    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
-    current_user: User = Depends(get_request_user),
+    _principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    _current_user: User = Depends(get_request_user),
 ) -> SandboxAdminMacOSDiagnosticsResponse:
-    del principal
-    del current_user
+    """Return detailed macOS sandbox diagnostics for admin troubleshooting."""
+
     return SandboxAdminMacOSDiagnosticsResponse.model_validate(_service.macos_diagnostics())
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/sandbox.py
+++ b/tldw_Server_API/app/api/v1/endpoints/sandbox.py
@@ -32,6 +32,7 @@ from loguru import logger
 from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import get_audit_service_for_user
 from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+    SandboxAdminMacOSDiagnosticsResponse,
     ArtifactListResponse,
     CancelResponse,
     SandboxAdminIdempotencyItem,
@@ -2219,6 +2220,19 @@ async def stream_run_logs(websocket: WebSocket, run_id: str) -> None:
 # -----------------------
 # Admin API (list/details)
 # -----------------------
+
+@router.get(
+    "/admin/macos-diagnostics",
+    response_model=SandboxAdminMacOSDiagnosticsResponse,
+    summary="Admin: macOS sandbox diagnostics",
+)
+async def admin_macos_diagnostics(
+    principal: AuthPrincipal = Depends(auth_deps.require_roles("admin")),
+    current_user: User = Depends(get_request_user),
+) -> SandboxAdminMacOSDiagnosticsResponse:
+    del principal
+    del current_user
+    return SandboxAdminMacOSDiagnosticsResponse.model_validate(_service.macos_diagnostics())
 
 @router.get(
     "/admin/runs",

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -269,6 +269,47 @@ class SandboxAdminUsageResponse(BaseModel):
     items: list[SandboxAdminUsageItem]
 
 
+class SandboxAdminMacOSHostDiagnostics(BaseModel):
+    os: str
+    arch: str
+    apple_silicon: bool
+    macos_version: str | None = None
+    supported: bool
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SandboxAdminMacOSHelperDiagnostics(BaseModel):
+    configured: bool
+    path: str | None = None
+    exists: bool
+    executable: bool
+    ready: bool
+    transport: str | None = None
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SandboxAdminMacOSTemplateDiagnostics(BaseModel):
+    configured: bool
+    ready: bool
+    source: str | None = None
+    reasons: list[str] = Field(default_factory=list)
+
+
+class SandboxAdminMacOSRuntimeDiagnostics(BaseModel):
+    available: bool
+    supported_trust_levels: list[TrustLevelType] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)
+    execution_mode: Literal["fake", "real", "none"]
+    remediation: str | None = None
+
+
+class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
+    host: SandboxAdminMacOSHostDiagnostics
+    helper: SandboxAdminMacOSHelperDiagnostics
+    templates: dict[str, SandboxAdminMacOSTemplateDiagnostics] = Field(default_factory=dict)
+    runtimes: dict[str, SandboxAdminMacOSRuntimeDiagnostics] = Field(default_factory=dict)
+
+
 # Snapshot/Clone Schemas
 class SnapshotCreateResponse(BaseModel):
     """Response when creating a session snapshot."""

--- a/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py
@@ -270,6 +270,8 @@ class SandboxAdminUsageResponse(BaseModel):
 
 
 class SandboxAdminMacOSHostDiagnostics(BaseModel):
+    """Admin-facing host facts for macOS sandbox readiness checks."""
+
     os: str
     arch: str
     apple_silicon: bool
@@ -279,6 +281,8 @@ class SandboxAdminMacOSHostDiagnostics(BaseModel):
 
 
 class SandboxAdminMacOSHelperDiagnostics(BaseModel):
+    """Admin-facing helper readiness and optional helper metadata."""
+
     configured: bool
     path: str | None = None
     exists: bool
@@ -289,6 +293,8 @@ class SandboxAdminMacOSHelperDiagnostics(BaseModel):
 
 
 class SandboxAdminMacOSTemplateDiagnostics(BaseModel):
+    """Admin-facing template readiness for a single VZ runtime family."""
+
     configured: bool
     ready: bool
     source: str | None = None
@@ -296,6 +302,8 @@ class SandboxAdminMacOSTemplateDiagnostics(BaseModel):
 
 
 class SandboxAdminMacOSRuntimeDiagnostics(BaseModel):
+    """Admin-facing runtime posture derived from shared runtime preflight checks."""
+
     available: bool
     supported_trust_levels: list[TrustLevelType] = Field(default_factory=list)
     reasons: list[str] = Field(default_factory=list)
@@ -304,6 +312,8 @@ class SandboxAdminMacOSRuntimeDiagnostics(BaseModel):
 
 
 class SandboxAdminMacOSDiagnosticsResponse(BaseModel):
+    """Structured admin response for macOS sandbox diagnostics."""
+
     host: SandboxAdminMacOSHostDiagnostics
     helper: SandboxAdminMacOSHelperDiagnostics
     templates: dict[str, SandboxAdminMacOSTemplateDiagnostics] = Field(default_factory=dict)

--- a/tldw_Server_API/app/core/Sandbox/README.md
+++ b/tldw_Server_API/app/core/Sandbox/README.md
@@ -59,7 +59,13 @@ Current limitations:
 - Recommended validation endpoints:
   - `/api/v1/sandbox/health`
   - `/api/v1/sandbox/runtimes`
+  - `/api/v1/sandbox/admin/macos-diagnostics`
   - `/api/v1/sandbox/runs`
+
+`/api/v1/sandbox/runtimes` is the summarized discovery surface used by clients and ACP.
+`/api/v1/sandbox/admin/macos-diagnostics` is an admin-only diagnostics surface for
+operator troubleshooting and exposes helper/template readiness details that are not
+included in the public discovery payload.
 
 Selected configuration knobs:
 
@@ -69,12 +75,15 @@ Selected configuration knobs:
   - `SANDBOX_IDEMPOTENCY_TTL_SEC`
 - macOS scaffolding:
   - `TLDW_SANDBOX_MACOS_HELPER_READY`
+  - `TLDW_SANDBOX_MACOS_HELPER_PATH`
   - `TLDW_SANDBOX_VZ_LINUX_AVAILABLE`
   - `TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC`
   - `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY`
+  - `TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE`
   - `TLDW_SANDBOX_VZ_MACOS_AVAILABLE`
   - `TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC`
   - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY`
+  - `TLDW_SANDBOX_VZ_MACOS_TEMPLATE_SOURCE`
   - `TLDW_SANDBOX_SEATBELT_AVAILABLE`
   - `TLDW_SANDBOX_SEATBELT_FAKE_EXEC`
   - `TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED`

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+from tldw_Server_API.app.core.testing import is_truthy
+
+from .models import RuntimeType
+from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
+from .runners.vz_common import vz_host_facts
+
+_VZ_LINUX_TEMPLATE_MISSING_REASON = "vz_linux_template_missing"
+_VZ_MACOS_TEMPLATE_MISSING_REASON = "macos_template_missing"
+
+
+def _truthy(value: str | None) -> bool:
+    return is_truthy(value)
+
+
+def _execution_mode_for_runtime(runtime: RuntimeType) -> str:
+    env_key_by_runtime = {
+        RuntimeType.vz_linux: "TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC",
+        RuntimeType.vz_macos: "TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC",
+        RuntimeType.seatbelt: "TLDW_SANDBOX_SEATBELT_FAKE_EXEC",
+    }
+    env_key = env_key_by_runtime.get(runtime)
+    if env_key and _truthy(os.getenv(env_key)):
+        return "fake"
+    return "none"
+
+
+def _remediation_for_reasons(reasons: list[str]) -> str | None:
+    if not reasons:
+        return None
+    if "macos_required" in reasons or "apple_silicon_required" in reasons:
+        return "Run this runtime on an Apple silicon macOS host."
+    if "macos_helper_missing" in reasons:
+        return "Configure the macOS virtualization helper and mark it ready."
+    if _VZ_LINUX_TEMPLATE_MISSING_REASON in reasons or _VZ_MACOS_TEMPLATE_MISSING_REASON in reasons:
+        return "Configure the required runtime template and mark it ready."
+    if "real_execution_not_implemented" in reasons:
+        return "Enable fake execution for scaffolding or implement the real runtime path."
+    if "strict_allowlist_not_supported" in reasons:
+        return "Use deny_all for this runtime; allowlist is not implemented."
+    if "seatbelt_unavailable" in reasons:
+        return "Enable the seatbelt runtime on supported macOS hosts."
+    return "Review runtime preflight reasons and host readiness."
+
+
+def probe_host() -> dict[str, object]:
+    facts = vz_host_facts()
+    reasons: list[str] = []
+    if facts.get("os") != "darwin":
+        reasons.append("macos_required")
+    if not bool(facts.get("apple_silicon")):
+        reasons.append("apple_silicon_required")
+    return {
+        **facts,
+        "macos_version": platform.mac_ver()[0] or None,
+        "supported": not reasons,
+        "reasons": reasons,
+    }
+
+
+def probe_helper() -> dict[str, object]:
+    raw_path = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_PATH") or "").strip()
+    path = raw_path or None
+    configured = bool(path)
+    exists = bool(path and Path(path).exists())
+    executable = bool(path and exists and os.access(path, os.X_OK))
+    ready = _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
+    reasons: list[str] = []
+
+    if not configured:
+        reasons.append("macos_helper_path_unconfigured")
+    elif not exists:
+        reasons.append("macos_helper_path_missing")
+    elif not executable:
+        reasons.append("macos_helper_not_executable")
+    if not ready:
+        reasons.append("macos_helper_missing")
+
+    transport = "fake" if _truthy(os.getenv("TEST_MODE")) and ready else None
+    return {
+        "configured": configured,
+        "path": path,
+        "exists": exists,
+        "executable": executable,
+        "ready": ready,
+        "transport": transport,
+        "reasons": reasons,
+    }
+
+
+def _template_status(
+    *,
+    source_env_key: str,
+    ready_env_key: str,
+    missing_reason: str,
+) -> dict[str, object]:
+    raw_source = str(os.getenv(source_env_key) or "").strip()
+    source = raw_source or None
+    ready = _truthy(os.getenv(ready_env_key))
+    configured = bool(source) or ready
+    reasons: list[str] = []
+
+    if not configured:
+        reasons.append("template_unconfigured")
+    if not ready:
+        reasons.append(missing_reason)
+
+    return {
+        "configured": configured,
+        "ready": ready,
+        "source": source,
+        "reasons": reasons,
+    }
+
+
+def probe_templates() -> dict[str, dict[str, object]]:
+    return {
+        "vz_linux": _template_status(
+            source_env_key="TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE",
+            ready_env_key="TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY",
+            missing_reason=_VZ_LINUX_TEMPLATE_MISSING_REASON,
+        ),
+        "vz_macos": _template_status(
+            source_env_key="TLDW_SANDBOX_VZ_MACOS_TEMPLATE_SOURCE",
+            ready_env_key="TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY",
+            missing_reason=_VZ_MACOS_TEMPLATE_MISSING_REASON,
+        ),
+    }
+
+
+def probe_runtime_statuses(
+    *,
+    runtime_preflights: dict[RuntimeType, RuntimePreflightResult],
+) -> dict[str, dict[str, object]]:
+    statuses: dict[str, dict[str, object]] = {}
+    for runtime in (RuntimeType.vz_linux, RuntimeType.vz_macos, RuntimeType.seatbelt):
+        preflight = runtime_preflights.get(runtime)
+        reasons = list((preflight.reasons if preflight else []) or [])
+        statuses[runtime.value] = {
+            "available": bool(preflight.available) if preflight is not None else False,
+            "supported_trust_levels": list((preflight.supported_trust_levels if preflight else []) or []),
+            "reasons": reasons,
+            "execution_mode": _execution_mode_for_runtime(runtime),
+            "remediation": _remediation_for_reasons(reasons),
+        }
+    return statuses
+
+
+def collect_macos_diagnostics() -> dict[str, Any]:
+    host = probe_host()
+    helper = probe_helper()
+    templates = probe_templates()
+    runtime_preflights = collect_runtime_preflights(network_policy="deny_all")
+    runtimes = probe_runtime_statuses(runtime_preflights=runtime_preflights)
+    return {
+        "host": host,
+        "helper": helper,
+        "templates": templates,
+        "runtimes": runtimes,
+    }

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -1,3 +1,5 @@
+"""Shared, side-effect-free diagnostics for macOS sandbox runtimes."""
+
 from __future__ import annotations
 
 import os
@@ -51,6 +53,8 @@ def _remediation_for_reasons(reasons: list[str]) -> str | None:
 
 
 def probe_host() -> dict[str, object]:
+    """Report coarse host facts and whether the host can support VZ runtimes."""
+
     facts = vz_host_facts()
     reasons: list[str] = []
     if facts.get("os") != "darwin":
@@ -66,6 +70,8 @@ def probe_host() -> dict[str, object]:
 
 
 def probe_helper() -> dict[str, object]:
+    """Report helper readiness plus optional operator metadata such as local path facts."""
+
     raw_path = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_PATH") or "").strip()
     path = raw_path or None
     ready = _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
@@ -121,6 +127,8 @@ def _template_status(
 
 
 def probe_templates() -> dict[str, dict[str, object]]:
+    """Report template readiness for the VZ runtime families."""
+
     return {
         "vz_linux": _template_status(
             source_env_key="TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE",
@@ -139,6 +147,8 @@ def probe_runtime_statuses(
     *,
     runtime_preflights: dict[RuntimeType, RuntimePreflightResult],
 ) -> dict[str, dict[str, object]]:
+    """Summarize admin-facing runtime posture from shared runtime preflight results."""
+
     statuses: dict[str, dict[str, object]] = {}
     for runtime in (RuntimeType.vz_linux, RuntimeType.vz_macos, RuntimeType.seatbelt):
         preflight = runtime_preflights.get(runtime)
@@ -154,6 +164,8 @@ def probe_runtime_statuses(
 
 
 def collect_macos_diagnostics() -> dict[str, Any]:
+    """Aggregate host, helper, template, and runtime diagnostics for admin callers."""
+
     host = probe_host()
     helper = probe_helper()
     templates = probe_templates()

--- a/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
+++ b/tldw_Server_API/app/core/Sandbox/macos_diagnostics.py
@@ -68,10 +68,10 @@ def probe_host() -> dict[str, object]:
 def probe_helper() -> dict[str, object]:
     raw_path = str(os.getenv("TLDW_SANDBOX_MACOS_HELPER_PATH") or "").strip()
     path = raw_path or None
-    configured = bool(path)
+    ready = _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
+    configured = bool(path) or ready
     exists = bool(path and Path(path).exists())
     executable = bool(path and exists and os.access(path, os.X_OK))
-    ready = _truthy(os.getenv("TLDW_SANDBOX_MACOS_HELPER_READY"))
     reasons: list[str] = []
 
     if not configured:

--- a/tldw_Server_API/app/core/Sandbox/service.py
+++ b/tldw_Server_API/app/core/Sandbox/service.py
@@ -37,6 +37,7 @@ from .models import (
     SessionSpec,
     TrustLevel,
 )
+from .macos_diagnostics import collect_macos_diagnostics
 from .orchestrator import SandboxOrchestrator, SessionActiveRunsConflict
 from .policy import SandboxPolicy, SandboxPolicyConfig, compute_policy_hash
 from .runtime_capabilities import RuntimePreflightResult, collect_runtime_preflights
@@ -962,6 +963,9 @@ class SandboxService:
                 **_preflight_fields(seatbelt_preflight),
             },
         ]
+
+    def macos_diagnostics(self) -> dict[str, object]:
+        return collect_macos_diagnostics()
 
     def _audit_run_completion(self, *, user_id: str | int | None, run_id: str, status: RunStatus, spec_version: str, session_id: str | None) -> None:
         """Log a completion audit event in a fire-and-forget manner."""

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py
@@ -88,6 +88,29 @@ class _FakeService:
             resource_usage=None,
         )
 
+    def macos_diagnostics(self):
+        return {
+            "host": {
+                "os": "darwin",
+                "arch": "arm64",
+                "apple_silicon": True,
+                "macos_version": "15.0",
+                "supported": True,
+                "reasons": [],
+            },
+            "helper": {
+                "configured": True,
+                "path": "/tmp/helper",
+                "exists": True,
+                "executable": True,
+                "ready": True,
+                "transport": "fake",
+                "reasons": [],
+            },
+            "templates": {},
+            "runtimes": {},
+        }
+
 
 def _build_app_with_overrides(principal: AuthPrincipal) -> FastAPI:
     app = FastAPI()
@@ -159,6 +182,25 @@ async def test_sandbox_admin_runs_allowed_for_admin_principal(monkeypatch):
     body = resp.json()
     assert isinstance(body.get("items"), list)
     assert body.get("total") == 0
+
+
+@pytest.mark.asyncio
+async def test_sandbox_admin_macos_diagnostics_allowed_for_admin_principal(monkeypatch):
+    principal = _make_principal(
+        roles=[ROLE_ADMIN],
+        permissions=[],
+        is_admin=True,
+    )
+    fake_service = _FakeService()
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(principal)
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/macos-diagnostics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["host"]["supported"] is True
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -44,7 +44,7 @@ def _build_app_with_overrides(principal: AuthPrincipal) -> FastAPI:
         )
         return principal
 
-    async def _fake_get_request_user():
+    async def _fake_get_request_user() -> SimpleNamespace:
         return SimpleNamespace(
             id=1,
             username="sandbox-admin",

--- a/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import sandbox as sandbox_mod
+from tldw_Server_API.app.core.AuthNZ.permissions import ROLE_ADMIN
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+
+
+def _make_principal(
+    *,
+    is_admin: bool,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=1,
+        api_key_id=None,
+        subject=None,
+        token_type="access",
+        jti=None,
+        roles=[ROLE_ADMIN] if is_admin else ["user"],
+        permissions=[],
+        is_admin=is_admin,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+def _build_app_with_overrides(principal: AuthPrincipal) -> FastAPI:
+    app = FastAPI()
+    app.include_router(sandbox_mod.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:  # type: ignore[override]
+        request.state.auth = AuthContext(
+            principal=principal,
+            ip=(request.client.host if getattr(request, "client", None) else None),
+            user_agent=(request.headers.get("User-Agent") if getattr(request, "headers", None) else None),
+            request_id=(request.headers.get("X-Request-ID") if getattr(request, "headers", None) else None),
+        )
+        return principal
+
+    async def _fake_get_request_user():
+        return SimpleNamespace(
+            id=1,
+            username="sandbox-admin",
+            is_active=True,
+            roles=list(principal.roles),
+            permissions=list(principal.permissions),
+            is_admin=principal.is_admin,
+            tenant_id="default",
+        )
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[sandbox_mod.get_request_user] = _fake_get_request_user
+    return app
+
+
+def _diagnostics_payload() -> dict:
+    return {
+        "host": {
+            "os": "darwin",
+            "arch": "arm64",
+            "apple_silicon": True,
+            "macos_version": "15.0",
+            "supported": True,
+            "reasons": [],
+        },
+        "helper": {
+            "configured": False,
+            "path": None,
+            "exists": False,
+            "executable": False,
+            "ready": False,
+            "transport": None,
+            "reasons": ["macos_helper_missing"],
+        },
+        "templates": {
+            "vz_linux": {
+                "configured": False,
+                "ready": False,
+                "source": None,
+                "reasons": ["vz_linux_template_missing"],
+            }
+        },
+        "runtimes": {
+            "vz_linux": {
+                "available": False,
+                "supported_trust_levels": ["trusted", "standard", "untrusted"],
+                "reasons": ["macos_helper_missing", "vz_linux_template_missing"],
+                "execution_mode": "none",
+                "remediation": "Configure the macOS virtualization helper and mark it ready.",
+            }
+        },
+    }
+
+
+def test_admin_macos_diagnostics_returns_structured_payload(monkeypatch) -> None:
+    fake_service = SimpleNamespace(macos_diagnostics=lambda: _diagnostics_payload())
+    monkeypatch.setattr(sandbox_mod, "_service", fake_service, raising=True)
+
+    app = _build_app_with_overrides(_make_principal(is_admin=True))
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/sandbox/admin/macos-diagnostics")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"host", "helper", "templates", "runtimes"}
+    assert body["host"]["supported"] is True
+    assert body["runtimes"]["vz_linux"]["execution_mode"] == "none"

--- a/tldw_Server_API/tests/sandbox/test_admin_rbac.py
+++ b/tldw_Server_API/tests/sandbox/test_admin_rbac.py
@@ -44,6 +44,7 @@ def test_admin_endpoints_require_admin_role(monkeypatch) -> None:
         client.app.dependency_overrides[get_request_user] = _non_admin_dep
         for path in (
             "/api/v1/sandbox/admin/runs",
+            "/api/v1/sandbox/admin/macos-diagnostics",
             "/api/v1/sandbox/admin/idempotency",
             "/api/v1/sandbox/admin/usage",
         ):

--- a/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
+++ b/tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py
@@ -142,3 +142,41 @@ def test_runtimes_discovery_includes_macos_runtime_capabilities(monkeypatch) -> 
         assert "supported_trust_levels" in runtimes["seatbelt"]
         assert runtimes["seatbelt"]["supported_trust_levels"] == ["trusted"]
         assert isinstance(runtimes["vz_macos"].get("host"), dict)
+
+
+def test_runtimes_discovery_keeps_macos_diagnostics_summarized(monkeypatch) -> None:
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_PATH", "/tmp/macos-helper")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_AVAILABLE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
+    clear_config_cache()
+
+    with TestClient(app) as client:
+        data = client.get("/api/v1/sandbox/runtimes").json()
+        vz_linux = next(item for item in data["runtimes"] if item["name"] == "vz_linux")
+
+    assert "helper" not in vz_linux
+    assert "templates" not in vz_linux
+    assert "remediation" not in vz_linux
+    assert "supported_trust_levels" in vz_linux
+    assert isinstance(vz_linux.get("host"), dict)
+
+
+def test_macos_diagnostics_runtime_reasons_align_with_feature_discovery(monkeypatch) -> None:
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("SANDBOX_STORE_BACKEND", "memory")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "0")
+    clear_config_cache()
+
+    svc = SandboxService()
+    diagnostics = svc.macos_diagnostics()
+    discovery = {item["name"]: item for item in svc.feature_discovery()}
+
+    assert diagnostics["runtimes"]["vz_linux"]["reasons"] == discovery["vz_linux"]["reasons"]
+    assert diagnostics["runtimes"]["vz_macos"]["reasons"] == discovery["vz_macos"]["reasons"]
+    assert diagnostics["runtimes"]["seatbelt"]["supported_trust_levels"] == discovery["seatbelt"]["supported_trust_levels"]

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -3,6 +3,19 @@ from __future__ import annotations
 import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
 
 
+def _patch_macos_host(monkeypatch) -> None:
+    monkeypatch.setattr(
+        diagnostics_module,
+        "vz_host_facts",
+        lambda: {
+            "os": "darwin",
+            "arch": "arm64",
+            "apple_silicon": True,
+        },
+    )
+    monkeypatch.setattr(diagnostics_module.platform, "mac_ver", lambda: ("15.0", ("", "", ""), ""))
+
+
 def _sample_diagnostics_payload() -> dict:
     return {
         "host": {
@@ -43,8 +56,7 @@ def _sample_diagnostics_payload() -> dict:
 
 
 def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypatch) -> None:
-    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
-    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    _patch_macos_host(monkeypatch)
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_PATH", raising=False)
     monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
@@ -68,8 +80,7 @@ def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypa
 
 
 def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypatch) -> None:
-    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
-    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    _patch_macos_host(monkeypatch)
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "1")
     monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
@@ -81,8 +92,7 @@ def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypa
 
 
 def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypatch) -> None:
-    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
-    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    _patch_macos_host(monkeypatch)
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_PATH", "/tmp/macos-helper")
     monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
@@ -94,8 +104,7 @@ def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypat
 
 
 def test_collect_macos_diagnostics_treats_ready_helper_as_configured_without_path(monkeypatch) -> None:
-    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
-    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    _patch_macos_host(monkeypatch)
     monkeypatch.setenv("TEST_MODE", "1")
     monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
     monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_PATH", raising=False)

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -93,6 +93,20 @@ def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypat
     assert data["templates"]["vz_linux"]["source"] == "/tmp/vz-linux.img"
 
 
+def test_collect_macos_diagnostics_treats_ready_helper_as_configured_without_path(monkeypatch) -> None:
+    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
+    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_READY", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_PATH", raising=False)
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert data["helper"]["configured"] is True
+    assert data["helper"]["ready"] is True
+    assert "macos_helper_path_unconfigured" not in data["helper"]["reasons"]
+
+
 def test_service_macos_diagnostics_returns_probe_payload(monkeypatch) -> None:
     from tldw_Server_API.app.core.Sandbox.service import SandboxService
 

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
+
+
+def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypatch) -> None:
+    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
+    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_PATH", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_MACOS_HELPER_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_TEMPLATE_READY", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_LINUX_FAKE_EXEC", raising=False)
+    monkeypatch.delenv("TLDW_SANDBOX_VZ_MACOS_FAKE_EXEC", raising=False)
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert data["host"]["supported"] is True
+    assert data["helper"]["configured"] is False
+    assert data["helper"]["path"] is None
+    assert data["helper"]["ready"] is False
+    assert data["templates"]["vz_linux"]["configured"] is False
+    assert data["templates"]["vz_linux"]["source"] is None
+    assert data["templates"]["vz_linux"]["ready"] is False
+    assert "macos_helper_missing" in data["runtimes"]["vz_linux"]["reasons"]
+    assert data["runtimes"]["vz_linux"]["execution_mode"] == "none"
+
+
+def test_collect_macos_diagnostics_separates_policy_from_host_readiness(monkeypatch) -> None:
+    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
+    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_SEATBELT_AVAILABLE", "1")
+    monkeypatch.delenv("TLDW_SANDBOX_SEATBELT_STANDARD_ENABLED", raising=False)
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert data["runtimes"]["seatbelt"]["supported_trust_levels"] == ["trusted"]
+    assert data["runtimes"]["seatbelt"]["available"] in (True, False)
+
+
+def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypatch) -> None:
+    monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
+    monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
+    monkeypatch.setenv("TEST_MODE", "1")
+    monkeypatch.setenv("TLDW_SANDBOX_MACOS_HELPER_PATH", "/tmp/macos-helper")
+    monkeypatch.setenv("TLDW_SANDBOX_VZ_LINUX_TEMPLATE_SOURCE", "/tmp/vz-linux.img")
+
+    data = diagnostics_module.collect_macos_diagnostics()
+
+    assert data["helper"]["path"] == "/tmp/macos-helper"
+    assert data["templates"]["vz_linux"]["source"] == "/tmp/vz-linux.img"

--- a/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
+++ b/tldw_Server_API/tests/sandbox/test_macos_diagnostics.py
@@ -3,6 +3,45 @@ from __future__ import annotations
 import tldw_Server_API.app.core.Sandbox.macos_diagnostics as diagnostics_module
 
 
+def _sample_diagnostics_payload() -> dict:
+    return {
+        "host": {
+            "os": "darwin",
+            "arch": "arm64",
+            "apple_silicon": True,
+            "macos_version": "15.0",
+            "supported": True,
+            "reasons": [],
+        },
+        "helper": {
+            "configured": True,
+            "path": "/tmp/helper",
+            "exists": True,
+            "executable": True,
+            "ready": True,
+            "transport": "fake",
+            "reasons": [],
+        },
+        "templates": {
+            "vz_linux": {
+                "configured": True,
+                "ready": True,
+                "source": "/tmp/vz-linux.img",
+                "reasons": [],
+            },
+        },
+        "runtimes": {
+            "vz_linux": {
+                "available": True,
+                "supported_trust_levels": ["trusted", "standard", "untrusted"],
+                "reasons": [],
+                "execution_mode": "fake",
+                "remediation": None,
+            }
+        },
+    }
+
+
 def test_collect_macos_diagnostics_reports_missing_helper_and_templates(monkeypatch) -> None:
     monkeypatch.setattr(diagnostics_module.sys, "platform", "darwin")
     monkeypatch.setattr(diagnostics_module.platform, "machine", lambda: "arm64")
@@ -52,3 +91,28 @@ def test_collect_macos_diagnostics_uses_optional_operator_metadata_env(monkeypat
 
     assert data["helper"]["path"] == "/tmp/macos-helper"
     assert data["templates"]["vz_linux"]["source"] == "/tmp/vz-linux.img"
+
+
+def test_service_macos_diagnostics_returns_probe_payload(monkeypatch) -> None:
+    from tldw_Server_API.app.core.Sandbox.service import SandboxService
+
+    expected = _sample_diagnostics_payload()
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Sandbox.service.collect_macos_diagnostics",
+        lambda: expected,
+    )
+
+    svc = SandboxService()
+
+    assert svc.macos_diagnostics() == expected
+
+
+def test_admin_schema_accepts_macos_diagnostics_payload() -> None:
+    from tldw_Server_API.app.api.v1.schemas.sandbox_schemas import (
+        SandboxAdminMacOSDiagnosticsResponse,
+    )
+
+    model = SandboxAdminMacOSDiagnosticsResponse.model_validate(_sample_diagnostics_payload())
+
+    assert model.host.supported is True
+    assert model.runtimes["vz_linux"].execution_mode == "fake"

--- a/tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py
+++ b/tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+from tldw_Server_API.app.core.Sandbox.macos_diagnostics import collect_macos_diagnostics
 from tldw_Server_API.app.core.Sandbox.runners.vz_linux_runner import VZLinuxRunner
 from tldw_Server_API.app.core.Sandbox.runners.vz_macos_runner import VZMacOSRunner
 
@@ -24,3 +25,14 @@ def test_vz_macos_preflight_smoke_on_real_host() -> None:
     assert isinstance(result.available, bool)
     assert isinstance(result.host, dict)
     assert "os" in result.host
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS host only")
+def test_collect_macos_diagnostics_smoke_on_real_host() -> None:
+    data = collect_macos_diagnostics()
+
+    assert "host" in data
+    assert "helper" in data
+    assert "templates" in data
+    assert "runtimes" in data
+    assert isinstance(data["host"].get("macos_version"), (str, type(None)))


### PR DESCRIPTION
## Summary
- add shared macOS sandbox diagnostics probes plus typed service and admin API support
- keep `/api/v1/sandbox/runtimes` summarized while adding alignment coverage and a real-host diagnostics smoke test
- document the admin diagnostics endpoint and the current env-driven fake-exec readiness model for operators

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/sandbox/test_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_macos_diagnostics.py tldw_Server_API/tests/sandbox/test_admin_rbac.py tldw_Server_API/tests/sandbox/test_feature_discovery_flags.py tldw_Server_API/tests/AuthNZ_Unit/test_sandbox_admin_permissions_claims.py tldw_Server_API/tests/sandbox/test_vz_runtime_macos_host_gated.py -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Sandbox/macos_diagnostics.py tldw_Server_API/app/core/Sandbox/service.py tldw_Server_API/app/api/v1/endpoints/sandbox.py tldw_Server_API/app/api/v1/schemas/sandbox_schemas.py -f json -o /tmp/bandit_macos_admin_diagnostics.json`
