### PR TITLE
Add workflows diagnostics, investigation APIs, and run inspector

### DIFF
--- a/Docs/Design/Workflows.md
+++ b/Docs/Design/Workflows.md
@@ -26,6 +26,7 @@ Base prefix: `/api/v1/workflows`
 - Definitions
   - `POST /` → Create definition (immutable versions)
   - `GET /` → List active definitions (tenant + owner scoped)
+  - `POST /preflight` → Server-authoritative definition preflight. Reuses runtime validation and adds replay-safety warnings for unsafe step types. Supports `validation_mode=block|non-block`.
   - `GET /{workflow_id}` → Get definition (includes stored snapshot)
   - `POST /{workflow_id}/versions` → Create new version
   - `DELETE /{workflow_id}` → Soft delete
@@ -34,6 +35,9 @@ Base prefix: `/api/v1/workflows`
   - `POST /run?mode=async|sync` → Run ad-hoc definition (configurable rate-limited)
   - `GET /runs?status=&owner=&workflow_id=&created_after=&created_before=&last_n_hours=&order_by=&order=&limit=&offset=&cursor=` → List runs with filters. Owner by default; admin may filter by `owner`. Returns `runs`, `next_offset` (legacy) and `next_cursor` (opaque continuation token). When `cursor` is present, `offset` is ignored.
   - `GET /runs/{run_id}` → Run status and final outputs
+  - `GET /runs/{run_id}/investigation` → Derived diagnostics summary for failed runs. Includes `primary_failure`, `failed_step`, attempt timeline, evidence refs, and recommended actions.
+  - `GET /runs/{run_id}/steps` → Step history for the run, including latest failure and attempt counts per step.
+  - `GET /runs/{run_id}/steps/{step_id}/attempts` → Attempt-level retry timeline for a logical step execution.
   - `GET /runs/{run_id}/events?since=&types=&limit=&cursor=` → Ordered event stream (HTTP polling). Supports server-side filtering by `types` (comma-separated). Returns `Next-Cursor` header when a full page is returned. When `cursor` is present, `since` is ignored.
   - `WS /ws?run_id=...&token=...` → Live event stream (JWT required; run owner only)
   - `POST /runs/{run_id}/pause|resume|cancel|retry` → Control actions
@@ -126,11 +130,33 @@ The following additional step types are available and surfaced via `/step-types`
 - `notify`: Minimal notifier (Slack/webhook) respecting SSRF/egress policy.
 - `diff_change_detector`: Compare previous vs current text and mark `changed` with diff metrics.
 
+### Replay Safety & Preflight
+
+- Each step type exposes replay metadata used by retries, diagnostics, and authoring warnings:
+  - `replay_safe`
+  - `idempotency_strategy`
+  - `compensation_supported`
+  - `requires_human_review_for_rerun`
+- Unknown or side-effecting steps default to unsafe replay semantics until explicitly classified.
+- `POST /preflight` uses the same server validation helpers as run-time definition checks and adds structured warnings such as `unsafe_replay_step`.
+- Preflight is the supported way to catch definition-time issues before save/run; client-only checks should be treated as hints, not the final authority.
+
 ## Engine Behavior
 
 - Modes: `async` (background via in-process scheduler) and `sync` (server-side synchronous; UI reattaches by `run_id`).
 - Lifecycle: `queued → running → (waiting_human|cancelled|failed|succeeded)`.
 - Retries/Timeouts: Per-step `retry` (exponential backoff + jitter) and `timeout_seconds` enforced. Cooperative cancellation via a cancel flag checked between sleeps/attempts.
+- Execution entities:
+  - `workflow_step_runs` remains the logical step execution record for a run.
+  - `workflow_step_attempts` records each retry attempt for that logical step, including structured failure metadata.
+- Failure taxonomy is layered and attempt-level:
+  - `reason_code_core`
+  - `reason_code_detail`
+  - `category`
+  - `blame_scope`
+  - `retryable`
+  - `retry_recommendation`
+- Terminal run failures copy the primary `reason_code_core` into `workflow_runs.status_reason` so run listings and alert triage can pivot quickly without replaying the full event stream.
 - Heartbeats/Leases: Step runs record `locked_by/locked_at/lock_expires_at/heartbeat_at`; orphan reaper marks stale step runs as failed and emits events.
 - Subprocess Steps: Launched in new process group; engine records `pid/pgid/workdir/stdout/stderr` and escalates termination on cancel/timeout.
 - Events: Strict `event_seq` ordering per run; WebSocket emits a `snapshot` and then ordered events with lightweight heartbeats.
@@ -139,7 +165,10 @@ The following additional step types are available and surfaced via `/step-types`
 
 - Default: SQLite (`Databases/workflows.db`) with WAL enabled.
 - PostgreSQL: Supported when a content backend is configured; schema migrations applied automatically (see tests under `tests/Workflows/test_workflows_postgres_migrations.py`).
-- Tables: `workflows`, `workflow_runs`, `workflow_step_runs`, `workflow_events`, `workflow_artifacts` (+ optional `workflow_event_counters`, `workflow_webhook_dlq`).
+- Tables: `workflows`, `workflow_runs`, `workflow_step_runs`, `workflow_step_attempts`, `workflow_events`, `workflow_artifacts` (+ optional `workflow_event_counters`, `workflow_webhook_dlq`).
+- Step run vs attempt model:
+  - `workflow_step_runs` stores the logical step lifecycle and approval/branching anchor.
+  - `workflow_step_attempts` stores retry order, structured reason codes, retryability decisions, and per-attempt metadata/evidence refs.
 - Idempotency: `idempotency_key` prevents duplicate run creation per `(tenant_id, user_id, workflow)`.
 - Indices/constraints and types:
   - Per-run event ordering: composite index and unique constraint on `(run_id, event_seq)` in `workflow_events`.
@@ -265,6 +294,10 @@ In single-user mode, the fixed user is exposed with admin-like claims for compat
   - Webhooks: `workflows_webhook_deliveries_total{status,host}` with status in `delivered|failed|blocked`.
   - Engine gauges: `workflows_engine_queue_depth`.
   - Scrape: `/metrics` (root) or `/api/v1/metrics` (JSON).
+- Investigation-first operations:
+  - The current metrics are rate/latency oriented; they do not yet expose `reason_code_core` as a Prometheus label.
+  - Operators should pivot from an alert into `GET /runs?status=failed` and then `GET /runs/{run_id}/investigation` / `GET /runs/{run_id}/steps/{step_id}/attempts` to classify failures by `reason_code_core`, `category`, `blame_scope`, and `retryable`.
+  - Attempt rows preserve the structured taxonomy even when raw event payloads are noisy or incomplete.
 
 - Tracing (OpenTelemetry):
   - Spans: `workflows.run` (per run), nested `workflows.step` (per step), and `workflows.webhook` (completion hook delivery).

--- a/Docs/Operations/Workflows_Debugging.md
+++ b/Docs/Operations/Workflows_Debugging.md
@@ -12,6 +12,36 @@ Set environment flags before starting the server:
 
 Check application logs for lines prefixed with `Workflows:` or `Artifacts:` hints.
 
+## Investigation-First Triage
+
+For failed or flaky runs, start with the derived diagnostics endpoints before reading raw events:
+
+1. `GET /api/v1/workflows/runs/{run_id}/investigation`
+2. `GET /api/v1/workflows/runs/{run_id}/steps`
+3. `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts`
+
+Focus on the structured fields first:
+
+- `reason_code_core` and `reason_code_detail`
+- `category`
+- `blame_scope`
+- `retryable`
+- `retry_recommendation`
+
+If investigation generation is incomplete, fall back to `GET /runs/{run_id}/events?limit=200` and artifacts/log excerpts. The attempt ledger is the preferred source for retry history.
+
+## Preflight & Replay Safety
+
+- Use `POST /api/v1/workflows/preflight` before saving or rerunning a changed definition.
+- `validation_mode=block` returns blocking validation errors.
+- `validation_mode=non-block` demotes definition validation issues to warnings so authors can inspect the rest of the payload.
+- Replay safety warnings come from step capability metadata:
+  - `replay_safe`
+  - `idempotency_strategy`
+  - `compensation_supported`
+  - `requires_human_review_for_rerun`
+- Treat `unsafe_replay_step` as a real warning. Side-effecting steps such as `webhook`, `notify`, or external tool calls should be reviewed before rerun even when the original failure looks transient.
+
 ## Artifact Downloads
 
 - Containment: Enforced only when a `workdir` is recorded on the run/step metadata. If strict mode blocks unexpected paths, ensure your step recorded the correct workdir.
@@ -57,6 +87,15 @@ def verify(secret: str, ts: str, body: str, received: str) -> bool:
 Debug checklist:
 - Inspect events stream (`GET /runs/{run_id}/events?limit=200`) for `run_paused`, `run_resumed`, `run_cancelled`, `step_*`.
 - If resume stalls, verify `after_step_id` handling via logs (enabled by `WORKFLOWS_DEBUG`).
+
+## Retry Decisions
+
+- `retryable=true` means the latest failure looked transient, not that replay is automatically safe.
+- Use attempt metadata plus step capability metadata together:
+  - Safe replay: transient failure + replay-safe step.
+  - Conditional replay: transient failure on a side-effecting or human-reviewed step.
+  - Fix-before-rerun: definition/policy/input failures; run preflight after the change.
+- If you need DB-level inspection, look at `workflow_step_attempts` before `workflow_events`; it is the canonical retry ledger.
 
 ## Idempotency
 

--- a/Docs/Operations/Workflows_Runbook.md
+++ b/Docs/Operations/Workflows_Runbook.md
@@ -43,22 +43,38 @@ Operational guidance for running, migrating, backing up, and troubleshooting the
 
 ## Incident Triage
 
-1) User cannot see run
+1) Failed run / repeated retries
+   - Start with `GET /api/v1/workflows/runs/{run_id}/investigation`.
+   - Use `primary_failure.reason_code_core`, `category`, `blame_scope`, `retryable`, and `recommended_actions` to classify the incident.
+   - If the investigation identifies a failed step, follow with `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts` to inspect retry history.
+   - Decide rerun policy from both the failure metadata and the step replay metadata:
+     - Safe replay: transient failure on a replay-safe step.
+     - Conditional replay: transient failure on a side-effecting or human-reviewed step.
+     - Fix-before-rerun: definition, input, or policy failures. Run `POST /api/v1/workflows/preflight` after the change before retrying.
+   - If the derived investigation looks stale or incomplete, fall back to `GET /runs/{run_id}/events` and artifact/log inspection.
+2) User cannot see run
    - Check tenant and owner constraints; admins can filter with `owner=`.
    - Confirm DB instance: the API and tests should use the same DB path/URL; check `DATABASE_URL_WORKFLOWS`.
-2) Webhook not firing
+3) Webhook not firing
    - Confirm `WORKFLOWS_DISABLE_COMPLETION_WEBHOOKS` is not set.
    - Check `webhook_delivery` events for `blocked|failed`.
    - Validate egress policy and allowlists; inspect DLQ with `SELECT * FROM workflow_webhook_dlq`.
    - If using signatures, ensure receiver computes HMAC over `"{ts}.{body}"` with header `X-Signature-Timestamp`.
-3) Event stream out of order / missing
+4) Event stream out of order / missing
    - Validate uniqueness of `(run_id, event_seq)` and counters table health.
-4) “database is locked” (SQLite)
+5) “database is locked” (SQLite)
    - WAL mode and busy timeout should handle most cases; reduce concurrency or move to Postgres.
-5) Artifact download 404/403
+6) Artifact download 404/403
    - Verify artifact exists for the run (`GET /runs/{run_id}/artifacts`).
    - Check path containment vs recorded `workdir` (strict mode may block).
    - In tests, ensure the route uses the same DB instance as the test fixture.
+
+## Authoring Checks
+
+- Use `POST /api/v1/workflows/preflight` before rollout, after definition edits, and before retrying a failed run from a changed workflow revision.
+- Treat `definition_invalid` as a release blocker.
+- Treat `unsafe_replay_step` warnings as rollout review items, not cosmetic lint.
+- For persistent incidents, compare the failing run’s `status_reason` and latest attempt `reason_code_core` before deciding whether to rollback or replay.
 
 ## Maintenance
 

--- a/Docs/Operations/monitoring/alerts/workflows_alerts.yml
+++ b/Docs/Operations/monitoring/alerts/workflows_alerts.yml
@@ -2,6 +2,11 @@ groups:
   - name: workflows.rules
     interval: 30s
     rules:
+      # Investigation-first guidance:
+      # These alerts stay rate/latency based because the current metrics do not
+      # expose reason_code_core as a label. After an alert fires, pivot into
+      # /api/v1/workflows/runs?status=failed and the investigation endpoints to
+      # classify failures by reason_code_core, blame_scope, and retryability.
       # High failure rate of runs (over 5 minutes)
       - alert: WorkflowsHighRunFailureRate
         expr: |
@@ -18,6 +23,9 @@ groups:
           description: |
             In the last 5 minutes, over 30% of started runs failed.
             Investigate failing definitions, providers, or recent deployments.
+            Start with /api/v1/workflows/runs?status=failed and then inspect
+            /api/v1/workflows/runs/{run_id}/investigation for reason_code_core
+            and retryability.
 
       # Webhook delivery failures (any non-zero failures sustained)
       - alert: WorkflowsWebhookFailures
@@ -32,6 +40,8 @@ groups:
           description: |
             Sustained webhook delivery failures in the last 10 minutes.
             Check egress policy, target availability, and secrets.
+            Confirm whether failing runs classify as transient_network_error or
+            a policy/definition issue before bulk replaying webhook steps.
 
       # Webhook deliveries blocked by policy (sustained)
       - alert: WorkflowsWebhookBlocked
@@ -46,6 +56,8 @@ groups:
           description: |
             Webhook deliveries are being blocked by egress policy.
             Review allowlists and profile settings if this is unexpected.
+            Matching run investigations should show policy-oriented reason codes
+            rather than transient runtime failures.
 
       # Engine queue depth high (backlog)
       - alert: WorkflowsQueueDepthHigh

--- a/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
+++ b/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
@@ -1,0 +1,338 @@
+# Chat Page Rate-Limit Lazy Hydration Design
+
+Date: 2026-03-11
+Owner: Codex collaboration session
+Status: Approved (design)
+
+## Context and Problem
+
+Users report hitting API rate limits during ordinary use of the WebUI `/chat` page and the extension chat surface.
+
+Current request pressure comes from a combination of frontend behaviors:
+
+- eager mount-time fetching for sidebar history, capability checks, MCP discovery, audio health, model catalogs, and preference hydration
+- duplicated server-chat metadata and transcript loading across multiple hooks and surfaces
+- full history sweeps for server chat lists
+- provider-sensitive model refreshes that can run on the send path
+
+Relevant current anchors:
+
+- [`apps/packages/ui/src/components/Layouts/Layout.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Layouts/Layout.tsx)
+- [`apps/packages/ui/src/components/Common/ChatSidebar.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/ChatSidebar.tsx)
+- [`apps/packages/ui/src/hooks/useServerChatHistory.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useServerChatHistory.ts)
+- [`apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx)
+- [`apps/packages/ui/src/hooks/useMessage.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx)
+- [`apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts)
+- [`apps/tldw-frontend/extension/routes/sidepanel-chat.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx)
+
+## Goals
+
+1. Reduce background and burst traffic to `tldw_server` during normal chat usage.
+2. Reduce downstream provider-sensitive traffic caused indirectly by chat UI refresh and validation flows.
+3. Preserve fast initial interaction by rendering the chat shell before optional remote data loads.
+4. Keep WebUI and extension behavior aligned through shared request-gating policy.
+5. Make lazy-loading explicit in the UI so users understand when data has not been fetched yet.
+
+## Non-Goals
+
+1. Rebuilding the chat UI information architecture from scratch.
+2. Adding a new backend endpoint purely for this phase unless pagination/search gaps require it.
+3. Replacing existing data-fetch services wholesale.
+4. Solving unrelated backend-side rate-limit policy tuning in this design.
+
+## User Decisions Captured During Brainstorming
+
+1. Prefer a broader redesign over a minimal low-risk patch.
+2. Optimize both `tldw_server` request volume and downstream provider-triggered traffic.
+3. Accept later population of optional chat surfaces if that materially reduces request pressure.
+
+## Design Summary
+
+Use a shared chat-surface request coordinator in `apps/packages/ui` that owns fetch policy rather than fetch implementation.
+
+The coordinator is responsible for:
+
+- visibility and interaction gates
+- per-resource freshness windows and cooldowns
+- single-flight request deduplication
+- scoped last-known snapshots for optional UI
+- coalesced invalidation rules
+
+Existing feature-specific hooks and services continue to execute the actual requests. The redesign changes when they are allowed to run and how their results are reused.
+
+## Architecture
+
+Render both WebUI `/chat` and the extension chat shell in phases.
+
+### Phase 1: Interactive shell
+
+Render immediately from local state:
+
+- current transcript
+- queued drafts
+- selected model and prompt state
+- connection snapshot
+- locally persisted active conversation identity
+
+This phase must not require optional remote fetches.
+
+### Phase 2: Conversation-critical load
+
+Only the active conversation may perform immediate remote work.
+
+Use one canonical server-backed conversation loader for:
+
+- transcript messages
+- minimal conversation metadata
+- any required local mirror updates
+
+Do not allow multiple hooks or surfaces to independently fetch:
+
+- `getChat`
+- `listChatMessages`
+- persona profile
+- character profile
+
+for the same active conversation at the same time.
+
+### Phase 3: Optional panel hydration
+
+Optional surfaces fetch only after explicit user engagement:
+
+- server history sidebar
+- MCP tools/catalogs/modules
+- audio and dictation health
+- model and image catalogs
+
+Optional surfaces may render cached snapshot data first, then reconcile after the user opens them.
+
+## Request Classes
+
+The coordinator should classify request behavior into four groups.
+
+### Shell-critical
+
+- no network required
+- render from local persisted state only
+
+### Conversation-critical
+
+- active conversation transcript load
+- minimal metadata needed for the selected chat
+- abortable and single-flight
+
+### Panel-optional
+
+- sidebar history
+- MCP health, tools, catalogs, modules
+- audio health probes
+- voices catalog
+
+These must not run until the owning UI surface is explicitly engaged.
+
+### Provider-expensive
+
+- model catalog refresh
+- provider-sensitive catalog refresh paths such as OpenRouter metadata refresh
+
+These must never run implicitly on submit by default.
+
+## Server History Design
+
+Server history needs its own split design because the current UI assumes full client-side filtering.
+
+### Overview mode
+
+Use lightweight, paginated history loading for browsing conversations.
+
+Rules:
+
+- do not sweep all pages on initial mount
+- fetch only when the server-history panel is actively engaged
+- page additional results on scroll or explicit pagination
+- do not use full remote history as a passive badge-count source
+
+### Search mode
+
+Search must not rely on page-one-only client filtering.
+
+Rules:
+
+- treat search as its own explicit fetch path
+- either call a server-backed filtered result set or fetch a search-specific paginated slice
+- do not silently degrade search completeness
+
+## Desktop Sidebar Gating
+
+The desktop WebUI mounts the chat sidebar persistently in layout, so “fetch when sidebar is visible” is insufficient.
+
+History loading should be gated by all of:
+
+- route is chat-capable
+- server-history tab or panel is active
+- user has expanded, focused, or otherwise intentionally engaged the panel
+
+Acceptable triggers include:
+
+- first open of the server-history panel
+- first focus into the server-history search input
+- first scroll or click inside the panel
+
+## Conversation Hydration Rules
+
+Canonical conversation loading should be two-phase.
+
+### Phase A
+
+Load:
+
+- transcript messages
+- minimal metadata needed to render the conversation shell
+
+This phase should complete without blocking on persona or character enrichment.
+
+### Phase B
+
+Hydrate secondary details after the transcript is visible:
+
+- persona profile
+- character profile
+- enriched assistant identity UI
+
+This prevents slow profile lookups from delaying transcript render.
+
+## Model Catalog and Provider Refresh Rules
+
+Model catalogs should be cached, scoped, and advisory unless freshly confirmed.
+
+Rules:
+
+- use persisted model snapshots first
+- scope cached model data by server URL, auth mode, and user or org identity
+- do not force provider refresh on send by default
+- if the selected model is stale or uncertain, warn instead of hard-blocking
+- hard-block only on a fresh confirmed miss or a real server-side rejection
+- expose explicit `Refresh models` and `Pick another model` actions
+- protect manual refresh with cooldowns and single-flight semantics
+
+This preserves provider quota while avoiding false-negative send blocks from stale local metadata.
+
+## Optional Surface UX
+
+Lazy-loading must be explicit in the UI.
+
+Recommended states:
+
+- sidebar history: `Load conversations`
+- MCP tools: `Not checked yet`
+- voice or dictation: `Check availability`
+- model freshness issue: `Selected model may be stale or unavailable`
+
+Do not conflate:
+
+- unchecked
+- unavailable
+- unhealthy
+- rate-limited
+
+## Invalidation Rules
+
+Current chat operations should stop triggering broad history refreshes when narrow local patches are sufficient.
+
+Rules:
+
+- patch local chat history metadata after rename, topic edit, or state change
+- coalesce follow-up refreshes instead of invalidating full history repeatedly
+- sending a message must not trigger repeated full history sweeps during the same turn
+- optional panel refreshes run only when their panel is open and the tab is visible
+
+## Error Handling
+
+### Optional panel failures
+
+- keep failures local to the panel
+- 429s on optional panels must not escalate into global chat errors
+- apply cooldowns before retry
+
+### Conversation-critical failures
+
+- keep abortable single-flight semantics for chat switching
+- cancel stale loads when the user changes chats or tabs quickly
+- only surface active-load errors to the current selected conversation
+
+### Provider-expensive failures
+
+- record last attempted refresh time
+- prevent repeated submit-click bursts from triggering repeated expensive refresh flows
+- prefer user-visible recovery actions over silent retry loops
+
+## Persistence and Cache Scope
+
+All lazy snapshots must be scoped to the active environment.
+
+Minimum cache scope:
+
+- server URL
+- auth mode
+- user identity or org context where applicable
+
+Clear or ignore stale snapshots when those values change.
+
+## Testing Strategy
+
+### Unit tests
+
+- coordinator visibility gates
+- cooldown and freshness policy
+- single-flight behavior
+- snapshot scoping and invalidation
+
+### Integration tests
+
+- `/chat` initial mount does not fetch server history before panel engagement
+- `/chat` initial mount does not fetch MCP tools or catalogs before tools UI is opened
+- `/chat` initial mount does not start audio probes before voice or dictation UI is opened
+- send flow does not implicitly trigger provider refresh
+- conversation load renders transcript before persona or character enrichment completes
+- server history search still returns complete results under the new search path
+
+### Extension parity tests
+
+- sidepanel follows the same gating policy as WebUI for optional surfaces
+- sidepanel conversation switching reuses canonical single-flight load behavior
+
+### Request-budget regression tests
+
+Use resource-class and forbidden-endpoint assertions rather than brittle raw request counts.
+
+Examples:
+
+- initial chat mount must not hit `/api/v1/chats/`
+- initial chat mount must not hit `/api/v1/mcp/health`
+- initial chat mount must not hit audio health endpoints
+- initial send must not trigger provider refresh endpoints implicitly
+
+## Risks and Mitigations
+
+1. Search completeness regression under paginated history
+   - Mitigation: separate overview mode from search mode.
+2. False send blocks from stale model cache
+   - Mitigation: advisory warning by default; hard-block only on fresh negative or server rejection.
+3. Coordinator becoming a monolith
+   - Mitigation: coordinator owns policy only, not all request implementations.
+4. Cross-account or cross-server stale snapshot bleed
+   - Mitigation: strict snapshot scoping and invalidation on auth or server changes.
+5. Lazy-loading feels like broken UI
+   - Mitigation: explicit unchecked/loading states and clear manual actions.
+
+## Rollout Guidance
+
+Implement incrementally:
+
+1. Introduce coordinator and gating primitives.
+2. Move server history behind engagement gates and split browse vs search behavior.
+3. Move conversation hydration to one canonical path with two-phase enrichment.
+4. Remove implicit provider refresh from send flow.
+5. Apply the same policy to extension sidepanel parity.
+
+This ordering reduces rate-limit pressure early while keeping the refactor reversible.

--- a/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
+++ b/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
@@ -17,13 +17,13 @@ Current request pressure comes from a combination of frontend behaviors:
 
 Relevant current anchors:
 
-- [`apps/packages/ui/src/components/Layouts/Layout.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Layouts/Layout.tsx)
-- [`apps/packages/ui/src/components/Common/ChatSidebar.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/ChatSidebar.tsx)
-- [`apps/packages/ui/src/hooks/useServerChatHistory.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useServerChatHistory.ts)
-- [`apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx)
-- [`apps/packages/ui/src/hooks/useMessage.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx)
-- [`apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts)
-- [`apps/tldw-frontend/extension/routes/sidepanel-chat.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx)
+- `apps/packages/ui/src/components/Layouts/Layout.tsx`
+- `apps/packages/ui/src/components/Common/ChatSidebar.tsx`
+- `apps/packages/ui/src/hooks/useServerChatHistory.ts`
+- `apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`
+- `apps/packages/ui/src/hooks/useMessage.tsx`
+- `apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`
+- `apps/tldw-frontend/extension/routes/sidepanel-chat.tsx`
 
 ## Goals
 

