### PR TITLE
feat(admin-dsr): add authoritative intake workflow

### DIFF
--- a/Docs/Plans/2026-03-10-admin-ui-dsr-authoritative-intake-design.md
+++ b/Docs/Plans/2026-03-10-admin-ui-dsr-authoritative-intake-design.md
@@ -1,0 +1,272 @@
+# Admin UI DSR Authoritative Intake Design
+
+Date: 2026-03-10
+Branch: `codex/admin-ui-dsr-authoritative-intake`
+
+## Context
+
+The production-readiness hardening work intentionally disabled the `admin-ui` data subject request workflow because it was not authoritative:
+
+- request history lived in browser `localStorage`
+- preview could fall back to synthetic category counts
+- create failures could still lead to local success messaging
+- export and erasure flows implied completion without backend persistence
+
+The next milestone is not full export/erasure execution. It is a truthful, durable first step that allows admins to preview user data coverage and record DSR requests for review without pretending that destructive or export actions already happened.
+
+## Goals
+
+1. Replace browser-local DSR history with durable backend persistence.
+2. Make preview authoritative and fail closed when the target user or requested coverage cannot be resolved.
+3. Make request creation idempotent and durable.
+4. Re-enable the admin UI DSR surface in safe mode using real backend data.
+5. Preserve admin auditability for both preview and request creation.
+
+## Non-Goals
+
+- Performing cross-store export generation in this milestone.
+- Performing cross-store erasure/deletion in this milestone.
+- Designing a full human review workflow with assignment and approval states.
+- Counting unsupported categories with estimates or placeholders.
+
+## Chosen Approach
+
+Add dedicated DSR persistence and endpoints under the existing admin data-ops contract:
+
+- `POST /api/v1/admin/data-subject-requests/preview`
+- `POST /api/v1/admin/data-subject-requests`
+- `GET /api/v1/admin/data-subject-requests`
+
+This approach keeps the contract aligned with the current admin UI, fits the existing admin routing and audit patterns, and avoids misusing the audit log as the primary request store.
+
+## Persistence Model
+
+DSR records will live in the AuthNZ database, not in a per-user content database.
+
+Rationale:
+
+- DSR records are control-plane metadata, not user content.
+- They must be visible to multiple authorized admins.
+- The existing admin data-op surfaces already use shared control-plane persistence patterns.
+- AuthNZ persistence is already designed to support both SQLite and PostgreSQL.
+
+### `data_subject_requests` table
+
+First-pass fields:
+
+- `id` integer primary key
+- `client_request_id` text unique, required
+- `requester_identifier` text required
+- `resolved_user_id` integer nullable
+- `request_type` text required, one of `access`, `export`, `erasure`
+- `status` text required, initial milestone uses `recorded`
+- `selected_categories` text/json required, default `[]`
+- `preview_summary` text/json required
+- `coverage_metadata` text/json nullable
+- `requested_by_user_id` integer nullable
+- `requested_at` timestamp required
+- `notes` text nullable
+
+Indexes:
+
+- `client_request_id`
+- `requester_identifier`
+- `resolved_user_id`
+- `request_type`
+- `status`
+- `requested_at`
+
+## API Behavior
+
+### 1. Preview
+
+`POST /admin/data-subject-requests/preview`
+
+Input:
+
+- `requester_identifier`
+- optional category filter if the UI later scopes preview to specific categories
+
+Behavior:
+
+- resolve the requester to a known user
+- enforce admin scope against the resolved user
+- count only authoritative categories supported by the current backend implementation
+- return a normalized summary payload and coverage metadata
+
+Failure semantics:
+
+- `404` if the requester cannot be resolved
+- `403` if the admin is not allowed to manage that user
+- `422` if unsupported categories are explicitly requested
+- `500` only for real backend failures
+
+Preview is not persisted in milestone 1.
+
+### 2. Create
+
+`POST /admin/data-subject-requests`
+
+Input:
+
+- `client_request_id`
+- `requester_identifier`
+- `request_type`
+- `categories`
+- optional `notes`
+
+Behavior:
+
+- resolve the requester again on the server
+- enforce admin scope again on the resolved user
+- recompute the authoritative preview snapshot on the server
+- validate the requested categories against supported coverage
+- persist the DSR record with status `recorded`
+- return the stored record
+
+Important rule:
+
+The server must not trust preview data supplied by the client. `create` always recomputes the preview snapshot before persistence.
+
+Idempotency:
+
+- `client_request_id` is treated as a unique idempotency key
+- repeated submits for the same request return the stored record instead of creating duplicates
+
+### 3. List
+
+`GET /admin/data-subject-requests`
+
+Input:
+
+- `limit`
+- `offset`
+- optional filters such as `request_type`, `status`, `requester_identifier`, `user_id`
+
+Behavior:
+
+- return newest-first paged request history
+- apply admin scope filtering so non-platform admins only see manageable users
+
+## Lifecycle Model
+
+Milestone 1 keeps the lifecycle intentionally narrow.
+
+Allowed persisted status:
+
+- `recorded`
+
+Deferred statuses for future work:
+
+- `in_review`
+- `completed`
+- `rejected`
+
+This avoids inventing states that the system cannot yet transition between honestly.
+
+## Authoritative Category Coverage
+
+Milestone 1 will ship only categories the backend can count cleanly and defensibly.
+
+Expected first-pass candidates:
+
+- `media_records`
+- `chat_messages`
+- `notes`
+- `audit_events`
+
+`embeddings` stays out of scope unless user linkage is straightforward in the existing vector-store path.
+
+If a category cannot be counted authoritatively:
+
+- it is omitted from the summary, or
+- it is returned with explicit coverage metadata showing it is unsupported
+
+The API must never fabricate or estimate category counts.
+
+## Access Control
+
+All endpoints remain under the admin router and therefore require admin authentication.
+
+In addition:
+
+- preview, create, and list must enforce the same admin-to-user scope rules used by other admin data-op endpoints
+- non-platform admins must not be able to probe unrelated users by email or numeric ID
+- list responses must exclude requests outside the caller's allowed scope
+
+## Auditability
+
+Preview and create actions must emit admin audit events using the shared admin audit helper.
+
+Recommended audit shape:
+
+- `resource_type`: `data_subject_request`
+- `action`: `data_subject_request.preview` or `data_subject_request.create`
+- metadata:
+  - `requester_identifier`
+  - `resolved_user_id`
+  - `request_type`
+  - `selected_categories`
+  - `client_request_id`
+
+Audit events are evidence, not the primary source of truth for request state.
+
+## Frontend Changes
+
+`admin-ui/components/data-ops/DataSubjectRequestsSection.tsx` will change in these ways:
+
+- remove browser `localStorage` request-log hydration and persistence
+- fetch request history from `GET /admin/data-subject-requests`
+- use only backend preview data
+- remove local JSON export generation
+- remove fake erasure completion messaging
+- record all request types as stored requests, including `access`
+
+Updated user-facing messaging:
+
+- `access`: show the authoritative preview summary and record the request
+- `export`: show `Request recorded for review`
+- `erasure`: show `Request recorded for review` after authoritative preview and category validation
+
+## Backend Compatibility Requirements
+
+Because DSR records live in AuthNZ, the implementation must support both configured AuthNZ backends:
+
+- SQLite
+- PostgreSQL
+
+That means:
+
+- additive AuthNZ migration support for SQLite
+- corresponding additive ensure path for PostgreSQL extras
+- repository queries written for both backends
+
+## Testing Strategy
+
+### Backend
+
+- migration coverage for the new DSR table
+- preview success and unknown-user failure
+- create success with idempotent replay
+- list pagination
+- admin scope enforcement
+- audit emission for preview and create
+- SQLite and PostgreSQL compatibility where existing AuthNZ test fixtures support it
+
+### Frontend
+
+- no `localStorage` request log behavior
+- no synthetic preview fallback
+- no success UI when backend create fails
+- request log fetched from the server and refreshed after submit
+- `export` and `erasure` success copy changed to `recorded` semantics
+
+## Risks And Follow-On Work
+
+1. Cross-store counting may expose gaps in user linkage for some categories.
+2. PostgreSQL support may require explicit additive migration handling beyond the existing SQLite migration path.
+3. Full export and full erasure will need a second milestone with stronger workflow, review, and operational safeguards.
+
+## Decision
+
+Proceed with milestone 1 as an authoritative intake, preview, and audit workflow only. Do not claim export generation or erasure execution until the backend can perform those actions across the supported stores coherently and durably.

