### PR TITLE
feat: add structured prompts across Prompts and Prompt Studio

### DIFF
--- a/Docs/Plans/2026-03-10-prompt-schema-foundation-design.md
+++ b/Docs/Plans/2026-03-10-prompt-schema-foundation-design.md
@@ -266,6 +266,12 @@ Suggested derived text shape:
 
 This avoids regressing search while keeping the canonical source structured.
 
+Implementation note:
+
+- regenerate the derived structured-search snapshot on prompt writes
+- merge that snapshot into the regular Prompts FTS index so enabled non-legacy blocks remain searchable without exposing `prompt_definition_json` as a user-facing query field
+- keep preview and execution parity covered by tests that compare Prompt Studio preview assembly against executor assembly with `few_shot_examples`, `modules_config`, and signatures applied
+
 ### 6.9 Local Sync and Conflict Detection
 
 The regular Prompts workspace currently syncs and detects conflicts using raw prompt text.

--- a/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-prompt-schema-foundation-implementation-plan.md
@@ -544,6 +544,8 @@ git commit -m "feat: route prompt studio execution through structured assembly"
 
 **Files:**
 - Modify: `apps/packages/ui/src/db/dexie/types.ts`
+- Modify: `apps/packages/ui/src/db/dexie/schema.ts`
+- Modify: `apps/packages/ui/src/db/dexie/chat.ts`
 - Modify: `apps/packages/ui/src/db/dexie/helpers.ts`
 - Modify: `apps/packages/ui/src/services/prompt-sync.ts`
 - Modify: `apps/packages/ui/src/services/prompt-studio.ts`
@@ -588,7 +590,7 @@ export type Prompt = {
 }
 ```
 
-Update sync hashing and conflict detection to hash canonical structured content when present. Keep legacy hashing for legacy prompts.
+Update Dexie schema upgrades and prompt normalization to preserve the new fields locally. Update sync hashing and conflict detection to hash the canonical sync payload, including `few_shot_examples` and `modules_config`, and the structured prompt definition when present. Keep legacy-only fallback hashing for older prompt records.
 
 **Step 4: Run test to verify it passes**
 
@@ -604,6 +606,8 @@ Expected: PASS for local-to-server, server-to-local, and conflict-hash coverage.
 
 ```bash
 git add apps/packages/ui/src/db/dexie/types.ts \
+        apps/packages/ui/src/db/dexie/schema.ts \
+        apps/packages/ui/src/db/dexie/chat.ts \
         apps/packages/ui/src/db/dexie/helpers.ts \
         apps/packages/ui/src/services/prompt-sync.ts \
         apps/packages/ui/src/services/prompt-studio.ts \

--- a/Docs/Published/API-related/Prompt_Studio_API.md
+++ b/Docs/Published/API-related/Prompt_Studio_API.md
@@ -159,6 +159,13 @@ curl -X GET "http://localhost:8000/api/v1/prompt-studio/optimizations/history/70
 - History: `GET /api/v1/prompt-studio/prompts/history/{prompt_id}`
 - Revert (new version): `POST /api/v1/prompt-studio/prompts/revert/{prompt_id}/{version}`
 - Execute (simple): `POST /api/v1/prompt-studio/prompts/execute`
+- Preview structured assembly: `POST /api/v1/prompt-studio/prompts/preview`
+- Convert legacy prompt text to structured definition: `POST /api/v1/prompt-studio/prompts/convert`
+
+Structured prompt notes
+- Structured prompts send `prompt_format="structured"`, `prompt_schema_version=1`, and `prompt_definition`.
+- The preview endpoint returns canonical `assembled_messages` plus legacy compatibility snapshots.
+- `few_shot_examples`, `modules_config`, and optional `signature_id` are applied through the same backend assembly path used by Prompt Studio execution, so preview and runtime stay aligned.
 
 ### Test Cases
 - Create: `POST /api/v1/prompt-studio/test-cases/create`

--- a/apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx
@@ -4,10 +4,13 @@ import { useTranslation } from "react-i18next"
 import { ChevronDown, ChevronUp, Info, Cloud, Plus, Trash2 } from "lucide-react"
 import type {
   FewShotExample,
+  PromptFormat,
   PromptSyncStatus,
-  PromptSourceSystem
+  PromptSourceSystem,
+  StructuredPromptDefinition
 } from "@/db/dexie/types"
 import { useFormDraft, formatDraftAge } from "@/hooks/useFormDraft"
+import { previewStructuredPromptServer, type StructuredPromptPreviewResponse } from "@/services/prompts-api"
 import {
   estimatePromptTokens,
   getPromptTokenBudgetState
@@ -17,6 +20,12 @@ import {
   tokenizeTemplateVariableHighlights,
   validateTemplateVariableSyntax
 } from "./prompt-template-variable-utils"
+import { StructuredPromptEditor } from "./Structured/StructuredPromptEditor"
+import {
+  convertLegacyPromptToStructuredDefinition,
+  createDefaultStructuredPromptDefinition,
+  renderStructuredPromptLegacySnapshot
+} from "./structured-prompt-utils"
 import { VersionHistoryDrawer } from "./Studio/Prompts/VersionHistoryDrawer"
 
 type DrawerFewShotExample = {
@@ -130,6 +139,8 @@ const normalizePromptDraftSnapshot = (values: {
   details?: unknown
   system_prompt?: unknown
   user_prompt?: unknown
+  promptFormat?: unknown
+  structuredPromptDefinition?: unknown
   keywords?: unknown
   fewShotExamples?: unknown
 }) => {
@@ -162,6 +173,13 @@ const normalizePromptDraftSnapshot = (values: {
     details: normalizeString(values?.details),
     system_prompt: normalizeString(values?.system_prompt),
     user_prompt: normalizeString(values?.user_prompt),
+    promptFormat: values?.promptFormat === "structured" ? "structured" : "legacy",
+    structuredPromptDefinition:
+      values?.promptFormat === "structured" &&
+      values?.structuredPromptDefinition &&
+      typeof values.structuredPromptDefinition === "object"
+        ? values.structuredPromptDefinition
+        : null,
     keywords,
     fewShotExamples
   }
@@ -178,6 +196,9 @@ interface PromptDrawerProps {
     details?: string
     system_prompt?: string
     user_prompt?: string
+    promptFormat?: PromptFormat
+    promptSchemaVersion?: number | null
+    structuredPromptDefinition?: StructuredPromptDefinition | null
     keywords?: string[]
     // Sync fields
     serverId?: number | null
@@ -223,6 +244,15 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
   const [showUserHelp, setShowUserHelp] = React.useState(false)
   const [versionHistoryOpen, setVersionHistoryOpen] = React.useState(false)
   const [closeConfirmOpen, setCloseConfirmOpen] = React.useState(false)
+  const [promptFormat, setPromptFormat] = React.useState<PromptFormat>("legacy")
+  const [structuredPromptDefinition, setStructuredPromptDefinition] =
+    React.useState<StructuredPromptDefinition>(
+      createDefaultStructuredPromptDefinition()
+    )
+  const [structuredPreviewResult, setStructuredPreviewResult] =
+    React.useState<StructuredPromptPreviewResponse | null>(null)
+  const [structuredPreviewLoading, setStructuredPreviewLoading] =
+    React.useState(false)
   const systemPromptValue = Form.useWatch("system_prompt", form)
   const userPromptValue = Form.useWatch("user_prompt", form)
   const systemTemplateVariables = React.useMemo(
@@ -269,13 +299,47 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
     if (open && initialValues) {
       form.setFieldsValue({
         ...initialValues,
-        fewShotExamples: normalizeFewShotExamplesForForm(initialValues.fewShotExamples)
+        fewShotExamples: normalizeFewShotExamplesForForm(initialValues.fewShotExamples),
+        promptFormat: initialValues.promptFormat || "legacy",
+        promptSchemaVersion:
+          initialValues.promptSchemaVersion ??
+          (initialValues.promptFormat === "structured" ? 1 : null),
+        structuredPromptDefinition:
+          initialValues.structuredPromptDefinition ||
+          createDefaultStructuredPromptDefinition()
       })
+      setPromptFormat(initialValues.promptFormat || "legacy")
+      setStructuredPromptDefinition(
+        initialValues.structuredPromptDefinition ||
+          createDefaultStructuredPromptDefinition()
+      )
+      setStructuredPreviewResult(null)
     }
     if (open && mode === "create") {
       form.resetFields()
+      setPromptFormat(
+        (initialValues?.promptFormat as PromptFormat | undefined) || "legacy"
+      )
+      setStructuredPromptDefinition(
+        initialValues?.structuredPromptDefinition ||
+          createDefaultStructuredPromptDefinition()
+      )
+      setStructuredPreviewResult(null)
     }
   }, [open, initialValues, mode, form])
+
+  React.useEffect(() => {
+    if (!open) return
+    form.setFieldValue("promptFormat", promptFormat)
+    form.setFieldValue(
+      "promptSchemaVersion",
+      promptFormat === "structured" ? 1 : null
+    )
+    form.setFieldValue(
+      "structuredPromptDefinition",
+      promptFormat === "structured" ? structuredPromptDefinition : null
+    )
+  }, [form, open, promptFormat, structuredPromptDefinition])
 
   React.useEffect(() => {
     if (!open) {
@@ -289,21 +353,70 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
     if (!open) return
     const interval = setInterval(() => {
       const values = form.getFieldsValue()
-      const hasContent = values.name || values.system_prompt || values.user_prompt
+      const hasContent =
+        values.name ||
+        values.system_prompt ||
+        values.user_prompt ||
+        (promptFormat === "structured" &&
+          Array.isArray(structuredPromptDefinition?.blocks) &&
+          structuredPromptDefinition.blocks.length > 0)
       if (hasContent) {
         saveDraft(values)
       }
     }, 30000)
     return () => clearInterval(interval)
-  }, [open, form, saveDraft])
+  }, [open, form, promptFormat, saveDraft, structuredPromptDefinition])
 
   const handleFinish = (values: any) => {
     clearDraft()
+    const structuredSnapshot =
+      promptFormat === "structured"
+        ? renderStructuredPromptLegacySnapshot(structuredPromptDefinition)
+        : null
     onSubmit({
       ...values,
+      promptFormat,
+      promptSchemaVersion: promptFormat === "structured" ? 1 : null,
+      structuredPromptDefinition:
+        promptFormat === "structured" ? structuredPromptDefinition : null,
+      system_prompt:
+        structuredSnapshot?.systemPrompt ?? values?.system_prompt,
+      user_prompt: structuredSnapshot?.userPrompt ?? values?.user_prompt,
       fewShotExamples: mapFewShotExamplesForSubmit(values?.fewShotExamples)
     })
   }
+
+  const handleConvertToStructured = React.useCallback(() => {
+    const currentValues = form.getFieldsValue(true)
+    setPromptFormat("structured")
+    setStructuredPromptDefinition(
+      convertLegacyPromptToStructuredDefinition(
+        currentValues?.system_prompt,
+        currentValues?.user_prompt
+      )
+    )
+    setStructuredPreviewResult(null)
+  }, [form])
+
+  const handleStructuredPreview = React.useCallback(
+    async (variables: Record<string, string>) => {
+      try {
+        setStructuredPreviewLoading(true)
+        const result = await previewStructuredPromptServer({
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: structuredPromptDefinition,
+          variables
+        })
+        setStructuredPreviewResult(result)
+      } catch {
+        setStructuredPreviewResult(null)
+      } finally {
+        setStructuredPreviewLoading(false)
+      }
+    },
+    [structuredPromptDefinition]
+  )
 
   const closeWithoutSaving = React.useCallback(() => {
     clearDraft()
@@ -824,10 +937,28 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
 
         {/* Section: Prompt Content */}
         <div className="mb-6">
-          <h3 className="text-sm font-medium text-text-muted mb-3">
-            {t("managePrompts.drawer.sectionContent", { defaultValue: "Prompt Content" })}
-          </h3>
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <h3 className="text-sm font-medium text-text-muted">
+              {t("managePrompts.drawer.sectionContent", { defaultValue: "Prompt Content" })}
+            </h3>
+            {promptFormat === "legacy" && (
+              <Button
+                type="default"
+                onClick={handleConvertToStructured}
+              >
+                Convert to structured
+              </Button>
+            )}
+          </div>
           <div className="space-y-4">
+            {promptFormat === "structured" && (
+              <Alert
+                type="info"
+                showIcon
+                title="Structured prompt"
+                description="Raw text fields are now locked for compatibility. Edit the block builder below; save and preview use the structured definition."
+              />
+            )}
             <Form.Item
               name="system_prompt"
               rules={[
@@ -877,6 +1008,7 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
                 })}
                 autoSize={{ minRows: 3, maxRows: 10 }}
                 data-testid="prompt-drawer-system"
+                disabled={promptFormat === "structured"}
               />
             </Form.Item>
 
@@ -953,6 +1085,7 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
                 })}
                 autoSize={{ minRows: 3, maxRows: 10 }}
                 data-testid="prompt-drawer-user"
+                disabled={promptFormat === "structured"}
               />
             </Form.Item>
 
@@ -978,6 +1111,16 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
                   {`Please review the following code and provide:\n1. A brief summary\n2. Potential issues\n3. Suggestions for improvement\n\nCode:\n{paste your code here}`}
                 </pre>
               </div>
+            )}
+
+            {promptFormat === "structured" && (
+              <StructuredPromptEditor
+                value={structuredPromptDefinition}
+                onChange={setStructuredPromptDefinition}
+                previewResult={structuredPreviewResult as any}
+                previewLoading={structuredPreviewLoading}
+                onPreview={handleStructuredPreview}
+              />
             )}
           </div>
         </div>

--- a/apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptDrawer.tsx
@@ -24,7 +24,8 @@ import { StructuredPromptEditor } from "./Structured/StructuredPromptEditor"
 import {
   convertLegacyPromptToStructuredDefinition,
   createDefaultStructuredPromptDefinition,
-  renderStructuredPromptLegacySnapshot
+  renderStructuredPromptLegacySnapshot,
+  stableSerializePromptSnapshot
 } from "./structured-prompt-utils"
 import { VersionHistoryDrawer } from "./Studio/Prompts/VersionHistoryDrawer"
 
@@ -430,7 +431,8 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
     )
     const hasDirtyValues =
       form.isFieldsTouched(true) ||
-      JSON.stringify(currentSnapshot) !== JSON.stringify(initialSnapshot)
+      stableSerializePromptSnapshot(currentSnapshot) !==
+        stableSerializePromptSnapshot(initialSnapshot)
 
     if (hasDirtyValues) {
       setCloseConfirmOpen(true)
@@ -1117,7 +1119,7 @@ export const PromptDrawer: React.FC<PromptDrawerProps> = ({
               <StructuredPromptEditor
                 value={structuredPromptDefinition}
                 onChange={setStructuredPromptDefinition}
-                previewResult={structuredPreviewResult as any}
+                previewResult={structuredPreviewResult}
                 previewLoading={structuredPreviewLoading}
                 onPreview={handleStructuredPreview}
               />

--- a/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
@@ -18,7 +18,8 @@ import { validateTemplateVariableSyntax } from "./prompt-template-variable-utils
 import {
   convertLegacyPromptToStructuredDefinition,
   createDefaultStructuredPromptDefinition,
-  renderStructuredPromptLegacySnapshot
+  renderStructuredPromptLegacySnapshot,
+  stableSerializePromptSnapshot
 } from "./structured-prompt-utils"
 
 const { TextArea } = Input
@@ -190,7 +191,8 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
     const hasDirtyValues =
       dirty ||
       form.isFieldsTouched(true) ||
-      JSON.stringify(currentSnapshot) !== JSON.stringify(initialSnapshot)
+      stableSerializePromptSnapshot(currentSnapshot) !==
+        stableSerializePromptSnapshot(initialSnapshot)
 
     if (hasDirtyValues) {
       const ok = window.confirm(

--- a/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptFullPageEditor.tsx
@@ -1,14 +1,25 @@
-import React, { useEffect, useCallback, useState } from "react"
-import { Form, Input, Select, Collapse } from "antd"
+import React, { useCallback, useEffect, useState } from "react"
+import { Alert, Collapse, Form, Input, Select } from "antd"
 import { useTranslation } from "react-i18next"
 import { ArrowLeft, Save } from "lucide-react"
+import type { PromptFormat, StructuredPromptDefinition } from "@/db/dexie/types"
+import {
+  previewStructuredPromptServer,
+  type StructuredPromptPreviewResponse
+} from "@/services/prompts-api"
 import { PromptEditorPreview } from "./PromptEditorPreview"
+import { StructuredPromptEditor } from "./Structured/StructuredPromptEditor"
 import { useFormDraft, formatDraftAge } from "@/hooks/useFormDraft"
 import {
   estimatePromptTokens,
   getPromptTokenBudgetState,
 } from "./prompt-length-utils"
 import { validateTemplateVariableSyntax } from "./prompt-template-variable-utils"
+import {
+  convertLegacyPromptToStructuredDefinition,
+  createDefaultStructuredPromptDefinition,
+  renderStructuredPromptLegacySnapshot
+} from "./structured-prompt-utils"
 
 const { TextArea } = Input
 
@@ -24,6 +35,39 @@ type PromptFullPageEditorProps = {
 
 const DRAFT_KEY_PREFIX = "tldw-prompt-fullpage-draft-"
 
+const normalizePromptDraftSnapshot = (
+  values: Record<string, any> | null | undefined
+) => {
+  const normalizeString = (value: unknown) =>
+    typeof value === "string" ? value.trim() : ""
+  const keywords = Array.isArray(values?.keywords)
+    ? values.keywords
+        .map((keyword: unknown) =>
+          typeof keyword === "string" ? keyword.trim() : ""
+        )
+        .filter((keyword: string) => keyword.length > 0)
+        .sort()
+    : []
+
+  return {
+    name: normalizeString(values?.name),
+    author: normalizeString(values?.author),
+    details: normalizeString(values?.details),
+    system_prompt: normalizeString(values?.system_prompt),
+    user_prompt: normalizeString(values?.user_prompt),
+    promptFormat:
+      values?.promptFormat === "structured" ? "structured" : "legacy",
+    structuredPromptDefinition:
+      values?.promptFormat === "structured" &&
+      values?.structuredPromptDefinition &&
+      typeof values.structuredPromptDefinition === "object"
+        ? values.structuredPromptDefinition
+        : null,
+    keywords,
+    changeDescription: normalizeString(values?.changeDescription)
+  }
+}
+
 export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   open,
   onClose,
@@ -37,6 +81,12 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   const [form] = Form.useForm()
   const [dirty, setDirty] = useState(false)
   const [showMobilePreview, setShowMobilePreview] = useState(false)
+  const [promptFormat, setPromptFormat] = useState<PromptFormat>("legacy")
+  const [structuredPromptDefinition, setStructuredPromptDefinition] =
+    useState<StructuredPromptDefinition>(createDefaultStructuredPromptDefinition())
+  const [structuredPreviewResult, setStructuredPreviewResult] =
+    useState<StructuredPromptPreviewResponse | null>(null)
+  const [structuredPreviewLoading, setStructuredPreviewLoading] = useState(false)
 
   const draftKey = `${DRAFT_KEY_PREFIX}${mode === "edit" ? initialValues?.id || "new" : "new"}`
   const { hasDraft, draftData, clearDraft, saveDraft, applyDraft, lastSaved } = useFormDraft({
@@ -48,17 +98,31 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
 
   const systemPromptValue = Form.useWatch("system_prompt", form) || ""
   const userPromptValue = Form.useWatch("user_prompt", form) || ""
+  const initialSnapshot = React.useMemo(
+    () => normalizePromptDraftSnapshot(initialValues),
+    [initialValues]
+  )
 
-  // Set initial values
   useEffect(() => {
     if (!open) return
+
     if (hasDraft && draftData) {
       const recovered = applyDraft()
       if (recovered) {
         form.setFieldsValue(recovered)
+        setPromptFormat(
+          recovered.promptFormat === "structured" ? "structured" : "legacy"
+        )
+        setStructuredPromptDefinition(
+          recovered.structuredPromptDefinition ||
+            createDefaultStructuredPromptDefinition()
+        )
+        setStructuredPreviewResult(null)
+        setDirty(false)
         return
       }
     }
+
     if (initialValues) {
       form.setFieldsValue({
         name: initialValues.name || "",
@@ -66,22 +130,52 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
         details: initialValues.details || "",
         system_prompt: initialValues.system_prompt || "",
         user_prompt: initialValues.user_prompt || "",
+        promptFormat:
+          initialValues.promptFormat === "structured" ? "structured" : "legacy",
+        promptSchemaVersion:
+          initialValues.promptSchemaVersion ??
+          (initialValues.promptFormat === "structured" ? 1 : null),
+        structuredPromptDefinition:
+          initialValues.structuredPromptDefinition ||
+          createDefaultStructuredPromptDefinition(),
         keywords: initialValues.keywords || [],
         changeDescription: initialValues.changeDescription || "",
       })
+      setPromptFormat(
+        initialValues.promptFormat === "structured" ? "structured" : "legacy"
+      )
+      setStructuredPromptDefinition(
+        initialValues.structuredPromptDefinition ||
+          createDefaultStructuredPromptDefinition()
+      )
     } else {
       form.resetFields()
+      setPromptFormat("legacy")
+      setStructuredPromptDefinition(createDefaultStructuredPromptDefinition())
     }
+
+    setStructuredPreviewResult(null)
     setDirty(false)
   }, [open, initialValues, hasDraft, draftData, applyDraft, form])
 
-  // Mark dirty changes for auto-save
+  useEffect(() => {
+    if (!open) return
+    form.setFieldValue("promptFormat", promptFormat)
+    form.setFieldValue(
+      "promptSchemaVersion",
+      promptFormat === "structured" ? 1 : null
+    )
+    form.setFieldValue(
+      "structuredPromptDefinition",
+      promptFormat === "structured" ? structuredPromptDefinition : null
+    )
+  }, [form, open, promptFormat, structuredPromptDefinition])
+
   useEffect(() => {
     if (!open || !dirty) return
-    saveDraft(form.getFieldsValue())
-  }, [open, dirty, form, saveDraft])
+    saveDraft(form.getFieldsValue(true))
+  }, [open, dirty, promptFormat, structuredPromptDefinition, form, saveDraft])
 
-  // beforeunload guard
   useEffect(() => {
     if (!open || !dirty) return
     const handler = (e: BeforeUnloadEvent) => {
@@ -92,7 +186,13 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
   }, [open, dirty])
 
   const handleRequestClose = useCallback(() => {
-    if (dirty) {
+    const currentSnapshot = normalizePromptDraftSnapshot(form.getFieldsValue(true))
+    const hasDirtyValues =
+      dirty ||
+      form.isFieldsTouched(true) ||
+      JSON.stringify(currentSnapshot) !== JSON.stringify(initialSnapshot)
+
+    if (hasDirtyValues) {
       const ok = window.confirm(
         t("managePrompts.drawer.unsavedChanges", {
           defaultValue: "You have unsaved changes. Discard them?",
@@ -100,11 +200,11 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
       )
       if (!ok) return
     }
+
     clearDraft()
     onClose()
-  }, [dirty, clearDraft, onClose, t])
+  }, [clearDraft, dirty, form, initialSnapshot, onClose, t])
 
-  // Keyboard shortcuts
   useEffect(() => {
     if (!open) return
     const handler = (e: KeyboardEvent) => {
@@ -128,19 +228,64 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
           .filter((k: string) => k.length > 0)
           .sort()
       : []
+    const structuredSnapshot =
+      promptFormat === "structured"
+        ? renderStructuredPromptLegacySnapshot(structuredPromptDefinition)
+        : null
 
     onSubmit({
       ...values,
+      promptFormat,
+      promptSchemaVersion: promptFormat === "structured" ? 1 : null,
+      structuredPromptDefinition:
+        promptFormat === "structured" ? structuredPromptDefinition : null,
       keywords,
       name: (values.name || "").trim(),
       author: (values.author || "").trim(),
       details: (values.details || "").trim(),
-      system_prompt: (values.system_prompt || "").trim(),
-      user_prompt: (values.user_prompt || "").trim(),
+      system_prompt: (
+        structuredSnapshot?.systemPrompt ?? values.system_prompt ?? ""
+      ).trim(),
+      user_prompt: (
+        structuredSnapshot?.userPrompt ?? values.user_prompt ?? ""
+      ).trim(),
     })
     clearDraft()
     setDirty(false)
   }
+
+  const handleConvertToStructured = useCallback(() => {
+    const currentValues = form.getFieldsValue(true)
+    setPromptFormat("structured")
+    setStructuredPromptDefinition(
+      convertLegacyPromptToStructuredDefinition(
+        currentValues?.system_prompt,
+        currentValues?.user_prompt
+      )
+    )
+    setStructuredPreviewResult(null)
+    setDirty(true)
+  }, [form])
+
+  const handleStructuredPreview = useCallback(
+    async (variables: Record<string, string>) => {
+      try {
+        setStructuredPreviewLoading(true)
+        const result = await previewStructuredPromptServer({
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: structuredPromptDefinition,
+          variables
+        })
+        setStructuredPreviewResult(result)
+      } catch {
+        setStructuredPreviewResult(null)
+      } finally {
+        setStructuredPreviewLoading(false)
+      }
+    },
+    [structuredPromptDefinition]
+  )
 
   const templateFieldValidator = (_: any, value: string) => {
     if (!value) return Promise.resolve()
@@ -154,8 +299,19 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
     return Promise.resolve()
   }
 
-  const sysTokens = estimatePromptTokens(systemPromptValue)
-  const userTokens = estimatePromptTokens(userPromptValue)
+  const structuredLegacySnapshot = React.useMemo(
+    () =>
+      promptFormat === "structured"
+        ? renderStructuredPromptLegacySnapshot(structuredPromptDefinition)
+        : null,
+    [promptFormat, structuredPromptDefinition]
+  )
+  const previewSystemPrompt =
+    structuredLegacySnapshot?.systemPrompt || systemPromptValue
+  const previewUserPrompt =
+    structuredLegacySnapshot?.userPrompt || userPromptValue
+  const sysTokens = estimatePromptTokens(previewSystemPrompt)
+  const userTokens = estimatePromptTokens(previewUserPrompt)
   const sysBudget = getPromptTokenBudgetState(sysTokens)
   const userBudget = getPromptTokenBudgetState(userTokens)
 
@@ -187,7 +343,6 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
       className="fixed inset-0 z-50 flex flex-col bg-background"
       data-testid="prompt-full-page-editor"
     >
-      {/* Top bar */}
       <div className="flex items-center justify-between border-b border-border px-4 py-2">
         <div className="flex items-center gap-3">
           <button
@@ -228,9 +383,7 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
         </div>
       </div>
 
-      {/* Two-column layout */}
       <div className="flex flex-1 min-h-0">
-        {/* Editor column */}
         <div className="flex-[55] overflow-y-auto border-r border-border p-6">
           <Form
             form={form}
@@ -239,7 +392,6 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
             onValuesChange={() => setDirty(true)}
             className="mx-auto max-w-2xl space-y-6"
           >
-            {/* Identity section */}
             <div>
               <h3 className="mb-3 text-sm font-semibold text-text">Identity</h3>
               <div className="grid grid-cols-2 gap-4">
@@ -259,11 +411,30 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
               </div>
             </div>
 
-            {/* Prompt Content */}
             <div>
               <h3 className="mb-3 text-sm font-semibold text-text">
                 Prompt Content
               </h3>
+              {promptFormat === "legacy" && (
+                <div className="mb-4">
+                  <button
+                    type="button"
+                    onClick={handleConvertToStructured}
+                    className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-medium text-text hover:border-primary/40 hover:text-primary"
+                  >
+                    Convert to structured
+                  </button>
+                </div>
+              )}
+              {promptFormat === "structured" && (
+                <Alert
+                  type="info"
+                  showIcon
+                  className="mb-4"
+                  title="Structured prompt"
+                  description="This prompt now uses ordered blocks. The raw system and user fields are locked for compatibility; save and preview use the structured definition."
+                />
+              )}
               <Form.Item
                 name="system_prompt"
                 label="AI Instructions (System Prompt)"
@@ -273,9 +444,12 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
                   autoSize={{ minRows: 6, maxRows: 30 }}
                   placeholder="You are a helpful assistant that..."
                   data-testid="full-editor-system-prompt"
+                  disabled={promptFormat === "structured"}
                 />
               </Form.Item>
-              <div className="mb-4 -mt-2">{tokenLabel(systemPromptValue.length, sysBudget)}</div>
+              <div className="mb-4 -mt-2">
+                {tokenLabel(previewSystemPrompt.length, sysBudget)}
+              </div>
 
               <Form.Item
                 name="user_prompt"
@@ -286,12 +460,30 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
                   autoSize={{ minRows: 4, maxRows: 20 }}
                   placeholder="Analyze the following: {{input}}"
                   data-testid="full-editor-user-prompt"
+                  disabled={promptFormat === "structured"}
                 />
               </Form.Item>
-              <div className="-mt-2">{tokenLabel(userPromptValue.length, userBudget)}</div>
+              <div className="-mt-2">
+                {tokenLabel(previewUserPrompt.length, userBudget)}
+              </div>
+
+              {promptFormat === "structured" && (
+                <div className="mt-4">
+                  <StructuredPromptEditor
+                    value={structuredPromptDefinition}
+                    onChange={(nextValue) => {
+                      setStructuredPromptDefinition(nextValue)
+                      setStructuredPreviewResult(null)
+                      setDirty(true)
+                    }}
+                    previewResult={structuredPreviewResult}
+                    previewLoading={structuredPreviewLoading}
+                    onPreview={handleStructuredPreview}
+                  />
+                </div>
+              )}
             </div>
 
-            {/* Organization */}
             <div>
               <h3 className="mb-3 text-sm font-semibold text-text">
                 Organization
@@ -300,7 +492,7 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
                 <Select
                   mode="tags"
                   placeholder="Add tags..."
-                  options={allTags.map((t) => ({ label: t, value: t }))}
+                  options={allTags.map((tag) => ({ label: tag, value: tag }))}
                   data-testid="full-editor-keywords"
                 />
               </Form.Item>
@@ -313,7 +505,6 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
               </Form.Item>
             </div>
 
-            {/* Advanced (collapsed) */}
             <Collapse
               ghost
               items={[
@@ -340,16 +531,14 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
           </Form>
         </div>
 
-        {/* Preview column - desktop */}
         <div className="hidden flex-[45] md:flex flex-col bg-surface">
           <PromptEditorPreview
-            systemPrompt={systemPromptValue}
-            userPrompt={userPromptValue}
+            systemPrompt={previewSystemPrompt}
+            userPrompt={previewUserPrompt}
           />
         </div>
       </div>
 
-      {/* Mobile preview toggle */}
       <div className="md:hidden">
         <button
           type="button"
@@ -361,8 +550,8 @@ export const PromptFullPageEditor: React.FC<PromptFullPageEditorProps> = ({
         {showMobilePreview && (
           <div className="fixed inset-0 z-40 bg-background pt-12">
             <PromptEditorPreview
-              systemPrompt={systemPromptValue}
-              userPrompt={userPromptValue}
+              systemPrompt={previewSystemPrompt}
+              userPrompt={previewUserPrompt}
             />
           </div>
         )}

--- a/apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/PromptStarterCards.tsx
@@ -1,12 +1,16 @@
 import React from "react"
 import { Code, FileText, Search } from "lucide-react"
+import type { PromptFormat, StructuredPromptDefinition } from "@/db/dexie/types"
+import {
+  createStructuredPromptDefinition,
+  renderStructuredPromptLegacySnapshot
+} from "./structured-prompt-utils"
 
 type StarterPrompt = {
   icon: React.ReactNode
   title: string
   description: string
-  system_prompt: string
-  user_prompt: string
+  structuredPromptDefinition: StructuredPromptDefinition
   keywords: string[]
 }
 
@@ -15,28 +19,120 @@ const STARTER_PROMPTS: StarterPrompt[] = [
     icon: <Code className="size-5 text-primary" />,
     title: "Code Review Assistant",
     description: "Reviews code for bugs, style, and best practices",
-    system_prompt:
-      "You are an expert code reviewer. Analyze code for bugs, performance issues, security vulnerabilities, and adherence to best practices. Provide specific, actionable feedback with line references.",
-    user_prompt: "Review the following code:\n\n{{code}}",
+    structuredPromptDefinition: createStructuredPromptDefinition({
+      variables: [
+        {
+          name: "code",
+          label: "Code",
+          description: "The source code or diff to review.",
+          required: true,
+          input_type: "textarea"
+        }
+      ],
+      blocks: [
+        {
+          id: "role",
+          name: "Role",
+          role: "system",
+          content:
+            "You are an expert code reviewer. Deliver precise, actionable feedback."
+        },
+        {
+          id: "review-focus",
+          name: "Review Focus",
+          role: "developer",
+          content:
+            "Check for correctness, regressions, security risks, performance issues, maintainability, and missing tests. Call out the most important findings first and cite exact evidence when possible."
+        },
+        {
+          id: "task",
+          name: "Task",
+          role: "user",
+          content: "Review the following code:\n\n{{code}}",
+          is_template: true
+        }
+      ]
+    }),
     keywords: ["code", "review", "development"],
   },
   {
     icon: <FileText className="size-5 text-primary" />,
     title: "Meeting Summary",
     description: "Extracts key points and action items from meeting notes",
-    system_prompt:
-      "You are a professional meeting summarizer. Extract key decisions, action items with owners, open questions, and important discussion points. Format the output clearly with sections.",
-    user_prompt:
-      "Summarize the following meeting notes:\n\n{{meeting_notes}}",
+    structuredPromptDefinition: createStructuredPromptDefinition({
+      variables: [
+        {
+          name: "meeting_notes",
+          label: "Meeting notes",
+          description: "Raw meeting notes or transcript text.",
+          required: true,
+          input_type: "textarea"
+        }
+      ],
+      blocks: [
+        {
+          id: "role",
+          name: "Role",
+          role: "system",
+          content:
+            "You are a professional meeting summarizer who extracts decisions and next steps."
+        },
+        {
+          id: "output-format",
+          name: "Output Format",
+          role: "developer",
+          content:
+            "Return sections for key decisions, action items with owners, open questions, and notable discussion points."
+        },
+        {
+          id: "task",
+          name: "Task",
+          role: "user",
+          content: "Summarize the following meeting notes:\n\n{{meeting_notes}}",
+          is_template: true
+        }
+      ]
+    }),
     keywords: ["meeting", "summary", "notes"],
   },
   {
     icon: <Search className="size-5 text-primary" />,
     title: "Research Analyst",
     description: "Analyzes topics with structured research methodology",
-    system_prompt:
-      "You are a thorough research analyst. When given a topic, provide a balanced analysis covering key facts, different perspectives, recent developments, and areas of uncertainty. Cite reasoning clearly.",
-    user_prompt: "Research and analyze the following topic:\n\n{{topic}}",
+    structuredPromptDefinition: createStructuredPromptDefinition({
+      variables: [
+        {
+          name: "topic",
+          label: "Topic",
+          description: "The subject to research and analyze.",
+          required: true,
+          input_type: "text"
+        }
+      ],
+      blocks: [
+        {
+          id: "role",
+          name: "Role",
+          role: "system",
+          content:
+            "You are a thorough research analyst who produces balanced, evidence-aware analysis."
+        },
+        {
+          id: "analysis-frame",
+          name: "Analysis Frame",
+          role: "developer",
+          content:
+            "Cover the key facts, competing perspectives, recent developments, and the main uncertainties or gaps in the evidence."
+        },
+        {
+          id: "task",
+          name: "Task",
+          role: "user",
+          content: "Research and analyze the following topic:\n\n{{topic}}",
+          is_template: true
+        }
+      ]
+    }),
     keywords: ["research", "analysis", "study"],
   },
 ]
@@ -47,6 +143,9 @@ type Props = {
     system_prompt: string
     user_prompt: string
     keywords: string[]
+    promptFormat?: PromptFormat
+    promptSchemaVersion?: number
+    structuredPromptDefinition?: StructuredPromptDefinition
   }) => void
 }
 
@@ -67,14 +166,20 @@ export const PromptStarterCards: React.FC<Props> = ({ onUse }) => {
           </p>
           <button
             type="button"
-            onClick={() =>
+            onClick={() => {
+              const legacySnapshot = renderStructuredPromptLegacySnapshot(
+                sp.structuredPromptDefinition
+              )
               onUse({
                 name: sp.title,
-                system_prompt: sp.system_prompt,
-                user_prompt: sp.user_prompt,
+                system_prompt: legacySnapshot.systemPrompt,
+                user_prompt: legacySnapshot.userPrompt,
                 keywords: sp.keywords,
+                promptFormat: "structured",
+                promptSchemaVersion: 1,
+                structuredPromptDefinition: sp.structuredPromptDefinition
               })
-            }
+            }}
             className="rounded bg-primary/10 px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/20"
             data-testid={`starter-use-${sp.title.toLowerCase().replace(/\s+/g, "-")}`}
           >

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/BlockEditorPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/BlockEditorPanel.tsx
@@ -1,0 +1,115 @@
+import React from "react"
+
+type StructuredPromptBlock = {
+  id: string
+  name: string
+  role: "system" | "developer" | "user" | "assistant"
+  content: string
+  enabled: boolean
+  order: number
+  is_template: boolean
+}
+
+type BlockEditorPanelProps = {
+  block: StructuredPromptBlock | null
+  onChange: (updates: Partial<StructuredPromptBlock>) => void
+}
+
+export const BlockEditorPanel: React.FC<BlockEditorPanelProps> = ({
+  block,
+  onChange
+}) => {
+  if (!block) {
+    return (
+      <section className="rounded-xl border border-border bg-surface1 p-4">
+        <h3 className="text-sm font-semibold text-text">Block editor</h3>
+        <p className="mt-2 text-sm text-text-muted">
+          Select a block to edit its role, content, and template behavior.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface1 p-4">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-text">Block editor</h3>
+        <p className="text-xs text-text-muted">
+          Keep each block focused on one job: identity, task, constraints, or examples.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+            Name
+          </span>
+          <input
+            type="text"
+            value={block.name}
+            onChange={(event) => onChange({ name: event.target.value })}
+            data-testid="structured-block-name"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-text"
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+            Role
+          </span>
+          <select
+            value={block.role}
+            onChange={(event) =>
+              onChange({
+                role: event.target.value as StructuredPromptBlock["role"]
+              })
+            }
+            data-testid="structured-block-role"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-text"
+          >
+            <option value="system">System</option>
+            <option value="developer">Developer</option>
+            <option value="user">User</option>
+            <option value="assistant">Assistant</option>
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+            Content
+          </span>
+          <textarea
+            value={block.content}
+            onChange={(event) => onChange({ content: event.target.value })}
+            rows={8}
+            data-testid="structured-block-content"
+            className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-text"
+          />
+        </label>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex items-center gap-2 text-sm text-text">
+            <input
+              type="checkbox"
+              checked={block.enabled}
+              onChange={(event) => onChange({ enabled: event.target.checked })}
+              data-testid="structured-block-enabled"
+            />
+            Enabled
+          </label>
+          <label className="flex items-center gap-2 text-sm text-text">
+            <input
+              type="checkbox"
+              checked={block.is_template}
+              onChange={(event) =>
+                onChange({ is_template: event.target.checked })
+              }
+              data-testid="structured-block-template"
+            />
+            Uses variables
+          </label>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/BlockListPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/BlockListPanel.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import { Plus, Trash2, ArrowUp, ArrowDown } from "lucide-react"
+
+type StructuredPromptBlock = {
+  id: string
+  name: string
+  role: "system" | "developer" | "user" | "assistant"
+  content: string
+  enabled: boolean
+  order: number
+  is_template: boolean
+}
+
+type BlockListPanelProps = {
+  blocks: StructuredPromptBlock[]
+  selectedBlockId: string | null
+  onSelect: (blockId: string) => void
+  onAddBlock: () => void
+  onMoveBlock: (blockId: string, direction: "up" | "down") => void
+  onRemoveBlock: (blockId: string) => void
+}
+
+export const BlockListPanel: React.FC<BlockListPanelProps> = ({
+  blocks,
+  selectedBlockId,
+  onSelect,
+  onAddBlock,
+  onMoveBlock,
+  onRemoveBlock
+}) => {
+  return (
+    <section className="rounded-xl border border-border bg-surface1 p-3">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-text">Blocks</h3>
+          <p className="text-xs text-text-muted">
+            Ordered prompt sections assembled by the backend.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onAddBlock}
+          data-testid="structured-block-add"
+          className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-text hover:bg-surface2"
+        >
+          <Plus className="size-3" />
+          Add block
+        </button>
+      </div>
+
+      <div className="space-y-2" data-testid="structured-block-list">
+        {blocks.map((block, index) => {
+          const isSelected = block.id === selectedBlockId
+          return (
+            <div
+              key={block.id}
+              data-testid={`structured-block-item-${block.id}`}
+              className={`rounded-lg border p-2 ${
+                isSelected
+                  ? "border-primary bg-primary/5"
+                  : "border-border bg-background"
+              }`}
+              onClick={() => onSelect(block.id)}
+            >
+              <button
+                type="button"
+                onClick={() => onSelect(block.id)}
+                className="flex w-full items-start justify-between gap-3 text-left"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-medium text-text">{block.name}</div>
+                  <div className="text-xs uppercase tracking-wide text-text-muted">
+                    {block.role}
+                    {!block.enabled ? " • disabled" : ""}
+                  </div>
+                </div>
+                <div className="line-clamp-2 max-w-[10rem] text-xs text-text-muted">
+                  {block.content || "No content"}
+                </div>
+              </button>
+
+              <div className="mt-2 flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onMoveBlock(block.id, "up")}
+                  disabled={index === 0}
+                  data-testid={`structured-block-move-up-${block.id}`}
+                  className="rounded border border-border p-1 text-text-muted disabled:opacity-40"
+                >
+                  <ArrowUp className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onMoveBlock(block.id, "down")}
+                  disabled={index === blocks.length - 1}
+                  data-testid={`structured-block-move-down-${block.id}`}
+                  className="rounded border border-border p-1 text-text-muted disabled:opacity-40"
+                >
+                  <ArrowDown className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRemoveBlock(block.id)}
+                  data-testid={`structured-block-remove-${block.id}`}
+                  className="rounded border border-border p-1 text-danger hover:bg-danger/5"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx
@@ -1,0 +1,300 @@
+import React from "react"
+import type {
+  StructuredPromptDefinition,
+  StructuredPromptPreviewResponse
+} from "@/services/prompt-studio"
+import { BlockListPanel } from "./BlockListPanel"
+import { BlockEditorPanel } from "./BlockEditorPanel"
+import { VariableEditorPanel } from "./VariableEditorPanel"
+
+type StructuredPromptBlock = {
+  id: string
+  name: string
+  role: "system" | "developer" | "user" | "assistant"
+  content: string
+  enabled: boolean
+  order: number
+  is_template: boolean
+}
+
+type StructuredPromptVariable = {
+  name: string
+  required?: boolean
+  input_type?: string
+  label?: string
+  description?: string
+}
+
+type StructuredPromptEditorProps = {
+  value: StructuredPromptDefinition | null | undefined
+  onChange: (nextValue: StructuredPromptDefinition) => void
+  previewResult: StructuredPromptPreviewResponse | null
+  previewLoading: boolean
+  onPreview: (variables: Record<string, string>) => void
+}
+
+const makeDefaultBlock = (): StructuredPromptBlock => ({
+  id: `block-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  name: "Task",
+  role: "user",
+  content: "Describe the task here.",
+  enabled: true,
+  order: 10,
+  is_template: false
+})
+
+const reindexBlocks = (blocks: StructuredPromptBlock[]): StructuredPromptBlock[] =>
+  blocks.map((block, index) => ({
+    ...block,
+    order: (index + 1) * 10
+  }))
+
+const normalizeDefinition = (
+  value: StructuredPromptDefinition | null | undefined
+): StructuredPromptDefinition => {
+  const candidate = value && typeof value === "object" ? value : {}
+  const blocks = Array.isArray(candidate.blocks)
+    ? reindexBlocks(
+        candidate.blocks.map((block: any, index: number) => ({
+          id: typeof block?.id === "string" ? block.id : `block-${index + 1}`,
+          name: typeof block?.name === "string" ? block.name : `Block ${index + 1}`,
+          role:
+            block?.role === "system" ||
+            block?.role === "developer" ||
+            block?.role === "assistant"
+              ? block.role
+              : "user",
+          content: typeof block?.content === "string" ? block.content : "",
+          enabled: block?.enabled !== false,
+          order:
+            typeof block?.order === "number" && Number.isFinite(block.order)
+              ? block.order
+              : (index + 1) * 10,
+          is_template: block?.is_template === true
+        }))
+      )
+    : [makeDefaultBlock()]
+
+  const variables = Array.isArray(candidate.variables)
+    ? candidate.variables.map((variable: any) => ({
+        name: typeof variable?.name === "string" ? variable.name : "",
+        required: variable?.required === true,
+        input_type:
+          typeof variable?.input_type === "string" ? variable.input_type : "text",
+        label: typeof variable?.label === "string" ? variable.label : undefined,
+        description:
+          typeof variable?.description === "string"
+            ? variable.description
+            : undefined
+      }))
+    : []
+
+  return {
+    schema_version:
+      typeof candidate.schema_version === "number" &&
+      Number.isFinite(candidate.schema_version)
+        ? candidate.schema_version
+        : 1,
+    format: "structured",
+    variables,
+    blocks
+  }
+}
+
+export const StructuredPromptEditor: React.FC<StructuredPromptEditorProps> = ({
+  value,
+  onChange,
+  previewResult,
+  previewLoading,
+  onPreview
+}) => {
+  const definition = React.useMemo(() => normalizeDefinition(value), [value])
+  const [selectedBlockId, setSelectedBlockId] = React.useState<string | null>(
+    definition.blocks[0]?.id || null
+  )
+  const [previewValues, setPreviewValues] = React.useState<Record<string, string>>(
+    {}
+  )
+
+  React.useEffect(() => {
+    if (!definition.blocks.some((block: any) => block.id === selectedBlockId)) {
+      setSelectedBlockId(definition.blocks[0]?.id || null)
+    }
+  }, [definition.blocks, selectedBlockId])
+
+  React.useEffect(() => {
+    setPreviewValues((currentValues) => {
+      const allowedNames = new Set(
+        definition.variables
+          .map((variable: any) => variable.name)
+          .filter((name: string) => name.length > 0)
+      )
+      return Object.fromEntries(
+        Object.entries(currentValues).filter(([name]) => allowedNames.has(name))
+      )
+    })
+  }, [definition.variables])
+
+  const selectedBlock =
+    definition.blocks.find((block: any) => block.id === selectedBlockId) || null
+
+  const updateDefinition = (nextValue: StructuredPromptDefinition) => {
+    onChange(normalizeDefinition(nextValue))
+  }
+
+  const updateBlocks = (blocks: StructuredPromptBlock[]) => {
+    updateDefinition({
+      ...definition,
+      blocks: reindexBlocks(blocks)
+    })
+  }
+
+  const handleAddBlock = () => {
+    const nextBlock = makeDefaultBlock()
+    updateBlocks([...definition.blocks, nextBlock as StructuredPromptBlock])
+    setSelectedBlockId(nextBlock.id)
+  }
+
+  const handleMoveBlock = (
+    blockId: string,
+    direction: "up" | "down"
+  ) => {
+    const currentIndex = definition.blocks.findIndex((block: any) => block.id === blockId)
+    if (currentIndex < 0) return
+    const targetIndex = direction === "up" ? currentIndex - 1 : currentIndex + 1
+    if (targetIndex < 0 || targetIndex >= definition.blocks.length) return
+
+    const nextBlocks = [...definition.blocks]
+    const [moved] = nextBlocks.splice(currentIndex, 1)
+    nextBlocks.splice(targetIndex, 0, moved)
+    updateBlocks(nextBlocks as StructuredPromptBlock[])
+  }
+
+  const handleRemoveBlock = (blockId: string) => {
+    const nextBlocks = definition.blocks.filter((block: any) => block.id !== blockId)
+    const fallbackBlocks =
+      nextBlocks.length > 0 ? nextBlocks : ([makeDefaultBlock()] as StructuredPromptBlock[])
+    updateBlocks(fallbackBlocks as StructuredPromptBlock[])
+    if (selectedBlockId === blockId) {
+      setSelectedBlockId(fallbackBlocks[0]?.id || null)
+    }
+  }
+
+  const handleUpdateBlock = (updates: Partial<StructuredPromptBlock>) => {
+    if (!selectedBlock) return
+    updateBlocks(
+      definition.blocks.map((block: any) =>
+        block.id === selectedBlock.id ? { ...block, ...updates } : block
+      ) as StructuredPromptBlock[]
+    )
+  }
+
+  const handleVariablesChange = (variables: StructuredPromptVariable[]) => {
+    updateDefinition({
+      ...definition,
+      variables
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3 rounded-xl border border-border bg-surface1 p-4">
+        <div>
+          <h3 className="text-sm font-semibold text-text">
+            Structured prompt builder
+          </h3>
+          <p className="text-sm text-text-muted">
+            Build prompts from ordered blocks and preview the assembled backend messages.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onPreview(previewValues)}
+          data-testid="structured-preview-button"
+          className="rounded-md bg-primary px-3 py-2 text-sm font-medium text-white hover:opacity-90 disabled:opacity-60"
+          disabled={previewLoading}
+        >
+          {previewLoading ? "Previewing..." : "Preview"}
+        </button>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[18rem_minmax(0,1fr)]">
+        <BlockListPanel
+          blocks={definition.blocks as StructuredPromptBlock[]}
+          selectedBlockId={selectedBlockId}
+          onSelect={setSelectedBlockId}
+          onAddBlock={handleAddBlock}
+          onMoveBlock={handleMoveBlock}
+          onRemoveBlock={handleRemoveBlock}
+        />
+        <BlockEditorPanel
+          block={selectedBlock as StructuredPromptBlock | null}
+          onChange={handleUpdateBlock}
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <VariableEditorPanel
+          variables={definition.variables as StructuredPromptVariable[]}
+          previewValues={previewValues}
+          onVariablesChange={handleVariablesChange}
+          onPreviewValuesChange={setPreviewValues}
+        />
+
+        <section className="rounded-xl border border-border bg-surface1 p-4">
+          <div className="mb-3">
+            <h3 className="text-sm font-semibold text-text">Preview</h3>
+            <p className="text-xs text-text-muted">
+              Live server-side assembly using the Prompt Studio preview endpoint.
+            </p>
+          </div>
+
+          {!previewResult && (
+            <p className="text-sm text-text-muted">
+              Run preview to inspect the assembled role-based messages and legacy snapshot.
+            </p>
+          )}
+
+          {previewResult && (
+            <div className="space-y-4" data-testid="structured-preview-panel">
+              <div className="space-y-2">
+                {previewResult.assembled_messages.map((message, index) => (
+                  <div
+                    key={`${message.role}-${index}`}
+                    className="rounded-lg border border-border bg-background p-3"
+                  >
+                    <div className="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">
+                      {message.role}
+                    </div>
+                    <div className="whitespace-pre-wrap text-sm text-text">
+                      {message.content}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-lg border border-border bg-background p-3">
+                  <div className="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">
+                    Legacy system
+                  </div>
+                  <div className="whitespace-pre-wrap text-sm text-text">
+                    {previewResult.legacy_system_prompt || "No system output"}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-border bg-background p-3">
+                  <div className="mb-1 text-xs font-medium uppercase tracking-wide text-text-muted">
+                    Legacy user
+                  </div>
+                  <div className="whitespace-pre-wrap text-sm text-text">
+                    {previewResult.legacy_user_prompt || "No user output"}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/StructuredPromptEditor.tsx
@@ -11,6 +11,7 @@ type StructuredPromptBlock = {
   id: string
   name: string
   role: "system" | "developer" | "user" | "assistant"
+  kind?: string
   content: string
   enabled: boolean
   order: number
@@ -23,6 +24,15 @@ type StructuredPromptVariable = {
   input_type?: string
   label?: string
   description?: string
+  default_value?: unknown
+  options?: string[] | null
+  max_length?: number
+}
+
+type StructuredPromptAssemblyConfig = {
+  legacy_system_roles: string[]
+  legacy_user_roles: string[]
+  block_separator: string
 }
 
 type StructuredPromptEditorProps = {
@@ -37,11 +47,18 @@ const makeDefaultBlock = (): StructuredPromptBlock => ({
   id: `block-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   name: "Task",
   role: "user",
+  kind: "task",
   content: "Describe the task here.",
   enabled: true,
   order: 10,
   is_template: false
 })
+
+const DEFAULT_ASSEMBLY_CONFIG: StructuredPromptAssemblyConfig = {
+  legacy_system_roles: ["system", "developer"],
+  legacy_user_roles: ["user"],
+  block_separator: "\n\n"
+}
 
 const reindexBlocks = (blocks: StructuredPromptBlock[]): StructuredPromptBlock[] =>
   blocks.map((block, index) => ({
@@ -53,6 +70,26 @@ const normalizeDefinition = (
   value: StructuredPromptDefinition | null | undefined
 ): StructuredPromptDefinition => {
   const candidate = value && typeof value === "object" ? value : {}
+  const assemblyConfigCandidate =
+    candidate.assembly_config &&
+    typeof candidate.assembly_config === "object" &&
+    !Array.isArray(candidate.assembly_config)
+      ? (candidate.assembly_config as Record<string, unknown>)
+      : null
+  const assemblyConfig: StructuredPromptAssemblyConfig = {
+    legacy_system_roles: Array.isArray(assemblyConfigCandidate?.legacy_system_roles)
+      ? assemblyConfigCandidate.legacy_system_roles
+          .filter((role): role is string => typeof role === "string")
+      : DEFAULT_ASSEMBLY_CONFIG.legacy_system_roles,
+    legacy_user_roles: Array.isArray(assemblyConfigCandidate?.legacy_user_roles)
+      ? assemblyConfigCandidate.legacy_user_roles
+          .filter((role): role is string => typeof role === "string")
+      : DEFAULT_ASSEMBLY_CONFIG.legacy_user_roles,
+    block_separator:
+      typeof assemblyConfigCandidate?.block_separator === "string"
+        ? assemblyConfigCandidate.block_separator
+        : DEFAULT_ASSEMBLY_CONFIG.block_separator
+  }
   const blocks = Array.isArray(candidate.blocks)
     ? reindexBlocks(
         candidate.blocks.map((block: any, index: number) => ({
@@ -64,6 +101,7 @@ const normalizeDefinition = (
             block?.role === "assistant"
               ? block.role
               : "user",
+          kind: typeof block?.kind === "string" ? block.kind : undefined,
           content: typeof block?.content === "string" ? block.content : "",
           enabled: block?.enabled !== false,
           order:
@@ -85,6 +123,24 @@ const normalizeDefinition = (
         description:
           typeof variable?.description === "string"
             ? variable.description
+            : undefined,
+        default_value:
+          variable && Object.prototype.hasOwnProperty.call(variable, "default_value")
+            ? variable.default_value
+            : undefined,
+        options:
+          variable?.options === null
+            ? null
+            : Array.isArray(variable?.options)
+              ? variable.options.filter(
+                  (option: unknown): option is string => typeof option === "string"
+                )
+              : undefined,
+        max_length:
+          typeof variable?.max_length === "number" &&
+          Number.isFinite(variable.max_length) &&
+          variable.max_length >= 1
+            ? variable.max_length
             : undefined
       }))
     : []
@@ -96,6 +152,7 @@ const normalizeDefinition = (
         ? candidate.schema_version
         : 1,
     format: "structured",
+    assembly_config: assemblyConfig,
     variables,
     blocks
   }

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/VariableEditorPanel.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/VariableEditorPanel.tsx
@@ -1,0 +1,184 @@
+import React from "react"
+import { Plus, Trash2 } from "lucide-react"
+
+type StructuredPromptVariable = {
+  name: string
+  required?: boolean
+  input_type?: string
+  label?: string
+  description?: string
+}
+
+type VariableEditorPanelProps = {
+  variables: StructuredPromptVariable[]
+  previewValues: Record<string, string>
+  onVariablesChange: (variables: StructuredPromptVariable[]) => void
+  onPreviewValuesChange: (values: Record<string, string>) => void
+}
+
+export const VariableEditorPanel: React.FC<VariableEditorPanelProps> = ({
+  variables,
+  previewValues,
+  onVariablesChange,
+  onPreviewValuesChange
+}) => {
+  const updateVariable = (
+    index: number,
+    updates: Partial<StructuredPromptVariable>
+  ) => {
+    const next = variables.map((variable, currentIndex) =>
+      currentIndex === index ? { ...variable, ...updates } : variable
+    )
+    onVariablesChange(next)
+  }
+
+  const removeVariable = (index: number) => {
+    const next = variables.filter((_, currentIndex) => currentIndex !== index)
+    onVariablesChange(next)
+    const nextPreviewValues = { ...previewValues }
+    const removedName = variables[index]?.name
+    if (removedName) {
+      delete nextPreviewValues[removedName]
+      onPreviewValuesChange(nextPreviewValues)
+    }
+  }
+
+  const addVariable = () => {
+    onVariablesChange([
+      ...variables,
+      {
+        name: `variable_${variables.length + 1}`,
+        required: false,
+        input_type: "text"
+      }
+    ])
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface1 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-text">Variables</h3>
+          <p className="text-xs text-text-muted">
+            Define reusable prompt inputs and optional preview values.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={addVariable}
+          data-testid="structured-variable-add"
+          className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-text hover:bg-surface2"
+        >
+          <Plus className="size-3" />
+          Add variable
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {variables.length === 0 && (
+          <p className="text-sm text-text-muted">
+            No variables yet. Add one to support dynamic prompt assembly.
+          </p>
+        )}
+
+        {variables.map((variable, index) => (
+          <div
+            key={`${variable.name}-${index}`}
+            className="rounded-lg border border-border bg-background p-3"
+          >
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <span className="text-xs font-medium uppercase tracking-wide text-text-muted">
+                Variable {index + 1}
+              </span>
+              <button
+                type="button"
+                onClick={() => removeVariable(index)}
+                className="rounded border border-border p-1 text-danger hover:bg-danger/5"
+              >
+                <Trash2 className="size-3" />
+              </button>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+                  Name
+                </span>
+                <input
+                  type="text"
+                  value={variable.name}
+                  onChange={(event) =>
+                    updateVariable(index, { name: event.target.value })
+                  }
+                  data-testid={`structured-variable-name-${index}`}
+                  className="w-full rounded-md border border-border bg-surface1 px-3 py-2 text-sm text-text"
+                />
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+                  Input type
+                </span>
+                <select
+                  value={variable.input_type || "text"}
+                  onChange={(event) =>
+                    updateVariable(index, { input_type: event.target.value })
+                  }
+                  className="w-full rounded-md border border-border bg-surface1 px-3 py-2 text-sm text-text"
+                >
+                  <option value="text">Text</option>
+                  <option value="textarea">Textarea</option>
+                  <option value="number">Number</option>
+                  <option value="boolean">Boolean</option>
+                  <option value="select">Select</option>
+                  <option value="json">JSON</option>
+                </select>
+              </label>
+            </div>
+
+            <label className="mt-3 flex items-center gap-2 text-sm text-text">
+              <input
+                type="checkbox"
+                checked={!!variable.required}
+                onChange={(event) =>
+                  updateVariable(index, { required: event.target.checked })
+                }
+              />
+              Required
+            </label>
+          </div>
+        ))}
+      </div>
+
+      {variables.length > 0 && (
+        <div className="mt-4 space-y-3 border-t border-border pt-4">
+          <div>
+            <h4 className="text-sm font-semibold text-text">Preview inputs</h4>
+            <p className="text-xs text-text-muted">
+              Sample values passed to the backend preview endpoint.
+            </p>
+          </div>
+          {variables.map((variable) => (
+            <label key={`preview-${variable.name}`} className="block">
+              <span className="mb-1 block text-xs font-medium uppercase tracking-wide text-text-muted">
+                {variable.name}
+              </span>
+              <input
+                type="text"
+                value={previewValues[variable.name] || ""}
+                onChange={(event) =>
+                  onPreviewValuesChange({
+                    ...previewValues,
+                    [variable.name]: event.target.value
+                  })
+                }
+                data-testid={`structured-preview-variable-${variable.name}`}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-text"
+              />
+            </label>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/packages/ui/src/components/Option/Prompt/Structured/__tests__/StructuredPromptEditor.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Structured/__tests__/StructuredPromptEditor.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+
+import { StructuredPromptEditor } from "../StructuredPromptEditor"
+
+describe("StructuredPromptEditor", () => {
+  it("preserves assembly_config and block metadata when editing blocks", () => {
+    const onChange = vi.fn()
+
+    render(
+      <StructuredPromptEditor
+        value={{
+          schema_version: 1,
+          format: "structured",
+          assembly_config: {
+            legacy_system_roles: ["developer"],
+            legacy_user_roles: ["assistant"],
+            block_separator: "\n--\n"
+          },
+          variables: [
+            {
+              name: "topic",
+              required: true,
+              input_type: "textarea"
+            }
+          ],
+          blocks: [
+            {
+              id: "guidance",
+              name: "Guidance",
+              role: "developer",
+              kind: "instructions",
+              content: "Rule one",
+              enabled: true,
+              order: 10,
+              is_template: false
+            }
+          ]
+        }}
+        onChange={onChange}
+        previewResult={null}
+        previewLoading={false}
+        onPreview={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByTestId("structured-block-content"), {
+      target: { value: "Rule one refined" }
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        assembly_config: {
+          legacy_system_roles: ["developer"],
+          legacy_user_roles: ["assistant"],
+          block_separator: "\n--\n"
+        },
+        blocks: [
+          expect.objectContaining({
+            id: "guidance",
+            kind: "instructions",
+            content: "Rule one refined"
+          })
+        ]
+      })
+    )
+  })
+
+  it("preserves variable defaults and constraints when editing variables", () => {
+    const onChange = vi.fn()
+
+    render(
+      <StructuredPromptEditor
+        value={{
+          schema_version: 1,
+          format: "structured",
+          variables: [
+            {
+              name: "topic",
+              label: "Topic",
+              description: "Prompt topic",
+              required: false,
+              input_type: "select",
+              default_value: "sqlite",
+              options: ["sqlite", "fts"],
+              max_length: 12
+            }
+          ],
+          blocks: [
+            {
+              id: "task",
+              name: "Task",
+              role: "user",
+              kind: "task",
+              content: "Summarize {{topic}}",
+              enabled: true,
+              order: 10,
+              is_template: true
+            }
+          ]
+        }}
+        onChange={onChange}
+        previewResult={null}
+        previewLoading={false}
+        onPreview={vi.fn()}
+      />
+    )
+
+    fireEvent.change(screen.getByTestId("structured-variable-name-0"), {
+      target: { value: "topic_name" }
+    })
+
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        variables: [
+          expect.objectContaining({
+            name: "topic_name",
+            label: "Topic",
+            description: "Prompt topic",
+            input_type: "select",
+            default_value: "sqlite",
+            options: ["sqlite", "fts"],
+            max_length: 12
+          })
+        ]
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
@@ -246,6 +246,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
 
     previewMutation.mutate({
       project_id: projectId,
+      signature_id: existingPrompt?.signature_id ?? null,
       prompt_format: promptFormat,
       system_prompt:
         promptFormat === "legacy" ? values.system_prompt?.trim() || null : null,

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
@@ -20,7 +20,8 @@ import { Button } from "@/components/Common/Button"
 import { StructuredPromptEditor } from "../../Structured/StructuredPromptEditor"
 import {
   convertLegacyPromptToStructuredDefinition,
-  createDefaultStructuredPromptDefinition
+  createDefaultStructuredPromptDefinition,
+  renderStructuredPromptLegacySnapshot
 } from "../../structured-prompt-utils"
 
 type PromptEditorDrawerProps = {
@@ -51,6 +52,11 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
   const [promptFormat, setPromptFormat] = useState<PromptFormat>("legacy")
   const [structuredDefinition, setStructuredDefinition] =
     useState<StructuredPromptDefinition>(createDefaultStructuredPromptDefinition())
+  const [hasStructuredDraft, setHasStructuredDraft] = useState(false)
+  const projectedLegacySnapshotRef = React.useRef<{
+    system_prompt: string
+    user_prompt: string
+  } | null>(null)
   const [previewResult, setPreviewResult] =
     useState<StructuredPromptPreviewResponse | null>(null)
 
@@ -88,6 +94,8 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
             existingPrompt.user_prompt
           )
       )
+      setHasStructuredDraft(existingPrompt.prompt_format === "structured")
+      projectedLegacySnapshotRef.current = null
       setPreviewResult(null)
     } else if (open && !isEditing) {
       form.resetFields()
@@ -101,6 +109,8 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
       })
       setPromptFormat("legacy")
       setStructuredDefinition(createDefaultStructuredPromptDefinition())
+      setHasStructuredDraft(false)
+      projectedLegacySnapshotRef.current = null
       setPreviewResult(null)
     }
   }, [open, isEditing, existingPrompt, form])
@@ -353,25 +363,44 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
               value={promptFormat}
               onChange={(event) => {
                 const nextFormat = event.target.value as PromptFormat
+                if (nextFormat === promptFormat) {
+                  return
+                }
+
+                if (nextFormat === "legacy") {
+                  const legacySnapshot =
+                    renderStructuredPromptLegacySnapshot(structuredDefinition)
+                  projectedLegacySnapshotRef.current = {
+                    system_prompt: legacySnapshot.systemPrompt,
+                    user_prompt: legacySnapshot.userPrompt
+                  }
+                  form.setFieldsValue({
+                    system_prompt: legacySnapshot.systemPrompt,
+                    user_prompt: legacySnapshot.userPrompt
+                  })
+                } else {
+                  const currentValues = form.getFieldsValue()
+                  const matchesProjectedLegacy =
+                    projectedLegacySnapshotRef.current !== null &&
+                    currentValues.system_prompt ===
+                      projectedLegacySnapshotRef.current.system_prompt &&
+                    currentValues.user_prompt ===
+                      projectedLegacySnapshotRef.current.user_prompt
+
+                  if (!hasStructuredDraft || !matchesProjectedLegacy) {
+                    setStructuredDefinition(
+                      convertLegacyPromptToStructuredDefinition(
+                        currentValues.system_prompt,
+                        currentValues.user_prompt
+                      )
+                    )
+                  }
+                  projectedLegacySnapshotRef.current = null
+                  setHasStructuredDraft(true)
+                }
+
                 setPromptFormat(nextFormat)
                 setPreviewResult(null)
-                if (nextFormat === "structured") {
-                  setStructuredDefinition((current) => {
-                    if (
-                      promptFormat === "structured" &&
-                      current &&
-                      Array.isArray((current as any).blocks) &&
-                      (current as any).blocks.length > 0
-                    ) {
-                      return current
-                    }
-                    const currentValues = form.getFieldsValue()
-                    return convertLegacyPromptToStructuredDefinition(
-                      currentValues.system_prompt,
-                      currentValues.user_prompt
-                    )
-                  })
-                }
               }}
             >
               <Radio.Button value="legacy">Legacy text</Radio.Button>
@@ -432,7 +461,11 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
           ) : (
             <StructuredPromptEditor
               value={structuredDefinition}
-              onChange={setStructuredDefinition}
+              onChange={(nextValue) => {
+                setStructuredDefinition(nextValue)
+                setHasStructuredDraft(true)
+                setPreviewResult(null)
+              }}
               previewResult={previewResult}
               previewLoading={previewMutation.isPending}
               onPreview={handlePreview}

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
@@ -18,6 +18,10 @@ import {
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
 import { StructuredPromptEditor } from "../../Structured/StructuredPromptEditor"
+import {
+  convertLegacyPromptToStructuredDefinition,
+  createDefaultStructuredPromptDefinition
+} from "../../structured-prompt-utils"
 
 type PromptEditorDrawerProps = {
   open: boolean
@@ -35,58 +39,6 @@ type FormValues = {
   modules_config?: string // JSON string for modules config
 }
 
-const createDefaultStructuredDefinition = (): StructuredPromptDefinition => ({
-  schema_version: 1,
-  format: "structured",
-  variables: [],
-  blocks: [
-    {
-      id: "task",
-      name: "Task",
-      role: "user",
-      content: "Describe the task here.",
-      enabled: true,
-      order: 10,
-      is_template: false
-    }
-  ]
-})
-
-const createStructuredDefinitionFromLegacy = (
-  systemPrompt?: string | null,
-  userPrompt?: string | null
-): StructuredPromptDefinition => {
-  const blocks: StructuredPromptDefinition["blocks"] = []
-  if (systemPrompt?.trim()) {
-    blocks.push({
-      id: "system",
-      name: "System Instructions",
-      role: "system",
-      content: systemPrompt.trim(),
-      enabled: true,
-      order: 10,
-      is_template: false
-    })
-  }
-  if (userPrompt?.trim()) {
-    blocks.push({
-      id: "task",
-      name: "Task",
-      role: "user",
-      content: userPrompt.trim(),
-      enabled: true,
-      order: blocks.length === 0 ? 10 : 20,
-      is_template: true
-    })
-  }
-  return {
-    schema_version: 1,
-    format: "structured",
-    variables: [],
-    blocks: blocks.length > 0 ? blocks : createDefaultStructuredDefinition().blocks
-  }
-}
-
 export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
   open,
   promptId,
@@ -98,7 +50,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
   const queryClient = useQueryClient()
   const [promptFormat, setPromptFormat] = useState<PromptFormat>("legacy")
   const [structuredDefinition, setStructuredDefinition] =
-    useState<StructuredPromptDefinition>(createDefaultStructuredDefinition())
+    useState<StructuredPromptDefinition>(createDefaultStructuredPromptDefinition())
   const [previewResult, setPreviewResult] =
     useState<StructuredPromptPreviewResponse | null>(null)
 
@@ -131,7 +83,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
       setPromptFormat(existingPrompt.prompt_format || "legacy")
       setStructuredDefinition(
         existingPrompt.prompt_definition ||
-          createStructuredDefinitionFromLegacy(
+          convertLegacyPromptToStructuredDefinition(
             existingPrompt.system_prompt,
             existingPrompt.user_prompt
           )
@@ -148,7 +100,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
         modules_config: ""
       })
       setPromptFormat("legacy")
-      setStructuredDefinition(createDefaultStructuredDefinition())
+      setStructuredDefinition(createDefaultStructuredPromptDefinition())
       setPreviewResult(null)
     }
   }, [open, isEditing, existingPrompt, form])
@@ -405,6 +357,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
                 if (nextFormat === "structured") {
                   setStructuredDefinition((current) => {
                     if (
+                      promptFormat === "structured" &&
                       current &&
                       Array.isArray((current as any).blocks) &&
                       (current as any).blocks.length > 0
@@ -412,7 +365,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
                       return current
                     }
                     const currentValues = form.getFieldsValue()
-                    return createStructuredDefinitionFromLegacy(
+                    return convertLegacyPromptToStructuredDefinition(
                       currentValues.system_prompt,
                       currentValues.user_prompt
                     )

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/PromptEditorDrawer.tsx
@@ -1,18 +1,23 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { Drawer, Form, Input, notification, Skeleton, Collapse, Alert } from "antd"
-import { Plus, Trash2 } from "lucide-react"
-import React, { useEffect } from "react"
+import { Drawer, Form, Input, notification, Skeleton, Collapse, Alert, Radio } from "antd"
+import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   createPrompt,
   updatePrompt,
   getPrompt,
+  previewPromptDefinition,
   type PromptCreatePayload,
   type PromptUpdatePayload,
   type FewShotExample,
-  type PromptModule
+  type PromptModule,
+  type PromptFormat,
+  type StructuredPromptDefinition,
+  type StructuredPromptPreviewResponse,
+  type StructuredPromptPreviewRequest
 } from "@/services/prompt-studio"
 import { Button } from "@/components/Common/Button"
+import { StructuredPromptEditor } from "../../Structured/StructuredPromptEditor"
 
 type PromptEditorDrawerProps = {
   open: boolean
@@ -30,6 +35,58 @@ type FormValues = {
   modules_config?: string // JSON string for modules config
 }
 
+const createDefaultStructuredDefinition = (): StructuredPromptDefinition => ({
+  schema_version: 1,
+  format: "structured",
+  variables: [],
+  blocks: [
+    {
+      id: "task",
+      name: "Task",
+      role: "user",
+      content: "Describe the task here.",
+      enabled: true,
+      order: 10,
+      is_template: false
+    }
+  ]
+})
+
+const createStructuredDefinitionFromLegacy = (
+  systemPrompt?: string | null,
+  userPrompt?: string | null
+): StructuredPromptDefinition => {
+  const blocks: StructuredPromptDefinition["blocks"] = []
+  if (systemPrompt?.trim()) {
+    blocks.push({
+      id: "system",
+      name: "System Instructions",
+      role: "system",
+      content: systemPrompt.trim(),
+      enabled: true,
+      order: 10,
+      is_template: false
+    })
+  }
+  if (userPrompt?.trim()) {
+    blocks.push({
+      id: "task",
+      name: "Task",
+      role: "user",
+      content: userPrompt.trim(),
+      enabled: true,
+      order: blocks.length === 0 ? 10 : 20,
+      is_template: true
+    })
+  }
+  return {
+    schema_version: 1,
+    format: "structured",
+    variables: [],
+    blocks: blocks.length > 0 ? blocks : createDefaultStructuredDefinition().blocks
+  }
+}
+
 export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
   open,
   promptId,
@@ -39,6 +96,11 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
   const { t } = useTranslation(["settings", "common"])
   const [form] = Form.useForm<FormValues>()
   const queryClient = useQueryClient()
+  const [promptFormat, setPromptFormat] = useState<PromptFormat>("legacy")
+  const [structuredDefinition, setStructuredDefinition] =
+    useState<StructuredPromptDefinition>(createDefaultStructuredDefinition())
+  const [previewResult, setPreviewResult] =
+    useState<StructuredPromptPreviewResponse | null>(null)
 
   const isEditing = promptId !== null
 
@@ -66,8 +128,28 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
           ? JSON.stringify(existingPrompt.modules_config, null, 2)
           : ""
       })
+      setPromptFormat(existingPrompt.prompt_format || "legacy")
+      setStructuredDefinition(
+        existingPrompt.prompt_definition ||
+          createStructuredDefinitionFromLegacy(
+            existingPrompt.system_prompt,
+            existingPrompt.user_prompt
+          )
+      )
+      setPreviewResult(null)
     } else if (open && !isEditing) {
       form.resetFields()
+      form.setFieldsValue({
+        name: "",
+        system_prompt: "",
+        user_prompt: "",
+        change_description: "",
+        few_shot_examples: "",
+        modules_config: ""
+      })
+      setPromptFormat("legacy")
+      setStructuredDefinition(createDefaultStructuredDefinition())
+      setPreviewResult(null)
     }
   }, [open, isEditing, existingPrompt, form])
 
@@ -123,6 +205,20 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
     }
   })
 
+  const previewMutation = useMutation({
+    mutationFn: (payload: StructuredPromptPreviewRequest) =>
+      previewPromptDefinition(payload),
+    onSuccess: (response) => {
+      setPreviewResult((response as any)?.data?.data || null)
+    },
+    onError: (error: any) => {
+      notification.error({
+        message: t("common:error", { defaultValue: "Error" }),
+        description: error?.message || t("common:unknownError")
+      })
+    }
+  })
+
   const parseJsonField = <T,>(value: string | undefined, defaultValue: T): T => {
     if (!value?.trim()) return defaultValue
     try {
@@ -145,8 +241,17 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
     if (isEditing) {
       const payload: PromptUpdatePayload = {
         name: values.name.trim(),
-        system_prompt: values.system_prompt?.trim() || null,
-        user_prompt: values.user_prompt?.trim() || null,
+        system_prompt:
+          promptFormat === "legacy" ? values.system_prompt?.trim() || null : null,
+        user_prompt:
+          promptFormat === "legacy" ? values.user_prompt?.trim() || null : null,
+        prompt_format: promptFormat,
+        prompt_schema_version:
+          promptFormat === "structured"
+            ? Number((structuredDefinition as any)?.schema_version || 1)
+            : null,
+        prompt_definition:
+          promptFormat === "structured" ? structuredDefinition : null,
         change_description:
           values.change_description?.trim() || "Updated prompt",
         few_shot_examples: fewShotExamples,
@@ -157,14 +262,53 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
       const payload: PromptCreatePayload = {
         project_id: projectId,
         name: values.name.trim(),
-        system_prompt: values.system_prompt?.trim() || null,
-        user_prompt: values.user_prompt?.trim() || null,
+        system_prompt:
+          promptFormat === "legacy" ? values.system_prompt?.trim() || null : null,
+        user_prompt:
+          promptFormat === "legacy" ? values.user_prompt?.trim() || null : null,
+        prompt_format: promptFormat,
+        prompt_schema_version:
+          promptFormat === "structured"
+            ? Number((structuredDefinition as any)?.schema_version || 1)
+            : null,
+        prompt_definition:
+          promptFormat === "structured" ? structuredDefinition : null,
         change_description: values.change_description?.trim() || "Initial version",
         few_shot_examples: fewShotExamples,
         modules_config: modulesConfig
       }
       createMutation.mutate(payload)
     }
+  }
+
+  const handlePreview = (variables: Record<string, string>) => {
+    const values = form.getFieldsValue()
+    const fewShotExamples = parseJsonField<FewShotExample[] | null>(
+      values.few_shot_examples,
+      null
+    )
+    const modulesConfig = parseJsonField<PromptModule[] | null>(
+      values.modules_config,
+      null
+    )
+
+    previewMutation.mutate({
+      project_id: projectId,
+      prompt_format: promptFormat,
+      system_prompt:
+        promptFormat === "legacy" ? values.system_prompt?.trim() || null : null,
+      user_prompt:
+        promptFormat === "legacy" ? values.user_prompt?.trim() || null : null,
+      prompt_schema_version:
+        promptFormat === "structured"
+          ? Number((structuredDefinition as any)?.schema_version || 1)
+          : null,
+      prompt_definition:
+        promptFormat === "structured" ? structuredDefinition : null,
+      few_shot_examples: fewShotExamples,
+      modules_config: modulesConfig,
+      variables
+    })
   }
 
   const validateJson = (_: any, value: string) => {
@@ -198,7 +342,7 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
               defaultValue: "Create Prompt"
             })
       }
-      styles={{ wrapper: { width: 640 } }}
+      styles={{ wrapper: { width: promptFormat === "structured" ? 1120 : 640 } }}
       destroyOnHidden
       footer={
         <div className="flex justify-end gap-2">
@@ -248,53 +392,98 @@ export const PromptEditorDrawer: React.FC<PromptEditorDrawerProps> = ({
             />
           </Form.Item>
 
-          <Form.Item
-            name="system_prompt"
-            label={t("managePrompts.studio.prompts.form.systemPrompt", {
-              defaultValue: "System Prompt"
-            })}
-            tooltip={t("managePrompts.studio.prompts.form.systemPromptHelp", {
-              defaultValue:
-                "Instructions that set the behavior and context for the AI"
-            })}
-          >
-            <Input.TextArea
-              placeholder={t(
-                "managePrompts.studio.prompts.form.systemPromptPlaceholder",
-                {
-                  defaultValue:
-                    "You are a helpful customer support agent..."
+          <div className="mb-6">
+            <div className="mb-2 text-sm font-medium text-text">
+              Authoring mode
+            </div>
+            <Radio.Group
+              value={promptFormat}
+              onChange={(event) => {
+                const nextFormat = event.target.value as PromptFormat
+                setPromptFormat(nextFormat)
+                setPreviewResult(null)
+                if (nextFormat === "structured") {
+                  setStructuredDefinition((current) => {
+                    if (
+                      current &&
+                      Array.isArray((current as any).blocks) &&
+                      (current as any).blocks.length > 0
+                    ) {
+                      return current
+                    }
+                    const currentValues = form.getFieldsValue()
+                    return createStructuredDefinitionFromLegacy(
+                      currentValues.system_prompt,
+                      currentValues.user_prompt
+                    )
+                  })
                 }
-              )}
-              rows={5}
-              showCount
-              maxLength={10000}
-            />
-          </Form.Item>
+              }}
+            >
+              <Radio.Button value="legacy">Legacy text</Radio.Button>
+              <Radio.Button value="structured">Structured builder</Radio.Button>
+            </Radio.Group>
+          </div>
 
-          <Form.Item
-            name="user_prompt"
-            label={t("managePrompts.studio.prompts.form.userPrompt", {
-              defaultValue: "User Prompt Template"
-            })}
-            tooltip={t("managePrompts.studio.prompts.form.userPromptHelp", {
-              defaultValue:
-                "Template for user messages. Use {{variable}} for inputs."
-            })}
-          >
-            <Input.TextArea
-              placeholder={t(
-                "managePrompts.studio.prompts.form.userPromptPlaceholder",
-                {
+          {promptFormat === "legacy" ? (
+            <>
+              <Form.Item
+                name="system_prompt"
+                label={t("managePrompts.studio.prompts.form.systemPrompt", {
+                  defaultValue: "System Prompt"
+                })}
+                tooltip={t("managePrompts.studio.prompts.form.systemPromptHelp", {
                   defaultValue:
-                    "Please help the customer with: {{customer_query}}"
-                }
-              )}
-              rows={5}
-              showCount
-              maxLength={10000}
+                    "Instructions that set the behavior and context for the AI"
+                })}
+              >
+                <Input.TextArea
+                  placeholder={t(
+                    "managePrompts.studio.prompts.form.systemPromptPlaceholder",
+                    {
+                      defaultValue:
+                        "You are a helpful customer support agent..."
+                    }
+                  )}
+                  rows={5}
+                  showCount
+                  maxLength={10000}
+                />
+              </Form.Item>
+
+              <Form.Item
+                name="user_prompt"
+                label={t("managePrompts.studio.prompts.form.userPrompt", {
+                  defaultValue: "User Prompt Template"
+                })}
+                tooltip={t("managePrompts.studio.prompts.form.userPromptHelp", {
+                  defaultValue:
+                    "Template for user messages. Use {{variable}} for inputs."
+                })}
+              >
+                <Input.TextArea
+                  placeholder={t(
+                    "managePrompts.studio.prompts.form.userPromptPlaceholder",
+                    {
+                      defaultValue:
+                        "Please help the customer with: {{customer_query}}"
+                    }
+                  )}
+                  rows={5}
+                  showCount
+                  maxLength={10000}
+                />
+              </Form.Item>
+            </>
+          ) : (
+            <StructuredPromptEditor
+              value={structuredDefinition}
+              onChange={setStructuredDefinition}
+              previewResult={previewResult}
+              previewLoading={previewMutation.isPending}
+              onPreview={handlePreview}
             />
-          </Form.Item>
+          )}
 
           {isEditing && (
             <Form.Item

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/StudioPromptsTab.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/StudioPromptsTab.tsx
@@ -77,6 +77,9 @@ export const StudioPromptsTab: React.FC = () => {
         name: `${prompt.name} (Copy)`,
         system_prompt: prompt.system_prompt,
         user_prompt: prompt.user_prompt,
+        prompt_format: prompt.prompt_format,
+        prompt_schema_version: prompt.prompt_schema_version,
+        prompt_definition: prompt.prompt_definition,
         few_shot_examples: prompt.few_shot_examples,
         modules_config: prompt.modules_config,
         change_description: `Duplicated from "${prompt.name}"`
@@ -107,10 +110,22 @@ export const StudioPromptsTab: React.FC = () => {
     if (searchText.trim()) {
       const q = searchText.toLowerCase()
       items = items.filter(
-        (p) =>
-          p.name.toLowerCase().includes(q) ||
-          p.system_prompt?.toLowerCase().includes(q) ||
-          p.user_prompt?.toLowerCase().includes(q)
+        (p) => {
+          const structuredContent = Array.isArray(p.prompt_definition?.blocks)
+            ? p.prompt_definition.blocks
+                .map((block: any) =>
+                  typeof block?.content === "string" ? block.content : ""
+                )
+                .join(" ")
+                .toLowerCase()
+            : ""
+          return (
+            p.name.toLowerCase().includes(q) ||
+            p.system_prompt?.toLowerCase().includes(q) ||
+            p.user_prompt?.toLowerCase().includes(q) ||
+            structuredContent.includes(q)
+          )
+        }
       )
     }
     return items.sort(
@@ -317,8 +332,10 @@ export const StudioPromptsTab: React.FC = () => {
               const hasUser = !!record.user_prompt?.trim()
               const hasFewShot =
                 record.few_shot_examples && record.few_shot_examples.length > 0
+              const isStructured = record.prompt_format === "structured"
               return (
                 <div className="flex flex-col gap-1 max-w-md">
+                  {isStructured && <Tag color="geekblue">Structured</Tag>}
                   {hasSystem && (
                     <div className="flex items-start gap-2">
                       <Tag color="volcano" className="shrink-0">

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
@@ -214,6 +214,33 @@ describe("PromptEditorDrawer structured prompt mode", () => {
     expect(previewMatches.length).toBeGreaterThan(0)
   })
 
+  it("projects structured edits into legacy fields and preserves them across mode switches", async () => {
+    renderDrawer()
+
+    await screen.findByTestId("structured-block-list")
+    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.change(screen.getByTestId("structured-block-content"), {
+      target: { value: "Summarize {{topic}} clearly" }
+    })
+
+    fireEvent.click(screen.getByRole("radio", { name: "Legacy text" }))
+
+    expect(
+      (screen.getByLabelText("System Prompt") as HTMLTextAreaElement).value
+    ).toBe("You are precise.")
+    expect(
+      (screen.getByLabelText("User Prompt Template") as HTMLTextAreaElement).value
+    ).toBe("Summarize {{topic}} clearly")
+
+    fireEvent.click(screen.getByRole("radio", { name: "Structured builder" }))
+
+    await screen.findByTestId("structured-block-content")
+    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    expect(
+      (screen.getByTestId("structured-block-content") as HTMLTextAreaElement).value
+    ).toBe("Summarize {{topic}} clearly")
+  })
+
   it("extracts template variables when switching a legacy draft to structured mode", async () => {
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/services/prompt-studio", () => ({
 const makeStructuredPrompt = () => ({
   id: 71,
   project_id: 9,
+  signature_id: 17,
   name: "Structured summarizer",
   system_prompt: "You are precise.",
   user_prompt: "Summarize {{topic}}",
@@ -196,6 +197,7 @@ describe("PromptEditorDrawer structured prompt mode", () => {
       expect(mocks.previewPromptDefinition).toHaveBeenCalledWith(
         expect.objectContaining({
           project_id: 9,
+          signature_id: 17,
           prompt_format: "structured",
           prompt_schema_version: 1,
           prompt_definition: expect.objectContaining({

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
@@ -1,0 +1,214 @@
+import React from "react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PromptEditorDrawer } from "../PromptEditorDrawer"
+
+const mocks = vi.hoisted(() => ({
+  createPrompt: vi.fn(),
+  updatePrompt: vi.fn(),
+  getPrompt: vi.fn(),
+  previewPromptDefinition: vi.fn()
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        if (fallbackOrOptions.defaultValue) {
+          return Object.entries(fallbackOrOptions).reduce(
+            (acc, [name, value]) =>
+              name === "defaultValue"
+                ? acc
+                : acc.replace(new RegExp(`{{${name}}}`, "g"), String(value)),
+            fallbackOrOptions.defaultValue
+          )
+        }
+        return key
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("@/services/prompt-studio", () => ({
+  createPrompt: (...args: unknown[]) =>
+    (mocks.createPrompt as (...args: unknown[]) => unknown)(...args),
+  updatePrompt: (...args: unknown[]) =>
+    (mocks.updatePrompt as (...args: unknown[]) => unknown)(...args),
+  getPrompt: (...args: unknown[]) =>
+    (mocks.getPrompt as (...args: unknown[]) => unknown)(...args),
+  previewPromptDefinition: (...args: unknown[]) =>
+    (mocks.previewPromptDefinition as (...args: unknown[]) => unknown)(...args)
+}))
+
+const makeStructuredPrompt = () => ({
+  id: 71,
+  project_id: 9,
+  name: "Structured summarizer",
+  system_prompt: "You are precise.",
+  user_prompt: "Summarize {{topic}}",
+  prompt_format: "structured",
+  prompt_schema_version: 1,
+  prompt_definition: {
+    schema_version: 1,
+    format: "structured",
+    variables: [
+      {
+        name: "topic",
+        required: true,
+        input_type: "text"
+      }
+    ],
+    blocks: [
+      {
+        id: "identity",
+        name: "Identity",
+        role: "system",
+        content: "You are precise.",
+        enabled: true,
+        order: 10,
+        is_template: false
+      },
+      {
+        id: "task",
+        name: "Task",
+        role: "user",
+        content: "Summarize {{topic}}",
+        enabled: true,
+        order: 20,
+        is_template: true
+      }
+    ]
+  },
+  version_number: 3,
+  updated_at: "2026-03-10T00:00:00Z"
+})
+
+const renderDrawer = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      },
+      mutations: {
+        retry: false
+      }
+    }
+  })
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PromptEditorDrawer
+        open
+        promptId={71}
+        projectId={9}
+        onClose={vi.fn()}
+      />
+    </QueryClientProvider>
+  )
+}
+
+describe("PromptEditorDrawer structured prompt mode", () => {
+  beforeEach(() => {
+    mocks.createPrompt.mockReset()
+    mocks.updatePrompt.mockReset()
+    mocks.getPrompt.mockReset()
+    mocks.previewPromptDefinition.mockReset()
+
+    mocks.getPrompt.mockResolvedValue({
+      data: {
+        data: makeStructuredPrompt()
+      }
+    })
+    mocks.updatePrompt.mockResolvedValue({
+      data: {
+        data: makeStructuredPrompt()
+      }
+    })
+    mocks.previewPromptDefinition.mockResolvedValue({
+      data: {
+        data: {
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          assembled_messages: [
+            {
+              role: "system",
+              content: "You are precise."
+            },
+            {
+              role: "user",
+              content: "Summarize SQLite FTS"
+            }
+          ],
+          legacy_system_prompt: "You are precise.",
+          legacy_user_prompt: "Summarize SQLite FTS"
+        }
+      }
+    })
+  })
+
+  it("loads structured prompts and submits prompt_definition updates", async () => {
+    renderDrawer()
+
+    await screen.findByTestId("structured-block-list")
+    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.change(screen.getByTestId("structured-block-content"), {
+      target: { value: "Summarize {{topic}} clearly" }
+    })
+    fireEvent.change(screen.getByLabelText("Change Description"), {
+      target: { value: "Refined task wording" }
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(mocks.updatePrompt).toHaveBeenCalledWith(
+        71,
+        expect.objectContaining({
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          change_description: "Refined task wording",
+          prompt_definition: expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                id: "task",
+                content: "Summarize {{topic}} clearly"
+              })
+            ])
+          })
+        })
+      )
+    })
+  })
+
+  it("requests and renders structured preview output", async () => {
+    renderDrawer()
+
+    await screen.findByTestId("structured-preview-button")
+    fireEvent.click(screen.getByTestId("structured-preview-button"))
+
+    await waitFor(() => {
+      expect(mocks.previewPromptDefinition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project_id: 9,
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({ id: "identity" }),
+              expect.objectContaining({ id: "task" })
+            ])
+          })
+        })
+      )
+    })
+
+    const previewMatches = await screen.findAllByText("Summarize SQLite FTS")
+    expect(previewMatches.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx
@@ -211,4 +211,64 @@ describe("PromptEditorDrawer structured prompt mode", () => {
     const previewMatches = await screen.findAllByText("Summarize SQLite FTS")
     expect(previewMatches.length).toBeGreaterThan(0)
   })
+
+  it("extracts template variables when switching a legacy draft to structured mode", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    })
+
+    mocks.createPrompt.mockResolvedValue({
+      data: {
+        data: {
+          ...makeStructuredPrompt(),
+          id: 72,
+          name: "Converted prompt"
+        }
+      }
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <PromptEditorDrawer
+          open
+          promptId={null}
+          projectId={9}
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>
+    )
+
+    fireEvent.change(screen.getByLabelText("Prompt Name"), {
+      target: { value: "Converted prompt" }
+    })
+    fireEvent.change(screen.getByLabelText("System Prompt"), {
+      target: { value: "You are precise about {{topic}}." }
+    })
+    fireEvent.change(screen.getByLabelText("User Prompt Template"), {
+      target: { value: "Summarize {{topic}} against {{baseline}}" }
+    })
+
+    fireEvent.click(screen.getByRole("radio", { name: "Structured builder" }))
+    await screen.findByTestId("structured-block-list")
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Prompt" }))
+
+    await waitFor(() => {
+      expect(mocks.createPrompt).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt_format: "structured",
+          prompt_definition: expect.objectContaining({
+            variables: expect.arrayContaining([
+              expect.objectContaining({ name: "topic", required: true }),
+              expect.objectContaining({ name: "baseline", required: true })
+            ])
+          })
+        }),
+        expect.any(String)
+      )
+    })
+  })
 })

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
@@ -117,7 +117,7 @@ describe("PromptDrawer structured prompts", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /convert to structured/i })
     )
-    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.click(screen.getByTestId("structured-block-item-legacy_user"))
     fireEvent.change(screen.getByTestId("structured-block-content"), {
       target: { value: "Summarize {{topic}} clearly" }
     })
@@ -134,7 +134,7 @@ describe("PromptDrawer structured prompts", () => {
           structuredPromptDefinition: expect.objectContaining({
             blocks: expect.arrayContaining([
               expect.objectContaining({
-                id: "task",
+                id: "legacy_user",
                 content: "Summarize {{topic}} clearly"
               })
             ])

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { PromptDrawer } from "../PromptDrawer"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        if (fallbackOrOptions.defaultValue) {
+          return Object.entries(fallbackOrOptions).reduce(
+            (acc, [name, value]) =>
+              name === "defaultValue"
+                ? acc
+                : acc.replace(new RegExp(`{{${name}}}`, "g"), String(value)),
+            fallbackOrOptions.defaultValue
+          )
+        }
+        return key
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("@/hooks/useFormDraft", () => ({
+  useFormDraft: () => ({
+    hasDraft: false,
+    draftData: null,
+    saveDraft: vi.fn(),
+    clearDraft: vi.fn(),
+    applyDraft: vi.fn(),
+    dismissDraft: vi.fn()
+  }),
+  formatDraftAge: () => "now"
+}))
+
+vi.mock("../Studio/Prompts/VersionHistoryDrawer", () => ({
+  VersionHistoryDrawer: () => null
+}))
+
+vi.mock("@/services/prompts-api", () => ({
+  previewStructuredPromptServer: vi.fn(async () => ({
+    prompt_format: "structured",
+    prompt_schema_version: 1,
+    assembled_messages: [],
+    legacy_system_prompt: "You are a careful analyst.",
+    legacy_user_prompt: "Summarize {{topic}}"
+  }))
+}))
+
+describe("PromptDrawer structured prompts", () => {
+  const baseProps = {
+    open: true,
+    onClose: vi.fn(),
+    mode: "edit" as const,
+    initialValues: {
+      id: "prompt-1",
+      name: "Legacy prompt",
+      system_prompt: "You are a careful analyst.",
+      user_prompt: "Summarize {{topic}}",
+      keywords: ["analysis"]
+    },
+    onSubmit: vi.fn(),
+    isLoading: false,
+    allTags: []
+  }
+
+  it("converts a legacy prompt into a structured prompt and locks raw fields", async () => {
+    render(<PromptDrawer {...baseProps} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /convert to structured/i })
+    )
+
+    expect(await screen.findByText("Structured prompt")).toBeInTheDocument()
+    expect(screen.getByTestId("prompt-drawer-system")).toBeDisabled()
+    expect(screen.getByTestId("prompt-drawer-user")).toBeDisabled()
+    expect(screen.getByTestId("structured-block-list")).toBeInTheDocument()
+  })
+
+  it("submits structured prompt state with the derived legacy snapshot", async () => {
+    const onSubmit = vi.fn()
+    render(<PromptDrawer {...baseProps} onSubmit={onSubmit} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /convert to structured/i })
+    )
+    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.change(screen.getByTestId("structured-block-content"), {
+      target: { value: "Summarize {{topic}} clearly" }
+    })
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "managePrompts.form.btnSave.save" })
+    )
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptFormat: "structured",
+          promptSchemaVersion: 1,
+          structuredPromptDefinition: expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                id: "task",
+                content: "Summarize {{topic}} clearly"
+              })
+            ])
+          }),
+          system_prompt: "You are a careful analyst.",
+          user_prompt: "Summarize {{topic}} clearly"
+        })
+      )
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptDrawer.structured-prompts.test.tsx
@@ -83,6 +83,33 @@ describe("PromptDrawer structured prompts", () => {
     expect(screen.getByTestId("structured-block-list")).toBeInTheDocument()
   })
 
+  it("extracts template variables when converting a legacy prompt", async () => {
+    const onSubmit = vi.fn()
+    render(<PromptDrawer {...baseProps} onSubmit={onSubmit} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /convert to structured/i })
+    )
+    fireEvent.click(
+      screen.getByRole("button", { name: "managePrompts.form.btnSave.save" })
+    )
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          structuredPromptDefinition: expect.objectContaining({
+            variables: expect.arrayContaining([
+              expect.objectContaining({
+                name: "topic",
+                required: true
+              })
+            ])
+          })
+        })
+      )
+    })
+  })
+
   it("submits structured prompt state with the derived legacy snapshot", async () => {
     const onSubmit = vi.fn()
     render(<PromptDrawer {...baseProps} onSubmit={onSubmit} />)

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptFullPageEditor.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptFullPageEditor.structured-prompts.test.tsx
@@ -1,0 +1,122 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { PromptFullPageEditor } from "../PromptFullPageEditor"
+
+const mockDraftState = {
+  hasDraft: false,
+  draftData: null,
+  saveDraft: vi.fn(),
+  clearDraft: vi.fn(),
+  applyDraft: vi.fn(),
+  dismissDraft: vi.fn(),
+  lastSaved: null
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      fallbackOrOptions?: string | { defaultValue?: string; [k: string]: unknown }
+    ) => {
+      if (typeof fallbackOrOptions === "string") return fallbackOrOptions
+      if (fallbackOrOptions && typeof fallbackOrOptions === "object") {
+        if (fallbackOrOptions.defaultValue) {
+          return Object.entries(fallbackOrOptions).reduce(
+            (acc, [name, value]) =>
+              name === "defaultValue"
+                ? acc
+                : acc.replace(new RegExp(`{{${name}}}`, "g"), String(value)),
+            fallbackOrOptions.defaultValue
+          )
+        }
+        return key
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("@/hooks/useFormDraft", () => ({
+  useFormDraft: () => mockDraftState,
+  formatDraftAge: () => "now"
+}))
+
+vi.mock("../PromptEditorPreview", () => ({
+  PromptEditorPreview: () => <div data-testid="prompt-editor-preview" />
+}))
+
+vi.mock("@/services/prompts-api", () => ({
+  previewStructuredPromptServer: vi.fn(async () => ({
+    prompt_format: "structured",
+    prompt_schema_version: 1,
+    assembled_messages: [],
+    legacy_system_prompt: "You are a careful analyst.",
+    legacy_user_prompt: "Summarize {{topic}}"
+  }))
+}))
+
+describe("PromptFullPageEditor structured prompts", () => {
+  const baseProps = {
+    open: true,
+    onClose: vi.fn(),
+    mode: "edit" as const,
+    initialValues: {
+      id: "prompt-1",
+      name: "Legacy prompt",
+      system_prompt: "You are a careful analyst.",
+      user_prompt: "Summarize {{topic}}",
+      keywords: ["analysis"]
+    },
+    onSubmit: vi.fn(),
+    isLoading: false,
+    allTags: []
+  }
+
+  it("converts a legacy full-page prompt into a structured prompt and locks raw fields", async () => {
+    render(<PromptFullPageEditor {...baseProps} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /convert to structured/i })
+    )
+
+    expect(await screen.findByText("Structured prompt")).toBeInTheDocument()
+    expect(screen.getByTestId("full-editor-system-prompt")).toBeDisabled()
+    expect(screen.getByTestId("full-editor-user-prompt")).toBeDisabled()
+    expect(screen.getByTestId("structured-block-list")).toBeInTheDocument()
+  })
+
+  it("submits structured prompt state with the derived legacy snapshot", async () => {
+    const onSubmit = vi.fn()
+    render(<PromptFullPageEditor {...baseProps} onSubmit={onSubmit} />)
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /convert to structured/i })
+    )
+    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.change(screen.getByTestId("structured-block-content"), {
+      target: { value: "Summarize {{topic}} clearly" }
+    })
+
+    fireEvent.click(screen.getByTestId("full-editor-save"))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          promptFormat: "structured",
+          promptSchemaVersion: 1,
+          structuredPromptDefinition: expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                id: "task",
+                content: "Summarize {{topic}} clearly"
+              })
+            ])
+          }),
+          system_prompt: "You are a careful analyst.",
+          user_prompt: "Summarize {{topic}} clearly"
+        })
+      )
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptFullPageEditor.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptFullPageEditor.structured-prompts.test.tsx
@@ -93,7 +93,7 @@ describe("PromptFullPageEditor structured prompts", () => {
     fireEvent.click(
       screen.getByRole("button", { name: /convert to structured/i })
     )
-    fireEvent.click(screen.getByTestId("structured-block-item-task"))
+    fireEvent.click(screen.getByTestId("structured-block-item-legacy_user"))
     fireEvent.change(screen.getByTestId("structured-block-content"), {
       target: { value: "Summarize {{topic}} clearly" }
     })
@@ -108,7 +108,7 @@ describe("PromptFullPageEditor structured prompts", () => {
           structuredPromptDefinition: expect.objectContaining({
             blocks: expect.arrayContaining([
               expect.objectContaining({
-                id: "task",
+                id: "legacy_user",
                 content: "Summarize {{topic}} clearly"
               })
             ])

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptStarterCards.structured-prompts.test.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/PromptStarterCards.structured-prompts.test.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { PromptStarterCards } from "../PromptStarterCards"
+
+describe("PromptStarterCards structured templates", () => {
+  it("emits a structured starter prompt with preconfigured blocks", () => {
+    const onUse = vi.fn()
+    render(<PromptStarterCards onUse={onUse} />)
+
+    fireEvent.click(
+      screen.getByTestId("starter-use-code-review-assistant")
+    )
+
+    expect(onUse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Code Review Assistant",
+        promptFormat: "structured",
+        structuredPromptDefinition: expect.objectContaining({
+          format: "structured",
+          blocks: expect.arrayContaining([
+            expect.objectContaining({ role: "system" }),
+            expect.objectContaining({ role: "developer" }),
+            expect.objectContaining({ role: "user" })
+          ]),
+          variables: expect.arrayContaining([
+            expect.objectContaining({ name: "code", required: true })
+          ])
+        })
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/structured-prompt-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/structured-prompt-utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest"
 import {
   convertLegacyPromptToStructuredDefinition,
-  renderStructuredPromptLegacySnapshot
+  renderStructuredPromptLegacySnapshot,
+  stableSerializePromptSnapshot
 } from "../structured-prompt-utils"
 
 describe("structured-prompt-utils", () => {
@@ -104,5 +105,58 @@ describe("structured-prompt-utils", () => {
       userPrompt: "Worked example",
       content: "Worked example"
     })
+  })
+
+  it("serializes equivalent prompt snapshots stably regardless of object key order", () => {
+    const first = {
+      promptFormat: "structured",
+      structuredPromptDefinition: {
+        format: "structured",
+        schema_version: 1,
+        blocks: [
+          {
+            role: "user",
+            id: "task",
+            content: "Summarize {{topic}}",
+            order: 10,
+            enabled: true,
+            is_template: true,
+            name: "Task"
+          }
+        ],
+        assembly_config: {
+          block_separator: "\n\n",
+          legacy_user_roles: ["user"],
+          legacy_system_roles: ["system", "developer"]
+        }
+      }
+    }
+    const second = {
+      structuredPromptDefinition: {
+        schema_version: 1,
+        format: "structured",
+        assembly_config: {
+          legacy_system_roles: ["system", "developer"],
+          legacy_user_roles: ["user"],
+          block_separator: "\n\n"
+        },
+        blocks: [
+          {
+            name: "Task",
+            is_template: true,
+            enabled: true,
+            order: 10,
+            content: "Summarize {{topic}}",
+            id: "task",
+            role: "user"
+          }
+        ]
+      },
+      promptFormat: "structured"
+    }
+
+    expect(stableSerializePromptSnapshot(first)).toBe(
+      stableSerializePromptSnapshot(second)
+    )
   })
 })

--- a/apps/packages/ui/src/components/Option/Prompt/__tests__/structured-prompt-utils.test.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/__tests__/structured-prompt-utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest"
+import {
+  convertLegacyPromptToStructuredDefinition,
+  renderStructuredPromptLegacySnapshot
+} from "../structured-prompt-utils"
+
+describe("structured-prompt-utils", () => {
+  it("converts legacy prompts into the backend-canonical structured shape", () => {
+    expect(
+      convertLegacyPromptToStructuredDefinition(
+        "Be precise about {{topic}}.",
+        "Summarize {{topic}} against {{baseline}}."
+      )
+    ).toEqual({
+      schema_version: 1,
+      format: "structured",
+      assembly_config: {
+        legacy_system_roles: ["system", "developer"],
+        legacy_user_roles: ["user"],
+        block_separator: "\n\n"
+      },
+      variables: [
+        {
+          name: "topic",
+          label: "Topic",
+          required: true,
+          input_type: "textarea"
+        },
+        {
+          name: "baseline",
+          label: "Baseline",
+          required: true,
+          input_type: "textarea"
+        }
+      ],
+      blocks: [
+        {
+          id: "legacy_system",
+          name: "System Instructions",
+          role: "system",
+          kind: "instructions",
+          content: "Be precise about {{topic}}.",
+          enabled: true,
+          order: 10,
+          is_template: true
+        },
+        {
+          id: "legacy_user",
+          name: "User Prompt",
+          role: "user",
+          kind: "task",
+          content: "Summarize {{topic}} against {{baseline}}.",
+          enabled: true,
+          order: 20,
+          is_template: true
+        }
+      ]
+    })
+  })
+
+  it("renders legacy snapshots using assembly_config role mapping and separators", () => {
+    expect(
+      renderStructuredPromptLegacySnapshot({
+        schema_version: 1,
+        format: "structured",
+        assembly_config: {
+          legacy_system_roles: ["developer"],
+          legacy_user_roles: ["assistant"],
+          block_separator: "\n--\n"
+        },
+        variables: [],
+        blocks: [
+          {
+            id: "dev_one",
+            name: "Developer One",
+            role: "developer",
+            content: "Rule one",
+            enabled: true,
+            order: 10,
+            is_template: false
+          },
+          {
+            id: "dev_two",
+            name: "Developer Two",
+            role: "developer",
+            content: "Rule two",
+            enabled: true,
+            order: 20,
+            is_template: false
+          },
+          {
+            id: "assistant_example",
+            name: "Assistant Example",
+            role: "assistant",
+            content: "Worked example",
+            enabled: true,
+            order: 30,
+            is_template: false
+          }
+        ]
+      })
+    ).toEqual({
+      systemPrompt: "Rule one\n--\nRule two",
+      userPrompt: "Worked example",
+      content: "Worked example"
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Option/Prompt/index.tsx
+++ b/apps/packages/ui/src/components/Option/Prompt/index.tsx
@@ -119,6 +119,7 @@ import {
   getPromptImportErrorNotice,
   parseImportPromptsPayload
 } from "./prompt-import-error-utils"
+import { renderStructuredPromptLegacySnapshot } from "./structured-prompt-utils"
 import { buildBulkCountSummary, collectFailedIds } from "./bulk-result-utils"
 import {
   filterTrashPromptsByName,
@@ -555,6 +556,10 @@ export const PromptBody = () => {
         lastSyncedAt: promptRecord?.lastSyncedAt,
         fewShotExamples: promptRecord?.fewShotExamples,
         modulesConfig: promptRecord?.modulesConfig,
+        promptFormat: promptRecord?.promptFormat ?? "legacy",
+        promptSchemaVersion: promptRecord?.promptSchemaVersion ?? null,
+        structuredPromptDefinition:
+          promptRecord?.structuredPromptDefinition ?? null,
         changeDescription: promptRecord?.changeDescription,
         versionNumber: promptRecord?.versionNumber
       })
@@ -808,12 +813,24 @@ export const PromptBody = () => {
   const normalizePromptPayload = React.useCallback((values: any) => {
     const keywords = values?.keywords ?? values?.tags ?? []
     const promptName = values?.name || values?.title
-    const hasSystemPrompt = !!(values?.system_prompt?.trim())
+    const promptFormat = values?.promptFormat === "structured" ? "structured" : "legacy"
+    const structuredPromptDefinition =
+      promptFormat === "structured" ? values?.structuredPromptDefinition ?? null : null
+    const structuredSnapshot =
+      promptFormat === "structured"
+        ? renderStructuredPromptLegacySnapshot(structuredPromptDefinition)
+        : null
+    const normalizedSystemPrompt =
+      structuredSnapshot?.systemPrompt ?? values?.system_prompt
+    const normalizedUserPrompt =
+      structuredSnapshot?.userPrompt ?? values?.user_prompt
+    const hasSystemPrompt = !!(normalizedSystemPrompt?.trim())
     const resolvedContent =
       values?.content ??
-      (hasSystemPrompt ? values?.system_prompt : values?.user_prompt) ??
-      values?.system_prompt ??
-      values?.user_prompt
+      structuredSnapshot?.content ??
+      (hasSystemPrompt ? normalizedSystemPrompt : normalizedUserPrompt) ??
+      normalizedSystemPrompt ??
+      normalizedUserPrompt
 
     return {
       ...values,
@@ -822,8 +839,11 @@ export const PromptBody = () => {
       tags: keywords,
       keywords,
       content: resolvedContent,
-      system_prompt: values?.system_prompt,
-      user_prompt: values?.user_prompt,
+      promptFormat,
+      promptSchemaVersion: promptFormat === "structured" ? values?.promptSchemaVersion ?? 1 : null,
+      structuredPromptDefinition,
+      system_prompt: normalizedSystemPrompt,
+      user_prompt: normalizedUserPrompt,
       author: values?.author,
       details: values?.details,
       is_system: hasSystemPrompt
@@ -2447,6 +2467,10 @@ export const PromptBody = () => {
           details: promptRecord?.details,
           system_prompt: systemText,
           user_prompt: userText,
+          promptFormat: promptRecord?.promptFormat ?? "legacy",
+          promptSchemaVersion: promptRecord?.promptSchemaVersion ?? null,
+          structuredPromptDefinition:
+            promptRecord?.structuredPromptDefinition ?? null,
           keywords: promptRecord?.keywords ?? promptRecord?.tags ?? [],
           changeDescription: promptRecord?.changeDescription,
         })
@@ -2900,6 +2924,9 @@ export const PromptBody = () => {
       details: record?.details,
       system_prompt: systemText,
       user_prompt: userText,
+      promptFormat: record?.promptFormat ?? "legacy",
+      promptSchemaVersion: record?.promptSchemaVersion ?? null,
+      structuredPromptDefinition: record?.structuredPromptDefinition ?? null,
       keywords: getPromptKeywords(record),
       // Sync fields for progressive disclosure
       serverId: record?.serverId,

--- a/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
@@ -237,3 +237,23 @@ export const renderStructuredPromptLegacySnapshot = (
     content: userPrompt || systemPrompt || ""
   }
 }
+
+const normalizeForStableComparison = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForStableComparison(item))
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, item]) => item !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, normalizeForStableComparison(item)])
+    )
+  }
+
+  return value
+}
+
+export const stableSerializePromptSnapshot = (value: unknown): string =>
+  JSON.stringify(normalizeForStableComparison(value)) ?? ""

--- a/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
@@ -4,6 +4,7 @@ type StructuredPromptBlock = {
   id: string
   name: string
   role: "system" | "developer" | "user" | "assistant"
+  kind?: string
   content: string
   enabled: boolean
   order: number
@@ -18,8 +19,20 @@ type StructuredPromptVariable = {
   input_type?: string
 }
 
+type StructuredPromptAssemblyConfig = {
+  legacy_system_roles: string[]
+  legacy_user_roles: string[]
+  block_separator: string
+}
+
 const LEGACY_TEMPLATE_PATTERN =
   /{{\s*([a-zA-Z0-9_]+)\s*}}|\{([a-zA-Z0-9_]+)\}|\$([a-zA-Z0-9_]+)|<([a-zA-Z0-9_]+)>/g
+
+const DEFAULT_ASSEMBLY_CONFIG: StructuredPromptAssemblyConfig = {
+  legacy_system_roles: ["system", "developer"],
+  legacy_user_roles: ["user"],
+  block_separator: "\n\n"
+}
 
 const matchVariableName = (
   groups: Array<string | undefined>
@@ -66,12 +79,14 @@ export const createDefaultStructuredPromptDefinition =
   (): StructuredPromptDefinition => ({
     schema_version: 1,
     format: "structured",
+    assembly_config: { ...DEFAULT_ASSEMBLY_CONFIG },
     variables: [],
     blocks: [
       {
         id: "task",
         name: "Task",
         role: "user",
+        kind: "task",
         content: "Describe the task here.",
         enabled: true,
         order: 10,
@@ -92,6 +107,7 @@ export const createStructuredPromptDefinition = ({
 }): StructuredPromptDefinition => ({
   schema_version: 1,
   format: "structured",
+  assembly_config: { ...DEFAULT_ASSEMBLY_CONFIG },
   variables: variables.map((variable) => ({
     name: variable.name,
     label: variable.label,
@@ -121,9 +137,10 @@ export const convertLegacyPromptToStructuredDefinition = (
 
   if (normalizedSystemPrompt.trim()) {
     blocks.push({
-      id: "system",
+      id: "legacy_system",
       name: "System Instructions",
       role: "system",
+      kind: "instructions",
       content: normalizedSystemPrompt.trim(),
       enabled: true,
       order: 10,
@@ -133,9 +150,10 @@ export const convertLegacyPromptToStructuredDefinition = (
 
   if (normalizedUserPrompt.trim()) {
     blocks.push({
-      id: "task",
-      name: "Task",
+      id: "legacy_user",
+      name: "User Prompt",
       role: "user",
+      kind: "task",
       content: normalizedUserPrompt.trim(),
       enabled: true,
       order: blocks.length === 0 ? 10 : 20,
@@ -146,6 +164,7 @@ export const convertLegacyPromptToStructuredDefinition = (
   return {
     schema_version: 1,
     format: "structured",
+    assembly_config: { ...DEFAULT_ASSEMBLY_CONFIG },
     variables: variables.map((variableName) => ({
       name: variableName,
       label: variableName.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()),
@@ -182,6 +201,24 @@ export const renderStructuredPromptLegacySnapshot = (
         })
     : []
 
+  const assemblyConfig = (
+    definition?.assembly_config &&
+    typeof definition.assembly_config === "object" &&
+    !Array.isArray(definition.assembly_config)
+      ? definition.assembly_config
+      : DEFAULT_ASSEMBLY_CONFIG
+  ) as Partial<StructuredPromptAssemblyConfig>
+  const separator =
+    typeof assemblyConfig.block_separator === "string"
+      ? assemblyConfig.block_separator
+      : DEFAULT_ASSEMBLY_CONFIG.block_separator
+  const systemRoles = Array.isArray(assemblyConfig.legacy_system_roles)
+    ? assemblyConfig.legacy_system_roles.map((role) => String(role))
+    : DEFAULT_ASSEMBLY_CONFIG.legacy_system_roles
+  const userRoles = Array.isArray(assemblyConfig.legacy_user_roles)
+    ? assemblyConfig.legacy_user_roles.map((role) => String(role))
+    : DEFAULT_ASSEMBLY_CONFIG.legacy_user_roles
+
   const pickContent = (roles: string[]) =>
     blocks
       .filter((block: any) => roles.includes(String(block?.role || "")))
@@ -189,10 +226,10 @@ export const renderStructuredPromptLegacySnapshot = (
         typeof block?.content === "string" ? block.content.trim() : ""
       )
       .filter((content: string) => content.length > 0)
-      .join("\n\n")
+      .join(separator)
 
-  const systemPrompt = pickContent(["system", "developer"])
-  const userPrompt = pickContent(["user"])
+  const systemPrompt = pickContent(systemRoles)
+  const userPrompt = pickContent(userRoles)
 
   return {
     systemPrompt,

--- a/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
@@ -18,6 +18,50 @@ type StructuredPromptVariable = {
   input_type?: string
 }
 
+const LEGACY_TEMPLATE_PATTERN =
+  /{{\s*([a-zA-Z0-9_]+)\s*}}|\{([a-zA-Z0-9_]+)\}|\$([a-zA-Z0-9_]+)|<([a-zA-Z0-9_]+)>/g
+
+const matchVariableName = (
+  groups: Array<string | undefined>
+): string => {
+  for (const group of groups) {
+    if (group) return group
+  }
+  return ""
+}
+
+export const extractLegacyPromptVariables = (
+  ...templates: Array<string | null | undefined>
+): string[] => {
+  const variables: string[] = []
+
+  for (const template of templates) {
+    LEGACY_TEMPLATE_PATTERN.lastIndex = 0
+    let match = LEGACY_TEMPLATE_PATTERN.exec(template || "")
+    while (match) {
+      const variableName = matchVariableName(match.slice(1))
+      if (variableName && !variables.includes(variableName)) {
+        variables.push(variableName)
+      }
+      match = LEGACY_TEMPLATE_PATTERN.exec(template || "")
+    }
+  }
+
+  return variables
+}
+
+export const normalizeLegacyPromptTemplate = (
+  template?: string | null
+): string => {
+  if (!template) return ""
+
+  LEGACY_TEMPLATE_PATTERN.lastIndex = 0
+  return template.replace(LEGACY_TEMPLATE_PATTERN, (...args) => {
+    const groups = args.slice(1, 5) as Array<string | undefined>
+    return `{{${matchVariableName(groups)}}}`
+  })
+}
+
 export const createDefaultStructuredPromptDefinition =
   (): StructuredPromptDefinition => ({
     schema_version: 1,
@@ -70,36 +114,44 @@ export const convertLegacyPromptToStructuredDefinition = (
   systemPrompt?: string | null,
   userPrompt?: string | null
 ): StructuredPromptDefinition => {
+  const variables = extractLegacyPromptVariables(systemPrompt, userPrompt)
   const blocks: StructuredPromptBlock[] = []
+  const normalizedSystemPrompt = normalizeLegacyPromptTemplate(systemPrompt)
+  const normalizedUserPrompt = normalizeLegacyPromptTemplate(userPrompt)
 
-  if (systemPrompt?.trim()) {
+  if (normalizedSystemPrompt.trim()) {
     blocks.push({
       id: "system",
       name: "System Instructions",
       role: "system",
-      content: systemPrompt.trim(),
+      content: normalizedSystemPrompt.trim(),
       enabled: true,
       order: 10,
-      is_template: false
+      is_template: normalizedSystemPrompt.includes("{{")
     })
   }
 
-  if (userPrompt?.trim()) {
+  if (normalizedUserPrompt.trim()) {
     blocks.push({
       id: "task",
       name: "Task",
       role: "user",
-      content: userPrompt.trim(),
+      content: normalizedUserPrompt.trim(),
       enabled: true,
       order: blocks.length === 0 ? 10 : 20,
-      is_template: true
+      is_template: normalizedUserPrompt.includes("{{")
     })
   }
 
   return {
     schema_version: 1,
     format: "structured",
-    variables: [],
+    variables: variables.map((variableName) => ({
+      name: variableName,
+      label: variableName.replace(/_/g, " ").replace(/\b\w/g, (char) => char.toUpperCase()),
+      required: true,
+      input_type: "textarea"
+    })),
     blocks:
       blocks.length > 0
         ? blocks

--- a/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
+++ b/apps/packages/ui/src/components/Option/Prompt/structured-prompt-utils.ts
@@ -1,0 +1,150 @@
+import type { StructuredPromptDefinition } from "@/services/prompt-studio"
+
+type StructuredPromptBlock = {
+  id: string
+  name: string
+  role: "system" | "developer" | "user" | "assistant"
+  content: string
+  enabled: boolean
+  order: number
+  is_template: boolean
+}
+
+type StructuredPromptVariable = {
+  name: string
+  label?: string
+  description?: string
+  required?: boolean
+  input_type?: string
+}
+
+export const createDefaultStructuredPromptDefinition =
+  (): StructuredPromptDefinition => ({
+    schema_version: 1,
+    format: "structured",
+    variables: [],
+    blocks: [
+      {
+        id: "task",
+        name: "Task",
+        role: "user",
+        content: "Describe the task here.",
+        enabled: true,
+        order: 10,
+        is_template: false
+      }
+    ]
+  })
+
+export const createStructuredPromptDefinition = ({
+  variables = [],
+  blocks
+}: {
+  variables?: StructuredPromptVariable[]
+  blocks: Array<
+    Omit<StructuredPromptBlock, "order" | "enabled" | "is_template"> &
+      Partial<Pick<StructuredPromptBlock, "order" | "enabled" | "is_template">>
+  >
+}): StructuredPromptDefinition => ({
+  schema_version: 1,
+  format: "structured",
+  variables: variables.map((variable) => ({
+    name: variable.name,
+    label: variable.label,
+    description: variable.description,
+    required: variable.required === true,
+    input_type: variable.input_type || "text"
+  })),
+  blocks: blocks.map((block, index) => ({
+    ...block,
+    enabled: block.enabled !== false,
+    order:
+      typeof block.order === "number" && Number.isFinite(block.order)
+        ? block.order
+        : (index + 1) * 10,
+    is_template: block.is_template === true
+  }))
+})
+
+export const convertLegacyPromptToStructuredDefinition = (
+  systemPrompt?: string | null,
+  userPrompt?: string | null
+): StructuredPromptDefinition => {
+  const blocks: StructuredPromptBlock[] = []
+
+  if (systemPrompt?.trim()) {
+    blocks.push({
+      id: "system",
+      name: "System Instructions",
+      role: "system",
+      content: systemPrompt.trim(),
+      enabled: true,
+      order: 10,
+      is_template: false
+    })
+  }
+
+  if (userPrompt?.trim()) {
+    blocks.push({
+      id: "task",
+      name: "Task",
+      role: "user",
+      content: userPrompt.trim(),
+      enabled: true,
+      order: blocks.length === 0 ? 10 : 20,
+      is_template: true
+    })
+  }
+
+  return {
+    schema_version: 1,
+    format: "structured",
+    variables: [],
+    blocks:
+      blocks.length > 0
+        ? blocks
+        : (createDefaultStructuredPromptDefinition().blocks as StructuredPromptBlock[])
+  }
+}
+
+export const renderStructuredPromptLegacySnapshot = (
+  definition: StructuredPromptDefinition | null | undefined
+): {
+  systemPrompt: string
+  userPrompt: string
+  content: string
+} => {
+  const blocks = Array.isArray(definition?.blocks)
+    ? [...definition.blocks]
+        .filter((block: any) => block?.enabled !== false)
+        .sort((left: any, right: any) => {
+          const leftOrder =
+            typeof left?.order === "number" && Number.isFinite(left.order)
+              ? left.order
+              : 0
+          const rightOrder =
+            typeof right?.order === "number" && Number.isFinite(right.order)
+              ? right.order
+              : 0
+          return leftOrder - rightOrder
+        })
+    : []
+
+  const pickContent = (roles: string[]) =>
+    blocks
+      .filter((block: any) => roles.includes(String(block?.role || "")))
+      .map((block: any) =>
+        typeof block?.content === "string" ? block.content.trim() : ""
+      )
+      .filter((content: string) => content.length > 0)
+      .join("\n\n")
+
+  const systemPrompt = pickContent(["system", "developer"])
+  const userPrompt = pickContent(["user"])
+
+  return {
+    systemPrompt,
+    userPrompt,
+    content: userPrompt || systemPrompt || ""
+  }
+}

--- a/apps/packages/ui/src/db/dexie/chat.ts
+++ b/apps/packages/ui/src/db/dexie/chat.ts
@@ -494,6 +494,13 @@ export class PageAssistDatabase {
       name: prompt.name ?? prompt.title,
       tags: mergedKeywords ?? prompt.tags,
       keywords: mergedKeywords ?? prompt.keywords ?? prompt.tags,
+      promptFormat: prompt.promptFormat ?? 'legacy',
+      promptSchemaVersion: prompt.promptSchemaVersion ?? null,
+      structuredPromptDefinition: prompt.structuredPromptDefinition ?? null,
+      syncPayloadVersion:
+        typeof prompt.syncPayloadVersion === "number" && Number.isFinite(prompt.syncPayloadVersion)
+          ? prompt.syncPayloadVersion
+          : 1,
       deletedAt: null,
       usageCount: normalizedUsageCount,
       lastUsedAt:
@@ -577,6 +584,21 @@ export class PageAssistDatabase {
       content: updates.content ?? existing.content,
       system_prompt: updates.system_prompt ?? existing.system_prompt,
       user_prompt: updates.user_prompt ?? existing.user_prompt,
+      promptFormat: updates.promptFormat ?? existing.promptFormat ?? 'legacy',
+      promptSchemaVersion:
+        updates.promptSchemaVersion === undefined
+          ? existing.promptSchemaVersion ?? null
+          : updates.promptSchemaVersion ?? null,
+      structuredPromptDefinition:
+        updates.structuredPromptDefinition === undefined
+          ? existing.structuredPromptDefinition ?? null
+          : updates.structuredPromptDefinition ?? null,
+      syncPayloadVersion:
+        typeof updates.syncPayloadVersion === "number" && Number.isFinite(updates.syncPayloadVersion)
+          ? updates.syncPayloadVersion
+          : typeof existing.syncPayloadVersion === "number" && Number.isFinite(existing.syncPayloadVersion)
+            ? existing.syncPayloadVersion
+            : 1,
       tags: mergedKeywords ?? existing.tags,
       keywords: mergedKeywords ?? existing.keywords ?? existing.tags,
       favorite:

--- a/apps/packages/ui/src/db/dexie/helpers.ts
+++ b/apps/packages/ui/src/db/dexie/helpers.ts
@@ -441,6 +441,10 @@ export const savePrompt = async ({
   user_prompt,
   fewShotExamples,
   modulesConfig,
+  promptFormat,
+  promptSchemaVersion,
+  structuredPromptDefinition,
+  syncPayloadVersion,
   versionNumber,
   changeDescription,
   parentVersionId,
@@ -459,6 +463,10 @@ export const savePrompt = async ({
   user_prompt?: string
   fewShotExamples?: Prompt["fewShotExamples"]
   modulesConfig?: Prompt["modulesConfig"]
+  promptFormat?: Prompt["promptFormat"]
+  promptSchemaVersion?: Prompt["promptSchemaVersion"]
+  structuredPromptDefinition?: Prompt["structuredPromptDefinition"]
+  syncPayloadVersion?: Prompt["syncPayloadVersion"]
   versionNumber?: Prompt["versionNumber"]
   changeDescription?: Prompt["changeDescription"]
   parentVersionId?: Prompt["parentVersionId"]
@@ -497,6 +505,10 @@ export const savePrompt = async ({
     details,
     system_prompt: system_prompt ?? (is_system ? resolvedContent : undefined),
     user_prompt: user_prompt ?? (!is_system ? resolvedContent : undefined),
+    promptFormat: promptFormat ?? 'legacy',
+    promptSchemaVersion: promptSchemaVersion ?? null,
+    structuredPromptDefinition: structuredPromptDefinition ?? null,
+    syncPayloadVersion: syncPayloadVersion ?? 1,
     fewShotExamples: fewShotExamples ?? null,
     modulesConfig: modulesConfig ?? null,
     versionNumber: versionNumber ?? null,
@@ -582,6 +594,10 @@ export const updatePrompt = async ({
   user_prompt,
   fewShotExamples,
   modulesConfig,
+  promptFormat,
+  promptSchemaVersion,
+  structuredPromptDefinition,
+  syncPayloadVersion,
   versionNumber,
   changeDescription,
   parentVersionId,
@@ -603,6 +619,10 @@ export const updatePrompt = async ({
   user_prompt?: string
   fewShotExamples?: Prompt["fewShotExamples"]
   modulesConfig?: Prompt["modulesConfig"]
+  promptFormat?: Prompt["promptFormat"]
+  promptSchemaVersion?: Prompt["promptSchemaVersion"]
+  structuredPromptDefinition?: Prompt["structuredPromptDefinition"]
+  syncPayloadVersion?: Prompt["syncPayloadVersion"]
   versionNumber?: Prompt["versionNumber"]
   changeDescription?: Prompt["changeDescription"]
   parentVersionId?: Prompt["parentVersionId"]
@@ -636,6 +656,10 @@ export const updatePrompt = async ({
     details,
     system_prompt,
     user_prompt,
+    promptFormat,
+    promptSchemaVersion,
+    structuredPromptDefinition,
+    syncPayloadVersion,
     fewShotExamples,
     modulesConfig,
     versionNumber,

--- a/apps/packages/ui/src/db/dexie/schema.ts
+++ b/apps/packages/ui/src/db/dexie/schema.ts
@@ -322,6 +322,46 @@ export class PageAssistDexieDB extends Dexie {
       ttsClips: 'id, createdAt, historyId, serverChatId, messageId, serverMessageId, provider',
       sttRecordings: 'id, createdAt'
     });
+
+    // Version 13: Structured prompt sync metadata defaults
+    this.version(13).stores({
+      chatHistories: 'id, title, is_rag, message_source, is_pinned, createdAt, doc_id, last_used_prompt, model_id, root_id, parent_conversation_id, server_chat_id',
+      messages: 'id, history_id, name, role, content, createdAt, messageType, modelName, clusterId, modelId, parent_message_id',
+      prompts: 'id, title, content, is_system, createdBy, createdAt, deletedAt, serverId, studioProjectId, syncStatus, sourceSystem, usageCount, lastUsedAt',
+      webshares: 'id, title, url, api_url, share_id, createdAt',
+      sessionFiles: 'sessionId, retrievalEnabled, createdAt',
+      userSettings: 'id, user_id',
+      customModels: 'id, model_id, name, model_name, model_image, provider_id, lookup, model_type, db_type',
+      modelNickname: 'id, model_id, model_name, model_avatar',
+      processedMedia: 'id, url, createdAt',
+      folders: 'id, name, parent_id, deleted',
+      keywords: 'id, keyword, deleted',
+      folderKeywordLinks: '[folder_id+keyword_id], folder_id, keyword_id',
+      conversationKeywordLinks: '[conversation_id+keyword_id], conversation_id, keyword_id',
+      compareStates: 'history_id',
+      contentDrafts: 'id, batchId, status, mediaType, createdAt, updatedAt, expiresAt',
+      draftBatches: 'id, createdAt, updatedAt',
+      draftAssets: 'id, draftId, createdAt',
+      audiobookProjects: 'id, title, status, createdAt, updatedAt, lastOpenedAt',
+      audiobookChapterAssets: 'id, projectId, chapterId, createdAt',
+      ttsClips: 'id, createdAt, historyId, serverChatId, messageId, serverMessageId, provider',
+      sttRecordings: 'id, createdAt'
+    }).upgrade(tx => {
+      return tx.table('prompts').toCollection().modify(prompt => {
+        if (prompt.promptFormat === undefined) {
+          prompt.promptFormat = 'legacy';
+        }
+        if (prompt.promptSchemaVersion === undefined) {
+          prompt.promptSchemaVersion = null;
+        }
+        if (prompt.structuredPromptDefinition === undefined) {
+          prompt.structuredPromptDefinition = null;
+        }
+        if (prompt.syncPayloadVersion === undefined) {
+          prompt.syncPayloadVersion = 1;
+        }
+      });
+    });
   }
 }
 

--- a/apps/packages/ui/src/db/dexie/types.ts
+++ b/apps/packages/ui/src/db/dexie/types.ts
@@ -120,6 +120,8 @@ export type FewShotExample = {
 
 export type PromptSyncStatus = 'local' | 'synced' | 'pending' | 'conflict';
 export type PromptSourceSystem = 'workspace' | 'studio' | 'copilot';
+export type PromptFormat = 'legacy' | 'structured';
+export type StructuredPromptDefinition = Record<string, any>;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Unified Prompt Type
@@ -164,6 +166,10 @@ export type Prompt = {
   serverUpdatedAt?: string | null;    // Server's updated_at for conflict detection
 
   // ─── Studio-specific Fields (progressive disclosure) ───
+  promptFormat?: PromptFormat;
+  promptSchemaVersion?: number | null;
+  structuredPromptDefinition?: StructuredPromptDefinition | null;
+  syncPayloadVersion?: number | null;
   fewShotExamples?: FewShotExample[] | null;
   modulesConfig?: PromptModule[] | null;
   versionNumber?: number | null;

--- a/apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
+++ b/apps/packages/ui/src/services/__tests__/prompt-sync.structured-prompts.test.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const state = vi.hoisted(() => ({
+  prompts: new Map<string, any>()
+}))
+
+const mocks = vi.hoisted(() => ({
+  createPrompt: vi.fn(),
+  getPrompt: vi.fn(),
+  promptAdd: vi.fn(),
+  promptGet: vi.fn(),
+  promptUpdate: vi.fn(),
+  promptWhere: vi.fn()
+}))
+
+vi.mock("@/services/prompt-studio-settings", () => ({
+  getPromptStudioDefaults: async () => ({
+    defaultProjectId: null,
+    autoSyncWorkspacePrompts: true
+  }),
+  setPromptStudioDefaults: async () => undefined
+}))
+
+vi.mock("@/services/prompt-studio", () => ({
+  listProjects: vi.fn(async () => ({ data: { data: [] } })),
+  createProject: vi.fn(async () => ({ data: { data: { id: 42 } } })),
+  createPrompt: (...args: unknown[]) =>
+    (mocks.createPrompt as (...args: unknown[]) => unknown)(...args),
+  updatePrompt: vi.fn(),
+  getPrompt: (...args: unknown[]) =>
+    (mocks.getPrompt as (...args: unknown[]) => unknown)(...args)
+}))
+
+vi.mock("@/db/dexie/schema", () => ({
+  db: {
+    prompts: {
+      add: (...args: unknown[]) =>
+        (mocks.promptAdd as (...args: unknown[]) => unknown)(...args),
+      get: (...args: unknown[]) =>
+        (mocks.promptGet as (...args: unknown[]) => unknown)(...args),
+      update: (...args: unknown[]) =>
+        (mocks.promptUpdate as (...args: unknown[]) => unknown)(...args),
+      where: (...args: unknown[]) =>
+        (mocks.promptWhere as (...args: unknown[]) => unknown)(...args)
+    }
+  }
+}))
+
+vi.mock("@/db/dexie/chat", () => ({
+  PageAssistDatabase: class {}
+}))
+
+vi.mock("@/db/dexie/helpers", () => ({
+  generateID: () => "generated-local-id"
+}))
+
+const importPromptSync = async () => import("@/services/prompt-sync")
+
+const makeDefinition = (content: string) => ({
+  schema_version: 1,
+  format: "structured",
+  variables: [
+    {
+      name: "topic",
+      required: true,
+      input_type: "text"
+    }
+  ],
+  blocks: [
+    {
+      id: "task",
+      name: "Task",
+      role: "user",
+      content,
+      enabled: true,
+      order: 10,
+      is_template: true
+    }
+  ]
+})
+
+describe("prompt-sync structured prompt support", () => {
+  beforeEach(() => {
+    state.prompts.clear()
+
+    mocks.createPrompt.mockReset()
+    mocks.getPrompt.mockReset()
+    mocks.promptAdd.mockReset()
+    mocks.promptGet.mockReset()
+    mocks.promptUpdate.mockReset()
+    mocks.promptWhere.mockReset()
+
+    mocks.promptAdd.mockImplementation(async (prompt: any) => {
+      state.prompts.set(prompt.id, prompt)
+    })
+    mocks.promptGet.mockImplementation(async (id: string) => state.prompts.get(id))
+    mocks.promptUpdate.mockImplementation(async (id: string, updates: Record<string, unknown>) => {
+      const current = state.prompts.get(id)
+      if (!current) return
+      state.prompts.set(id, { ...current, ...updates })
+    })
+    mocks.promptWhere.mockImplementation((field: string) => ({
+      equals: (value: unknown) => ({
+        first: async () => {
+          for (const prompt of state.prompts.values()) {
+            if (prompt?.[field] === value) return prompt
+          }
+          return undefined
+        }
+      })
+    }))
+  })
+
+  it("pushes structured prompt fields to Prompt Studio create payloads", async () => {
+    state.prompts.set("local-structured", {
+      id: "local-structured",
+      title: "Structured Prompt",
+      name: "Structured Prompt",
+      content: "Explain {{topic}}",
+      is_system: false,
+      system_prompt: "Legacy system snapshot",
+      user_prompt: "Explain {{topic}}",
+      promptFormat: "structured",
+      promptSchemaVersion: 1,
+      structuredPromptDefinition: makeDefinition("Explain {{topic}}"),
+      fewShotExamples: [
+        {
+          inputs: { topic: "Indexes" },
+          outputs: { answer: "Use the covering index." }
+        }
+      ],
+      modulesConfig: [
+        {
+          type: "style_rules",
+          enabled: true,
+          config: { tone: "concise" }
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 1,
+      syncStatus: "local"
+    })
+
+    mocks.createPrompt.mockResolvedValue({
+      data: {
+        data: {
+          id: 101,
+          project_id: 42,
+          name: "Structured Prompt",
+          system_prompt: "Legacy system snapshot",
+          user_prompt: "Explain {{topic}}",
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: makeDefinition("Explain {{topic}}"),
+          version_number: 1,
+          updated_at: "2026-03-10T00:00:00Z"
+        }
+      }
+    })
+
+    const { pushToStudio } = await importPromptSync()
+    await pushToStudio("local-structured", 42)
+
+    expect(mocks.createPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project_id: 42,
+        prompt_format: "structured",
+        prompt_schema_version: 1,
+        prompt_definition: makeDefinition("Explain {{topic}}"),
+        few_shot_examples: [
+          {
+            inputs: { topic: "Indexes" },
+            outputs: { answer: "Use the covering index." }
+          }
+        ],
+        modules_config: [
+          {
+            type: "style_rules",
+            enabled: true,
+            config: { tone: "concise" }
+          }
+        ]
+      })
+    )
+  })
+
+  it("pulls structured prompt fields into the local prompt record", async () => {
+    mocks.getPrompt.mockResolvedValue({
+      data: {
+        data: {
+          id: 501,
+          project_id: 9,
+          name: "Server Structured Prompt",
+          system_prompt: "Legacy system snapshot",
+          user_prompt: "Explain {{topic}}",
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: makeDefinition("Explain {{topic}}"),
+          few_shot_examples: [
+            {
+              inputs: { topic: "SQLite" },
+              outputs: { answer: "Use FTS5." }
+            }
+          ],
+          modules_config: [
+            {
+              type: "style_rules",
+              enabled: true,
+              config: { tone: "formal" }
+            }
+          ],
+          version_number: 2,
+          updated_at: "2026-03-10T00:00:00Z"
+        }
+      }
+    })
+
+    const { pullFromStudio } = await importPromptSync()
+    await pullFromStudio(501)
+
+    expect(state.prompts.get("generated-local-id")).toEqual(
+      expect.objectContaining({
+        promptFormat: "structured",
+        promptSchemaVersion: 1,
+        structuredPromptDefinition: makeDefinition("Explain {{topic}}"),
+        fewShotExamples: [
+          {
+            inputs: { topic: "SQLite" },
+            outputs: { answer: "Use FTS5." }
+          }
+        ],
+        modulesConfig: [
+          {
+            type: "style_rules",
+            enabled: true,
+            config: { tone: "formal" }
+          }
+        ]
+      })
+    )
+  })
+
+  it("treats structured definition changes as sync conflicts even when legacy text matches", async () => {
+    state.prompts.set("local-conflict-structured", {
+      id: "local-conflict-structured",
+      title: "Structured Prompt",
+      name: "Structured Prompt",
+      content: "Explain {{topic}}",
+      is_system: false,
+      system_prompt: "Legacy system snapshot",
+      user_prompt: "Explain {{topic}}",
+      promptFormat: "structured",
+      promptSchemaVersion: 1,
+      structuredPromptDefinition: makeDefinition("Explain {{topic}}"),
+      createdAt: 1,
+      updatedAt: 20,
+      serverId: 77,
+      syncStatus: "synced",
+      serverUpdatedAt: "2026-03-10T00:00:00Z",
+      lastSyncedAt: 10
+    })
+
+    mocks.getPrompt.mockResolvedValue({
+      data: {
+        data: {
+          id: 77,
+          project_id: 9,
+          name: "Structured Prompt",
+          system_prompt: "Legacy system snapshot",
+          user_prompt: "Explain {{topic}}",
+          prompt_format: "structured",
+          prompt_schema_version: 1,
+          prompt_definition: makeDefinition("Summarize {{topic}}"),
+          version_number: 2,
+          updated_at: "2026-03-10T01:00:00Z"
+        }
+      }
+    })
+
+    const { getSyncStatus } = await importPromptSync()
+    await expect(getSyncStatus("local-conflict-structured")).resolves.toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        hasConflict: true
+      })
+    )
+  })
+
+  it("treats few-shot or module changes as sync conflicts for legacy prompts", async () => {
+    state.prompts.set("local-conflict-legacy", {
+      id: "local-conflict-legacy",
+      title: "Legacy Prompt",
+      name: "Legacy Prompt",
+      content: "Explain topic",
+      is_system: false,
+      system_prompt: "Legacy system snapshot",
+      user_prompt: "Explain topic",
+      fewShotExamples: [
+        {
+          inputs: { topic: "SQLite" },
+          outputs: { answer: "Use indexes." }
+        }
+      ],
+      modulesConfig: [
+        {
+          type: "style_rules",
+          enabled: true,
+          config: { tone: "concise" }
+        }
+      ],
+      createdAt: 1,
+      updatedAt: 20,
+      serverId: 88,
+      syncStatus: "synced",
+      serverUpdatedAt: "2026-03-10T00:00:00Z",
+      lastSyncedAt: 10
+    })
+
+    mocks.getPrompt.mockResolvedValue({
+      data: {
+        data: {
+          id: 88,
+          project_id: 9,
+          name: "Legacy Prompt",
+          system_prompt: "Legacy system snapshot",
+          user_prompt: "Explain topic",
+          few_shot_examples: [
+            {
+              inputs: { topic: "SQLite" },
+              outputs: { answer: "Use FTS5." }
+            }
+          ],
+          modules_config: [
+            {
+              type: "style_rules",
+              enabled: true,
+              config: { tone: "formal" }
+            }
+          ],
+          version_number: 2,
+          updated_at: "2026-03-10T01:00:00Z"
+        }
+      }
+    })
+
+    const { getSyncStatus } = await importPromptSync()
+    await expect(getSyncStatus("local-conflict-legacy")).resolves.toEqual(
+      expect.objectContaining({
+        status: "conflict",
+        hasConflict: true
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/prompt-studio.ts
+++ b/apps/packages/ui/src/services/prompt-studio.ts
@@ -106,6 +106,30 @@ export type PromptUpdatePayload = {
   change_description: string
 }
 
+export type StructuredPromptPreviewRequest = {
+  project_id: number
+  signature_id?: number | null
+  prompt_format: PromptFormat
+  system_prompt?: string | null
+  user_prompt?: string | null
+  prompt_schema_version?: number | null
+  prompt_definition?: StructuredPromptDefinition | null
+  few_shot_examples?: FewShotExample[] | null
+  modules_config?: PromptModule[] | null
+  variables?: Record<string, any>
+}
+
+export type StructuredPromptPreviewResponse = {
+  prompt_format: PromptFormat
+  prompt_schema_version?: number | null
+  assembled_messages: Array<{
+    role: string
+    content: string
+  }>
+  legacy_system_prompt: string
+  legacy_user_prompt: string
+}
+
 export type PromptVersion = {
   id: number
   uuid?: string
@@ -372,6 +396,16 @@ export async function updatePrompt(promptId: number, payload: PromptUpdatePayloa
       `/api/v1/prompt-studio/prompts/update/${encodeURIComponent(promptId)}`
     ),
     method: "PUT",
+    body: payload
+  })
+}
+
+export async function previewPromptDefinition(
+  payload: StructuredPromptPreviewRequest
+) {
+  return await apiSend<StandardResponse<StructuredPromptPreviewResponse>>({
+    path: "/api/v1/prompt-studio/prompts/preview",
+    method: "POST",
     body: payload
   })
 }

--- a/apps/packages/ui/src/services/prompt-studio.ts
+++ b/apps/packages/ui/src/services/prompt-studio.ts
@@ -56,6 +56,9 @@ export type FewShotExample = {
   explanation?: string | null
 }
 
+export type PromptFormat = "legacy" | "structured"
+export type StructuredPromptDefinition = Record<string, any>
+
 export type Prompt = {
   id: number
   uuid?: string
@@ -63,6 +66,9 @@ export type Prompt = {
   name: string
   system_prompt?: string | null
   user_prompt?: string | null
+  prompt_format?: PromptFormat
+  prompt_schema_version?: number | null
+  prompt_definition?: StructuredPromptDefinition | null
   few_shot_examples?: FewShotExample[] | null
   modules_config?: PromptModule[] | null
   signature_id?: number | null
@@ -78,6 +84,9 @@ export type PromptCreatePayload = {
   name: string
   system_prompt?: string | null
   user_prompt?: string | null
+  prompt_format?: PromptFormat
+  prompt_schema_version?: number | null
+  prompt_definition?: StructuredPromptDefinition | null
   few_shot_examples?: FewShotExample[] | null
   modules_config?: PromptModule[] | null
   change_description?: string | null
@@ -89,6 +98,9 @@ export type PromptUpdatePayload = {
   name?: string
   system_prompt?: string | null
   user_prompt?: string | null
+  prompt_format?: PromptFormat
+  prompt_schema_version?: number | null
+  prompt_definition?: StructuredPromptDefinition | null
   few_shot_examples?: FewShotExample[] | null
   modules_config?: PromptModule[] | null
   change_description: string

--- a/apps/packages/ui/src/services/prompt-sync.ts
+++ b/apps/packages/ui/src/services/prompt-sync.ts
@@ -55,6 +55,19 @@ export type ConflictResolution = 'keep_local' | 'keep_server' | 'keep_both'
 const AUTO_SYNC_PROJECT_NAME = 'Workspace Prompts'
 const AUTO_SYNC_PROJECT_DESCRIPTION =
   'Auto-created project used to persist prompts saved from the Prompts workspace.'
+const CURRENT_PROMPT_SYNC_PAYLOAD_VERSION = 1
+
+type PromptFormat = 'legacy' | 'structured'
+
+type ComparablePromptPayload = {
+  promptFormat: PromptFormat
+  promptSchemaVersion: number | null
+  promptDefinition: Record<string, any> | null
+  systemPrompt: string
+  userPrompt: string
+  fewShotExamples: FewShotExample[] | null
+  modulesConfig: PromptModule[] | null
+}
 
 const isValidProjectId = (value: unknown): value is number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0
@@ -65,6 +78,16 @@ const unwrapResponseData = <T>(response: unknown): T | null => {
 }
 
 const toText = (value: unknown): string => (typeof value === 'string' ? value : '')
+const toFiniteNumberOrNull = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+const toPromptFormat = (value: unknown): PromptFormat =>
+  value === 'structured' ? 'structured' : 'legacy'
+const toRecordOrNull = (value: unknown): Record<string, any> | null =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, any>)
+    : null
+const toArrayOrNull = <T>(value: unknown): T[] | null =>
+  Array.isArray(value) ? (value as T[]) : null
 
 const getLocalPromptTextsForConflict = (
   local: LocalPrompt
@@ -88,8 +111,25 @@ const getServerPromptTextsForConflict = (
   userPrompt: toText(server.user_prompt)
 })
 
-const promptTextHash = (systemPrompt: string, userPrompt: string): string => {
-  const combined = `${systemPrompt}\u241f${userPrompt}`
+const normalizeForStableHash = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeForStableHash(item))
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, item]) => item !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, normalizeForStableHash(item)])
+    )
+  }
+
+  return value
+}
+
+const promptPayloadHash = (payload: ComparablePromptPayload): string => {
+  const combined = JSON.stringify(normalizeForStableHash(payload))
   let hash = 0x811c9dc5
   for (let i = 0; i < combined.length; i += 1) {
     hash ^= combined.charCodeAt(i)
@@ -98,16 +138,43 @@ const promptTextHash = (systemPrompt: string, userPrompt: string): string => {
   return hash.toString(16).padStart(8, '0')
 }
 
+const getLocalPromptComparablePayload = (
+  local: LocalPrompt
+): ComparablePromptPayload => {
+  const localText = getLocalPromptTextsForConflict(local)
+  return {
+    promptFormat: toPromptFormat(local.promptFormat),
+    promptSchemaVersion: toFiniteNumberOrNull(local.promptSchemaVersion),
+    promptDefinition: toRecordOrNull(local.structuredPromptDefinition),
+    systemPrompt: localText.systemPrompt,
+    userPrompt: localText.userPrompt,
+    fewShotExamples: toArrayOrNull<FewShotExample>(local.fewShotExamples),
+    modulesConfig: toArrayOrNull<PromptModule>(local.modulesConfig)
+  }
+}
+
+const getServerPromptComparablePayload = (
+  server: ServerPrompt
+): ComparablePromptPayload => {
+  const serverText = getServerPromptTextsForConflict(server)
+  return {
+    promptFormat: toPromptFormat(server.prompt_format),
+    promptSchemaVersion: toFiniteNumberOrNull(server.prompt_schema_version),
+    promptDefinition: toRecordOrNull(server.prompt_definition),
+    systemPrompt: serverText.systemPrompt,
+    userPrompt: serverText.userPrompt,
+    fewShotExamples: toArrayOrNull<FewShotExample>(server.few_shot_examples),
+    modulesConfig: toArrayOrNull<PromptModule>(server.modules_config)
+  }
+}
+
 const hasPromptContentConflict = (
   local: LocalPrompt,
   server: ServerPrompt
 ): boolean => {
-  const localText = getLocalPromptTextsForConflict(local)
-  const serverText = getServerPromptTextsForConflict(server)
-  return (
-    promptTextHash(localText.systemPrompt, localText.userPrompt) !==
-    promptTextHash(serverText.systemPrompt, serverText.userPrompt)
-  )
+  const localPayload = getLocalPromptComparablePayload(local)
+  const serverPayload = getServerPromptComparablePayload(server)
+  return promptPayloadHash(localPayload) !== promptPayloadHash(serverPayload)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -121,11 +188,21 @@ function localToServerPayload(
   local: LocalPrompt,
   projectId: number
 ): PromptCreatePayload {
+  const promptFormat = toPromptFormat(local.promptFormat)
   return {
     project_id: projectId,
     name: local.name || local.title,
     system_prompt: local.system_prompt,
     user_prompt: local.user_prompt,
+    prompt_format: promptFormat,
+    prompt_schema_version:
+      promptFormat === 'structured'
+        ? toFiniteNumberOrNull(local.promptSchemaVersion)
+        : null,
+    prompt_definition:
+      promptFormat === 'structured'
+        ? toRecordOrNull(local.structuredPromptDefinition)
+        : null,
     few_shot_examples: local.fewShotExamples,
     modules_config: local.modulesConfig,
     change_description: local.changeDescription || 'Initial sync from workspace'
@@ -136,10 +213,20 @@ function localToServerPayload(
  * Convert a local prompt to server update payload.
  */
 function localToServerUpdatePayload(local: LocalPrompt): PromptUpdatePayload {
+  const promptFormat = toPromptFormat(local.promptFormat)
   return {
     name: local.name || local.title,
     system_prompt: local.system_prompt,
     user_prompt: local.user_prompt,
+    prompt_format: promptFormat,
+    prompt_schema_version:
+      promptFormat === 'structured'
+        ? toFiniteNumberOrNull(local.promptSchemaVersion)
+        : null,
+    prompt_definition:
+      promptFormat === 'structured'
+        ? toRecordOrNull(local.structuredPromptDefinition)
+        : null,
     few_shot_examples: local.fewShotExamples,
     modules_config: local.modulesConfig,
     change_description: local.changeDescription || 'Synced from workspace'
@@ -157,8 +244,12 @@ function serverToLocalFields(server: ServerPrompt): Partial<LocalPrompt> {
     name: server.name,
     system_prompt: server.system_prompt,
     user_prompt: server.user_prompt,
-    fewShotExamples: server.few_shot_examples as FewShotExample[] | undefined,
-    modulesConfig: server.modules_config as PromptModule[] | undefined,
+    promptFormat: toPromptFormat(server.prompt_format),
+    promptSchemaVersion: toFiniteNumberOrNull(server.prompt_schema_version),
+    structuredPromptDefinition: toRecordOrNull(server.prompt_definition),
+    syncPayloadVersion: CURRENT_PROMPT_SYNC_PAYLOAD_VERSION,
+    fewShotExamples: toArrayOrNull<FewShotExample>(server.few_shot_examples),
+    modulesConfig: toArrayOrNull<PromptModule>(server.modules_config),
     versionNumber: server.version_number,
     changeDescription: server.change_description,
     serverParentVersionId: server.parent_version_id,
@@ -181,6 +272,10 @@ function serverToNewLocalPrompt(server: ServerPrompt): LocalPrompt {
     is_system: !!server.system_prompt,
     system_prompt: server.system_prompt,
     user_prompt: server.user_prompt,
+    promptFormat: toPromptFormat(server.prompt_format),
+    promptSchemaVersion: toFiniteNumberOrNull(server.prompt_schema_version),
+    structuredPromptDefinition: toRecordOrNull(server.prompt_definition),
+    syncPayloadVersion: CURRENT_PROMPT_SYNC_PAYLOAD_VERSION,
     createdAt: now,
     updatedAt: now,
     usageCount: 0,
@@ -189,8 +284,8 @@ function serverToNewLocalPrompt(server: ServerPrompt): LocalPrompt {
     serverId: server.id,
     studioProjectId: server.project_id,
     studioPromptId: server.id,
-    fewShotExamples: server.few_shot_examples as FewShotExample[] | undefined,
-    modulesConfig: server.modules_config as PromptModule[] | undefined,
+    fewShotExamples: toArrayOrNull<FewShotExample>(server.few_shot_examples),
+    modulesConfig: toArrayOrNull<PromptModule>(server.modules_config),
     versionNumber: server.version_number,
     changeDescription: server.change_description,
     serverParentVersionId: server.parent_version_id,

--- a/apps/packages/ui/src/services/prompts-api.ts
+++ b/apps/packages/ui/src/services/prompts-api.ts
@@ -75,6 +75,26 @@ export type PromptCollectionUpdatePayload = {
   prompt_ids?: number[]
 }
 
+export type StructuredPromptPreviewRequest = {
+  prompt_format: "legacy" | "structured"
+  system_prompt?: string | null
+  user_prompt?: string | null
+  prompt_schema_version?: number | null
+  prompt_definition?: Record<string, any> | null
+  variables?: Record<string, any>
+}
+
+export type StructuredPromptPreviewResponse = {
+  prompt_format: "legacy" | "structured"
+  prompt_schema_version?: number | null
+  assembled_messages: Array<{
+    role: string
+    content: string
+  }>
+  legacy_system_prompt: string
+  legacy_user_prompt: string
+}
+
 export const buildPromptSearchQuery = ({
   searchQuery,
   searchFields = [],
@@ -187,6 +207,22 @@ export async function updatePromptCollectionServer(
 
   if (!response.ok || !response.data) {
     throw new Error(response.error || "Failed to update prompt collection")
+  }
+
+  return response.data
+}
+
+export async function previewStructuredPromptServer(
+  payload: StructuredPromptPreviewRequest
+): Promise<StructuredPromptPreviewResponse> {
+  const response = await apiSend<StructuredPromptPreviewResponse>({
+    path: toAllowedPath("/api/v1/prompts/preview"),
+    method: "POST",
+    body: payload
+  })
+
+  if (!response.ok || !response.data) {
+    throw new Error(response.error || "Failed to preview structured prompt")
   }
 
   return response.data

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Path, Query, status
 from loguru import logger
+from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import (
     PromptStudioDatabase,
@@ -37,12 +38,24 @@ from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import (
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import ListResponse, StandardResponse
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_project import (
     PromptCreate,
+    StructuredPromptConvertRequest,
+    StructuredPromptConvertResponse,
+    StructuredPromptPreviewRequest,
+    StructuredPromptPreviewResponse,
     PromptResponse,
     PromptUpdate,
     PromptVersion,
 )
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_schemas import ExecutePromptSimpleRequest
 from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import ConflictError, DatabaseError, InputError
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
+    PromptDefinition,
+    assemble_prompt_definition,
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
+    render_legacy_snapshot,
+    validate_prompt_definition,
+)
 from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
 ########################################################################################################################
@@ -61,6 +74,42 @@ router = APIRouter(
 
 ########################################################################################################################
 # Prompt CRUD Endpoints
+
+
+def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str, str]:
+    messages = [
+        {"role": block.role, "content": block.content}
+        for block in sorted(definition.blocks, key=lambda item: item.order)
+        if block.enabled
+    ]
+    legacy = render_legacy_snapshot(messages, definition)
+    return legacy.system_prompt, legacy.user_prompt
+
+
+def _coerce_preview_definition(
+    *,
+    prompt_format: str,
+    prompt_schema_version: int | None,
+    prompt_definition_payload: dict[str, Any] | None,
+    system_prompt: str | None,
+    user_prompt: str | None,
+) -> tuple[PromptDefinition, str, int | None]:
+    if prompt_format == "structured":
+        if prompt_schema_version is None:
+            raise InputError("Structured prompts require prompt_schema_version.")
+        if not isinstance(prompt_definition_payload, dict):
+            raise InputError("Structured prompts require prompt_definition.")
+        definition = PromptDefinition.model_validate(prompt_definition_payload)
+        issues = validate_prompt_definition(definition)
+        if issues:
+            raise InputError(issues[0].message)
+        return definition, "structured", int(prompt_schema_version)
+
+    definition = convert_legacy_prompt_to_definition(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+    )
+    return definition, "legacy", None
 
 # Compatibility: simple POST on base path returns prompt object directly
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -366,6 +415,92 @@ async def execute_prompt_simple(
         "tokens_used": result.get("tokens_used", 0),
         "execution_time": result.get("execution_time_ms", 0) / 1000.0
     }
+
+
+@router.post("/preview", response_model=StandardResponse)
+async def preview_prompt(
+    payload: StructuredPromptPreviewRequest,
+    db: PromptStudioDatabase = Depends(get_prompt_studio_db),
+    user_context: dict = Depends(get_prompt_studio_user),
+) -> StandardResponse:
+    from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import PromptExecutor
+
+    try:
+        await require_project_access(payload.project_id, user_context=user_context, db=db)
+        definition, prompt_format, prompt_schema_version = _coerce_preview_definition(
+            prompt_format=payload.prompt_format,
+            prompt_schema_version=payload.prompt_schema_version,
+            prompt_definition_payload=payload.prompt_definition,
+            system_prompt=payload.system_prompt,
+            user_prompt=payload.user_prompt,
+        )
+
+        extras = {
+            "few_shot_examples": [model_dump_compat(example) for example in (payload.few_shot_examples or [])],
+            "modules_config": [model_dump_compat(module) for module in (payload.modules_config or [])],
+        }
+        assembly = assemble_prompt_definition(definition, payload.variables, extras=extras)
+        messages = assembly.messages
+
+        if payload.signature_id is not None:
+            signature = db.get_signature(payload.signature_id)
+            if not signature:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Signature {payload.signature_id} not found",
+                )
+            if int(signature.get("project_id") or -1) != int(payload.project_id):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Signature does not belong to the requested project",
+                )
+            messages = PromptExecutor(db)._apply_signature_to_messages(messages, signature)
+
+        legacy = render_legacy_snapshot(messages, definition)
+        preview_data = StructuredPromptPreviewResponse(
+            prompt_format=prompt_format,
+            prompt_schema_version=prompt_schema_version,
+            assembled_messages=messages,
+            legacy_system_prompt=legacy.system_prompt,
+            legacy_user_prompt=legacy.user_prompt,
+        )
+        return StandardResponse(success=True, data=preview_data)
+    except HTTPException:
+        raise
+    except InputError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=getattr(e, "safe_message", str(e)),
+        ) from e
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid prompt_definition: {e}",
+        ) from e
+
+
+@router.post("/convert", response_model=StandardResponse)
+async def convert_prompt(
+    payload: StructuredPromptConvertRequest,
+    db: PromptStudioDatabase = Depends(get_prompt_studio_db),
+    user_context: dict = Depends(get_prompt_studio_user),
+) -> StandardResponse:
+    await require_project_access(payload.project_id, user_context=user_context, db=db)
+    definition = convert_legacy_prompt_to_definition(
+        system_prompt=payload.system_prompt,
+        user_prompt=payload.user_prompt,
+    )
+    legacy_system_prompt, legacy_user_prompt = _render_definition_legacy_fields(definition)
+    response = StructuredPromptConvertResponse(
+        prompt_definition=definition.model_dump(),
+        extracted_variables=extract_legacy_prompt_variables(
+            payload.system_prompt,
+            payload.user_prompt,
+        ),
+        legacy_system_prompt=legacy_system_prompt,
+        legacy_user_prompt=legacy_user_prompt,
+    )
+    return StandardResponse(success=True, data=response)
 
 @router.get("/get/{prompt_id}", response_model=StandardResponse, openapi_extra={
     "responses": {"200": {"description": "Prompt", "content": {"application/json": {"examples": {"get": {"summary": "Prompt details", "value": {"success": True, "data": {"id": 12, "name": "Summarizer", "version_number": 2}}}}}}}}

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -162,6 +162,25 @@ def _validate_message_lengths(
         )
 
 
+def _validate_total_message_length(
+    *,
+    messages: list[dict[str, str]],
+) -> None:
+    from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import PromptExecutor
+
+    total_length = sum(len(message.get("content") or "") for message in messages)
+    if total_length <= PromptExecutor.MAX_TOTAL_PROMPT_LENGTH:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+            "Structured prompt exceeds maximum total length of "
+            f"{PromptExecutor.MAX_TOTAL_PROMPT_LENGTH} and would be truncated during execution"
+        ),
+    )
+
+
 def _validation_variables(definition: PromptDefinition) -> dict[str, Any]:
     variables: dict[str, Any] = {}
     for variable in definition.variables:
@@ -225,6 +244,7 @@ def _validate_prompt_content(
         messages=messages,
         security_config=security_config,
     )
+    _validate_total_message_length(messages=messages)
 
 
 def _coerce_preview_definition(
@@ -623,6 +643,7 @@ async def preview_prompt(
             messages=messages,
             security_config=security_config,
         )
+        _validate_total_message_length(messages=messages)
         preview_data = StructuredPromptPreviewResponse(
             prompt_format=prompt_format,
             prompt_schema_version=prompt_schema_version,

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -47,7 +47,12 @@ from tldw_Server_API.app.api.v1.schemas.prompt_studio_project import (
     PromptVersion,
 )
 from tldw_Server_API.app.api.v1.schemas.prompt_studio_schemas import ExecutePromptSimpleRequest
-from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import ConflictError, DatabaseError, InputError
+from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import (
+    ConflictError,
+    DatabaseError,
+    InputError,
+    _prepare_prompt_record_fields,
+)
 from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
     PromptDefinition,
     assemble_prompt_definition,
@@ -86,6 +91,48 @@ def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str,
     return legacy.system_prompt, legacy.user_prompt
 
 
+def _coerce_structured_definition(
+    *,
+    prompt_schema_version: int | None,
+    prompt_definition_payload: dict[str, Any] | None,
+) -> tuple[PromptDefinition, int]:
+    if prompt_schema_version is None:
+        raise InputError("Structured prompts require prompt_schema_version.")
+    if not isinstance(prompt_definition_payload, dict):
+        raise InputError("Structured prompts require prompt_definition.")
+    definition = PromptDefinition.model_validate(prompt_definition_payload)
+    issues = validate_prompt_definition(definition)
+    if issues:
+        raise InputError(issues[0].message)
+
+    definition_schema_version = int(definition.schema_version)
+    if int(prompt_schema_version) != definition_schema_version:
+        raise InputError(
+            "prompt_schema_version must match prompt_definition.schema_version."
+        )
+
+    return definition, definition_schema_version
+
+
+def _validate_prompt_lengths(
+    *,
+    system_prompt: str | None,
+    user_prompt: str | None,
+    security_config: SecurityConfig,
+) -> None:
+    if system_prompt and len(system_prompt) > security_config.max_prompt_length:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"System prompt exceeds maximum length of {security_config.max_prompt_length}"
+        )
+
+    if user_prompt and len(user_prompt) > security_config.max_prompt_length:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"User prompt exceeds maximum length of {security_config.max_prompt_length}"
+        )
+
+
 def _coerce_preview_definition(
     *,
     prompt_format: str,
@@ -95,15 +142,11 @@ def _coerce_preview_definition(
     user_prompt: str | None,
 ) -> tuple[PromptDefinition, str, int | None]:
     if prompt_format == "structured":
-        if prompt_schema_version is None:
-            raise InputError("Structured prompts require prompt_schema_version.")
-        if not isinstance(prompt_definition_payload, dict):
-            raise InputError("Structured prompts require prompt_definition.")
-        definition = PromptDefinition.model_validate(prompt_definition_payload)
-        issues = validate_prompt_definition(definition)
-        if issues:
-            raise InputError(issues[0].message)
-        return definition, "structured", int(prompt_schema_version)
+        definition, definition_schema_version = _coerce_structured_definition(
+            prompt_schema_version=prompt_schema_version,
+            prompt_definition_payload=prompt_definition_payload,
+        )
+        return definition, "structured", definition_schema_version
 
     definition = convert_legacy_prompt_to_definition(
         system_prompt=system_prompt,
@@ -199,18 +242,18 @@ async def create_prompt(
     try:
         if not isinstance(idempotency_key, str):
             idempotency_key = None
-        # Validate prompt length
-        if prompt_data.system_prompt and len(prompt_data.system_prompt) > security_config.max_prompt_length:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"System prompt exceeds maximum length of {security_config.max_prompt_length}"
-            )
-
-        if prompt_data.user_prompt and len(prompt_data.user_prompt) > security_config.max_prompt_length:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"User prompt exceeds maximum length of {security_config.max_prompt_length}"
-            )
+        normalized_prompt_fields = _prepare_prompt_record_fields(
+            prompt_format=prompt_data.prompt_format,
+            prompt_schema_version=prompt_data.prompt_schema_version,
+            prompt_definition=prompt_data.prompt_definition,
+            system_prompt=prompt_data.system_prompt,
+            user_prompt=prompt_data.user_prompt,
+        )
+        _validate_prompt_lengths(
+            system_prompt=normalized_prompt_fields["system_prompt"],
+            user_prompt=normalized_prompt_fields["user_prompt"],
+            security_config=security_config,
+        )
 
         # Ensure write access to the project
         await require_project_write_access(prompt_data.project_id, user_context=user_context, db=db)
@@ -247,11 +290,11 @@ async def create_prompt(
             name=prompt_data.name,
             signature_id=prompt_data.signature_id,
             version_number=1,
-            system_prompt=prompt_data.system_prompt,
-            user_prompt=prompt_data.user_prompt,
-            prompt_format=prompt_data.prompt_format,
-            prompt_schema_version=prompt_data.prompt_schema_version,
-            prompt_definition=prompt_data.prompt_definition,
+            system_prompt=normalized_prompt_fields["system_prompt"],
+            user_prompt=normalized_prompt_fields["user_prompt"],
+            prompt_format=normalized_prompt_fields["prompt_format"],
+            prompt_schema_version=normalized_prompt_fields["prompt_schema_version"],
+            prompt_definition=normalized_prompt_fields["prompt_definition"],
             few_shot_examples=few_shot_payload,
             modules_config=modules_payload,
             parent_version_id=prompt_data.parent_version_id,
@@ -621,19 +664,6 @@ async def update_prompt(
         New prompt version details
     """
     try:
-        # Validate prompt lengths if provided
-        if updates.system_prompt and len(updates.system_prompt) > security_config.max_prompt_length:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"System prompt exceeds maximum length of {security_config.max_prompt_length}"
-            )
-
-        if updates.user_prompt and len(updates.user_prompt) > security_config.max_prompt_length:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"User prompt exceeds maximum length of {security_config.max_prompt_length}"
-            )
-
         current_prompt = db.get_prompt_with_project(prompt_id)
         if not current_prompt:
             raise HTTPException(
@@ -645,6 +675,20 @@ async def update_prompt(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied to this prompt"
             )
+
+        normalized_prompt_fields = _prepare_prompt_record_fields(
+            prompt_format=updates.prompt_format,
+            prompt_schema_version=updates.prompt_schema_version,
+            prompt_definition=updates.prompt_definition,
+            system_prompt=updates.system_prompt,
+            user_prompt=updates.user_prompt,
+            current_prompt=current_prompt,
+        )
+        _validate_prompt_lengths(
+            system_prompt=normalized_prompt_fields["system_prompt"],
+            user_prompt=normalized_prompt_fields["user_prompt"],
+            security_config=security_config,
+        )
 
         # Create new version
         few_shot_payload = None
@@ -659,11 +703,11 @@ async def update_prompt(
             prompt_id,
             change_description=updates.change_description,
             name=updates.name,
-            system_prompt=updates.system_prompt,
-            user_prompt=updates.user_prompt,
-            prompt_format=updates.prompt_format,
-            prompt_schema_version=updates.prompt_schema_version,
-            prompt_definition=updates.prompt_definition,
+            system_prompt=normalized_prompt_fields["system_prompt"],
+            user_prompt=normalized_prompt_fields["user_prompt"],
+            prompt_format=normalized_prompt_fields["prompt_format"],
+            prompt_schema_version=normalized_prompt_fields["prompt_schema_version"],
+            prompt_definition=normalized_prompt_fields["prompt_definition"],
             few_shot_examples=few_shot_payload,
             modules_config=modules_payload,
             client_id=user_context.get("client_id"),

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -152,8 +152,14 @@ def _validate_message_lengths(
         )
 
 
-def _placeholder_variables(definition: PromptDefinition) -> dict[str, str]:
-    return {variable.name: "" for variable in definition.variables}
+def _validation_variables(definition: PromptDefinition) -> dict[str, Any]:
+    variables: dict[str, Any] = {}
+    for variable in definition.variables:
+        # Preserve stored defaults during save-time validation so oversized
+        # default content is measured consistently with preview/execution.
+        if variable.default_value is None:
+            variables[variable.name] = ""
+    return variables
 
 
 def _validate_prompt_content(
@@ -164,7 +170,7 @@ def _validate_prompt_content(
 ) -> None:
     assembly = assemble_prompt_definition(
         definition,
-        _placeholder_variables(definition),
+        _validation_variables(definition),
         extras=extras,
     )
     _validate_prompt_lengths(

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -55,6 +55,7 @@ from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import (
 )
 from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
     PromptDefinition,
+    StructuredPromptAssemblyError,
     assemble_prompt_definition,
     convert_legacy_prompt_to_definition,
     extract_legacy_prompt_variables,
@@ -663,6 +664,11 @@ async def preview_prompt(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid prompt_definition: {e}",
+        ) from e
+    except StructuredPromptAssemblyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
         ) from e
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -133,6 +133,51 @@ def _validate_prompt_lengths(
         )
 
 
+def _validate_message_lengths(
+    *,
+    messages: list[dict[str, str]],
+    security_config: SecurityConfig,
+) -> None:
+    for message in messages:
+        content = message.get("content") or ""
+        if len(content) <= security_config.max_prompt_length:
+            continue
+        role = str(message.get("role") or "prompt")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"{role.title()} prompt exceeds maximum length of "
+                f"{security_config.max_prompt_length}"
+            ),
+        )
+
+
+def _placeholder_variables(definition: PromptDefinition) -> dict[str, str]:
+    return {variable.name: "" for variable in definition.variables}
+
+
+def _validate_prompt_content(
+    *,
+    definition: PromptDefinition,
+    extras: dict[str, Any],
+    security_config: SecurityConfig,
+) -> None:
+    assembly = assemble_prompt_definition(
+        definition,
+        _placeholder_variables(definition),
+        extras=extras,
+    )
+    _validate_prompt_lengths(
+        system_prompt=assembly.legacy.system_prompt,
+        user_prompt=assembly.legacy.user_prompt,
+        security_config=security_config,
+    )
+    _validate_message_lengths(
+        messages=assembly.messages,
+        security_config=security_config,
+    )
+
+
 def _coerce_preview_definition(
     *,
     prompt_format: str,
@@ -265,6 +310,25 @@ async def create_prompt(
         modules_payload = None
         if prompt_data.modules_config:
             modules_payload = [model_dump_compat(mod) for mod in prompt_data.modules_config]
+
+        extras = {
+            "few_shot_examples": few_shot_payload or [],
+            "modules_config": modules_payload or [],
+        }
+        if normalized_prompt_fields["prompt_format"] == "structured":
+            definition = PromptDefinition.model_validate(
+                normalized_prompt_fields["prompt_definition"]
+            )
+        else:
+            definition = convert_legacy_prompt_to_definition(
+                system_prompt=normalized_prompt_fields["system_prompt"],
+                user_prompt=normalized_prompt_fields["user_prompt"],
+            )
+        _validate_prompt_content(
+            definition=definition,
+            extras=extras,
+            security_config=security_config,
+        )
 
         # Idempotency: if provided, return existing prompt for this key
         user_id_str = str(user_context.get("user_id", "anonymous"))
@@ -464,6 +528,7 @@ async def execute_prompt_simple(
 async def preview_prompt(
     payload: StructuredPromptPreviewRequest,
     db: PromptStudioDatabase = Depends(get_prompt_studio_db),
+    security_config: SecurityConfig = Depends(get_security_config),
     user_context: dict = Depends(get_prompt_studio_user),
 ) -> StandardResponse:
     from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import PromptExecutor
@@ -500,6 +565,15 @@ async def preview_prompt(
             messages = PromptExecutor(db)._apply_signature_to_messages(messages, signature)
 
         legacy = render_legacy_snapshot(messages, definition)
+        _validate_prompt_lengths(
+            system_prompt=legacy.system_prompt,
+            user_prompt=legacy.user_prompt,
+            security_config=security_config,
+        )
+        _validate_message_lengths(
+            messages=messages,
+            security_config=security_config,
+        )
         preview_data = StructuredPromptPreviewResponse(
             prompt_format=prompt_format,
             prompt_schema_version=prompt_schema_version,
@@ -699,6 +773,25 @@ async def update_prompt(
         if updates.modules_config is not None:
             modules_payload = [model_dump_compat(mod) for mod in updates.modules_config]
 
+        extras = {
+            "few_shot_examples": few_shot_payload or [],
+            "modules_config": modules_payload or [],
+        }
+        if normalized_prompt_fields["prompt_format"] == "structured":
+            definition = PromptDefinition.model_validate(
+                normalized_prompt_fields["prompt_definition"]
+            )
+        else:
+            definition = convert_legacy_prompt_to_definition(
+                system_prompt=normalized_prompt_fields["system_prompt"],
+                user_prompt=normalized_prompt_fields["user_prompt"],
+            )
+        _validate_prompt_content(
+            definition=definition,
+            extras=extras,
+            security_config=security_config,
+        )
+
         new_prompt = db.create_prompt_version(
             prompt_id,
             change_description=updates.change_description,
@@ -736,12 +829,6 @@ async def update_prompt(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=getattr(e, "safe_message", str(e)),
-        ) from e
-    except InputError as e:
-        logger.warning(f"Prompt studio input error updating prompt: {getattr(e, 'original_message', str(e))}")
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=getattr(e, "safe_message", "Invalid input.")
         ) from e
 
 @router.get("/history/{prompt_id}", response_model=StandardResponse, openapi_extra={

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -91,6 +91,12 @@ def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str,
     return legacy.system_prompt, legacy.user_prompt
 
 
+def _coerce_security_config(security_config: SecurityConfig | Any) -> SecurityConfig:
+    if isinstance(security_config, SecurityConfig):
+        return security_config
+    return get_security_config()
+
+
 def _coerce_structured_definition(
     *,
     prompt_schema_version: int | None,
@@ -120,16 +126,18 @@ def _validate_prompt_lengths(
     user_prompt: str | None,
     security_config: SecurityConfig,
 ) -> None:
-    if system_prompt and len(system_prompt) > security_config.max_prompt_length:
+    config = _coerce_security_config(security_config)
+
+    if system_prompt and len(system_prompt) > config.max_prompt_length:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"System prompt exceeds maximum length of {security_config.max_prompt_length}"
+            detail=f"System prompt exceeds maximum length of {config.max_prompt_length}"
         )
 
-    if user_prompt and len(user_prompt) > security_config.max_prompt_length:
+    if user_prompt and len(user_prompt) > config.max_prompt_length:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"User prompt exceeds maximum length of {security_config.max_prompt_length}"
+            detail=f"User prompt exceeds maximum length of {config.max_prompt_length}"
         )
 
 
@@ -138,16 +146,18 @@ def _validate_message_lengths(
     messages: list[dict[str, str]],
     security_config: SecurityConfig,
 ) -> None:
+    config = _coerce_security_config(security_config)
+
     for message in messages:
         content = message.get("content") or ""
-        if len(content) <= security_config.max_prompt_length:
+        if len(content) <= config.max_prompt_length:
             continue
         role = str(message.get("role") or "prompt")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
                 f"{role.title()} prompt exceeds maximum length of "
-                f"{security_config.max_prompt_length}"
+                f"{config.max_prompt_length}"
             ),
         )
 
@@ -162,24 +172,57 @@ def _validation_variables(definition: PromptDefinition) -> dict[str, Any]:
     return variables
 
 
+def _get_signature_for_project(
+    *,
+    db: PromptStudioDatabase,
+    project_id: int,
+    signature_id: int | None,
+) -> dict[str, Any] | None:
+    if signature_id is None:
+        return None
+
+    signature = db.get_signature(signature_id)
+    if not signature:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Signature {signature_id} not found",
+        )
+
+    if int(signature.get("project_id") or -1) != int(project_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Signature does not belong to the requested project",
+        )
+
+    return signature
+
+
 def _validate_prompt_content(
     *,
     definition: PromptDefinition,
     extras: dict[str, Any],
     security_config: SecurityConfig,
+    signature: dict[str, Any] | None = None,
 ) -> None:
+    from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import PromptExecutor
+
     assembly = assemble_prompt_definition(
         definition,
         _validation_variables(definition),
         extras=extras,
     )
+    messages = assembly.messages
+    legacy = assembly.legacy
+    if signature is not None:
+        messages = PromptExecutor._apply_signature_to_messages(messages, signature)
+        legacy = render_legacy_snapshot(messages, definition)
     _validate_prompt_lengths(
-        system_prompt=assembly.legacy.system_prompt,
-        user_prompt=assembly.legacy.user_prompt,
+        system_prompt=legacy.system_prompt,
+        user_prompt=legacy.user_prompt,
         security_config=security_config,
     )
     _validate_message_lengths(
-        messages=assembly.messages,
+        messages=messages,
         security_config=security_config,
     )
 
@@ -308,6 +351,11 @@ async def create_prompt(
 
         # Ensure write access to the project
         await require_project_write_access(prompt_data.project_id, user_context=user_context, db=db)
+        signature = _get_signature_for_project(
+            db=db,
+            project_id=prompt_data.project_id,
+            signature_id=prompt_data.signature_id,
+        )
 
         few_shot_payload = None
         if prompt_data.few_shot_examples:
@@ -334,6 +382,7 @@ async def create_prompt(
             definition=definition,
             extras=extras,
             security_config=security_config,
+            signature=signature,
         )
 
         # Idempotency: if provided, return existing prompt for this key
@@ -556,18 +605,12 @@ async def preview_prompt(
         assembly = assemble_prompt_definition(definition, payload.variables, extras=extras)
         messages = assembly.messages
 
-        if payload.signature_id is not None:
-            signature = db.get_signature(payload.signature_id)
-            if not signature:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"Signature {payload.signature_id} not found",
-                )
-            if int(signature.get("project_id") or -1) != int(payload.project_id):
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Signature does not belong to the requested project",
-                )
+        signature = _get_signature_for_project(
+            db=db,
+            project_id=payload.project_id,
+            signature_id=payload.signature_id,
+        )
+        if signature is not None:
             messages = PromptExecutor(db)._apply_signature_to_messages(messages, signature)
 
         legacy = render_legacy_snapshot(messages, definition)
@@ -755,6 +798,11 @@ async def update_prompt(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Access denied to this prompt"
             )
+        signature = _get_signature_for_project(
+            db=db,
+            project_id=int(current_prompt["project_id"]),
+            signature_id=current_prompt.get("signature_id"),
+        )
 
         normalized_prompt_fields = _prepare_prompt_record_fields(
             prompt_format=updates.prompt_format,
@@ -796,6 +844,7 @@ async def update_prompt(
             definition=definition,
             extras=extras,
             security_config=security_config,
+            signature=signature,
         )
 
         new_prompt = db.create_prompt_version(

--- a/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py
@@ -200,6 +200,9 @@ async def create_prompt(
             version_number=1,
             system_prompt=prompt_data.system_prompt,
             user_prompt=prompt_data.user_prompt,
+            prompt_format=prompt_data.prompt_format,
+            prompt_schema_version=prompt_data.prompt_schema_version,
+            prompt_definition=prompt_data.prompt_definition,
             few_shot_examples=few_shot_payload,
             modules_config=modules_payload,
             parent_version_id=prompt_data.parent_version_id,
@@ -234,6 +237,12 @@ async def create_prompt(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to create prompt"
+        ) from e
+    except InputError as e:
+        logger.warning(f"Prompt studio input error creating prompt: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=getattr(e, "safe_message", str(e)),
         ) from e
 
 @router.get(
@@ -517,6 +526,9 @@ async def update_prompt(
             name=updates.name,
             system_prompt=updates.system_prompt,
             user_prompt=updates.user_prompt,
+            prompt_format=updates.prompt_format,
+            prompt_schema_version=updates.prompt_schema_version,
+            prompt_definition=updates.prompt_definition,
             few_shot_examples=few_shot_payload,
             modules_config=modules_payload,
             client_id=user_context.get("client_id"),
@@ -539,6 +551,12 @@ async def update_prompt(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update prompt"
+        ) from e
+    except InputError as e:
+        logger.warning(f"Prompt studio input error updating prompt: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=getattr(e, "safe_message", str(e)),
         ) from e
     except InputError as e:
         logger.warning(f"Prompt studio input error updating prompt: {getattr(e, 'original_message', str(e))}")

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -27,6 +27,9 @@ from tldw_Server_API.app.core.DB_Management.Prompts_DB import (
 )
 from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
     PromptDefinition,
+    assemble_prompt_definition,
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
     render_legacy_snapshot,
     validate_prompt_definition,
 )
@@ -99,6 +102,35 @@ def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str,
     ]
     legacy = render_legacy_snapshot(messages, definition)
     return legacy.system_prompt, legacy.user_prompt
+
+
+def _coerce_preview_definition(
+    prompt_format: str,
+    prompt_schema_version: int | None,
+    prompt_definition_payload: dict[str, Any] | None,
+    *,
+    system_prompt: str | None,
+    user_prompt: str | None,
+) -> tuple[PromptDefinition, str, int | None]:
+    if prompt_format == "structured":
+        if prompt_schema_version is None:
+            raise InputError("Structured prompts require prompt_schema_version.")
+        if not isinstance(prompt_definition_payload, dict):
+            raise InputError("Structured prompts require prompt_definition.")
+        try:
+            definition = PromptDefinition.model_validate(prompt_definition_payload)
+        except ValidationError as exc:
+            raise InputError(f"Invalid prompt_definition: {exc}") from exc
+        issues = validate_prompt_definition(definition)
+        if issues:
+            raise InputError(issues[0].message)
+        return definition, "structured", int(prompt_schema_version)
+
+    definition = convert_legacy_prompt_to_definition(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+    )
+    return definition, "legacy", None
 
 
 def _prepare_prompt_storage_payload(
@@ -787,6 +819,69 @@ async def render_template_api(
             detail=f"Missing template variable: {missing_key}"
         ) from e
     return schemas.TemplateRenderResponse(rendered=rendered)
+
+
+@router.post(
+    "/preview",
+    response_model=schemas.StructuredPromptPreviewResponse,
+    summary="Preview assembled prompt messages",
+    dependencies=[Depends(verify_prompts_user)],
+)
+async def preview_prompt_api(
+    payload: schemas.StructuredPromptPreviewRequest = Body(...),
+):
+    try:
+        definition, prompt_format, prompt_schema_version = _coerce_preview_definition(
+            payload.prompt_format,
+            payload.prompt_schema_version,
+            payload.prompt_definition,
+            system_prompt=payload.system_prompt,
+            user_prompt=payload.user_prompt,
+        )
+        assembly = assemble_prompt_definition(definition, payload.variables)
+    except InputError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except ValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid prompt_definition: {e}",
+        ) from e
+
+    return schemas.StructuredPromptPreviewResponse(
+        prompt_format=prompt_format,
+        prompt_schema_version=prompt_schema_version,
+        assembled_messages=assembly.messages,
+        legacy_system_prompt=assembly.legacy.system_prompt,
+        legacy_user_prompt=assembly.legacy.user_prompt,
+    )
+
+
+@router.post(
+    "/convert",
+    response_model=schemas.StructuredPromptConvertResponse,
+    summary="Convert a legacy prompt to a structured definition",
+    dependencies=[Depends(verify_prompts_user)],
+)
+async def convert_prompt_api(
+    payload: schemas.StructuredPromptConvertRequest = Body(...),
+):
+    definition = convert_legacy_prompt_to_definition(
+        system_prompt=payload.system_prompt,
+        user_prompt=payload.user_prompt,
+    )
+    legacy_system_prompt, legacy_user_prompt = _render_definition_legacy_fields(definition)
+    return schemas.StructuredPromptConvertResponse(
+        prompt_definition=definition.model_dump(),
+        extracted_variables=extract_legacy_prompt_variables(
+            payload.system_prompt,
+            payload.user_prompt,
+        ),
+        legacy_system_prompt=legacy_system_prompt,
+        legacy_user_prompt=legacy_user_prompt,
+    )
 
 
 # === Bulk Operations Endpoints ===

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -12,6 +12,7 @@ from typing import Any, Optional, Union
 # 3rd-party imports
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request, Response, status
 from loguru import logger
+from pydantic import ValidationError
 
 from tldw_Server_API.app.api.v1.API_Deps.Prompts_DB_Deps import get_prompts_db_for_user
 from tldw_Server_API.app.api.v1.schemas import prompt_schemas as schemas
@@ -23,6 +24,11 @@ from tldw_Server_API.app.core.DB_Management.Prompts_DB import (
     DatabaseError,
     InputError,
     PromptsDatabase,
+)
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
+    PromptDefinition,
+    render_legacy_snapshot,
+    validate_prompt_definition,
 )
 
 #
@@ -83,6 +89,68 @@ def _render_template(template: str, variables: dict[str, Any]) -> str:
         return str(variables[key])
 
     return _TEMPLATE_VAR_RE.sub(repl, template)
+
+
+def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str, str]:
+    messages = [
+        {"role": block.role, "content": block.content}
+        for block in sorted(definition.blocks, key=lambda item: item.order)
+        if block.enabled
+    ]
+    legacy = render_legacy_snapshot(messages, definition)
+    return legacy.system_prompt, legacy.user_prompt
+
+
+def _prepare_prompt_storage_payload(
+    prompt_data: schemas.PromptCreate | dict[str, Any],
+    *,
+    existing_prompt: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if isinstance(prompt_data, schemas.PromptCreate):
+        payload = prompt_data.model_dump()
+    else:
+        payload = dict(prompt_data)
+
+    prompt_format = payload.get("prompt_format") or (
+        existing_prompt.get("prompt_format") if existing_prompt else "legacy"
+    ) or "legacy"
+    prompt_schema_version = payload.get("prompt_schema_version")
+    if prompt_schema_version is None and existing_prompt and prompt_format == "structured":
+        prompt_schema_version = existing_prompt.get("prompt_schema_version")
+    prompt_definition_payload = payload.get("prompt_definition")
+    if prompt_definition_payload is None and existing_prompt and prompt_format == "structured":
+        prompt_definition_payload = existing_prompt.get("prompt_definition")
+
+    if prompt_format == "structured":
+        if prompt_schema_version is None:
+            raise InputError("Structured prompts require prompt_schema_version.")
+        if not isinstance(prompt_definition_payload, dict):
+            raise InputError("Structured prompts require prompt_definition.")
+        try:
+            definition = PromptDefinition.model_validate(prompt_definition_payload)
+        except ValidationError as exc:
+            raise InputError(f"Invalid prompt_definition: {exc}") from exc
+        issues = validate_prompt_definition(definition)
+        if issues:
+            raise InputError(issues[0].message)
+
+        system_prompt, user_prompt = _render_definition_legacy_fields(definition)
+        payload["prompt_definition"] = definition.model_dump()
+        payload["prompt_schema_version"] = int(prompt_schema_version)
+        payload["prompt_format"] = "structured"
+        payload["system_prompt"] = system_prompt
+        payload["user_prompt"] = user_prompt
+        return payload
+
+    if prompt_definition_payload is not None:
+        raise InputError("Legacy prompts cannot include prompt_definition.")
+    if prompt_schema_version is not None:
+        raise InputError("Legacy prompts cannot include prompt_schema_version.")
+
+    payload["prompt_format"] = "legacy"
+    payload["prompt_schema_version"] = None
+    payload["prompt_definition"] = None
+    return payload
 
 
 def _generate_unique_prompt_name(base_name: str, used_names: set, name_counts: dict[str, int]) -> str:
@@ -875,15 +943,19 @@ async def create_prompt(
     db: PromptsDatabase = Depends(get_prompts_db_for_user)
 ):
     try:
+        storage_payload = _prepare_prompt_storage_payload(prompt_data)
         # The db.add_prompt method with overwrite=False should raise ConflictError
         # if the name already exists and is active (as per our DB layer modification).
         p_id, p_uuid, db_message = db.add_prompt(  # db_message is returned by add_prompt on success
-            name=prompt_data.name,
-            author=prompt_data.author,
-            details=prompt_data.details,
-            system_prompt=prompt_data.system_prompt,
-            user_prompt=prompt_data.user_prompt,
-            keywords=prompt_data.keywords,
+            name=storage_payload["name"],
+            author=storage_payload.get("author"),
+            details=storage_payload.get("details"),
+            system_prompt=storage_payload.get("system_prompt"),
+            user_prompt=storage_payload.get("user_prompt"),
+            prompt_format=storage_payload.get("prompt_format", "legacy"),
+            prompt_schema_version=storage_payload.get("prompt_schema_version"),
+            prompt_definition=storage_payload.get("prompt_definition"),
+            keywords=storage_payload.get("keywords"),
             overwrite=False  # For a POST/create, we don't want to overwrite.
         )
         # If add_prompt successfully created or undeleted (if that's its logic for overwrite=False and deleted=True)
@@ -1130,8 +1202,11 @@ async def update_prompt(
 
         # 2. Call the new update method
         # Convert Pydantic model to dict, excluding unset to allow partial-like updates if some fields are optional
-        update_payload_dict = prompt_data.model_dump(
-            exclude_unset=False)  # exclude_unset=False means all fields are included
+        update_input = prompt_data.model_dump(exclude_unset=True)
+        update_payload_dict = _prepare_prompt_storage_payload(
+            update_input,
+            existing_prompt=target_prompt_dict,
+        )
 
         updated_prompt_uuid, msg = db.update_prompt_by_id(prompt_id_to_update, update_payload_dict)
 

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -104,6 +104,31 @@ def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str,
     return legacy.system_prompt, legacy.user_prompt
 
 
+def _coerce_structured_definition(
+    prompt_schema_version: int | None,
+    prompt_definition_payload: dict[str, Any] | None,
+) -> tuple[PromptDefinition, int]:
+    if prompt_schema_version is None:
+        raise InputError("Structured prompts require prompt_schema_version.")
+    if not isinstance(prompt_definition_payload, dict):
+        raise InputError("Structured prompts require prompt_definition.")
+    try:
+        definition = PromptDefinition.model_validate(prompt_definition_payload)
+    except ValidationError as exc:
+        raise InputError(f"Invalid prompt_definition: {exc}") from exc
+    issues = validate_prompt_definition(definition)
+    if issues:
+        raise InputError(issues[0].message)
+
+    definition_schema_version = int(definition.schema_version)
+    if int(prompt_schema_version) != definition_schema_version:
+        raise InputError(
+            "prompt_schema_version must match prompt_definition.schema_version."
+        )
+
+    return definition, definition_schema_version
+
+
 def _coerce_preview_definition(
     prompt_format: str,
     prompt_schema_version: int | None,
@@ -113,18 +138,11 @@ def _coerce_preview_definition(
     user_prompt: str | None,
 ) -> tuple[PromptDefinition, str, int | None]:
     if prompt_format == "structured":
-        if prompt_schema_version is None:
-            raise InputError("Structured prompts require prompt_schema_version.")
-        if not isinstance(prompt_definition_payload, dict):
-            raise InputError("Structured prompts require prompt_definition.")
-        try:
-            definition = PromptDefinition.model_validate(prompt_definition_payload)
-        except ValidationError as exc:
-            raise InputError(f"Invalid prompt_definition: {exc}") from exc
-        issues = validate_prompt_definition(definition)
-        if issues:
-            raise InputError(issues[0].message)
-        return definition, "structured", int(prompt_schema_version)
+        definition, definition_schema_version = _coerce_structured_definition(
+            prompt_schema_version,
+            prompt_definition_payload,
+        )
+        return definition, "structured", definition_schema_version
 
     definition = convert_legacy_prompt_to_definition(
         system_prompt=system_prompt,
@@ -154,21 +172,14 @@ def _prepare_prompt_storage_payload(
         prompt_definition_payload = existing_prompt.get("prompt_definition")
 
     if prompt_format == "structured":
-        if prompt_schema_version is None:
-            raise InputError("Structured prompts require prompt_schema_version.")
-        if not isinstance(prompt_definition_payload, dict):
-            raise InputError("Structured prompts require prompt_definition.")
-        try:
-            definition = PromptDefinition.model_validate(prompt_definition_payload)
-        except ValidationError as exc:
-            raise InputError(f"Invalid prompt_definition: {exc}") from exc
-        issues = validate_prompt_definition(definition)
-        if issues:
-            raise InputError(issues[0].message)
+        definition, definition_schema_version = _coerce_structured_definition(
+            prompt_schema_version,
+            prompt_definition_payload,
+        )
 
         system_prompt, user_prompt = _render_definition_legacy_fields(definition)
         payload["prompt_definition"] = definition.model_dump()
-        payload["prompt_schema_version"] = int(prompt_schema_version)
+        payload["prompt_schema_version"] = definition_schema_version
         payload["prompt_format"] = "structured"
         payload["system_prompt"] = system_prompt
         payload["user_prompt"] = user_prompt

--- a/tldw_Server_API/app/api/v1/endpoints/prompts.py
+++ b/tldw_Server_API/app/api/v1/endpoints/prompts.py
@@ -27,6 +27,7 @@ from tldw_Server_API.app.core.DB_Management.Prompts_DB import (
 )
 from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
     PromptDefinition,
+    StructuredPromptAssemblyError,
     assemble_prompt_definition,
     convert_legacy_prompt_to_definition,
     extract_legacy_prompt_variables,
@@ -859,6 +860,11 @@ async def preview_prompt_api(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Invalid prompt_definition: {e}",
+        ) from e
+    except StructuredPromptAssemblyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
         ) from e
 
     return schemas.StructuredPromptPreviewResponse(

--- a/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
@@ -2,7 +2,7 @@
 #
 # Imports
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -41,6 +41,19 @@ class PromptBase(BaseModel):
     details: Optional[str] = Field(None, max_length=4000, description="Detailed description or notes about the prompt.")
     system_prompt: Optional[str] = Field(None, max_length=20000, description="The system part of the prompt.")
     user_prompt: Optional[str] = Field(None, max_length=20000, description="The user part of the prompt.")
+    prompt_format: Literal["legacy", "structured"] = Field(
+        "legacy",
+        description="Whether the prompt is stored as legacy text fields or a structured definition.",
+    )
+    prompt_schema_version: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Structured prompt schema version when prompt_format is 'structured'.",
+    )
+    prompt_definition: Optional[dict[str, Any]] = Field(
+        None,
+        description="Structured prompt definition when prompt_format is 'structured'.",
+    )
 
 
 class PromptCreate(PromptBase):

--- a/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_schemas.py
@@ -188,6 +188,38 @@ class TemplateRenderResponse(BaseModel):
     rendered: str
 
 
+# --- Structured Prompt Preview / Conversion ---
+class StructuredPromptPreviewRequest(BaseModel):
+    prompt_format: Literal["legacy", "structured"] = "legacy"
+    system_prompt: Optional[str] = Field(None, max_length=20000)
+    user_prompt: Optional[str] = Field(None, max_length=20000)
+    prompt_schema_version: Optional[int] = Field(None, ge=1)
+    prompt_definition: Optional[dict[str, Any]] = None
+    variables: dict[str, Any] = Field(default_factory=dict)
+
+
+class StructuredPromptPreviewResponse(BaseModel):
+    prompt_format: Literal["legacy", "structured"]
+    prompt_schema_version: Optional[int] = None
+    assembled_messages: list[dict[str, str]] = Field(default_factory=list)
+    legacy_system_prompt: str = ""
+    legacy_user_prompt: str = ""
+
+
+class StructuredPromptConvertRequest(BaseModel):
+    system_prompt: Optional[str] = Field(None, max_length=20000)
+    user_prompt: Optional[str] = Field(None, max_length=20000)
+
+
+class StructuredPromptConvertResponse(BaseModel):
+    prompt_format: Literal["structured"] = "structured"
+    prompt_schema_version: int = 1
+    prompt_definition: dict[str, Any]
+    extracted_variables: list[str] = Field(default_factory=list)
+    legacy_system_prompt: str = ""
+    legacy_user_prompt: str = ""
+
+
 # --- Bulk Operations ---
 class PromptBulkDeleteRequest(BaseModel):
     prompt_ids: list[int] = Field(..., min_length=1)

--- a/tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py
@@ -184,6 +184,46 @@ class PromptCompareResponse(BaseModel):
     differences: dict[str, Any]
     metrics_comparison: Optional[dict[str, Any]] = None
 
+
+class StructuredPromptPreviewRequest(BaseModel):
+    """Request to preview assembled prompt messages."""
+    project_id: int
+    signature_id: Optional[int] = None
+    prompt_format: Literal["legacy", "structured"] = "legacy"
+    system_prompt: Optional[str] = Field(None, max_length=50000)
+    user_prompt: Optional[str] = Field(None, max_length=50000)
+    prompt_schema_version: Optional[int] = Field(None, ge=1)
+    prompt_definition: Optional[dict[str, Any]] = None
+    few_shot_examples: Optional[list[FewShotExample]] = None
+    modules_config: Optional[list[PromptModule]] = None
+    variables: dict[str, Any] = Field(default_factory=dict)
+
+
+class StructuredPromptPreviewResponse(BaseModel):
+    """Preview response with assembled messages and legacy compatibility text."""
+    prompt_format: Literal["legacy", "structured"]
+    prompt_schema_version: Optional[int] = None
+    assembled_messages: list[dict[str, str]] = Field(default_factory=list)
+    legacy_system_prompt: str = ""
+    legacy_user_prompt: str = ""
+
+
+class StructuredPromptConvertRequest(BaseModel):
+    """Convert raw prompt fields into a structured prompt definition."""
+    project_id: int
+    system_prompt: Optional[str] = Field(None, max_length=50000)
+    user_prompt: Optional[str] = Field(None, max_length=50000)
+
+
+class StructuredPromptConvertResponse(BaseModel):
+    """Structured prompt conversion result."""
+    prompt_format: Literal["structured"] = "structured"
+    prompt_schema_version: int = 1
+    prompt_definition: dict[str, Any]
+    extracted_variables: list[str] = Field(default_factory=list)
+    legacy_system_prompt: str = ""
+    legacy_user_prompt: str = ""
+
 ########################################################################################################################
 # Generation Requests
 

--- a/tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py
+++ b/tldw_Server_API/app/api/v1/schemas/prompt_studio_project.py
@@ -2,7 +2,7 @@
 # Project and prompt schemas for Prompt Studio
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -114,6 +114,19 @@ class PromptBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=255, description="Prompt name")
     system_prompt: Optional[str] = Field(None, max_length=50000, description="System prompt")
     user_prompt: Optional[str] = Field(None, max_length=50000, description="User prompt template")
+    prompt_format: Literal["legacy", "structured"] = Field(
+        "legacy",
+        description="Whether the prompt stores raw legacy fields or a structured definition.",
+    )
+    prompt_schema_version: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Structured prompt schema version when prompt_format is 'structured'.",
+    )
+    prompt_definition: Optional[dict[str, Any]] = Field(
+        None,
+        description="Structured prompt definition when prompt_format is 'structured'.",
+    )
     few_shot_examples: Optional[list[FewShotExample]] = Field(None, description="Few-shot examples")
     modules_config: Optional[list[PromptModule]] = Field(None, description="Module configurations")
     change_description: Optional[str] = Field(None, max_length=500, description="Description of changes")
@@ -129,6 +142,9 @@ class PromptUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     system_prompt: Optional[str] = Field(None, max_length=50000)
     user_prompt: Optional[str] = Field(None, max_length=50000)
+    prompt_format: Optional[Literal["legacy", "structured"]] = None
+    prompt_schema_version: Optional[int] = Field(None, ge=1)
+    prompt_definition: Optional[dict[str, Any]] = None
     few_shot_examples: Optional[list[FewShotExample]] = None
     modules_config: Optional[list[PromptModule]] = None
     change_description: str = Field(..., min_length=1, max_length=500, description="Required change description")

--- a/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
+++ b/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
@@ -487,7 +487,7 @@ class BackendPromptStudioDatabaseBase:
         try:
             yield conn
             ctx.__exit__(None, None, None)
-        except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             ctx.__exit__(exc.__class__, exc, exc.__traceback__)
             raise
 
@@ -6643,7 +6643,7 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         try:
             yield conn
             conn.commit()
-        except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+        except Exception:
             conn.rollback()
             raise
 

--- a/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
+++ b/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
@@ -14,6 +14,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional, Union
 
+from pydantic import ValidationError
+
 try:  # psycopg v3 preferred; fall back to psycopg2 if installed
     from psycopg import sql as psycopg_sql  # type: ignore
 except ImportError:  # pragma: no cover
@@ -42,6 +44,11 @@ from .backends.query_utils import (
 
 # Local imports
 from .Prompts_DB import ConflictError, DatabaseError, InputError, PromptsDatabase, SchemaError
+from ..Prompt_Management.structured_prompts import (
+    PromptDefinition,
+    render_legacy_snapshot,
+    validate_prompt_definition,
+)
 
 _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS = (
     AssertionError,
@@ -135,6 +142,82 @@ def _format_test_case_record(record: Optional[dict[str, Any]]) -> Optional[dict[
                 normalised[json_field] = json.loads(value)
 
     return normalised
+
+
+def _render_definition_legacy_fields(definition: PromptDefinition) -> tuple[str, str]:
+    messages = [
+        {"role": block.role, "content": block.content}
+        for block in sorted(definition.blocks, key=lambda item: item.order)
+        if block.enabled
+    ]
+    legacy = render_legacy_snapshot(messages, definition)
+    return legacy.system_prompt, legacy.user_prompt
+
+
+def _prepare_prompt_record_fields(
+    *,
+    prompt_format: Optional[str],
+    prompt_schema_version: Optional[int],
+    prompt_definition: Optional[Any],
+    system_prompt: Optional[str],
+    user_prompt: Optional[str],
+    current_prompt: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    effective_format = prompt_format or (
+        current_prompt.get("prompt_format") if current_prompt else "legacy"
+    ) or "legacy"
+
+    if effective_format == "structured":
+        effective_schema_version = prompt_schema_version
+        if effective_schema_version is None and current_prompt:
+            effective_schema_version = current_prompt.get("prompt_schema_version")
+        effective_definition = prompt_definition
+        if effective_definition is None and current_prompt:
+            effective_definition = current_prompt.get("prompt_definition")
+
+        if effective_schema_version is None:
+            raise InputError("Structured prompts require prompt_schema_version.")  # noqa: TRY003
+        if not isinstance(effective_definition, dict):
+            raise InputError("Structured prompts require prompt_definition.")  # noqa: TRY003
+
+        try:
+            definition = PromptDefinition.model_validate(effective_definition)
+        except ValidationError as exc:
+            raise InputError(f"Invalid prompt_definition: {exc}") from exc  # noqa: TRY003
+
+        issues = validate_prompt_definition(definition)
+        if issues:
+            raise InputError(issues[0].message)  # noqa: TRY003
+
+        derived_system_prompt, derived_user_prompt = _render_definition_legacy_fields(definition)
+        return {
+            "prompt_format": "structured",
+            "prompt_schema_version": int(effective_schema_version),
+            "prompt_definition": definition.model_dump(),
+            "system_prompt": derived_system_prompt,
+            "user_prompt": derived_user_prompt,
+        }
+
+    if prompt_definition is not None:
+        raise InputError("Legacy prompts cannot include prompt_definition.")  # noqa: TRY003
+    if prompt_schema_version is not None:
+        raise InputError("Legacy prompts cannot include prompt_schema_version.")  # noqa: TRY003
+
+    return {
+        "prompt_format": "legacy",
+        "prompt_schema_version": None,
+        "prompt_definition": None,
+        "system_prompt": (
+            system_prompt
+            if system_prompt is not None
+            else current_prompt.get("system_prompt") if current_prompt else None
+        ),
+        "user_prompt": (
+            user_prompt
+            if user_prompt is not None
+            else current_prompt.get("user_prompt") if current_prompt else None
+        ),
+    }
 
 
 ########################################################################################################################
@@ -553,6 +636,7 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
         # 003 triggers file intentionally omitted (no-op placeholder)
         # 004 FTS handled via backend abstraction
         "005_add_chunking_templates.sql",
+        "006_prompt_studio_structured_prompts.sql",
     ]
 
     _FTS_CONFIG = (
@@ -569,6 +653,7 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
         "validation_rules",
         "few_shot_examples",
         "modules_config",
+        "prompt_definition",
         "model_params",
         "inputs",
         "outputs",
@@ -706,6 +791,36 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
                 except BackendDatabaseError:
                     self.backend.execute(
                         "ALTER TABLE prompt_studio_optimizations ADD COLUMN test_case_ids JSONB",
+                        connection=conn,
+                    )
+                try:
+                    self.backend.execute(
+                        "SELECT prompt_format FROM prompt_studio_prompts LIMIT 1",
+                        connection=conn,
+                    )
+                except BackendDatabaseError:
+                    self.backend.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_format TEXT NOT NULL DEFAULT 'legacy'",
+                        connection=conn,
+                    )
+                try:
+                    self.backend.execute(
+                        "SELECT prompt_schema_version FROM prompt_studio_prompts LIMIT 1",
+                        connection=conn,
+                    )
+                except BackendDatabaseError:
+                    self.backend.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_schema_version INTEGER",
+                        connection=conn,
+                    )
+                try:
+                    self.backend.execute(
+                        "SELECT prompt_definition FROM prompt_studio_prompts LIMIT 1",
+                        connection=conn,
+                    )
+                except BackendDatabaseError:
+                    self.backend.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_definition JSONB",
                         connection=conn,
                     )
         self._ensure_postgres_fts()
@@ -1169,12 +1284,22 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
         version_number: int = 1,
         system_prompt: Optional[str] = None,
         user_prompt: Optional[str] = None,
+        prompt_format: str = "legacy",
+        prompt_schema_version: Optional[int] = None,
+        prompt_definition: Optional[Any] = None,
         few_shot_examples: Optional[Any] = None,
         modules_config: Optional[Any] = None,
         parent_version_id: Optional[int] = None,
         change_description: Optional[str] = None,
         client_id: Optional[str] = None,
     ) -> dict[str, Any]:
+        normalized_prompt_fields = _prepare_prompt_record_fields(
+            prompt_format=prompt_format,
+            prompt_schema_version=prompt_schema_version,
+            prompt_definition=prompt_definition,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+        )
         prompt_uuid = str(uuid.uuid4())
         payload = (
             prompt_uuid,
@@ -1182,8 +1307,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
             signature_id,
             version_number,
             name,
-            system_prompt,
-            user_prompt,
+            normalized_prompt_fields["system_prompt"],
+            normalized_prompt_fields["user_prompt"],
+            normalized_prompt_fields["prompt_format"],
+            normalized_prompt_fields["prompt_schema_version"],
+            json.dumps(normalized_prompt_fields["prompt_definition"])
+            if normalized_prompt_fields["prompt_definition"] is not None
+            else None,
             json.dumps(few_shot_examples) if few_shot_examples is not None else None,
             json.dumps(modules_config) if modules_config is not None else None,
             parent_version_id,
@@ -1194,12 +1324,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
         insert_sql = """
             INSERT INTO prompt_studio_prompts (
                 uuid, project_id, signature_id, version_number, name, system_prompt,
-                user_prompt, few_shot_examples, modules_config, parent_version_id,
+                user_prompt, prompt_format, prompt_schema_version, prompt_definition,
+                few_shot_examples, modules_config, parent_version_id,
                 change_description, client_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING id, uuid, project_id, signature_id, version_number, name,
-                      system_prompt, user_prompt, few_shot_examples, modules_config,
-                      parent_version_id, change_description, client_id, deleted,
+                      system_prompt, user_prompt, prompt_format, prompt_schema_version,
+                      prompt_definition, few_shot_examples, modules_config, parent_version_id, change_description, client_id, deleted,
                       deleted_at, created_at, updated_at
         """
 
@@ -2866,6 +2997,9 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
         name: Optional[str] = None,
         system_prompt: Optional[str] = None,
         user_prompt: Optional[str] = None,
+        prompt_format: Optional[str] = None,
+        prompt_schema_version: Optional[int] = None,
+        prompt_definition: Optional[Any] = None,
         few_shot_examples: Optional[Any] = None,
         modules_config: Optional[Any] = None,
         client_id: Optional[str] = None,
@@ -2893,15 +3027,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
             new_version = int(current_prompt.get("version_number", 0)) + 1
 
             next_name = name if name is not None else current_prompt.get("name")
-            next_system = (
-                system_prompt
-                if system_prompt is not None
-                else current_prompt.get("system_prompt")
-            )
-            next_user = (
-                user_prompt
-                if user_prompt is not None
-                else current_prompt.get("user_prompt")
+            normalized_prompt_fields = _prepare_prompt_record_fields(
+                prompt_format=prompt_format,
+                prompt_schema_version=prompt_schema_version,
+                prompt_definition=prompt_definition,
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                current_prompt=current_prompt,
             )
             next_examples = (
                 few_shot_examples
@@ -2923,12 +3055,15 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
                         name,
                         system_prompt,
                         user_prompt,
+                        prompt_format,
+                        prompt_schema_version,
+                        prompt_definition,
                         few_shot_examples,
                         modules_config,
                         parent_version_id,
                         change_description,
                         client_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING *
                 """
 
@@ -2938,8 +3073,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
                 current_prompt.get("signature_id"),
                 new_version,
                 next_name,
-                next_system,
-                next_user,
+                normalized_prompt_fields["system_prompt"],
+                normalized_prompt_fields["user_prompt"],
+                normalized_prompt_fields["prompt_format"],
+                normalized_prompt_fields["prompt_schema_version"],
+                json.dumps(normalized_prompt_fields["prompt_definition"])
+                if normalized_prompt_fields["prompt_definition"] is not None
+                else None,
                 json.dumps(next_examples) if next_examples is not None else None,
                 json.dumps(next_modules) if next_modules is not None else None,
                 prompt_id,
@@ -3023,6 +3163,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
             next_version = int(max_version_row[0]) + 1 if max_version_row else 1
 
             new_uuid = str(uuid.uuid4())
+            normalized_prompt_fields = _prepare_prompt_record_fields(
+                prompt_format=target_prompt.get("prompt_format"),
+                prompt_schema_version=target_prompt.get("prompt_schema_version"),
+                prompt_definition=target_prompt.get("prompt_definition"),
+                system_prompt=target_prompt.get("system_prompt"),
+                user_prompt=target_prompt.get("user_prompt"),
+            )
             insert_sql = """
                     INSERT INTO prompt_studio_prompts (
                         uuid,
@@ -3032,12 +3179,15 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
                         name,
                         system_prompt,
                         user_prompt,
+                        prompt_format,
+                        prompt_schema_version,
+                        prompt_definition,
                         few_shot_examples,
                         modules_config,
                         parent_version_id,
                         change_description,
                         client_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     RETURNING *
                 """
 
@@ -3047,8 +3197,13 @@ class _BackendPromptStudioDatabase(BackendPromptStudioDatabaseBase):
                 target_prompt.get("signature_id"),
                 next_version,
                 target_prompt.get("name"),
-                target_prompt.get("system_prompt"),
-                target_prompt.get("user_prompt"),
+                normalized_prompt_fields["system_prompt"],
+                normalized_prompt_fields["user_prompt"],
+                normalized_prompt_fields["prompt_format"],
+                normalized_prompt_fields["prompt_schema_version"],
+                json.dumps(normalized_prompt_fields["prompt_definition"])
+                if normalized_prompt_fields["prompt_definition"] is not None
+                else None,
                 json.dumps(target_prompt.get("few_shot_examples"))
                 if target_prompt.get("few_shot_examples") is not None
                 else None,
@@ -3633,6 +3788,36 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                     conn.commit()
                 except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
                     pass
+            try:
+                cursor.execute("SELECT prompt_format FROM prompt_studio_prompts LIMIT 1")
+            except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                try:
+                    cursor.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_format TEXT NOT NULL DEFAULT 'legacy'"
+                    )
+                    conn.commit()
+                except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                    pass
+            try:
+                cursor.execute("SELECT prompt_schema_version FROM prompt_studio_prompts LIMIT 1")
+            except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                try:
+                    cursor.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_schema_version INTEGER"
+                    )
+                    conn.commit()
+                except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                    pass
+            try:
+                cursor.execute("SELECT prompt_definition FROM prompt_studio_prompts LIMIT 1")
+            except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                try:
+                    cursor.execute(
+                        "ALTER TABLE prompt_studio_prompts ADD COLUMN prompt_definition JSON"
+                    )
+                    conn.commit()
+                except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS:
+                    pass
 
         except _PROMPT_STUDIO_NONCRITICAL_EXCEPTIONS as e:
             logger.error(f"Error initializing Prompt Studio schema: {e}")
@@ -3680,6 +3865,7 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
             "002_prompt_studio_indexes.sql",
             "003_prompt_studio_triggers.sql",
             "004_prompt_studio_fts.sql",
+            "006_prompt_studio_structured_prompts.sql",
         ]
         # Allow explicitly skipping FTS migrations when requested, but default to running them
         try:
@@ -4737,6 +4923,9 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         version_number: int = 1,
         system_prompt: Optional[str] = None,
         user_prompt: Optional[str] = None,
+        prompt_format: str = "legacy",
+        prompt_schema_version: Optional[int] = None,
+        prompt_definition: Optional[Any] = None,
         few_shot_examples: Optional[Any] = None,
         modules_config: Optional[Any] = None,
         parent_version_id: Optional[int] = None,
@@ -4746,6 +4935,13 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         import random
         import time
 
+        normalized_prompt_fields = _prepare_prompt_record_fields(
+            prompt_format=prompt_format,
+            prompt_schema_version=prompt_schema_version,
+            prompt_definition=prompt_definition,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+        )
         prompt_uuid = str(uuid.uuid4())
         payload = (
             prompt_uuid,
@@ -4753,8 +4949,13 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
             signature_id,
             version_number,
             name,
-            system_prompt,
-            user_prompt,
+            normalized_prompt_fields["system_prompt"],
+            normalized_prompt_fields["user_prompt"],
+            normalized_prompt_fields["prompt_format"],
+            normalized_prompt_fields["prompt_schema_version"],
+            json.dumps(normalized_prompt_fields["prompt_definition"])
+            if normalized_prompt_fields["prompt_definition"] is not None
+            else None,
             json.dumps(few_shot_examples) if few_shot_examples is not None else None,
             json.dumps(modules_config) if modules_config is not None else None,
             parent_version_id,
@@ -4765,9 +4966,10 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         insert_sql = """
             INSERT INTO prompt_studio_prompts (
                 uuid, project_id, signature_id, version_number, name, system_prompt,
-                user_prompt, few_shot_examples, modules_config, parent_version_id,
+                user_prompt, prompt_format, prompt_schema_version, prompt_definition,
+                few_shot_examples, modules_config, parent_version_id,
                 change_description, client_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """
 
         conn = self.get_connection()
@@ -4884,6 +5086,7 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         # Parse JSON fields
         json_fields = ["metadata", "input_schema", "output_schema", "constraints",
                       "validation_rules", "few_shot_examples", "modules_config",
+                      "prompt_definition",
                       "model_params", "inputs", "outputs", "expected_outputs",
                       "actual_outputs", "scores", "test_case_ids", "test_run_ids",
                       "aggregate_metrics", "model_configs", "payload", "result",
@@ -5031,6 +5234,9 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
         name: Optional[str] = None,
         system_prompt: Optional[str] = None,
         user_prompt: Optional[str] = None,
+        prompt_format: Optional[str] = None,
+        prompt_schema_version: Optional[int] = None,
+        prompt_definition: Optional[Any] = None,
         few_shot_examples: Optional[Any] = None,
         modules_config: Optional[Any] = None,
         client_id: Optional[str] = None,
@@ -5067,15 +5273,13 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                     new_version = int(current_prompt.get("version_number", 0)) + 1
 
                     next_name = name if name is not None else current_prompt.get("name")
-                    next_system = (
-                        system_prompt
-                        if system_prompt is not None
-                        else current_prompt.get("system_prompt")
-                    )
-                    next_user = (
-                        user_prompt
-                        if user_prompt is not None
-                        else current_prompt.get("user_prompt")
+                    normalized_prompt_fields = _prepare_prompt_record_fields(
+                        prompt_format=prompt_format,
+                        prompt_schema_version=prompt_schema_version,
+                        prompt_definition=prompt_definition,
+                        system_prompt=system_prompt,
+                        user_prompt=user_prompt,
+                        current_prompt=current_prompt,
                     )
                     next_examples = (
                         few_shot_examples
@@ -5092,9 +5296,10 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                         """
                         INSERT INTO prompt_studio_prompts (
                             uuid, project_id, signature_id, version_number, name,
-                            system_prompt, user_prompt, few_shot_examples, modules_config,
+                            system_prompt, user_prompt, prompt_format, prompt_schema_version,
+                            prompt_definition, few_shot_examples, modules_config,
                             parent_version_id, change_description, client_id
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             new_uuid,
@@ -5102,8 +5307,13 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                             current_prompt.get("signature_id"),
                             new_version,
                             next_name,
-                            next_system,
-                            next_user,
+                            normalized_prompt_fields["system_prompt"],
+                            normalized_prompt_fields["user_prompt"],
+                            normalized_prompt_fields["prompt_format"],
+                            normalized_prompt_fields["prompt_schema_version"],
+                            json.dumps(normalized_prompt_fields["prompt_definition"])
+                            if normalized_prompt_fields["prompt_definition"] is not None
+                            else None,
                             json.dumps(next_examples) if next_examples is not None else None,
                             json.dumps(next_modules) if next_modules is not None else None,
                             prompt_id,
@@ -5210,13 +5420,21 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                     new_version = max_version + 1
 
                     new_uuid = str(uuid.uuid4())
+                    normalized_prompt_fields = _prepare_prompt_record_fields(
+                        prompt_format=target_prompt.get("prompt_format"),
+                        prompt_schema_version=target_prompt.get("prompt_schema_version"),
+                        prompt_definition=target_prompt.get("prompt_definition"),
+                        system_prompt=target_prompt.get("system_prompt"),
+                        user_prompt=target_prompt.get("user_prompt"),
+                    )
                     cursor.execute(
                         """
                         INSERT INTO prompt_studio_prompts (
                             uuid, project_id, signature_id, version_number, name,
-                            system_prompt, user_prompt, few_shot_examples, modules_config,
+                            system_prompt, user_prompt, prompt_format, prompt_schema_version,
+                            prompt_definition, few_shot_examples, modules_config,
                             parent_version_id, change_description, client_id
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             new_uuid,
@@ -5224,8 +5442,13 @@ class _SQLitePromptStudioDatabase(PromptsDatabase):
                             target_prompt.get("signature_id"),
                             new_version,
                             target_prompt.get("name"),
-                            target_prompt.get("system_prompt"),
-                            target_prompt.get("user_prompt"),
+                            normalized_prompt_fields["system_prompt"],
+                            normalized_prompt_fields["user_prompt"],
+                            normalized_prompt_fields["prompt_format"],
+                            normalized_prompt_fields["prompt_schema_version"],
+                            json.dumps(normalized_prompt_fields["prompt_definition"])
+                            if normalized_prompt_fields["prompt_definition"] is not None
+                            else None,
                             json.dumps(target_prompt.get("few_shot_examples"))
                             if target_prompt.get("few_shot_examples") is not None
                             else None,

--- a/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
+++ b/tldw_Server_API/app/core/DB_Management/PromptStudioDatabase.py
@@ -189,10 +189,16 @@ def _prepare_prompt_record_fields(
         if issues:
             raise InputError(issues[0].message)  # noqa: TRY003
 
+        definition_schema_version = int(definition.schema_version)
+        if int(effective_schema_version) != definition_schema_version:
+            raise InputError(
+                "prompt_schema_version must match prompt_definition.schema_version."
+            )  # noqa: TRY003
+
         derived_system_prompt, derived_user_prompt = _render_definition_legacy_fields(definition)
         return {
             "prompt_format": "structured",
-            "prompt_schema_version": int(effective_schema_version),
+            "prompt_schema_version": definition_schema_version,
             "prompt_definition": definition.model_dump(),
             "system_prompt": derived_system_prompt,
             "user_prompt": derived_user_prompt,

--- a/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
@@ -113,7 +113,7 @@ _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # --- Database Class ---
 class PromptsDatabase:
-    _CURRENT_SCHEMA_VERSION = 3
+    _CURRENT_SCHEMA_VERSION = 4
 
     _TABLES_SQL_V1 = """
     PRAGMA foreign_keys = ON;
@@ -550,6 +550,7 @@ class PromptsDatabase:
     _SCHEMA_UPDATE_VERSION_SQL_V1 = "UPDATE schema_version SET version = 1 WHERE version = 0;"
     _SCHEMA_UPDATE_VERSION_SQL_V2 = "UPDATE schema_version SET version = 2 WHERE version = 1;"
     _SCHEMA_UPDATE_VERSION_SQL_V3 = "UPDATE schema_version SET version = 3 WHERE version = 2;"
+    _SCHEMA_UPDATE_VERSION_SQL_V4 = "UPDATE schema_version SET version = 4 WHERE version = 3;"
 
     def _apply_schema_v1(self, conn: sqlite3.Connection):
         logging.info(f"Applying initial schema (Version 1) to DB: {self.db_path_str}...")
@@ -663,6 +664,40 @@ class PromptsDatabase:
             logging.error(f"[Schema V3] Application failed: {e}", exc_info=True)
             raise DatabaseError(f"DB schema V3 setup failed: {e}") from e  # noqa: TRY003
 
+    def _apply_schema_v4(self, conn: sqlite3.Connection):
+        logging.info(f"Applying schema migration (Version 4) to DB: {self.db_path_str}...")
+        try:
+            with self.transaction():
+                existing_columns = {
+                    row["name"] for row in conn.execute("PRAGMA table_info(Prompts)").fetchall()
+                }
+                if "prompt_format" not in existing_columns:
+                    conn.execute(
+                        "ALTER TABLE Prompts ADD COLUMN prompt_format TEXT NOT NULL DEFAULT 'legacy'"
+                    )
+                if "prompt_schema_version" not in existing_columns:
+                    conn.execute("ALTER TABLE Prompts ADD COLUMN prompt_schema_version INTEGER")
+                if "prompt_definition_json" not in existing_columns:
+                    conn.execute("ALTER TABLE Prompts ADD COLUMN prompt_definition_json TEXT")
+                conn.execute(self._SCHEMA_UPDATE_VERSION_SQL_V4)
+                cursor_check = conn.execute("SELECT version FROM schema_version LIMIT 1")
+                version_in_tx = cursor_check.fetchone()
+                if not version_in_tx or version_in_tx["version"] != 4:
+                    raise SchemaError("Schema V4 version update did not take effect within transaction.")  # noqa: TRY003
+                prompts_columns = {
+                    row["name"] for row in conn.execute("PRAGMA table_info(Prompts)").fetchall()
+                }
+                required = {"prompt_format", "prompt_schema_version", "prompt_definition_json"}
+                missing = required - prompts_columns
+                if missing:
+                    raise SchemaError(
+                        f"Schema V4 validation failed: missing prompt columns {sorted(missing)}."
+                    )  # noqa: TRY003
+            logging.info(f"[Schema V4] Structured prompt fields applied for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logging.error(f"[Schema V4] Application failed: {e}", exc_info=True)
+            raise DatabaseError(f"DB schema V4 setup failed: {e}") from e  # noqa: TRY003
+
     def _initialize_schema(self):
         conn = self.get_connection()
         try:
@@ -685,6 +720,10 @@ class PromptsDatabase:
                     continue
                 if current_db_version == 2:
                     self._apply_schema_v3(conn)
+                    current_db_version = self._get_db_version(conn)
+                    continue
+                if current_db_version == 3:
+                    self._apply_schema_v4(conn)
                     current_db_version = self._get_db_version(conn)
                     continue
                 raise SchemaError(  # noqa: TRY003
@@ -713,6 +752,40 @@ class PromptsDatabase:
 
     def _generate_uuid(self) -> str:
         return str(uuid.uuid4())
+
+    @staticmethod
+    def _serialize_prompt_definition(prompt_definition: Any) -> Optional[str]:
+        if prompt_definition is None:
+            return None
+        if isinstance(prompt_definition, str):
+            return prompt_definition
+        return json.dumps(prompt_definition, sort_keys=True)
+
+    @staticmethod
+    def _deserialize_prompt_record(prompt_data: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if not prompt_data:
+            return prompt_data
+
+        record = dict(prompt_data)
+        record["prompt_format"] = record.get("prompt_format") or "legacy"
+
+        prompt_definition_payload = record.pop("prompt_definition_json", None)
+        if prompt_definition_payload is None:
+            record["prompt_definition"] = None
+            return record
+
+        if isinstance(prompt_definition_payload, dict):
+            record["prompt_definition"] = prompt_definition_payload
+            return record
+
+        if isinstance(prompt_definition_payload, str) and prompt_definition_payload.strip():
+            try:
+                record["prompt_definition"] = json.loads(prompt_definition_payload)
+            except json.JSONDecodeError:
+                record["prompt_definition"] = None
+        else:
+            record["prompt_definition"] = None
+        return record
 
     def _normalize_keyword(self, keyword: str) -> str:
         """Normalize keyword while preserving case for round-trip display/export.
@@ -848,6 +921,9 @@ class PromptsDatabase:
                         "details": payload.get("details"),
                         "system_prompt": payload.get("system_prompt"),
                         "user_prompt": payload.get("user_prompt"),
+                        "prompt_format": payload.get("prompt_format"),
+                        "prompt_schema_version": payload.get("prompt_schema_version"),
+                        "prompt_definition": payload.get("prompt_definition"),
                     })
                 versions_by_number[ver] = entry
             return [versions_by_number[v] for v in sorted(versions_by_number)]
@@ -918,7 +994,16 @@ class PromptsDatabase:
             raise InputError(f"Version {version} not found for prompt {prompt_id}.")  # noqa: TRY003
 
         update_data: dict[str, Any] = {}
-        for field in ("name", "author", "details", "system_prompt", "user_prompt"):
+        for field in (
+            "name",
+            "author",
+            "details",
+            "system_prompt",
+            "user_prompt",
+            "prompt_format",
+            "prompt_schema_version",
+            "prompt_definition",
+        ):
             if field in payload:
                 update_data[field] = payload.get(field)
         if "keywords" in payload and isinstance(payload.get("keywords"), list):
@@ -1019,6 +1104,9 @@ class PromptsDatabase:
 
     def add_prompt(self, name: str, author: Optional[str], details: Optional[str],
                    system_prompt: Optional[str] = None, user_prompt: Optional[str] = None,
+                   prompt_format: str = "legacy",
+                   prompt_schema_version: Optional[int] = None,
+                   prompt_definition: Optional[Any] = None,
                    keywords: Optional[list[str]] = None, overwrite: bool = False) -> tuple[
         Optional[int], Optional[str], str]:
         if not isinstance(name, str) or name == "":
@@ -1026,6 +1114,7 @@ class PromptsDatabase:
 
         current_time = self._get_current_utc_timestamp_str()
         client_id = self.client_id
+        prompt_definition_json = self._serialize_prompt_definition(prompt_definition)
 
         try:
             with self.transaction() as conn:
@@ -1052,6 +1141,9 @@ class PromptsDatabase:
                     update_data = {
                         'name': name, 'author': author, 'details': details, 'system_prompt': system_prompt,
                         'user_prompt': user_prompt,
+                        'prompt_format': prompt_format,
+                        'prompt_schema_version': prompt_schema_version,
+                        'prompt_definition': prompt_definition,
                         'last_modified': current_time, 'version': new_version, 'client_id': client_id, 'deleted': 0,
                         'uuid': prompt_uuid
                     }
@@ -1060,13 +1152,17 @@ class PromptsDatabase:
                                           details=?,
                                           system_prompt=?,
                                           user_prompt=?,
+                                          prompt_format=?,
+                                          prompt_schema_version=?,
+                                          prompt_definition_json=?,
                                           last_modified=?,
                                           version=?,
                                           client_id=?,
                                           deleted=0
                                       WHERE id = ?
                                         AND version = ?""",
-                                   (author, details, system_prompt, user_prompt, current_time, new_version, client_id,
+                                   (author, details, system_prompt, user_prompt, prompt_format, prompt_schema_version,
+                                    prompt_definition_json, current_time, new_version, client_id,
                                     prompt_id, current_version))
                     if cursor.rowcount == 0:
                         # If it was deleted and overwrite is true, version check might fail if version wasn't for active.
@@ -1093,6 +1189,9 @@ class PromptsDatabase:
                     insert_data = {
                         'name': name, 'author': author, 'details': details, 'system_prompt': system_prompt,
                         'user_prompt': user_prompt,
+                        'prompt_format': prompt_format,
+                        'prompt_schema_version': prompt_schema_version,
+                        'prompt_definition': prompt_definition,
                         'usage_count': 0, 'last_used_at': None,
                         'uuid': prompt_uuid, 'last_modified': current_time, 'version': new_version,
                         'client_id': client_id, 'deleted': 0
@@ -1104,6 +1203,9 @@ class PromptsDatabase:
                             details,
                             system_prompt,
                             user_prompt,
+                            prompt_format,
+                            prompt_schema_version,
+                            prompt_definition_json,
                             usage_count,
                             last_used_at,
                             uuid,
@@ -1112,13 +1214,16 @@ class PromptsDatabase:
                             client_id,
                             deleted
                         )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)""",
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)""",
                         (
                             name,
                             author,
                             details,
                             system_prompt,
                             user_prompt,
+                            prompt_format,
+                            prompt_schema_version,
+                            prompt_definition_json,
                             0,
                             None,
                             prompt_uuid,
@@ -1292,6 +1397,15 @@ class PromptsDatabase:
                 if 'user_prompt' in update_data:
                     set_clauses.append("user_prompt = ?")
                     params.append(update_data.get('user_prompt'))
+                if 'prompt_format' in update_data:
+                    set_clauses.append("prompt_format = ?")
+                    params.append(update_data.get('prompt_format') or 'legacy')
+                if 'prompt_schema_version' in update_data:
+                    set_clauses.append("prompt_schema_version = ?")
+                    params.append(update_data.get('prompt_schema_version'))
+                if 'prompt_definition' in update_data:
+                    set_clauses.append("prompt_definition_json = ?")
+                    params.append(self._serialize_prompt_definition(update_data.get('prompt_definition')))
                 if 'usage_count' in update_data:
                     usage_count = update_data.get('usage_count')
                     if usage_count is not None:
@@ -1330,7 +1444,7 @@ class PromptsDatabase:
                 # Log sync event
                 # Fetch the full updated row for payload
                 cursor.execute("SELECT * FROM Prompts WHERE id = ?", (prompt_id,))
-                updated_payload = dict(cursor.fetchone())
+                updated_payload = self._deserialize_prompt_record(dict(cursor.fetchone()))
                 self._log_sync_event(conn, 'Prompts', original_uuid, 'update', new_version, updated_payload)
 
                 # Update FTS
@@ -1858,7 +1972,7 @@ class PromptsDatabase:
         try:
             cursor = self.execute_query(query, tuple(params))
             result = cursor.fetchone()
-            return dict(result) if result else None
+            return self._deserialize_prompt_record(dict(result)) if result else None
         except (DatabaseError, sqlite3.Error) as e:
             logger.error(f"Error fetching prompt by ID {prompt_id}: {e}")
             raise DatabaseError(f"Failed fetch prompt by ID: {e}") from e  # noqa: TRY003
@@ -1871,7 +1985,7 @@ class PromptsDatabase:
         try:
             cursor = self.execute_query(query, tuple(params))
             result = cursor.fetchone()
-            return dict(result) if result else None
+            return self._deserialize_prompt_record(dict(result)) if result else None
         except (DatabaseError, sqlite3.Error) as e:
             logger.error(f"Error fetching prompt by UUID {prompt_uuid}: {e}")
             raise DatabaseError(f"Failed fetch prompt by UUID: {e}") from e  # noqa: TRY003
@@ -1884,7 +1998,7 @@ class PromptsDatabase:
         try:
             cursor = self.execute_query(query, tuple(params))
             result = cursor.fetchone()
-            return dict(result) if result else None
+            return self._deserialize_prompt_record(dict(result)) if result else None
         except (DatabaseError, sqlite3.Error) as e:
             logger.error(f"Error fetching prompt by name '{name}': {e}")
             raise DatabaseError(f"Failed fetch prompt by name: {e}") from e  # noqa: TRY003

--- a/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
@@ -941,7 +941,7 @@ class PromptsDatabase:
             logging.error(f"Failed FTS update Prompt ID {prompt_id}: {e}", exc_info=True)
             raise DatabaseError(f"Failed FTS update Prompt ID {prompt_id}: {e}") from e  # noqa: TRY003
 
-    def _rebuild_prompts_fts(self, conn: sqlite3.Connection):
+    def _rebuild_prompts_fts(self, conn: sqlite3.Connection) -> None:
         try:
             conn.executescript(self._FTS_TABLES_SQL)
             conn.execute("DELETE FROM prompts_fts")

--- a/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Prompts_DB.py
@@ -113,7 +113,7 @@ _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # --- Database Class ---
 class PromptsDatabase:
-    _CURRENT_SCHEMA_VERSION = 4
+    _CURRENT_SCHEMA_VERSION = 5
 
     _TABLES_SQL_V1 = """
     PRAGMA foreign_keys = ON;
@@ -551,6 +551,7 @@ class PromptsDatabase:
     _SCHEMA_UPDATE_VERSION_SQL_V2 = "UPDATE schema_version SET version = 2 WHERE version = 1;"
     _SCHEMA_UPDATE_VERSION_SQL_V3 = "UPDATE schema_version SET version = 3 WHERE version = 2;"
     _SCHEMA_UPDATE_VERSION_SQL_V4 = "UPDATE schema_version SET version = 4 WHERE version = 3;"
+    _SCHEMA_UPDATE_VERSION_SQL_V5 = "UPDATE schema_version SET version = 5 WHERE version = 4;"
 
     def _apply_schema_v1(self, conn: sqlite3.Connection):
         logging.info(f"Applying initial schema (Version 1) to DB: {self.db_path_str}...")
@@ -698,6 +699,21 @@ class PromptsDatabase:
             logging.error(f"[Schema V4] Application failed: {e}", exc_info=True)
             raise DatabaseError(f"DB schema V4 setup failed: {e}") from e  # noqa: TRY003
 
+    def _apply_schema_v5(self, conn: sqlite3.Connection):
+        logging.info(f"Applying schema migration (Version 5) to DB: {self.db_path_str}...")
+        try:
+            with self.transaction():
+                conn.execute(self._SCHEMA_UPDATE_VERSION_SQL_V5)
+                cursor_check = conn.execute("SELECT version FROM schema_version LIMIT 1")
+                version_in_tx = cursor_check.fetchone()
+                if not version_in_tx or version_in_tx["version"] != 5:
+                    raise SchemaError("Schema V5 version update did not take effect within transaction.")  # noqa: TRY003
+                self._rebuild_prompts_fts(conn)
+            logging.info(f"[Schema V5] Prompt FTS index rebuilt for DB: {self.db_path_str}.")
+        except sqlite3.Error as e:
+            logging.error(f"[Schema V5] Application failed: {e}", exc_info=True)
+            raise DatabaseError(f"DB schema V5 setup failed: {e}") from e  # noqa: TRY003
+
     def _initialize_schema(self):
         conn = self.get_connection()
         try:
@@ -724,6 +740,10 @@ class PromptsDatabase:
                     continue
                 if current_db_version == 3:
                     self._apply_schema_v4(conn)
+                    current_db_version = self._get_db_version(conn)
+                    continue
+                if current_db_version == 4:
+                    self._apply_schema_v5(conn)
                     current_db_version = self._get_db_version(conn)
                     continue
                 raise SchemaError(  # noqa: TRY003
@@ -786,6 +806,61 @@ class PromptsDatabase:
         else:
             record["prompt_definition"] = None
         return record
+
+    @staticmethod
+    def build_structured_prompt_searchable_text(prompt_definition: Any) -> str:
+        if prompt_definition is None:
+            return ""
+
+        definition_payload = prompt_definition
+        if isinstance(prompt_definition, str):
+            with suppress(TypeError, ValueError, json.JSONDecodeError):
+                definition_payload = json.loads(prompt_definition)
+
+        if not isinstance(definition_payload, dict):
+            return ""
+
+        parts: list[str] = []
+
+        variables = definition_payload.get("variables")
+        if isinstance(variables, list):
+            for variable in variables:
+                if not isinstance(variable, dict):
+                    continue
+                for key in ("name", "label", "description"):
+                    value = variable.get(key)
+                    if isinstance(value, str) and value.strip():
+                        parts.append(value.strip())
+
+        blocks = definition_payload.get("blocks")
+        if isinstance(blocks, list):
+            for block in blocks:
+                if not isinstance(block, dict) or block.get("enabled") is False:
+                    continue
+                for key in ("name", "role", "content"):
+                    value = block.get(key)
+                    if isinstance(value, str) and value.strip():
+                        parts.append(value.strip())
+
+        normalized_parts: list[str] = []
+        seen: set[str] = set()
+        for part in parts:
+            if part in seen:
+                continue
+            normalized_parts.append(part)
+            seen.add(part)
+        return "\n".join(normalized_parts)
+
+    def _build_fts_details_text(self, details: Optional[str], prompt_definition: Any) -> str:
+        detail_parts: list[str] = []
+        if isinstance(details, str) and details.strip():
+            detail_parts.append(details.strip())
+
+        structured_text = self.build_structured_prompt_searchable_text(prompt_definition)
+        if structured_text:
+            detail_parts.append(structured_text)
+
+        return "\n\n".join(detail_parts)
 
     def _normalize_keyword(self, keyword: str) -> str:
         """Normalize keyword while preserving case for round-trip display/export.
@@ -854,15 +929,43 @@ class PromptsDatabase:
 
     # --- FTS Helper Methods ---
     def _update_fts_prompt(self, conn: sqlite3.Connection, prompt_id: int, name: str, author: Optional[str],
-                           details: Optional[str], system_prompt: Optional[str], user_prompt: Optional[str]):
+                           details: Optional[str], system_prompt: Optional[str], user_prompt: Optional[str],
+                           prompt_definition: Any = None):
         try:
+            fts_details = self._build_fts_details_text(details, prompt_definition)
             conn.execute(
                 "INSERT OR REPLACE INTO prompts_fts (rowid, name, author, details, system_prompt, user_prompt) VALUES (?, ?, ?, ?, ?, ?)",
-                (prompt_id, name, author or "", details or "", system_prompt or "", user_prompt or ""))
+                (prompt_id, name, author or "", fts_details, system_prompt or "", user_prompt or ""))
             logging.debug(f"Updated FTS for Prompt ID {prompt_id}")
         except sqlite3.Error as e:
             logging.error(f"Failed FTS update Prompt ID {prompt_id}: {e}", exc_info=True)
             raise DatabaseError(f"Failed FTS update Prompt ID {prompt_id}: {e}") from e  # noqa: TRY003
+
+    def _rebuild_prompts_fts(self, conn: sqlite3.Connection):
+        try:
+            conn.executescript(self._FTS_TABLES_SQL)
+            conn.execute("DELETE FROM prompts_fts")
+            cursor = conn.execute(
+                """
+                SELECT id, name, author, details, system_prompt, user_prompt, prompt_definition_json
+                FROM Prompts
+                WHERE deleted = 0
+                """
+            )
+            for row in cursor.fetchall():
+                self._update_fts_prompt(
+                    conn,
+                    row["id"],
+                    row["name"],
+                    row["author"],
+                    row["details"],
+                    row["system_prompt"],
+                    row["user_prompt"],
+                    row["prompt_definition_json"],
+                )
+        except sqlite3.Error as e:
+            logging.error(f"Failed to rebuild prompt FTS index: {e}", exc_info=True)
+            raise DatabaseError(f"Failed to rebuild prompt FTS index: {e}") from e  # noqa: TRY003
 
     def _delete_fts_prompt(self, conn: sqlite3.Connection, prompt_id: int):
         try:
@@ -1181,7 +1284,16 @@ class PromptsDatabase:
                         raise ConflictError(f"Failed to update prompt '{name}'.", "Prompts", prompt_id)  # noqa: TRY003, TRY301
 
                     self._log_sync_event(conn, 'Prompts', prompt_uuid, 'update', new_version, update_data)
-                    self._update_fts_prompt(conn, prompt_id, name, author, details, system_prompt, user_prompt)
+                    self._update_fts_prompt(
+                        conn,
+                        prompt_id,
+                        name,
+                        author,
+                        details,
+                        system_prompt,
+                        user_prompt,
+                        prompt_definition,
+                    )
                 else:  # New prompt
                     action_taken = "added"
                     prompt_uuid = self._generate_uuid()
@@ -1235,7 +1347,16 @@ class PromptsDatabase:
                     prompt_id = cursor.lastrowid
                     if not prompt_id: raise DatabaseError("Failed to get ID for new prompt.")  # noqa: E701, TRY003, TRY301
                     self._log_sync_event(conn, 'Prompts', prompt_uuid, 'create', new_version, insert_data)
-                    self._update_fts_prompt(conn, prompt_id, name, author, details, system_prompt, user_prompt)
+                    self._update_fts_prompt(
+                        conn,
+                        prompt_id,
+                        name,
+                        author,
+                        details,
+                        system_prompt,
+                        user_prompt,
+                        prompt_definition,
+                    )
 
                 if prompt_id:
                     # Apply provided keywords only; do not inject a default tag when none provided
@@ -1451,7 +1572,8 @@ class PromptsDatabase:
                 self._update_fts_prompt(conn, prompt_id,
                                         updated_payload['name'], updated_payload.get('author'),
                                         updated_payload.get('details'), updated_payload.get('system_prompt'),
-                                        updated_payload.get('user_prompt'))
+                                        updated_payload.get('user_prompt'),
+                                        updated_payload.get('prompt_definition'))
 
                 # Handle keywords if provided in update_data (assuming 'keywords' is a list of strings)
                 if 'keywords' in update_data and isinstance(update_data['keywords'], list):
@@ -2370,6 +2492,14 @@ class PromptsDatabase:
                         rowd = dict(row)
                         kws = self.fetch_keywords_for_prompt(rowd['id'], include_deleted=False)
                         haystack_parts = []
+                        if fields_to_scan & text_fields:
+                            haystack_parts.append(
+                                self._normalize_text_for_search(
+                                    self.build_structured_prompt_searchable_text(
+                                        rowd.get("prompt_definition_json")
+                                    )
+                                )
+                            )
                         for f in fields_to_scan:
                             if f == "keywords":
                                 haystack_parts.extend([self._normalize_text_for_search(k) for k in kws])

--- a/tldw_Server_API/app/core/DB_Management/migrations/006_prompt_studio_structured_prompts.sql
+++ b/tldw_Server_API/app/core/DB_Management/migrations/006_prompt_studio_structured_prompts.sql
@@ -1,0 +1,12 @@
+-- Migration 006: Add structured prompt fields to Prompt Studio prompts
+-- This migration is additive and stores structured prompt metadata alongside
+-- the existing legacy compatibility fields.
+
+ALTER TABLE prompt_studio_prompts
+    ADD COLUMN prompt_format TEXT NOT NULL DEFAULT 'legacy';
+
+ALTER TABLE prompt_studio_prompts
+    ADD COLUMN prompt_schema_version INTEGER;
+
+ALTER TABLE prompt_studio_prompts
+    ADD COLUMN prompt_definition JSON;

--- a/tldw_Server_API/app/core/Prompt_Management/Prompts_Interop.py
+++ b/tldw_Server_API/app/core/Prompt_Management/Prompts_Interop.py
@@ -174,11 +174,25 @@ def add_keyword(keyword_text: str) -> tuple[Optional[int], Optional[str]]:
 
 def add_prompt(name: str, author: Optional[str], details: Optional[str],
                system_prompt: Optional[str] = None, user_prompt: Optional[str] = None,
-               keywords: Optional[list[str]] = None, overwrite: bool = False
+               keywords: Optional[list[str]] = None, overwrite: bool = False,
+               prompt_format: str = "legacy",
+               prompt_schema_version: Optional[int] = None,
+               prompt_definition: Optional[Any] = None,
                ) -> tuple[Optional[int], Optional[str], str]:
     """Adds or updates a prompt. See PromptsDatabase.add_prompt for details."""
     db = get_db_instance()
-    return db.add_prompt(name, author, details, system_prompt, user_prompt, keywords, overwrite)
+    return db.add_prompt(
+        name=name,
+        author=author,
+        details=details,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        prompt_format=prompt_format,
+        prompt_schema_version=prompt_schema_version,
+        prompt_definition=prompt_definition,
+        keywords=keywords,
+        overwrite=overwrite,
+    )
 
 def update_keywords_for_prompt(prompt_id: int, keywords_list: list[str]) -> None:
     """Updates keywords for a specific prompt. See PromptsDatabase.update_keywords_for_prompt for details."""

--- a/tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py
+++ b/tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py
@@ -571,8 +571,8 @@ class PromptExecutor:
 
         return prepared_inputs
 
+    @staticmethod
     def _apply_signature_to_messages(
-        self,
         messages: list[dict[str, Any]],
         signature: Optional[dict[str, Any]],
     ) -> list[dict[str, str]]:
@@ -593,7 +593,7 @@ class PromptExecutor:
         if target_index is not None:
             target_content = rendered_messages[target_index]["content"]
 
-        updated_content = self._apply_signature_to_text(target_content, signature)
+        updated_content = PromptExecutor._apply_signature_to_text(target_content, signature)
         if target_index is None:
             rendered_messages.append({"role": "user", "content": updated_content})
         else:
@@ -601,19 +601,21 @@ class PromptExecutor:
 
         return rendered_messages
 
-    def _apply_signature_to_text(self, text: str, signature: dict[str, Any]) -> str:
+    @staticmethod
+    def _apply_signature_to_text(text: str, signature: dict[str, Any]) -> str:
         updated_text = text
         sig_instruction = signature.get("instruction", "")
         if sig_instruction:
             updated_text = f"{sig_instruction}\n\n{updated_text}" if updated_text else sig_instruction
 
-        output_instruction = self._render_output_schema_instruction(signature.get("output_schema"))
+        output_instruction = PromptExecutor._render_output_schema_instruction(signature.get("output_schema"))
         if output_instruction:
             updated_text = f"{updated_text}\n\n{output_instruction}" if updated_text else output_instruction
 
         return updated_text
 
-    def _render_output_schema_instruction(self, output_schema: Any) -> str:
+    @staticmethod
+    def _render_output_schema_instruction(output_schema: Any) -> str:
         if not output_schema:
             return ""
 

--- a/tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py
+++ b/tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py
@@ -19,6 +19,10 @@ from tldw_Server_API.app.core.LLM_Calls.adapter_utils import (
     resolve_provider_model,
     split_system_message,
 )
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
+    StructuredPromptAssemblyError,
+    assemble_prompt_definition,
+)
 
 ########################################################################################################################
 # Prompt Executor
@@ -98,8 +102,8 @@ class PromptExecutor:
             if prompt.get("signature_id"):
                 signature = self._get_signature(prompt["signature_id"])
 
-            # Build the final prompt
-            final_prompt = self._build_prompt(prompt, signature, test_inputs)
+            # Build the final prompt or canonical message list
+            prompt_request = self._build_prompt_request(prompt, signature, test_inputs)
 
             # Execute with LLM
             provider = model_config.get("provider", "openai")
@@ -108,8 +112,9 @@ class PromptExecutor:
             result = await self._call_llm(
                 provider=provider,
                 model=model,
-                prompt=final_prompt,
-                system_prompt=prompt.get("system_prompt"),
+                prompt=prompt_request.get("prompt"),
+                messages=prompt_request.get("messages"),
+                system_prompt=prompt_request.get("system_prompt"),
                 parameters=model_config.get("parameters", {})
             )
 
@@ -133,6 +138,7 @@ class PromptExecutor:
                     provider, model, result.get("tokens", 0)
                 ),
                 "metadata": {
+                    "assembled_messages": prompt_request.get("assembled_messages", []),
                     "temperature": model_config.get("parameters", {}).get("temperature"),
                     "max_tokens": model_config.get("parameters", {}).get("max_tokens"),
                     "timestamp": datetime.utcnow().isoformat()
@@ -323,9 +329,16 @@ class PromptExecutor:
             return content, tokens
         return str(response), 0
 
-    async def _call_llm(self, provider: str, model: str, prompt: str,
-                       system_prompt: Optional[str] = None,
-                       parameters: dict[str, Any] = None) -> dict[str, Any]:
+    async def _call_llm(
+        self,
+        provider: str,
+        model: str,
+        prompt: Optional[str] = None,
+        *,
+        messages: Optional[list[dict[str, Any]]] = None,
+        system_prompt: Optional[str] = None,
+        parameters: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """
         Call the appropriate LLM provider.
 
@@ -333,6 +346,7 @@ class PromptExecutor:
             provider: Provider name
             model: Model name
             prompt: User prompt
+            messages: Canonical chat messages
             system_prompt: System prompt
             parameters: Additional parameters
 
@@ -345,7 +359,11 @@ class PromptExecutor:
         max_tokens = params.get("max_tokens", 1000)
 
         api_endpoint = self._normalize_provider(provider)
-        messages = [{"role": "user", "content": prompt}]
+        request_messages = list(messages or [])
+        if not request_messages:
+            if prompt is None:
+                raise ValueError("Either prompt or messages must be provided")
+            request_messages = [{"role": "user", "content": prompt}]
 
         # Backoff + retry for transient/provider limit errors
         last_exc = None
@@ -357,7 +375,7 @@ class PromptExecutor:
                     response = await asyncio.to_thread(
                         _legacy_call,
                         api_endpoint=api_endpoint,
-                        messages_payload=messages,
+                        messages_payload=request_messages,
                         system_message=system_prompt,
                         temp=temperature,
                         max_tokens=max_tokens,
@@ -368,7 +386,7 @@ class PromptExecutor:
                     request = self._build_adapter_request(
                         provider=api_endpoint,
                         model=model,
-                        messages=messages,
+                        messages=request_messages,
                         system_prompt=system_prompt,
                         temperature=temperature,
                         max_tokens=max_tokens,
@@ -409,6 +427,27 @@ class PromptExecutor:
         if signature and signature.get("deleted"):
             return None
         return signature
+
+    def _build_prompt_request(
+        self,
+        prompt: dict[str, Any],
+        signature: Optional[dict[str, Any]],
+        inputs: dict[str, Any],
+    ) -> dict[str, Any]:
+        prepared_inputs = self._prepare_prompt_inputs(inputs)
+        if prompt.get("prompt_format") == "structured" and prompt.get("prompt_definition"):
+            return self._build_structured_prompt_request(prompt, signature, prepared_inputs)
+
+        final_prompt = self._build_prompt(prompt, signature, prepared_inputs)
+        return {
+            "prompt": final_prompt,
+            "messages": None,
+            "system_prompt": prompt.get("system_prompt"),
+            "assembled_messages": self._build_legacy_assembled_messages(
+                final_prompt,
+                prompt.get("system_prompt"),
+            ),
+        }
 
     def _build_prompt(self, prompt: dict[str, Any], signature: Optional[dict[str, Any]],
                      inputs: dict[str, Any]) -> str:
@@ -467,21 +506,173 @@ class PromptExecutor:
 
         # Add signature instructions if present
         if signature:
-            sig_instruction = signature.get("instruction", "")
-            if sig_instruction:
-                template = f"{sig_instruction}\n\n{template}"
-
-            # Add output format instruction
-            if signature.get("output_schema"):
-                template += "\n\nPlease format your response as JSON with the following structure:\n"
-                template += json.dumps(
-                    {field["name"]: f"<{field.get('type', 'string')}>"
-                     for field in signature["output_schema"]
-                     if isinstance(field, dict)},
-                    indent=2
-                )
+            template = self._apply_signature_to_text(template, signature)
 
         return template
+
+    def _build_structured_prompt_request(
+        self,
+        prompt: dict[str, Any],
+        signature: Optional[dict[str, Any]],
+        inputs: dict[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            assembly = assemble_prompt_definition(
+                prompt["prompt_definition"],
+                inputs,
+                extras={
+                    "few_shot_examples": prompt.get("few_shot_examples"),
+                    "modules_config": prompt.get("modules_config"),
+                },
+            )
+        except StructuredPromptAssemblyError:
+            raise
+        except Exception as exc:
+            raise StructuredPromptAssemblyError(
+                "prompt_assembly_failed",
+                f"Failed to assemble structured prompt: {exc}",
+            ) from exc
+
+        messages = self._apply_signature_to_messages(assembly.messages, signature)
+        messages = self._enforce_messages_length(messages)
+        return {
+            "prompt": None,
+            "messages": messages,
+            "system_prompt": None,
+            "assembled_messages": [message.copy() for message in messages],
+        }
+
+    def _build_legacy_assembled_messages(
+        self,
+        final_prompt: str,
+        system_prompt: Optional[str],
+    ) -> list[dict[str, str]]:
+        messages: list[dict[str, str]] = []
+        if system_prompt:
+            messages.append({"role": "system", "content": str(system_prompt)})
+        messages.append({"role": "user", "content": final_prompt})
+        return messages
+
+    def _prepare_prompt_inputs(self, inputs: dict[str, Any]) -> dict[str, str]:
+        prepared_inputs: dict[str, str] = {}
+        for key, value in inputs.items():
+            if not key or not isinstance(key, str):
+                logger.warning(f"Skipping invalid variable key: {key!r}")
+                continue
+
+            str_value = str(value) if value is not None else ""
+            if len(str_value) > self.MAX_VARIABLE_VALUE_LENGTH:
+                logger.warning(
+                    f"Variable '{key}' value truncated from {len(str_value)} to {self.MAX_VARIABLE_VALUE_LENGTH} chars"
+                )
+                str_value = str_value[:self.MAX_VARIABLE_VALUE_LENGTH] + "... [truncated]"
+
+            prepared_inputs[key] = str_value
+
+        return prepared_inputs
+
+    def _apply_signature_to_messages(
+        self,
+        messages: list[dict[str, Any]],
+        signature: Optional[dict[str, Any]],
+    ) -> list[dict[str, str]]:
+        rendered_messages = [
+            {"role": str(message.get("role") or "user"), "content": str(message.get("content") or "")}
+            for message in messages
+        ]
+        if not signature:
+            return rendered_messages
+
+        target_index = next(
+            (index for index in range(len(rendered_messages) - 1, -1, -1)
+             if rendered_messages[index]["role"] == "user"),
+            None,
+        )
+
+        target_content = ""
+        if target_index is not None:
+            target_content = rendered_messages[target_index]["content"]
+
+        updated_content = self._apply_signature_to_text(target_content, signature)
+        if target_index is None:
+            rendered_messages.append({"role": "user", "content": updated_content})
+        else:
+            rendered_messages[target_index]["content"] = updated_content
+
+        return rendered_messages
+
+    def _apply_signature_to_text(self, text: str, signature: dict[str, Any]) -> str:
+        updated_text = text
+        sig_instruction = signature.get("instruction", "")
+        if sig_instruction:
+            updated_text = f"{sig_instruction}\n\n{updated_text}" if updated_text else sig_instruction
+
+        output_instruction = self._render_output_schema_instruction(signature.get("output_schema"))
+        if output_instruction:
+            updated_text = f"{updated_text}\n\n{output_instruction}" if updated_text else output_instruction
+
+        return updated_text
+
+    def _render_output_schema_instruction(self, output_schema: Any) -> str:
+        if not output_schema:
+            return ""
+
+        if isinstance(output_schema, str):
+            try:
+                output_schema = json.loads(output_schema)
+            except Exception:
+                return ""
+
+        if not isinstance(output_schema, list):
+            return ""
+
+        schema_shape = {
+            field["name"]: f"<{field.get('type', 'string')}>"
+            for field in output_schema
+            if isinstance(field, dict) and field.get("name")
+        }
+        if not schema_shape:
+            return ""
+
+        return (
+            "Please format your response as JSON with the following structure:\n"
+            + json.dumps(schema_shape, indent=2)
+        )
+
+    def _enforce_messages_length(self, messages: list[dict[str, str]]) -> list[dict[str, str]]:
+        rendered_messages = [message.copy() for message in messages]
+        total_length = sum(len(message.get("content", "")) for message in rendered_messages)
+        if total_length <= self.MAX_TOTAL_PROMPT_LENGTH or not rendered_messages:
+            return rendered_messages
+
+        logger.warning(
+            f"Structured prompt truncated from {total_length} to {self.MAX_TOTAL_PROMPT_LENGTH} chars"
+        )
+
+        target_index = next(
+            (index for index in range(len(rendered_messages) - 1, -1, -1)
+             if rendered_messages[index]["role"] == "user"),
+            len(rendered_messages) - 1,
+        )
+        preserved_length = total_length - len(rendered_messages[target_index].get("content", ""))
+        remaining_budget = max(self.MAX_TOTAL_PROMPT_LENGTH - preserved_length, 0)
+        notice = "\n... [prompt truncated due to length]"
+
+        if remaining_budget <= 0:
+            rendered_messages[target_index]["content"] = ""
+            return rendered_messages
+
+        if remaining_budget > len(notice):
+            trimmed_length = remaining_budget - len(notice)
+            rendered_messages[target_index]["content"] = (
+                rendered_messages[target_index].get("content", "")[:trimmed_length] + notice
+            )
+            return rendered_messages
+
+        rendered_messages[target_index]["content"] = (
+            rendered_messages[target_index].get("content", "")[:remaining_budget]
+        )
+        return rendered_messages
 
     # Compatibility alias used by tests
     async def execute(self, prompt_id: int, inputs: dict[str, Any], provider: str = "openai", model: str = "gpt-3.5-turbo",

--- a/tldw_Server_API/app/core/Prompt_Management/prompt_studio/test_runner.py
+++ b/tldw_Server_API/app/core/Prompt_Management/prompt_studio/test_runner.py
@@ -16,6 +16,7 @@ from ....core.LLM_Calls.adapter_utils import (
     resolve_provider_model,
     split_system_message,
 )
+from .prompt_executor import PromptExecutor
 from .program_evaluator import ProgramEvaluator
 
 
@@ -106,21 +107,24 @@ class TestRunner:
         inputs = test_case.get("inputs") or {}
         expected = test_case.get("expected_outputs") or {}
 
-        # Format prompt with inputs
-        user_prompt = prompt.get("user_prompt", "")
-        for key, value in inputs.items():
-            user_prompt = user_prompt.replace(f"{{{key}}}", str(value))
-
         # Call LLM
         try:
+            signature = None
+            if prompt.get("signature_id"):
+                signature = self.db.get_signature(prompt["signature_id"])
+                if signature and signature.get("deleted"):
+                    signature = None
+
+            prompt_request = PromptExecutor(self.db)._build_prompt_request(prompt, signature, inputs)
+            messages_payload = prompt_request.get("messages") or [
+                {"role": "user", "content": prompt_request.get("prompt", "")}
+            ]
             response = await asyncio.to_thread(
                 self._call_adapter,
                 provider=provider,
                 model=model,
-                messages_payload=[
-                    {"role": "user", "content": user_prompt}
-                ],
-                system_message=prompt.get("system_prompt"),
+                messages_payload=messages_payload,
+                system_message=prompt_request.get("system_prompt"),
                 temperature=temperature,
                 max_tokens=max_tokens,
                 app_config=app_config,

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
@@ -1,0 +1,17 @@
+from .models import (
+    PromptAssemblyConfig,
+    PromptBlock,
+    PromptDefinition,
+    PromptVariableDefinition,
+    ValidationIssue,
+)
+from .validator import validate_prompt_definition
+
+__all__ = [
+    "PromptAssemblyConfig",
+    "PromptBlock",
+    "PromptDefinition",
+    "PromptVariableDefinition",
+    "ValidationIssue",
+    "validate_prompt_definition",
+]

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
@@ -2,6 +2,11 @@ from .assembler import (
     StructuredPromptAssemblyError,
     assemble_prompt_definition,
 )
+from .conversion import (
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
+    normalize_legacy_prompt_template,
+)
 from .legacy_renderer import render_legacy_snapshot
 from .models import (
     PromptAssemblyConfig,
@@ -24,6 +29,9 @@ __all__ = [
     "StructuredPromptAssemblyError",
     "ValidationIssue",
     "assemble_prompt_definition",
+    "convert_legacy_prompt_to_definition",
+    "extract_legacy_prompt_variables",
+    "normalize_legacy_prompt_template",
     "render_legacy_snapshot",
     "validate_prompt_definition",
 ]

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/__init__.py
@@ -1,7 +1,14 @@
+from .assembler import (
+    StructuredPromptAssemblyError,
+    assemble_prompt_definition,
+)
+from .legacy_renderer import render_legacy_snapshot
 from .models import (
     PromptAssemblyConfig,
+    PromptAssemblyResult,
     PromptBlock,
     PromptDefinition,
+    PromptLegacySnapshot,
     PromptVariableDefinition,
     ValidationIssue,
 )
@@ -9,9 +16,14 @@ from .validator import validate_prompt_definition
 
 __all__ = [
     "PromptAssemblyConfig",
+    "PromptAssemblyResult",
     "PromptBlock",
     "PromptDefinition",
+    "PromptLegacySnapshot",
     "PromptVariableDefinition",
+    "StructuredPromptAssemblyError",
     "ValidationIssue",
+    "assemble_prompt_definition",
+    "render_legacy_snapshot",
     "validate_prompt_definition",
 ]

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/assembler.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/assembler.py
@@ -1,0 +1,210 @@
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from .legacy_renderer import render_legacy_snapshot
+from .models import PromptAssemblyResult, PromptDefinition, PromptVariableDefinition
+from .validator import validate_prompt_definition
+
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
+
+
+class StructuredPromptAssemblyError(ValueError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        variable_name: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.variable_name = variable_name
+
+
+def assemble_prompt_definition(
+    definition: dict[str, Any] | PromptDefinition,
+    variables: Mapping[str, Any] | None,
+    *,
+    extras: Mapping[str, Any] | None = None,
+) -> PromptAssemblyResult:
+    prompt_definition = _coerce_definition(definition)
+    validation_issues = validate_prompt_definition(prompt_definition)
+    if validation_issues:
+        first_issue = validation_issues[0]
+        raise StructuredPromptAssemblyError(
+            "invalid_prompt_definition",
+            first_issue.message,
+        )
+
+    resolved_variables = _resolve_variables(prompt_definition, variables or {})
+    rendered_messages = _render_block_messages(prompt_definition, resolved_variables)
+    messages = _insert_fixed_sections(rendered_messages, extras or {})
+    legacy = render_legacy_snapshot(messages, prompt_definition)
+    return PromptAssemblyResult(messages=messages, legacy=legacy)
+
+
+def _coerce_definition(definition: dict[str, Any] | PromptDefinition) -> PromptDefinition:
+    if isinstance(definition, PromptDefinition):
+        return definition
+    return PromptDefinition.model_validate(definition)
+
+
+def _resolve_variables(
+    definition: PromptDefinition,
+    variables: Mapping[str, Any],
+) -> dict[str, Any]:
+    resolved: dict[str, Any] = {}
+    for variable in definition.variables:
+        resolved[variable.name] = _resolve_variable(variable, variables)
+    return resolved
+
+
+def _resolve_variable(
+    variable: PromptVariableDefinition,
+    variables: Mapping[str, Any],
+) -> Any:
+    if variable.name in variables:
+        return variables[variable.name]
+    if variable.default_value is not None:
+        return variable.default_value
+    if variable.required:
+        raise StructuredPromptAssemblyError(
+            "missing_required_variable",
+            f"Missing required variable: {variable.name}",
+            variable_name=variable.name,
+        )
+    return ""
+
+
+def _render_block_messages(
+    definition: PromptDefinition,
+    resolved_variables: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    ordered_blocks = sorted(definition.blocks, key=lambda block: block.order)
+    rendered_messages: list[dict[str, str]] = []
+
+    for block in ordered_blocks:
+        if not block.enabled:
+            continue
+        rendered_messages.append(
+            {
+                "role": block.role,
+                "content": _render_block_content(block.content, block.is_template, resolved_variables),
+            }
+        )
+
+    return rendered_messages
+
+
+def _render_block_content(
+    content: str,
+    is_template: bool,
+    resolved_variables: Mapping[str, Any],
+) -> str:
+    if not is_template:
+        return content
+
+    def replace_variable(match: re.Match[str]) -> str:
+        variable_name = match.group(1)
+        if variable_name not in resolved_variables:
+            raise StructuredPromptAssemblyError(
+                "unknown_variable_reference",
+                f"Unknown variable reference: {variable_name}",
+                variable_name=variable_name,
+            )
+        value = resolved_variables[variable_name]
+        return "" if value is None else str(value)
+
+    return _TEMPLATE_VARIABLE_PATTERN.sub(replace_variable, content)
+
+
+def _insert_fixed_sections(
+    rendered_messages: list[dict[str, str]],
+    extras: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    inserted_messages = _render_module_messages(extras.get("modules_config"))
+    inserted_messages.extend(_render_example_messages(extras.get("few_shot_examples")))
+
+    if not inserted_messages:
+        return list(rendered_messages)
+
+    first_user_index = next(
+        (index for index, message in enumerate(rendered_messages) if message["role"] == "user"),
+        len(rendered_messages),
+    )
+    return (
+        rendered_messages[:first_user_index]
+        + inserted_messages
+        + rendered_messages[first_user_index:]
+    )
+
+
+def _render_module_messages(modules_config: Any) -> list[dict[str, str]]:
+    if not isinstance(modules_config, list):
+        return []
+
+    rendered_modules: list[dict[str, str]] = []
+    for module in modules_config:
+        if not isinstance(module, Mapping):
+            continue
+        if module.get("enabled") is False:
+            continue
+
+        module_type = str(module.get("type") or "unknown")
+        config = module.get("config")
+        if isinstance(config, Mapping) and config:
+            config_text = ", ".join(
+                f"{key}={_stringify_module_value(value)}"
+                for key, value in sorted(config.items())
+            )
+            content = f"Module {module_type}: {config_text}"
+        else:
+            content = f"Module {module_type}"
+
+        rendered_modules.append({"role": "developer", "content": content})
+
+    return rendered_modules
+
+
+def _stringify_module_value(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, sort_keys=True)
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value)
+
+
+def _render_example_messages(few_shot_examples: Any) -> list[dict[str, str]]:
+    if not isinstance(few_shot_examples, list):
+        return []
+
+    rendered_examples: list[dict[str, str]] = []
+    for example in few_shot_examples:
+        if not isinstance(example, Mapping):
+            continue
+
+        example_inputs = example.get("inputs", example.get("input"))
+        example_outputs = example.get("outputs", example.get("output"))
+
+        if example_inputs is not None:
+            rendered_examples.append(
+                {
+                    "role": "user",
+                    "content": f"Example input: {_json_text(example_inputs)}",
+                }
+            )
+        if example_outputs is not None:
+            rendered_examples.append(
+                {
+                    "role": "assistant",
+                    "content": f"Example output: {_json_text(example_outputs)}",
+                }
+            )
+
+    return rendered_examples
+
+
+def _json_text(value: Any) -> str:
+    return json.dumps(value, sort_keys=True)

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/conversion.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/conversion.py
@@ -1,0 +1,87 @@
+import re
+
+from .models import PromptBlock, PromptDefinition, PromptVariableDefinition
+
+_LEGACY_TEMPLATE_PATTERN = re.compile(
+    r"{{\s*([a-zA-Z0-9_]+)\s*}}|\{([a-zA-Z0-9_]+)\}|\$([a-zA-Z0-9_]+)|<([a-zA-Z0-9_]+)>"
+)
+
+
+def extract_legacy_prompt_variables(*templates: str | None) -> list[str]:
+    variables: list[str] = []
+    for template in templates:
+        for match in _LEGACY_TEMPLATE_PATTERN.finditer(template or ""):
+            variable_name = _match_variable_name(match)
+            if variable_name not in variables:
+                variables.append(variable_name)
+    return variables
+
+
+def normalize_legacy_prompt_template(template: str | None) -> str:
+    if not template:
+        return ""
+    return _LEGACY_TEMPLATE_PATTERN.sub(
+        lambda match: "{{" + _match_variable_name(match) + "}}",
+        template,
+    )
+
+
+def convert_legacy_prompt_to_definition(
+    *,
+    system_prompt: str | None,
+    user_prompt: str | None,
+) -> PromptDefinition:
+    variables = extract_legacy_prompt_variables(system_prompt, user_prompt)
+    blocks: list[PromptBlock] = []
+
+    normalized_system_prompt = normalize_legacy_prompt_template(system_prompt)
+    if normalized_system_prompt:
+        blocks.append(
+            PromptBlock(
+                id="legacy_system",
+                name="System Instructions",
+                role="system",
+                kind="instructions",
+                content=normalized_system_prompt,
+                enabled=True,
+                order=10,
+                is_template="{{" in normalized_system_prompt,
+            )
+        )
+
+    normalized_user_prompt = normalize_legacy_prompt_template(user_prompt)
+    if normalized_user_prompt:
+        blocks.append(
+            PromptBlock(
+                id="legacy_user",
+                name="User Prompt",
+                role="user",
+                kind="task",
+                content=normalized_user_prompt,
+                enabled=True,
+                order=20,
+                is_template="{{" in normalized_user_prompt,
+            )
+        )
+
+    variable_definitions = [
+        PromptVariableDefinition(
+            name=variable_name,
+            label=variable_name.replace("_", " ").title(),
+            required=True,
+            input_type="textarea",
+        )
+        for variable_name in variables
+    ]
+
+    return PromptDefinition(
+        variables=variable_definitions,
+        blocks=blocks,
+    )
+
+
+def _match_variable_name(match: re.Match[str]) -> str:
+    for group in match.groups():
+        if group:
+            return group
+    return ""

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/legacy_renderer.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/legacy_renderer.py
@@ -1,0 +1,18 @@
+from .models import PromptDefinition, PromptLegacySnapshot
+
+
+def render_legacy_snapshot(
+    messages: list[dict[str, str]],
+    definition: PromptDefinition,
+) -> PromptLegacySnapshot:
+    separator = definition.assembly_config.block_separator
+    system_roles = set(definition.assembly_config.legacy_system_roles)
+    user_roles = set(definition.assembly_config.legacy_user_roles)
+
+    system_prompt = separator.join(
+        message["content"] for message in messages if message["role"] in system_roles
+    )
+    user_prompt = separator.join(
+        message["content"] for message in messages if message["role"] in user_roles
+    )
+    return PromptLegacySnapshot(system_prompt=system_prompt, user_prompt=user_prompt)

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py
@@ -1,0 +1,53 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ValidationIssue(BaseModel):
+    code: str
+    message: str
+    path: str | None = None
+
+
+class PromptVariableDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1)
+    label: str | None = None
+    description: str | None = None
+    required: bool = False
+    default_value: Any = None
+    input_type: str = "text"
+    options: list[str] | None = None
+    max_length: int | None = Field(default=None, ge=1)
+
+
+class PromptBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    role: Literal["system", "developer", "user", "assistant"]
+    kind: str | None = None
+    content: str
+    enabled: bool = True
+    order: int
+    is_template: bool = False
+
+
+class PromptAssemblyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    legacy_system_roles: list[str] = Field(default_factory=lambda: ["system", "developer"])
+    legacy_user_roles: list[str] = Field(default_factory=lambda: ["user"])
+    block_separator: str = "\n\n"
+
+
+class PromptDefinition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = 1
+    format: Literal["structured"] = "structured"
+    variables: list[PromptVariableDefinition] = Field(default_factory=list)
+    blocks: list[PromptBlock] = Field(default_factory=list)
+    assembly_config: PromptAssemblyConfig = Field(default_factory=PromptAssemblyConfig)

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/models.py
@@ -3,6 +3,16 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class PromptLegacySnapshot(BaseModel):
+    system_prompt: str
+    user_prompt: str
+
+
+class PromptAssemblyResult(BaseModel):
+    messages: list[dict[str, str]]
+    legacy: PromptLegacySnapshot
+
+
 class ValidationIssue(BaseModel):
     code: str
     message: str

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py
@@ -1,10 +1,12 @@
 from collections.abc import Mapping
+import re
 from typing import Any
 
 from .models import PromptDefinition, ValidationIssue
 
 SUPPORTED_SCHEMA_VERSION = 1
 VALID_BLOCK_ROLES = {"system", "developer", "user", "assistant"}
+_TEMPLATE_VARIABLE_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
@@ -18,6 +20,7 @@ def _as_mapping(value: Any) -> Mapping[str, Any]:
 def validate_prompt_definition(definition: dict[str, Any] | PromptDefinition) -> list[ValidationIssue]:
     payload = _as_mapping(definition)
     issues: list[ValidationIssue] = []
+    declared_variable_names: set[str] = set()
 
     if payload.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
         issues.append(
@@ -47,6 +50,7 @@ def validate_prompt_definition(definition: dict[str, Any] | PromptDefinition) ->
                 )
                 break
             seen_variable_names.add(name)
+            declared_variable_names.add(name)
 
     blocks = payload.get("blocks", [])
     if isinstance(blocks, list):
@@ -78,5 +82,21 @@ def validate_prompt_definition(definition: dict[str, Any] | PromptDefinition) ->
                     )
                 )
                 break
+
+            if block.get("is_template") is True:
+                content = str(block.get("content") or "")
+                for match in _TEMPLATE_VARIABLE_PATTERN.finditer(content):
+                    variable_name = match.group(1)
+                    if variable_name not in declared_variable_names:
+                        issues.append(
+                            ValidationIssue(
+                                code="unknown_variable_reference",
+                                message=f"Unknown variable reference: {variable_name}",
+                                path=f"blocks[{index}].content",
+                            )
+                        )
+                        break
+                if issues:
+                    break
 
     return issues

--- a/tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py
+++ b/tldw_Server_API/app/core/Prompt_Management/structured_prompts/validator.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any
+
+from .models import PromptDefinition, ValidationIssue
+
+SUPPORTED_SCHEMA_VERSION = 1
+VALID_BLOCK_ROLES = {"system", "developer", "user", "assistant"}
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    if isinstance(value, PromptDefinition):
+        return value.model_dump()
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def validate_prompt_definition(definition: dict[str, Any] | PromptDefinition) -> list[ValidationIssue]:
+    payload = _as_mapping(definition)
+    issues: list[ValidationIssue] = []
+
+    if payload.get("schema_version") != SUPPORTED_SCHEMA_VERSION:
+        issues.append(
+            ValidationIssue(
+                code="unsupported_schema_version",
+                message=f"Unsupported schema version: {payload.get('schema_version')!r}",
+                path="schema_version",
+            )
+        )
+
+    variables = payload.get("variables", [])
+    if isinstance(variables, list):
+        seen_variable_names: set[str] = set()
+        for index, variable in enumerate(variables):
+            if not isinstance(variable, Mapping):
+                continue
+            name = str(variable.get("name") or "").strip()
+            if not name:
+                continue
+            if name in seen_variable_names:
+                issues.append(
+                    ValidationIssue(
+                        code="duplicate_variable_name",
+                        message=f"Duplicate variable name: {name}",
+                        path=f"variables[{index}].name",
+                    )
+                )
+                break
+            seen_variable_names.add(name)
+
+    blocks = payload.get("blocks", [])
+    if isinstance(blocks, list):
+        seen_block_ids: set[str] = set()
+        for index, block in enumerate(blocks):
+            if not isinstance(block, Mapping):
+                continue
+
+            block_id = str(block.get("id") or "").strip()
+            if block_id:
+                if block_id in seen_block_ids:
+                    issues.append(
+                        ValidationIssue(
+                            code="duplicate_block_id",
+                            message=f"Duplicate block id: {block_id}",
+                            path=f"blocks[{index}].id",
+                        )
+                    )
+                    break
+                seen_block_ids.add(block_id)
+
+            role = block.get("role")
+            if role not in VALID_BLOCK_ROLES:
+                issues.append(
+                    ValidationIssue(
+                        code="invalid_block_role",
+                        message=f"Invalid block role: {role!r}",
+                        path=f"blocks[{index}].role",
+                    )
+                )
+                break
+
+    return issues

--- a/tldw_Server_API/tests/Prompt_Management/test_prompts_interop.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_prompts_interop.py
@@ -72,6 +72,66 @@ def test_interop_add_prompt_via_global_instance(interop_manager):
     assert details["name"] == "Interop Prompt"
 
 
+def test_interop_add_prompt_preserves_legacy_keyword_positionals(interop_manager):
+
+    p_id, p_uuid, msg = interop_add_prompt(
+        "Interop Keyword Prompt",
+        "Interop",
+        "Keyword positional compatibility",
+        None,
+        None,
+        ["legacy_kw"],
+        False,
+    )
+
+    assert p_id is not None
+    assert "added" in msg
+
+    details = interop_fetch_prompt_details(p_uuid)
+    assert details is not None
+    assert "legacy_kw" in details["keywords"]
+
+
+def test_interop_add_prompt_passes_structured_fields_and_keywords(interop_manager):
+
+    prompt_definition = {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [],
+        "blocks": [
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize this input.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            }
+        ],
+    }
+
+    p_id, p_uuid, msg = interop_add_prompt(
+        name="Interop Structured Prompt",
+        author="Interop",
+        details="Structured via global instance",
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=prompt_definition,
+        keywords=["structured_kw"],
+    )
+
+    assert p_id is not None
+    assert "added" in msg
+
+    details = interop_fetch_prompt_details(p_uuid)
+    assert details is not None
+    assert details["prompt_format"] == "structured"
+    assert details["prompt_schema_version"] == 1
+    assert details["prompt_definition"]["blocks"][0]["content"] == "Summarize this input."
+    assert "structured_kw" in details["keywords"]
+
+
 # --- Testing standalone wrapper functions from interop ---
 # These take a db_instance, so we need to provide one.
 # For these, the interop's global instance isn't directly used by the function itself,

--- a/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_assembler.py
@@ -1,0 +1,103 @@
+# test_structured_prompt_assembler.py
+# Unit tests for structured prompt assembly and legacy rendering
+
+import pytest
+
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts.assembler import (
+    StructuredPromptAssemblyError,
+    assemble_prompt_definition,
+)
+
+
+def _make_definition(**overrides):
+    definition = {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "topic",
+                "label": "Topic",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are precise.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize {{topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+    definition.update(overrides)
+    return definition
+
+
+def test_assembler_returns_canonical_messages_and_legacy_snapshot():
+    result = assemble_prompt_definition(_make_definition(), {"topic": "SQLite FTS"})
+
+    assert result.messages == [
+        {"role": "system", "content": "You are precise."},
+        {"role": "user", "content": "Summarize SQLite FTS"},
+    ]
+    assert result.legacy.system_prompt == "You are precise."
+    assert result.legacy.user_prompt == "Summarize SQLite FTS"
+
+
+def test_assembler_raises_when_required_variable_missing():
+    with pytest.raises(StructuredPromptAssemblyError) as exc_info:
+        assemble_prompt_definition(_make_definition(), {})
+
+    assert exc_info.value.code == "missing_required_variable"
+    assert exc_info.value.variable_name == "topic"
+
+
+def test_assembler_inserts_few_shot_examples_and_modules_at_fixed_points():
+    result = assemble_prompt_definition(
+        _make_definition(),
+        {"topic": "SQLite FTS"},
+        extras={
+            "few_shot_examples": [
+                {
+                    "inputs": {"topic": "Indexes"},
+                    "outputs": {"answer": "Use the covering index."},
+                }
+            ],
+            "modules_config": [
+                {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+            ],
+        },
+    )
+
+    assert [message["role"] for message in result.messages] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert result.messages[1]["content"] == "Module style_rules: tone=concise"
+    assert result.messages[2]["content"] == 'Example input: {"topic": "Indexes"}'
+    assert result.messages[3]["content"] == 'Example output: {"answer": "Use the covering index."}'
+    assert result.messages[4]["content"] == "Summarize SQLite FTS"
+    assert "Module style_rules: tone=concise" in result.legacy.system_prompt
+    assert 'Example input: {"topic": "Indexes"}' in result.legacy.user_prompt
+    assert "Summarize SQLite FTS" in result.legacy.user_prompt

--- a/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_conversion.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_conversion.py
@@ -1,0 +1,32 @@
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts import (
+    convert_legacy_prompt_to_definition,
+    extract_legacy_prompt_variables,
+)
+
+
+def test_extract_legacy_prompt_variables_preserves_first_seen_order():
+    variables = extract_legacy_prompt_variables(
+        "You are helping with {topic}.",
+        "Summarize $topic and compare against <baseline> with {{style}}.",
+    )
+
+    assert variables == ["topic", "baseline", "style"]
+
+
+def test_convert_legacy_prompt_to_definition_normalizes_placeholder_styles():
+    definition = convert_legacy_prompt_to_definition(
+        system_prompt="Be precise about {topic}.",
+        user_prompt="Summarize $topic and compare against <baseline> in {{style}}.",
+    )
+
+    assert [variable.name for variable in definition.variables] == [
+        "topic",
+        "baseline",
+        "style",
+    ]
+    assert definition.blocks[0].content == "Be precise about {{topic}}."
+    assert definition.blocks[0].is_template is True
+    assert definition.blocks[1].content == (
+        "Summarize {{topic}} and compare against {{baseline}} in {{style}}."
+    )
+    assert definition.blocks[1].is_template is True

--- a/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py
@@ -120,3 +120,24 @@ def test_validator_rejects_unsupported_schema_version():
     errors = validate_prompt_definition(_make_definition(schema_version=99))
 
     assert [error.code for error in errors] == ["unsupported_schema_version"]
+
+
+def test_validator_rejects_unknown_variable_references():
+    definition = _make_definition(
+        variables=[],
+        blocks=[
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize {{missing_topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            }
+        ],
+    )
+
+    errors = validate_prompt_definition(definition)
+
+    assert [error.code for error in errors] == ["unknown_variable_reference"]

--- a/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py
+++ b/tldw_Server_API/tests/Prompt_Management/test_structured_prompt_validator.py
@@ -1,0 +1,122 @@
+# test_structured_prompt_validator.py
+# Unit tests for structured prompt definition validation
+
+from tldw_Server_API.app.core.Prompt_Management.structured_prompts.validator import (
+    validate_prompt_definition,
+)
+
+
+def _make_definition(**overrides):
+    definition = {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "topic",
+                "label": "Topic",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are precise.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize {{topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+    definition.update(overrides)
+    return definition
+
+
+def test_validator_accepts_valid_definition():
+    errors = validate_prompt_definition(_make_definition())
+
+    assert errors == []
+
+
+def test_validator_rejects_duplicate_variable_names():
+    definition = _make_definition(
+        variables=[
+            {"name": "topic", "required": True, "input_type": "textarea"},
+            {"name": "topic", "required": False, "input_type": "text"},
+        ]
+    )
+
+    errors = validate_prompt_definition(definition)
+
+    assert [error.code for error in errors] == ["duplicate_variable_name"]
+
+
+def test_validator_rejects_duplicate_block_ids():
+    definition = _make_definition(
+        blocks=[
+            {
+                "id": "task",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are precise.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize {{topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ]
+    )
+
+    errors = validate_prompt_definition(definition)
+
+    assert [error.code for error in errors] == ["duplicate_block_id"]
+
+
+def test_validator_rejects_invalid_block_role():
+    definition = _make_definition(
+        blocks=[
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "tool",
+                "content": "Summarize {{topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            }
+        ]
+    )
+
+    errors = validate_prompt_definition(definition)
+
+    assert [error.code for error in errors] == ["invalid_block_role"]
+
+
+def test_validator_rejects_unsupported_schema_version():
+    errors = validate_prompt_definition(_make_definition(schema_version=99))
+
+    assert [error.code for error in errors] == ["unsupported_schema_version"]

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
@@ -120,3 +120,46 @@ def test_update_structured_prompt_preserves_format_when_prompt_format_is_omitted
     updated_body = update_response.json()
     assert updated_body["prompt_format"] == "structured"
     assert updated_body["prompt_definition"]["blocks"][1]["content"] == "Evaluate {{topic}} carefully."
+
+
+def test_preview_prompt_returns_assembled_messages_and_legacy_snapshot(test_client, auth_headers):
+    response = test_client.post(
+        "/api/v1/prompts/preview",
+        json={
+            "prompt_format": "structured",
+            "prompt_schema_version": 1,
+            "prompt_definition": _make_prompt_definition_payload(),
+            "variables": {"topic": "SQLite FTS"},
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["assembled_messages"] == [
+        {"role": "system", "content": "You are precise."},
+        {"role": "user", "content": "Summarize SQLite FTS"},
+    ]
+    assert body["legacy_system_prompt"] == "You are precise."
+    assert body["legacy_user_prompt"] == "Summarize SQLite FTS"
+
+
+def test_convert_prompt_returns_structured_definition_with_normalized_variables(test_client, auth_headers):
+    response = test_client.post(
+        "/api/v1/prompts/convert",
+        json={
+            "system_prompt": "Be precise about {topic}.",
+            "user_prompt": "Summarize $topic against <baseline> in {{style}}.",
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["prompt_format"] == "structured"
+    assert body["prompt_schema_version"] == 1
+    assert body["extracted_variables"] == ["topic", "baseline", "style"]
+    assert body["prompt_definition"]["blocks"][0]["content"] == "Be precise about {{topic}}."
+    assert body["prompt_definition"]["blocks"][1]["content"] == (
+        "Summarize {{topic}} against {{baseline}} in {{style}}."
+    )

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
@@ -1,0 +1,122 @@
+"""
+Integration tests for structured prompt support in the regular Prompts API.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _make_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "topic",
+                "label": "Topic",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are precise.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Summarize {{topic}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
+
+def test_create_structured_prompt_persists_definition_and_format(test_client, auth_headers):
+    payload = {
+        "name": "Structured Summarizer",
+        "author": "integration-test",
+        "prompt_format": "structured",
+        "prompt_schema_version": 1,
+        "prompt_definition": _make_prompt_definition_payload(),
+        "keywords": ["summary"],
+    }
+
+    create_response = test_client.post(
+        "/api/v1/prompts",
+        json=payload,
+        headers=auth_headers,
+    )
+
+    assert create_response.status_code == 201, create_response.text
+    created_body = create_response.json()
+    assert created_body["prompt_format"] == "structured"
+    assert created_body["prompt_schema_version"] == 1
+    assert created_body["prompt_definition"]["schema_version"] == 1
+
+    prompt_id = created_body["id"]
+    get_response = test_client.get(
+        f"/api/v1/prompts/{prompt_id}",
+        headers=auth_headers,
+    )
+
+    assert get_response.status_code == 200, get_response.text
+    fetched_body = get_response.json()
+    assert fetched_body["prompt_format"] == "structured"
+    assert fetched_body["prompt_schema_version"] == 1
+    assert fetched_body["prompt_definition"]["blocks"][1]["content"] == "Summarize {{topic}}"
+
+
+def test_update_structured_prompt_preserves_format_when_prompt_format_is_omitted(
+    test_client,
+    auth_headers,
+):
+    create_response = test_client.post(
+        "/api/v1/prompts",
+        json={
+            "name": "Structured Evaluator",
+            "author": "integration-test",
+            "prompt_format": "structured",
+            "prompt_schema_version": 1,
+            "prompt_definition": _make_prompt_definition_payload(),
+            "keywords": ["evaluate"],
+        },
+        headers=auth_headers,
+    )
+
+    assert create_response.status_code == 201, create_response.text
+    created_body = create_response.json()
+    updated_definition = _make_prompt_definition_payload()
+    updated_definition["blocks"][1]["content"] = "Evaluate {{topic}} carefully."
+
+    update_response = test_client.put(
+        f"/api/v1/prompts/{created_body['id']}",
+        json={
+            "name": created_body["name"],
+            "author": created_body["author"],
+            "prompt_schema_version": 1,
+            "prompt_definition": updated_definition,
+            "keywords": created_body["keywords"],
+        },
+        headers=auth_headers,
+    )
+
+    assert update_response.status_code == 200, update_response.text
+    updated_body = update_response.json()
+    assert updated_body["prompt_format"] == "structured"
+    assert updated_body["prompt_definition"]["blocks"][1]["content"] == "Evaluate {{topic}} carefully."

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
@@ -144,6 +144,25 @@ def test_preview_prompt_returns_assembled_messages_and_legacy_snapshot(test_clie
     assert body["legacy_user_prompt"] == "Summarize SQLite FTS"
 
 
+def test_preview_prompt_rejects_missing_required_variable_with_client_error(
+    test_client,
+    auth_headers,
+):
+    response = test_client.post(
+        "/api/v1/prompts/preview",
+        json={
+            "prompt_format": "structured",
+            "prompt_schema_version": 1,
+            "prompt_definition": _make_prompt_definition_payload(),
+            "variables": {},
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert "Missing required variable: topic" in response.json()["detail"]
+
+
 def test_convert_prompt_returns_structured_definition_with_normalized_variables(test_client, auth_headers):
     response = test_client.post(
         "/api/v1/prompts/convert",

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_prompts_structured_api.py
@@ -163,3 +163,40 @@ def test_convert_prompt_returns_structured_definition_with_normalized_variables(
     assert body["prompt_definition"]["blocks"][1]["content"] == (
         "Summarize {{topic}} against {{baseline}} in {{style}}."
     )
+
+
+def test_create_structured_prompt_rejects_unknown_variable_references(test_client, auth_headers):
+    invalid_definition = _make_prompt_definition_payload()
+    invalid_definition["variables"] = []
+
+    response = test_client.post(
+        "/api/v1/prompts",
+        json={
+            "name": "Broken Structured Prompt",
+            "author": "integration-test",
+            "prompt_format": "structured",
+            "prompt_schema_version": 1,
+            "prompt_definition": invalid_definition,
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert "Unknown variable reference" in response.json()["detail"]
+
+
+def test_create_structured_prompt_rejects_schema_version_mismatch(test_client, auth_headers):
+    response = test_client.post(
+        "/api/v1/prompts",
+        json={
+            "name": "Mismatched Structured Prompt",
+            "author": "integration-test",
+            "prompt_format": "structured",
+            "prompt_schema_version": 999,
+            "prompt_definition": _make_prompt_definition_payload(),
+        },
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert "must match prompt_definition.schema_version" in response.json()["detail"]

--- a/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py
+++ b/tldw_Server_API/tests/Prompt_Management_NEW/integration/test_structured_prompt_search.py
@@ -1,0 +1,82 @@
+"""
+Integration tests for structured prompt search indexing.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _make_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "text",
+                "label": "Text",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a classifier.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Classify {{text}} by sentiment.",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+            {
+                "id": "rubric",
+                "name": "Rubric",
+                "role": "assistant",
+                "content": "Use the mauveflint verdict label when sentiment is mixed.",
+                "enabled": True,
+                "order": 30,
+                "is_template": False,
+            },
+        ],
+    }
+
+
+def test_structured_prompt_search_indexes_enabled_block_content(
+    test_client,
+    auth_headers,
+):
+    create_response = test_client.post(
+        "/api/v1/prompts",
+        json={
+            "name": "Structured Classifier",
+            "author": "integration-test",
+            "prompt_format": "structured",
+            "prompt_schema_version": 1,
+            "prompt_definition": _make_prompt_definition_payload(),
+            "keywords": ["classification"],
+        },
+        headers=auth_headers,
+    )
+
+    assert create_response.status_code == 201, create_response.text
+
+    search_response = test_client.post(
+        "/api/v1/prompts/search",
+        params={"search_query": "mauveflint"},
+        headers=auth_headers,
+    )
+
+    assert search_response.status_code == 200, search_response.text
+    body = search_response.json()
+    assert body["total_matches"] == 1
+    assert body["items"][0]["name"] == "Structured Classifier"

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -20,6 +20,46 @@ from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import get_prompt_st
 ########################################################################################################################
 # Test Client Setup
 
+
+def _make_structured_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "input",
+                "label": "Input",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a careful evaluator.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Evaluate {{input}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
 @pytest.fixture
 def client(mock_user, test_db):
     """Create a test client for the FastAPI app with mocked authentication."""
@@ -295,6 +335,80 @@ class TestPromptEndpoints:
                 data = response.json()
                 assert "output" in data
                 assert data["tokens_used"] == 100
+
+    def test_preview_prompt_renders_structured_messages(self, client, test_db, project_id, auth_headers):
+
+        """Test previewing a structured prompt with modules/examples/signature output."""
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        signature = test_db.create_signature(
+            project_id=project_id,
+            name="Preview Signature",
+            input_schema=[{"name": "input", "type": "string"}],
+            output_schema=[{"name": "answer", "type": "string"}],
+        )
+
+        response = client.post(
+            "/api/v1/prompt-studio/prompts/preview",
+            json={
+                "project_id": project_id,
+                "signature_id": signature["id"],
+                "prompt_format": "structured",
+                "prompt_schema_version": 1,
+                "prompt_definition": _make_structured_prompt_definition_payload(),
+                "few_shot_examples": [
+                    {
+                        "inputs": {"input": "Indexes"},
+                        "outputs": {"answer": "Use the covering index."},
+                    }
+                ],
+                "modules_config": [
+                    {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+                ],
+                "variables": {"input": "SQLite FTS"},
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()["data"]
+        assert [message["role"] for message in data["assembled_messages"]] == [
+            "system",
+            "developer",
+            "user",
+            "assistant",
+            "user",
+        ]
+        assert data["assembled_messages"][1]["content"] == "Module style_rules: tone=concise"
+        assert data["assembled_messages"][4]["content"].startswith("Evaluate SQLite FTS")
+        assert "Please format your response as JSON" in data["assembled_messages"][4]["content"]
+
+    def test_convert_prompt_returns_structured_definition(self, client, project_id, auth_headers):
+
+        """Test converting a legacy prompt payload into a structured definition."""
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        response = client.post(
+            "/api/v1/prompt-studio/prompts/convert",
+            json={
+                "project_id": project_id,
+                "system_prompt": "Be precise about {input}.",
+                "user_prompt": "Evaluate $input against <baseline>.",
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200, response.text
+        data = response.json()["data"]
+        assert data["prompt_format"] == "structured"
+        assert data["prompt_schema_version"] == 1
+        assert data["extracted_variables"] == ["input", "baseline"]
+        assert data["prompt_definition"]["blocks"][0]["content"] == "Be precise about {{input}}."
+        assert data["prompt_definition"]["blocks"][1]["content"] == (
+            "Evaluate {{input}} against {{baseline}}."
+        )
 
 ########################################################################################################################
 # Test Case Endpoints Tests

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -68,6 +68,17 @@ def _make_structured_prompt_definition_with_default(*, default_value: str) -> di
     definition["variables"][0]["default_value"] = default_value
     return definition
 
+
+def _make_structured_prompt_definition_with_literal_user_content(
+    *,
+    user_content: str,
+) -> dict:
+    definition = _make_structured_prompt_definition_payload()
+    definition["variables"] = []
+    definition["blocks"][1]["content"] = user_content
+    definition["blocks"][1]["is_template"] = False
+    return definition
+
 @pytest.fixture
 def client(mock_user, test_db):
     """Create a test client for the FastAPI app with mocked authentication."""
@@ -443,6 +454,52 @@ class TestPromptEndpoints:
         finally:
             app.dependency_overrides.pop(get_security_config, None)
 
+    def test_create_prompt_rejects_signature_augmented_payload_exceeding_security_limit(
+        self,
+        client,
+        test_db,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        signature = test_db.create_signature(
+            project_id=project_id,
+            name="Create Limit Signature",
+            input_schema=[{"name": "input", "type": "string"}],
+            output_schema=[{"name": "x" * 20, "type": "string"}],
+        )
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=120,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "signature_id": signature["id"],
+                    "name": "Signature Length Prompt",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_with_literal_user_content(
+                        user_content="x" * 40
+                    ),
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 400, response.text
+            assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
     def test_convert_prompt_returns_structured_definition(self, client, project_id, auth_headers):
 
         """Test converting a legacy prompt payload into a structured definition."""
@@ -638,6 +695,68 @@ class TestPromptEndpoints:
                         default_value="x" * 140
                     ),
                     "change_description": "Introduce oversized default",
+                },
+                headers=auth_headers,
+            )
+
+            assert update_response.status_code == 400, update_response.text
+            assert "exceeds maximum length" in update_response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
+    def test_update_prompt_rejects_signature_augmented_payload_exceeding_security_limit(
+        self,
+        client,
+        test_db,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        signature = test_db.create_signature(
+            project_id=project_id,
+            name="Update Limit Signature",
+            input_schema=[{"name": "input", "type": "string"}],
+            output_schema=[{"name": "x" * 20, "type": "string"}],
+        )
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=120,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            create_response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "signature_id": signature["id"],
+                    "name": "Structured Prompt With Signature",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_with_literal_user_content(
+                        user_content="short"
+                    ),
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert create_response.status_code in [200, 201], create_response.text
+            prompt_id = create_response.json()["id"]
+
+            update_response = client.put(
+                f"/api/v1/prompt-studio/prompts/update/{prompt_id}",
+                json={
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_with_literal_user_content(
+                        user_content="x" * 40
+                    ),
+                    "change_description": "Increase task text",
                 },
                 headers=auth_headers,
             )

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -428,6 +428,30 @@ class TestPromptEndpoints:
         assert data["assembled_messages"][4]["content"].startswith("Evaluate SQLite FTS")
         assert "Please format your response as JSON" in data["assembled_messages"][4]["content"]
 
+    def test_preview_prompt_rejects_missing_required_variable_with_client_error(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        response = client.post(
+            "/api/v1/prompt-studio/prompts/preview",
+            json={
+                "project_id": project_id,
+                "prompt_format": "structured",
+                "prompt_schema_version": 1,
+                "prompt_definition": _make_structured_prompt_definition_payload(),
+                "variables": {},
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, response.text
+        assert "Missing required variable: input" in response.json()["detail"]
+
     def test_preview_prompt_rejects_oversized_assistant_block(
         self,
         client,

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -13,6 +13,8 @@ os.environ["AUTH_MODE"] = "single_user"
 os.environ["CSRF_ENABLED"] = "false"
 
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import get_security_config
+from tldw_Server_API.app.api.v1.schemas.prompt_studio_base import SecurityConfig
 from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import PromptStudioDatabase
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_current_active_user
 from tldw_Server_API.app.api.v1.API_Deps.prompt_studio_deps import get_prompt_studio_db
@@ -409,6 +411,44 @@ class TestPromptEndpoints:
         assert data["prompt_definition"]["blocks"][1]["content"] == (
             "Evaluate {{input}} against {{baseline}}."
         )
+
+    def test_create_prompt_rejects_structured_payload_exceeding_security_limit(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=100,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            definition = _make_structured_prompt_definition_payload()
+            definition["blocks"][1]["content"] = "Evaluate " + ("x" * 140)
+
+            response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "name": "Too Long Structured Prompt",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": definition,
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 400, response.text
+            assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
 
 ########################################################################################################################
 # Test Case Endpoints Tests

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -62,6 +62,12 @@ def _make_structured_prompt_definition_payload() -> dict:
         },
     }
 
+
+def _make_structured_prompt_definition_with_default(*, default_value: str) -> dict:
+    definition = _make_structured_prompt_definition_payload()
+    definition["variables"][0]["default_value"] = default_value
+    return definition
+
 @pytest.fixture
 def client(mock_user, test_db):
     """Create a test client for the FastAPI app with mocked authentication."""
@@ -550,6 +556,94 @@ class TestPromptEndpoints:
 
             assert response.status_code == 400, response.text
             assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
+    def test_create_prompt_rejects_oversized_variable_default_value(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=100,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "name": "Oversized Structured Default Prompt",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_with_default(
+                        default_value="x" * 140
+                    ),
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 400, response.text
+            assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
+    def test_update_prompt_rejects_oversized_variable_default_value(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=100,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            create_response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "name": "Structured Prompt For Update",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_payload(),
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert create_response.status_code in [200, 201], create_response.text
+            prompt_id = create_response.json()["id"]
+
+            update_response = client.put(
+                f"/api/v1/prompt-studio/prompts/update/{prompt_id}",
+                json={
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": _make_structured_prompt_definition_with_default(
+                        default_value="x" * 140
+                    ),
+                    "change_description": "Introduce oversized default",
+                },
+                headers=auth_headers,
+            )
+
+            assert update_response.status_code == 400, update_response.text
+            assert "exceeds maximum length" in update_response.json()["detail"]
         finally:
             app.dependency_overrides.pop(get_security_config, None)
 

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -386,6 +386,57 @@ class TestPromptEndpoints:
         assert data["assembled_messages"][4]["content"].startswith("Evaluate SQLite FTS")
         assert "Please format your response as JSON" in data["assembled_messages"][4]["content"]
 
+    def test_preview_prompt_rejects_oversized_assistant_block(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=100,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            definition = {
+                "schema_version": 1,
+                "format": "structured",
+                "variables": [],
+                "blocks": [
+                    {
+                        "id": "assistant_example",
+                        "name": "Assistant Example",
+                        "role": "assistant",
+                        "content": "x" * 140,
+                        "enabled": True,
+                        "order": 10,
+                        "is_template": False,
+                    }
+                ],
+            }
+
+            response = client.post(
+                "/api/v1/prompt-studio/prompts/preview",
+                json={
+                    "project_id": project_id,
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": definition,
+                    "variables": {},
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 400, response.text
+            assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
     def test_convert_prompt_returns_structured_definition(self, client, project_id, auth_headers):
 
         """Test converting a legacy prompt payload into a structured definition."""
@@ -437,6 +488,58 @@ class TestPromptEndpoints:
                 json={
                     "project_id": project_id,
                     "name": "Too Long Structured Prompt",
+                    "prompt_format": "structured",
+                    "prompt_schema_version": 1,
+                    "prompt_definition": definition,
+                    "change_description": "Initial version",
+                },
+                headers=auth_headers,
+            )
+
+            assert response.status_code == 400, response.text
+            assert "exceeds maximum length" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_security_config, None)
+
+    def test_create_prompt_rejects_oversized_assistant_block(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        app.dependency_overrides[get_security_config] = lambda: SecurityConfig(
+            max_prompt_length=100,
+            allowed_models=[],
+            blocked_patterns=[],
+            rate_limits={},
+        )
+
+        try:
+            definition = {
+                "schema_version": 1,
+                "format": "structured",
+                "variables": [],
+                "blocks": [
+                    {
+                        "id": "assistant_example",
+                        "name": "Assistant Example",
+                        "role": "assistant",
+                        "content": "x" * 140,
+                        "enabled": True,
+                        "order": 10,
+                        "is_template": False,
+                    }
+                ],
+            }
+
+            response = client.post(
+                "/api/v1/prompt-studio/prompts",
+                json={
+                    "project_id": project_id,
+                    "name": "Oversized Structured Assistant Prompt",
                     "prompt_format": "structured",
                     "prompt_schema_version": 1,
                     "prompt_definition": definition,

--- a/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
+++ b/tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py
@@ -79,6 +79,31 @@ def _make_structured_prompt_definition_with_literal_user_content(
     definition["blocks"][1]["is_template"] = False
     return definition
 
+
+def _make_structured_prompt_definition_exceeding_total_runtime_limit() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [],
+        "blocks": [
+            {
+                "id": f"assistant_{index + 1}",
+                "name": f"Assistant Block {index + 1}",
+                "role": "assistant",
+                "content": "x" * 49000,
+                "enabled": True,
+                "order": (index + 1) * 10,
+                "is_template": False,
+            }
+            for index in range(11)
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
 @pytest.fixture
 def client(mock_user, test_db):
     """Create a test client for the FastAPI app with mocked authentication."""
@@ -454,6 +479,30 @@ class TestPromptEndpoints:
         finally:
             app.dependency_overrides.pop(get_security_config, None)
 
+    def test_preview_prompt_rejects_structured_payload_exceeding_total_runtime_limit(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        response = client.post(
+            "/api/v1/prompt-studio/prompts/preview",
+            json={
+                "project_id": project_id,
+                "prompt_format": "structured",
+                "prompt_schema_version": 1,
+                "prompt_definition": _make_structured_prompt_definition_exceeding_total_runtime_limit(),
+                "variables": {},
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, response.text
+        assert "maximum total length" in response.json()["detail"]
+
     def test_create_prompt_rejects_signature_augmented_payload_exceeding_security_limit(
         self,
         client,
@@ -652,6 +701,31 @@ class TestPromptEndpoints:
             assert "exceeds maximum length" in response.json()["detail"]
         finally:
             app.dependency_overrides.pop(get_security_config, None)
+
+    def test_create_prompt_rejects_structured_payload_exceeding_total_runtime_limit(
+        self,
+        client,
+        project_id,
+        auth_headers,
+    ):
+        if not project_id:
+            pytest.skip("Project creation failed")
+
+        response = client.post(
+            "/api/v1/prompt-studio/prompts",
+            json={
+                "project_id": project_id,
+                "name": "Aggregate Runtime Limit Prompt",
+                "prompt_format": "structured",
+                "prompt_schema_version": 1,
+                "prompt_definition": _make_structured_prompt_definition_exceeding_total_runtime_limit(),
+                "change_description": "Initial version",
+            },
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 400, response.text
+        assert "maximum total length" in response.json()["detail"]
 
     def test_update_prompt_rejects_oversized_variable_default_value(
         self,

--- a/tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py
+++ b/tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py
@@ -1,0 +1,156 @@
+import pytest
+
+from tldw_Server_API.app.core.Prompt_Management.prompt_studio.evaluation_manager import EvaluationManager
+from tldw_Server_API.app.core.Prompt_Management.prompt_studio.test_runner import TestRunner
+
+
+def _make_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "input",
+                "label": "Input",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a careful evaluator.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Evaluate {{input}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
+
+def _seed_structured_prompt_and_case(isolated_db):
+    project = isolated_db.create_project(name="Structured Execution Project", user_id="test-user")
+    prompt = isolated_db.create_prompt(
+        project_id=project["id"],
+        name="Structured Execution Prompt",
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=_make_prompt_definition_payload(),
+        few_shot_examples=[
+            {
+                "inputs": {"input": "Indexes"},
+                "outputs": {"answer": "Use the covering index."},
+            }
+        ],
+        modules_config=[
+            {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+        ],
+    )
+    test_case = isolated_db.create_test_case(
+        project_id=project["id"],
+        name="Structured Execution Test Case",
+        inputs={"input": "SQLite FTS"},
+        expected_outputs={"response": "ok"},
+        is_golden=True,
+    )
+    return prompt, test_case
+
+
+@pytest.mark.asyncio
+async def test_test_runner_uses_structured_assembly_for_execution(isolated_db):
+    prompt, test_case = _seed_structured_prompt_and_case(isolated_db)
+    captured: dict[str, object] = {}
+
+    def _fake_call_adapter(
+        *,
+        provider: str,
+        model: str,
+        messages_payload,
+        system_message,
+        temperature: float,
+        max_tokens: int,
+        app_config=None,
+        api_key_override=None,
+    ) -> str:
+        captured["messages_payload"] = messages_payload
+        captured["system_message"] = system_message
+        return "ok"
+
+    runner = TestRunner(isolated_db)
+    runner._call_adapter = _fake_call_adapter  # type: ignore[method-assign]
+
+    result = await runner.run_single_test(
+        prompt_id=prompt["id"],
+        test_case_id=test_case["id"],
+        model_config={"provider": "openai", "model": "gpt-4", "parameters": {}},
+    )
+
+    assert [message["role"] for message in captured["messages_payload"]] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert captured["system_message"] is None
+    assert result["actual"]["response"] == "ok"
+    assert result["scores"]["aggregate_score"] == 1.0
+
+
+def test_evaluation_manager_uses_structured_assembly_for_evaluations(isolated_db, monkeypatch):
+    prompt, test_case = _seed_structured_prompt_and_case(isolated_db)
+    captured: dict[str, object] = {}
+
+    def _fake_call_adapter_text(
+        *,
+        provider: str,
+        messages_payload,
+        temperature: float,
+        max_tokens: int,
+        api_key,
+        model,
+        app_config=None,
+        timeout=None,
+    ) -> str:
+        captured["messages_payload"] = messages_payload
+        return "ok"
+
+    monkeypatch.setattr(
+        EvaluationManager,
+        "_call_adapter_text",
+        staticmethod(_fake_call_adapter_text),
+    )
+
+    manager = EvaluationManager(isolated_db)
+    result = manager.run_evaluation(
+        prompt_id=prompt["id"],
+        test_case_ids=[test_case["id"]],
+        model="gpt-4",
+        provider="openai",
+    )
+
+    assert [message["role"] for message in captured["messages_payload"]] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert result["status"] == "completed"
+    assert result["metrics"]["average_score"] == 1.0

--- a/tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py
+++ b/tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py
@@ -1,0 +1,127 @@
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints.prompt_studio.prompt_studio_prompts import (
+    preview_prompt,
+)
+from tldw_Server_API.app.api.v1.schemas.prompt_studio_project import (
+    StructuredPromptPreviewRequest,
+)
+from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import (
+    PromptExecutor,
+)
+
+
+def _make_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "input",
+                "label": "Input",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a careful evaluator.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Evaluate {{input}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_structured_prompt_preview_matches_executor_assembly(isolated_db):
+    project = isolated_db.create_project(
+        name="Structured Preview Project",
+        user_id="test-user",
+    )
+    signature = isolated_db.create_signature(
+        project_id=project["id"],
+        name="Structured Preview Signature",
+        input_schema=[{"name": "input", "type": "string"}],
+        output_schema=[{"name": "answer", "type": "string"}],
+    )
+    prompt = isolated_db.create_prompt(
+        project_id=project["id"],
+        signature_id=signature["id"],
+        name="Structured Preview Prompt",
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=_make_prompt_definition_payload(),
+        few_shot_examples=[
+            {
+                "inputs": {"input": "Indexes"},
+                "outputs": {"answer": "Use the covering index."},
+            }
+        ],
+        modules_config=[
+            {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+        ],
+    )
+
+    preview_response = await preview_prompt(
+        StructuredPromptPreviewRequest(
+            project_id=project["id"],
+            signature_id=signature["id"],
+            prompt_format="structured",
+            prompt_schema_version=1,
+            prompt_definition=_make_prompt_definition_payload(),
+            few_shot_examples=[
+                {
+                    "inputs": {"input": "Indexes"},
+                    "outputs": {"answer": "Use the covering index."},
+                }
+            ],
+            modules_config=[
+                {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+            ],
+            variables={"input": "SQLite FTS"},
+        ),
+        db=isolated_db,
+        user_context={
+            "user_id": "test-user",
+            "client_id": "test-client",
+            "is_admin": False,
+        },
+    )
+
+    preview_data = preview_response.data
+    assert preview_data is not None
+
+    executor = PromptExecutor(isolated_db)
+    prompt_record = isolated_db.get_prompt(prompt["id"])
+    signature_record = isolated_db.get_signature(signature["id"])
+    execution_request = executor._build_structured_prompt_request(
+        prompt_record,
+        signature_record,
+        {"input": "SQLite FTS"},
+    )
+
+    assert preview_data.assembled_messages == execution_request["assembled_messages"]
+    assert [message["role"] for message in preview_data.assembled_messages] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert preview_data.assembled_messages[1]["content"] == "Module style_rules: tone=concise"
+    assert "Evaluate SQLite FTS" in preview_data.legacy_user_prompt
+    assert "Please format your response as JSON" in preview_data.legacy_user_prompt

--- a/tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py
+++ b/tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py
@@ -1,0 +1,69 @@
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import PromptStudioDatabase
+
+
+def _make_prompt_definition_payload(task_text: str = "Evaluate {{input}}") -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "input",
+                "label": "Input",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a careful evaluator.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": task_text,
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
+
+def test_prompt_studio_update_creates_new_structured_prompt_version(
+    isolated_db: PromptStudioDatabase,
+):
+    project = isolated_db.create_project(name="Structured Prompt Project", user_id="test-user")
+    created = isolated_db.create_prompt(
+        project_id=project["id"],
+        name="Structured Evaluator",
+        version_number=1,
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=_make_prompt_definition_payload(),
+        client_id="test-client",
+    )
+
+    updated = isolated_db.create_prompt_version(
+        created["id"],
+        change_description="Adjust instructions",
+        prompt_definition=_make_prompt_definition_payload("Evaluate {{input}} carefully."),
+        client_id="test-client",
+    )
+
+    assert updated["version_number"] == 2
+    assert updated["prompt_format"] == "structured"
+    assert updated["prompt_definition"]["blocks"][1]["content"] == "Evaluate {{input}} carefully."

--- a/tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py
+++ b/tldw_Server_API/tests/prompt_studio/test_structured_prompt_versions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import PromptStudioDatabase
+from tldw_Server_API.app.core.DB_Management.PromptStudioDatabase import InputError, PromptStudioDatabase
 
 
 def _make_prompt_definition_payload(task_text: str = "Evaluate {{input}}") -> dict:
@@ -67,3 +67,20 @@ def test_prompt_studio_update_creates_new_structured_prompt_version(
     assert updated["version_number"] == 2
     assert updated["prompt_format"] == "structured"
     assert updated["prompt_definition"]["blocks"][1]["content"] == "Evaluate {{input}} carefully."
+
+
+def test_prompt_studio_rejects_schema_version_mismatch(
+    isolated_db: PromptStudioDatabase,
+):
+    project = isolated_db.create_project(name="Structured Prompt Project", user_id="test-user")
+
+    with pytest.raises(InputError, match="must match prompt_definition.schema_version"):
+        isolated_db.create_prompt(
+            project_id=project["id"],
+            name="Structured Evaluator",
+            version_number=1,
+            prompt_format="structured",
+            prompt_schema_version=999,
+            prompt_definition=_make_prompt_definition_payload(),
+            client_id="test-client",
+        )

--- a/tldw_Server_API/tests/prompt_studio/unit/test_prompt_executor_structured.py
+++ b/tldw_Server_API/tests/prompt_studio/unit/test_prompt_executor_structured.py
@@ -1,0 +1,141 @@
+import pytest
+
+from tldw_Server_API.app.core.Prompt_Management.prompt_studio.prompt_executor import PromptExecutor
+
+
+def _make_prompt_definition_payload() -> dict:
+    return {
+        "schema_version": 1,
+        "format": "structured",
+        "variables": [
+            {
+                "name": "input",
+                "label": "Input",
+                "required": True,
+                "input_type": "textarea",
+            }
+        ],
+        "blocks": [
+            {
+                "id": "identity",
+                "name": "Identity",
+                "role": "system",
+                "content": "You are a careful evaluator.",
+                "enabled": True,
+                "order": 10,
+                "is_template": False,
+            },
+            {
+                "id": "task",
+                "name": "Task",
+                "role": "user",
+                "content": "Evaluate {{input}}",
+                "enabled": True,
+                "order": 20,
+                "is_template": True,
+            },
+        ],
+        "assembly_config": {
+            "legacy_system_roles": ["system", "developer"],
+            "legacy_user_roles": ["user"],
+            "block_separator": "\n\n",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_prompt_uses_structured_assembled_messages(isolated_db, monkeypatch):
+    project = isolated_db.create_project(name="Executor Structured Project", user_id="test-user")
+    prompt = isolated_db.create_prompt(
+        project_id=project["id"],
+        name="Structured Executor Prompt",
+        prompt_format="structured",
+        prompt_schema_version=1,
+        prompt_definition=_make_prompt_definition_payload(),
+        few_shot_examples=[
+            {
+                "inputs": {"input": "Indexes"},
+                "outputs": {"answer": "Use the covering index."},
+            }
+        ],
+        modules_config=[
+            {"type": "style_rules", "enabled": True, "config": {"tone": "concise"}}
+        ],
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _fake_call_llm(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        captured["system_prompt"] = kwargs.get("system_prompt")
+        captured["prompt"] = kwargs.get("prompt")
+        return {"content": '{"answer": "ok"}', "tokens": 11}
+
+    monkeypatch.setattr(PromptExecutor, "_call_llm", staticmethod(_fake_call_llm))
+
+    executor = PromptExecutor(isolated_db)
+    result = await executor.execute_prompt(
+        prompt["id"],
+        {"input": "SQLite FTS"},
+        {"provider": "openai", "model": "gpt-4", "parameters": {}},
+    )
+
+    assert [message["role"] for message in captured["messages"]] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert captured["messages"][1]["content"] == "Module style_rules: tone=concise"
+    assert captured["messages"][2]["content"] == 'Example input: {"input": "Indexes"}'
+    assert captured["messages"][3]["content"] == 'Example output: {"answer": "Use the covering index."}'
+    assert captured["messages"][4]["content"] == "Evaluate SQLite FTS"
+    assert captured["system_prompt"] is None
+    assert result["success"] is True
+    assert [message["role"] for message in result["metadata"]["assembled_messages"]] == [
+        "system",
+        "developer",
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert result["parsed_output"]["raw"] == '{"answer": "ok"}'
+
+
+@pytest.mark.asyncio
+async def test_execute_prompt_keeps_legacy_prompt_string_path(isolated_db, monkeypatch):
+    project = isolated_db.create_project(name="Executor Legacy Project", user_id="test-user")
+    prompt = isolated_db.create_prompt(
+        project_id=project["id"],
+        name="Legacy Executor Prompt",
+        system_prompt="Stay concise.",
+        user_prompt="Evaluate {input}",
+    )
+
+    captured: dict[str, object] = {}
+
+    async def _fake_call_llm(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        captured["system_prompt"] = kwargs.get("system_prompt")
+        captured["prompt"] = kwargs.get("prompt")
+        return {"content": "ok", "tokens": 3}
+
+    monkeypatch.setattr(PromptExecutor, "_call_llm", staticmethod(_fake_call_llm))
+
+    executor = PromptExecutor(isolated_db)
+    result = await executor.execute_prompt(
+        prompt["id"],
+        {"input": "SQLite FTS"},
+        {"provider": "openai", "model": "gpt-4", "parameters": {}},
+    )
+
+    assert captured["messages"] is None
+    assert captured["system_prompt"] == "Stay concise."
+    assert captured["prompt"] == "Evaluate SQLite FTS"
+    assert result["success"] is True
+    assert result["metadata"]["assembled_messages"] == [
+        {"role": "system", "content": "Stay concise."},
+        {"role": "user", "content": "Evaluate SQLite FTS"},
+    ]
+    assert result["parsed_output"]["raw"] == "ok"


### PR DESCRIPTION
## Summary
- add structured prompt models, validation, assembly, legacy rendering, and legacy-to-structured conversion on the backend
- support structured prompt persistence, preview, execution, versioning, sync, and search across both regular Prompts and Prompt Studio
- add structured editing UI, block/variable management, and starter-template flows for prompt authoring
- fix review-identified parity gaps around schema metadata preservation, variable/default validation, and signature-aware Prompt Studio preview/save behavior

## Notes
- adds Prompt Studio migration `006_prompt_studio_structured_prompts.sql`
- keeps legacy prompt fields as compatibility projections for structured prompts

## Test Plan
- [x] `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/prompt_studio/test_structured_prompt_preview_parity.py tldw_Server_API/tests/prompt_studio/integration/test_api_endpoints.py tldw_Server_API/tests/prompt_studio/test_structured_prompt_execution.py tldw_Server_API/tests/prompt_studio/unit/test_prompt_executor_structured.py -q`
- [x] `cd apps/packages/ui && bunx vitest run src/components/Option/Prompt/Studio/Prompts/__tests__/PromptEditorDrawer.structured.test.tsx`
- [x] `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/prompt_studio/prompt_studio_prompts.py tldw_Server_API/app/core/Prompt_Management/prompt_studio/prompt_executor.py -f json -o /tmp/bandit_prompt_studio_signature_parity.json`