--- a/Docs/Plans/2026-03-11-fish-s2-pro-tts-registry-design.md
+++ b/Docs/Plans/2026-03-11-fish-s2-pro-tts-registry-design.md
@@ -1,0 +1,417 @@
+# Fish Audio S2 Pro TTS Registry Design
+
+Date: 2026-03-11
+Status: Approved for planning
+Scope: Design only, no implementation
+
+## Overview
+
+This document describes how to add Fish Audio S2 Pro support to the tldw TTS
+registry without breaking the current adapter, voice-management, or auth
+patterns.
+
+The approved direction is:
+
+- add one canonical provider: `fish_s2`
+- support the upstream Fish HTTP server first
+- keep a future local-runtime backend as an internal design target, but not a
+  normal v1 deployment mode
+- support Fish-style managed reference workflows from day one
+
+Key upstream constraints confirmed during design:
+
+- Fish ships a native HTTP server with `POST /v1/tts`
+- managed references are handled via `/v1/references/add|list|delete`
+- the native server supports `wav`, `pcm`, and `mp3` output for non-streaming
+- native streaming is limited to `wav`
+- S2 Pro is documented as SGLang-first; the Hugging Face model card does not
+  expose hosted inference
+
+Sources:
+
+- https://github.com/fishaudio/fish-speech
+- https://speech.fish.audio/server/
+- https://huggingface.co/fishaudio/s2-pro
+- https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md
+
+## Goals
+
+- Add Fish Audio S2 Pro to the TTS registry as a first-class provider.
+- Support generation through the existing `POST /api/v1/audio/speech` route.
+- Support managed reference creation, listing, and deletion from day one.
+- Reuse existing tldw voice storage and metadata where practical.
+- Preserve user isolation when multiple tldw users share one Fish backend.
+- Avoid claiming unsupported semantics such as non-WAV streaming.
+
+## Non-Goals
+
+- Implementing the in-process local runtime in v1.
+- Supporting arbitrary remote-only Fish references with no local tldw record.
+- Surfacing Fish managed references in the global `/api/v1/audio/voices/catalog`
+  route in v1.
+- Adding a new multi-speaker public request surface in v1.
+- Adding raw ad hoc inline `extra_params.references` audio uploads in v1.
+
+## Primary Decisions
+
+### 1. Canonical Provider
+
+Add a new provider enum and registry entry:
+
+- provider key: `fish_s2`
+- adapter class: `FishS2Adapter`
+
+Model aliases should resolve to `fish_s2`, including at least:
+
+- `fish_s2`
+- `fish-s2`
+- `fish-s2-pro`
+- `s2-pro`
+- `fishaudio/s2-pro`
+
+### 2. Backend Shape
+
+The public provider is always `fish_s2`. Internally, the adapter delegates to a
+backend strategy:
+
+- `FishS2NativeHttpBackend` in v1
+- `FishS2LocalRuntimeBackend` as a future internal extension point
+
+This keeps registry, fallback, metrics, and API routing stable while allowing a
+later local runtime without changing the external provider contract.
+
+### 3. Reference Identity
+
+In v1, the user-facing Fish `reference_id` is the local tldw `voice_id`.
+
+This is the most important design revision from review. It avoids creating a
+second public namespace or a second persistence layer. The backend-specific Fish
+reference ID becomes an internal implementation detail derived from:
+
+- `user_id`
+- `voice_id`
+
+Example internal remote ID pattern:
+
+- `tldw_u{user_id}_v{voice_id}`
+
+The exact formatting can be finalized during implementation, but it must be
+deterministic and collision-resistant.
+
+### 4. Storage Reuse
+
+Reuse existing voice metadata in `voice_manager` for Fish mappings.
+
+Store Fish state under:
+
+- `provider_artifacts["fish_s2"]`
+
+Expected fields:
+
+- `remote_reference_id`
+- `reference_text`
+- `backend`
+- `created_remote`
+- `updated_remote`
+- optional health/sync metadata
+
+No second logical-reference store should be introduced in v1.
+
+## Architecture
+
+### Adapter and Backend Components
+
+Planned components:
+
+- `tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py`
+- `tldw_Server_API/app/core/TTS/backends/fish_s2_base.py`
+- `tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py`
+
+The adapter is responsible for:
+
+- capability reporting
+- request validation delegation
+- mapping `TTSRequest` into backend-native requests
+- consistent exception mapping
+
+The native HTTP backend is responsible for:
+
+- `GET /v1/health`
+- `POST /v1/tts`
+- `POST /v1/references/add`
+- `GET /v1/references/list`
+- `DELETE /v1/references/delete`
+- bearer auth header handling
+
+### API Integration
+
+Speech generation remains on the existing route:
+
+- `POST /api/v1/audio/speech`
+
+Fish managed reference routes are added under the audio namespace:
+
+- `POST /api/v1/audio/providers/fish_s2/references`
+- `GET /api/v1/audio/providers/fish_s2/references`
+- `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
+
+In v1, `reference_id` on these routes is the local `voice_id`.
+
+## Request Mapping
+
+### Speech Generation
+
+Existing request fields map as follows:
+
+- `input` -> Fish `text`
+- `response_format` -> Fish `format`
+- `stream` -> Fish `streaming`
+
+Fish-specific request controls live in `extra_params`:
+
+- `reference_id`
+- `chunk_length`
+- `normalize`
+- `seed`
+- `use_memory_cache`
+- `top_p`
+- `temperature`
+- `repetition_penalty`
+
+### Reference Selection Precedence
+
+For `model=fish_s2`, v1 resolution order is:
+
+1. `extra_params.reference_id`
+2. `voice=custom:<voice_id>`
+3. no managed reference
+
+If `extra_params.reference_id` is present, it resolves to a local `voice_id`
+owned by the current user, then loads the Fish provider artifact mapping from
+that voice metadata.
+
+If `voice=custom:<voice_id>` is present, the service resolves the stored voice
+through `voice_manager`. If a Fish remote reference already exists for that
+voice, reuse it. Otherwise, create the remote Fish reference on demand using the
+stored audio and transcript, then persist the mapping.
+
+### Optional Shorthand
+
+`voice=fishref:<id>` may be accepted as compatibility sugar, but it is not the
+primary documented contract. If implemented, `<id>` still resolves to the local
+logical `reference_id` / `voice_id`, not the backend remote ID.
+
+## Managed Reference Lifecycle
+
+### Creation
+
+`POST /api/v1/audio/providers/fish_s2/references` supports two modes:
+
+1. Existing stored voice:
+   - request supplies `voice_id`
+   - optionally allows overriding `reference_text`
+
+2. New upload:
+   - request supplies audio file plus transcript and metadata
+   - route first creates a local stored voice via existing `voice_manager`
+   - then creates the remote Fish reference for that voice
+
+This preserves one authoritative local record per managed reference.
+
+### Listing
+
+`GET /api/v1/audio/providers/fish_s2/references` should list current-user
+managed references from local metadata, not from Fish’s global backend list.
+
+This avoids cross-user leakage and keeps the local database authoritative.
+Backend sync checks may be added as best-effort status indicators, but local
+metadata remains the source of truth for listing.
+
+### Deletion
+
+`DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`:
+
+- resolves `reference_id` as a local `voice_id`
+- deletes the remote Fish reference if present
+- removes `provider_artifacts["fish_s2"]`
+- does not delete the local stored voice itself
+
+If the user wants to remove the underlying uploaded voice, they should continue
+to use the existing `/api/v1/audio/voices/{voice_id}` delete route.
+
+## Voice Catalog Behavior
+
+Fish managed references should not appear in:
+
+- `GET /api/v1/audio/voices/catalog`
+
+Reason:
+
+- that route is currently capability-driven and not user-aware
+- Fish managed references are user-scoped data, not provider-global presets
+
+`fish_s2` may still appear in provider capabilities with:
+
+- empty built-in voices
+- voice cloning support enabled
+
+## Validation
+
+### Provider-Level Validation
+
+V1 validation should be conservative and honest:
+
+- `stream=true` requires `response_format=wav` for `fish_s2`
+- `mp3` and `pcm` are allowed for non-streaming requests
+- `lang_code` is not validated as a hard provider contract in v1 because the
+  native Fish HTTP request does not take an explicit language field
+- `target_sample_rate` is ignored unless a backend later supports it explicitly
+
+Fish-specific sampling controls should be validated into upstream ranges:
+
+- `chunk_length`: 100-300
+- `top_p`: 0.1-1.0
+- `temperature`: 0.1-1.0
+- `repetition_penalty`: 0.9-2.0
+
+### Reference Audio Validation
+
+Fish reference audio should reuse the existing upload and storage pipeline
+instead of bypassing it. Add a `fish_s2` entry to `voice_manager`
+`PROVIDER_REQUIREMENTS` with conservative defaults.
+
+Recommended v1 defaults:
+
+- allowed formats: `.wav`, `.mp3`, `.flac`, `.ogg`, `.m4a`, `.opus`
+- conversion target: `wav`
+- sample rate target: `24000`
+- transcript required
+- initial duration envelope: 3-60s
+- user guidance should recommend 10-30s as the high-quality target
+
+Arbitrary raw inline `extra_params.references` payloads should be deferred from
+v1. Supporting only:
+
+- managed references via `reference_id`
+- stored voices via `custom:<voice_id>`
+
+keeps validation, quota enforcement, and user isolation much cleaner.
+
+## Capability Reporting
+
+`fish_s2` should report:
+
+- `provider_name = "Fish Audio S2"`
+- `supports_voice_cloning = true`
+- `supports_streaming = true`
+- `supported_formats = {wav, mp3, pcm}`
+- `default_format = wav`
+
+V1 should not advertise:
+
+- provider-global preset voices
+- `supports_multi_speaker = true`
+
+unless a first-class supported request surface exists for those features.
+
+## Auth and Route Policy
+
+Do not introduce a new Fish-specific privilege scope family in v1.
+
+Instead, mirror the policy posture of the existing voice-management routes:
+
+- same token-scope mode as current audio voice endpoints
+- same quota/counting category where appropriate
+
+This avoids unnecessary privilege-catalog churn and reduces startup validation
+risk while the provider is still new.
+
+## Configuration
+
+Add a `fish_s2` block to the TTS provider config:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: false
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    verify_api_key_on_init: false
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 0
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
+```
+
+Notes:
+
+- `backend=local_runtime` remains an internal future shape, not a supported
+  operator-facing mode in v1 docs
+- health verification should prefer `/v1/health`
+- bearer auth should be used when `api_key` is configured
+
+## Error Handling
+
+Map backend failures into existing TTS exceptions:
+
+- 401/403 -> `TTSAuthenticationError`
+- 400 -> `TTSValidationError`
+- 404 managed reference missing -> validation/not-found provider error
+- 429 -> `TTSRateLimitError`
+- network failure -> `TTSNetworkError`
+- timeout -> `TTSTimeoutError`
+- unsupported local backend mode in v1 -> `TTSProviderInitializationError`
+
+Managed reference routes should return user-shaped responses:
+
+- 400 invalid transcript or payload
+- 404 unknown current-user `reference_id`
+- 409 duplicate or conflicting mapping
+- 502/503 backend unavailable
+
+## Testing Plan
+
+### Unit Tests
+
+- registry resolves `fish_s2` and its model aliases
+- request mapping to Fish `/v1/tts`
+- `reference_id` resolves through local `voice_id`
+- `custom:<voice_id>` creates or reuses Fish provider artifacts correctly
+- validation rejects `stream=true` with non-`wav`
+- provider artifact persistence under `provider_artifacts["fish_s2"]`
+
+### Integration Tests
+
+- `/api/v1/audio/speech` with `model=fish_s2`
+- add/list/delete Fish managed references
+- create managed Fish reference from an existing stored voice
+- create managed Fish reference from a fresh upload
+- user A cannot list or delete user B’s Fish references
+- deleting a Fish reference does not delete the underlying local stored voice
+
+### Documentation
+
+Add a Fish S2 setup guide that documents:
+
+- starting the upstream Fish server
+- configuring `fish_s2`
+- WAV-only streaming on the native server backend
+- creating and using managed references
+- using `custom:<voice_id>` with Fish
+
+## Summary
+
+The approved v1 design is intentionally conservative:
+
+- one provider: `fish_s2`
+- one real backend: native Fish HTTP server
+- one logical reference namespace: local `voice_id`
+- one persistence path: existing `voice_manager` metadata
+
+That keeps the design aligned with upstream Fish behavior while fitting the
+current tldw TTS architecture, auth model, and user-isolated voice storage.