--- a/Docs/Plans/2026-03-10-admin-ui-dsr-authoritative-intake-implementation-plan.md
+++ b/Docs/Plans/2026-03-10-admin-ui-dsr-authoritative-intake-implementation-plan.md
@@ -1,0 +1,288 @@
+# Admin UI DSR Authoritative Intake Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the admin UI's disabled local-only data subject request flow with an authoritative backend-backed preview, intake, and audit workflow that records requests truthfully without claiming export or erasure execution.
+
+**Architecture:** Add a small dedicated DSR persistence layer in AuthNZ, expose preview/create/list endpoints from the existing admin data-ops router, and then rewire the admin UI component to consume only server-backed preview and history data. Keep milestone 1 narrow: record requests with idempotency and audit events, but do not execute export or deletion.
+
+**Tech Stack:** FastAPI, AuthNZ SQLite/PostgreSQL migrations, repository/service pattern under `tldw_Server_API`, Next.js 15, React 19, TypeScript 5, Vitest, Pytest, Bun.
+
+---
+
+## Stage 1: Add Durable DSR Persistence
+**Goal:** Create a shared control-plane store for recorded data subject requests that works across AuthNZ backends.
+**Success Criteria:** The AuthNZ layer can persist and list DSR records by `client_request_id`, and duplicate create attempts do not create duplicate rows.
+**Tests:** `python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py -q`
+**Status:** Not Started
+
+### Task 1: Add the DSR table and repository
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/AuthNZ/migrations.py`
+- Modify: `tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- Create: `tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py`
+- Test: `tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py`
+
+**Step 1: Write the failing repository test**
+
+Create `tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py` with a case that inserts one request and then replays the same `client_request_id`.
+
+```python
+async def test_repo_create_request_is_idempotent(tmp_path):
+    repo = DataSubjectRequestsRepo()
+
+    first = await repo.create_or_get_request(
+        client_request_id="dsr-1",
+        requester_identifier="user@example.com",
+        resolved_user_id=7,
+        request_type="export",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 3}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+    )
+    second = await repo.create_or_get_request(
+        client_request_id="dsr-1",
+        requester_identifier="user@example.com",
+        resolved_user_id=7,
+        request_type="export",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 3}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+    )
+
+    assert first["id"] == second["id"]
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py -q`
+
+Expected: FAIL because the repo and/or table do not exist yet.
+
+**Step 3: Write the minimal persistence layer**
+
+Add an additive AuthNZ migration for `data_subject_requests`, add the matching PostgreSQL ensure statements, and implement a small repo with:
+
+```python
+class DataSubjectRequestsRepo:
+    async def create_or_get_request(...): ...
+    async def list_requests(...): ...
+```
+
+Store `selected_categories`, `preview_summary`, and `coverage_metadata` as JSON text.
+
+**Step 4: Run the repo test to verify it passes**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/AuthNZ/migrations.py tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py
+git commit -m "feat(admin-dsr): add durable request persistence"
+```
+
+## Stage 2: Expose Authoritative Preview, Create, And List APIs
+**Goal:** Add admin-scoped DSR preview and intake endpoints that recompute preview server-side, enforce user scope, and emit audit events.
+**Success Criteria:** Preview fails closed, create persists only authoritative snapshots, duplicate `client_request_id` calls are idempotent, and list returns paged results filtered by admin scope.
+**Tests:** `python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_api.py -q`
+**Status:** Not Started
+
+### Task 2: Add the backend API contract and service layer
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/admin_schemas.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py`
+- Create: `tldw_Server_API/app/services/admin_data_subject_requests_service.py`
+- Test: `tldw_Server_API/tests/Admin/test_data_subject_requests_api.py`
+
+**Step 1: Write the failing API tests**
+
+Create `tldw_Server_API/tests/Admin/test_data_subject_requests_api.py` with these cases:
+
+```python
+def test_preview_returns_404_for_unknown_requester(...): ...
+def test_create_records_request_and_reuses_client_request_id(...): ...
+def test_list_returns_newest_first_with_limit_offset(...): ...
+def test_preview_enforces_admin_scope(...): ...
+```
+
+For the create test, assert that the stored row contains the server-computed preview summary, not client-supplied preview data.
+
+**Step 2: Run the test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_api.py -q`
+
+Expected: FAIL because the schemas, service, and endpoints do not exist.
+
+**Step 3: Write the minimal backend implementation**
+
+Add schema models for preview/create/list and implement a service with functions similar to:
+
+```python
+async def preview_data_subject_request(principal, requester_identifier: str) -> dict[str, Any]: ...
+async def create_data_subject_request(principal, payload, request: Request) -> dict[str, Any]: ...
+async def list_data_subject_requests(principal, *, limit: int, offset: int, ...) -> dict[str, Any]: ...
+```
+
+Requirements:
+
+- resolve requester to a known user
+- call `_enforce_admin_user_scope(...)`
+- count only authoritative categories supported in milestone 1
+- recompute preview inside `create`
+- emit admin audit events for preview and create
+
+**Step 4: Run the API tests to verify behavior**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_api.py -q`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/admin_schemas.py tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py tldw_Server_API/app/services/admin_data_subject_requests_service.py tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+git commit -m "feat(admin-dsr): add preview and intake endpoints"
+```
+
+## Stage 3: Replace The Admin UI Local-Only DSR Flow
+**Goal:** Re-enable the DSR screen using only authoritative backend preview and request-log data.
+**Success Criteria:** The admin UI no longer reads or writes DSR history from `localStorage`, no longer fabricates preview data, and records requests with truthful milestone-1 copy.
+**Tests:** `bunx vitest run components/data-ops/DataSubjectRequestsSection.test.tsx app/data-ops/__tests__/page.a11y.test.tsx`
+**Status:** Not Started
+
+### Task 3: Update the admin UI DSR component and tests
+
+**Files:**
+- Modify: `admin-ui/lib/api-client.ts`
+- Modify: `admin-ui/components/data-ops/DataSubjectRequestsSection.tsx`
+- Modify: `admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx`
+- Test: `admin-ui/app/data-ops/__tests__/page.a11y.test.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Extend `admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx` with cases like:
+
+```tsx
+it('loads request history from the backend instead of localStorage', async () => {
+  apiMock.listDataSubjectRequests.mockResolvedValue({ items: [{ id: 1, requester_identifier: 'user@example.com', request_type: 'export', status: 'recorded', requested_at: '2026-03-10T12:00:00Z' }], total: 1, limit: 50, offset: 0 });
+  render(<DataSubjectRequestsSection refreshSignal={0} />);
+  expect(await screen.findByText('user@example.com')).toBeInTheDocument();
+});
+
+it('does not show success when request creation fails', async () => {
+  apiMock.previewDataSubjectRequest.mockResolvedValue(...);
+  apiMock.createDataSubjectRequest.mockRejectedValue(new Error('boom'));
+  render(<DataSubjectRequestsSection refreshSignal={0} />);
+  // submit and assert no recorded row or success copy
+});
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run: `cd admin-ui && bunx vitest run components/data-ops/DataSubjectRequestsSection.test.tsx`
+
+Expected: FAIL because the component still depends on local storage and fake-success flows.
+
+**Step 3: Write the minimal frontend implementation**
+
+Update the API client with:
+
+```ts
+listDataSubjectRequests: (params?: Record<string, string>) =>
+  requestJson('/admin/data-subject-requests?...'),
+```
+
+Then update `DataSubjectRequestsSection.tsx` to:
+
+- load request history from the backend on mount and after submit
+- remove `localStorage` helpers entirely
+- remove `buildLocalCategorySummary`
+- remove `downloadExportArchive`
+- change success copy for `export` and `erasure` to `Request recorded for review`
+- keep `access` summary rendering but also refresh the server-backed log
+
+**Step 4: Run the frontend tests to verify behavior**
+
+Run: `cd admin-ui && bunx vitest run components/data-ops/DataSubjectRequestsSection.test.tsx app/data-ops/__tests__/page.a11y.test.tsx`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/lib/api-client.ts admin-ui/components/data-ops/DataSubjectRequestsSection.tsx admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx admin-ui/app/data-ops/__tests__/page.a11y.test.tsx
+git commit -m "feat(admin-ui): use authoritative DSR backend flow"
+```
+
+## Stage 4: Verify The End-To-End Milestone Contract
+**Goal:** Prove the new backend-backed DSR intake flow works across the touched surfaces and does not introduce new security findings in changed code.
+**Success Criteria:** Focused frontend and backend suites pass, the admin data-ops tests stay green, and Bandit is clean for the touched Python scope after filtering expected pytest `B101` assertions.
+**Tests:** Focused Vitest and Pytest suites, Bandit, optional targeted build/typecheck if frontend contract changes require it.
+**Status:** Not Started
+
+### Task 4: Run the verification gate
+
+**Files:**
+- Verify only
+
+**Step 1: Run the focused backend suites**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-dsr-authoritative-intake
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py tldw_Server_API/tests/Admin/test_data_subject_requests_api.py tldw_Server_API/tests/Admin/test_data_ops.py -q
+```
+
+Expected: PASS
+
+**Step 2: Run the focused frontend suites**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-dsr-authoritative-intake/admin-ui
+bunx vitest run components/data-ops/DataSubjectRequestsSection.test.tsx app/data-ops/__tests__/page.a11y.test.tsx
+```
+
+Expected: PASS
+
+**Step 3: Run type-aware frontend verification if API shapes changed**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-dsr-authoritative-intake/admin-ui
+bun run typecheck
+```
+
+Expected: PASS
+
+**Step 4: Run Bandit on touched backend paths**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-dsr-authoritative-intake
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py tldw_Server_API/app/services/admin_data_subject_requests_service.py tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py -s B101 -f json -o /tmp/bandit_admin_dsr.json
+```
+
+Expected: exit code `0` with no actionable findings.
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test(admin-dsr): verify authoritative intake milestone"
+```

--- a/admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx
+++ b/admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx
@@ -2,16 +2,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DataSubjectRequestsSection } from './DataSubjectRequestsSection';
-import { api } from '@/lib/api-client';
 
-const unsafeLocalToolsEnabledMock = vi.hoisted(() => vi.fn(() => false));
+import { api } from '@/lib/api-client';
+import { DataSubjectRequestsSection } from './DataSubjectRequestsSection';
+
 const toastSuccessMock = vi.hoisted(() => vi.fn());
 const toastErrorMock = vi.hoisted(() => vi.fn());
-
-vi.mock('@/lib/admin-ui-flags', () => ({
-  isUnsafeLocalToolsEnabled: unsafeLocalToolsEnabledMock,
-}));
 
 vi.mock('@/components/ui/toast', () => ({
   useToast: () => ({
@@ -22,33 +18,56 @@ vi.mock('@/components/ui/toast', () => ({
 
 vi.mock('@/lib/api-client', () => ({
   api: {
+    listDataSubjectRequests: vi.fn(),
     previewDataSubjectRequest: vi.fn(),
     createDataSubjectRequest: vi.fn(),
   },
 }));
 
 type ApiMock = {
+  listDataSubjectRequests: ReturnType<typeof vi.fn>;
   previewDataSubjectRequest: ReturnType<typeof vi.fn>;
   createDataSubjectRequest: ReturnType<typeof vi.fn>;
 };
 
 const apiMock = api as unknown as ApiMock;
 
+const emptyListResponse = {
+  items: [],
+  total: 0,
+  limit: 50,
+  offset: 0,
+};
+
 beforeEach(() => {
-  unsafeLocalToolsEnabledMock.mockReturnValue(false);
   toastSuccessMock.mockClear();
   toastErrorMock.mockClear();
 
+  apiMock.listDataSubjectRequests.mockResolvedValue(emptyListResponse);
   apiMock.previewDataSubjectRequest.mockResolvedValue({
-    summary: {
-      media_records: 12,
-      chat_messages: 20,
-      notes: 8,
-      audit_events: 31,
-      embeddings: 4,
+    summary: [
+      { key: 'media_records', label: 'Media records', count: 12 },
+      { key: 'chat_messages', label: 'Chat sessions/messages', count: 20 },
+      { key: 'notes', label: 'Notes', count: 8 },
+      { key: 'audit_events', label: 'Audit log events', count: 31 },
+    ],
+  });
+  apiMock.createDataSubjectRequest.mockResolvedValue({
+    item: {
+      id: 1,
+      client_request_id: 'dsr-1',
+      requester_identifier: 'user@example.com',
+      request_type: 'access',
+      status: 'recorded',
+      requested_at: '2026-03-10T12:00:00Z',
+      selected_categories: ['media_records', 'chat_messages', 'notes', 'audit_events'],
+      preview_summary: [
+        { key: 'media_records', label: 'Media records', count: 12 },
+        { key: 'chat_messages', label: 'Chat sessions/messages', count: 20 },
+      ],
+      coverage_metadata: {},
     },
   });
-  apiMock.createDataSubjectRequest.mockResolvedValue({ status: 'ok' });
 
   localStorage.clear();
 });
@@ -60,32 +79,52 @@ afterEach(() => {
 });
 
 describe('DataSubjectRequestsSection', () => {
-  it('disables request actions and ignores local-only request history in safe mode', async () => {
-    localStorage.setItem('data_ops_data_subject_requests_log_v1', JSON.stringify([
-      {
-        id: 'local-entry',
-        requester: 'seeded@example.com',
-        request_type: 'access',
-        status: 'completed',
-        requested_at: '2026-03-01T12:00:00.000Z',
-      },
-    ]));
+  it('loads request history from the backend instead of localStorage', async () => {
+    localStorage.setItem(
+      'data_ops_data_subject_requests_log_v1',
+      JSON.stringify([
+        {
+          id: 'local-entry',
+          requester: 'local-only@example.com',
+          request_type: 'access',
+          status: 'completed',
+          requested_at: '2026-03-01T12:00:00.000Z',
+        },
+      ]),
+    );
+    apiMock.listDataSubjectRequests.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          client_request_id: 'dsr-1',
+          requester_identifier: 'seeded@example.com',
+          request_type: 'export',
+          status: 'recorded',
+          requested_at: '2026-03-01T12:00:00Z',
+          selected_categories: ['media_records'],
+          preview_summary: [{ key: 'media_records', label: 'Media records', count: 3 }],
+          coverage_metadata: {},
+        },
+      ],
+      total: 1,
+      limit: 50,
+      offset: 0,
+    });
 
     render(<DataSubjectRequestsSection refreshSignal={0} />);
 
-    expect(
-      screen.getByText('Data subject request workflows are unavailable until server-backed APIs are available.')
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText('User identifier (email or user ID)')).toBeDisabled();
-    expect(screen.getByLabelText('Request type')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Submit request' })).toBeDisabled();
-    expect(screen.queryByText('seeded@example.com')).not.toBeInTheDocument();
+    expect(await screen.findByText('seeded@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('local-only@example.com')).not.toBeInTheDocument();
+    expect(apiMock.listDataSubjectRequests).toHaveBeenCalledWith({ limit: '50', offset: '0' });
   });
 
   it('validates requester identifier before submission', async () => {
-    unsafeLocalToolsEnabledMock.mockReturnValue(true);
     const user = userEvent.setup();
     render(<DataSubjectRequestsSection refreshSignal={0} />);
+
+    await waitFor(() => {
+      expect(apiMock.listDataSubjectRequests).toHaveBeenCalled();
+    });
 
     await user.click(screen.getByRole('button', { name: 'Submit request' }));
 
@@ -93,9 +132,46 @@ describe('DataSubjectRequestsSection', () => {
   });
 
   it('enforces erasure category selection and irreversible-action confirmation', async () => {
-    unsafeLocalToolsEnabledMock.mockReturnValue(true);
+    apiMock.listDataSubjectRequests
+      .mockResolvedValueOnce(emptyListResponse)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 7,
+            client_request_id: 'dsr-erasure-1',
+            requester_identifier: 'erasure@example.com',
+            request_type: 'erasure',
+            status: 'recorded',
+            requested_at: '2026-03-10T12:00:00Z',
+            selected_categories: ['media_records'],
+            preview_summary: [{ key: 'media_records', label: 'Media records', count: 12 }],
+            coverage_metadata: {},
+          },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      });
+    apiMock.createDataSubjectRequest.mockResolvedValue({
+      item: {
+        id: 7,
+        client_request_id: 'dsr-erasure-1',
+        requester_identifier: 'erasure@example.com',
+        request_type: 'erasure',
+        status: 'recorded',
+        requested_at: '2026-03-10T12:00:00Z',
+        selected_categories: ['media_records'],
+        preview_summary: [{ key: 'media_records', label: 'Media records', count: 12 }],
+        coverage_metadata: {},
+      },
+    });
+
     const user = userEvent.setup();
     render(<DataSubjectRequestsSection refreshSignal={0} />);
+
+    await waitFor(() => {
+      expect(apiMock.listDataSubjectRequests).toHaveBeenCalledTimes(1);
+    });
 
     await user.type(screen.getByLabelText('User identifier (email or user ID)'), 'erasure@example.com');
     await user.selectOptions(screen.getByLabelText('Request type'), 'erasure');
@@ -119,20 +195,68 @@ describe('DataSubjectRequestsSection', () => {
           requester_identifier: 'erasure@example.com',
           request_type: 'erasure',
           categories: ['media_records'],
-        })
+        }),
       );
     });
 
-    const log = screen.getByTestId('dsr-request-log');
+    const log = await screen.findByTestId('dsr-request-log');
     const row = within(log).getAllByTestId('dsr-request-log-row')[0];
     expect(within(row).getByText('erasure')).toBeInTheDocument();
     expect(within(row).getByText('erasure@example.com')).toBeInTheDocument();
+    expect(within(row).getByText('recorded')).toBeInTheDocument();
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Request recorded',
+      'The request was recorded for review. Export and erasure are not executed automatically in this release.',
+    );
   });
 
   it('renders request log row after an access request', async () => {
-    unsafeLocalToolsEnabledMock.mockReturnValue(true);
+    apiMock.listDataSubjectRequests
+      .mockResolvedValueOnce(emptyListResponse)
+      .mockResolvedValueOnce({
+        items: [
+          {
+            id: 11,
+            client_request_id: 'dsr-access-1',
+            requester_identifier: 'access@example.com',
+            request_type: 'access',
+            status: 'recorded',
+            requested_at: '2026-03-10T12:00:00Z',
+            selected_categories: ['media_records', 'chat_messages', 'notes', 'audit_events'],
+            preview_summary: [
+              { key: 'media_records', label: 'Media records', count: 12 },
+              { key: 'chat_messages', label: 'Chat sessions/messages', count: 20 },
+            ],
+            coverage_metadata: {},
+          },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      });
+    apiMock.createDataSubjectRequest.mockResolvedValue({
+      item: {
+        id: 11,
+        client_request_id: 'dsr-access-1',
+        requester_identifier: 'access@example.com',
+        request_type: 'access',
+        status: 'recorded',
+        requested_at: '2026-03-10T12:00:00Z',
+        selected_categories: ['media_records', 'chat_messages', 'notes', 'audit_events'],
+        preview_summary: [
+          { key: 'media_records', label: 'Media records', count: 12 },
+          { key: 'chat_messages', label: 'Chat sessions/messages', count: 20 },
+        ],
+        coverage_metadata: {},
+      },
+    });
+
     const user = userEvent.setup();
     render(<DataSubjectRequestsSection refreshSignal={0} />);
+
+    await waitFor(() => {
+      expect(apiMock.listDataSubjectRequests).toHaveBeenCalledTimes(1);
+    });
 
     await user.type(screen.getByLabelText('User identifier (email or user ID)'), 'access@example.com');
     await user.click(screen.getByRole('button', { name: 'Submit request' }));
@@ -144,6 +268,33 @@ describe('DataSubjectRequestsSection', () => {
       expect(within(requestLog).getAllByTestId('dsr-request-log-row').length).toBe(1);
     });
     expect(within(requestLog).getByText('access@example.com')).toBeInTheDocument();
-    expect(within(requestLog).getByText('completed')).toBeInTheDocument();
+    expect(within(requestLog).getByText('recorded')).toBeInTheDocument();
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      'Request recorded',
+      'The access request was recorded and the authoritative summary is shown below.',
+    );
+  });
+
+  it('does not show success when request creation fails', async () => {
+    apiMock.createDataSubjectRequest.mockRejectedValue(new Error('boom'));
+
+    const user = userEvent.setup();
+    render(<DataSubjectRequestsSection refreshSignal={0} />);
+
+    await waitFor(() => {
+      expect(apiMock.listDataSubjectRequests).toHaveBeenCalledTimes(1);
+    });
+
+    await user.type(screen.getByLabelText('User identifier (email or user ID)'), 'failure@example.com');
+    await user.click(screen.getByRole('button', { name: 'Submit request' }));
+
+    await waitFor(() => {
+      expect(apiMock.createDataSubjectRequest).toHaveBeenCalled();
+    });
+
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith('Request failed', 'boom');
+    expect(screen.queryByTestId('dsr-access-summary')).not.toBeInTheDocument();
+    expect(screen.getByText('No recorded requests yet.')).toBeInTheDocument();
   });
 });

--- a/admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx
+++ b/admin-ui/components/data-ops/DataSubjectRequestsSection.test.tsx
@@ -192,6 +192,7 @@ describe('DataSubjectRequestsSection', () => {
     await waitFor(() => {
       expect(apiMock.createDataSubjectRequest).toHaveBeenCalledWith(
         expect.objectContaining({
+          client_request_id: expect.stringMatching(/^dsr-/),
           requester_identifier: 'erasure@example.com',
           request_type: 'erasure',
           categories: ['media_records'],
@@ -262,6 +263,13 @@ describe('DataSubjectRequestsSection', () => {
     await user.click(screen.getByRole('button', { name: 'Submit request' }));
 
     expect(await screen.findByTestId('dsr-access-summary')).toBeInTheDocument();
+    expect(apiMock.createDataSubjectRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_request_id: expect.stringMatching(/^dsr-/),
+        requester_identifier: 'access@example.com',
+        request_type: 'access',
+      }),
+    );
 
     const requestLog = screen.getByTestId('dsr-request-log');
     await waitFor(() => {

--- a/admin-ui/components/data-ops/DataSubjectRequestsSection.tsx
+++ b/admin-ui/components/data-ops/DataSubjectRequestsSection.tsx
@@ -1,27 +1,27 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ShieldAlert } from 'lucide-react';
+
+import { Field } from '@/components/data-ops/Field';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Badge } from '@/components/ui/badge';
-import { Checkbox } from '@/components/ui/checkbox';
 import { useToast } from '@/components/ui/toast';
 import { api } from '@/lib/api-client';
 import { formatDateTime } from '@/lib/format';
-import { isUnsafeLocalToolsEnabled } from '@/lib/admin-ui-flags';
-import { ShieldAlert } from 'lucide-react';
-import { Field } from '@/components/data-ops/Field';
 
 type DataSubjectRequestsSectionProps = {
   refreshSignal: number;
 };
 
 type DataSubjectRequestType = 'export' | 'erasure' | 'access';
-type DataSubjectRequestStatus = 'completed' | 'failed';
+type DataSubjectRequestStatus = 'recorded' | 'completed' | 'failed' | 'rejected' | 'in_review';
 
 type DataCategoryCount = {
   key: string;
@@ -31,22 +31,19 @@ type DataCategoryCount = {
 
 type DataSubjectRequestLogItem = {
   id: string;
-  requester: string;
+  requester_identifier: string;
   request_type: DataSubjectRequestType;
   status: DataSubjectRequestStatus;
   requested_at: string;
-  completed_at?: string;
-  selected_categories?: string[];
+  selected_categories: string[];
+  preview_summary: DataCategoryCount[];
 };
-
-const REQUEST_LOG_STORAGE_KEY = 'data_ops_data_subject_requests_log_v1';
 
 const CATEGORY_DEFS: Array<{ key: string; label: string }> = [
   { key: 'media_records', label: 'Media records' },
   { key: 'chat_messages', label: 'Chat sessions/messages' },
   { key: 'notes', label: 'Notes' },
   { key: 'audit_events', label: 'Audit log events' },
-  { key: 'embeddings', label: 'Embeddings' },
 ];
 
 const REQUEST_TYPE_OPTIONS: Array<{ value: DataSubjectRequestType; label: string }> = [
@@ -60,40 +57,36 @@ const parseNonNegativeInteger = (value: unknown): number | null => {
   return Math.floor(value);
 };
 
-const parseRequestLogStorage = (value: unknown): DataSubjectRequestLogItem[] => {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((entry): DataSubjectRequestLogItem | null => {
+const parseSummaryArray = (value: unknown): DataCategoryCount[] | null => {
+  if (!Array.isArray(value)) return null;
+  const parsed = value
+    .map((entry) => {
       if (!entry || typeof entry !== 'object') return null;
-      const record = entry as Partial<DataSubjectRequestLogItem>;
-      if (typeof record.id !== 'string' || !record.id) return null;
-      if (typeof record.requester !== 'string' || !record.requester.trim()) return null;
-      if (!record.request_type || !['export', 'erasure', 'access'].includes(record.request_type)) return null;
-      if (!record.status || !['completed', 'failed'].includes(record.status)) return null;
-      if (typeof record.requested_at !== 'string' || !record.requested_at) return null;
-      return {
-        id: record.id,
-        requester: record.requester,
-        request_type: record.request_type,
-        status: record.status,
-        requested_at: record.requested_at,
-        completed_at: typeof record.completed_at === 'string' ? record.completed_at : undefined,
-        selected_categories: Array.isArray(record.selected_categories)
-          ? record.selected_categories.filter((value): value is string => typeof value === 'string')
-          : undefined,
-      };
+      const record = entry as Record<string, unknown>;
+      const key = typeof record.key === 'string' ? record.key : null;
+      const label = typeof record.label === 'string' ? record.label : null;
+      const count = parseNonNegativeInteger(record.count);
+      if (!key || !label || count === null) return null;
+      return { key, label, count };
     })
-    .filter((entry): entry is DataSubjectRequestLogItem => entry !== null)
-    .slice(0, 50);
+    .filter((entry): entry is DataCategoryCount => entry !== null);
+  return parsed.length > 0 ? parsed : null;
 };
 
 const parseCategorySummary = (value: unknown): DataCategoryCount[] | null => {
+  const fromArray = parseSummaryArray(value);
+  if (fromArray) return fromArray;
   if (!value || typeof value !== 'object') return null;
+
   const root = value as Record<string, unknown>;
+  const nestedArray = parseSummaryArray(root.summary);
+  if (nestedArray) return nestedArray;
 
   const sourceSummary = (() => {
-    if (root.summary && typeof root.summary === 'object') return root.summary as Record<string, unknown>;
     if (root.counts && typeof root.counts === 'object') return root.counts as Record<string, unknown>;
+    if (root.summary && typeof root.summary === 'object' && !Array.isArray(root.summary)) {
+      return root.summary as Record<string, unknown>;
+    }
     if (root.categories && typeof root.categories === 'object') return root.categories as Record<string, unknown>;
     return root;
   })();
@@ -104,7 +97,6 @@ const parseCategorySummary = (value: unknown): DataCategoryCount[] | null => {
       chat_messages: ['chat_messages', 'chats', 'chat_sessions'],
       notes: ['notes', 'note_items'],
       audit_events: ['audit_events', 'audit_logs', 'audit_log_entries'],
-      embeddings: ['embeddings', 'embedding_vectors', 'vectors'],
     };
     const keys = aliases[def.key] ?? [def.key];
     for (const key of keys) {
@@ -119,104 +111,78 @@ const parseCategorySummary = (value: unknown): DataCategoryCount[] | null => {
   return mapped;
 };
 
-const buildLocalCategorySummary = (requester: string): DataCategoryCount[] => {
-  const seed = requester
-    .split('')
-    .reduce((accumulator, character, index) => accumulator + (character.charCodeAt(0) * (index + 3)), 0);
+const parseRequestLogItem = (value: unknown): DataSubjectRequestLogItem | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
 
-  return CATEGORY_DEFS.map((def, index) => {
-    const base = (seed * (index + 5)) % 240;
-    return {
-      key: def.key,
-      label: def.label,
-      count: base + (index + 1) * 3,
-    };
-  });
+  const rawId = record.client_request_id ?? record.id;
+  const id = typeof rawId === 'string' || typeof rawId === 'number' ? String(rawId) : '';
+  const requesterIdentifier = typeof record.requester_identifier === 'string'
+    ? record.requester_identifier
+    : typeof record.requester === 'string'
+      ? record.requester
+      : '';
+  const requestType = typeof record.request_type === 'string'
+    ? record.request_type
+    : '';
+  const status = typeof record.status === 'string'
+    ? record.status
+    : '';
+  const requestedAt = typeof record.requested_at === 'string'
+    ? record.requested_at
+    : '';
+
+  if (!id || !requesterIdentifier || !requestedAt) return null;
+  if (!['export', 'erasure', 'access'].includes(requestType)) return null;
+  if (!['recorded', 'completed', 'failed', 'rejected', 'in_review'].includes(status)) return null;
+
+  const previewSummary = parseCategorySummary(record.preview_summary) ?? [];
+  const selectedCategories = Array.isArray(record.selected_categories)
+    ? record.selected_categories.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+
+  return {
+    id,
+    requester_identifier: requesterIdentifier,
+    request_type: requestType as DataSubjectRequestType,
+    status: status as DataSubjectRequestStatus,
+    requested_at: requestedAt,
+    selected_categories: selectedCategories,
+    preview_summary: previewSummary,
+  };
 };
 
-const downloadExportArchive = (requester: string, categories: DataCategoryCount[]) => {
-  const payload = {
-    requester,
-    generated_at: new Date().toISOString(),
-    datasets: categories,
-  };
-  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
-  const objectUrl = window.URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = objectUrl;
-  link.download = `data-subject-export-${requester.replace(/[^a-zA-Z0-9_-]/g, '_') || 'user'}.json`;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  window.URL.revokeObjectURL(objectUrl);
+const parseRequestLogResponse = (value: unknown): DataSubjectRequestLogItem[] => {
+  if (!value || typeof value !== 'object') return [];
+  const root = value as Record<string, unknown>;
+  const items = Array.isArray(root.items) ? root.items : [];
+  return items
+    .map(parseRequestLogItem)
+    .filter((entry): entry is DataSubjectRequestLogItem => entry !== null);
+};
+
+const badgeVariantForStatus = (status: DataSubjectRequestStatus) => {
+  if (status === 'failed' || status === 'rejected') return 'destructive';
+  if (status === 'recorded' || status === 'in_review') return 'secondary';
+  return 'default';
 };
 
 export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequestsSectionProps) => {
   const { success, error: showError } = useToast();
-  const unsafeLocalToolsEnabled = isUnsafeLocalToolsEnabled();
 
   const [requesterIdentifier, setRequesterIdentifier] = useState('');
   const [requestType, setRequestType] = useState<DataSubjectRequestType>('access');
   const [submitting, setSubmitting] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(false);
+  const [requestLogLoading, setRequestLogLoading] = useState(true);
   const [formError, setFormError] = useState('');
+  const [requestLogError, setRequestLogError] = useState('');
 
   const [accessSummary, setAccessSummary] = useState<DataCategoryCount[] | null>(null);
   const [erasurePreview, setErasurePreview] = useState<DataCategoryCount[] | null>(null);
   const [selectedErasureCategories, setSelectedErasureCategories] = useState<Record<string, boolean>>({});
   const [erasureConfirmed, setErasureConfirmed] = useState(false);
-
   const [requestLog, setRequestLog] = useState<DataSubjectRequestLogItem[]>([]);
-
-  useEffect(() => {
-    if (refreshSignal === 0) return;
-    setRequesterIdentifier('');
-    setRequestType('access');
-    setFormError('');
-    setAccessSummary(null);
-    setErasurePreview(null);
-    setSelectedErasureCategories({});
-    setErasureConfirmed(false);
-  }, [refreshSignal]);
-
-  useEffect(() => {
-    if (!unsafeLocalToolsEnabled) {
-      setRequestLog([]);
-      return;
-    }
-    if (typeof window === 'undefined') return;
-    try {
-      const raw = window.localStorage.getItem(REQUEST_LOG_STORAGE_KEY);
-      if (!raw) return;
-      const parsed = parseRequestLogStorage(JSON.parse(raw));
-      setRequestLog(parsed);
-    } catch (error) {
-      console.warn('Failed to read data subject request log storage:', error);
-      setRequestLog([]);
-    }
-  }, [unsafeLocalToolsEnabled]);
-
-  const persistRequestLog = (nextLog: DataSubjectRequestLogItem[]) => {
-    if (!unsafeLocalToolsEnabled) return;
-    setRequestLog(nextLog);
-    if (typeof window === 'undefined') return;
-    try {
-      window.localStorage.setItem(REQUEST_LOG_STORAGE_KEY, JSON.stringify(nextLog.slice(0, 50)));
-    } catch (error) {
-      console.warn('Failed to persist data subject request log:', error);
-    }
-  };
-
-  const resolveCategorySummary = async (requester: string) => {
-    try {
-      const response = await api.previewDataSubjectRequest({ requester_identifier: requester });
-      const parsed = parseCategorySummary(response);
-      if (parsed) return parsed;
-    } catch {
-      // Fallback to local estimate when backend preview endpoint is unavailable.
-    }
-    return buildLocalCategorySummary(requester);
-  };
 
   const selectedErasureKeys = useMemo(() => {
     return Object.entries(selectedErasureCategories)
@@ -224,13 +190,80 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
       .map(([key]) => key);
   }, [selectedErasureCategories]);
 
-  const addRequestLogEntry = (entry: DataSubjectRequestLogItem) => {
-    const deduped = requestLog.filter((item) => item.id !== entry.id);
-    persistRequestLog([entry, ...deduped].slice(0, 50));
+  const loadRequestLog = async () => {
+    setRequestLogLoading(true);
+    setRequestLogError('');
+    try {
+      const response = await api.listDataSubjectRequests({ limit: '50', offset: '0' });
+      setRequestLog(parseRequestLogResponse(response));
+    } catch (error: unknown) {
+      const message = error instanceof Error && error.message
+        ? error.message
+        : 'Failed to load data subject requests';
+      setRequestLog([]);
+      setRequestLogError(message);
+      showError('Request log unavailable', message);
+    } finally {
+      setRequestLogLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadInitialRequestLog = async () => {
+      setRequestLogLoading(true);
+      setRequestLogError('');
+      try {
+        const response = await api.listDataSubjectRequests({ limit: '50', offset: '0' });
+        if (cancelled) return;
+        setRequestLog(parseRequestLogResponse(response));
+      } catch (error: unknown) {
+        if (cancelled) return;
+        const message = error instanceof Error && error.message
+          ? error.message
+          : 'Failed to load data subject requests';
+        setRequestLog([]);
+        setRequestLogError(message);
+        showError('Request log unavailable', message);
+      } finally {
+        if (!cancelled) {
+          setRequestLogLoading(false);
+        }
+      }
+    };
+
+    setRequesterIdentifier('');
+    setRequestType('access');
+    setFormError('');
+    setAccessSummary(null);
+    setErasurePreview(null);
+    setSelectedErasureCategories({});
+    setErasureConfirmed(false);
+    void loadInitialRequestLog();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshSignal, showError]);
+
+  const resolveCategorySummary = async (
+    requester: string,
+    request: { requestType?: DataSubjectRequestType; categories?: string[] } = {},
+  ) => {
+    const response = await api.previewDataSubjectRequest({
+      requester_identifier: requester,
+      request_type: request.requestType,
+      categories: request.categories,
+    });
+    const parsed = parseCategorySummary(response);
+    if (!parsed) {
+      throw new Error('Preview response did not include a valid category summary');
+    }
+    return parsed;
   };
 
   const handlePreviewErasure = async () => {
-    if (!unsafeLocalToolsEnabled) return;
     const normalizedRequester = requesterIdentifier.trim();
     if (!normalizedRequester) {
       setFormError('User identifier (email or user ID) is required.');
@@ -240,7 +273,10 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
     setPreviewLoading(true);
     setFormError('');
     try {
-      const summary = await resolveCategorySummary(normalizedRequester);
+      const summary = await resolveCategorySummary(normalizedRequester, {
+        requestType: 'erasure',
+        categories: CATEGORY_DEFS.map((entry) => entry.key),
+      });
       setErasurePreview(summary);
       setSelectedErasureCategories({});
       setErasureConfirmed(false);
@@ -253,7 +289,6 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
   };
 
   const handleSubmitRequest = async () => {
-    if (!unsafeLocalToolsEnabled) return;
     const normalizedRequester = requesterIdentifier.trim();
     if (!normalizedRequester) {
       setFormError('User identifier (email or user ID) is required.');
@@ -277,58 +312,35 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
     setFormError('');
 
     const requestId = `dsr-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
-    const requestedAt = new Date().toISOString();
 
     try {
-      const summary = requestType === 'erasure'
-        ? (erasurePreview as DataCategoryCount[])
-        : await resolveCategorySummary(normalizedRequester);
-
-      try {
-        await api.createDataSubjectRequest({
-          request_id: requestId,
-          requester_identifier: normalizedRequester,
-          request_type: requestType,
-          categories: requestType === 'erasure' ? selectedErasureKeys : undefined,
-        });
-      } catch {
-        // Continue with local fallback handling.
-      }
-
-      if (requestType === 'export') {
-        downloadExportArchive(normalizedRequester, summary);
-        success('Export generated', 'A downloadable archive for this user was generated.');
-      } else if (requestType === 'access') {
-        setAccessSummary(summary);
-        success('Access summary ready', 'User data category summary is available below.');
-      } else {
-        const deletedCount = summary
-          .filter((entry) => selectedErasureKeys.includes(entry.key))
-          .reduce((total, entry) => total + entry.count, 0);
-        success('Erasure request completed', `Marked ${deletedCount} records for deletion across selected categories.`);
-      }
-
-      addRequestLogEntry({
-        id: requestId,
-        requester: normalizedRequester,
+      const response = await api.createDataSubjectRequest({
+        request_id: requestId,
+        requester_identifier: normalizedRequester,
         request_type: requestType,
-        status: 'completed',
-        requested_at: requestedAt,
-        completed_at: new Date().toISOString(),
-        selected_categories: requestType === 'erasure' ? selectedErasureKeys : undefined,
+        categories: requestType === 'erasure' ? selectedErasureKeys : undefined,
       });
+      const createdItem = parseRequestLogItem(
+        response && typeof response === 'object'
+          ? (response as Record<string, unknown>).item
+          : null,
+      );
+      const createdSummary = createdItem?.preview_summary ?? [];
+
+      if (requestType === 'access' && createdSummary.length > 0) {
+        setAccessSummary(createdSummary);
+        success('Request recorded', 'The access request was recorded and the authoritative summary is shown below.');
+      } else {
+        success(
+          'Request recorded',
+          'The request was recorded for review. Export and erasure are not executed automatically in this release.',
+        );
+      }
+
+      await loadRequestLog();
     } catch (error: unknown) {
       const message = error instanceof Error && error.message ? error.message : 'Failed to process data subject request';
       showError('Request failed', message);
-      addRequestLogEntry({
-        id: requestId,
-        requester: normalizedRequester,
-        request_type: requestType,
-        status: 'failed',
-        requested_at: requestedAt,
-        completed_at: new Date().toISOString(),
-        selected_categories: requestType === 'erasure' ? selectedErasureKeys : undefined,
-      });
     } finally {
       setSubmitting(false);
     }
@@ -341,22 +353,14 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
           <ShieldAlert className="h-5 w-5" />
           Data Subject Requests
         </CardTitle>
-        <CardDescription>Handle GDPR-style export, erasure, and access requests.</CardDescription>
+        <CardDescription>Record GDPR-style access, export, and erasure requests with authoritative backend data.</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {!unsafeLocalToolsEnabled ? (
-          <Alert>
-            <AlertDescription>
-              Data subject request workflows are unavailable until server-backed APIs are available.
-            </AlertDescription>
-          </Alert>
-        ) : (
-          <Alert>
-            <AlertDescription>
-              Local-only mode is enabled for development. Results shown here are not persisted server-side.
-            </AlertDescription>
-          </Alert>
-        )}
+        <Alert>
+          <AlertDescription>
+            Requests are recorded server-side for review. Export and erasure are not executed automatically in this release.
+          </AlertDescription>
+        </Alert>
 
         <div className="grid gap-3 md:grid-cols-3">
           <Field id="dsr-requester" label="User identifier (email or user ID)">
@@ -365,19 +369,18 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
               value={requesterIdentifier}
               onChange={(event) => setRequesterIdentifier(event.target.value)}
               placeholder="user@example.com or 42"
-              disabled={!unsafeLocalToolsEnabled}
             />
           </Field>
           <Field id="dsr-request-type" label="Request type">
             <Select
               id="dsr-request-type"
               value={requestType}
-              disabled={!unsafeLocalToolsEnabled}
               onChange={(event) => {
-                setRequestType(event.target.value as DataSubjectRequestType);
+                const nextValue = event.target.value as DataSubjectRequestType;
+                setRequestType(nextValue);
                 setFormError('');
                 setAccessSummary(null);
-                if (event.target.value !== 'erasure') {
+                if (nextValue !== 'erasure') {
                   setErasurePreview(null);
                   setSelectedErasureCategories({});
                   setErasureConfirmed(false);
@@ -396,7 +399,7 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
               <Button
                 variant="outline"
                 onClick={() => { void handlePreviewErasure(); }}
-                disabled={previewLoading || !unsafeLocalToolsEnabled}
+                disabled={previewLoading}
                 loading={previewLoading}
                 loadingText="Previewing..."
               >
@@ -405,7 +408,7 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
             )}
             <Button
               onClick={() => { void handleSubmitRequest(); }}
-              disabled={submitting || !unsafeLocalToolsEnabled}
+              disabled={submitting}
               loading={submitting}
               loadingText="Submitting..."
             >
@@ -417,6 +420,12 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
         {formError && (
           <Alert variant="destructive">
             <AlertDescription>{formError}</AlertDescription>
+          </Alert>
+        )}
+
+        {requestLogError && (
+          <Alert variant="destructive">
+            <AlertDescription>{requestLogError}</AlertDescription>
           </Alert>
         )}
 
@@ -487,26 +496,28 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
                 <TableHead>Type</TableHead>
                 <TableHead>Requester</TableHead>
                 <TableHead>Status</TableHead>
-                <TableHead>Completed</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {requestLog.length === 0 ? (
+              {requestLogLoading ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-muted-foreground">No requests submitted yet.</TableCell>
+                  <TableCell colSpan={4} className="text-muted-foreground">Loading requests…</TableCell>
+                </TableRow>
+              ) : requestLog.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-muted-foreground">No recorded requests yet.</TableCell>
                 </TableRow>
               ) : (
                 requestLog.map((entry) => (
                   <TableRow key={entry.id} data-testid="dsr-request-log-row">
                     <TableCell>{formatDateTime(entry.requested_at, { fallback: '—' })}</TableCell>
                     <TableCell className="capitalize">{entry.request_type}</TableCell>
-                    <TableCell>{entry.requester}</TableCell>
+                    <TableCell>{entry.requester_identifier}</TableCell>
                     <TableCell>
-                      <Badge variant={entry.status === 'completed' ? 'default' : 'destructive'}>
+                      <Badge variant={badgeVariantForStatus(entry.status)}>
                         {entry.status}
                       </Badge>
                     </TableCell>
-                    <TableCell>{formatDateTime(entry.completed_at, { fallback: '—' })}</TableCell>
                   </TableRow>
                 ))
               )}

--- a/admin-ui/components/data-ops/DataSubjectRequestsSection.tsx
+++ b/admin-ui/components/data-ops/DataSubjectRequestsSection.tsx
@@ -315,7 +315,7 @@ export const DataSubjectRequestsSection = ({ refreshSignal }: DataSubjectRequest
 
     try {
       const response = await api.createDataSubjectRequest({
-        request_id: requestId,
+        client_request_id: requestId,
         requester_identifier: normalizedRequester,
         request_type: requestType,
         categories: requestType === 'erasure' ? selectedErasureKeys : undefined,

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -474,6 +474,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  listDataSubjectRequests: (params?: Record<string, string>) => {
+    const queryParams = params ? new URLSearchParams(params).toString() : '';
+    return requestJson(`/admin/data-subject-requests${queryParams ? `?${queryParams}` : ''}`);
+  },
   createDataSubjectRequest: (data: Record<string, unknown>) =>
     requestJson('/admin/data-subject-requests', {
       method: 'POST',

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -32,26 +32,14 @@ from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
 from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.services.admin_data_ops_service import (
     create_backup_snapshot as svc_create_backup_snapshot,
-)
-from tldw_Server_API.app.services.admin_data_ops_service import (
     list_backup_items as svc_list_backup_items,
-)
-from tldw_Server_API.app.services.admin_data_ops_service import (
     list_retention_policies as svc_list_retention_policies,
-)
-from tldw_Server_API.app.services.admin_data_ops_service import (
     restore_backup_snapshot as svc_restore_backup_snapshot,
-)
-from tldw_Server_API.app.services.admin_data_ops_service import (
     update_retention_policy as svc_update_retention_policy,
 )
 from tldw_Server_API.app.services.admin_data_subject_requests_service import (
     list_data_subject_requests as svc_list_data_subject_requests,
-)
-from tldw_Server_API.app.services.admin_data_subject_requests_service import (
     preview_data_subject_request as svc_preview_data_subject_request,
-)
-from tldw_Server_API.app.services.admin_data_subject_requests_service import (
     record_data_subject_request as svc_record_data_subject_request,
 )
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -24,7 +24,12 @@ from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     RetentionPolicy,
     RetentionPolicyUpdateRequest,
 )
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+    AuthnzDataSubjectRequestsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.services.admin_data_ops_service import (
     create_backup_snapshot as svc_create_backup_snapshot,
 )
@@ -72,6 +77,14 @@ _DATA_OPS_NONCRITICAL_EXCEPTIONS = (
     UnicodeDecodeError,
     HTTPException,
 )
+
+
+async def _build_dsr_repos() -> tuple[AuthnzUsersRepo, AuthnzDataSubjectRequestsRepo]:
+    db_pool = await get_db_pool()
+    return (
+        AuthnzUsersRepo(db_pool=db_pool),
+        AuthnzDataSubjectRequestsRepo(db_pool=db_pool),
+    )
 
 
 async def _enforce_admin_user_scope(
@@ -275,11 +288,13 @@ async def preview_data_subject_request(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> DataSubjectRequestPreviewResponse:
     try:
+        users_repo, _ = await _build_dsr_repos()
         preview = await svc_preview_data_subject_request(
             requester_identifier=payload.requester_identifier,
             request_type=payload.request_type,
             categories=payload.categories,
             principal=principal,
+            users_repo=users_repo,
         )
         await _emit_admin_audit_event(
             request,
@@ -310,18 +325,22 @@ async def create_data_subject_request(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> DataSubjectRequestCreateResponse:
     try:
+        users_repo, requests_repo = await _build_dsr_repos()
         preview = await svc_preview_data_subject_request(
             requester_identifier=payload.requester_identifier,
             request_type=payload.request_type,
             categories=payload.categories,
             principal=principal,
+            users_repo=users_repo,
         )
         record = await svc_record_data_subject_request(
             principal=principal,
-            client_request_id=payload.request_id,
+            client_request_id=payload.client_request_id,
             requester_identifier=payload.requester_identifier,
             request_type=payload.request_type,
             categories=payload.categories,
+            users_repo=users_repo,
+            requests_repo=requests_repo,
             preview=preview,
             notes=payload.notes,
         )
@@ -331,7 +350,7 @@ async def create_data_subject_request(
             event_type="data.write",
             category="compliance",
             resource_type="data_subject_request",
-            resource_id=str(record.get("id") or payload.request_id),
+            resource_id=str(record.get("id") or payload.client_request_id),
             action="data_subject_request.record",
             metadata={
                 "requester_identifier": record.get("requester_identifier"),
@@ -355,10 +374,12 @@ async def list_data_subject_requests(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> DataSubjectRequestListResponse:
     try:
+        _, requests_repo = await _build_dsr_repos()
         items, total = await svc_list_data_subject_requests(
             principal,
             limit=limit,
             offset=offset,
+            requests_repo=requests_repo,
         )
         return DataSubjectRequestListResponse(
             items=[_dsr_item_from_record(item) for item in items],

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -14,6 +14,12 @@ from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     BackupListResponse,
     BackupRestoreRequest,
     BackupRestoreResponse,
+    DataSubjectRequestCreateRequest,
+    DataSubjectRequestCreateResponse,
+    DataSubjectRequestItem,
+    DataSubjectRequestListResponse,
+    DataSubjectRequestPreviewRequest,
+    DataSubjectRequestPreviewResponse,
     RetentionPoliciesResponse,
     RetentionPolicy,
     RetentionPolicyUpdateRequest,
@@ -33,6 +39,15 @@ from tldw_Server_API.app.services.admin_data_ops_service import (
 )
 from tldw_Server_API.app.services.admin_data_ops_service import (
     update_retention_policy as svc_update_retention_policy,
+)
+from tldw_Server_API.app.services.admin_data_subject_requests_service import (
+    list_data_subject_requests as svc_list_data_subject_requests,
+)
+from tldw_Server_API.app.services.admin_data_subject_requests_service import (
+    preview_data_subject_request as svc_preview_data_subject_request,
+)
+from tldw_Server_API.app.services.admin_data_subject_requests_service import (
+    record_data_subject_request as svc_record_data_subject_request,
 )
 
 router = APIRouter()
@@ -105,6 +120,10 @@ _PER_USER_BACKUP_DATASETS = _BACKUP_DATASETS - {"authnz"}
 def _require_user_id_for_dataset(dataset: str, user_id: int | None) -> None:
     if dataset in _PER_USER_BACKUP_DATASETS and user_id is None:
         raise HTTPException(status_code=400, detail="user_id_required")
+
+
+def _dsr_item_from_record(record: dict[str, Any]) -> DataSubjectRequestItem:
+    return DataSubjectRequestItem(**record)
 
 
 @router.get("/backups", response_model=BackupListResponse)
@@ -247,6 +266,117 @@ async def restore_backup(
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
         logger.error(f"Failed to restore backup: {exc}")
         raise HTTPException(status_code=500, detail="Failed to restore backup") from exc
+
+
+@router.post("/data-subject-requests/preview", response_model=DataSubjectRequestPreviewResponse)
+async def preview_data_subject_request(
+    payload: DataSubjectRequestPreviewRequest,
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> DataSubjectRequestPreviewResponse:
+    try:
+        preview = await svc_preview_data_subject_request(
+            requester_identifier=payload.requester_identifier,
+        )
+        await _enforce_admin_user_scope(
+            principal,
+            int(preview["resolved_user_id"]),
+            require_hierarchy=False,
+        )
+        await _emit_admin_audit_event(
+            request,
+            principal,
+            event_type="data.read",
+            category="compliance",
+            resource_type="data_subject_request",
+            resource_id=str(preview["resolved_user_id"]),
+            action="data_subject_request.preview",
+            metadata={
+                "requester_identifier": preview["requester_identifier"],
+                "resolved_user_id": preview["resolved_user_id"],
+                "selected_categories": preview["selected_categories"],
+            },
+        )
+        return DataSubjectRequestPreviewResponse(**preview)
+    except HTTPException:
+        raise
+    except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"Failed to preview data subject request: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to preview data subject request") from exc
+
+
+@router.post("/data-subject-requests", response_model=DataSubjectRequestCreateResponse)
+async def create_data_subject_request(
+    payload: DataSubjectRequestCreateRequest,
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> DataSubjectRequestCreateResponse:
+    try:
+        preview = await svc_preview_data_subject_request(
+            requester_identifier=payload.requester_identifier,
+            request_type=payload.request_type,
+            categories=payload.categories,
+        )
+        await _enforce_admin_user_scope(
+            principal,
+            int(preview["resolved_user_id"]),
+            require_hierarchy=False,
+        )
+        record = await svc_record_data_subject_request(
+            principal=principal,
+            client_request_id=payload.request_id,
+            requester_identifier=payload.requester_identifier,
+            request_type=payload.request_type,
+            categories=payload.categories,
+            preview=preview,
+            notes=payload.notes,
+        )
+        await _emit_admin_audit_event(
+            request,
+            principal,
+            event_type="data.write",
+            category="compliance",
+            resource_type="data_subject_request",
+            resource_id=str(record.get("id") or payload.request_id),
+            action="data_subject_request.record",
+            metadata={
+                "requester_identifier": record.get("requester_identifier"),
+                "resolved_user_id": record.get("resolved_user_id"),
+                "request_type": record.get("request_type"),
+                "selected_categories": record.get("selected_categories"),
+            },
+        )
+        return DataSubjectRequestCreateResponse(item=_dsr_item_from_record(record))
+    except HTTPException:
+        raise
+    except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"Failed to record data subject request: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to record data subject request") from exc
+
+
+@router.get("/data-subject-requests", response_model=DataSubjectRequestListResponse)
+async def list_data_subject_requests(
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> DataSubjectRequestListResponse:
+    try:
+        items, total = await svc_list_data_subject_requests(
+            principal,
+            limit=limit,
+            offset=offset,
+        )
+        return DataSubjectRequestListResponse(
+            items=[_dsr_item_from_record(item) for item in items],
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+    except HTTPException:
+        raise
+    except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"Failed to list data subject requests: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to list data subject requests") from exc
 
 
 @router.get("/retention-policies", response_model=RetentionPoliciesResponse)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -277,11 +277,9 @@ async def preview_data_subject_request(
     try:
         preview = await svc_preview_data_subject_request(
             requester_identifier=payload.requester_identifier,
-        )
-        await _enforce_admin_user_scope(
-            principal,
-            int(preview["resolved_user_id"]),
-            require_hierarchy=False,
+            request_type=payload.request_type,
+            categories=payload.categories,
+            principal=principal,
         )
         await _emit_admin_audit_event(
             request,
@@ -316,11 +314,7 @@ async def create_data_subject_request(
             requester_identifier=payload.requester_identifier,
             request_type=payload.request_type,
             categories=payload.categories,
-        )
-        await _enforce_admin_user_scope(
-            principal,
-            int(preview["resolved_user_id"]),
-            require_hierarchy=False,
+            principal=principal,
         )
         record = await svc_record_data_subject_request(
             principal=principal,

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -578,13 +578,13 @@ class DataSubjectRequestPreviewResponse(BaseModel):
 class DataSubjectRequestCreateRequest(BaseModel):
     """Request payload to record a DSR for review."""
 
-    request_id: str = Field(..., min_length=3, max_length=128)
+    client_request_id: str = Field(..., min_length=3, max_length=128)
     requester_identifier: str = Field(..., min_length=1, max_length=255)
     request_type: Literal["access", "export", "erasure"]
     categories: list[str] | None = None
     notes: str | None = Field(default=None, max_length=1000)
 
-    @field_validator("request_id", "requester_identifier")
+    @field_validator("client_request_id", "requester_identifier")
     @classmethod
     def normalize_nonempty_string(cls, value: str) -> str:
         normalized = value.strip()

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -514,6 +514,123 @@ class RetentionPolicyUpdateRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class DataSubjectRequestSummaryItem(BaseModel):
+    """Authoritative per-category summary entry for a DSR preview/request."""
+
+    key: str
+    label: str
+    count: NonNegativeInt
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestPreviewRequest(BaseModel):
+    """Request payload for authoritative DSR preview."""
+
+    requester_identifier: str = Field(..., min_length=1, max_length=255)
+
+    @field_validator("requester_identifier")
+    @classmethod
+    def normalize_requester_identifier(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("requester_identifier is required")
+        return normalized
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestPreviewResponse(BaseModel):
+    """Response payload for authoritative DSR preview."""
+
+    requester_identifier: str
+    resolved_user_id: int
+    request_type: Literal["access", "export", "erasure"] | None = None
+    selected_categories: list[str]
+    summary: list[DataSubjectRequestSummaryItem]
+    counts: dict[str, NonNegativeInt]
+    coverage_metadata: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestCreateRequest(BaseModel):
+    """Request payload to record a DSR for review."""
+
+    request_id: str = Field(..., min_length=3, max_length=128)
+    requester_identifier: str = Field(..., min_length=1, max_length=255)
+    request_type: Literal["access", "export", "erasure"]
+    categories: list[str] | None = None
+    notes: str | None = Field(default=None, max_length=1000)
+
+    @field_validator("request_id", "requester_identifier")
+    @classmethod
+    def normalize_nonempty_string(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value is required")
+        return normalized
+
+    @field_validator("categories", mode="before")
+    @classmethod
+    def normalize_categories(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            raise ValueError("categories must be a list")
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for entry in value:
+            if not isinstance(entry, str):
+                raise ValueError("categories must contain strings")
+            item = entry.strip().lower()
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            normalized.append(item)
+        return normalized
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestItem(BaseModel):
+    """Persisted DSR record returned by admin endpoints."""
+
+    id: int
+    client_request_id: str
+    requester_identifier: str
+    resolved_user_id: int | None = None
+    request_type: Literal["access", "export", "erasure"]
+    status: str
+    selected_categories: list[str]
+    preview_summary: list[DataSubjectRequestSummaryItem]
+    coverage_metadata: dict[str, Any] = Field(default_factory=dict)
+    requested_by_user_id: int | None = None
+    requested_at: datetime
+    notes: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestCreateResponse(BaseModel):
+    """Response payload for DSR record creation."""
+
+    item: DataSubjectRequestItem
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class DataSubjectRequestListResponse(BaseModel):
+    """Response payload for DSR request log listing."""
+
+    items: list[DataSubjectRequestItem]
+    total: int
+    limit: int
+    offset: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 #######################################################################################################################
 #
 # System Ops Schemas (Logs, Incidents, Maintenance, Feature Flags)

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -528,6 +528,8 @@ class DataSubjectRequestPreviewRequest(BaseModel):
     """Request payload for authoritative DSR preview."""
 
     requester_identifier: str = Field(..., min_length=1, max_length=255)
+    request_type: Literal["access", "export", "erasure"] | None = None
+    categories: list[str] | None = None
 
     @field_validator("requester_identifier")
     @classmethod
@@ -535,6 +537,25 @@ class DataSubjectRequestPreviewRequest(BaseModel):
         normalized = value.strip()
         if not normalized:
             raise ValueError("requester_identifier is required")
+        return normalized
+
+    @field_validator("categories", mode="before")
+    @classmethod
+    def normalize_categories(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            raise ValueError("categories must be a list")
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for entry in value:
+            if not isinstance(entry, str):
+                raise ValueError("categories must contain strings")
+            item = entry.strip().lower()
+            if not item or item in seen:
+                continue
+            seen.add(item)
+            normalized.append(item)
         return normalized
 
     model_config = ConfigDict(from_attributes=True)

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -2676,6 +2676,58 @@ def rollback_048_drop_org_team_config_overrides(conn: sqlite3.Connection) -> Non
     logger.info("Rollback 048: Dropped org/team config overrides tables")
 
 
+def migration_059_create_data_subject_requests_table(conn: sqlite3.Connection) -> None:
+    """Create data_subject_requests table for authoritative DSR intake."""
+    logger.info("Migration 059: START data_subject_requests table")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS data_subject_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            client_request_id TEXT NOT NULL UNIQUE,
+            requester_identifier TEXT NOT NULL,
+            resolved_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+            request_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            selected_categories TEXT NOT NULL DEFAULT '[]',
+            preview_summary TEXT NOT NULL DEFAULT '[]',
+            coverage_metadata TEXT DEFAULT '{}',
+            requested_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+            requested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            notes TEXT
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_requester "
+        "ON data_subject_requests(requester_identifier)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_resolved_user "
+        "ON data_subject_requests(resolved_user_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_type "
+        "ON data_subject_requests(request_type)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_status "
+        "ON data_subject_requests(status)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_requested_at "
+        "ON data_subject_requests(requested_at)"
+    )
+    conn.commit()
+    logger.info("Migration 059: Created data_subject_requests table")
+
+
+def rollback_059_drop_data_subject_requests_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 059 by dropping data_subject_requests."""
+    conn.execute("DROP TABLE IF EXISTS data_subject_requests")
+    conn.commit()
+    logger.info("Rollback 059: Dropped data_subject_requests table")
+
+
 def migration_041_add_llm_provider_overrides(conn: sqlite3.Connection) -> None:
     """Add llm_provider_overrides table for runtime provider overrides."""
     logger.info("Migration 041: START llm_provider_overrides table")
@@ -3075,6 +3127,12 @@ def get_authnz_migrations() -> list[Migration]:
             58,
             "Harden MCP policy override schema",
             migration_058_harden_mcp_policy_override_schema,
+        ),
+        Migration(
+            59,
+            "Create data subject requests table",
+            migration_059_create_data_subject_requests_table,
+            rollback_059_drop_data_subject_requests_table,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1369,6 +1369,53 @@ _CREATE_GENERATED_FILES_TABLES = [
     ),
 ]
 
+_CREATE_DATA_SUBJECT_REQUESTS_TABLES = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS data_subject_requests (
+            id SERIAL PRIMARY KEY,
+            client_request_id TEXT NOT NULL UNIQUE,
+            requester_identifier TEXT NOT NULL,
+            resolved_user_id INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+            request_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            selected_categories JSONB NOT NULL DEFAULT '[]'::jsonb,
+            preview_summary JSONB NOT NULL DEFAULT '[]'::jsonb,
+            coverage_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+            requested_by_user_id INTEGER NULL REFERENCES users(id) ON DELETE SET NULL,
+            requested_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            notes TEXT NULL
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_requester "
+        "ON data_subject_requests(requester_identifier)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_resolved_user "
+        "ON data_subject_requests(resolved_user_id)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_type "
+        "ON data_subject_requests(request_type)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_status "
+        "ON data_subject_requests(status)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_data_subject_requests_requested_at "
+        "ON data_subject_requests(requested_at)",
+        (),
+    ),
+]
+
 
 async def ensure_tool_catalogs_tables_pg(pool: DatabasePool | None = None) -> bool:
     """Ensure tool catalogs tables exist on PostgreSQL backends.
@@ -2083,6 +2130,28 @@ async def ensure_generated_files_table_pg(pool: DatabasePool | None = None) -> b
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL generated_files table: {exc}")
+        return False
+
+
+async def ensure_data_subject_requests_table_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure data_subject_requests table exists for PostgreSQL backends."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+        try:
+            await ensure_authnz_core_tables_pg(db_pool)
+        except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"PG ensure authnz core tables before data_subject_requests failed: {exc}")
+        for sql, params in _CREATE_DATA_SUBJECT_REQUESTS_TABLES:
+            try:
+                await db_pool.execute(sql, *params)
+            except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(f"PG ensure data_subject_requests DDL failed: {exc}")
+        logger.info("Ensured PostgreSQL data_subject_requests table (idempotent)")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL data_subject_requests table: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import contextlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+@dataclass
+class AuthnzDataSubjectRequestsRepo:
+    """Repository for AuthNZ data subject request records."""
+
+    db_pool: DatabasePool
+
+    def _is_postgres_backend(self) -> bool:
+        """Return True when the current AuthNZ backend is PostgreSQL."""
+        return bool(getattr(self.db_pool, "pool", None))
+
+    async def ensure_schema(self) -> None:
+        """Ensure the DSR table exists for the current backend."""
+        try:
+            if self._is_postgres_backend():
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_data_subject_requests_table_pg,
+                )
+
+                await ensure_data_subject_requests_table_pg(self.db_pool)
+                return
+
+            from pathlib import Path
+
+            from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+
+            db_fs_path = getattr(self.db_pool, "_sqlite_fs_path", None) or getattr(
+                self.db_pool, "db_path", None
+            )
+            if db_fs_path:
+                ensure_authnz_tables(Path(str(db_fs_path)))
+        except Exception as exc:  # pragma: no cover - surfaced via callers
+            logger.debug(f"AuthnzDataSubjectRequestsRepo.ensure_schema skipped/failed: {exc}")
+
+    @staticmethod
+    def _parse_json_field(value: Any, *, fallback: Any) -> Any:
+        if value is None:
+            return fallback
+        if isinstance(value, (list, dict)):
+            return value
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return fallback
+        return fallback
+
+    @classmethod
+    def _normalize_record(cls, row: Any) -> dict[str, Any]:
+        """Normalize backend row types into JSON-friendly dicts."""
+        if row is None:
+            return {}
+
+        try:
+            record = dict(row) if hasattr(row, "keys") or isinstance(row, dict) else {}
+        except Exception:
+            record = {}
+
+        for field in ("id", "resolved_user_id", "requested_by_user_id"):
+            if field in record and record[field] is not None:
+                with contextlib.suppress(Exception):
+                    record[field] = int(record[field])
+
+        record["selected_categories"] = cls._parse_json_field(
+            record.get("selected_categories"),
+            fallback=[],
+        )
+        record["preview_summary"] = cls._parse_json_field(
+            record.get("preview_summary"),
+            fallback=[],
+        )
+        record["coverage_metadata"] = cls._parse_json_field(
+            record.get("coverage_metadata"),
+            fallback={},
+        )
+
+        if "requested_at" in record and record["requested_at"] is not None:
+            with contextlib.suppress(Exception):
+                if hasattr(record["requested_at"], "isoformat"):
+                    record["requested_at"] = record["requested_at"].isoformat()
+
+        return record
+
+    async def create_or_get_request(
+        self,
+        *,
+        client_request_id: str,
+        requester_identifier: str,
+        resolved_user_id: int | None,
+        request_type: str,
+        status: str,
+        selected_categories: list[str],
+        preview_summary: list[dict[str, Any]],
+        coverage_metadata: dict[str, Any] | None,
+        requested_by_user_id: int | None,
+        notes: str | None,
+    ) -> dict[str, Any]:
+        """Persist a request unless the client idempotency key already exists."""
+        now = datetime.now(timezone.utc)
+        selected_categories_json = json.dumps(selected_categories or [])
+        preview_summary_json = json.dumps(preview_summary or [])
+        coverage_metadata_json = json.dumps(coverage_metadata or {})
+
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO data_subject_requests (
+                            client_request_id,
+                            requester_identifier,
+                            resolved_user_id,
+                            request_type,
+                            status,
+                            selected_categories,
+                            preview_summary,
+                            coverage_metadata,
+                            requested_by_user_id,
+                            requested_at,
+                            notes
+                        ) VALUES (
+                            $1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10, $11
+                        )
+                        ON CONFLICT (client_request_id) DO NOTHING
+                        RETURNING *
+                        """,
+                        client_request_id,
+                        requester_identifier,
+                        resolved_user_id,
+                        request_type,
+                        status,
+                        selected_categories_json,
+                        preview_summary_json,
+                        coverage_metadata_json,
+                        requested_by_user_id,
+                        now,
+                        notes,
+                    )
+                    if row is None:
+                        row = await conn.fetchrow(
+                            "SELECT * FROM data_subject_requests WHERE client_request_id = $1",
+                            client_request_id,
+                        )
+                    return self._normalize_record(row)
+
+                await conn.execute(
+                    """
+                    INSERT OR IGNORE INTO data_subject_requests (
+                        client_request_id,
+                        requester_identifier,
+                        resolved_user_id,
+                        request_type,
+                        status,
+                        selected_categories,
+                        preview_summary,
+                        coverage_metadata,
+                        requested_by_user_id,
+                        requested_at,
+                        notes
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        client_request_id,
+                        requester_identifier,
+                        resolved_user_id,
+                        request_type,
+                        status,
+                        selected_categories_json,
+                        preview_summary_json,
+                        coverage_metadata_json,
+                        requested_by_user_id,
+                        now.isoformat(),
+                        notes,
+                    ),
+                )
+                cursor = await conn.execute(
+                    "SELECT * FROM data_subject_requests WHERE client_request_id = ?",
+                    (client_request_id,),
+                )
+                row = await cursor.fetchone()
+                if row is None:
+                    raise RuntimeError("Failed to fetch persisted data subject request")
+                return self._normalize_record(row)
+        except Exception as exc:  # pragma: no cover - surfaced via callers
+            logger.error(f"AuthnzDataSubjectRequestsRepo.create_or_get_request failed: {exc}")
+            raise
+
+    async def list_requests(
+        self,
+        *,
+        limit: int,
+        offset: int,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return paged request rows ordered newest-first."""
+        try:
+            async with self.db_pool.acquire() as conn:
+                if self._is_postgres_backend():
+                    rows = await conn.fetch(
+                        """
+                        SELECT *
+                        FROM data_subject_requests
+                        ORDER BY requested_at DESC, id DESC
+                        LIMIT $1 OFFSET $2
+                        """,
+                        limit,
+                        offset,
+                    )
+                    total = await conn.fetchval("SELECT COUNT(*) FROM data_subject_requests")
+                    return [self._normalize_record(row) for row in rows], int(total or 0)
+
+                cursor = await conn.execute(
+                    """
+                    SELECT *
+                    FROM data_subject_requests
+                    ORDER BY requested_at DESC, id DESC
+                    LIMIT ? OFFSET ?
+                    """,
+                    (limit, offset),
+                )
+                rows = await cursor.fetchall()
+                total_cursor = await conn.execute("SELECT COUNT(*) FROM data_subject_requests")
+                total_row = await total_cursor.fetchone()
+                total = int(total_row[0]) if total_row else 0
+                return [self._normalize_record(row) for row in rows], total
+        except Exception as exc:  # pragma: no cover - surfaced via callers
+            logger.error(f"AuthnzDataSubjectRequestsRepo.list_requests failed: {exc}")
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
@@ -202,38 +202,78 @@ class AuthnzDataSubjectRequestsRepo:
         *,
         limit: int,
         offset: int,
+        resolved_user_ids: list[int] | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Return paged request rows ordered newest-first."""
         try:
+            if resolved_user_ids is not None and not resolved_user_ids:
+                return [], 0
+            allowed_user_ids = {int(value) for value in resolved_user_ids or []}
+
             async with self.db_pool.acquire() as conn:
                 if self._is_postgres_backend():
+                    if resolved_user_ids is None:
+                        rows = await conn.fetch(
+                            """
+                            SELECT *
+                            FROM data_subject_requests
+                            ORDER BY requested_at DESC, id DESC
+                            LIMIT $1 OFFSET $2
+                            """,
+                            limit,
+                            offset,
+                        )
+                        total = await conn.fetchval("SELECT COUNT(*) FROM data_subject_requests")
+                        return [self._normalize_record(row) for row in rows], int(total or 0)
+
                     rows = await conn.fetch(
                         """
                         SELECT *
                         FROM data_subject_requests
                         ORDER BY requested_at DESC, id DESC
-                        LIMIT $1 OFFSET $2
                         """,
-                        limit,
-                        offset,
                     )
-                    total = await conn.fetchval("SELECT COUNT(*) FROM data_subject_requests")
-                    return [self._normalize_record(row) for row in rows], int(total or 0)
+                    filtered = [
+                        self._normalize_record(row)
+                        for row in rows
+                        if row.get("resolved_user_id") is not None
+                        and int(row.get("resolved_user_id")) in allowed_user_ids
+                    ]
+                    total = len(filtered)
+                    return filtered[offset: offset + limit], total
 
-                cursor = await conn.execute(
+                if resolved_user_ids is None:
+                    cursor = await conn.execute(
+                        """
+                        SELECT *
+                        FROM data_subject_requests
+                        ORDER BY requested_at DESC, id DESC
+                        LIMIT ? OFFSET ?
+                        """,
+                        (limit, offset),
+                    )
+                    rows = await cursor.fetchall()
+                    total_cursor = await conn.execute("SELECT COUNT(*) FROM data_subject_requests")
+                    total_row = await total_cursor.fetchone()
+                    total = int(total_row[0]) if total_row else 0
+                    return [self._normalize_record(row) for row in rows], total
+
+                all_cursor = await conn.execute(
                     """
                     SELECT *
                     FROM data_subject_requests
                     ORDER BY requested_at DESC, id DESC
-                    LIMIT ? OFFSET ?
-                    """,
-                    (limit, offset),
+                    """
                 )
-                rows = await cursor.fetchall()
-                total_cursor = await conn.execute("SELECT COUNT(*) FROM data_subject_requests")
-                total_row = await total_cursor.fetchone()
-                total = int(total_row[0]) if total_row else 0
-                return [self._normalize_record(row) for row in rows], total
+                all_rows = await all_cursor.fetchall()
+                filtered = [
+                    self._normalize_record(row)
+                    for row in all_rows
+                    if row["resolved_user_id"] is not None
+                    and int(row["resolved_user_id"]) in allowed_user_ids
+                ]
+                total = len(filtered)
+                return filtered[offset: offset + limit], total
         except Exception as exc:  # pragma: no cover - surfaced via callers
             logger.error(f"AuthnzDataSubjectRequestsRepo.list_requests failed: {exc}")
             raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/data_subject_requests_repo.py
@@ -23,26 +23,23 @@ class AuthnzDataSubjectRequestsRepo:
 
     async def ensure_schema(self) -> None:
         """Ensure the DSR table exists for the current backend."""
-        try:
-            if self._is_postgres_backend():
-                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
-                    ensure_data_subject_requests_table_pg,
-                )
-
-                await ensure_data_subject_requests_table_pg(self.db_pool)
-                return
-
-            from pathlib import Path
-
-            from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
-
-            db_fs_path = getattr(self.db_pool, "_sqlite_fs_path", None) or getattr(
-                self.db_pool, "db_path", None
+        if self._is_postgres_backend():
+            from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                ensure_data_subject_requests_table_pg,
             )
-            if db_fs_path:
-                ensure_authnz_tables(Path(str(db_fs_path)))
-        except Exception as exc:  # pragma: no cover - surfaced via callers
-            logger.debug(f"AuthnzDataSubjectRequestsRepo.ensure_schema skipped/failed: {exc}")
+
+            await ensure_data_subject_requests_table_pg(self.db_pool)
+            return
+
+        from pathlib import Path
+
+        from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+
+        db_fs_path = getattr(self.db_pool, "_sqlite_fs_path", None) or getattr(
+            self.db_pool, "db_path", None
+        )
+        if db_fs_path:
+            ensure_authnz_tables(Path(str(db_fs_path)))
 
     @staticmethod
     def _parse_json_field(value: Any, *, fallback: Any) -> Any:
@@ -203,77 +200,70 @@ class AuthnzDataSubjectRequestsRepo:
         limit: int,
         offset: int,
         resolved_user_ids: list[int] | None = None,
+        org_ids: list[int] | None = None,
     ) -> tuple[list[dict[str, Any]], int]:
         """Return paged request rows ordered newest-first."""
         try:
             if resolved_user_ids is not None and not resolved_user_ids:
                 return [], 0
-            allowed_user_ids = {int(value) for value in resolved_user_ids or []}
+            if org_ids is not None and not org_ids:
+                return [], 0
 
             async with self.db_pool.acquire() as conn:
                 if self._is_postgres_backend():
-                    if resolved_user_ids is None:
-                        rows = await conn.fetch(
-                            """
-                            SELECT *
-                            FROM data_subject_requests
-                            ORDER BY requested_at DESC, id DESC
-                            LIMIT $1 OFFSET $2
-                            """,
-                            limit,
-                            offset,
-                        )
-                        total = await conn.fetchval("SELECT COUNT(*) FROM data_subject_requests")
-                        return [self._normalize_record(row) for row in rows], int(total or 0)
+                    where_clauses: list[str] = []
+                    params: list[Any] = []
 
-                    rows = await conn.fetch(
-                        """
-                        SELECT *
-                        FROM data_subject_requests
-                        ORDER BY requested_at DESC, id DESC
-                        """,
-                    )
-                    filtered = [
-                        self._normalize_record(row)
-                        for row in rows
-                        if row.get("resolved_user_id") is not None
-                        and int(row.get("resolved_user_id")) in allowed_user_ids
-                    ]
-                    total = len(filtered)
-                    return filtered[offset: offset + limit], total
+                    if resolved_user_ids is not None:
+                        where_clauses.append(f"resolved_user_id = ANY(${len(params) + 1})")
+                        params.append([int(value) for value in resolved_user_ids])
 
-                if resolved_user_ids is None:
-                    cursor = await conn.execute(
-                        """
-                        SELECT *
-                        FROM data_subject_requests
-                        ORDER BY requested_at DESC, id DESC
-                        LIMIT ? OFFSET ?
-                        """,
-                        (limit, offset),
-                    )
-                    rows = await cursor.fetchall()
-                    total_cursor = await conn.execute("SELECT COUNT(*) FROM data_subject_requests")
-                    total_row = await total_cursor.fetchone()
-                    total = int(total_row[0]) if total_row else 0
-                    return [self._normalize_record(row) for row in rows], total
+                    if org_ids is not None:
+                        org_scope_param_index = len(params) + 1
+                        # Placeholder index is int-derived; values remain parameterized.
+                        org_scope_clause = f"EXISTS (SELECT 1 FROM org_members om WHERE om.user_id = data_subject_requests.resolved_user_id AND om.org_id = ANY(${org_scope_param_index}) AND om.status = 'active')"  # nosec
+                        where_clauses.append(org_scope_clause)
+                        params.append([int(value) for value in org_ids])
 
-                all_cursor = await conn.execute(
-                    """
-                    SELECT *
-                    FROM data_subject_requests
-                    ORDER BY requested_at DESC, id DESC
-                    """
+                    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+                    # where_sql is built only from fixed clauses with parameter placeholders.
+                    query = f"SELECT * FROM data_subject_requests {where_sql} ORDER BY requested_at DESC, id DESC LIMIT ${len(params) + 1} OFFSET ${len(params) + 2}"  # nosec
+                    count_query = f"SELECT COUNT(*) FROM data_subject_requests {where_sql}"  # nosec
+                    rows = await conn.fetch(query, *params, limit, offset)
+                    total = await conn.fetchval(count_query, *params)
+                    return [self._normalize_record(row) for row in rows], int(total or 0)
+
+                where_clauses: list[str] = []
+                params: list[Any] = []
+
+                if resolved_user_ids is not None:
+                    placeholders = ", ".join(["?"] * len(resolved_user_ids))
+                    where_clauses.append(f"resolved_user_id IN ({placeholders})")
+                    params.extend(int(value) for value in resolved_user_ids)
+
+                if org_ids is not None:
+                    placeholders = ", ".join(["?"] * len(org_ids))
+                    # Placeholder count is int-derived; values remain parameterized.
+                    org_scope_clause = f"EXISTS (SELECT 1 FROM org_members om WHERE om.user_id = data_subject_requests.resolved_user_id AND om.org_id IN ({placeholders}) AND om.status = 'active')"  # nosec
+                    where_clauses.append(org_scope_clause)
+                    params.extend(int(value) for value in org_ids)
+
+                where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+                # where_sql is built only from fixed clauses with parameter placeholders.
+                query = f"SELECT * FROM data_subject_requests {where_sql} ORDER BY requested_at DESC, id DESC LIMIT ? OFFSET ?"  # nosec
+                cursor = await conn.execute(
+                    query,
+                    (*params, limit, offset),
                 )
-                all_rows = await all_cursor.fetchall()
-                filtered = [
-                    self._normalize_record(row)
-                    for row in all_rows
-                    if row["resolved_user_id"] is not None
-                    and int(row["resolved_user_id"]) in allowed_user_ids
-                ]
-                total = len(filtered)
-                return filtered[offset: offset + limit], total
+                rows = await cursor.fetchall()
+                count_query = f"SELECT COUNT(*) FROM data_subject_requests {where_sql}"  # nosec
+                total_cursor = await conn.execute(
+                    count_query,
+                    tuple(params),
+                )
+                total_row = await total_cursor.fetchone()
+                total = int(total_row[0]) if total_row else 0
+                return [self._normalize_record(row) for row in rows], total
         except Exception as exc:  # pragma: no cover - surfaced via callers
             logger.error(f"AuthnzDataSubjectRequestsRepo.list_requests failed: {exc}")
             raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
@@ -108,6 +108,20 @@ class AuthnzUsersRepo:
             logger.error(f"AuthnzUsersRepo.get_user_by_username failed: {exc}")
             raise
 
+    async def get_user_by_email(self, email: str) -> dict[str, Any] | None:
+        """Fetch a user row by email address."""
+        db = await self._users_db()
+        try:
+            row = await db.get_user_by_email(email)
+            if row is None:
+                return None
+            return self._normalize_user_record(row)
+        except DatabaseError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"AuthnzUsersRepo.get_user_by_email failed: {exc}")
+            raise
+
     async def create_user(
         self,
         *,

--- a/tldw_Server_API/app/services/admin_data_subject_requests_service.py
+++ b/tldw_Server_API/app/services/admin_data_subject_requests_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -7,11 +8,11 @@ from typing import Any
 from fastapi import HTTPException, status
 from loguru import logger
 
-from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
     AuthnzDataSubjectRequestsRepo,
 )
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.services import admin_scope_service
 
@@ -23,6 +24,10 @@ _CATEGORY_DEFS: tuple[dict[str, str], ...] = (
 )
 _SUPPORTED_CATEGORY_KEYS = {entry["key"] for entry in _CATEGORY_DEFS}
 _UNSUPPORTED_CATEGORY_KEYS = {"embeddings"}
+
+
+class DataSubjectRequestCoverageUnavailableError(RuntimeError):
+    """Raised when a DSR preview cannot query an authoritative subject store."""
 
 
 def _normalize_identifier(value: str) -> str:
@@ -77,25 +82,22 @@ def _normalize_requested_categories(
     return normalized
 
 
-async def _resolve_requester_user(requester_identifier: str) -> dict[str, Any]:
+async def _resolve_requester_user(
+    requester_identifier: str,
+    *,
+    users_repo: AuthnzUsersRepo,
+) -> dict[str, Any]:
     normalized = _normalize_identifier(requester_identifier)
-    db_pool = await get_db_pool()
 
     row: dict[str, Any] | None = None
     if normalized.isdigit():
-        row = await db_pool.fetchrow("SELECT * FROM users WHERE id = ?", int(normalized))
+        row = await users_repo.get_user_by_id(int(normalized))
     if row is None and "@" in normalized:
-        row = await db_pool.fetchrow(
-            "SELECT * FROM users WHERE LOWER(email) = LOWER(?)",
-            normalized,
-        )
+        row = await users_repo.get_user_by_email(normalized)
     if row is None:
-        row = await db_pool.fetchrow(
-            "SELECT * FROM users WHERE LOWER(username) = LOWER(?)",
-            normalized,
-        )
+        row = await users_repo.get_user_by_username(normalized)
     if row is None and "-" in normalized:
-        row = await db_pool.fetchrow("SELECT * FROM users WHERE uuid = ?", normalized)
+        row = await users_repo.get_user_by_uuid(normalized)
 
     if row is None:
         raise HTTPException(
@@ -136,34 +138,39 @@ async def _enforce_requester_visibility(
         raise
 
 
-def _sqlite_count(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
+def _sqlite_count_sync(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
     if not path.exists():
         return 0
     try:
         with sqlite3.connect(path) as conn:
             row = conn.execute(query, params).fetchone()
     except sqlite3.Error as exc:
-        logger.debug("DSR count query failed for {}: {}", path, exc)
-        return 0
+        raise DataSubjectRequestCoverageUnavailableError(
+            f"DSR count query failed for {path}: {exc}"
+        ) from exc
     return int(row[0] if row else 0)
 
 
-def _count_media_records(user_id: int) -> int:
-    return _sqlite_count(
+async def _sqlite_count(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
+    return await asyncio.to_thread(_sqlite_count_sync, path, query, params)
+
+
+async def _count_media_records(user_id: int) -> int:
+    return await _sqlite_count(
         DatabasePaths.get_media_db_path(user_id),
         "SELECT COUNT(*) FROM Media WHERE deleted = 0 AND is_trash = 0",
     )
 
 
-def _count_notes(user_id: int) -> int:
-    return _sqlite_count(
+async def _count_notes(user_id: int) -> int:
+    return await _sqlite_count(
         DatabasePaths.get_chacha_db_path(user_id),
         "SELECT COUNT(*) FROM notes WHERE deleted = 0",
     )
 
 
-def _count_chat_messages(user_id: int) -> int:
-    return _sqlite_count(
+async def _count_chat_messages(user_id: int) -> int:
+    return await _sqlite_count(
         DatabasePaths.get_chacha_db_path(user_id),
         """
         SELECT COUNT(1)
@@ -175,7 +182,7 @@ def _count_chat_messages(user_id: int) -> int:
     )
 
 
-def _count_audit_events(user_id: int) -> int:
+async def _count_audit_events(user_id: int) -> int:
     from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import _resolve_audit_storage_mode
 
     shared_mode = _resolve_audit_storage_mode() == "shared"
@@ -185,24 +192,30 @@ def _count_audit_events(user_id: int) -> int:
         else DatabasePaths.get_audit_db_path(user_id)
     )
     if shared_mode:
-        return _sqlite_count(
+        return await _sqlite_count(
             path,
             "SELECT COUNT(*) FROM audit_events WHERE tenant_user_id = ?",
             (str(user_id),),
         )
-    return _sqlite_count(path, "SELECT COUNT(*) FROM audit_events")
+    return await _sqlite_count(path, "SELECT COUNT(*) FROM audit_events")
 
 
-def _build_summary_for_user(
+async def _build_summary_for_user(
     *,
     user_id: int,
     selected_categories: list[str],
 ) -> list[dict[str, Any]]:
+    media_records, chat_messages, notes, audit_events = await asyncio.gather(
+        _count_media_records(user_id),
+        _count_chat_messages(user_id),
+        _count_notes(user_id),
+        _count_audit_events(user_id),
+    )
     count_map = {
-        "media_records": _count_media_records(user_id),
-        "chat_messages": _count_chat_messages(user_id),
-        "notes": _count_notes(user_id),
-        "audit_events": _count_audit_events(user_id),
+        "media_records": media_records,
+        "chat_messages": chat_messages,
+        "notes": notes,
+        "audit_events": audit_events,
     }
     return [
         {
@@ -232,8 +245,12 @@ async def preview_data_subject_request(
     request_type: str | None = None,
     categories: list[str] | None = None,
     principal: AuthPrincipal | None = None,
+    users_repo: AuthnzUsersRepo,
 ) -> dict[str, Any]:
-    user = await _resolve_requester_user(requester_identifier)
+    user = await _resolve_requester_user(
+        requester_identifier,
+        users_repo=users_repo,
+    )
     await _enforce_requester_visibility(
         principal=principal,
         target_user_id=int(user["id"]),
@@ -242,10 +259,17 @@ async def preview_data_subject_request(
         request_type=request_type,
         categories=categories,
     )
-    summary = _build_summary_for_user(
-        user_id=int(user["id"]),
-        selected_categories=selected_categories,
-    )
+    try:
+        summary = await _build_summary_for_user(
+            user_id=int(user["id"]),
+            selected_categories=selected_categories,
+        )
+    except DataSubjectRequestCoverageUnavailableError as exc:
+        logger.warning("DSR preview unavailable for user {}: {}", user["id"], exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="requester_data_unavailable",
+        ) from exc
     return {
         "requester_identifier": user.get("email") or user.get("username") or requester_identifier,
         "resolved_user_id": int(user["id"]),
@@ -257,7 +281,11 @@ async def preview_data_subject_request(
     }
 
 
-async def _normalize_requested_by_user_id(principal: AuthPrincipal) -> int | None:
+async def _normalize_requested_by_user_id(
+    principal: AuthPrincipal,
+    *,
+    users_repo: AuthnzUsersRepo,
+) -> int | None:
     if getattr(principal, "user_id", None) is None:
         return None
     try:
@@ -265,8 +293,7 @@ async def _normalize_requested_by_user_id(principal: AuthPrincipal) -> int | Non
     except (TypeError, ValueError):
         return None
 
-    db_pool = await get_db_pool()
-    row = await db_pool.fetchrow("SELECT id FROM users WHERE id = ?", candidate)
+    row = await users_repo.get_user_by_id(candidate)
     if row is None:
         return None
     return candidate
@@ -279,6 +306,8 @@ async def record_data_subject_request(
     requester_identifier: str,
     request_type: str,
     categories: list[str] | None,
+    users_repo: AuthnzUsersRepo,
+    requests_repo: AuthnzDataSubjectRequestsRepo,
     preview: dict[str, Any] | None = None,
     notes: str | None = None,
 ) -> dict[str, Any]:
@@ -288,13 +317,12 @@ async def record_data_subject_request(
             request_type=request_type,
             categories=categories,
             principal=principal,
+            users_repo=users_repo,
         )
 
-    db_pool = await get_db_pool()
-    repo = AuthnzDataSubjectRequestsRepo(db_pool=db_pool)
-    await repo.ensure_schema()
+    await requests_repo.ensure_schema()
 
-    return await repo.create_or_get_request(
+    return await requests_repo.create_or_get_request(
         client_request_id=str(client_request_id).strip(),
         requester_identifier=str(preview["requester_identifier"]),
         resolved_user_id=int(preview["resolved_user_id"]),
@@ -303,58 +331,12 @@ async def record_data_subject_request(
         selected_categories=list(preview["selected_categories"]),
         preview_summary=list(preview["summary"]),
         coverage_metadata=dict(preview["coverage_metadata"]),
-        requested_by_user_id=await _normalize_requested_by_user_id(principal),
+        requested_by_user_id=await _normalize_requested_by_user_id(
+            principal,
+            users_repo=users_repo,
+        ),
         notes=notes,
     )
-
-
-async def _load_scoped_user_ids(principal: AuthPrincipal) -> list[int] | None:
-    if admin_scope_service.is_platform_admin(principal):
-        return None
-
-    org_ids = await admin_scope_service.get_admin_org_ids(principal)
-    if org_ids is None:
-        return None
-
-    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
-
-    users_repo = await AuthnzUsersRepo.from_pool()
-    scoped_user_ids: list[int] = []
-    seen_user_ids: set[int] = set()
-    offset = 0
-    page_size = 1000
-    total = 0
-
-    while True:
-        scoped_users, total = await users_repo.list_users(
-            offset=offset,
-            limit=page_size,
-            org_ids=org_ids,
-        )
-        if not scoped_users:
-            break
-        for row in scoped_users:
-            user_id = row.get("id")
-            if user_id is None:
-                continue
-            normalized_user_id = int(user_id)
-            if normalized_user_id in seen_user_ids:
-                continue
-            seen_user_ids.add(normalized_user_id)
-            scoped_user_ids.append(normalized_user_id)
-        offset += len(scoped_users)
-        if offset >= total:
-            break
-
-    if getattr(principal, "user_id", None) is not None:
-        try:
-            principal_user_id = int(principal.user_id)
-        except (TypeError, ValueError):
-            principal_user_id = None
-        if principal_user_id is not None and principal_user_id not in seen_user_ids:
-            scoped_user_ids.append(principal_user_id)
-
-    return scoped_user_ids
 
 
 async def list_data_subject_requests(
@@ -362,17 +344,12 @@ async def list_data_subject_requests(
     *,
     limit: int,
     offset: int,
+    requests_repo: AuthnzDataSubjectRequestsRepo,
 ) -> tuple[list[dict[str, Any]], int]:
-    db_pool = await get_db_pool()
-    repo = AuthnzDataSubjectRequestsRepo(db_pool=db_pool)
-    await repo.ensure_schema()
-
-    scoped_user_ids = await _load_scoped_user_ids(principal)
-    if scoped_user_ids is None:
-        return await repo.list_requests(limit=limit, offset=offset)
-
-    return await repo.list_requests(
+    await requests_repo.ensure_schema()
+    org_ids = await admin_scope_service.get_admin_org_ids(principal)
+    return await requests_repo.list_requests(
         limit=limit,
         offset=offset,
-        resolved_user_ids=scoped_user_ids,
+        org_ids=org_ids,
     )

--- a/tldw_Server_API/app/services/admin_data_subject_requests_service.py
+++ b/tldw_Server_API/app/services/admin_data_subject_requests_service.py
@@ -249,6 +249,12 @@ async def preview_data_subject_request(
     principal: AuthPrincipal | None = None,
     users_repo: AuthnzUsersRepo,
 ) -> dict[str, Any]:
+    """Return an authoritative DSR preview for a requester within admin scope.
+
+    The requester is resolved through the AuthNZ user repo, then scoped visibility is
+    enforced before any per-user store is queried. Unsupported or unavailable coverage
+    fails closed so the caller never receives synthetic zero-count summaries.
+    """
     user = await _resolve_requester_user(
         requester_identifier,
         users_repo=users_repo,
@@ -313,6 +319,12 @@ async def record_data_subject_request(
     preview: dict[str, Any] | None = None,
     notes: str | None = None,
 ) -> dict[str, Any]:
+    """Persist an idempotent DSR intake record after authoritative preview validation.
+
+    Callers may supply a previously computed preview to avoid duplicate work, but the
+    preview must still come from the authoritative preview path. Records are stored in
+    the AuthNZ control-plane DB with newest request history and review status metadata.
+    """
     if preview is None:
         preview = await preview_data_subject_request(
             requester_identifier=requester_identifier,
@@ -348,6 +360,12 @@ async def list_data_subject_requests(
     offset: int,
     requests_repo: AuthnzDataSubjectRequestsRepo,
 ) -> tuple[list[dict[str, Any]], int]:
+    """Return paged DSR history limited to the admin's permitted scope.
+
+    Platform admins receive the full request log. Org-scoped admins are limited by the
+    same org scope used elsewhere in admin data-ops, and that filtering is delegated to
+    the repository query so pagination stays authoritative.
+    """
     await requests_repo.ensure_schema()
     org_ids = await admin_scope_service.get_admin_org_ids(principal)
     return await requests_repo.list_requests(

--- a/tldw_Server_API/app/services/admin_data_subject_requests_service.py
+++ b/tldw_Server_API/app/services/admin_data_subject_requests_service.py
@@ -114,6 +114,28 @@ async def _resolve_requester_user(requester_identifier: str) -> dict[str, Any]:
     return row
 
 
+async def _enforce_requester_visibility(
+    *,
+    principal: AuthPrincipal | None,
+    target_user_id: int,
+) -> None:
+    if principal is None or admin_scope_service.is_platform_admin(principal):
+        return
+    try:
+        await admin_scope_service.enforce_admin_user_scope(
+            principal,
+            target_user_id,
+            require_hierarchy=False,
+        )
+    except HTTPException as exc:
+        if exc.status_code == status.HTTP_403_FORBIDDEN:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="requester_not_found",
+            ) from exc
+        raise
+
+
 def _sqlite_count(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
     if not path.exists():
         return 0
@@ -209,8 +231,13 @@ async def preview_data_subject_request(
     requester_identifier: str,
     request_type: str | None = None,
     categories: list[str] | None = None,
+    principal: AuthPrincipal | None = None,
 ) -> dict[str, Any]:
     user = await _resolve_requester_user(requester_identifier)
+    await _enforce_requester_visibility(
+        principal=principal,
+        target_user_id=int(user["id"]),
+    )
     selected_categories = _normalize_requested_categories(
         request_type=request_type,
         categories=categories,
@@ -260,6 +287,7 @@ async def record_data_subject_request(
             requester_identifier=requester_identifier,
             request_type=request_type,
             categories=categories,
+            principal=principal,
         )
 
     db_pool = await get_db_pool()
@@ -280,6 +308,55 @@ async def record_data_subject_request(
     )
 
 
+async def _load_scoped_user_ids(principal: AuthPrincipal) -> list[int] | None:
+    if admin_scope_service.is_platform_admin(principal):
+        return None
+
+    org_ids = await admin_scope_service.get_admin_org_ids(principal)
+    if org_ids is None:
+        return None
+
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+    users_repo = await AuthnzUsersRepo.from_pool()
+    scoped_user_ids: list[int] = []
+    seen_user_ids: set[int] = set()
+    offset = 0
+    page_size = 1000
+    total = 0
+
+    while True:
+        scoped_users, total = await users_repo.list_users(
+            offset=offset,
+            limit=page_size,
+            org_ids=org_ids,
+        )
+        if not scoped_users:
+            break
+        for row in scoped_users:
+            user_id = row.get("id")
+            if user_id is None:
+                continue
+            normalized_user_id = int(user_id)
+            if normalized_user_id in seen_user_ids:
+                continue
+            seen_user_ids.add(normalized_user_id)
+            scoped_user_ids.append(normalized_user_id)
+        offset += len(scoped_users)
+        if offset >= total:
+            break
+
+    if getattr(principal, "user_id", None) is not None:
+        try:
+            principal_user_id = int(principal.user_id)
+        except (TypeError, ValueError):
+            principal_user_id = None
+        if principal_user_id is not None and principal_user_id not in seen_user_ids:
+            scoped_user_ids.append(principal_user_id)
+
+    return scoped_user_ids
+
+
 async def list_data_subject_requests(
     principal: AuthPrincipal,
     *,
@@ -290,29 +367,9 @@ async def list_data_subject_requests(
     repo = AuthnzDataSubjectRequestsRepo(db_pool=db_pool)
     await repo.ensure_schema()
 
-    if admin_scope_service.is_platform_admin(principal):
+    scoped_user_ids = await _load_scoped_user_ids(principal)
+    if scoped_user_ids is None:
         return await repo.list_requests(limit=limit, offset=offset)
-
-    org_ids = await admin_scope_service.get_admin_org_ids(principal)
-    if org_ids is None:
-        return await repo.list_requests(limit=limit, offset=offset)
-
-    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
-
-    users_repo = await AuthnzUsersRepo.from_pool()
-    scoped_users, _ = await users_repo.list_users(
-        offset=0,
-        limit=1000,
-        org_ids=org_ids,
-    )
-    scoped_user_ids = [int(row["id"]) for row in scoped_users if row.get("id") is not None]
-    if getattr(principal, "user_id", None) is not None:
-        try:
-            principal_user_id = int(principal.user_id)
-        except (TypeError, ValueError):
-            principal_user_id = None
-        if principal_user_id is not None and principal_user_id not in scoped_user_ids:
-            scoped_user_ids.append(principal_user_id)
 
     return await repo.list_requests(
         limit=limit,

--- a/tldw_Server_API/app/services/admin_data_subject_requests_service.py
+++ b/tldw_Server_API/app/services/admin_data_subject_requests_service.py
@@ -140,7 +140,9 @@ async def _enforce_requester_visibility(
 
 def _sqlite_count_sync(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
     if not path.exists():
-        return 0
+        raise DataSubjectRequestCoverageUnavailableError(
+            f"DSR subject store missing for {path}"
+        )
     try:
         with sqlite3.connect(path) as conn:
             row = conn.execute(query, params).fetchone()

--- a/tldw_Server_API/app/services/admin_data_subject_requests_service.py
+++ b/tldw_Server_API/app/services/admin_data_subject_requests_service.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException, status
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+    AuthnzDataSubjectRequestsRepo,
+)
+from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+from tldw_Server_API.app.services import admin_scope_service
+
+_CATEGORY_DEFS: tuple[dict[str, str], ...] = (
+    {"key": "media_records", "label": "Media records"},
+    {"key": "chat_messages", "label": "Chat sessions/messages"},
+    {"key": "notes", "label": "Notes"},
+    {"key": "audit_events", "label": "Audit log events"},
+)
+_SUPPORTED_CATEGORY_KEYS = {entry["key"] for entry in _CATEGORY_DEFS}
+_UNSUPPORTED_CATEGORY_KEYS = {"embeddings"}
+
+
+def _normalize_identifier(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="requester_identifier_required",
+        )
+    return normalized
+
+
+def _normalize_requested_categories(
+    *,
+    request_type: str | None,
+    categories: list[str] | None,
+) -> list[str]:
+    if categories is None:
+        if request_type == "erasure":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="categories_required",
+            )
+        return [entry["key"] for entry in _CATEGORY_DEFS]
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in categories:
+        value = str(raw_value or "").strip().lower()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+
+    if request_type == "erasure" and not normalized:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="categories_required",
+        )
+
+    unsupported = [
+        value
+        for value in normalized
+        if value not in _SUPPORTED_CATEGORY_KEYS
+    ]
+    if unsupported:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="unsupported_category",
+        )
+
+    return normalized
+
+
+async def _resolve_requester_user(requester_identifier: str) -> dict[str, Any]:
+    normalized = _normalize_identifier(requester_identifier)
+    db_pool = await get_db_pool()
+
+    row: dict[str, Any] | None = None
+    if normalized.isdigit():
+        row = await db_pool.fetchrow("SELECT * FROM users WHERE id = ?", int(normalized))
+    if row is None and "@" in normalized:
+        row = await db_pool.fetchrow(
+            "SELECT * FROM users WHERE LOWER(email) = LOWER(?)",
+            normalized,
+        )
+    if row is None:
+        row = await db_pool.fetchrow(
+            "SELECT * FROM users WHERE LOWER(username) = LOWER(?)",
+            normalized,
+        )
+    if row is None and "-" in normalized:
+        row = await db_pool.fetchrow("SELECT * FROM users WHERE uuid = ?", normalized)
+
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="requester_not_found",
+        )
+
+    try:
+        row["id"] = int(row["id"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="requester_resolution_failed",
+        ) from exc
+
+    return row
+
+
+def _sqlite_count(path: Path, query: str, params: tuple[Any, ...] = ()) -> int:
+    if not path.exists():
+        return 0
+    try:
+        with sqlite3.connect(path) as conn:
+            row = conn.execute(query, params).fetchone()
+    except sqlite3.Error as exc:
+        logger.debug("DSR count query failed for {}: {}", path, exc)
+        return 0
+    return int(row[0] if row else 0)
+
+
+def _count_media_records(user_id: int) -> int:
+    return _sqlite_count(
+        DatabasePaths.get_media_db_path(user_id),
+        "SELECT COUNT(*) FROM Media WHERE deleted = 0 AND is_trash = 0",
+    )
+
+
+def _count_notes(user_id: int) -> int:
+    return _sqlite_count(
+        DatabasePaths.get_chacha_db_path(user_id),
+        "SELECT COUNT(*) FROM notes WHERE deleted = 0",
+    )
+
+
+def _count_chat_messages(user_id: int) -> int:
+    return _sqlite_count(
+        DatabasePaths.get_chacha_db_path(user_id),
+        """
+        SELECT COUNT(1)
+        FROM messages m
+        JOIN conversations c ON m.conversation_id = c.id
+        WHERE c.client_id = ? AND c.deleted = 0 AND m.deleted = 0
+        """,
+        (str(user_id),),
+    )
+
+
+def _count_audit_events(user_id: int) -> int:
+    from tldw_Server_API.app.api.v1.API_Deps.Audit_DB_Deps import _resolve_audit_storage_mode
+
+    shared_mode = _resolve_audit_storage_mode() == "shared"
+    path = (
+        DatabasePaths.get_shared_audit_db_path()
+        if shared_mode
+        else DatabasePaths.get_audit_db_path(user_id)
+    )
+    if shared_mode:
+        return _sqlite_count(
+            path,
+            "SELECT COUNT(*) FROM audit_events WHERE tenant_user_id = ?",
+            (str(user_id),),
+        )
+    return _sqlite_count(path, "SELECT COUNT(*) FROM audit_events")
+
+
+def _build_summary_for_user(
+    *,
+    user_id: int,
+    selected_categories: list[str],
+) -> list[dict[str, Any]]:
+    count_map = {
+        "media_records": _count_media_records(user_id),
+        "chat_messages": _count_chat_messages(user_id),
+        "notes": _count_notes(user_id),
+        "audit_events": _count_audit_events(user_id),
+    }
+    return [
+        {
+            "key": entry["key"],
+            "label": entry["label"],
+            "count": int(count_map.get(entry["key"], 0)),
+        }
+        for entry in _CATEGORY_DEFS
+        if entry["key"] in selected_categories
+    ]
+
+
+def _coverage_metadata(*, selected_categories: list[str]) -> dict[str, Any]:
+    return {
+        "supported_categories": [entry["key"] for entry in _CATEGORY_DEFS],
+        "selected_categories": selected_categories,
+        "unsupported_categories": sorted(_UNSUPPORTED_CATEGORY_KEYS),
+        "unsupported_details": {
+            "embeddings": "Milestone 1 does not include authoritative embedding counts.",
+        },
+    }
+
+
+async def preview_data_subject_request(
+    *,
+    requester_identifier: str,
+    request_type: str | None = None,
+    categories: list[str] | None = None,
+) -> dict[str, Any]:
+    user = await _resolve_requester_user(requester_identifier)
+    selected_categories = _normalize_requested_categories(
+        request_type=request_type,
+        categories=categories,
+    )
+    summary = _build_summary_for_user(
+        user_id=int(user["id"]),
+        selected_categories=selected_categories,
+    )
+    return {
+        "requester_identifier": user.get("email") or user.get("username") or requester_identifier,
+        "resolved_user_id": int(user["id"]),
+        "request_type": request_type,
+        "selected_categories": selected_categories,
+        "summary": summary,
+        "counts": {entry["key"]: entry["count"] for entry in summary},
+        "coverage_metadata": _coverage_metadata(selected_categories=selected_categories),
+    }
+
+
+async def _normalize_requested_by_user_id(principal: AuthPrincipal) -> int | None:
+    if getattr(principal, "user_id", None) is None:
+        return None
+    try:
+        candidate = int(principal.user_id)
+    except (TypeError, ValueError):
+        return None
+
+    db_pool = await get_db_pool()
+    row = await db_pool.fetchrow("SELECT id FROM users WHERE id = ?", candidate)
+    if row is None:
+        return None
+    return candidate
+
+
+async def record_data_subject_request(
+    *,
+    principal: AuthPrincipal,
+    client_request_id: str,
+    requester_identifier: str,
+    request_type: str,
+    categories: list[str] | None,
+    preview: dict[str, Any] | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    if preview is None:
+        preview = await preview_data_subject_request(
+            requester_identifier=requester_identifier,
+            request_type=request_type,
+            categories=categories,
+        )
+
+    db_pool = await get_db_pool()
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=db_pool)
+    await repo.ensure_schema()
+
+    return await repo.create_or_get_request(
+        client_request_id=str(client_request_id).strip(),
+        requester_identifier=str(preview["requester_identifier"]),
+        resolved_user_id=int(preview["resolved_user_id"]),
+        request_type=request_type,
+        status="recorded",
+        selected_categories=list(preview["selected_categories"]),
+        preview_summary=list(preview["summary"]),
+        coverage_metadata=dict(preview["coverage_metadata"]),
+        requested_by_user_id=await _normalize_requested_by_user_id(principal),
+        notes=notes,
+    )
+
+
+async def list_data_subject_requests(
+    principal: AuthPrincipal,
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[list[dict[str, Any]], int]:
+    db_pool = await get_db_pool()
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=db_pool)
+    await repo.ensure_schema()
+
+    if admin_scope_service.is_platform_admin(principal):
+        return await repo.list_requests(limit=limit, offset=offset)
+
+    org_ids = await admin_scope_service.get_admin_org_ids(principal)
+    if org_ids is None:
+        return await repo.list_requests(limit=limit, offset=offset)
+
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+    users_repo = await AuthnzUsersRepo.from_pool()
+    scoped_users, _ = await users_repo.list_users(
+        offset=0,
+        limit=1000,
+        org_ids=org_ids,
+    )
+    scoped_user_ids = [int(row["id"]) for row in scoped_users if row.get("id") is not None]
+    if getattr(principal, "user_id", None) is not None:
+        try:
+            principal_user_id = int(principal.user_id)
+        except (TypeError, ValueError):
+            principal_user_id = None
+        if principal_user_id is not None and principal_user_id not in scoped_user_ids:
+            scoped_user_ids.append(principal_user_id)
+
+    return await repo.list_requests(
+        limit=limit,
+        offset=offset,
+        resolved_user_ids=scoped_user_ids,
+    )

--- a/tldw_Server_API/tests/Admin/test_admin_data_subject_requests_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_data_subject_requests_service.py
@@ -6,16 +6,34 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_list_data_subject_requests_pages_all_scoped_users(monkeypatch) -> None:
+async def test_list_data_subject_requests_passes_org_scope_to_repo(monkeypatch) -> None:
     from tldw_Server_API.app.services import admin_data_subject_requests_service as service
 
     principal = SimpleNamespace(user_id=17, roles=["admin"])
 
     class _StubRepo:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
         async def ensure_schema(self) -> None:
             return None
 
-        async def list_requests(self, *, limit: int, offset: int, resolved_user_ids: list[int] | None = None):
+        async def list_requests(
+            self,
+            *,
+            limit: int,
+            offset: int,
+            org_ids: list[int] | None = None,
+            resolved_user_ids: list[int] | None = None,
+        ):
+            self.calls.append(
+                {
+                    "limit": limit,
+                    "offset": offset,
+                    "org_ids": list(org_ids or []),
+                    "resolved_user_ids": list(resolved_user_ids or []),
+                }
+            )
             return [
                 {
                     "id": 1,
@@ -31,31 +49,10 @@ async def test_list_data_subject_requests_pages_all_scoped_users(monkeypatch) ->
                     "requested_at": "2026-03-10T12:00:00+00:00",
                     "notes": None,
                 }
-            ], len(resolved_user_ids or [])
+            ], 1
 
-    class _StubUsersRepo:
-        def __init__(self) -> None:
-            self.calls: list[tuple[int, int, tuple[int, ...]]] = []
+    stub_repo = _StubRepo()
 
-        async def list_users(self, *, offset: int, limit: int, org_ids: list[int] | None = None, **kwargs):
-            del kwargs
-            self.calls.append((offset, limit, tuple(org_ids or [])))
-            user_ids = list(range(1, 1051))
-            page = user_ids[offset: offset + limit]
-            return [{"id": user_id} for user_id in page], len(user_ids)
-
-    stub_users_repo = _StubUsersRepo()
-
-    async def _fake_get_db_pool():
-        return object()
-
-    @classmethod
-    async def _fake_from_pool(cls):
-        del cls
-        return stub_users_repo
-
-    monkeypatch.setattr(service, "get_db_pool", _fake_get_db_pool)
-    monkeypatch.setattr(service, "AuthnzDataSubjectRequestsRepo", lambda db_pool: _StubRepo())
     monkeypatch.setattr(service.admin_scope_service, "is_platform_admin", lambda current_principal: False)
 
     async def _fake_get_admin_org_ids(current_principal):
@@ -64,19 +61,20 @@ async def test_list_data_subject_requests_pages_all_scoped_users(monkeypatch) ->
 
     monkeypatch.setattr(service.admin_scope_service, "get_admin_org_ids", _fake_get_admin_org_ids)
 
-    from tldw_Server_API.app.core.AuthNZ.repos import users_repo as users_repo_mod
-
-    monkeypatch.setattr(users_repo_mod.AuthnzUsersRepo, "from_pool", _fake_from_pool)
-
     items, total = await service.list_data_subject_requests(
         principal,
         limit=50,
         offset=0,
+        requests_repo=stub_repo,
     )
 
-    assert total == 1050
+    assert total == 1
     assert len(items) == 1
-    assert stub_users_repo.calls == [
-        (0, 1000, (99,)),
-        (1000, 1000, (99,)),
+    assert stub_repo.calls == [
+        {
+            "limit": 50,
+            "offset": 0,
+            "org_ids": [99],
+            "resolved_user_ids": [],
+        }
     ]

--- a/tldw_Server_API/tests/Admin/test_admin_data_subject_requests_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_data_subject_requests_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_data_subject_requests_pages_all_scoped_users(monkeypatch) -> None:
+    from tldw_Server_API.app.services import admin_data_subject_requests_service as service
+
+    principal = SimpleNamespace(user_id=17, roles=["admin"])
+
+    class _StubRepo:
+        async def ensure_schema(self) -> None:
+            return None
+
+        async def list_requests(self, *, limit: int, offset: int, resolved_user_ids: list[int] | None = None):
+            return [
+                {
+                    "id": 1,
+                    "client_request_id": "dsr-1",
+                    "requester_identifier": "subject@example.com",
+                    "resolved_user_id": 1005,
+                    "request_type": "access",
+                    "status": "recorded",
+                    "selected_categories": ["media_records"],
+                    "preview_summary": [],
+                    "coverage_metadata": {},
+                    "requested_by_user_id": 17,
+                    "requested_at": "2026-03-10T12:00:00+00:00",
+                    "notes": None,
+                }
+            ], len(resolved_user_ids or [])
+
+    class _StubUsersRepo:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int, tuple[int, ...]]] = []
+
+        async def list_users(self, *, offset: int, limit: int, org_ids: list[int] | None = None, **kwargs):
+            del kwargs
+            self.calls.append((offset, limit, tuple(org_ids or [])))
+            user_ids = list(range(1, 1051))
+            page = user_ids[offset: offset + limit]
+            return [{"id": user_id} for user_id in page], len(user_ids)
+
+    stub_users_repo = _StubUsersRepo()
+
+    async def _fake_get_db_pool():
+        return object()
+
+    @classmethod
+    async def _fake_from_pool(cls):
+        del cls
+        return stub_users_repo
+
+    monkeypatch.setattr(service, "get_db_pool", _fake_get_db_pool)
+    monkeypatch.setattr(service, "AuthnzDataSubjectRequestsRepo", lambda db_pool: _StubRepo())
+    monkeypatch.setattr(service.admin_scope_service, "is_platform_admin", lambda current_principal: False)
+
+    async def _fake_get_admin_org_ids(current_principal):
+        assert current_principal is principal
+        return [99]
+
+    monkeypatch.setattr(service.admin_scope_service, "get_admin_org_ids", _fake_get_admin_org_ids)
+
+    from tldw_Server_API.app.core.AuthNZ.repos import users_repo as users_repo_mod
+
+    monkeypatch.setattr(users_repo_mod.AuthnzUsersRepo, "from_pool", _fake_from_pool)
+
+    items, total = await service.list_data_subject_requests(
+        principal,
+        limit=50,
+        offset=0,
+    )
+
+    assert total == 1050
+    assert len(items) == 1
+    assert stub_users_repo.calls == [
+        (0, 1000, (99,)),
+        (1000, 1000, (99,)),
+    ]

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _setup_env(tmp_path) -> None:
+    os.environ["AUTH_MODE"] = "single_user"
+    os.environ["SINGLE_USER_API_KEY"] = "unit-test-api-key"
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'users_test_dsr_api.db'}"
+    os.environ["TLDW_DB_ALLOWED_BASE_DIRS"] = str(tmp_path)
+    os.environ["TLDW_DB_BACKUP_PATH"] = str(tmp_path / "backups")
+    os.environ["USER_DB_BASE_DIR"] = str(tmp_path / "user_dbs")
+
+
+async def _reset_auth_state() -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+    await reset_session_manager()
+
+
+async def _seed_user(*, user_id: int, username: str, email: str) -> int:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+    pool = await get_db_pool()
+    await pool.execute(
+        """
+        INSERT OR REPLACE INTO users (id, uuid, username, email, password_hash, is_active)
+        VALUES (?, ?, ?, ?, ?, 1)
+        """,
+        user_id,
+        str(uuid.uuid4()),
+        username,
+        email,
+        "x",
+    )
+    return int(user_id)
+
+
+def _seed_subject_store_data(*, tmp_path, user_id: int, media_count: int, note_count: int, message_count: int, audit_count: int) -> None:
+    from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+    media_db_path = DatabasePaths.get_media_db_path(user_id)
+    media_db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(media_db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS Media (
+                id INTEGER PRIMARY KEY,
+                deleted INTEGER DEFAULT 0,
+                is_trash INTEGER DEFAULT 0
+            )
+            """
+        )
+        for index in range(media_count):
+            conn.execute(
+                "INSERT INTO Media (id, deleted, is_trash) VALUES (?, 0, 0)",
+                (index + 1,),
+            )
+        conn.execute("INSERT INTO Media (id, deleted, is_trash) VALUES (?, 1, 0)", (9001,))
+        conn.execute("INSERT INTO Media (id, deleted, is_trash) VALUES (?, 0, 1)", (9002,))
+        conn.commit()
+
+    chacha_db_path = DatabasePaths.get_chacha_db_path(user_id)
+    with sqlite3.connect(chacha_db_path) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS notes (id TEXT PRIMARY KEY, deleted INTEGER DEFAULT 0)")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS conversations (
+                id TEXT PRIMARY KEY,
+                client_id TEXT NOT NULL,
+                deleted INTEGER DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS messages (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                deleted INTEGER DEFAULT 0
+            )
+            """
+        )
+        for index in range(note_count):
+            conn.execute("INSERT INTO notes (id, deleted) VALUES (?, 0)", (f"note-{index}",))
+        conn.execute("INSERT INTO notes (id, deleted) VALUES (?, 1)", ("note-deleted",))
+        conn.execute(
+            "INSERT INTO conversations (id, client_id, deleted) VALUES (?, ?, 0)",
+            ("conv-1", str(user_id)),
+        )
+        conn.execute(
+            "INSERT INTO conversations (id, client_id, deleted) VALUES (?, ?, 1)",
+            ("conv-deleted", str(user_id)),
+        )
+        for index in range(message_count):
+            conn.execute(
+                "INSERT INTO messages (id, conversation_id, deleted) VALUES (?, ?, 0)",
+                (f"msg-{index}", "conv-1"),
+            )
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, deleted) VALUES (?, ?, 1)",
+            ("msg-deleted", "conv-1"),
+        )
+        conn.commit()
+
+    audit_db_path = DatabasePaths.get_audit_db_path(user_id)
+    with sqlite3.connect(audit_db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS audit_events (
+                event_id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                category TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                context_user_id TEXT
+            )
+            """
+        )
+        for index in range(audit_count):
+            conn.execute(
+                """
+                INSERT INTO audit_events (event_id, timestamp, category, event_type, severity, context_user_id)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"evt-{index}",
+                    f"2026-03-10T12:00:0{index}Z",
+                    "system",
+                    "test.event",
+                    "low",
+                    str(user_id),
+                ),
+            )
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_404_for_unknown_requester(tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests/preview",
+            json={"requester_identifier": "missing@example.com"},
+        )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "requester_not_found"
+
+
+@pytest.mark.asyncio
+async def test_create_records_request_and_reuses_client_request_id(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+    _seed_subject_store_data(
+        tmp_path=tmp_path,
+        user_id=7,
+        media_count=3,
+        note_count=2,
+        message_count=4,
+        audit_count=5,
+    )
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_data_ops
+
+    emitted: list[dict[str, object]] = []
+
+    async def _fake_emit(*args, **kwargs):
+        emitted.append(kwargs)
+
+    monkeypatch.setattr(admin_data_ops, "_emit_admin_audit_event", _fake_emit)
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+    payload = {
+        "request_id": "dsr-client-1",
+        "requester_identifier": "subject@example.com",
+        "request_type": "export",
+    }
+
+    with TestClient(app, headers=headers) as client:
+        first = client.post("/api/v1/admin/data-subject-requests", json=payload)
+        second = client.post("/api/v1/admin/data-subject-requests", json=payload)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+
+    first_item = first.json()["item"]
+    second_item = second.json()["item"]
+    assert first_item["id"] == second_item["id"]
+    assert first_item["client_request_id"] == "dsr-client-1"
+    assert first_item["status"] == "recorded"
+    assert first_item["selected_categories"] == [
+        "media_records",
+        "chat_messages",
+        "notes",
+        "audit_events",
+    ]
+
+    summary_by_key = {
+        entry["key"]: entry["count"]
+        for entry in first_item["preview_summary"]
+    }
+    assert summary_by_key == {
+        "media_records": 3,
+        "chat_messages": 4,
+        "notes": 2,
+        "audit_events": 5,
+    }
+    assert len(emitted) == 2
+    assert emitted[0]["action"] == "data_subject_request.record"
+
+
+@pytest.mark.asyncio
+async def test_list_returns_newest_first_with_limit_offset(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+
+    await _seed_user(user_id=7, username="subject_one", email="subject1@example.com")
+    await _seed_user(user_id=8, username="subject_two", email="subject2@example.com")
+    await _seed_user(user_id=9, username="subject_three", email="subject3@example.com")
+
+    for user_id in (7, 8, 9):
+        _seed_subject_store_data(
+            tmp_path=tmp_path,
+            user_id=user_id,
+            media_count=1,
+            note_count=1,
+            message_count=1,
+            audit_count=1,
+        )
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_data_ops
+
+    async def _fake_emit(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(admin_data_ops, "_emit_admin_audit_event", _fake_emit)
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        for index, email in enumerate(
+            ["subject1@example.com", "subject2@example.com", "subject3@example.com"],
+            start=1,
+        ):
+            response = client.post(
+                "/api/v1/admin/data-subject-requests",
+                json={
+                    "request_id": f"dsr-client-{index}",
+                    "requester_identifier": email,
+                    "request_type": "access",
+                },
+            )
+            assert response.status_code == 200, response.text
+
+        listed = client.get(
+            "/api/v1/admin/data-subject-requests",
+            params={"limit": 2, "offset": 1},
+        )
+
+    assert listed.status_code == 200, listed.text
+    payload = listed.json()
+    assert payload["total"] == 3
+    assert [item["client_request_id"] for item in payload["items"]] == [
+        "dsr-client-2",
+        "dsr-client-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_preview_enforces_admin_scope(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+    _seed_subject_store_data(
+        tmp_path=tmp_path,
+        user_id=7,
+        media_count=1,
+        note_count=1,
+        message_count=1,
+        audit_count=1,
+    )
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_data_ops
+
+    async def _deny_scope(*args, **kwargs):
+        raise HTTPException(status_code=403, detail="scoped_out")
+
+    monkeypatch.setattr(admin_data_ops, "_enforce_admin_user_scope", _deny_scope)
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests/preview",
+            json={"requester_identifier": "subject@example.com"},
+        )
+
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"] == "scoped_out"

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -166,6 +166,32 @@ async def test_preview_returns_404_for_unknown_requester(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_preview_returns_500_when_subject_store_query_fails(tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+
+    from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+
+    media_db_path = DatabasePaths.get_media_db_path(7)
+    media_db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(media_db_path) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS unrelated_table (id INTEGER PRIMARY KEY)")
+        conn.commit()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests/preview",
+            json={"requester_identifier": "subject@example.com"},
+        )
+
+    assert response.status_code == 500, response.text
+    assert response.json()["detail"] == "requester_data_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_create_records_request_and_reuses_client_request_id(monkeypatch, tmp_path):
     _setup_env(tmp_path)
     await _reset_auth_state()
@@ -190,7 +216,7 @@ async def test_create_records_request_and_reuses_client_request_id(monkeypatch, 
 
     headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
     payload = {
-        "request_id": "dsr-client-1",
+        "client_request_id": "dsr-client-1",
         "requester_identifier": "subject@example.com",
         "request_type": "export",
     }
@@ -264,7 +290,7 @@ async def test_list_returns_newest_first_with_limit_offset(monkeypatch, tmp_path
             response = client.post(
                 "/api/v1/admin/data-subject-requests",
                 json={
-                    "request_id": f"dsr-client-{index}",
+                    "client_request_id": f"dsr-client-{index}",
                     "requester_identifier": email,
                     "request_type": "access",
                 },
@@ -395,7 +421,7 @@ async def test_create_hides_out_of_scope_requesters_before_counting(monkeypatch,
         response = client.post(
             "/api/v1/admin/data-subject-requests",
             json={
-                "request_id": "out-of-scope-dsr",
+                "client_request_id": "out-of-scope-dsr",
                 "requester_identifier": "subject@example.com",
                 "request_type": "access",
             },

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import uuid
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
@@ -298,12 +299,13 @@ async def test_preview_enforces_admin_scope(monkeypatch, tmp_path):
         audit_count=1,
     )
 
-    from tldw_Server_API.app.api.v1.endpoints.admin import admin_data_ops
+    from tldw_Server_API.app.services import admin_data_subject_requests_service as dsr_service
 
     async def _deny_scope(*args, **kwargs):
         raise HTTPException(status_code=403, detail="scoped_out")
 
-    monkeypatch.setattr(admin_data_ops, "_enforce_admin_user_scope", _deny_scope)
+    monkeypatch.setattr(dsr_service.admin_scope_service, "is_platform_admin", lambda principal: False)
+    monkeypatch.setattr(dsr_service.admin_scope_service, "enforce_admin_user_scope", _deny_scope)
 
     headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
 
@@ -313,5 +315,91 @@ async def test_preview_enforces_admin_scope(monkeypatch, tmp_path):
             json={"requester_identifier": "subject@example.com"},
         )
 
-    assert response.status_code == 403, response.text
-    assert response.json()["detail"] == "scoped_out"
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "requester_not_found"
+
+
+@pytest.mark.asyncio
+async def test_preview_hides_out_of_scope_requesters_before_counting(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+    _seed_subject_store_data(
+        tmp_path=tmp_path,
+        user_id=7,
+        media_count=1,
+        note_count=1,
+        message_count=1,
+        audit_count=1,
+    )
+
+    from tldw_Server_API.app.services import admin_data_subject_requests_service as dsr_service
+
+    monkeypatch.setattr(dsr_service.admin_scope_service, "is_platform_admin", lambda principal: False)
+
+    async def _deny_scope(principal, target_user_id: int, *, require_hierarchy: bool) -> None:
+        del principal, target_user_id, require_hierarchy
+        raise HTTPException(status_code=403, detail="scoped_out")
+
+    monkeypatch.setattr(dsr_service.admin_scope_service, "enforce_admin_user_scope", _deny_scope)
+
+    def _unexpected_summary_build(*args, **kwargs):
+        raise AssertionError("summary should not be built for out-of-scope requester")
+
+    monkeypatch.setattr(dsr_service, "_build_summary_for_user", _unexpected_summary_build)
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests/preview",
+            json={"requester_identifier": "subject@example.com"},
+        )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "requester_not_found"
+
+
+@pytest.mark.asyncio
+async def test_create_hides_out_of_scope_requesters_before_counting(monkeypatch, tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+    _seed_subject_store_data(
+        tmp_path=tmp_path,
+        user_id=7,
+        media_count=1,
+        note_count=1,
+        message_count=1,
+        audit_count=1,
+    )
+
+    from tldw_Server_API.app.services import admin_data_subject_requests_service as dsr_service
+
+    monkeypatch.setattr(dsr_service.admin_scope_service, "is_platform_admin", lambda principal: False)
+
+    async def _deny_scope(principal, target_user_id: int, *, require_hierarchy: bool) -> None:
+        del principal, target_user_id, require_hierarchy
+        raise HTTPException(status_code=403, detail="scoped_out")
+
+    monkeypatch.setattr(dsr_service.admin_scope_service, "enforce_admin_user_scope", _deny_scope)
+
+    def _unexpected_summary_build(*args, **kwargs):
+        raise AssertionError("summary should not be built for out-of-scope requester")
+
+    monkeypatch.setattr(dsr_service, "_build_summary_for_user", _unexpected_summary_build)
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests",
+            json={
+                "request_id": "out-of-scope-dsr",
+                "requester_identifier": "subject@example.com",
+                "request_type": "access",
+            },
+        )
+
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"] == "requester_not_found"

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_api.py
@@ -192,6 +192,24 @@ async def test_preview_returns_500_when_subject_store_query_fails(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_preview_returns_500_when_subject_store_is_missing(tmp_path):
+    _setup_env(tmp_path)
+    await _reset_auth_state()
+    await _seed_user(user_id=7, username="subject_user", email="subject@example.com")
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        response = client.post(
+            "/api/v1/admin/data-subject-requests/preview",
+            json={"requester_identifier": "subject@example.com"},
+        )
+
+    assert response.status_code == 500, response.text
+    assert response.json()["detail"] == "requester_data_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_create_records_request_and_reuses_client_request_id(monkeypatch, tmp_path):
     _setup_env(tmp_path)
     await _reset_auth_state()

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py
@@ -94,3 +94,133 @@ async def test_repo_create_request_is_idempotent(tmp_path):
     assert total == 1
     assert len(rows) == 1
     assert rows[0]["id"] == first["id"]
+
+
+@pytest.mark.asyncio
+async def test_repo_ensure_schema_surfaces_sqlite_failures(tmp_path, monkeypatch):
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+        AuthnzDataSubjectRequestsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+
+    pool = await get_db_pool()
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=pool)
+
+    from tldw_Server_API.app.core.AuthNZ import migrations
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("schema failed")
+
+    monkeypatch.setattr(migrations, "ensure_authnz_tables", _boom)
+
+    with pytest.raises(RuntimeError, match="schema failed"):
+        await repo.ensure_schema()
+
+
+@pytest.mark.asyncio
+async def test_repo_list_requests_scopes_by_org_ids(tmp_path):
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+        AuthnzDataSubjectRequestsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+
+    pool = await get_db_pool()
+    await pool.execute(
+        """
+        INSERT INTO users (id, username, email, password_hash, role, is_active, uuid)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        1,
+        "admin_requester",
+        "admin_requester@example.com",
+        "hash",
+        "admin",
+        1,
+        str(uuid.uuid4()),
+    )
+    await pool.execute(
+        """
+        INSERT INTO users (id, username, email, password_hash, role, is_active, uuid)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        7,
+        "subject_user_one",
+        "subject_user_one@example.com",
+        "hash",
+        "user",
+        1,
+        str(uuid.uuid4()),
+    )
+    await pool.execute(
+        """
+        INSERT INTO users (id, username, email, password_hash, role, is_active, uuid)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        8,
+        "subject_user_two",
+        "subject_user_two@example.com",
+        "hash",
+        "user",
+        1,
+        str(uuid.uuid4()),
+    )
+
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=pool)
+    await repo.ensure_schema()
+
+    await pool.execute(
+        "INSERT INTO organizations (name, slug, owner_user_id) VALUES (?, ?, ?)",
+        "Scoped Org",
+        "scoped-org",
+        1,
+    )
+    org_row = await pool.fetchone("SELECT id FROM organizations WHERE slug = ?", "scoped-org")
+    org_id = int(org_row["id"])
+    await pool.execute(
+        "INSERT INTO org_members (org_id, user_id, role, status) VALUES (?, ?, ?, ?)",
+        org_id,
+        7,
+        "member",
+        "active",
+    )
+
+    await repo.create_or_get_request(
+        client_request_id="dsr-org-1",
+        requester_identifier="subject_user_one@example.com",
+        resolved_user_id=7,
+        request_type="access",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 1}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+        notes=None,
+    )
+    await repo.create_or_get_request(
+        client_request_id="dsr-org-2",
+        requester_identifier="subject_user_two@example.com",
+        resolved_user_id=8,
+        request_type="access",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 2}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+        notes=None,
+    )
+
+    rows, total = await repo.list_requests(limit=10, offset=0, org_ids=[org_id])
+    assert total == 1
+    assert [row["client_request_id"] for row in rows] == ["dsr-org-1"]

--- a/tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py
+++ b/tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+def _setup_env(tmp_path) -> None:
+    os.environ["AUTH_MODE"] = "single_user"
+    os.environ["SINGLE_USER_API_KEY"] = "unit-test-api-key"
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'users_test_dsr_repo.db'}"
+    os.environ["TLDW_DB_ALLOWED_BASE_DIRS"] = str(tmp_path)
+    os.environ["TLDW_DB_BACKUP_PATH"] = str(tmp_path / "backups")
+    os.environ["USER_DB_BASE_DIR"] = str(tmp_path / "user_dbs")
+
+
+@pytest.mark.asyncio
+async def test_repo_create_request_is_idempotent(tmp_path):
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+        AuthnzDataSubjectRequestsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+
+    pool = await get_db_pool()
+    await pool.execute(
+        """
+        INSERT INTO users (id, username, email, password_hash, role, is_active, uuid)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        1,
+        "admin_requester",
+        "admin_requester@example.com",
+        "hash",
+        "admin",
+        1,
+        str(uuid.uuid4()),
+    )
+    await pool.execute(
+        """
+        INSERT INTO users (id, username, email, password_hash, role, is_active, uuid)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        7,
+        "subject_user",
+        "subject_user@example.com",
+        "hash",
+        "user",
+        1,
+        str(uuid.uuid4()),
+    )
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=pool)
+    await repo.ensure_schema()
+
+    first = await repo.create_or_get_request(
+        client_request_id="dsr-1",
+        requester_identifier="user@example.com",
+        resolved_user_id=7,
+        request_type="export",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 3}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+        notes=None,
+    )
+    second = await repo.create_or_get_request(
+        client_request_id="dsr-1",
+        requester_identifier="user@example.com",
+        resolved_user_id=7,
+        request_type="export",
+        status="recorded",
+        selected_categories=["media_records"],
+        preview_summary=[{"key": "media_records", "count": 3}],
+        coverage_metadata={"supported": ["media_records"]},
+        requested_by_user_id=1,
+        notes=None,
+    )
+
+    assert first["id"] == second["id"]
+    assert first["client_request_id"] == "dsr-1"
+    assert first["request_type"] == "export"
+    assert first["status"] == "recorded"
+    assert first["selected_categories"] == ["media_records"]
+    assert first["preview_summary"] == [{"key": "media_records", "count": 3}]
+
+    rows, total = await repo.list_requests(limit=10, offset=0)
+    assert total == 1
+    assert len(rows) == 1
+    assert rows[0]["id"] == first["id"]

--- a/tldw_Server_API/tests/AuthNZ/integration/test_authnz_data_subject_requests_repo_postgres.py
+++ b/tldw_Server_API/tests/AuthNZ/integration/test_authnz_data_subject_requests_repo_postgres.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_authnz_data_subject_requests_repo_idempotent_postgres(
+    isolated_test_environment,
+):
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.data_subject_requests_repo import (
+        AuthnzDataSubjectRequestsRepo,
+    )
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    client, _db_name = isolated_test_environment
+    assert client is not None
+
+    pool = await get_db_pool()
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+
+    requested_by = await users_db.create_user(
+        username="dsr_admin_pg",
+        email="dsr_admin_pg@example.com",
+        password_hash="hash",
+        role="admin",
+        is_active=True,
+        is_superuser=False,
+        storage_quota_mb=5120,
+    )
+    subject = await users_db.create_user(
+        username="dsr_subject_pg",
+        email="dsr_subject_pg@example.com",
+        password_hash="hash",
+        role="user",
+        is_active=True,
+        is_superuser=False,
+        storage_quota_mb=5120,
+    )
+
+    repo = AuthnzDataSubjectRequestsRepo(db_pool=pool)
+    await repo.ensure_schema()
+
+    first = await repo.create_or_get_request(
+        client_request_id="pg-dsr-1",
+        requester_identifier="dsr_subject_pg@example.com",
+        resolved_user_id=int(subject["id"]),
+        request_type="access",
+        status="recorded",
+        selected_categories=["media_records", "chat_messages"],
+        preview_summary=[
+            {"key": "media_records", "count": 4},
+            {"key": "chat_messages", "count": 9},
+        ],
+        coverage_metadata={"supported": ["media_records", "chat_messages"]},
+        requested_by_user_id=int(requested_by["id"]),
+        notes="repo integration",
+    )
+    second = await repo.create_or_get_request(
+        client_request_id="pg-dsr-1",
+        requester_identifier="dsr_subject_pg@example.com",
+        resolved_user_id=int(subject["id"]),
+        request_type="access",
+        status="recorded",
+        selected_categories=["media_records", "chat_messages"],
+        preview_summary=[
+            {"key": "media_records", "count": 4},
+            {"key": "chat_messages", "count": 9},
+        ],
+        coverage_metadata={"supported": ["media_records", "chat_messages"]},
+        requested_by_user_id=int(requested_by["id"]),
+        notes="repo integration",
+    )
+
+    assert first["id"] == second["id"]
+    rows, total = await repo.list_requests(limit=10, offset=0)
+    assert total == 1
+    assert rows[0]["client_request_id"] == "pg-dsr-1"


### PR DESCRIPTION
## Summary
- add authoritative admin DSR preview, record, and list endpoints backed by AuthNZ persistence
- switch the admin-ui DSR screen from local-only behavior to real backend request history and truthful recorded-request messaging
- harden DSR requester visibility and scope handling so out-of-scope subjects are hidden and org-scoped history pages past 1000 users

## Verification
- `python -m pytest tldw_Server_API/tests/Admin/test_data_subject_requests_api.py tldw_Server_API/tests/Admin/test_data_subject_requests_repo.py tldw_Server_API/tests/Admin/test_admin_data_subject_requests_service.py tldw_Server_API/tests/Admin/test_data_ops.py -q`
- `bunx vitest run components/data-ops/DataSubjectRequestsSection.test.tsx app/data-ops/__tests__/page.a11y.test.tsx`
- `python -m bandit -r tldw_Server_API/app/services/admin_data_subject_requests_service.py tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_admin_dsr_scope_fix.json`