--- a/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
+++ b/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
@@ -1,0 +1,339 @@
+# Qwen3-TTS On M-Series macOS Design
+
+**Date:** 2026-03-11
+
+## Goal
+
+Add support for `qwen3_tts` on Apple Silicon macOS while preserving one public provider surface in `tldw_server`, and also support users who already run a hosted or sidecar Qwen backend and do not want a duplicate local process.
+
+## Current State
+
+The codebase already contains substantial Qwen3-TTS scaffolding:
+
+- A registered `qwen3_tts` provider in the TTS registry.
+- A `Qwen3TTSAdapter` with model routing, streaming, and voice-clone prompt handling.
+- Provider validation for Qwen-specific request shapes.
+- Voice metadata persistence for `voice_clone_prompt`.
+- Tokenizer endpoints and tests.
+
+However, the current adapter is effectively built around one backend assumption. It does not cleanly separate:
+
+- Linux/CUDA upstream `qwen_tts`
+- Apple Silicon in-process execution
+- Remote OpenAI-compatible sidecar execution
+
+It also currently advertises provider-wide capabilities that are too optimistic for a runtime-split design.
+
+## Design Constraints
+
+### Functional
+
+- Keep one public provider key: `qwen3_tts`.
+- Support three execution modes:
+  - In-process upstream runtime
+  - In-process Apple Silicon runtime
+  - Remote sidecar/hosted runtime
+- Preserve the existing `/api/v1/audio/speech` API shape for callers.
+- Preserve existing Qwen-specific behavior already implemented in the adapter and service layer.
+
+### Scope
+
+Initial Apple Silicon support is intentionally limited:
+
+- `mlx` runtime starts with preset-speaker `CustomVoice` only.
+- It does **not** initially support:
+  - Uploaded `custom:<voice_id>` voices
+  - `Base` model reference-audio cloning
+  - `VoiceDesign`
+  - tokenizer-heavy flows that depend on unavailable runtime support
+
+This wording is important. In the current codebase, uploaded custom voices flow through `Base`-style reference audio and stored prompt metadata, not through preset-speaker `CustomVoice`.
+
+### Non-Goals
+
+- No new public provider names such as `qwen3_tts_mlx`.
+- No promise of full Qwen parity on Apple Silicon in v1.
+- No fake CI claim that proves M-series runtime behavior without Apple Silicon hardware.
+
+## Research Summary
+
+- Official Qwen3-TTS upstream support exists and is current, but published examples are CUDA-oriented and recommend `flash-attn`.
+- PyTorch MPS is a valid Apple Silicon execution substrate, but that alone does not guarantee upstream Qwen runtime maturity on macOS.
+- `mlx-audio` is a practical Apple Silicon path and already exposes Qwen3-TTS models plus an OpenAI-compatible REST API.
+
+Sources:
+
+- [Qwen3-TTS README](https://github.com/QwenLM/Qwen3-TTS)
+- [MLX-Audio README](https://github.com/Blaizzy/mlx-audio)
+- [PyTorch MPS docs](https://docs.pytorch.org/docs/stable/notes/mps.html)
+
+## Recommended Approach
+
+Keep `qwen3_tts` as one logical provider and split execution behind it into runtime backends.
+
+### Why
+
+- Matches the current codebase, which already treats Qwen3-TTS as one provider with one adapter, one config block, one validation surface, and one set of voice metadata rules.
+- Avoids leaking infrastructure choices into public API/provider names.
+- Allows platform-specific truth without forcing callers to integrate against multiple providers.
+
+## Architecture
+
+### Public Surface
+
+The following remain stable:
+
+- Provider key: `qwen3_tts`
+- Registry entry and model family
+- Audio API endpoints
+- Existing voice metadata persistence behavior
+
+### Internal Structure
+
+Refactor the current `Qwen3TTSAdapter` into:
+
+- An orchestration layer that stays responsible for:
+  - request normalization
+  - model aliasing
+  - mode selection
+  - custom voice metadata resolution
+  - Qwen-specific validation hooks
+  - service-compatible `TTSResponse` generation
+- Runtime backends that handle actual execution:
+  - `UpstreamQwenRuntime`
+  - `MlxQwenRuntime`
+  - `RemoteQwenRuntime`
+
+### Runtime Responsibilities
+
+#### `UpstreamQwenRuntime`
+
+- In-process runtime for `qwen_tts`
+- Preferred on Linux/CUDA and any explicitly forced upstream environment
+- Can continue to support the broader Qwen feature set where proven
+
+#### `MlxQwenRuntime`
+
+- In-process Apple Silicon runtime
+- Preferred by `runtime=auto` on `Darwin + arm64`
+- Initial support is intentionally limited to preset-speaker `CustomVoice`
+- Must reject unsupported modes with structured validation errors
+
+#### `RemoteQwenRuntime`
+
+- Used when the user points `qwen3_tts` at an already-hosted backend
+- Keeps the public provider name unchanged
+- Must preserve Qwen-specific semantics rather than silently collapsing to generic OpenAI TTS
+
+## Runtime Selection
+
+Add a provider-level runtime selector under `providers.qwen3_tts`:
+
+- `runtime: auto | upstream | mlx | remote`
+
+Selection rules:
+
+- `auto` on macOS arm64 prefers `mlx`
+- `auto` on Linux/CUDA prefers `upstream`
+- `auto` never silently chooses `remote` unless remote connectivity is explicitly configured
+- Explicit runtime selection always wins
+
+This avoids accidentally choosing an importable but less-stable upstream runtime on Apple Silicon.
+
+## Capability Model
+
+The current capability booleans are too coarse for this feature. The design should retain the existing `TTSCapabilities` envelope but extend the serialized payload for Qwen with runtime-aware metadata.
+
+### Required Capability Fields
+
+Existing fields remain, but Qwen capability serialization should also include:
+
+- `runtime`
+- `supported_modes`
+  - `custom_voice_preset`
+  - `base_clone`
+  - `voice_design`
+- `supports_uploaded_custom_voices`
+- `supports_qwen_voice_clone_prompt`
+- `runtime_notes`
+
+### Initial Runtime Truth Table
+
+#### `upstream`
+
+- `custom_voice_preset`: supported
+- `base_clone`: supported when upstream backend supports it
+- `voice_design`: supported when upstream backend supports it
+- `supports_uploaded_custom_voices`: true via existing `custom:<voice_id>` flow
+
+#### `mlx`
+
+- `custom_voice_preset`: supported
+- `base_clone`: unsupported in v1
+- `voice_design`: unsupported in v1
+- `supports_uploaded_custom_voices`: false in v1
+
+#### `remote`
+
+- Capability truth depends on the remote backend
+- If the remote backend cannot report capabilities, default to conservative values and do not over-advertise support
+
+## Request And Data Flow
+
+### Normal Flow
+
+1. API receives `OpenAISpeechRequest`
+2. `TTSServiceV2` resolves provider `qwen3_tts`
+3. `Qwen3TTSAdapter`:
+   - normalizes request
+   - resolves model/mode
+   - resolves stored voice metadata
+   - selects runtime
+4. Selected runtime validates mode support
+5. Runtime produces PCM or a stream
+6. Existing TTS service logic handles format conversion, history, and persistence
+
+### Uploaded Custom Voice Behavior
+
+Existing `custom:<voice_id>` semantics stay intact for supported runtimes. For `mlx`:
+
+- do not silently degrade uploaded voices into preset speakers
+- fail early with a structured validation error explaining that uploaded custom voices are not supported by the selected runtime
+
+## Remote Runtime Contract
+
+This needs to be explicit. A generic OpenAI-compatible `/audio/speech` request is not sufficient for full Qwen behavior because Qwen clone flows need fields such as:
+
+- `ref_audio`
+- `ref_text`
+- `x_vector_only_mode`
+- `voice_clone_prompt`
+
+### v1 Remote Contract
+
+`RemoteQwenRuntime` must target a **Qwen-extended OpenAI-compatible** backend contract, not a plain generic TTS endpoint.
+
+That means:
+
+- standard OpenAI TTS fields are still used where applicable
+- Qwen-specific fields are passed through using documented request extensions
+- if the remote backend does not support the Qwen extension contract, remote mode must either:
+  - advertise only preset-speaker `CustomVoice`, or
+  - fail configuration validation rather than silently dropping Qwen-only fields
+
+## Configuration
+
+Avoid unnecessary config sprawl. Reuse existing generic provider fields where possible.
+
+### Additions Under `providers.qwen3_tts`
+
+- `runtime`
+- `base_url`
+- `api_key`
+- `mlx_model`
+- `mlx_model_path`
+- `capability_override` only if needed for remote truthing
+
+### Do Not Add Unless Proven Necessary
+
+- separate `remote_base_url`
+- separate `remote_api_key`
+- a nested runtime matrix config
+
+The current provider config model already supports generic `base_url` and `api_key`, and remote mode should reuse that surface.
+
+## Error Handling
+
+Error behavior must distinguish configuration errors, unsupported-mode errors, and runtime failures.
+
+### Expected Cases
+
+- `runtime=mlx` on non-macOS arm64:
+  - provider initialization error with explicit platform message
+- `runtime=upstream` without `qwen_tts` installed:
+  - provider initialization error naming missing dependency
+- `runtime=remote` without usable `base_url`:
+  - provider configuration error
+- `runtime=mlx` with `Base` or `VoiceDesign`:
+  - structured validation error
+- `runtime=mlx` with `voice="custom:<id>"`:
+  - structured validation error explaining uploaded custom voices are unsupported on MLX in v1
+- `runtime=auto` with no viable backend:
+  - initialization error describing which runtimes were attempted
+
+## Health, Metrics, And Circuit Breakers
+
+Public provider identity remains `qwen3_tts`, but operational state must include runtime identity.
+
+### Required Improvement
+
+Namespace runtime-specific operational metadata as:
+
+- `qwen3_tts:upstream`
+- `qwen3_tts:mlx`
+- `qwen3_tts:remote`
+
+This applies to:
+
+- health detail envelopes
+- circuit breaker state
+- runtime-specific metrics/log context
+
+Without this, one failing runtime path can pollute provider-wide state and make debugging misleading.
+
+## Testing Strategy
+
+### Unit Tests
+
+- runtime selection for:
+  - macOS arm64 auto
+  - Linux/CUDA auto
+  - explicit upstream
+  - explicit mlx
+  - explicit remote
+- capability gating for each runtime
+- rejection of unsupported MLX modes
+- rejection of uploaded custom voices on MLX
+- remote request translation of Qwen-specific extension fields
+
+### Integration Tests
+
+- fake upstream backend
+- fake MLX backend
+- fake remote backend
+- provider-level API behavior remains stable for `qwen3_tts`
+- capability payload exposes truthful runtime metadata
+
+### Manual Verification
+
+Document a manual Apple Silicon smoke checklist:
+
+- install/runtime prerequisites
+- minimal preset-speaker request
+- streaming request
+- provider health inspection
+- failure behavior for unsupported `Base` and `VoiceDesign`
+
+## Migration Notes
+
+- No caller-facing provider rename
+- Existing `qwen3_tts` requests remain valid
+- Existing uploaded custom voice flows continue to work only on runtimes that actually support them
+- Capability output becomes more precise, which may slightly change UI/provider-catalog behavior in a good way
+
+## Risks
+
+- The largest product risk is confusing “preset-speaker CustomVoice” with uploaded user voices
+- The largest technical risk is under-defining the remote Qwen extension contract
+- The largest operations risk is failing to namespace runtime-level breaker and health state
+
+## Design Decision Summary
+
+- One provider key: `qwen3_tts`
+- Multiple internal runtimes: `upstream`, `mlx`, `remote`
+- `auto` prefers MLX on Apple Silicon
+- MLX v1 scope is preset-speaker `CustomVoice` only
+- Remote mode must preserve Qwen-specific semantics or advertise a reduced capability set
+- Capability reporting must become runtime-aware
+- Health and breaker state must carry runtime identity
+

--- a/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md
+++ b/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md
@@ -1,0 +1,481 @@
+# Workflows Diagnostics and Improvements Design
+
+Date: 2026-03-11
+Status: Approved
+
+## Summary
+
+Improve the Workflows module with equal weight for workflow authors, operators, and API consumers, while making failed-run diagnosis the first vertical slice. The current runtime already persists substantial execution state, but troubleshooting is still exposed as low-level events, logs, and DB-oriented runbook steps rather than a coherent diagnostics model.
+
+The recommended design adds a structured diagnostics layer on top of the existing run/event/artifact ledger. It introduces explicit step replay capabilities, separates logical step runs from per-attempt retry records, defines a layered failure taxonomy, and exposes a first-class run investigation API plus shared run-inspection UI. The first milestone should also add server-authoritative preflight validation so author-time failures move earlier in the lifecycle.
+
+## Investigated Context
+
+- Runtime and state management already exist in:
+  - `tldw_Server_API/app/core/Workflows/engine.py`
+  - `tldw_Server_API/app/core/DB_Management/Workflows_DB.py`
+- Public API already exposes run summaries, events, artifacts, control, approvals, and DLQ endpoints:
+  - `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+  - `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Existing operational and design docs are present, but they are still largely raw and operator-oriented:
+  - `Docs/Operations/Workflows_Debugging.md`
+  - `Docs/Operations/Workflows_Runbook.md`
+  - `Docs/Design/Workflows.md`
+- Existing workflow editor execution UX is not yet a real server-backed run inspector:
+  - `apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx`
+  - `apps/packages/ui/src/store/workflow-editor.ts`
+
+## User-Confirmed Scope
+
+1. Review the Workflows module and brainstorm improvements with equal weight for authors, operators, and API users.
+2. Prioritize failed-run diagnostics as the first vertical slice.
+3. Allow additive API/schema/model changes and, if necessary, larger model changes.
+4. Pressure-test the design before freezing it, then incorporate revisions.
+
+## Problem Statement
+
+The module has meaningful runtime depth but a weak diagnostics experience.
+
+- Execution evidence is fragmented across `workflow_runs`, `workflow_step_runs`, `workflow_events`, artifacts, logs, and DLQ rows.
+- Retry history is collapsed into mutable step-run state rather than modeled as a first-class attempt ledger.
+- Failure semantics are not authoritative; reason codes, retryability, and remediation hints are inferred inconsistently from free-text errors and event payloads.
+- The primary troubleshooting path is still raw event polling, debug env flags, and DB inspection.
+- The current editor execution UI is local/mock, so there is no shared product-grade run inspector for authors or operators.
+
+## Goals
+
+- Add a coherent failed-run investigation model that answers:
+  - what failed
+  - why it failed
+  - what evidence exists
+  - what next action is safe
+- Keep equal value for three audiences:
+  - workflow authors in the WebUI
+  - operators debugging production runs
+  - API clients automating runs externally
+- Make preflight validation authoritative and server-backed.
+- Preserve existing execution primitives where practical, rather than rewriting the entire engine.
+- Keep the first rollout additive and backward-compatible where possible.
+
+## Non-Goals
+
+- Full orchestration engine redesign for distributed workers or general DAG execution.
+- Replacing the raw event ledger with a diagnostics-only model.
+- Shipping an editor-only diagnostics surface.
+- Persisting unrestricted raw internal exceptions, secrets, or large payload copies as diagnostics.
+
+## Approaches Considered
+
+### 1. Diagnostics Facade Over Existing Surfaces
+
+Add a single aggregated debug endpoint and a lightweight UI that composes existing run, event, and artifact data without deeper data-model changes.
+
+Pros:
+- Fastest path.
+- Lowest migration risk.
+
+Cons:
+- Keeps failure meaning implicit.
+- Leaves retry/attempt history underspecified.
+- Produces a brittle diagnostics layer that still depends on parsing raw events and error strings.
+
+### 2. Structured Diagnostics Layer Beside the Current Runtime
+
+Keep the current run/event/artifact ledger as the source of truth, but add explicit attempt records, failure taxonomy, replay capability metadata, and a first-class investigation API and UI.
+
+Pros:
+- Solves the actual user problem instead of only improving visibility.
+- Reuses most existing runtime behavior.
+- Supports all three audiences with one coherent interpretation layer.
+
+Cons:
+- Requires schema, API, and UI work.
+- Requires careful projection/versioning rules to avoid drift.
+
+### 3. Full Execution Model Redesign
+
+Replace the current model with a more opinionated orchestration plane centered on explicit graph execution, attempts, compensation, and richer lifecycle rules.
+
+Pros:
+- Cleanest long-term architecture.
+
+Cons:
+- Too large for the immediate diagnostics problem.
+- High migration and delivery risk.
+
+## Recommended Approach
+
+Use Approach 2: a structured diagnostics layer beside the current runtime.
+
+This yields the best balance between delivery risk and long-term value. The current engine and persistence model already provide enough operational signal to support a better diagnostics system, but the interpretation layer is missing. The proposed work should refine the existing runtime into a coherent run-investigation product rather than replace it outright.
+
+## Architecture
+
+### 1. Raw Execution Ledger Remains the Source of Truth
+
+Retain the current raw execution entities as authoritative records:
+
+- `workflow_runs`
+- `workflow_step_runs`
+- `workflow_events`
+- `workflow_artifacts`
+- `workflow_webhook_dlq`
+
+These tables remain the execution ledger used for control flow, auditing, and low-level troubleshooting.
+
+### 2. Separate Logical Step Runs From Step Attempts
+
+Current step retries mutate a single `workflow_step_runs.attempt` value in place. That is acceptable for runtime flow control but insufficient for diagnosis.
+
+The revised model should be:
+
+- `workflow_step_runs`
+  - one logical step execution record per step occurrence within a run
+  - stable anchor for routing, approvals, and human-in-the-loop semantics
+- `workflow_step_attempts`
+  - one child row per actual attempt or retry
+  - authoritative ledger for retry history, per-attempt status, timing, evidence, and failure semantics
+
+This split is required to avoid ambiguity in:
+
+- retry-from-step behavior
+- approval and reject flows
+- timeout and retry analysis
+- per-attempt evidence capture
+
+### 3. Add Explicit Replay and Idempotency Capabilities Per Step Type
+
+Safe reruns cannot be inferred from reason code alone. Each step type must declare a small capability contract:
+
+- `replay_safe`
+- `idempotency_strategy`
+- `compensation_supported`
+- `requires_human_review_for_rerun`
+- `evidence_level`
+
+Default behavior for unknown or side-effecting steps is `unsafe`.
+
+Examples:
+
+- `prompt`, `rag_search`, and pure transforms may be replay-safe when inputs are unchanged.
+- `webhook`, `notify`, `mcp_tool`, `kanban`, and ingestion-like steps should default to unsafe or conditional unless explicit idempotency guarantees exist.
+
+### 4. Add a Derived Run Investigation Read Model
+
+Expose a first-class `run investigation` surface that answers the main user questions without replacing the raw ledger.
+
+The investigation model should be computed on demand or stored as a projection with explicit versioning:
+
+- `schema_version`
+- `derived_from_event_seq`
+- `generated_at`
+- stale/rebuild semantics
+
+If projection generation fails, the raw run, attempts, events, and artifacts must remain available.
+
+## Data Model
+
+### `workflow_step_attempts`
+
+Representative fields:
+
+- `attempt_id`
+- `tenant_id`
+- `run_id`
+- `step_run_id`
+- `step_id`
+- `attempt_number`
+- `status`
+- `started_at`
+- `ended_at`
+- `duration_ms`
+- `reason_code_core`
+- `reason_code_detail`
+- `category`
+- `blame_scope`
+- `retryable`
+- `retry_recommendation`
+- `error_summary`
+- `error_detail_redacted`
+- `provider_name`
+- `provider_request_id`
+- `workdir`
+- `stdout_path`
+- `stderr_path`
+- `metadata_json`
+
+### `workflow_run_investigations` (optional materialized projection)
+
+Representative fields:
+
+- `run_id`
+- `schema_version`
+- `derived_from_event_seq`
+- `generated_at`
+- `primary_failure_json`
+- `failed_step_json`
+- `evidence_refs_json`
+- `recommended_actions_json`
+- `stale`
+
+If the projection is materialized, rebuild tooling and migration/version checks are mandatory.
+
+## Failure Semantics
+
+### Layered Taxonomy
+
+Use layered failure semantics instead of a single flat canonical list:
+
+- `reason_code_core`
+  - stable top-level code such as `validation_error`, `policy_blocked`, `provider_timeout`, `runtime_error`
+- `reason_code_detail`
+  - narrower adapter-specific detail such as `template_render_error`, `webhook_blocked_private_ip`, `llm_provider_429`
+- `category`
+  - `user_config`, `external_dependency`, `policy`, `runtime`, `platform`
+- `blame_scope`
+  - `workflow_definition`, `run_input`, `provider`, `system`, `operator_action`
+- `retryable`
+  - boolean
+- `retry_recommendation`
+  - `safe`, `unsafe`, `requires_input_change`, `requires_operator_review`
+
+### Audience-Safe Explanations
+
+Every failed or blocked attempt should support:
+
+- `user_message`
+  - concise, safe explanation for authors and ordinary API callers
+- `operator_message`
+  - more precise remediation-oriented explanation
+- `internal_detail`
+  - privileged raw exception or deep context, if retained at all
+- `suggested_actions`
+  - structured next steps such as `fix_input`, `change_timeout`, `retry_from_step`, `replay_webhook`, `contact_operator`
+
+## Evidence Capture
+
+Evidence must be structured, bounded, and redacted by default.
+
+### Evidence Refs
+
+Prefer typed references and excerpts over duplicating full payloads:
+
+- event refs
+  - exact `event_seq` values
+- attempt refs
+  - specific failed attempt ids
+- artifact refs
+  - stdout, stderr, output, logs, manifests
+- config refs
+  - validation error output, schema path, step config hash or bounded snapshot
+- external refs
+  - provider request id, webhook delivery code, approval record, policy decision id
+
+### Retention and Redaction Rules
+
+Do not persist unrestricted rendered prompts, provider payloads, or secrets in diagnostics records.
+
+The design must include:
+
+- bounded excerpts for stdout/stderr
+- redaction of known secret-bearing fields
+- restricted access to raw deep detail
+- explicit retention windows for per-attempt diagnostics
+
+## API Surface
+
+Retain existing low-level APIs, but add investigation-oriented endpoints:
+
+- `GET /api/v1/workflows/runs/{run_id}/investigation`
+- `GET /api/v1/workflows/runs/{run_id}/steps`
+- `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts`
+- `POST /api/v1/workflows/preflight`
+
+Existing APIs such as:
+
+- `GET /runs/{run_id}`
+- `GET /runs/{run_id}/events`
+- `GET /runs/{run_id}/artifacts`
+- `POST /runs/{run_id}/retry`
+- approval/reject endpoints
+
+remain available as the raw or control surfaces.
+
+### Auth Model
+
+Diagnostic detail must be layered by authorization.
+
+- Base response:
+  - safe summaries, stable reason codes, bounded evidence metadata
+- Elevated operator/admin response:
+  - richer remediation detail, excerpts, provider correlation ids where appropriate
+- Privileged internal detail:
+  - tightly restricted, redacted, and ideally separated from ordinary responses
+
+Do not rely solely on endpoint-level owner/admin gating without field-level response design.
+
+## User Surfaces
+
+### Shared Run Inspector
+
+The first diagnostics UI must be a shared run inspector, not an editor-only feature.
+
+It should include:
+
+- failure summary card
+- step graph or ordered step list with failed node highlighted
+- attempt timeline
+- evidence tabs
+  - logs
+  - artifacts
+  - webhook deliveries
+  - approvals
+- next-action panel
+  - retry
+  - retry from step
+  - inspect config
+  - operator escalation
+
+This shared inspector can then be embedded or linked from the workflow editor.
+
+### Workflow Editor Integration
+
+The editor should not own the diagnostics model. Instead, it should:
+
+- link to the shared run inspector for real runs
+- highlight failed nodes using investigation data
+- show preflight warnings before execution
+
+### Runs Index Improvements
+
+Add run filtering and triage based on structured diagnostics fields:
+
+- `reason_code_core`
+- `category`
+- `blame_scope`
+- `retryable`
+- `workflow_id`
+- `provider_name`
+- stuck age
+
+These filters require explicit denormalization and indexes rather than expensive event scans.
+
+## Preflight Validation
+
+Preflight must be server-authoritative.
+
+Do not implement client-only preflight logic as the main source of truth.
+
+The preflight endpoint should reuse server-side:
+
+- definition schema validation
+- DAG and routing validation
+- template/input resolution where possible
+- capability-based replay/rerun warnings
+- environment and step-compatibility warnings
+
+The UI may still provide immediate local hints, but only the server decides what is valid or dangerous.
+
+## Operational Improvements
+
+The first rollout should also make operations more coherent:
+
+- reason-code-aware dashboards and alerts
+- better stuck-run and retry-exhaustion reporting
+- DLQ and approval evidence linked from the run inspector
+- docs rewritten around investigation flows instead of raw DB spelunking as the default path
+
+## Rollout Plan
+
+### Phase 1: Capability and Attempt Foundation
+
+- Introduce per-step replay/idempotency capability metadata.
+- Add `workflow_step_attempts` and migrations.
+- Preserve current control flow while dual-writing attempt information.
+
+### Phase 2: Failure Taxonomy and Investigation API
+
+- Emit layered failure semantics from engine and adapters.
+- Add investigation service and APIs.
+- Add denormalized fields and indexes needed for triage.
+
+### Phase 3: Shared Run Inspector and Preflight
+
+- Build a shared run inspector UI and data client.
+- Integrate it into the workflow editor.
+- Add server-authoritative preflight UX.
+
+### Phase 4: Docs and Operational Hardening
+
+- Update runbook and debugging docs.
+- Update alerts and dashboards to use reason codes and retryability classes.
+
+## Risks and Mitigations
+
+### Risk: Projection Drift
+
+Mitigation:
+- treat investigation as a derived read model
+- include `schema_version` and `derived_from_event_seq`
+- support rebuild and stale detection
+
+### Risk: Retry Safety Misclassification
+
+Mitigation:
+- do not infer replay safety from reason code alone
+- require explicit step capability declarations
+- default to unsafe
+
+### Risk: Secret Leakage
+
+Mitigation:
+- store evidence refs and excerpts
+- redact known sensitive fields
+- restrict raw internal detail
+- define retention windows
+
+### Risk: UI Built Before Authoritative Data Contract
+
+Mitigation:
+- build investigation API and auth model before editor integration
+- make the shared run inspector the first real UI consumer
+
+## Testing Strategy
+
+### Unit Tests
+
+- step capability contract evaluation
+- attempt record creation and status transitions
+- failure envelope normalization
+- investigation summary generation
+- replay-safety decisioning
+
+### Integration Tests
+
+- failed run produces attempt rows and investigation summary
+- approval/reject flows still anchor correctly on logical step runs
+- retry-from-step respects step replay capabilities
+- preflight returns validation errors and warnings consistent with runtime behavior
+- field-level auth and redaction rules are enforced
+
+### UI Tests
+
+- shared run inspector renders failed-run summary and attempts
+- workflow editor links to or embeds the shared inspector
+- preflight warnings render deterministically
+
+### Operational Verification
+
+- alerts pivot on reason-code-aware metrics
+- debugging docs reflect investigation-first workflows
+- indexes support expected triage queries
+
+## Acceptance Criteria
+
+- Failed runs can be investigated through a first-class API and shared UI without parsing raw events manually.
+- Retry/partial-rerun safety is explicit per step type and defaults to unsafe.
+- Logical step runs and retry attempts are represented as separate entities.
+- Investigation data cannot silently drift from the raw ledger without detection.
+- Diagnostic evidence is bounded, redacted, and authorization-aware.
+- Preflight validation is server-authoritative.
+- Operators, authors, and API consumers all gain usable diagnostics in the first milestone.

--- a/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-implementation-plan.md
+++ b/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-implementation-plan.md
@@ -1,0 +1,575 @@
+# Workflows Diagnostics and Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a first-class workflows diagnostics model with explicit replay safety, per-attempt execution history, investigation APIs, a shared run inspector, and server-authoritative preflight validation.
+
+**Architecture:** Keep the current workflows runtime and raw execution ledger in place, but add a structured diagnostics layer beside it. Preserve `workflow_step_runs` as the logical step record, add child `workflow_step_attempts`, derive a `run investigation` view from runs/events/artifacts, and expose that view consistently to the API and shared UI. Build replay safety from explicit step capability metadata rather than inferring it from failures after the fact.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL via `Workflows_DB`, asyncio workflow engine, pytest, React, Zustand, shared UI services, Vitest
+
+---
+
+**Execution Notes**
+
+- Use @using-git-worktrees before implementation so the work happens in an isolated worktree.
+- Follow @test-driven-development for every code task.
+- If tests fail unexpectedly, use @systematic-debugging before changing the implementation approach.
+- Before claiming completion, use @verification-before-completion.
+
+### Task 1: Establish replay capability metadata for step types
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/capabilities.py`
+- Modify: `tldw_Server_API/app/core/Workflows/registry.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py`
+
+**Step 1: Write the failing test**
+
+Create `tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py` with expectations for safe and unsafe step types.
+
+Example:
+
+```python
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+
+
+def test_webhook_steps_default_to_unsafe_replay():
+    capability = get_step_capability("webhook")
+    assert capability.replay_safe is False
+    assert capability.requires_human_review_for_rerun is True
+
+
+def test_prompt_steps_expose_safe_replay_defaults():
+    capability = get_step_capability("prompt")
+    assert capability.replay_safe is True
+    assert capability.idempotency_strategy == "run_scoped"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+
+Expected: FAIL because the capability module and helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a small capability model and registry helper.
+
+Implementation target:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StepCapability:
+    replay_safe: bool = False
+    idempotency_strategy: str = "none"
+    compensation_supported: bool = False
+    requires_human_review_for_rerun: bool = False
+    evidence_level: str = "standard"
+```
+
+Register per-step defaults in `registry.py`, and extend `/api/v1/workflows/step-types` output so clients can inspect replay semantics without hard-coding them.
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/capabilities.py \
+  tldw_Server_API/app/core/Workflows/registry.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py
+git commit -m "feat(workflows): add step replay capabilities"
+```
+
+### Task 2: Add `workflow_step_attempts` schema and DB adapter support
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Workflows_DB.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_db.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py`
+- Test: `tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py`
+
+**Step 1: Write the failing tests**
+
+Add DB-level tests that assert:
+- the new `workflow_step_attempts` table exists in SQLite and PostgreSQL
+- attempt rows can be inserted and listed
+- `workflow_step_runs` remains the logical parent row
+
+Example:
+
+```python
+def test_create_step_attempt_persists_attempt_history(workflows_db):
+    workflows_db.create_step_run(...)
+    attempt_id = workflows_db.create_step_attempt(...)
+    rows = workflows_db.list_step_attempts(run_id="run-1", step_id="step-a")
+    assert rows[0]["attempt_id"] == attempt_id
+    assert rows[0]["attempt_number"] == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_db.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py -k step_attempt -v`
+
+Expected: FAIL because the schema and adapter methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a new table and adapter methods such as:
+
+```sql
+CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_run_id TEXT NOT NULL,
+    step_id TEXT NOT NULL,
+    attempt_number INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ,
+    ended_at TIMESTAMPTZ,
+    reason_code_core TEXT,
+    reason_code_detail TEXT,
+    retryable BOOLEAN,
+    error_summary TEXT,
+    metadata_json TEXT
+)
+```
+
+Add adapter helpers like:
+- `create_step_attempt(...)`
+- `complete_step_attempt(...)`
+- `list_step_attempts(run_id, step_id=None, step_run_id=None)`
+
+Do not remove or repurpose `workflow_step_runs`.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_db.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py -k step_attempt -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Workflows_DB.py \
+  tldw_Server_API/tests/Workflows/test_workflows_db.py \
+  tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py \
+  tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
+git commit -m "feat(workflows): add step attempt persistence"
+```
+
+### Task 3: Emit layered failure semantics and attempt-level engine records
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/failures.py`
+- Modify: `tldw_Server_API/app/core/Workflows/engine.py`
+- Modify: `tldw_Server_API/app/core/Workflows/adapters/_base.py`
+- Test: `tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_api.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+- each failed attempt gets a `reason_code_core` and `retryable` decision
+- retry loops create multiple attempt rows instead of mutating only a counter
+- unsafe step types do not report safe replay recommendations
+
+Example:
+
+```python
+def test_retrying_step_records_multiple_attempt_rows(workflows_db, engine):
+    run_id = create_retrying_run(...)
+    asyncio.run(engine.start_run(run_id))
+    attempts = workflows_db.list_step_attempts(run_id=run_id, step_id="prompt_1")
+    assert len(attempts) == 2
+    assert attempts[0]["reason_code_core"] == "runtime_error"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+
+Expected: FAIL because the engine does not yet emit attempt rows or layered failure envelopes.
+
+**Step 3: Write minimal implementation**
+
+Create a helper model such as:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailureEnvelope:
+    reason_code_core: str
+    reason_code_detail: str | None
+    category: str
+    blame_scope: str
+    retryable: bool
+    retry_recommendation: str
+    error_summary: str
+```
+
+Update the engine so each loop iteration:
+- creates an attempt row before adapter execution
+- completes that attempt with success, waiting, cancel, or failure state
+- persists failure envelope fields
+- keeps `workflow_step_runs` as the stable parent row for approvals and routing
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_api.py -k retry -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/failures.py \
+  tldw_Server_API/app/core/Workflows/engine.py \
+  tldw_Server_API/app/core/Workflows/adapters/_base.py \
+  tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py \
+  tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py \
+  tldw_Server_API/tests/Workflows/test_workflows_api.py
+git commit -m "feat(workflows): emit attempt-level failure diagnostics"
+```
+
+### Task 4: Add the run investigation service and API endpoints
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/investigation.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py`
+
+**Step 1: Write the failing tests**
+
+Add API tests for:
+- `GET /api/v1/workflows/runs/{run_id}/investigation`
+- `GET /api/v1/workflows/runs/{run_id}/steps`
+- `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts`
+- auth gating between safe summary fields and operator-only detail
+
+Example:
+
+```python
+def test_investigation_endpoint_returns_primary_failure(client, failed_run):
+    resp = client.get(f"/api/v1/workflows/runs/{failed_run}/investigation", headers=auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["primary_failure"]["reason_code_core"] == "runtime_error"
+    assert "recommended_actions" in data
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+
+Expected: FAIL because the service, schemas, and endpoints do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a service that assembles investigation data from:
+- `workflow_runs`
+- `workflow_step_runs`
+- `workflow_step_attempts`
+- `workflow_events`
+- artifacts and webhook delivery evidence
+
+Response shape target:
+
+```python
+{
+    "run_id": run_id,
+    "primary_failure": {...},
+    "failed_step": {...},
+    "attempts": [...],
+    "evidence": {...},
+    "recommended_actions": [...]
+}
+```
+
+If you materialize this view, include `schema_version` and `derived_from_event_seq`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/investigation.py \
+  tldw_Server_API/app/api/v1/schemas/workflows.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+git commit -m "feat(workflows): add investigation APIs"
+```
+
+### Task 5: Add server-authoritative preflight validation
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert preflight returns:
+- blocking validation errors
+- non-blocking warnings
+- replay safety warnings for unsafe step types
+
+Example:
+
+```python
+def test_preflight_flags_unsafe_replay_steps(client, workflow_definition):
+    resp = client.post("/api/v1/workflows/preflight", json={"definition": workflow_definition}, headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["warnings"][0]["code"] == "unsafe_replay_step"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+
+Expected: FAIL because the endpoint and schema do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Reuse existing validation helpers instead of creating a second rules engine.
+
+Response shape target:
+
+```python
+{
+    "valid": False,
+    "errors": [{"code": "missing_required_input", "message": "..."}],
+    "warnings": [{"code": "unsafe_replay_step", "message": "..."}]
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/workflows.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
+git commit -m "feat(workflows): add preflight validation endpoint"
+```
+
+### Task 6: Extend shared UI workflow services and types for diagnostics
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/workflows.ts`
+- Modify: `apps/packages/ui/src/types/workflow-editor.ts`
+- Create: `apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add service tests for:
+- fetching investigation data
+- fetching step attempts
+- posting preflight requests
+
+Example:
+
+```ts
+it("fetches workflow investigation data", async () => {
+  mockBgRequest.mockResolvedValueOnce({ run_id: "run-1", primary_failure: { reason_code_core: "runtime_error" } })
+  const result = await getWorkflowInvestigation("run-1")
+  expect(result.primary_failure.reason_code_core).toBe("runtime_error")
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+
+Expected: FAIL because the functions and types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add typed service helpers such as:
+
+```ts
+export const getWorkflowInvestigation = (runId: string) =>
+  bgRequest<WorkflowRunInvestigation>({
+    path: `/api/v1/workflows/runs/${runId}/investigation`,
+    method: "GET"
+  })
+```
+
+Also add typed models for:
+- `WorkflowRunInvestigation`
+- `WorkflowStepAttempt`
+- `WorkflowPreflightResult`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/workflows.ts \
+  apps/packages/ui/src/types/workflow-editor.ts \
+  apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
+git commit -m "feat(ui): add workflow diagnostics services"
+```
+
+### Task 7: Build a shared run inspector and embed it in the workflow editor
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx`
+- Modify: `apps/packages/ui/src/components/Common/Workflow/index.ts`
+- Modify: `apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx`
+- Modify: `apps/packages/ui/src/store/workflow-editor.ts`
+- Create: `apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add component tests that assert the inspector renders:
+- failure summary
+- attempt timeline
+- evidence tabs
+- recommended actions
+
+Example:
+
+```tsx
+it("renders failure summary and attempts", () => {
+  render(<WorkflowRunInspector investigation={investigationFixture} />)
+  expect(screen.getByText("runtime_error")).toBeInTheDocument()
+  expect(screen.getByText("Attempt 2")).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: /evidence/i })).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+Expected: FAIL because the component does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Build a shared inspector component that accepts typed investigation data and exposes:
+- summary card
+- attempts list
+- evidence tabs
+- next-action panel
+
+Then update `ExecutionPanel.tsx` to open or render that shared component for real run ids instead of only displaying local mock state.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+- `cd apps/packages/ui && bunx vitest run src/components/WorkflowEditor/__tests__/WorkflowEditor.responsive.test.tsx`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx \
+  apps/packages/ui/src/components/Common/Workflow/index.ts \
+  apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx \
+  apps/packages/ui/src/store/workflow-editor.ts \
+  apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
+git commit -m "feat(ui): add shared workflow run inspector"
+```
+
+### Task 8: Update docs, alerts, and final verification
+
+**Files:**
+- Modify: `Docs/Design/Workflows.md`
+- Modify: `Docs/Operations/Workflows_Debugging.md`
+- Modify: `Docs/Operations/Workflows_Runbook.md`
+- Modify: `Docs/Operations/monitoring/alerts/workflows_alerts.yml`
+- Reference: `Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md`
+
+**Step 1: Write the doc and alert updates**
+
+Document:
+- the new attempt model
+- investigation endpoints
+- preflight endpoint
+- replay safety rules
+- operator workflows for investigation-first triage
+
+Extend alerts or dashboards to key on structured reason codes where possible.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+- `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+Expected: PASS
+
+**Step 3: Run Bandit on the touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Workflows \
+  tldw_Server_API/app/core/DB_Management/Workflows_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/app/api/v1/schemas/workflows.py \
+  -f json -o /tmp/bandit_workflows_diagnostics.json
+```
+
+Expected: no new findings in changed workflows code.
+
+**Step 4: Review the final diff**
+
+Run: `git diff --stat`
+
+Expected: only workflows diagnostics, UI inspector, docs, and tests are changed.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Design/Workflows.md \
+  Docs/Operations/Workflows_Debugging.md \
+  Docs/Operations/Workflows_Runbook.md \
+  Docs/Operations/monitoring/alerts/workflows_alerts.yml
+git commit -m "docs(workflows): document diagnostics investigation flow"
+```

--- a/Docs/Plans/2026-03-11-workspace-source-folders-and-collections-design.md
+++ b/Docs/Plans/2026-03-11-workspace-source-folders-and-collections-design.md
@@ -1,0 +1,433 @@
+# Workspace Source Folders + Workspace Collections Design
+
+Date: 2026-03-11
+Owner: Codex collaboration session
+Status: Approved (revised after design review)
+
+## Context and Problem
+
+`/workspace-playground` currently has two organization gaps:
+
+- Sources inside a workspace live in one flat `WorkspaceSource[]` list.
+- Saved workspaces are presented as a flat browser with search, pinning, and archive, but no true topical grouping.
+
+This prevents two common research workflows:
+
+1. Organizing sources inside a workspace by nested themes, evidence buckets, or modality-specific subtopics.
+2. Organizing multiple related workspaces under a broader topic while keeping each workspace focused on a narrower question.
+
+The current implementation is also local-first and persistence-heavy, so any design must respect the existing Zustand workspace store, split storage/indexed DB offload, and workspace import/export bundle flow.
+
+## Goals
+
+1. Add nested source folders inside a workspace.
+2. Allow a source to belong to multiple source folders in the same workspace.
+3. Make source folders selectable for grounded chat/output scope, with recursive inclusion of descendant folders.
+4. Add flat workspace collections across saved workspaces.
+5. Allow exactly one collection per workspace in v1.
+6. Keep the design local-first for v1, but shape it so future server-backed sync is straightforward.
+
+## Non-Goals
+
+1. Server-backed sync/storage for folders or collections in v1.
+2. Shared collection overview pages, shared notes, or collection-level RAG behavior.
+3. Collection nesting in v1.
+4. Folder-level exclusion rules in v1.
+5. Auto-generating folders from source type or collections from workspace name/tag.
+6. Sharing, permissions, color systems, or collaborative editing.
+
+## Current Constraints
+
+### Workspace sources are flat
+
+The current workspace state stores:
+
+- `sources: WorkspaceSource[]`
+- `selectedSourceIds: string[]`
+
+There is no existing folder or membership model for workspace sources.
+
+### Saved workspaces are flat and capped
+
+Saved workspaces currently store only:
+
+- `id`
+- `name`
+- `tag`
+- `createdAt`
+- `lastAccessedAt`
+- `sourceCount`
+
+The current store truncates `savedWorkspaces` to `MAX_SAVED_WORKSPACES = 10`. That cap is incompatible with meaningful collection browsing and must change as part of this work.
+
+### Persistence is local-first
+
+Workspace persistence already uses:
+
+- persisted Zustand state
+- split-key storage/indexed DB offload for large payloads
+- quota recovery that evicts heavy snapshot/session payloads
+
+The design should preserve those mechanisms instead of replacing them.
+
+## Design Decision
+
+Use two independent organization systems:
+
+1. **Source folders**
+   - Scoped to a single workspace snapshot.
+   - Nested.
+   - Many-to-many with sources.
+   - Selectable as recursive grounded context.
+
+2. **Workspace collections**
+   - Scoped to the global saved-workspace browser.
+   - Flat in v1.
+   - Exactly one collection per workspace.
+   - Organizational container only.
+
+Use a **local-first, server-ready entity/link model** for both systems so a future backend API can adopt the same shapes without rewriting the client semantics.
+
+## Proposed Data Model
+
+### 1) Source folders
+
+Add two new entities to the workspace snapshot.
+
+#### `WorkspaceSourceFolder`
+
+- `id: string`
+- `workspaceId: string`
+- `name: string`
+- `parentFolderId: string | null`
+- `createdAt: Date`
+- `updatedAt: Date`
+
+#### `WorkspaceSourceFolderMembership`
+
+- `folderId: string`
+- `sourceId: string`
+
+### 2) Workspace collections
+
+Add one global entity plus a collection reference on saved workspace metadata.
+
+#### `WorkspaceCollection`
+
+- `id: string`
+- `name: string`
+- `description: string | null`
+- `createdAt: Date`
+- `updatedAt: Date`
+
+#### `SavedWorkspace` extension
+
+Add:
+
+- `collectionId: string | null`
+
+### 3) Workspace state additions
+
+Add to current workspace snapshot/state:
+
+- `sourceFolders: WorkspaceSourceFolder[]`
+- `sourceFolderMemberships: WorkspaceSourceFolderMembership[]`
+- `selectedSourceFolderIds: string[]`
+- `activeFolderId: string | null`
+
+Add to global workspace list state:
+
+- `workspaceCollections: WorkspaceCollection[]`
+
+## Validation Rules
+
+### Source folders
+
+1. Folder IDs must be unique within the workspace.
+2. A folder cannot parent itself.
+3. A folder cannot move under one of its descendants.
+4. Sibling folder names must be unique under the same parent.
+5. Duplicate `folderId + sourceId` memberships are not allowed.
+
+### Workspace collections
+
+1. Collection IDs must be unique.
+2. Collection names must be unique after trim/case-normalization.
+3. A workspace may reference at most one collection ID.
+
+## Selection Model
+
+The existing direct source selection remains in place. Folder selection is additive, not a replacement.
+
+### State
+
+- `selectedSourceIds`
+  - direct source picks
+- `selectedSourceFolderIds`
+  - folder picks for grounded context
+- `activeFolderId`
+  - browse/filter focus only; does not affect grounded context by itself
+
+### Derived selection
+
+Add a derived selector:
+
+- `effectiveSelectedSourceIds: string[]`
+
+It is the unique set of ready source IDs from:
+
+1. directly selected ready sources
+2. all ready sources reachable from selected folders
+3. all ready sources reachable from descendant folders of selected folders
+
+### Folder recursion rules
+
+Selecting a parent folder includes:
+
+1. sources directly assigned to the folder
+2. sources assigned to every descendant folder at any depth
+
+No exclusion model is included in v1.
+
+### Source selection origin
+
+Each source row should derive one of:
+
+- `direct`
+- `folder`
+- `both`
+- `none`
+
+This is required because a source can be selected through a folder even if its direct checkbox was never toggled.
+
+### Source row interaction rules
+
+1. If a source is `none`, clicking selects it directly.
+2. If a source is `direct`, clicking deselects it directly.
+3. If a source is `folder`, clicking does not remove it from effective context; the UI should make clear it is included via folder.
+4. If a source is `both`, clicking removes only the direct selection; the source remains included via folder.
+
+### Folder checkbox state
+
+Folder checkboxes must be tri-state:
+
+- `unchecked`
+- `checked`
+- `indeterminate`
+
+Tri-state calculations must be based on **unique descendant ready source IDs**, not raw membership row counts, because a source can belong to multiple folders.
+
+## Source Folder UI
+
+### Placement
+
+Add a collapsible source-folder tree above the source list in the Sources pane.
+
+### Folder row behavior
+
+Each folder row should expose:
+
+- expand/collapse
+- context checkbox
+- folder name
+- descendant ready-source count
+- actions:
+  - new subfolder
+  - rename
+  - move
+  - delete
+
+### Folder focus vs context selection
+
+Separate two concepts:
+
+1. **Focus/filter**
+   - clicking the folder name sets `activeFolderId`
+   - source list filters to the focused subtree
+
+2. **Context selection**
+   - clicking the folder checkbox toggles `selectedSourceFolderIds`
+   - grounded chat/output uses `effectiveSelectedSourceIds`
+
+### Membership management
+
+Support both:
+
+1. drag/drop source rows onto folders
+2. source-row and bulk "Add to folders" action
+
+Because membership is many-to-many, users must be able to add a source to several folders without moving it out of previous folders.
+
+### Folder deletion
+
+Deleting a folder:
+
+1. never deletes sources
+2. deletes memberships attached to that folder
+3. reparents child folders to the deleted folder's parent
+4. removes the folder from `selectedSourceFolderIds`
+5. clears `activeFolderId` if that folder was focused
+
+## Workspace Collection UI
+
+### Placement
+
+Collections belong in the workspace browser/header flow, not inside the current workspace panes.
+
+### Browser behavior
+
+The workspace browser should support:
+
+1. create collection
+2. rename collection
+3. delete collection
+4. filter workspaces by collection
+5. grouped display by collection
+6. an `Unassigned` bucket
+7. assign/reassign a workspace to exactly one collection
+
+### Collection deletion
+
+Deleting a collection:
+
+1. never deletes workspaces
+2. sets member workspaces to `collectionId = null`
+3. moves those workspaces into `Unassigned`
+
+### Duplicate/import behavior
+
+1. Duplicated workspaces inherit `collectionId`.
+2. Imported workspaces are placed in `Unassigned`.
+
+Imported workspace bundles must not blindly recreate global collection membership because collections are library-level organization, not intrinsic workspace content.
+
+## Persistence and Migration
+
+### Migration defaults
+
+Existing persisted workspaces must load with:
+
+- `sourceFolders = []`
+- `sourceFolderMemberships = []`
+- `selectedSourceFolderIds = []`
+- `activeFolderId = null`
+- `workspaceCollections = []`
+- `collectionId = null` on all saved workspaces
+
+### Import/export rules
+
+Single-workspace bundle export/import should include:
+
+- source folders
+- source folder memberships
+- selected source folder IDs
+
+Single-workspace bundle export/import should not restore:
+
+- global workspace collection assignments
+- collection definitions
+
+If import data is inconsistent:
+
+1. memberships pointing to missing sources or folders are dropped
+2. folders pointing to missing parents are reparented to root
+3. selected folder IDs pointing to missing folders are dropped
+
+### Saved workspace cap
+
+Replace the current 10-item truncation for saved workspaces in any collection-aware release.
+
+Recommended v1 rule:
+
+- do not truncate saved workspace metadata
+- rely on existing split storage and quota recovery to evict heavy snapshots/chat sessions instead of deleting workspace metadata
+
+## Performance and Selector Architecture
+
+Do not bury all recursive logic inside React components or the giant workspace store body.
+
+Create pure selector/helper utilities for:
+
+- `childrenByFolderId`
+- `sourceIdsByFolderId`
+- `folderIdsBySourceId`
+- descendant folder resolution
+- unique descendant source resolution
+- effective selected source IDs
+- folder tri-state status
+- source selection origin
+
+These selectors should be memoized at the component/store boundary and tested independently.
+
+This is necessary to avoid:
+
+1. duplicate counting bugs
+2. tri-state inconsistencies
+3. unreadable store logic
+4. performance cliffs on medium/large folder trees
+
+## Error Handling and Edge Cases
+
+1. Folders may contain processing/error sources, but only ready sources participate in `effectiveSelectedSourceIds`.
+2. If a selected folder currently resolves to zero ready sources, show that clearly in the UI.
+3. Reject invalid moves that would create cycles.
+4. Reject duplicate memberships silently at the store layer and explicitly in the UI.
+5. Keep undo for folder/collection delete and move operations, consistent with existing source/workspace undo patterns.
+
+## Risks and Mitigations
+
+### Risk: inherited selection feels broken
+
+If a source is selected via folder and the user clicks its checkbox, they may expect it to disappear from context.
+
+Mitigation:
+
+- explicit `direct/folder/both` origin state
+- source-row UI copy that distinguishes direct selection from inherited inclusion
+
+### Risk: collections do not scale
+
+If the 10-workspace cap remains, collections become misleading and lossy.
+
+Mitigation:
+
+- remove saved-workspace truncation as part of this design
+
+### Risk: import/export pollutes library-level organization
+
+If single-workspace bundles restore global collection membership, imports can create invalid or surprising browser organization.
+
+Mitigation:
+
+- do not restore collection membership from workspace bundles
+
+### Risk: duplicate counts and incorrect tri-state
+
+Many-to-many memberships make naive subtree counting wrong.
+
+Mitigation:
+
+- all subtree counts and states must use unique source IDs
+
+## Delivery Staging
+
+Recommended delivery sequence:
+
+1. workspace type/store migration and saved-workspace cap fix
+2. workspace collections in the workspace browser
+3. source-folder data model and pure selectors
+4. source-folder UI and membership editing
+5. effective selection integration with chat/output
+6. import/export updates and regression coverage
+
+This sequence delivers the simpler collection feature first while isolating the higher-risk recursive selection work.
+
+## Success Criteria
+
+1. Users can create nested source folders inside a workspace.
+2. A source can belong to multiple folders.
+3. Selecting a parent folder includes every ready source in descendant folders.
+4. Direct source selection continues to work and is clearly distinguished from folder-derived inclusion.
+5. Users can create flat workspace collections and assign each workspace to exactly one collection.
+6. Workspace collections remain accurate beyond 10 saved workspaces.
+7. Persistence/import/export behaves predictably without corrupting organization metadata.

--- a/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx
@@ -1,0 +1,139 @@
+import { Empty, Tabs, Tag } from "antd"
+
+import type {
+  WorkflowRunInvestigation,
+  WorkflowStepAttempt
+} from "@/types/workflow-editor"
+
+interface WorkflowRunInspectorProps {
+  investigation: WorkflowRunInvestigation | null
+  className?: string
+}
+
+const formatAttemptSubtitle = (attempt: WorkflowStepAttempt) => {
+  const details = [
+    attempt.reason_code_core,
+    attempt.error_summary,
+    attempt.metadata?.retry_recommendation as string | undefined
+  ].filter(Boolean)
+  return details.join(" • ")
+}
+
+export const WorkflowRunInspector = ({
+  investigation,
+  className = ""
+}: WorkflowRunInspectorProps) => {
+  if (!investigation) {
+    return <Empty description="No run diagnostics available" />
+  }
+
+  const failure = investigation.primary_failure
+  const attemptItems = investigation.attempts ?? []
+  const recommendedActions = investigation.recommended_actions ?? []
+  const evidenceJson = JSON.stringify(investigation.evidence ?? {}, null, 2)
+
+  return (
+    <section
+      aria-label="Workflow run inspector"
+      className={`rounded-lg border border-border bg-surface ${className}`}
+    >
+      <Tabs
+        defaultActiveKey="summary"
+        items={[
+          {
+            key: "summary",
+            label: "Summary",
+            children: (
+              <div className="space-y-4 p-1">
+                <div>
+                  <h4 className="text-sm font-semibold text-text-muted">
+                    Failure summary
+                  </h4>
+                  <div className="mt-2 flex flex-wrap items-center gap-2">
+                    {failure?.reason_code_core && (
+                      <Tag color="error">{failure.reason_code_core}</Tag>
+                    )}
+                    {failure?.category && <Tag>{failure.category}</Tag>}
+                    {failure?.blame_scope && <Tag>{failure.blame_scope}</Tag>}
+                    {failure?.retryable !== undefined && (
+                      <Tag color={failure.retryable ? "success" : "default"}>
+                        {failure.retryable ? "Retryable" : "Non-retryable"}
+                      </Tag>
+                    )}
+                  </div>
+                  {failure?.error_summary && (
+                    <p className="mt-3 text-sm text-text-muted">
+                      {failure.error_summary}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <h4 className="text-sm font-semibold text-text-muted">
+                    Attempts
+                  </h4>
+                  {attemptItems.length > 0 ? (
+                    <div className="mt-2 space-y-2">
+                      {attemptItems.map((attempt) => (
+                        <div
+                          key={attempt.attempt_id}
+                          className="rounded-md border border-border p-3"
+                        >
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="font-medium text-sm">
+                              Attempt {attempt.attempt_number}
+                            </span>
+                            <Tag color={attempt.status === "failed" ? "error" : "default"}>
+                              {attempt.status}
+                            </Tag>
+                          </div>
+                          {formatAttemptSubtitle(attempt) && (
+                            <p className="mt-2 text-xs text-text-subtle">
+                              {formatAttemptSubtitle(attempt)}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-text-subtle">
+                      No attempts recorded.
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <h4 className="text-sm font-semibold text-text-muted">
+                    Recommended actions
+                  </h4>
+                  {recommendedActions.length > 0 ? (
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-text-muted">
+                      {recommendedActions.map((action) => (
+                        <li key={action}>{action}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-2 text-xs text-text-subtle">
+                      No recommended actions captured.
+                    </p>
+                  )}
+                </div>
+              </div>
+            )
+          },
+          {
+            key: "evidence",
+            label: "Evidence",
+            children: (
+              <pre className="max-h-64 overflow-auto rounded-md bg-black/5 p-3 text-xs">
+                {evidenceJson}
+              </pre>
+            )
+          }
+        ]}
+      />
+    </section>
+  )
+}
+
+export default WorkflowRunInspector

--- a/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
+++ b/apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import type { WorkflowRunInvestigation } from "@/types/workflow-editor"
+
+import { WorkflowRunInspector } from "../WorkflowRunInspector"
+
+const investigation: WorkflowRunInvestigation = {
+  run_id: "run-42",
+  status: "failed",
+  schema_version: 1,
+  derived_from_event_seq: 3,
+  failed_step: {
+    step_run_id: "run-42:s1:1",
+    step_id: "s1",
+    name: "Deliver webhook",
+    type: "webhook",
+    status: "failed",
+    attempt_count: 2,
+    latest_failure: {
+      reason_code_core: "runtime_error",
+      category: "runtime",
+      blame_scope: "external_dependency",
+      retryable: true,
+      retry_recommendation: "conditional",
+      error_summary: "Gateway timeout"
+    }
+  },
+  primary_failure: {
+    reason_code_core: "runtime_error",
+    category: "runtime",
+    blame_scope: "external_dependency",
+    retryable: true,
+    retry_recommendation: "conditional",
+    error_summary: "Gateway timeout",
+    internal_detail: { event_count: 3 }
+  },
+  attempts: [
+    {
+      attempt_id: "attempt-1",
+      step_run_id: "run-42:s1:1",
+      step_id: "s1",
+      attempt_number: 1,
+      status: "failed",
+      started_at: "2026-03-11T10:00:00Z",
+      metadata: { retry_recommendation: "conditional" }
+    },
+    {
+      attempt_id: "attempt-2",
+      step_run_id: "run-42:s1:1",
+      step_id: "s1",
+      attempt_number: 2,
+      status: "failed",
+      started_at: "2026-03-11T10:00:02Z",
+      metadata: { retry_recommendation: "conditional" }
+    }
+  ],
+  evidence: {
+    events: [{ event_type: "step_failed" }],
+    artifacts: [{ type: "log", uri: "file:///tmp/workflow.log" }]
+  },
+  recommended_actions: [
+    "Retry after verifying downstream connectivity",
+    "Inspect webhook stderr excerpt"
+  ]
+}
+
+describe("WorkflowRunInspector", () => {
+  it("renders failure summary and attempts", () => {
+    render(<WorkflowRunInspector investigation={investigation} />)
+
+    expect(screen.getByText("Failure summary")).toBeInTheDocument()
+    expect(screen.getByText("runtime_error")).toBeInTheDocument()
+    expect(screen.getByText("Attempt 2")).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /evidence/i })).toBeInTheDocument()
+    expect(
+      screen.getByText("Retry after verifying downstream connectivity")
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Common/Workflow/index.ts
+++ b/apps/packages/ui/src/components/Common/Workflow/index.ts
@@ -11,6 +11,7 @@ export { WorkflowCard } from "./WorkflowCard"
 export { WorkflowLanding, WorkflowLandingModal } from "./WorkflowLanding"
 export { WorkflowContainer, WorkflowOverlay } from "./WorkflowContainer"
 export { WorkflowIntegrationHost } from "./WorkflowIntegrationHost"
+export { WorkflowRunInspector } from "./WorkflowRunInspector"
 export {
   ContextualSuggestionCard,
   ContextualSuggestionList,

--- a/apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx
+++ b/apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx
@@ -5,7 +5,7 @@
  * and handles human-in-the-loop approvals.
  */
 
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import {
   Button,
   Progress,
@@ -30,6 +30,7 @@ import {
   Hand,
   ChevronRight
 } from "lucide-react"
+import { WorkflowRunInspector } from "@/components/Common/Workflow"
 import type { StepExecutionStatus } from "@/types/workflow-editor"
 import { useWorkflowEditorStore } from "@/store/workflow-editor"
 
@@ -101,6 +102,9 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
   const error = useWorkflowEditorStore((s) => s.error)
   const startedAt = useWorkflowEditorStore((s) => s.startedAt)
   const completedAt = useWorkflowEditorStore((s) => s.completedAt)
+  const runInvestigation = useWorkflowEditorStore((s) => s.runInvestigation)
+  const runInvestigationLoading = useWorkflowEditorStore((s) => s.runInvestigationLoading)
+  const runInvestigationError = useWorkflowEditorStore((s) => s.runInvestigationError)
 
   // Store actions
   const startRun = useWorkflowEditorStore((s) => s.startRun)
@@ -110,6 +114,7 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
   const resetExecution = useWorkflowEditorStore((s) => s.resetExecution)
   const respondToApproval = useWorkflowEditorStore((s) => s.respondToApproval)
   const validate = useWorkflowEditorStore((s) => s.validate)
+  const loadRunInvestigation = useWorkflowEditorStore((s) => s.loadRunInvestigation)
 
   // Calculate progress
   const progress = useMemo(() => {
@@ -221,6 +226,12 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
   const isIdle = status === "idle"
   const isCompleted = status === "completed" || status === "failed" || status === "cancelled"
 
+  useEffect(() => {
+    if (status === "failed" && runId) {
+      void loadRunInvestigation(runId)
+    }
+  }, [loadRunInvestigation, runId, status])
+
   return (
     <div className={`flex flex-col h-full ${className}`}>
       {/* Header */}
@@ -326,6 +337,33 @@ export const ExecutionPanel = ({ className = "" }: ExecutionPanelProps) => {
             showIcon
             className="mb-3"
           />
+        )}
+
+        {status === "failed" && runId && (
+          <div className="mb-4">
+            {runInvestigationLoading ? (
+              <div className="rounded-lg border border-border p-3">
+                <Spin size="small" />
+                <span className="ml-2 text-xs text-text-subtle">
+                  Loading run diagnostics...
+                </span>
+              </div>
+            ) : runInvestigationError ? (
+              <Alert
+                type="warning"
+                title="Diagnostics unavailable"
+                description={runInvestigationError}
+                showIcon
+                action={(
+                  <Button size="small" onClick={() => void loadRunInvestigation(runId)}>
+                    Retry diagnostics
+                  </Button>
+                )}
+              />
+            ) : runInvestigation ? (
+              <WorkflowRunInspector investigation={runInvestigation} />
+            ) : null}
+          </div>
         )}
 
         {/* Pending approval */}

--- a/apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
@@ -42,12 +42,22 @@ describe("workflow diagnostics service helpers", () => {
     mocks.bgRequest.mockResolvedValueOnce({
       run_id: "run-1",
       step_id: "step-2",
-      attempts: [{ attempt: 2, status: "failed" }]
+      attempts: [
+        {
+          attempt_id: "attempt-2",
+          step_run_id: "run-1:step-2:1",
+          step_id: "step-2",
+          attempt_number: 2,
+          status: "failed",
+          started_at: "2026-03-11T10:00:00Z",
+          metadata: {}
+        }
+      ]
     })
 
     const result = await getWorkflowStepAttempts("run-1", "step-2")
 
-    expect(result.attempts[0]?.attempt).toBe(2)
+    expect(result.attempts[0]?.attempt_number).toBe(2)
     expect(mocks.bgRequest).toHaveBeenCalledWith(
       expect.objectContaining({
         path: "/api/v1/workflows/runs/run-1/steps/step-2/attempts",

--- a/apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bgRequest: vi.fn()
+}))
+
+vi.mock("@/services/background-proxy", () => ({
+  bgRequest: (...args: unknown[]) => mocks.bgRequest(...args)
+}))
+
+import {
+  getWorkflowInvestigation,
+  getWorkflowStepAttempts,
+  preflightWorkflowDefinition
+} from "../workflows"
+
+describe("workflow diagnostics service helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("fetches workflow investigation data", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: "run-1",
+      status: "failed",
+      schema_version: 1,
+      primary_failure: { reason_code_core: "runtime_error" }
+    })
+
+    const result = await getWorkflowInvestigation("run-1")
+
+    expect(result.primary_failure?.reason_code_core).toBe("runtime_error")
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/workflows/runs/run-1/investigation",
+        method: "GET"
+      })
+    )
+  })
+
+  it("fetches workflow step attempts", async () => {
+    mocks.bgRequest.mockResolvedValueOnce({
+      run_id: "run-1",
+      step_id: "step-2",
+      attempts: [{ attempt: 2, status: "failed" }]
+    })
+
+    const result = await getWorkflowStepAttempts("run-1", "step-2")
+
+    expect(result.attempts[0]?.attempt).toBe(2)
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/workflows/runs/run-1/steps/step-2/attempts",
+        method: "GET"
+      })
+    )
+  })
+
+  it("posts workflow preflight requests", async () => {
+    const definition = {
+      name: "preflight-test",
+      version: 1,
+      steps: [{ id: "s1", type: "webhook", config: { url: "https://example.invalid" } }]
+    }
+
+    mocks.bgRequest.mockResolvedValueOnce({
+      valid: true,
+      errors: [],
+      warnings: [{ code: "unsafe_replay_step", message: "unsafe" }]
+    })
+
+    const result = await preflightWorkflowDefinition({
+      definition,
+      validation_mode: "non-block"
+    })
+
+    expect(result.warnings[0]?.code).toBe("unsafe_replay_step")
+    expect(mocks.bgRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/workflows/preflight",
+        method: "POST",
+        body: {
+          definition,
+          validation_mode: "non-block"
+        }
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/tldw/workflows.ts
+++ b/apps/packages/ui/src/services/tldw/workflows.ts
@@ -1,5 +1,11 @@
 import { bgRequest } from "@/services/background-proxy"
-import type { WorkflowStepTypeInfo } from "@/types/workflow-editor"
+import type {
+  WorkflowPreflightRequest,
+  WorkflowPreflightResult,
+  WorkflowRunInvestigation,
+  WorkflowStepAttemptsResponse,
+  WorkflowStepTypeInfo
+} from "@/types/workflow-editor"
 
 const STEP_TYPES_TTL_MS = 5 * 60 * 1000
 
@@ -46,3 +52,29 @@ export const getWorkflowStepTypes = async (
 
   return stepTypesPromise
 }
+
+export const getWorkflowInvestigation = async (
+  runId: string
+): Promise<WorkflowRunInvestigation> =>
+  bgRequest<WorkflowRunInvestigation>({
+    path: `/api/v1/workflows/runs/${runId}/investigation`,
+    method: "GET"
+  })
+
+export const getWorkflowStepAttempts = async (
+  runId: string,
+  stepId: string
+): Promise<WorkflowStepAttemptsResponse> =>
+  bgRequest<WorkflowStepAttemptsResponse>({
+    path: `/api/v1/workflows/runs/${runId}/steps/${stepId}/attempts`,
+    method: "GET"
+  })
+
+export const preflightWorkflowDefinition = async (
+  body: WorkflowPreflightRequest
+): Promise<WorkflowPreflightResult> =>
+  bgRequest<WorkflowPreflightResult>({
+    path: "/api/v1/workflows/preflight",
+    method: "POST",
+    body
+  })

--- a/apps/packages/ui/src/store/workflow-editor.ts
+++ b/apps/packages/ui/src/store/workflow-editor.ts
@@ -45,6 +45,7 @@ import type {
   HumanApprovalRequest,
   HumanApprovalResponse,
   EditorHistoryEntry,
+  WorkflowRunInvestigation,
   ServerWorkflowDefinition,
   ValidationIssue
 } from "@/types/workflow-editor"
@@ -54,7 +55,10 @@ import {
   humanizeStepType,
   type StepRegistry
 } from "@/components/WorkflowEditor/step-registry"
-import { getWorkflowStepTypes } from "@/services/tldw/workflows"
+import {
+  getWorkflowInvestigation,
+  getWorkflowStepTypes
+} from "@/services/tldw/workflows"
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Storage Keys
@@ -83,6 +87,9 @@ interface UIState extends EditorUIState {
 
 interface ExecutionState extends WorkflowRunState {
   isConnected: boolean
+  runInvestigation: WorkflowRunInvestigation | null
+  runInvestigationLoading: boolean
+  runInvestigationError: string | null
 }
 
 interface HistoryState {
@@ -173,6 +180,8 @@ interface ExecutionActions {
   setPendingApproval: (request: HumanApprovalRequest | null) => void
   respondToApproval: (response: HumanApprovalResponse) => void
   setRunError: (error: string | null) => void
+  loadRunInvestigation: (runId: string) => Promise<void>
+  clearRunInvestigation: () => void
   resetExecution: () => void
   setConnected: (connected: boolean) => void
 }
@@ -249,7 +258,10 @@ const initialExecutionState: ExecutionState = {
   currentNodeId: undefined,
   pendingApproval: null,
   error: undefined,
-  isConnected: false
+  isConnected: false,
+  runInvestigation: null,
+  runInvestigationLoading: false,
+  runInvestigationError: null
 }
 
 const initialHistoryState: HistoryState = {
@@ -682,15 +694,21 @@ export const useWorkflowEditorStore = createWithEqualityFn<WorkflowEditorState>(
         nodeStates: {},
         currentNodeId: undefined,
         pendingApproval: null,
-        error: undefined
+        error: undefined,
+        runInvestigation: null,
+        runInvestigationLoading: false,
+        runInvestigationError: null
       })
     },
 
     stopRun: () => {
-      set((state) => ({
+      set(() => ({
         status: "cancelled",
         completedAt: Date.now(),
-        currentNodeId: undefined
+        currentNodeId: undefined,
+        runInvestigation: null,
+        runInvestigationLoading: false,
+        runInvestigationError: null
       }))
     },
 
@@ -799,7 +817,55 @@ export const useWorkflowEditorStore = createWithEqualityFn<WorkflowEditorState>(
       set({
         error,
         status: error ? "failed" : get().status,
-        completedAt: error ? Date.now() : undefined
+        completedAt: error ? Date.now() : undefined,
+        runInvestigation: error ? null : get().runInvestigation,
+        runInvestigationLoading: false,
+        runInvestigationError: null
+      })
+    },
+
+    loadRunInvestigation: async (runId) => {
+      if (!runId) return
+      const state = get()
+      if (state.runInvestigationLoading) return
+      if (
+        state.runInvestigation?.run_id === runId &&
+        !state.runInvestigationError
+      ) {
+        return
+      }
+
+      set({
+        runInvestigationLoading: true,
+        runInvestigationError: null
+      })
+
+      try {
+        const investigation = await getWorkflowInvestigation(runId)
+        if (get().runId && get().runId !== runId) return
+        set({
+          runInvestigation: investigation,
+          runInvestigationLoading: false,
+          runInvestigationError: null
+        })
+      } catch (error) {
+        if (get().runId && get().runId !== runId) return
+        set({
+          runInvestigation: null,
+          runInvestigationLoading: false,
+          runInvestigationError:
+            error instanceof Error
+              ? error.message
+              : "Could not load run diagnostics."
+        })
+      }
+    },
+
+    clearRunInvestigation: () => {
+      set({
+        runInvestigation: null,
+        runInvestigationLoading: false,
+        runInvestigationError: null
       })
     },
 

--- a/apps/packages/ui/src/types/workflow-editor.ts
+++ b/apps/packages/ui/src/types/workflow-editor.ts
@@ -80,34 +80,35 @@ export interface WorkflowFailureSummary {
   blame_scope?: string | null
   retryable?: boolean | null
   retry_recommendation?: string | null
-  message?: string | null
-  summary?: string | null
-  internal_detail?: string | null
+  error_summary?: string | null
+  internal_detail?: Record<string, unknown> | null
 }
 
 export interface WorkflowStepAttempt {
-  attempt: number
+  attempt_id: string
+  step_run_id: string
+  step_id: string
+  attempt_number: number
   status: string
   reason_code_core?: string | null
   reason_code_detail?: string | null
-  category?: string | null
-  blame_scope?: string | null
   retryable?: boolean | null
-  retry_recommendation?: string | null
-  error?: string | null
+  error_summary?: string | null
   started_at?: string | null
-  finished_at?: string | null
-  evidence?: Record<string, unknown> | null
-  step_capability?: Record<string, unknown> | null
+  ended_at?: string | null
+  duration_ms?: number | null
+  metadata?: Record<string, unknown>
   [key: string]: unknown
 }
 
 export interface WorkflowRunStepSummary {
   step_id: string
-  step_run_id?: number
-  step_type?: string | null
+  step_run_id?: string
+  name?: string | null
+  type?: string | null
   status?: string
-  attempts?: WorkflowStepAttempt[]
+  attempt_count?: number
+  latest_failure?: WorkflowFailureSummary | null
   [key: string]: unknown
 }
 

--- a/apps/packages/ui/src/types/workflow-editor.ts
+++ b/apps/packages/ui/src/types/workflow-editor.ts
@@ -49,6 +49,104 @@ export interface WorkflowStepTypeInfo {
   min_engine_version?: string
 }
 
+export interface WorkflowDefinitionStepPayload {
+  id: string
+  name?: string
+  type: string
+  config?: Record<string, unknown>
+  retry?: number | null
+  timeout_seconds?: number | null
+  on_success?: string | null
+  on_failure?: string | null
+  on_timeout?: string | null
+}
+
+export interface WorkflowDefinitionPayload {
+  name: string
+  version?: number
+  description?: string | null
+  tags?: string[]
+  inputs?: Record<string, unknown>
+  on_completion_webhook?: Record<string, unknown> | string | null
+  steps: WorkflowDefinitionStepPayload[]
+  metadata?: Record<string, unknown>
+  visibility?: "private"
+}
+
+export interface WorkflowFailureSummary {
+  reason_code_core?: string | null
+  reason_code_detail?: string | null
+  category?: string | null
+  blame_scope?: string | null
+  retryable?: boolean | null
+  retry_recommendation?: string | null
+  message?: string | null
+  summary?: string | null
+  internal_detail?: string | null
+}
+
+export interface WorkflowStepAttempt {
+  attempt: number
+  status: string
+  reason_code_core?: string | null
+  reason_code_detail?: string | null
+  category?: string | null
+  blame_scope?: string | null
+  retryable?: boolean | null
+  retry_recommendation?: string | null
+  error?: string | null
+  started_at?: string | null
+  finished_at?: string | null
+  evidence?: Record<string, unknown> | null
+  step_capability?: Record<string, unknown> | null
+  [key: string]: unknown
+}
+
+export interface WorkflowRunStepSummary {
+  step_id: string
+  step_run_id?: number
+  step_type?: string | null
+  status?: string
+  attempts?: WorkflowStepAttempt[]
+  [key: string]: unknown
+}
+
+export interface WorkflowRunInvestigation {
+  run_id: string
+  status: string
+  schema_version: number
+  derived_from_event_seq: number
+  failed_step?: WorkflowRunStepSummary | null
+  primary_failure?: WorkflowFailureSummary | null
+  attempts: WorkflowStepAttempt[]
+  evidence: Record<string, unknown>
+  recommended_actions: string[]
+}
+
+export interface WorkflowStepAttemptsResponse {
+  run_id: string
+  step_id: string
+  attempts: WorkflowStepAttempt[]
+}
+
+export interface WorkflowValidationIssue {
+  code: string
+  message: string
+  step_id?: string | null
+  step_type?: string | null
+}
+
+export interface WorkflowPreflightRequest {
+  definition: WorkflowDefinitionPayload
+  validation_mode?: "block" | "non-block"
+}
+
+export interface WorkflowPreflightResult {
+  valid: boolean
+  errors: WorkflowValidationIssue[]
+  warnings: WorkflowValidationIssue[]
+}
+
 // StepTypeMetadata is defined in step-registry.ts to avoid circular deps
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -39,10 +39,13 @@ from tldw_Server_API.app.api.v1.schemas.workflows import (
     RunRequest,
     WorkflowDefinitionCreate,
     WorkflowDefinitionResponse,
+    WorkflowRunInvestigationResponse,
     WorkflowRagSearchConfig,
     WorkflowRunListItem,
     WorkflowRunListResponse,
     WorkflowRunResponse,
+    WorkflowRunStepsResponse,
+    WorkflowStepAttemptsResponse,
 )
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditContext,
@@ -94,6 +97,9 @@ from tldw_Server_API.app.core.Workflows.daily_ledger import (
     record_workflow_run,
     workflows_ledger_category,
 )
+from tldw_Server_API.app.core.Workflows.investigation import build_run_investigation
+from tldw_Server_API.app.core.Workflows.investigation import list_run_steps as build_run_steps
+from tldw_Server_API.app.core.Workflows.investigation import list_step_attempts as build_step_attempts
 from tldw_Server_API.app.core.Workflows.registry import StepTypeRegistry
 
 _WORKFLOWS_NONCRITICAL_EXCEPTIONS = (
@@ -177,6 +183,24 @@ def _is_workflows_admin_user(current_user: User) -> bool:
     except _WORKFLOWS_NONCRITICAL_EXCEPTIONS:
         return False
     return False
+
+
+def _get_authorized_run_or_404(
+    *,
+    run_id: str,
+    current_user: User,
+    db: WorkflowsDatabase,
+) -> tuple[Any, bool]:
+    run = db.get_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+    tenant_id = str(getattr(current_user, "tenant_id", "default"))
+    if run.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Run not found")
+    is_admin = _is_workflows_admin_user(current_user)
+    if str(run.user_id) != str(current_user.id) and not is_admin:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return run, is_admin
 
 
 router = APIRouter(prefix="/api/v1/workflows", tags=["workflows"])
@@ -3002,6 +3026,71 @@ async def get_chunker_options():
 
 
 
+
+
+@router.get(
+    "/runs/{run_id}/investigation",
+    response_model=WorkflowRunInvestigationResponse,
+    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+)
+async def get_run_investigation(
+    run_id: str,
+    current_user: User = Depends(get_request_user),
+    db: WorkflowsDatabase = Depends(_get_db),
+):
+    _run, is_admin = _get_authorized_run_or_404(run_id=run_id, current_user=current_user, db=db)
+    investigation = build_run_investigation(
+        db,
+        run_id=run_id,
+        include_operator_detail=is_admin,
+    )
+    if investigation is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return WorkflowRunInvestigationResponse(**investigation)
+
+
+@router.get(
+    "/runs/{run_id}/steps",
+    response_model=WorkflowRunStepsResponse,
+    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+)
+async def get_run_steps(
+    run_id: str,
+    current_user: User = Depends(get_request_user),
+    db: WorkflowsDatabase = Depends(_get_db),
+):
+    _run, is_admin = _get_authorized_run_or_404(run_id=run_id, current_user=current_user, db=db)
+    steps = build_run_steps(
+        db,
+        run_id=run_id,
+        include_operator_detail=is_admin,
+    )
+    if steps is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return WorkflowRunStepsResponse(**steps)
+
+
+@router.get(
+    "/runs/{run_id}/steps/{step_id}/attempts",
+    response_model=WorkflowStepAttemptsResponse,
+    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+)
+async def get_step_attempts(
+    run_id: str,
+    step_id: str,
+    current_user: User = Depends(get_request_user),
+    db: WorkflowsDatabase = Depends(_get_db),
+):
+    _run, is_admin = _get_authorized_run_or_404(run_id=run_id, current_user=current_user, db=db)
+    attempts = build_step_attempts(
+        db,
+        run_id=run_id,
+        step_id=step_id,
+        include_operator_detail=is_admin,
+    )
+    if attempts is None:
+        raise HTTPException(status_code=404, detail="Run not found")
+    return WorkflowStepAttemptsResponse(**attempts)
 
 
 @router.post(

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -3417,6 +3417,7 @@ async def list_step_types():
             "schema": sch,
             "example": sch.get("example", {}),
             "min_engine_version": sch.get("min_engine_version", "0.1.0"),
+            "capabilities": s.capability.to_dict(),
         })
     return out
 

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -39,6 +39,8 @@ from tldw_Server_API.app.api.v1.schemas.workflows import (
     RunRequest,
     WorkflowDefinitionCreate,
     WorkflowDefinitionResponse,
+    WorkflowPreflightRequest,
+    WorkflowPreflightResponse,
     WorkflowRunInvestigationResponse,
     WorkflowRagSearchConfig,
     WorkflowRunListItem,
@@ -90,6 +92,7 @@ from tldw_Server_API.app.core.testing import (
 )
 from tldw_Server_API.app.core.Workflows import RunMode, WorkflowEngine, WorkflowScheduler
 from tldw_Server_API.app.core.Workflows.adapters._common import artifacts_base_dir, is_subpath
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
 from tldw_Server_API.app.core.Workflows.adapters._registry import get_parallelizable
 from tldw_Server_API.app.core.Workflows.daily_ledger import (
     backfill_legacy_runs_to_ledger,
@@ -1135,6 +1138,48 @@ async def _record_workflow_run_usage(
         return
 
 
+def _build_preflight_issue(
+    *,
+    code: str,
+    message: str,
+    step_id: str | None = None,
+    step_type: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "code": code,
+        "message": message,
+        "step_id": step_id,
+        "step_type": step_type,
+    }
+
+
+def _collect_preflight_warnings(definition: dict[str, Any]) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    steps = definition.get("steps") or []
+    if not isinstance(steps, list):
+        return warnings
+    for idx, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        step_id = str(step.get("id") or f"step_{idx+1}")
+        step_type = str(step.get("type") or "").strip()
+        if not step_type:
+            continue
+        capability = get_step_capability(step_type)
+        if not capability.replay_safe or capability.requires_human_review_for_rerun:
+            warnings.append(
+                _build_preflight_issue(
+                    code="unsafe_replay_step",
+                    message=(
+                        f"Step '{step_id}' ({step_type}) is not replay-safe and should be reviewed before rerun"
+                    ),
+                    step_id=step_id,
+                    step_type=step_type,
+                )
+            )
+    return warnings
+
+
 @router.post("", response_model=WorkflowDefinitionResponse, status_code=201)
 async def create_definition(
     body: WorkflowDefinitionCreate,
@@ -1208,6 +1253,41 @@ async def list_definitions(
         )
         for d in defs
     ]
+
+
+@router.post(
+    "/preflight",
+    response_model=WorkflowPreflightResponse,
+    dependencies=[Depends(auth_deps.require_permissions(WORKFLOWS_RUNS_READ))],
+)
+async def preflight_definition(
+    body: WorkflowPreflightRequest,
+    current_user: User = Depends(get_request_user),
+):
+    _ = current_user
+    definition = body.definition.model_dump()
+    errors: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    try:
+        _validate_definition_payload(definition)
+    except HTTPException as exc:
+        issue = _build_preflight_issue(
+            code="definition_invalid",
+            message=str(exc.detail),
+        )
+        if body.validation_mode == "non-block":
+            issue["code"] = "definition_validation_warning"
+            warnings.append(issue)
+        else:
+            errors.append(issue)
+
+    warnings.extend(_collect_preflight_warnings(definition))
+
+    return WorkflowPreflightResponse(
+        valid=len(errors) == 0,
+        errors=errors,
+        warnings=warnings,
+    )
 
 
 ## get_definition moved below '/runs*' routes to avoid path shadowing

--- a/tldw_Server_API/app/api/v1/endpoints/workflows.py
+++ b/tldw_Server_API/app/api/v1/endpoints/workflows.py
@@ -516,6 +516,8 @@ def _classify_webhook_status(status_code: int) -> str:
 
 def _validate_definition_payload(defn: dict[str, Any]) -> None:
     import json
+    if not isinstance(defn, dict):
+        raise HTTPException(status_code=422, detail="Workflow definition must be an object")
     # Optional JSON Schema validator
     try:
         import jsonschema  # type: ignore
@@ -712,6 +714,8 @@ def _validate_definition_payload(defn: dict[str, Any]) -> None:
         },
     }
     for i, s in enumerate(steps):
+        if not isinstance(s, dict):
+            raise HTTPException(status_code=422, detail=f"Step {i + 1} must be an object")
         t = (s.get("type") or "").strip()
         sid = str(s.get("id") or f"step_{i+1}")
         if not reg.has(t):
@@ -1155,6 +1159,8 @@ def _build_preflight_issue(
 
 def _collect_preflight_warnings(definition: dict[str, Any]) -> list[dict[str, Any]]:
     warnings: list[dict[str, Any]] = []
+    if not isinstance(definition, dict):
+        return warnings
     steps = definition.get("steps") or []
     if not isinstance(steps, list):
         return warnings
@@ -1177,6 +1183,85 @@ def _collect_preflight_warnings(definition: dict[str, Any]) -> list[dict[str, An
                     step_type=step_type,
                 )
             )
+    return warnings
+
+
+def _format_preflight_validation_message(error: dict[str, Any]) -> str:
+    loc = error.get("loc") or ()
+    if isinstance(loc, tuple):
+        loc_parts = [str(part) for part in loc]
+    elif isinstance(loc, list):
+        loc_parts = [str(part) for part in loc]
+    else:
+        loc_parts = [str(loc)] if loc else []
+    location = ".".join(part for part in loc_parts if part)
+    message = str(error.get("msg") or "Invalid workflow definition").strip()
+    return f"{location}: {message}" if location else message
+
+
+def _build_preflight_schema_issues(definition: Any) -> list[dict[str, Any]]:
+    if not isinstance(definition, dict):
+        return [
+            _build_preflight_issue(
+                code="definition_invalid",
+                message="definition: Workflow definition must be an object",
+            )
+        ]
+
+    try:
+        WorkflowDefinitionCreate.model_validate(definition)
+    except ValidationError as exc:
+        issues: list[dict[str, Any]] = []
+        steps = definition.get("steps") if isinstance(definition.get("steps"), list) else []
+        for error in exc.errors():
+            step_id = None
+            step_type = None
+            loc = error.get("loc") or ()
+            if len(loc) >= 2 and loc[0] == "steps" and isinstance(loc[1], int):
+                idx = int(loc[1])
+                if 0 <= idx < len(steps):
+                    step = steps[idx]
+                    if isinstance(step, dict):
+                        raw_step_id = step.get("id")
+                        raw_step_type = step.get("type")
+                        if raw_step_id is not None:
+                            step_id = str(raw_step_id)
+                        if raw_step_type is not None:
+                            step_type = str(raw_step_type)
+            issues.append(
+                _build_preflight_issue(
+                    code="definition_invalid",
+                    message=_format_preflight_validation_message(error),
+                    step_id=step_id,
+                    step_type=step_type,
+                )
+            )
+        return issues
+    return []
+
+
+def _build_preflight_validation_issues(definition: Any) -> list[dict[str, Any]]:
+    schema_issues = _build_preflight_schema_issues(definition)
+    if schema_issues:
+        return schema_issues
+    try:
+        _validate_definition_payload(definition)
+    except HTTPException as exc:
+        return [
+            _build_preflight_issue(
+                code="definition_invalid",
+                message=str(exc.detail),
+            )
+        ]
+    return []
+
+
+def _demote_preflight_issues_to_warnings(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    for issue in issues:
+        warning = dict(issue)
+        warning["code"] = "definition_validation_warning"
+        warnings.append(warning)
     return warnings
 
 
@@ -1265,21 +1350,14 @@ async def preflight_definition(
     current_user: User = Depends(get_request_user),
 ):
     _ = current_user
-    definition = body.definition.model_dump()
+    definition = body.definition
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
-    try:
-        _validate_definition_payload(definition)
-    except HTTPException as exc:
-        issue = _build_preflight_issue(
-            code="definition_invalid",
-            message=str(exc.detail),
-        )
-        if body.validation_mode == "non-block":
-            issue["code"] = "definition_validation_warning"
-            warnings.append(issue)
-        else:
-            errors.append(issue)
+    issues = _build_preflight_validation_issues(definition)
+    if body.validation_mode == "non-block":
+        warnings.extend(_demote_preflight_issues_to_warnings(issues))
+    else:
+        errors.extend(issues)
 
     warnings.extend(_collect_preflight_warnings(definition))
 

--- a/tldw_Server_API/app/api/v1/schemas/workflows.py
+++ b/tldw_Server_API/app/api/v1/schemas/workflows.py
@@ -203,3 +203,66 @@ class WorkflowRunListResponse(BaseModel):
     runs: list[WorkflowRunListItem]
     next_offset: int | None = None
     next_cursor: str | None = None
+
+
+class WorkflowFailureSummary(BaseModel):
+    reason_code_core: str | None = None
+    reason_code_detail: str | None = None
+    category: str | None = None
+    blame_scope: str | None = None
+    retryable: bool | None = None
+    retry_recommendation: str | None = None
+    error_summary: str | None = None
+    internal_detail: dict[str, Any] | None = None
+
+
+class WorkflowStepAttemptResponse(BaseModel):
+    attempt_id: str
+    step_run_id: str
+    step_id: str
+    attempt_number: int
+    status: str
+    started_at: str
+    ended_at: str | None = None
+    duration_ms: int | None = None
+    reason_code_core: str | None = None
+    reason_code_detail: str | None = None
+    retryable: bool | None = None
+    error_summary: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowRunStepResponse(BaseModel):
+    step_run_id: str
+    step_id: str
+    name: str | None = None
+    type: str | None = None
+    status: str
+    attempt_count: int = 0
+    started_at: str | None = None
+    ended_at: str | None = None
+    error: str | None = None
+    latest_failure: WorkflowFailureSummary | None = None
+
+
+class WorkflowStepAttemptsResponse(BaseModel):
+    run_id: str
+    step_id: str
+    attempts: list[WorkflowStepAttemptResponse] = Field(default_factory=list)
+
+
+class WorkflowRunStepsResponse(BaseModel):
+    run_id: str
+    steps: list[WorkflowRunStepResponse] = Field(default_factory=list)
+
+
+class WorkflowRunInvestigationResponse(BaseModel):
+    run_id: str
+    status: str
+    schema_version: int
+    derived_from_event_seq: int = 0
+    failed_step: WorkflowRunStepResponse | None = None
+    primary_failure: WorkflowFailureSummary | None = None
+    attempts: list[WorkflowStepAttemptResponse] = Field(default_factory=list)
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    recommended_actions: list[str] = Field(default_factory=list)

--- a/tldw_Server_API/app/api/v1/schemas/workflows.py
+++ b/tldw_Server_API/app/api/v1/schemas/workflows.py
@@ -276,7 +276,7 @@ class WorkflowValidationIssue(BaseModel):
 
 
 class WorkflowPreflightRequest(BaseModel):
-    definition: WorkflowDefinitionCreate
+    definition: Any
     validation_mode: Literal["block", "non-block"] = "block"
 
 

--- a/tldw_Server_API/app/api/v1/schemas/workflows.py
+++ b/tldw_Server_API/app/api/v1/schemas/workflows.py
@@ -266,3 +266,21 @@ class WorkflowRunInvestigationResponse(BaseModel):
     attempts: list[WorkflowStepAttemptResponse] = Field(default_factory=list)
     evidence: dict[str, Any] = Field(default_factory=dict)
     recommended_actions: list[str] = Field(default_factory=list)
+
+
+class WorkflowValidationIssue(BaseModel):
+    code: str
+    message: str
+    step_id: str | None = None
+    step_type: str | None = None
+
+
+class WorkflowPreflightRequest(BaseModel):
+    definition: WorkflowDefinitionCreate
+    validation_mode: Literal["block", "non-block"] = "block"
+
+
+class WorkflowPreflightResponse(BaseModel):
+    valid: bool
+    errors: list[WorkflowValidationIssue] = Field(default_factory=list)
+    warnings: list[WorkflowValidationIssue] = Field(default_factory=list)

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -191,6 +191,9 @@ CREATE TABLE IF NOT EXISTS workflow_artifacts (
 CREATE INDEX IF NOT EXISTS idx_workflows_owner ON workflows(owner_id);
 CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status);
 CREATE INDEX IF NOT EXISTS idx_runs_idempotency_lookup ON workflow_runs(tenant_id, user_id, idempotency_key, created_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_run_attempts ON workflow_step_attempts(run_id, attempt_number, started_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_run_step_attempts ON workflow_step_attempts(run_id, step_id, attempt_number, started_at);
+CREATE INDEX IF NOT EXISTS idx_step_attempts_step_run_attempts ON workflow_step_attempts(step_run_id, attempt_number, started_at);
     CREATE INDEX IF NOT EXISTS idx_events_run_seq ON workflow_events(run_id, event_seq);
 
 -- Ensure uniqueness of per-run event sequence
@@ -480,7 +483,7 @@ class WorkflowRun:
 
 
 class WorkflowsDatabase:
-    _CURRENT_SCHEMA_VERSION = 7
+    _CURRENT_SCHEMA_VERSION = 8
     """Workflow persistence adapter supporting SQLite and DatabaseBackend instances."""
 
     def __init__(
@@ -728,6 +731,7 @@ class WorkflowsDatabase:
             5: self._backend_migrate_to_v5,
             6: self._backend_migrate_to_v6,
             7: self._backend_migrate_to_v7,
+            8: self._backend_migrate_to_v8,
         }
 
     def _backend_migrate_to_v1(self, conn) -> None:
@@ -970,6 +974,33 @@ class WorkflowsDatabase:
             connection=conn,
         )
 
+    def _backend_migrate_to_v8(self, conn) -> None:
+        if not self.backend:
+            return
+        backend = self.backend
+        ident = backend.escape_identifier
+        index_definitions = (
+            (
+                "idx_step_attempts_run_attempts",
+                ("run_id", "attempt_number", "started_at"),
+            ),
+            (
+                "idx_step_attempts_run_step_attempts",
+                ("run_id", "step_id", "attempt_number", "started_at"),
+            ),
+            (
+                "idx_step_attempts_step_run_attempts",
+                ("step_run_id", "attempt_number", "started_at"),
+            ),
+        )
+        for index_name, columns in index_definitions:
+            cols = ", ".join(ident(column) for column in columns)
+            backend.execute(
+                f"CREATE INDEX IF NOT EXISTS {ident(index_name)} "  # nosec B608
+                f"ON {ident('workflow_step_attempts')} ({cols})",
+                connection=conn,
+            )
+
     def _initialize_schema_backend(self) -> None:
         if not self.backend:
             return
@@ -1138,6 +1169,15 @@ class WorkflowsDatabase:
         cur.execute("CREATE INDEX IF NOT EXISTS idx_runs_status ON workflow_runs(status)")
         cur.execute(
             "CREATE INDEX IF NOT EXISTS idx_runs_idempotency_lookup ON workflow_runs(tenant_id, user_id, idempotency_key, created_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_attempts ON workflow_step_attempts(run_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_run_step_attempts ON workflow_step_attempts(run_id, step_id, attempt_number, started_at)"
+        )
+        cur.execute(
+            "CREATE INDEX IF NOT EXISTS idx_step_attempts_step_run_attempts ON workflow_step_attempts(step_run_id, attempt_number, started_at)"
         )
         # Partial indexes for frequently accessed statuses (supported on modern SQLite)
         try:

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import os
 import sqlite3
+import uuid
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -136,6 +137,25 @@ CREATE TABLE IF NOT EXISTS workflow_step_runs (
     workdir TEXT,
     stdout_path TEXT,
     stderr_path TEXT,
+    FOREIGN KEY (run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_run_id TEXT NOT NULL,
+    step_id TEXT NOT NULL,
+    attempt_number INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    ended_at TIMESTAMPTZ,
+    duration_ms INTEGER,
+    reason_code_core TEXT,
+    reason_code_detail TEXT,
+    retryable BOOLEAN,
+    error_summary TEXT,
+    metadata_json TEXT,
     FOREIGN KEY (run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE
 );
 
@@ -460,7 +480,7 @@ class WorkflowRun:
 
 
 class WorkflowsDatabase:
-    _CURRENT_SCHEMA_VERSION = 6
+    _CURRENT_SCHEMA_VERSION = 7
     """Workflow persistence adapter supporting SQLite and DatabaseBackend instances."""
 
     def __init__(
@@ -707,6 +727,7 @@ class WorkflowsDatabase:
             4: self._backend_migrate_to_v4,
             5: self._backend_migrate_to_v5,
             6: self._backend_migrate_to_v6,
+            7: self._backend_migrate_to_v7,
         }
 
     def _backend_migrate_to_v1(self, conn) -> None:
@@ -922,6 +943,33 @@ class WorkflowsDatabase:
                 connection=conn,
             )
 
+    def _backend_migrate_to_v7(self, conn) -> None:
+        if not self.backend:
+            return
+        backend = self.backend
+        ident = backend.escape_identifier
+        backend.execute(
+            f"CREATE TABLE IF NOT EXISTS {ident('workflow_step_attempts')} ("
+            f"attempt_id TEXT PRIMARY KEY,"
+            f"tenant_id TEXT NOT NULL,"
+            f"run_id TEXT NOT NULL,"
+            f"step_run_id TEXT NOT NULL,"
+            f"step_id TEXT NOT NULL,"
+            f"attempt_number INTEGER NOT NULL,"
+            f"status TEXT NOT NULL,"
+            f"started_at TIMESTAMPTZ NOT NULL,"
+            f"ended_at TIMESTAMPTZ,"
+            f"duration_ms INTEGER,"
+            f"reason_code_core TEXT,"
+            f"reason_code_detail TEXT,"
+            f"retryable BOOLEAN,"
+            f"error_summary TEXT,"
+            f"metadata_json TEXT,"
+            f"FOREIGN KEY ({ident('run_id')}) REFERENCES {ident('workflow_runs')}({ident('run_id')}) ON DELETE CASCADE"
+            ")",
+            connection=conn,
+        )
+
     def _initialize_schema_backend(self) -> None:
         if not self.backend:
             return
@@ -1040,6 +1088,29 @@ class WorkflowsDatabase:
                 workdir TEXT,
                 stdout_path TEXT,
                 stderr_path TEXT,
+                FOREIGN KEY(run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE
+            );
+            """
+        )
+
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+                attempt_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                step_run_id TEXT NOT NULL,
+                step_id TEXT NOT NULL,
+                attempt_number INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                duration_ms INTEGER,
+                reason_code_core TEXT,
+                reason_code_detail TEXT,
+                retryable INTEGER,
+                error_summary TEXT,
+                metadata_json TEXT,
                 FOREIGN KEY(run_id) REFERENCES workflow_runs(run_id) ON DELETE CASCADE
             );
             """
@@ -1878,6 +1949,146 @@ class WorkflowsDatabase:
                 self._sqlite_retry_commit()
             else:
                 raise
+
+    def create_step_attempt(
+        self,
+        *,
+        tenant_id: str,
+        run_id: str,
+        step_run_id: str,
+        step_id: str,
+        attempt_number: int,
+        status: str = "running",
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        attempt_id = str(uuid.uuid4())
+        started_at = _utcnow_iso()
+        params = (
+            attempt_id,
+            tenant_id,
+            run_id,
+            step_run_id,
+            step_id,
+            int(attempt_number),
+            status,
+            started_at,
+            json.dumps(metadata or {}),
+        )
+        query = """
+            INSERT INTO workflow_step_attempts(
+                attempt_id, tenant_id, run_id, step_run_id, step_id,
+                attempt_number, status, started_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                self._execute_backend(query, params, connection=conn)
+            return attempt_id
+
+        try:
+            self._conn.execute(query, params)
+            self._conn.commit()
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower():
+                self._sqlite_retry_execute(query, params)
+                self._sqlite_retry_commit()
+            else:
+                raise
+        return attempt_id
+
+    def complete_step_attempt(
+        self,
+        *,
+        attempt_id: str,
+        status: str,
+        reason_code_core: str | None = None,
+        reason_code_detail: str | None = None,
+        retryable: bool | None = None,
+        error_summary: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        ended_at = _utcnow_iso()
+        duration_ms = None
+        row = None
+        query_started = "SELECT started_at FROM workflow_step_attempts WHERE attempt_id = ?"
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                row = self._row_from_result(self._execute_backend(query_started, (attempt_id,), connection=conn))
+        else:
+            row = self._conn.cursor().execute(query_started, (attempt_id,)).fetchone()
+        try:
+            started_raw = row["started_at"] if row else None
+            if started_raw:
+                started_dt = datetime.fromisoformat(str(started_raw))
+                ended_dt = datetime.fromisoformat(ended_at)
+                duration_ms = max(0, int((ended_dt - started_dt).total_seconds() * 1000))
+        except _WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS:
+            duration_ms = None
+
+        params = (
+            status,
+            ended_at,
+            duration_ms,
+            reason_code_core,
+            reason_code_detail,
+            retryable,
+            error_summary,
+            json.dumps(metadata or {}),
+            attempt_id,
+        )
+        query = """
+            UPDATE workflow_step_attempts
+            SET status = ?, ended_at = ?, duration_ms = ?, reason_code_core = ?, reason_code_detail = ?,
+                retryable = ?, error_summary = ?, metadata_json = ?
+            WHERE attempt_id = ?
+        """
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                self._execute_backend(query, params, connection=conn)
+            return
+
+        try:
+            self._conn.execute(query, params)
+            self._conn.commit()
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e).lower():
+                self._sqlite_retry_execute(query, params)
+                self._sqlite_retry_commit()
+            else:
+                raise
+
+    def list_step_attempts(
+        self,
+        *,
+        run_id: str,
+        step_id: str | None = None,
+        step_run_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM workflow_step_attempts WHERE run_id = ?"
+        params: list[Any] = [str(run_id)]
+        if step_id is not None:
+            query += " AND step_id = ?"
+            params.append(str(step_id))
+        if step_run_id is not None:
+            query += " AND step_run_id = ?"
+            params.append(str(step_run_id))
+        query += " ORDER BY attempt_number ASC, started_at ASC"
+
+        rows: list[Any]
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                result = self._execute_backend(query, tuple(params), connection=conn)
+            rows = self._rows_from_result(result)
+        else:
+            rows = self._conn.cursor().execute(query, params).fetchall()
+
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            data = self._row_to_dict(row)
+            with contextlib.suppress(_WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS):
+                data["metadata_json"] = json.loads(data.get("metadata_json") or "{}")
+            out.append(data)
+        return out
 
     def get_latest_step_run(self, *, run_id: str, step_id: str) -> dict[str, Any] | None:
         """Return the most recent step run for a run/step_id pair."""

--- a/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Workflows_DB.py
@@ -2112,6 +2112,35 @@ class WorkflowsDatabase:
         finally:
             self._release_sqlite(conn)
 
+    def list_step_runs(self, *, run_id: str) -> list[dict[str, Any]]:
+        query = """
+            SELECT * FROM workflow_step_runs
+            WHERE run_id = ?
+            ORDER BY started_at ASC, step_run_id ASC
+        """
+        params = (str(run_id),)
+        rows: list[Any]
+        if self._using_backend():
+            with self.backend.transaction() as conn:  # type: ignore[union-attr]
+                result = self._execute_backend(query, params, connection=conn)
+            rows = self._rows_from_result(result)
+        else:
+            conn = self._acquire_sqlite()
+            try:
+                rows = conn.cursor().execute(query, params).fetchall()
+            finally:
+                self._release_sqlite(conn)
+
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            data = self._row_to_dict(row)
+            with contextlib.suppress(_WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS):
+                data["inputs_json"] = json.loads(data.get("inputs_json") or "{}")
+            with contextlib.suppress(_WORKFLOWS_DB_NONCRITICAL_EXCEPTIONS):
+                data["outputs_json"] = json.loads(data.get("outputs_json") or "{}")
+            out.append(data)
+        return out
+
     def update_step_attempt(self, *, step_run_id: str, attempt: int) -> None:
         """Persist the current attempt count for a step run."""
         params = (int(attempt), step_run_id)

--- a/tldw_Server_API/app/core/Workflows/adapters/_base.py
+++ b/tldw_Server_API/app/core/Workflows/adapters/_base.py
@@ -25,6 +25,7 @@ class AdapterContext(BaseModel):
     prev: dict[str, Any] = Field(default_factory=dict)
     last: dict[str, Any] = Field(default_factory=dict)
     secrets: dict[str, str] = Field(default_factory=dict)
+    step_capability: dict[str, Any] = Field(default_factory=dict)
     workflow_metadata: dict[str, Any] = Field(default_factory=dict)
     workflow_mcp_policy: dict[str, Any] = Field(default_factory=dict)
 

--- a/tldw_Server_API/app/core/Workflows/capabilities.py
+++ b/tldw_Server_API/app/core/Workflows/capabilities.py
@@ -1,3 +1,10 @@
+"""Workflow step replay and evidence capabilities.
+
+This registry is intentionally small and stable. Execution and diagnostics code
+uses it to decide whether reruns are safe by default and how much evidence to
+capture for a given step type.
+"""
+
 from __future__ import annotations
 
 from dataclasses import asdict
@@ -6,6 +13,8 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class StepCapability:
+    """Static replay, compensation, and evidence characteristics for a step type."""
+
     replay_safe: bool = False
     idempotency_strategy: str = "none"
     compensation_supported: bool = False
@@ -93,6 +102,12 @@ _CAPABILITY_OVERRIDES: dict[str, StepCapability] = {
 
 
 def get_step_capability(step_type: str) -> StepCapability:
+    """Return the normalized capability record for a step type.
+
+    Unknown or blank step types intentionally fall back to the default unsafe
+    capability so new adapters do not become replay-safe implicitly.
+    """
+
     normalized = str(step_type or "").strip()
     if not normalized:
         return _DEFAULT_CAPABILITY

--- a/tldw_Server_API/app/core/Workflows/capabilities.py
+++ b/tldw_Server_API/app/core/Workflows/capabilities.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StepCapability:
+    replay_safe: bool = False
+    idempotency_strategy: str = "none"
+    compensation_supported: bool = False
+    requires_human_review_for_rerun: bool = False
+    evidence_level: str = "standard"
+
+    def to_dict(self) -> dict[str, bool | str]:
+        return asdict(self)
+
+
+_DEFAULT_CAPABILITY = StepCapability()
+
+_CAPABILITY_OVERRIDES: dict[str, StepCapability] = {
+    "prompt": StepCapability(
+        replay_safe=True,
+        idempotency_strategy="run_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=False,
+        evidence_level="standard",
+    ),
+    "rag_search": StepCapability(
+        replay_safe=True,
+        idempotency_strategy="run_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=False,
+        evidence_level="standard",
+    ),
+    "delay": StepCapability(
+        replay_safe=True,
+        idempotency_strategy="run_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=False,
+        evidence_level="minimal",
+    ),
+    "log": StepCapability(
+        replay_safe=True,
+        idempotency_strategy="run_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=False,
+        evidence_level="minimal",
+    ),
+    "branch": StepCapability(
+        replay_safe=True,
+        idempotency_strategy="run_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=False,
+        evidence_level="standard",
+    ),
+    "webhook": StepCapability(
+        replay_safe=False,
+        idempotency_strategy="external",
+        compensation_supported=False,
+        requires_human_review_for_rerun=True,
+        evidence_level="detailed",
+    ),
+    "notify": StepCapability(
+        replay_safe=False,
+        idempotency_strategy="external",
+        compensation_supported=False,
+        requires_human_review_for_rerun=True,
+        evidence_level="detailed",
+    ),
+    "mcp_tool": StepCapability(
+        replay_safe=False,
+        idempotency_strategy="external",
+        compensation_supported=False,
+        requires_human_review_for_rerun=True,
+        evidence_level="detailed",
+    ),
+    "kanban": StepCapability(
+        replay_safe=False,
+        idempotency_strategy="external",
+        compensation_supported=True,
+        requires_human_review_for_rerun=True,
+        evidence_level="detailed",
+    ),
+    "media_ingest": StepCapability(
+        replay_safe=False,
+        idempotency_strategy="asset_scoped",
+        compensation_supported=False,
+        requires_human_review_for_rerun=True,
+        evidence_level="detailed",
+    ),
+}
+
+
+def get_step_capability(step_type: str) -> StepCapability:
+    normalized = str(step_type or "").strip()
+    if not normalized:
+        return _DEFAULT_CAPABILITY
+    return _CAPABILITY_OVERRIDES.get(normalized, _DEFAULT_CAPABILITY)

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -18,6 +18,11 @@ from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabas
 from tldw_Server_API.app.core.exceptions import AdapterError
 from tldw_Server_API.app.core.testing import is_truthy
 from tldw_Server_API.app.core.Workflows.adapters import get_adapter
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+from tldw_Server_API.app.core.Workflows.failures import FailureEnvelope
+from tldw_Server_API.app.core.Workflows.failures import build_failure_envelope
+from tldw_Server_API.app.core.Workflows.failures import is_retriable_reason
+from tldw_Server_API.app.core.Workflows.failures import normalize_reason_code
 
 _WF_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
@@ -72,15 +77,6 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "waiting_approval": {"running", "failed", "cancelled"},
 }
 
-_NON_RETRIABLE_REASONS: set[str] = {
-    "validation_error",
-    "authz_error",
-    "acp_governance_blocked",
-    "session_access_denied",
-    "invariant_violation",
-}
-
-
 def _is_allowed_transition(current: str, target: str) -> bool:
     """Return True when a run status transition is allowed by the state contract."""
     return target in _ALLOWED_TRANSITIONS.get(current, set())
@@ -88,24 +84,12 @@ def _is_allowed_transition(current: str, target: str) -> bool:
 
 def _reason_code_from_error(error: BaseException | str | None) -> str:
     """Normalize an error payload into a reason code token used for retry policy."""
-    if error is None:
-        return ""
-    text = str(error).strip().lower()
-    if not text:
-        return ""
-    for sep in (":", ";", "|", "\n", "\t", " "):
-        if sep in text:
-            text = text.split(sep, 1)[0].strip()
-            break
-    return text
+    return normalize_reason_code(error)
 
 
 def _is_retriable_error(reason_code: str | None) -> bool:
     """Return True when a reason code should consume retry attempts."""
-    normalized = _reason_code_from_error(reason_code)
-    if not normalized:
-        return True
-    return normalized not in _NON_RETRIABLE_REASONS
+    return is_retriable_reason(reason_code)
 
 
 def _resolve_config_templates(cfg: Any, context: dict[str, Any]) -> Any:
@@ -256,6 +240,80 @@ class WorkflowEngine:
             return self.db.aggregate_run_token_usage(run_id)
         except _WF_NONCRITICAL_EXCEPTIONS:
             return (None, None, None)
+
+    def _attempt_metadata_base(self, step_type: str) -> dict[str, Any]:
+        capability = get_step_capability(step_type)
+        return {
+            "step_type": step_type,
+            "step_capability": capability.to_dict(),
+            "evidence_level": capability.evidence_level,
+        }
+
+    def _create_step_attempt_record(
+        self,
+        *,
+        run_id: str,
+        step_run_id: str,
+        step_id: str,
+        step_type: str,
+        attempt_number: int,
+    ) -> str | None:
+        try:
+            return self.db.create_step_attempt(
+                tenant_id=self._tenant_for_run(run_id),
+                run_id=run_id,
+                step_run_id=step_run_id,
+                step_id=step_id,
+                attempt_number=attempt_number,
+                metadata=self._attempt_metadata_base(step_type),
+            )
+        except _WF_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(
+                "WorkflowEngine: failed to create step attempt run_id={} step_id={} attempt={} error={}",
+                run_id,
+                step_id,
+                attempt_number,
+                e,
+            )
+            return None
+
+    def _complete_step_attempt_record(
+        self,
+        *,
+        attempt_id: str | None,
+        step_type: str,
+        status: str,
+        failure: FailureEnvelope | None = None,
+    ) -> None:
+        if not attempt_id:
+            return
+        metadata = self._attempt_metadata_base(step_type)
+        if failure is not None:
+            metadata.update(
+                {
+                    "category": failure.category,
+                    "blame_scope": failure.blame_scope,
+                    "retry_recommendation": failure.retry_recommendation,
+                    "failure_envelope": failure.to_dict(),
+                }
+            )
+        try:
+            self.db.complete_step_attempt(
+                attempt_id=attempt_id,
+                status=status,
+                reason_code_core=failure.reason_code_core if failure else None,
+                reason_code_detail=failure.reason_code_detail if failure else None,
+                retryable=failure.retryable if failure else None,
+                error_summary=failure.error_summary if failure else None,
+                metadata=metadata,
+            )
+        except _WF_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(
+                "WorkflowEngine: failed to complete step attempt attempt_id={} status={} error={}",
+                attempt_id,
+                status,
+                e,
+            )
 
     def _append_event(self, run_id: str, event_type: str, payload: dict[str, Any] | None = None, step_run_id: str | None = None) -> None:
         try:
@@ -531,6 +589,7 @@ class WorkflowEngine:
                     attempt = 0
                     err: Exception | None = None
                     error_reason_code = ""
+                    failure: FailureEnvelope | None = None
                     outputs: dict[str, Any] = {}
 
                     step_start_ts = time.time()
@@ -544,6 +603,13 @@ class WorkflowEngine:
                         # Persist attempt
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             self.db.update_step_attempt(step_run_id=step_run_id, attempt=attempt)
+                        attempt_id = self._create_step_attempt_record(
+                            run_id=run_id,
+                            step_run_id=step_run_id,
+                            step_id=step_id,
+                            step_type=step_type,
+                            attempt_number=attempt,
+                        )
                         # Honor pause before attempting execution
                         await self._wait_if_paused(run_id, step_run_id)
                         try:
@@ -585,21 +651,40 @@ class WorkflowEngine:
                                 except _WF_NONCRITICAL_EXCEPTIONS:
                                     pass
                             err = None
+                            failure = None
                             break
                         except asyncio.TimeoutError as te:
                             err = te
-                            error_reason_code = _reason_code_from_error(te)
-                            self._append_event(run_id, "step_timeout", {"step_id": step_id, "attempt": attempt})
+                            failure = build_failure_envelope(te, step_type=step_type)
+                            error_reason_code = failure.reason_code_core
+                            self._append_event(
+                                run_id,
+                                "step_timeout",
+                                {"step_id": step_id, "attempt": attempt, "reason_code": error_reason_code},
+                            )
                             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                                 record_span_exception(te)
+                            self._complete_step_attempt_record(
+                                attempt_id=attempt_id,
+                                step_type=step_type,
+                                status="failed",
+                                failure=failure,
+                            )
                         except _WF_NONCRITICAL_EXCEPTIONS as e:
                             err = e
-                            error_reason_code = _reason_code_from_error(e)
+                            failure = build_failure_envelope(e, step_type=step_type)
+                            error_reason_code = failure.reason_code_core
                             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                                 record_span_exception(e)
+                            self._complete_step_attempt_record(
+                                attempt_id=attempt_id,
+                                step_type=step_type,
+                                status="failed",
+                                failure=failure,
+                            )
 
                         if attempt <= max_retries:
-                            if not _is_retriable_error(error_reason_code):
+                            if not failure or not failure.retryable:
                                 self._append_event(
                                     run_id,
                                     "step_retry_suppressed",
@@ -607,6 +692,7 @@ class WorkflowEngine:
                                         "step_id": step_id,
                                         "attempt": attempt,
                                         "reason_code": error_reason_code,
+                                        "retry_recommendation": failure.retry_recommendation if failure else "unsafe",
                                     },
                                 )
                                 break
@@ -622,7 +708,18 @@ class WorkflowEngine:
                     # Final outcome
                     if err:
                         # Failed step
-                        self._append_event(run_id, "step_failed", {"step_id": step_id, "error": str(err)})
+                        final_failure = failure or build_failure_envelope(err, step_type=step_type)
+                        self._append_event(
+                            run_id,
+                            "step_failed",
+                            {
+                                "step_id": step_id,
+                                "error": str(err),
+                                "reason_code": final_failure.reason_code_core,
+                                "retryable": final_failure.retryable,
+                                "retry_recommendation": final_failure.retry_recommendation,
+                            },
+                        )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             increment_counter("workflows_steps_failed", labels={"type": step_type})
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
@@ -645,14 +742,22 @@ class WorkflowEngine:
                         self.db.update_run_status(
                             run_id,
                             status="failed",
-                            status_reason=str(err),
+                            status_reason=final_failure.reason_code_core or str(err),
                             ended_at=self._now_iso(),
                             error=str(err),
                             tokens_input=tokens_in,
                             tokens_output=tokens_out,
                             cost_usd=cost_usd,
                         )
-                        self._append_event(run_id, "run_failed", {"error": str(err)})
+                        self._append_event(
+                            run_id,
+                            "run_failed",
+                            {
+                                "error": str(err),
+                                "reason_code": final_failure.reason_code_core,
+                                "retry_recommendation": final_failure.retry_recommendation,
+                            },
+                        )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             increment_counter("workflows_runs_failed", labels={"tenant": self._tenant_for_run(run_id)})
                         # Completion webhook on failure
@@ -669,6 +774,11 @@ class WorkflowEngine:
                     # If adapter returned special status
                     status_flag = last_outputs.get("__status__") if isinstance(last_outputs, dict) else None
                     if status_flag in {"waiting_human", "waiting_approval"}:
+                        self._complete_step_attempt_record(
+                            attempt_id=attempt_id,
+                            step_type=step_type,
+                            status="waiting_human",
+                        )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             self.db.complete_step_run(step_run_id=step_run_id, status="waiting_human", outputs=last_outputs)
                         try:
@@ -683,6 +793,11 @@ class WorkflowEngine:
                         finalized = True
                         return
                     if status_flag == "cancelled":
+                        self._complete_step_attempt_record(
+                            attempt_id=attempt_id,
+                            step_type=step_type,
+                            status="cancelled",
+                        )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                             self.db.complete_step_run(step_run_id=step_run_id, status="cancelled", outputs=last_outputs)
                         # Emit a step_cancelled event for observability
@@ -706,6 +821,11 @@ class WorkflowEngine:
                             int((time.time() - step_start_ts) * 1000),
                             labels={"type": step_type, "tenant": self._tenant_for_run(run_id)},
                         )
+                    self._complete_step_attempt_record(
+                        attempt_id=attempt_id,
+                        step_type=step_type,
+                        status="succeeded",
+                    )
                     with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                         self.db.complete_step_run(step_run_id=step_run_id, status="succeeded", outputs=last_outputs)
 
@@ -944,6 +1064,7 @@ class WorkflowEngine:
             attempt = 0
             err: Exception | None = None
             error_reason_code = ""
+            failure: FailureEnvelope | None = None
             outputs: dict[str, Any] = {}
             while attempt <= max_retries:
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
@@ -951,6 +1072,13 @@ class WorkflowEngine:
                 attempt += 1
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.update_step_attempt(step_run_id=step_run_id, attempt=attempt)
+                attempt_id = self._create_step_attempt_record(
+                    run_id=run_id,
+                    step_run_id=step_run_id,
+                    step_id=sid,
+                    step_type=stype,
+                    attempt_number=attempt,
+                )
                 await self._wait_if_paused(run_id, step_run_id)
                 try:
                     outputs = await asyncio.wait_for(
@@ -958,16 +1086,31 @@ class WorkflowEngine:
                         timeout=step_timeout,
                     )
                     err = None
+                    failure = None
                     break
                 except asyncio.TimeoutError as te:
                     err = te
-                    error_reason_code = _reason_code_from_error(te)
-                    self._append_event(run_id, "step_timeout", {"step_id": sid, "attempt": attempt})
+                    failure = build_failure_envelope(te, step_type=stype)
+                    error_reason_code = failure.reason_code_core
+                    self._append_event(run_id, "step_timeout", {"step_id": sid, "attempt": attempt, "reason_code": error_reason_code})
+                    self._complete_step_attempt_record(
+                        attempt_id=attempt_id,
+                        step_type=stype,
+                        status="failed",
+                        failure=failure,
+                    )
                 except _WF_NONCRITICAL_EXCEPTIONS as e:
                     err = e
-                    error_reason_code = _reason_code_from_error(e)
+                    failure = build_failure_envelope(e, step_type=stype)
+                    error_reason_code = failure.reason_code_core
+                    self._complete_step_attempt_record(
+                        attempt_id=attempt_id,
+                        step_type=stype,
+                        status="failed",
+                        failure=failure,
+                    )
                 if attempt <= max_retries:
-                    if not _is_retriable_error(error_reason_code):
+                    if not failure or not failure.retryable:
                         self._append_event(
                             run_id,
                             "step_retry_suppressed",
@@ -975,6 +1118,7 @@ class WorkflowEngine:
                                 "step_id": sid,
                                 "attempt": attempt,
                                 "reason_code": error_reason_code,
+                                "retry_recommendation": failure.retry_recommendation if failure else "unsafe",
                             },
                         )
                         break
@@ -987,7 +1131,18 @@ class WorkflowEngine:
                     await asyncio.sleep(backoff + jitter)
 
             if err:
-                self._append_event(run_id, "step_failed", {"step_id": sid, "error": str(err)})
+                final_failure = failure or build_failure_envelope(err, step_type=stype)
+                self._append_event(
+                    run_id,
+                    "step_failed",
+                    {
+                        "step_id": sid,
+                        "error": str(err),
+                        "reason_code": final_failure.reason_code_core,
+                        "retryable": final_failure.retryable,
+                        "retry_recommendation": final_failure.retry_recommendation,
+                    },
+                )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.complete_step_run(step_run_id=step_run_id, status="failed", outputs=outputs, error=str(err))
                 failure_next = str(step.get("on_failure") or "").strip()
@@ -1000,14 +1155,22 @@ class WorkflowEngine:
                 self.db.update_run_status(
                     run_id,
                     status="failed",
-                    status_reason=str(err),
+                    status_reason=final_failure.reason_code_core or str(err),
                     ended_at=self._now_iso(),
                     error=str(err),
                     tokens_input=tokens_in,
                     tokens_output=tokens_out,
                     cost_usd=cost_usd,
                 )
-                self._append_event(run_id, "run_failed", {"error": str(err)})
+                self._append_event(
+                    run_id,
+                    "run_failed",
+                    {
+                        "error": str(err),
+                        "reason_code": final_failure.reason_code_core,
+                        "retry_recommendation": final_failure.retry_recommendation,
+                    },
+                )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     await self._maybe_send_completion_webhook(definition, run_id, status="failed")
                 _finalize(False)
@@ -1017,6 +1180,11 @@ class WorkflowEngine:
             last = outputs or {}
             context.update({"last": last})
             if last.get("__status__") in {"waiting_human", "waiting_approval"}:
+                self._complete_step_attempt_record(
+                    attempt_id=attempt_id,
+                    step_type=stype,
+                    status="waiting_human",
+                )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.complete_step_run(step_run_id=step_run_id, status="waiting_human", outputs=last)
                 try:
@@ -1031,6 +1199,11 @@ class WorkflowEngine:
                 finalized = True
                 return
             if last.get("__status__") == "cancelled":
+                self._complete_step_attempt_record(
+                    attempt_id=attempt_id,
+                    step_type=stype,
+                    status="cancelled",
+                )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                     self.db.complete_step_run(step_run_id=step_run_id, status="cancelled", outputs=last)
                 self._append_event(run_id, "step_cancelled", {"step_id": sid})
@@ -1049,6 +1222,11 @@ class WorkflowEngine:
                 return
 
             self._append_event(run_id, "step_completed", {"step_id": sid, "type": stype})
+            self._complete_step_attempt_record(
+                attempt_id=attempt_id,
+                step_type=stype,
+                status="succeeded",
+            )
             with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
                 self.db.complete_step_run(step_run_id=step_run_id, status="succeeded", outputs=last)
 
@@ -1350,6 +1528,7 @@ class WorkflowEngine:
         # Inject helper hooks
         ctx = {**context, "prev": last_outputs}
         ctx["run_id"] = run_id
+        ctx["step_capability"] = get_step_capability(step_type).to_dict()
         if step_run_id:
             ctx["step_run_id"] = step_run_id
         ctx["is_cancelled"] = lambda: self.db.is_cancel_requested(run_id)

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -777,10 +777,10 @@ class WorkflowEngine:
                         self._complete_step_attempt_record(
                             attempt_id=attempt_id,
                             step_type=step_type,
-                            status="waiting_human",
+                            status=status_flag,
                         )
                         with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                            self.db.complete_step_run(step_run_id=step_run_id, status="waiting_human", outputs=last_outputs)
+                            self.db.complete_step_run(step_run_id=step_run_id, status=status_flag, outputs=last_outputs)
                         try:
                             on_timeout = str(step.get("on_timeout") or "").strip() or None
                             timeout_cfg = step_cfg.get("timeout_seconds") if isinstance(step_cfg, dict) else None
@@ -1197,13 +1197,14 @@ class WorkflowEngine:
             context.update({"last": last})
             context[str(sid)] = last
             if last.get("__status__") in {"waiting_human", "waiting_approval"}:
+                wait_status = str(last["__status__"])
                 self._complete_step_attempt_record(
                     attempt_id=attempt_id,
                     step_type=stype,
-                    status="waiting_human",
+                    status=wait_status,
                 )
                 with contextlib.suppress(_WF_NONCRITICAL_EXCEPTIONS):
-                    self.db.complete_step_run(step_run_id=step_run_id, status="waiting_human", outputs=last)
+                    self.db.complete_step_run(step_run_id=step_run_id, status=wait_status, outputs=last)
                 try:
                     on_timeout = str(step.get("on_timeout") or "").strip() or None
                     timeout_cfg = scfg.get("timeout_seconds") if isinstance(scfg, dict) else None

--- a/tldw_Server_API/app/core/Workflows/engine.py
+++ b/tldw_Server_API/app/core/Workflows/engine.py
@@ -999,8 +999,24 @@ class WorkflowEngine:
                 e,
                 exc_info=True,
             )
-        if last_outputs:
+        try:
+            for prior_step in self.db.list_step_runs(run_id=run_id):
+                prior_status = str(prior_step.get("status") or "").strip().lower()
+                if prior_status != "succeeded":
+                    continue
+                prior_step_id = str(prior_step.get("step_id") or "").strip()
+                prior_outputs = prior_step.get("outputs_json")
+                if prior_step_id and isinstance(prior_outputs, dict):
+                    context[prior_step_id] = prior_outputs
+        except _WF_NONCRITICAL_EXCEPTIONS as e:
+            logger.debug(
+                "WorkflowEngine: continue_run failed to restore step context "
+                f"run_id={run_id}: {e}",
+                exc_info=True,
+            )
+        if last_outputs is not None:
             context["last"] = last_outputs
+            context[str(after_step_id)] = last_outputs
         # Mark running
         if not self._update_run_status_guarded(run_id, status="running", status_reason=None):
             _finalize(False)
@@ -1179,6 +1195,7 @@ class WorkflowEngine:
 
             last = outputs or {}
             context.update({"last": last})
+            context[str(sid)] = last
             if last.get("__status__") in {"waiting_human", "waiting_approval"}:
                 self._complete_step_attempt_record(
                     attempt_id=attempt_id,

--- a/tldw_Server_API/app/core/Workflows/failures.py
+++ b/tldw_Server_API/app/core/Workflows/failures.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.Workflows.capabilities import StepCapability, get_step_capability
+
+_NON_RETRIABLE_REASONS: set[str] = {
+    "validation_error",
+    "authz_error",
+    "acp_governance_blocked",
+    "session_access_denied",
+    "invariant_violation",
+}
+
+_POLICY_REASONS: set[str] = {
+    "acp_governance_blocked",
+    "authz_error",
+    "session_access_denied",
+}
+
+_DEFINITION_REASONS: set[str] = {
+    "validation_error",
+    "invariant_violation",
+    "assigned_to_required",
+    "branch_loop_exceeded",
+}
+
+
+@dataclass(frozen=True)
+class FailureEnvelope:
+    reason_code_core: str
+    reason_code_detail: str | None
+    category: str
+    blame_scope: str
+    retryable: bool
+    retry_recommendation: str
+    error_summary: str
+
+    def to_dict(self) -> dict[str, str | bool | None]:
+        return asdict(self)
+
+
+def normalize_reason_code(error: BaseException | str | None) -> str:
+    if error is None:
+        return ""
+    text = str(error).strip().lower()
+    if not text:
+        return ""
+    for sep in (":", ";", "|", "\n", "\t", " "):
+        if sep in text:
+            text = text.split(sep, 1)[0].strip()
+            break
+    return text
+
+
+def is_retriable_reason(reason_code: str | None) -> bool:
+    normalized = normalize_reason_code(reason_code)
+    if not normalized:
+        return True
+    return normalized not in _NON_RETRIABLE_REASONS
+
+
+def build_failure_envelope(
+    error: BaseException | str | None,
+    *,
+    step_type: str,
+) -> FailureEnvelope:
+    capability = get_step_capability(step_type)
+    core = normalize_reason_code(error) or "runtime_error"
+    detail = _extract_reason_detail(error, core)
+    retryable = is_retriable_reason(core)
+    category = _classify_category(core)
+    blame_scope = _classify_blame_scope(core, capability)
+    retry_recommendation = _classify_retry_recommendation(
+        retryable=retryable,
+        category=category,
+        capability=capability,
+    )
+    error_summary = _summarize_error(error)
+    return FailureEnvelope(
+        reason_code_core=core,
+        reason_code_detail=detail,
+        category=category,
+        blame_scope=blame_scope,
+        retryable=retryable,
+        retry_recommendation=retry_recommendation,
+        error_summary=error_summary,
+    )
+
+
+def _extract_reason_detail(error: BaseException | str | None, core: str) -> str | None:
+    if error is None:
+        return None
+    raw = str(error).strip()
+    if not raw:
+        return None
+    lowered = raw.lower()
+    for sep in (":", ";", "|", "\n", "\t"):
+        if sep in raw:
+            tail = raw.split(sep, 1)[1].strip()
+            return tail or None
+        if sep in lowered:
+            tail = lowered.split(sep, 1)[1].strip()
+            return tail or None
+    exc_name = type(error).__name__.strip().lower() if isinstance(error, BaseException) else ""
+    if exc_name and exc_name != core:
+        return exc_name
+    return None
+
+
+def _classify_category(reason_code_core: str) -> str:
+    if reason_code_core in _POLICY_REASONS:
+        return "policy"
+    if reason_code_core in _DEFINITION_REASONS:
+        return "definition"
+    if "timeout" in reason_code_core:
+        return "timeout"
+    if reason_code_core == "cancelled_by_user":
+        return "cancellation"
+    return "runtime"
+
+
+def _classify_blame_scope(reason_code_core: str, capability: StepCapability) -> str:
+    if reason_code_core in _POLICY_REASONS:
+        return "policy"
+    if reason_code_core in _DEFINITION_REASONS:
+        return "workflow"
+    if capability.idempotency_strategy == "external":
+        return "external_dependency"
+    return "step"
+
+
+def _classify_retry_recommendation(
+    *,
+    retryable: bool,
+    category: str,
+    capability: StepCapability,
+) -> str:
+    if not retryable or category in {"definition", "policy"}:
+        return "unsafe"
+    if capability.requires_human_review_for_rerun:
+        return "conditional"
+    if capability.replay_safe:
+        return "safe"
+    return "unsafe"
+
+
+def _summarize_error(error: BaseException | str | None, *, limit: int = 240) -> str:
+    if error is None:
+        return ""
+    text = str(error).strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3]}..."

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+from tldw_Server_API.app.core.Workflows.failures import build_failure_envelope
+
+_SCHEMA_VERSION = 1
+_MAX_EVENTS = 1000
+
+
+def build_run_investigation(
+    db: WorkflowsDatabase,
+    *,
+    run_id: str,
+    include_operator_detail: bool = False,
+) -> dict[str, Any] | None:
+    run = db.get_run(run_id)
+    if run is None:
+        return None
+
+    step_runs = db.list_step_runs(run_id=run_id)
+    attempts = db.list_step_attempts(run_id=run_id)
+    events = db.get_events(run_id, limit=_MAX_EVENTS)
+    artifacts = db.list_artifacts_for_run(run_id)
+
+    failed_step = _select_failed_step(step_runs)
+    failed_attempts = _attempts_for_step(
+        attempts,
+        step_id=failed_step.get("step_id") if failed_step else None,
+        step_run_id=failed_step.get("step_run_id") if failed_step else None,
+    )
+    primary_failure = _build_primary_failure(
+        run=run,
+        failed_step=failed_step,
+        failed_attempts=failed_attempts,
+        events=events,
+        artifacts=artifacts,
+        include_operator_detail=include_operator_detail,
+    )
+
+    return {
+        "run_id": run_id,
+        "status": run.status,
+        "schema_version": _SCHEMA_VERSION,
+        "derived_from_event_seq": max((int(event.get("event_seq") or 0) for event in events), default=0),
+        "failed_step": _serialize_step(
+            failed_step,
+            attempts=failed_attempts,
+            include_operator_detail=include_operator_detail,
+        ) if failed_step else None,
+        "primary_failure": primary_failure,
+        "attempts": [
+            _serialize_attempt(attempt, include_operator_detail=include_operator_detail)
+            for attempt in failed_attempts
+        ],
+        "evidence": {
+            "event_count": len(events),
+            "artifact_count": len(artifacts),
+            "webhook_delivery_count": sum(1 for event in events if event.get("event_type") == "webhook_delivery"),
+            "artifact_types": [artifact.get("type") for artifact in artifacts],
+        },
+        "recommended_actions": _recommended_actions(primary_failure, artifacts),
+    }
+
+
+def list_run_steps(
+    db: WorkflowsDatabase,
+    *,
+    run_id: str,
+    include_operator_detail: bool = False,
+) -> dict[str, Any] | None:
+    run = db.get_run(run_id)
+    if run is None:
+        return None
+    attempts = db.list_step_attempts(run_id=run_id)
+    attempts_by_step_run: dict[str, list[dict[str, Any]]] = {}
+    for attempt in attempts:
+        attempts_by_step_run.setdefault(str(attempt.get("step_run_id") or ""), []).append(attempt)
+
+    steps = []
+    for step_run in db.list_step_runs(run_id=run_id):
+        step_attempts = attempts_by_step_run.get(str(step_run.get("step_run_id") or ""), [])
+        steps.append(
+            _serialize_step(
+                step_run,
+                attempts=step_attempts,
+                include_operator_detail=include_operator_detail,
+            )
+        )
+    return {"run_id": run_id, "steps": steps}
+
+
+def list_step_attempts(
+    db: WorkflowsDatabase,
+    *,
+    run_id: str,
+    step_id: str,
+    include_operator_detail: bool = False,
+) -> dict[str, Any] | None:
+    run = db.get_run(run_id)
+    if run is None:
+        return None
+    attempts = db.list_step_attempts(run_id=run_id, step_id=step_id)
+    return {
+        "run_id": run_id,
+        "step_id": step_id,
+        "attempts": [
+            _serialize_attempt(attempt, include_operator_detail=include_operator_detail)
+            for attempt in attempts
+        ],
+    }
+
+
+def _select_failed_step(step_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for step_run in reversed(step_runs):
+        if str(step_run.get("status") or "") == "failed":
+            return step_run
+    return step_runs[-1] if step_runs else None
+
+
+def _attempts_for_step(
+    attempts: list[dict[str, Any]],
+    *,
+    step_id: str | None,
+    step_run_id: str | None,
+) -> list[dict[str, Any]]:
+    filtered = attempts
+    if step_id:
+        filtered = [attempt for attempt in filtered if str(attempt.get("step_id") or "") == str(step_id)]
+    if step_run_id:
+        scoped = [attempt for attempt in filtered if str(attempt.get("step_run_id") or "") == str(step_run_id)]
+        if scoped:
+            filtered = scoped
+    return filtered
+
+
+def _build_primary_failure(
+    *,
+    run: Any,
+    failed_step: dict[str, Any] | None,
+    failed_attempts: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    include_operator_detail: bool,
+) -> dict[str, Any] | None:
+    latest_attempt = failed_attempts[-1] if failed_attempts else None
+    step_type = str((failed_step or {}).get("type") or "unknown")
+    if latest_attempt and latest_attempt.get("reason_code_core"):
+        metadata = latest_attempt.get("metadata_json") or {}
+        failure = {
+            "reason_code_core": latest_attempt.get("reason_code_core"),
+            "reason_code_detail": latest_attempt.get("reason_code_detail"),
+            "category": metadata.get("category"),
+            "blame_scope": metadata.get("blame_scope"),
+            "retryable": bool(latest_attempt.get("retryable")) if latest_attempt.get("retryable") is not None else None,
+            "retry_recommendation": metadata.get("retry_recommendation"),
+            "error_summary": latest_attempt.get("error_summary"),
+            "internal_detail": None,
+        }
+    else:
+        envelope = build_failure_envelope(run.error or run.status_reason, step_type=step_type)
+        failure = {
+            "reason_code_core": envelope.reason_code_core,
+            "reason_code_detail": envelope.reason_code_detail,
+            "category": envelope.category,
+            "blame_scope": envelope.blame_scope,
+            "retryable": envelope.retryable,
+            "retry_recommendation": envelope.retry_recommendation,
+            "error_summary": envelope.error_summary,
+            "internal_detail": None,
+        }
+    if include_operator_detail:
+        failure["internal_detail"] = {
+            "run_error": getattr(run, "error", None),
+            "event_count": len(events),
+            "artifact_count": len(artifacts),
+            "latest_event_types": [event.get("event_type") for event in events[-5:]],
+        }
+    return failure
+
+
+def _serialize_step(
+    step_run: dict[str, Any],
+    *,
+    attempts: list[dict[str, Any]],
+    include_operator_detail: bool,
+) -> dict[str, Any]:
+    latest_failed_attempt = None
+    for attempt in reversed(attempts):
+        if str(attempt.get("status") or "") == "failed":
+            latest_failed_attempt = attempt
+            break
+    latest_failure = None
+    if latest_failed_attempt is not None:
+        latest_failure = _serialize_failure(
+            latest_failed_attempt,
+            include_operator_detail=include_operator_detail,
+        )
+    return {
+        "step_run_id": step_run.get("step_run_id"),
+        "step_id": step_run.get("step_id"),
+        "name": step_run.get("name"),
+        "type": step_run.get("type"),
+        "status": step_run.get("status"),
+        "attempt_count": int(step_run.get("attempt") or len(attempts) or 0),
+        "started_at": step_run.get("started_at"),
+        "ended_at": step_run.get("ended_at"),
+        "error": step_run.get("error"),
+        "latest_failure": latest_failure,
+    }
+
+
+def _serialize_failure(
+    attempt: dict[str, Any],
+    *,
+    include_operator_detail: bool,
+) -> dict[str, Any]:
+    metadata = attempt.get("metadata_json") or {}
+    return {
+        "reason_code_core": attempt.get("reason_code_core"),
+        "reason_code_detail": attempt.get("reason_code_detail"),
+        "category": metadata.get("category"),
+        "blame_scope": metadata.get("blame_scope"),
+        "retryable": bool(attempt.get("retryable")) if attempt.get("retryable") is not None else None,
+        "retry_recommendation": metadata.get("retry_recommendation"),
+        "error_summary": attempt.get("error_summary"),
+        "internal_detail": (
+            {"failure_envelope": metadata.get("failure_envelope")}
+            if include_operator_detail and metadata.get("failure_envelope") is not None
+            else None
+        ),
+    }
+
+
+def _serialize_attempt(
+    attempt: dict[str, Any],
+    *,
+    include_operator_detail: bool,
+) -> dict[str, Any]:
+    metadata = dict(attempt.get("metadata_json") or {})
+    if not include_operator_detail:
+        metadata.pop("failure_envelope", None)
+    return {
+        "attempt_id": attempt.get("attempt_id"),
+        "step_run_id": attempt.get("step_run_id"),
+        "step_id": attempt.get("step_id"),
+        "attempt_number": int(attempt.get("attempt_number") or 0),
+        "status": attempt.get("status"),
+        "started_at": attempt.get("started_at"),
+        "ended_at": attempt.get("ended_at"),
+        "duration_ms": attempt.get("duration_ms"),
+        "reason_code_core": attempt.get("reason_code_core"),
+        "reason_code_detail": attempt.get("reason_code_detail"),
+        "retryable": bool(attempt.get("retryable")) if attempt.get("retryable") is not None else None,
+        "error_summary": attempt.get("error_summary"),
+        "metadata": metadata,
+    }
+
+
+def _recommended_actions(primary_failure: dict[str, Any] | None, artifacts: list[dict[str, Any]]) -> list[str]:
+    if not primary_failure:
+        return []
+    recommendation = str(primary_failure.get("retry_recommendation") or "").strip().lower()
+    if recommendation == "safe":
+        actions = ["Retry the failed step with the same inputs."]
+    elif recommendation == "conditional":
+        actions = [
+            "Review side effects before retrying the failed step.",
+            "Inspect external dependency and delivery evidence before rerun.",
+        ]
+    else:
+        actions = ["Inspect workflow definition, inputs, or policy state before retrying."]
+    if artifacts:
+        actions.append("Review captured artifacts for the failed run.")
+    return actions

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -173,9 +173,7 @@ def _build_primary_failure(
         }
     else:
         status = str(getattr(run, "status", "") or "").strip().lower()
-        run_error = getattr(run, "error", None)
-        run_reason = getattr(run, "status_reason", None)
-        if status != "failed" and not run_error and not run_reason:
+        if status != "failed":
             return None
         envelope = build_failure_envelope(run.error or run.status_reason, step_type=step_type)
         failure = {

--- a/tldw_Server_API/app/core/Workflows/investigation.py
+++ b/tldw_Server_API/app/core/Workflows/investigation.py
@@ -24,11 +24,18 @@ def build_run_investigation(
     events = db.get_events(run_id, limit=_MAX_EVENTS)
     artifacts = db.list_artifacts_for_run(run_id)
 
-    failed_step = _select_failed_step(step_runs)
-    failed_attempts = _attempts_for_step(
-        attempts,
-        step_id=failed_step.get("step_id") if failed_step else None,
-        step_run_id=failed_step.get("step_run_id") if failed_step else None,
+    failed_step = _select_failed_step(
+        step_runs,
+        allow_latest_fallback=str(getattr(run, "status", "") or "") == "failed",
+    )
+    failed_attempts = (
+        _attempts_for_step(
+            attempts,
+            step_id=failed_step.get("step_id") if failed_step else None,
+            step_run_id=failed_step.get("step_run_id") if failed_step else None,
+        )
+        if failed_step is not None
+        else []
     )
     primary_failure = _build_primary_failure(
         run=run,
@@ -112,11 +119,17 @@ def list_step_attempts(
     }
 
 
-def _select_failed_step(step_runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+def _select_failed_step(
+    step_runs: list[dict[str, Any]],
+    *,
+    allow_latest_fallback: bool = False,
+) -> dict[str, Any] | None:
     for step_run in reversed(step_runs):
         if str(step_run.get("status") or "") == "failed":
             return step_run
-    return step_runs[-1] if step_runs else None
+    if allow_latest_fallback and step_runs:
+        return step_runs[-1]
+    return None
 
 
 def _attempts_for_step(
@@ -159,6 +172,11 @@ def _build_primary_failure(
             "internal_detail": None,
         }
     else:
+        status = str(getattr(run, "status", "") or "").strip().lower()
+        run_error = getattr(run, "error", None)
+        run_reason = getattr(run, "status_reason", None)
+        if status != "failed" and not run_error and not run_reason:
+            return None
         envelope = build_failure_envelope(run.error or run.status_reason, step_type=step_type)
         failure = {
             "reason_code_core": envelope.reason_code_core,

--- a/tldw_Server_API/app/core/Workflows/registry.py
+++ b/tldw_Server_API/app/core/Workflows/registry.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import builtins
 from dataclasses import dataclass
 
+from tldw_Server_API.app.core.Workflows.capabilities import StepCapability
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+
 
 @dataclass
 class StepType:
     name: str
     description: str
+
+    @property
+    def capability(self) -> StepCapability:
+        return get_step_capability(self.name)
 
 
 class StepTypeRegistry:

--- a/tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
+++ b/tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
@@ -139,6 +139,25 @@ def test_workflow_definition_and_run_roundtrip(workflows_dual_backend_db):
         status="succeeded",
         outputs={"response": "Hello"},
     )
+    attempt_id = db.create_step_attempt(
+        tenant_id="tenant-1",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        step_id="step-1",
+        attempt_number=1,
+        status="running",
+        metadata={"backend": backend_label},
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt_id,
+        status="succeeded",
+        metadata={"backend": backend_label, "result": "ok"},
+    )
+    attempts = db.list_step_attempts(run_id=run_id, step_id="step-1")
+    assert len(attempts) == 1
+    assert attempts[0]["attempt_id"] == attempt_id
+    assert attempts[0]["status"] == "succeeded"
+    assert attempts[0]["metadata_json"]["backend"] == backend_label
 
     db.add_artifact(
         artifact_id=f"artifact-{backend_label}",

--- a/tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py
@@ -80,6 +80,11 @@ async def test_non_retriable_reason_does_not_consume_retries(tmp_path, monkeypat
     assert row is not None
     assert int(row[0] or 0) == 1
 
+    attempts = db.list_step_attempts(run_id=run_id, step_id="s1")
+    assert len(attempts) == 1
+    assert attempts[0]["reason_code_core"] == "acp_governance_blocked"
+    assert bool(attempts[0]["retryable"]) is False
+
     events = db.get_events(run_id)
     assert any(event.get("event_type") == "step_retry_suppressed" for event in events)
 
@@ -121,3 +126,8 @@ async def test_retriable_reason_consumes_retry_attempts(tmp_path, monkeypatch):
     ).fetchone()
     assert row is not None
     assert int(row[0] or 0) == 3
+
+    attempts = db.list_step_attempts(run_id=run_id, step_id="s1")
+    assert len(attempts) == 3
+    assert {attempt["reason_code_core"] for attempt in attempts} == {"transient_network_error"}
+    assert all(bool(attempt["retryable"]) is True for attempt in attempts)

--- a/tldw_Server_API/tests/Workflows/test_engine_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_scheduler.py
@@ -127,6 +127,41 @@ def test_waiting_run_keeps_secrets_and_releases_slot(workflows_db: WorkflowsData
     assert stats["active_workflows"] == 0
 
 
+def test_wait_for_approval_persists_waiting_approval_status(workflows_db: WorkflowsDatabase):
+    definition = {
+        "name": "await-approval",
+        "steps": [
+            {
+                "id": "approve",
+                "type": "wait_for_approval",
+                "config": {"assigned_to_user_id": "user"},
+                "on_success": "next",
+            },
+            {"id": "next", "type": "log", "config": {"message": "done"}},
+        ],
+    }
+    run_id = "approval-run"
+    workflows_db.create_run(
+        run_id=run_id,
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot=definition,
+    )
+    engine = WorkflowEngine(workflows_db)
+    engine.submit(run_id, RunMode.ASYNC)
+
+    status = _wait_for_status(workflows_db, run_id)
+    assert status == "waiting_approval"
+    step_runs = workflows_db.list_step_runs(run_id=run_id)
+    attempts = workflows_db.list_step_attempts(run_id=run_id, step_id="approve")
+
+    assert step_runs[0]["status"] == "waiting_approval"
+    assert attempts[0]["status"] == "waiting_approval"
+
+
 def test_continue_run_clears_secrets(workflows_db: WorkflowsDatabase):
     scheduler = WorkflowScheduler.instance()
     definition = {
@@ -165,6 +200,53 @@ def test_continue_run_clears_secrets(workflows_db: WorkflowsDatabase):
     stats = scheduler.stats()
     assert stats["active_tenants"] == 0
     assert stats["active_workflows"] == 0
+
+
+def test_continue_run_preserves_waiting_approval_status(workflows_db: WorkflowsDatabase):
+    definition = {
+        "name": "resume-to-approval",
+        "steps": [
+            {
+                "id": "wait",
+                "type": "wait_for_human",
+                "config": {"assigned_to_user_id": "user"},
+                "on_success": "approve",
+            },
+            {
+                "id": "approve",
+                "type": "wait_for_approval",
+                "config": {"assigned_to_user_id": "user"},
+                "on_success": "next",
+            },
+            {"id": "next", "type": "log", "config": {"message": "finished"}},
+        ],
+    }
+    run_id = "resume-approval-run"
+    workflows_db.create_run(
+        run_id=run_id,
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot=definition,
+    )
+
+    engine = WorkflowEngine(workflows_db)
+    engine.submit(run_id, RunMode.ASYNC)
+    status = _wait_for_status(workflows_db, run_id)
+    assert status == "waiting_human"
+
+    asyncio.run(engine.continue_run(run_id, after_step_id="wait", last_outputs={"approved": True}))
+
+    status = _wait_for_status(workflows_db, run_id)
+    assert status == "waiting_approval"
+    step_runs = workflows_db.list_step_runs(run_id=run_id)
+    approval_step_run = next(step_run for step_run in step_runs if step_run["step_id"] == "approve")
+    attempts = workflows_db.list_step_attempts(run_id=run_id, step_id="approve")
+
+    assert approval_step_run["status"] == "waiting_approval"
+    assert attempts[0]["status"] == "waiting_approval"
 
 
 def test_continue_run_restores_step_context_bindings(workflows_db: WorkflowsDatabase):

--- a/tldw_Server_API/tests/Workflows/test_engine_scheduler.py
+++ b/tldw_Server_API/tests/Workflows/test_engine_scheduler.py
@@ -167,6 +167,51 @@ def test_continue_run_clears_secrets(workflows_db: WorkflowsDatabase):
     assert stats["active_workflows"] == 0
 
 
+def test_continue_run_restores_step_context_bindings(workflows_db: WorkflowsDatabase):
+    definition = {
+        "name": "resume-context-flow",
+        "steps": [
+            {"id": "prepare", "type": "prompt", "config": {"template": "Alpha"}},
+            {
+                "id": "wait",
+                "type": "wait_for_human",
+                "config": {"assigned_to_user_id": "user"},
+                "on_success": "render",
+            },
+            {
+                "id": "render",
+                "type": "prompt",
+                "config": {"template": "Prev={{ prepare.text }} Approved={{ wait.approved }}"},
+            },
+        ],
+    }
+    run_id = "resume-context-run"
+    workflows_db.create_run(
+        run_id=run_id,
+        tenant_id="tenant",
+        user_id="user",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot=definition,
+    )
+
+    engine = WorkflowEngine(workflows_db)
+    engine.submit(run_id, RunMode.ASYNC)
+    status = _wait_for_status(workflows_db, run_id)
+    assert status == "waiting_human"
+
+    asyncio.run(engine.continue_run(run_id, after_step_id="wait", last_outputs={"approved": True}))
+
+    status = _wait_for_status(workflows_db, run_id)
+    assert status == "succeeded"
+    run = workflows_db.get_run(run_id)
+    assert run is not None
+    assert run.outputs_json is not None
+    assert "Prev=Alpha" in run.outputs_json
+    assert "Approved=True" in run.outputs_json
+
+
 def test_run_saved_sync_waits_for_completion(workflows_db: WorkflowsDatabase, monkeypatch):
     definition_doc = {
         "name": "sync-run",

--- a/tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py
@@ -1,0 +1,98 @@
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+from tldw_Server_API.app.core.Workflows import engine as engine_mod
+
+
+pytestmark = pytest.mark.unit
+
+
+def _create_run(
+    db: WorkflowsDatabase,
+    *,
+    run_id: str,
+    step_type: str,
+    retry: int,
+    config: dict,
+) -> None:
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": f"{step_type}-attempt-failures",
+            "version": 1,
+            "steps": [{"id": "s1", "type": step_type, "retry": retry, "config": config}],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_retrying_step_records_multiple_attempt_rows(tmp_path, monkeypatch):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-attempt-history"
+    _create_run(
+        db,
+        run_id=run_id,
+        step_type="prompt",
+        retry=1,
+        config={"template": "ok"},
+    )
+
+    state = {"calls": 0}
+
+    async def _flaky_adapter(_config, _context):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("transient_network_error")
+        return {"text": "ok"}
+
+    async def _fast_sleep(_duration: float):
+        return None
+
+    monkeypatch.setattr(engine_mod, "get_adapter", lambda _step_type: _flaky_adapter)
+    monkeypatch.setattr(engine_mod.asyncio, "sleep", _fast_sleep)
+
+    engine = engine_mod.WorkflowEngine(db)
+    await engine.start_run(run_id)
+
+    attempts = db.list_step_attempts(run_id=run_id, step_id="s1")
+    assert len(attempts) == 2
+    assert attempts[0]["status"] == "failed"
+    assert attempts[0]["reason_code_core"] == "transient_network_error"
+    assert bool(attempts[0]["retryable"]) is True
+    assert attempts[0]["metadata_json"]["retry_recommendation"] == "safe"
+    assert attempts[0]["metadata_json"]["blame_scope"] == "step"
+    assert attempts[1]["status"] == "succeeded"
+    assert attempts[1]["reason_code_core"] is None
+
+
+@pytest.mark.asyncio
+async def test_unsafe_step_types_do_not_report_safe_replay(tmp_path, monkeypatch):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    run_id = "run-unsafe-replay-guidance"
+    _create_run(
+        db,
+        run_id=run_id,
+        step_type="webhook",
+        retry=0,
+        config={"url": "https://example.invalid/hook"},
+    )
+
+    async def _transient_adapter(_config, _context):
+        raise RuntimeError("transient_network_error")
+
+    monkeypatch.setattr(engine_mod, "get_adapter", lambda _step_type: _transient_adapter)
+
+    engine = engine_mod.WorkflowEngine(db)
+    await engine.start_run(run_id)
+
+    attempts = db.list_step_attempts(run_id=run_id, step_id="s1")
+    assert len(attempts) == 1
+    assert attempts[0]["reason_code_core"] == "transient_network_error"
+    assert bool(attempts[0]["retryable"]) is True
+    assert attempts[0]["metadata_json"]["retry_recommendation"] == "conditional"
+    assert attempts[0]["metadata_json"]["step_capability"]["replay_safe"] is False

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -284,6 +284,76 @@ def _seed_succeeded_run(db: WorkflowsDatabase) -> str:
     return run_id
 
 
+def _seed_cancelled_run(db: WorkflowsDatabase) -> str:
+    run_id = f"run-investigation-cancelled-{uuid4().hex[:8]}"
+    step_run_id = f"{run_id}:s1:1"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={"target": "hook"},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": "investigation-cancelled",
+            "version": 1,
+            "steps": [
+                {"id": "s1", "name": "Render output", "type": "prompt", "config": {"template": "ok"}},
+            ],
+        },
+    )
+    db.update_run_status(
+        run_id,
+        status="cancelled",
+        status_reason="cancelled_by_user",
+        started_at="2026-03-11T10:00:00",
+        ended_at="2026-03-11T10:00:02",
+    )
+    db.create_step_run(
+        step_run_id=step_run_id,
+        tenant_id="default",
+        run_id=run_id,
+        step_id="s1",
+        name="Render output",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "ok"}},
+    )
+    attempt_id = db.create_step_attempt(
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        step_id="s1",
+        attempt_number=1,
+        metadata={"step_type": "prompt"},
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt_id,
+        status="succeeded",
+        metadata={"step_type": "prompt"},
+    )
+    db.complete_step_run(
+        step_run_id=step_run_id,
+        status="succeeded",
+        outputs={"text": "ok"},
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "step_completed",
+        {"step_id": "s1"},
+        step_run_id=step_run_id,
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "run_cancelled",
+        {"reason": "cancelled_by_user"},
+        step_run_id=step_run_id,
+    )
+    return run_id
+
+
 def test_investigation_endpoint_returns_primary_failure(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
     client, db, _state = client_with_investigation_db
     run_id = _seed_failed_run(db)
@@ -307,6 +377,21 @@ def test_investigation_endpoint_omits_failure_for_successful_run(client_with_inv
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["status"] == "succeeded"
+    assert data["failed_step"] is None
+    assert data["primary_failure"] is None
+    assert data["attempts"] == []
+    assert data["recommended_actions"] == []
+
+
+def test_investigation_endpoint_omits_failure_for_cancelled_run(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = _seed_cancelled_run(db)
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/investigation")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "cancelled"
     assert data["failed_step"] is None
     assert data["primary_failure"] is None
     assert data["attempts"] == []

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -1,0 +1,276 @@
+import importlib.machinery
+import sys
+import types
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Stub heavyweight audio deps before app import for local test stability.
+if "torch" not in sys.modules:
+    _fake_torch = types.ModuleType("torch")
+    _fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    _fake_torch.Tensor = object
+    _fake_torch.nn = types.SimpleNamespace(Module=object)
+    sys.modules["torch"] = _fake_torch
+
+if "faster_whisper" not in sys.modules:
+    _fake_fw = types.ModuleType("faster_whisper")
+    _fake_fw.__spec__ = importlib.machinery.ModuleSpec("faster_whisper", loader=None)
+
+    class _StubWhisperModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    _fake_fw.WhisperModel = _StubWhisperModel
+    _fake_fw.BatchedInferencePipeline = _StubWhisperModel
+    sys.modules["faster_whisper"] = _fake_fw
+
+if "transformers" not in sys.modules:
+    _fake_tf = types.ModuleType("transformers")
+    _fake_tf.__spec__ = importlib.machinery.ModuleSpec("transformers", loader=None)
+
+    class _StubProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    class _StubModel:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    _fake_tf.AutoProcessor = _StubProcessor
+    _fake_tf.Qwen2AudioForConditionalGeneration = _StubModel
+    sys.modules["transformers"] = _fake_tf
+
+from tldw_Server_API.app.main import app
+from tldw_Server_API.app.api.v1.endpoints import workflows as wf_mod
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def client_with_investigation_db(tmp_path, auth_headers):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+    state = {
+        "user": User(
+            id=1,
+            username="tester",
+            email="tester@example.com",
+            is_active=True,
+            is_admin=True,
+            tenant_id="default",
+            roles=["admin"],
+        )
+    }
+
+    async def override_user():
+        return state["user"]
+
+    def override_db():
+        return db
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    with TestClient(app, headers=auth_headers) as client:
+        yield client, db, state
+
+    app.dependency_overrides.clear()
+
+
+def _seed_failed_run(db: WorkflowsDatabase) -> str:
+    run_id = f"run-investigation-{uuid4().hex[:8]}"
+    step_run_id = f"{run_id}:s1:1"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={"target": "hook"},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": "investigation-failure",
+            "version": 1,
+            "steps": [
+                {"id": "s1", "name": "Call hook", "type": "webhook", "retry": 1, "config": {"url": "https://example.invalid/hook"}},
+            ],
+        },
+    )
+    db.update_run_status(
+        run_id,
+        status="failed",
+        status_reason="transient_network_error",
+        started_at="2026-03-11T10:00:00",
+        ended_at="2026-03-11T10:00:04",
+        error="transient_network_error: upstream reset",
+    )
+    db.create_step_run(
+        step_run_id=step_run_id,
+        tenant_id="default",
+        run_id=run_id,
+        step_id="s1",
+        name="Call hook",
+        step_type="webhook",
+        status="running",
+        inputs={"config": {"url": "https://example.invalid/hook"}},
+    )
+    db.update_step_attempt(step_run_id=step_run_id, attempt=2)
+    attempt1 = db.create_step_attempt(
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        step_id="s1",
+        attempt_number=1,
+        metadata={
+            "step_type": "webhook",
+            "category": "runtime",
+            "blame_scope": "external_dependency",
+            "retry_recommendation": "conditional",
+        },
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt1,
+        status="failed",
+        reason_code_core="transient_network_error",
+        reason_code_detail="RuntimeError",
+        retryable=True,
+        error_summary="upstream reset",
+        metadata={
+            "step_type": "webhook",
+            "category": "runtime",
+            "blame_scope": "external_dependency",
+            "retry_recommendation": "conditional",
+        },
+    )
+    attempt2 = db.create_step_attempt(
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        step_id="s1",
+        attempt_number=2,
+        metadata={
+            "step_type": "webhook",
+            "category": "runtime",
+            "blame_scope": "external_dependency",
+            "retry_recommendation": "conditional",
+        },
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt2,
+        status="failed",
+        reason_code_core="transient_network_error",
+        reason_code_detail="RuntimeError",
+        retryable=True,
+        error_summary="upstream reset",
+        metadata={
+            "step_type": "webhook",
+            "category": "runtime",
+            "blame_scope": "external_dependency",
+            "retry_recommendation": "conditional",
+            "failure_envelope": {"reason_code_core": "transient_network_error"},
+        },
+    )
+    db.complete_step_run(
+        step_run_id=step_run_id,
+        status="failed",
+        outputs={},
+        error="transient_network_error: upstream reset",
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "step_failed",
+        {"step_id": "s1", "reason_code": "transient_network_error"},
+        step_run_id=step_run_id,
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "webhook_delivery",
+        {"step_id": "s1", "status": "failed", "response_status": 502},
+        step_run_id=step_run_id,
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "run_failed",
+        {"reason_code": "transient_network_error"},
+        step_run_id=step_run_id,
+    )
+    db.add_artifact(
+        artifact_id=f"artifact-{uuid4().hex[:8]}",
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        type="log",
+        uri="file:///tmp/workflow.log",
+        metadata={"kind": "stderr_excerpt"},
+    )
+    return run_id
+
+
+def test_investigation_endpoint_returns_primary_failure(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = _seed_failed_run(db)
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/investigation")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["primary_failure"]["reason_code_core"] == "transient_network_error"
+    assert data["failed_step"]["step_id"] == "s1"
+    assert data["recommended_actions"]
+    assert data["primary_failure"]["internal_detail"]["event_count"] >= 3
+
+
+def test_steps_endpoint_returns_step_history(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = _seed_failed_run(db)
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/steps")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["steps"][0]["step_id"] == "s1"
+    assert data["steps"][0]["attempt_count"] == 2
+    assert data["steps"][0]["latest_failure"]["reason_code_core"] == "transient_network_error"
+
+
+def test_step_attempts_endpoint_returns_attempt_timeline(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = _seed_failed_run(db)
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/steps/s1/attempts")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data["attempts"]) == 2
+    assert data["attempts"][0]["attempt_number"] == 1
+    assert data["attempts"][0]["reason_code_core"] == "transient_network_error"
+    assert data["attempts"][0]["metadata"]["retry_recommendation"] == "conditional"
+
+
+def test_investigation_redacts_operator_detail_for_non_admin(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, state = client_with_investigation_db
+    run_id = _seed_failed_run(db)
+    state["user"] = User(
+        id=1,
+        username="tester",
+        email="tester@example.com",
+        is_active=True,
+        is_admin=False,
+        tenant_id="default",
+        roles=["user"],
+    )
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/investigation")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["primary_failure"]["reason_code_core"] == "transient_network_error"
+    assert data["primary_failure"]["internal_detail"] is None

--- a/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
@@ -214,6 +214,76 @@ def _seed_failed_run(db: WorkflowsDatabase) -> str:
     return run_id
 
 
+def _seed_succeeded_run(db: WorkflowsDatabase) -> str:
+    run_id = f"run-investigation-success-{uuid4().hex[:8]}"
+    step_run_id = f"{run_id}:s1:1"
+    db.create_run(
+        run_id=run_id,
+        tenant_id="default",
+        user_id="1",
+        inputs={"target": "hook"},
+        workflow_id=None,
+        definition_version=1,
+        definition_snapshot={
+            "name": "investigation-success",
+            "version": 1,
+            "steps": [
+                {"id": "s1", "name": "Render output", "type": "prompt", "config": {"template": "ok"}},
+            ],
+        },
+    )
+    db.update_run_status(
+        run_id,
+        status="succeeded",
+        started_at="2026-03-11T10:00:00",
+        ended_at="2026-03-11T10:00:02",
+        outputs={"text": "ok"},
+    )
+    db.create_step_run(
+        step_run_id=step_run_id,
+        tenant_id="default",
+        run_id=run_id,
+        step_id="s1",
+        name="Render output",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "ok"}},
+    )
+    attempt_id = db.create_step_attempt(
+        tenant_id="default",
+        run_id=run_id,
+        step_run_id=step_run_id,
+        step_id="s1",
+        attempt_number=1,
+        metadata={"step_type": "prompt"},
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt_id,
+        status="succeeded",
+        metadata={"step_type": "prompt"},
+    )
+    db.complete_step_run(
+        step_run_id=step_run_id,
+        status="succeeded",
+        outputs={"text": "ok"},
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "step_completed",
+        {"step_id": "s1"},
+        step_run_id=step_run_id,
+    )
+    db.append_event(
+        "default",
+        run_id,
+        "run_completed",
+        {"success": True},
+        step_run_id=step_run_id,
+    )
+    return run_id
+
+
 def test_investigation_endpoint_returns_primary_failure(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
     client, db, _state = client_with_investigation_db
     run_id = _seed_failed_run(db)
@@ -226,6 +296,21 @@ def test_investigation_endpoint_returns_primary_failure(client_with_investigatio
     assert data["failed_step"]["step_id"] == "s1"
     assert data["recommended_actions"]
     assert data["primary_failure"]["internal_detail"]["event_count"] >= 3
+
+
+def test_investigation_endpoint_omits_failure_for_successful_run(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):
+    client, db, _state = client_with_investigation_db
+    run_id = _seed_succeeded_run(db)
+
+    resp = client.get(f"/api/v1/workflows/runs/{run_id}/investigation")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["status"] == "succeeded"
+    assert data["failed_step"] is None
+    assert data["primary_failure"] is None
+    assert data["attempts"] == []
+    assert data["recommended_actions"] == []
 
 
 def test_steps_endpoint_returns_step_history(client_with_investigation_db: tuple[TestClient, WorkflowsDatabase, dict]):

--- a/tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
@@ -118,6 +118,47 @@ def test_preflight_demotes_validation_errors_in_non_block_mode(client_for_prefli
     assert data["warnings"][0]["code"] == "definition_validation_warning"
 
 
+def test_preflight_accepts_malformed_drafts_in_non_block_mode(client_for_preflight: TestClient):
+    resp = client_for_preflight.post(
+        "/api/v1/workflows/preflight",
+        json={
+            "validation_mode": "non-block",
+            "definition": {
+                "name": "draft-preflight",
+                "version": 1,
+                "steps": [{"id": "s1", "config": {}}],
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["errors"] == []
+    assert data["warnings"][0]["code"] == "definition_validation_warning"
+    assert "steps.0.type" in data["warnings"][0]["message"]
+
+
+def test_preflight_reports_malformed_drafts_in_block_mode(client_for_preflight: TestClient):
+    resp = client_for_preflight.post(
+        "/api/v1/workflows/preflight",
+        json={
+            "definition": {
+                "name": "draft-preflight-block",
+                "version": 1,
+                "steps": [{"id": "s1", "config": {}}],
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is False
+    assert data["warnings"] == []
+    assert data["errors"][0]["code"] == "definition_invalid"
+    assert "steps.0.type" in data["errors"][0]["message"]
+
+
 def test_preflight_flags_unsafe_replay_steps(client_for_preflight: TestClient):
     resp = client_for_preflight.post(
         "/api/v1/workflows/preflight",

--- a/tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
@@ -1,0 +1,136 @@
+import importlib.machinery
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Stub heavyweight audio deps before app import for local test stability.
+if "torch" not in sys.modules:
+    _fake_torch = types.ModuleType("torch")
+    _fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    _fake_torch.Tensor = object
+    _fake_torch.nn = types.SimpleNamespace(Module=object)
+    sys.modules["torch"] = _fake_torch
+
+if "faster_whisper" not in sys.modules:
+    _fake_fw = types.ModuleType("faster_whisper")
+    _fake_fw.__spec__ = importlib.machinery.ModuleSpec("faster_whisper", loader=None)
+
+    class _StubWhisperModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    _fake_fw.WhisperModel = _StubWhisperModel
+    _fake_fw.BatchedInferencePipeline = _StubWhisperModel
+    sys.modules["faster_whisper"] = _fake_fw
+
+if "transformers" not in sys.modules:
+    _fake_tf = types.ModuleType("transformers")
+    _fake_tf.__spec__ = importlib.machinery.ModuleSpec("transformers", loader=None)
+
+    class _StubProcessor:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    class _StubModel:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            return cls()
+
+    _fake_tf.AutoProcessor = _StubProcessor
+    _fake_tf.Qwen2AudioForConditionalGeneration = _StubModel
+    sys.modules["transformers"] = _fake_tf
+
+from tldw_Server_API.app.main import app
+from tldw_Server_API.app.api.v1.endpoints import workflows as wf_mod
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.Workflows_DB import WorkflowsDatabase
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def client_for_preflight(tmp_path, auth_headers):
+    db = WorkflowsDatabase(str(tmp_path / "wf.db"))
+
+    async def override_user():
+        return User(
+            id=1,
+            username="tester",
+            email="tester@example.com",
+            is_active=True,
+            is_admin=True,
+            tenant_id="default",
+            roles=["admin"],
+        )
+
+    def override_db():
+        return db
+
+    app.dependency_overrides[get_request_user] = override_user
+    app.dependency_overrides[wf_mod._get_db] = override_db
+
+    with TestClient(app, headers=auth_headers) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
+def test_preflight_reports_blocking_validation_errors(client_for_preflight: TestClient):
+    resp = client_for_preflight.post(
+        "/api/v1/workflows/preflight",
+        json={
+            "definition": {
+                "name": "bad-preflight",
+                "version": 1,
+                "steps": [{"id": "s1", "type": "wait_for_human", "config": {}}],
+            }
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is False
+    assert data["errors"][0]["code"] == "definition_invalid"
+    assert "assigned_to_user_id" in data["errors"][0]["message"]
+
+
+def test_preflight_demotes_validation_errors_in_non_block_mode(client_for_preflight: TestClient):
+    resp = client_for_preflight.post(
+        "/api/v1/workflows/preflight",
+        json={
+            "validation_mode": "non-block",
+            "definition": {
+                "name": "warn-preflight",
+                "version": 1,
+                "steps": [{"id": "s1", "type": "wait_for_human", "config": {}}],
+            },
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is True
+    assert data["errors"] == []
+    assert data["warnings"][0]["code"] == "definition_validation_warning"
+
+
+def test_preflight_flags_unsafe_replay_steps(client_for_preflight: TestClient):
+    resp = client_for_preflight.post(
+        "/api/v1/workflows/preflight",
+        json={
+            "definition": {
+                "name": "unsafe-replay",
+                "version": 1,
+                "steps": [{"id": "s1", "type": "webhook", "config": {"url": "https://example.invalid/hook"}}],
+            }
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["valid"] is True
+    assert any(warning["code"] == "unsafe_replay_step" for warning in data["warnings"])

--- a/tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py
+++ b/tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py
@@ -1,0 +1,30 @@
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+
+
+def test_webhook_steps_default_to_unsafe_replay():
+    capability = get_step_capability("webhook")
+
+    assert capability.replay_safe is False
+    assert capability.requires_human_review_for_rerun is True
+    assert capability.idempotency_strategy == "external"
+
+
+def test_prompt_steps_expose_safe_replay_defaults():
+    capability = get_step_capability("prompt")
+
+    assert capability.replay_safe is True
+    assert capability.idempotency_strategy == "run_scoped"
+    assert capability.compensation_supported is False
+
+
+def test_step_types_endpoint_includes_capability_metadata(client_user_only):
+    response = client_user_only.get("/api/v1/workflows/step-types")
+
+    assert response.status_code == 200
+    prompt = next(item for item in response.json() if item["name"] == "prompt")
+    webhook = next(item for item in response.json() if item["name"] == "webhook")
+
+    assert prompt["capabilities"]["replay_safe"] is True
+    assert prompt["capabilities"]["idempotency_strategy"] == "run_scoped"
+    assert webhook["capabilities"]["replay_safe"] is False
+    assert webhook["capabilities"]["requires_human_review_for_rerun"] is True

--- a/tldw_Server_API/tests/Workflows/test_workflows_db.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db.py
@@ -60,3 +60,68 @@ def test_workflows_db_crud(tmp_path):
     assert [e["event_type"] for e in events] == ["run_started", "step_completed"]
     events_since = db.get_events(run_id, since=1)
     assert len(events_since) == 1 and events_since[0]["event_seq"] == 2
+
+
+def test_workflows_db_step_attempt_crud(tmp_path):
+    db_path = tmp_path / "workflows.db"
+    db = WorkflowsDatabase(str(db_path))
+
+    definition = {
+        "name": "attempt-demo",
+        "version": 1,
+        "steps": [{"id": "s1", "type": "prompt", "config": {"template": "Hi"}}],
+    }
+
+    workflow_id = db.create_definition(
+        tenant_id="tenant-1",
+        name="attempt-demo",
+        version=1,
+        owner_id="owner-1",
+        visibility="private",
+        description="",
+        tags=[],
+        definition=definition,
+    )
+
+    db.create_run(
+        run_id="run-attempt",
+        tenant_id="tenant-1",
+        user_id="owner-1",
+        inputs={},
+        workflow_id=workflow_id,
+        definition_version=1,
+        definition_snapshot=definition,
+    )
+    db.create_step_run(
+        step_run_id="run-attempt:s1",
+        tenant_id="tenant-1",
+        run_id="run-attempt",
+        step_id="s1",
+        name="Step 1",
+        step_type="prompt",
+        status="running",
+        inputs={"config": {"template": "Hi"}},
+    )
+
+    attempt_id = db.create_step_attempt(
+        tenant_id="tenant-1",
+        run_id="run-attempt",
+        step_run_id="run-attempt:s1",
+        step_id="s1",
+        attempt_number=1,
+        status="running",
+        metadata={"source": "test"},
+    )
+    db.complete_step_attempt(
+        attempt_id=attempt_id,
+        status="failed",
+        error_summary="forced_error",
+        metadata={"source": "test", "result": "failed"},
+    )
+
+    attempts = db.list_step_attempts(run_id="run-attempt", step_id="s1")
+    assert len(attempts) == 1
+    assert attempts[0]["attempt_id"] == attempt_id
+    assert attempts[0]["attempt_number"] == 1
+    assert attempts[0]["status"] == "failed"
+    assert attempts[0]["metadata_json"]["result"] == "failed"

--- a/tldw_Server_API/tests/Workflows/test_workflows_db.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_db.py
@@ -125,3 +125,14 @@ def test_workflows_db_step_attempt_crud(tmp_path):
     assert attempts[0]["attempt_number"] == 1
     assert attempts[0]["status"] == "failed"
     assert attempts[0]["metadata_json"]["result"] == "failed"
+
+
+def test_workflows_db_step_attempt_indexes_exist(tmp_path):
+    db = WorkflowsDatabase(str(tmp_path / "workflows.db"))
+
+    rows = db._conn.cursor().execute("PRAGMA index_list('workflow_step_attempts')").fetchall()
+    index_names = {row["name"] for row in rows}
+
+    assert "idx_step_attempts_run_attempts" in index_names
+    assert "idx_step_attempts_run_step_attempts" in index_names
+    assert "idx_step_attempts_step_run_attempts" in index_names

--- a/tldw_Server_API/tests/Workflows/test_workflows_postgres_indexes.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_postgres_indexes.py
@@ -75,6 +75,22 @@ def test_workflows_postgres_fresh_schema_has_jsonb_and_indexes(pg_database_confi
             assert succ_def and ("where" in succ_def.lower() and "succeeded" in succ_def.lower())
             fail_def = _index_def(backend, conn, "workflow_runs", "idx_runs_status_failed")
             assert fail_def and ("where" in fail_def.lower() and "failed" in fail_def.lower())
+            run_attempts_def = _index_def(backend, conn, "workflow_step_attempts", "idx_step_attempts_run_attempts")
+            assert run_attempts_def and "(run_id, attempt_number, started_at)" in run_attempts_def
+            run_step_attempts_def = _index_def(
+                backend,
+                conn,
+                "workflow_step_attempts",
+                "idx_step_attempts_run_step_attempts",
+            )
+            assert run_step_attempts_def and "(run_id, step_id, attempt_number, started_at)" in run_step_attempts_def
+            step_run_attempts_def = _index_def(
+                backend,
+                conn,
+                "workflow_step_attempts",
+                "idx_step_attempts_step_run_attempts",
+            )
+            assert step_run_attempts_def and "(step_run_id, attempt_number, started_at)" in step_run_attempts_def
 
             # Schema version table exists and equals current
             version = backend.execute(
@@ -203,6 +219,20 @@ def test_workflows_postgres_migration_preserves_indexes_from_legacy(pg_database_
             succ_def = _index_def(backend, conn, "workflow_runs", "idx_runs_status_succeeded")
             fail_def = _index_def(backend, conn, "workflow_runs", "idx_runs_status_failed")
             assert running_def and queued_def and succ_def and fail_def
+            run_attempts_def = _index_def(backend, conn, "workflow_step_attempts", "idx_step_attempts_run_attempts")
+            run_step_attempts_def = _index_def(
+                backend,
+                conn,
+                "workflow_step_attempts",
+                "idx_step_attempts_run_step_attempts",
+            )
+            step_run_attempts_def = _index_def(
+                backend,
+                conn,
+                "workflow_step_attempts",
+                "idx_step_attempts_step_run_attempts",
+            )
+            assert run_attempts_def and run_step_attempts_def and step_run_attempts_def
 
             version = backend.execute(
                 "SELECT version FROM workflow_schema_version LIMIT 1",

--- a/tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py
+++ b/tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py
@@ -188,8 +188,20 @@ def test_workflows_postgres_schema_migration_adds_missing_columns(pg_database_co
             assert _column_exists(backend, conn, "workflow_step_runs", "assigned_to")
 
             assert backend.table_exists("workflow_artifacts", connection=conn)
+            assert backend.table_exists("workflow_step_attempts", connection=conn)
             # Per-run event counters table present
             assert backend.table_exists("workflow_event_counters", connection=conn)
+            for column in (
+                "attempt_id",
+                "tenant_id",
+                "run_id",
+                "step_run_id",
+                "step_id",
+                "attempt_number",
+                "status",
+                "metadata_json",
+            ):
+                assert _column_exists(backend, conn, "workflow_step_attempts", column)
 
             version = backend.execute(
                 "SELECT version FROM workflow_schema_version LIMIT 1",


### PR DESCRIPTION
## Summary
- add workflows replay capabilities, step attempt persistence, structured failure envelopes, investigation endpoints, and server-authoritative preflight validation
- add typed UI diagnostics services plus a shared workflow run inspector wired into the workflow editor execution panel
- update workflows design, debugging, runbook, and alert docs around investigation-first triage and replay safety

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v
- cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts
- cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
- cd apps/packages/ui && bunx vitest run src/components/WorkflowEditor/__tests__/WorkflowEditor.responsive.test.tsx

## Notes
- broad Bandit scan over the workflows backend scope still reports existing low-severity findings in untouched adapter/subprocess files
- existing unrelated UI regression remains in src/components/WorkflowEditor/__tests__/step-registry.test.ts around the missing acp_stage mapping
