### PR TITLE
Add runtime-aware qwen3_tts support for MLX and remote backends

### DIFF
--- a/.github/workflows/backend-required.yml
+++ b/.github/workflows/backend-required.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: backend-required-${{ github.event.pull_request.head.sha || github.sha }}
+  group: backend-required-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ env:
   PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
 
 concurrency:
-  # Ensure push and PR for the same commit share one slot
-  group: ci-${{ github.event.pull_request.head.sha || github.sha }}
+  # Ensure newer PR commits cancel older queued runs for the same PR.
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/coverage-required.yml
+++ b/.github/workflows/coverage-required.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: coverage-required-${{ github.event.pull_request.head.sha || github.sha }}
+  group: coverage-required-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/e2e-required.yml
+++ b/.github/workflows/e2e-required.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: e2e-required-${{ github.event.pull_request.head.sha || github.sha }}
+  group: e2e-required-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-required.yml
+++ b/.github/workflows/frontend-required.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-required-${{ github.event.pull_request.head.sha || github.sha }}
+  group: frontend-required-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend-ux-gates.yml
+++ b/.github/workflows/frontend-ux-gates.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-ux-gates-${{ github.event.pull_request.head.sha || github.sha }}
+  group: frontend-ux-gates-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pre-commit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pypi-package-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-check:
     name: Build and Validate Distributions

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: sbom-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-sbom:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-required.yml
+++ b/.github/workflows/security-required.yml
@@ -12,7 +12,7 @@ permissions:
   security-events: read
 
 concurrency:
-  group: security-required-${{ github.event.pull_request.head.sha || github.sha }}
+  group: security-required-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
+++ b/Docs/Plans/2026-03-11-chat-page-rate-limit-lazy-hydration-design.md
@@ -1,0 +1,338 @@
+# Chat Page Rate-Limit Lazy Hydration Design
+
+Date: 2026-03-11
+Owner: Codex collaboration session
+Status: Approved (design)
+
+## Context and Problem
+
+Users report hitting API rate limits during ordinary use of the WebUI `/chat` page and the extension chat surface.
+
+Current request pressure comes from a combination of frontend behaviors:
+
+- eager mount-time fetching for sidebar history, capability checks, MCP discovery, audio health, model catalogs, and preference hydration
+- duplicated server-chat metadata and transcript loading across multiple hooks and surfaces
+- full history sweeps for server chat lists
+- provider-sensitive model refreshes that can run on the send path
+
+Relevant current anchors:
+
+- [`apps/packages/ui/src/components/Layouts/Layout.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Layouts/Layout.tsx)
+- [`apps/packages/ui/src/components/Common/ChatSidebar.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Common/ChatSidebar.tsx)
+- [`apps/packages/ui/src/hooks/useServerChatHistory.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useServerChatHistory.ts)
+- [`apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/components/Option/Playground/PlaygroundForm.tsx)
+- [`apps/packages/ui/src/hooks/useMessage.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/useMessage.tsx)
+- [`apps/packages/ui/src/hooks/chat/useServerChatLoader.ts`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/packages/ui/src/hooks/chat/useServerChatLoader.ts)
+- [`apps/tldw-frontend/extension/routes/sidepanel-chat.tsx`](/Users/macbook-dev/Documents/GitHub/tldw_server2/apps/tldw-frontend/extension/routes/sidepanel-chat.tsx)
+
+## Goals
+
+1. Reduce background and burst traffic to `tldw_server` during normal chat usage.
+2. Reduce downstream provider-sensitive traffic caused indirectly by chat UI refresh and validation flows.
+3. Preserve fast initial interaction by rendering the chat shell before optional remote data loads.
+4. Keep WebUI and extension behavior aligned through shared request-gating policy.
+5. Make lazy-loading explicit in the UI so users understand when data has not been fetched yet.
+
+## Non-Goals
+
+1. Rebuilding the chat UI information architecture from scratch.
+2. Adding a new backend endpoint purely for this phase unless pagination/search gaps require it.
+3. Replacing existing data-fetch services wholesale.
+4. Solving unrelated backend-side rate-limit policy tuning in this design.
+
+## User Decisions Captured During Brainstorming
+
+1. Prefer a broader redesign over a minimal low-risk patch.
+2. Optimize both `tldw_server` request volume and downstream provider-triggered traffic.
+3. Accept later population of optional chat surfaces if that materially reduces request pressure.
+
+## Design Summary
+
+Use a shared chat-surface request coordinator in `apps/packages/ui` that owns fetch policy rather than fetch implementation.
+
+The coordinator is responsible for:
+
+- visibility and interaction gates
+- per-resource freshness windows and cooldowns
+- single-flight request deduplication
+- scoped last-known snapshots for optional UI
+- coalesced invalidation rules
+
+Existing feature-specific hooks and services continue to execute the actual requests. The redesign changes when they are allowed to run and how their results are reused.
+
+## Architecture
+
+Render both WebUI `/chat` and the extension chat shell in phases.
+
+### Phase 1: Interactive shell
+
+Render immediately from local state:
+
+- current transcript
+- queued drafts
+- selected model and prompt state
+- connection snapshot
+- locally persisted active conversation identity
+
+This phase must not require optional remote fetches.
+
+### Phase 2: Conversation-critical load
+
+Only the active conversation may perform immediate remote work.
+
+Use one canonical server-backed conversation loader for:
+
+- transcript messages
+- minimal conversation metadata
+- any required local mirror updates
+
+Do not allow multiple hooks or surfaces to independently fetch:
+
+- `getChat`
+- `listChatMessages`
+- persona profile
+- character profile
+
+for the same active conversation at the same time.
+
+### Phase 3: Optional panel hydration
+
+Optional surfaces fetch only after explicit user engagement:
+
+- server history sidebar
+- MCP tools/catalogs/modules
+- audio and dictation health
+- model and image catalogs
+
+Optional surfaces may render cached snapshot data first, then reconcile after the user opens them.
+
+## Request Classes
+
+The coordinator should classify request behavior into four groups.
+
+### Shell-critical
+
+- no network required
+- render from local persisted state only
+
+### Conversation-critical
+
+- active conversation transcript load
+- minimal metadata needed for the selected chat
+- abortable and single-flight
+
+### Panel-optional
+
+- sidebar history
+- MCP health, tools, catalogs, modules
+- audio health probes
+- voices catalog
+
+These must not run until the owning UI surface is explicitly engaged.
+
+### Provider-expensive
+
+- model catalog refresh
+- provider-sensitive catalog refresh paths such as OpenRouter metadata refresh
+
+These must never run implicitly on submit by default.
+
+## Server History Design
+
+Server history needs its own split design because the current UI assumes full client-side filtering.
+
+### Overview mode
+
+Use lightweight, paginated history loading for browsing conversations.
+
+Rules:
+
+- do not sweep all pages on initial mount
+- fetch only when the server-history panel is actively engaged
+- page additional results on scroll or explicit pagination
+- do not use full remote history as a passive badge-count source
+
+### Search mode
+
+Search must not rely on page-one-only client filtering.
+
+Rules:
+
+- treat search as its own explicit fetch path
+- either call a server-backed filtered result set or fetch a search-specific paginated slice
+- do not silently degrade search completeness
+
+## Desktop Sidebar Gating
+
+The desktop WebUI mounts the chat sidebar persistently in layout, so “fetch when sidebar is visible” is insufficient.
+
+History loading should be gated by all of:
+
+- route is chat-capable
+- server-history tab or panel is active
+- user has expanded, focused, or otherwise intentionally engaged the panel
+
+Acceptable triggers include:
+
+- first open of the server-history panel
+- first focus into the server-history search input
+- first scroll or click inside the panel
+
+## Conversation Hydration Rules
+
+Canonical conversation loading should be two-phase.
+
+### Phase A
+
+Load:
+
+- transcript messages
+- minimal metadata needed to render the conversation shell
+
+This phase should complete without blocking on persona or character enrichment.
+
+### Phase B
+
+Hydrate secondary details after the transcript is visible:
+
+- persona profile
+- character profile
+- enriched assistant identity UI
+
+This prevents slow profile lookups from delaying transcript render.
+
+## Model Catalog and Provider Refresh Rules
+
+Model catalogs should be cached, scoped, and advisory unless freshly confirmed.
+
+Rules:
+
+- use persisted model snapshots first
+- scope cached model data by server URL, auth mode, and user or org identity
+- do not force provider refresh on send by default
+- if the selected model is stale or uncertain, warn instead of hard-blocking
+- hard-block only on a fresh confirmed miss or a real server-side rejection
+- expose explicit `Refresh models` and `Pick another model` actions
+- protect manual refresh with cooldowns and single-flight semantics
+
+This preserves provider quota while avoiding false-negative send blocks from stale local metadata.
+
+## Optional Surface UX
+
+Lazy-loading must be explicit in the UI.
+
+Recommended states:
+
+- sidebar history: `Load conversations`
+- MCP tools: `Not checked yet`
+- voice or dictation: `Check availability`
+- model freshness issue: `Selected model may be stale or unavailable`
+
+Do not conflate:
+
+- unchecked
+- unavailable
+- unhealthy
+- rate-limited
+
+## Invalidation Rules
+
+Current chat operations should stop triggering broad history refreshes when narrow local patches are sufficient.
+
+Rules:
+
+- patch local chat history metadata after rename, topic edit, or state change
+- coalesce follow-up refreshes instead of invalidating full history repeatedly
+- sending a message must not trigger repeated full history sweeps during the same turn
+- optional panel refreshes run only when their panel is open and the tab is visible
+
+## Error Handling
+
+### Optional panel failures
+
+- keep failures local to the panel
+- 429s on optional panels must not escalate into global chat errors
+- apply cooldowns before retry
+
+### Conversation-critical failures
+
+- keep abortable single-flight semantics for chat switching
+- cancel stale loads when the user changes chats or tabs quickly
+- only surface active-load errors to the current selected conversation
+
+### Provider-expensive failures
+
+- record last attempted refresh time
+- prevent repeated submit-click bursts from triggering repeated expensive refresh flows
+- prefer user-visible recovery actions over silent retry loops
+
+## Persistence and Cache Scope
+
+All lazy snapshots must be scoped to the active environment.
+
+Minimum cache scope:
+
+- server URL
+- auth mode
+- user identity or org context where applicable
+
+Clear or ignore stale snapshots when those values change.
+
+## Testing Strategy
+
+### Unit tests
+
+- coordinator visibility gates
+- cooldown and freshness policy
+- single-flight behavior
+- snapshot scoping and invalidation
+
+### Integration tests
+
+- `/chat` initial mount does not fetch server history before panel engagement
+- `/chat` initial mount does not fetch MCP tools or catalogs before tools UI is opened
+- `/chat` initial mount does not start audio probes before voice or dictation UI is opened
+- send flow does not implicitly trigger provider refresh
+- conversation load renders transcript before persona or character enrichment completes
+- server history search still returns complete results under the new search path
+
+### Extension parity tests
+
+- sidepanel follows the same gating policy as WebUI for optional surfaces
+- sidepanel conversation switching reuses canonical single-flight load behavior
+
+### Request-budget regression tests
+
+Use resource-class and forbidden-endpoint assertions rather than brittle raw request counts.
+
+Examples:
+
+- initial chat mount must not hit `/api/v1/chats/`
+- initial chat mount must not hit `/api/v1/mcp/health`
+- initial chat mount must not hit audio health endpoints
+- initial send must not trigger provider refresh endpoints implicitly
+
+## Risks and Mitigations
+
+1. Search completeness regression under paginated history
+   - Mitigation: separate overview mode from search mode.
+2. False send blocks from stale model cache
+   - Mitigation: advisory warning by default; hard-block only on fresh negative or server rejection.
+3. Coordinator becoming a monolith
+   - Mitigation: coordinator owns policy only, not all request implementations.
+4. Cross-account or cross-server stale snapshot bleed
+   - Mitigation: strict snapshot scoping and invalidation on auth or server changes.
+5. Lazy-loading feels like broken UI
+   - Mitigation: explicit unchecked/loading states and clear manual actions.
+
+## Rollout Guidance
+
+Implement incrementally:
+
+1. Introduce coordinator and gating primitives.
+2. Move server history behind engagement gates and split browse vs search behavior.
+3. Move conversation hydration to one canonical path with two-phase enrichment.
+4. Remove implicit provider refresh from send flow.
+5. Apply the same policy to extension sidepanel parity.
+
+This ordering reduces rate-limit pressure early while keeping the refactor reversible.

--- a/Docs/Plans/2026-03-11-fish-s2-pro-tts-registry-design.md
+++ b/Docs/Plans/2026-03-11-fish-s2-pro-tts-registry-design.md
@@ -1,0 +1,417 @@
+# Fish Audio S2 Pro TTS Registry Design
+
+Date: 2026-03-11
+Status: Approved for planning
+Scope: Design only, no implementation
+
+## Overview
+
+This document describes how to add Fish Audio S2 Pro support to the tldw TTS
+registry without breaking the current adapter, voice-management, or auth
+patterns.
+
+The approved direction is:
+
+- add one canonical provider: `fish_s2`
+- support the upstream Fish HTTP server first
+- keep a future local-runtime backend as an internal design target, but not a
+  normal v1 deployment mode
+- support Fish-style managed reference workflows from day one
+
+Key upstream constraints confirmed during design:
+
+- Fish ships a native HTTP server with `POST /v1/tts`
+- managed references are handled via `/v1/references/add|list|delete`
+- the native server supports `wav`, `pcm`, and `mp3` output for non-streaming
+- native streaming is limited to `wav`
+- S2 Pro is documented as SGLang-first; the Hugging Face model card does not
+  expose hosted inference
+
+Sources:
+
+- https://github.com/fishaudio/fish-speech
+- https://speech.fish.audio/server/
+- https://huggingface.co/fishaudio/s2-pro
+- https://github.com/sgl-project/sglang-omni/blob/main/sglang_omni/models/fishaudio_s2_pro/README.md
+
+## Goals
+
+- Add Fish Audio S2 Pro to the TTS registry as a first-class provider.
+- Support generation through the existing `POST /api/v1/audio/speech` route.
+- Support managed reference creation, listing, and deletion from day one.
+- Reuse existing tldw voice storage and metadata where practical.
+- Preserve user isolation when multiple tldw users share one Fish backend.
+- Avoid claiming unsupported semantics such as non-WAV streaming.
+
+## Non-Goals
+
+- Implementing the in-process local runtime in v1.
+- Supporting arbitrary remote-only Fish references with no local tldw record.
+- Surfacing Fish managed references in the global `/api/v1/audio/voices/catalog`
+  route in v1.
+- Adding a new multi-speaker public request surface in v1.
+- Adding raw ad hoc inline `extra_params.references` audio uploads in v1.
+
+## Primary Decisions
+
+### 1. Canonical Provider
+
+Add a new provider enum and registry entry:
+
+- provider key: `fish_s2`
+- adapter class: `FishS2Adapter`
+
+Model aliases should resolve to `fish_s2`, including at least:
+
+- `fish_s2`
+- `fish-s2`
+- `fish-s2-pro`
+- `s2-pro`
+- `fishaudio/s2-pro`
+
+### 2. Backend Shape
+
+The public provider is always `fish_s2`. Internally, the adapter delegates to a
+backend strategy:
+
+- `FishS2NativeHttpBackend` in v1
+- `FishS2LocalRuntimeBackend` as a future internal extension point
+
+This keeps registry, fallback, metrics, and API routing stable while allowing a
+later local runtime without changing the external provider contract.
+
+### 3. Reference Identity
+
+In v1, the user-facing Fish `reference_id` is the local tldw `voice_id`.
+
+This is the most important design revision from review. It avoids creating a
+second public namespace or a second persistence layer. The backend-specific Fish
+reference ID becomes an internal implementation detail derived from:
+
+- `user_id`
+- `voice_id`
+
+Example internal remote ID pattern:
+
+- `tldw_u{user_id}_v{voice_id}`
+
+The exact formatting can be finalized during implementation, but it must be
+deterministic and collision-resistant.
+
+### 4. Storage Reuse
+
+Reuse existing voice metadata in `voice_manager` for Fish mappings.
+
+Store Fish state under:
+
+- `provider_artifacts["fish_s2"]`
+
+Expected fields:
+
+- `remote_reference_id`
+- `reference_text`
+- `backend`
+- `created_remote`
+- `updated_remote`
+- optional health/sync metadata
+
+No second logical-reference store should be introduced in v1.
+
+## Architecture
+
+### Adapter and Backend Components
+
+Planned components:
+
+- `tldw_Server_API/app/core/TTS/adapters/fish_s2_adapter.py`
+- `tldw_Server_API/app/core/TTS/backends/fish_s2_base.py`
+- `tldw_Server_API/app/core/TTS/backends/fish_s2_native_http.py`
+
+The adapter is responsible for:
+
+- capability reporting
+- request validation delegation
+- mapping `TTSRequest` into backend-native requests
+- consistent exception mapping
+
+The native HTTP backend is responsible for:
+
+- `GET /v1/health`
+- `POST /v1/tts`
+- `POST /v1/references/add`
+- `GET /v1/references/list`
+- `DELETE /v1/references/delete`
+- bearer auth header handling
+
+### API Integration
+
+Speech generation remains on the existing route:
+
+- `POST /api/v1/audio/speech`
+
+Fish managed reference routes are added under the audio namespace:
+
+- `POST /api/v1/audio/providers/fish_s2/references`
+- `GET /api/v1/audio/providers/fish_s2/references`
+- `DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`
+
+In v1, `reference_id` on these routes is the local `voice_id`.
+
+## Request Mapping
+
+### Speech Generation
+
+Existing request fields map as follows:
+
+- `input` -> Fish `text`
+- `response_format` -> Fish `format`
+- `stream` -> Fish `streaming`
+
+Fish-specific request controls live in `extra_params`:
+
+- `reference_id`
+- `chunk_length`
+- `normalize`
+- `seed`
+- `use_memory_cache`
+- `top_p`
+- `temperature`
+- `repetition_penalty`
+
+### Reference Selection Precedence
+
+For `model=fish_s2`, v1 resolution order is:
+
+1. `extra_params.reference_id`
+2. `voice=custom:<voice_id>`
+3. no managed reference
+
+If `extra_params.reference_id` is present, it resolves to a local `voice_id`
+owned by the current user, then loads the Fish provider artifact mapping from
+that voice metadata.
+
+If `voice=custom:<voice_id>` is present, the service resolves the stored voice
+through `voice_manager`. If a Fish remote reference already exists for that
+voice, reuse it. Otherwise, create the remote Fish reference on demand using the
+stored audio and transcript, then persist the mapping.
+
+### Optional Shorthand
+
+`voice=fishref:<id>` may be accepted as compatibility sugar, but it is not the
+primary documented contract. If implemented, `<id>` still resolves to the local
+logical `reference_id` / `voice_id`, not the backend remote ID.
+
+## Managed Reference Lifecycle
+
+### Creation
+
+`POST /api/v1/audio/providers/fish_s2/references` supports two modes:
+
+1. Existing stored voice:
+   - request supplies `voice_id`
+   - optionally allows overriding `reference_text`
+
+2. New upload:
+   - request supplies audio file plus transcript and metadata
+   - route first creates a local stored voice via existing `voice_manager`
+   - then creates the remote Fish reference for that voice
+
+This preserves one authoritative local record per managed reference.
+
+### Listing
+
+`GET /api/v1/audio/providers/fish_s2/references` should list current-user
+managed references from local metadata, not from Fish’s global backend list.
+
+This avoids cross-user leakage and keeps the local database authoritative.
+Backend sync checks may be added as best-effort status indicators, but local
+metadata remains the source of truth for listing.
+
+### Deletion
+
+`DELETE /api/v1/audio/providers/fish_s2/references/{reference_id}`:
+
+- resolves `reference_id` as a local `voice_id`
+- deletes the remote Fish reference if present
+- removes `provider_artifacts["fish_s2"]`
+- does not delete the local stored voice itself
+
+If the user wants to remove the underlying uploaded voice, they should continue
+to use the existing `/api/v1/audio/voices/{voice_id}` delete route.
+
+## Voice Catalog Behavior
+
+Fish managed references should not appear in:
+
+- `GET /api/v1/audio/voices/catalog`
+
+Reason:
+
+- that route is currently capability-driven and not user-aware
+- Fish managed references are user-scoped data, not provider-global presets
+
+`fish_s2` may still appear in provider capabilities with:
+
+- empty built-in voices
+- voice cloning support enabled
+
+## Validation
+
+### Provider-Level Validation
+
+V1 validation should be conservative and honest:
+
+- `stream=true` requires `response_format=wav` for `fish_s2`
+- `mp3` and `pcm` are allowed for non-streaming requests
+- `lang_code` is not validated as a hard provider contract in v1 because the
+  native Fish HTTP request does not take an explicit language field
+- `target_sample_rate` is ignored unless a backend later supports it explicitly
+
+Fish-specific sampling controls should be validated into upstream ranges:
+
+- `chunk_length`: 100-300
+- `top_p`: 0.1-1.0
+- `temperature`: 0.1-1.0
+- `repetition_penalty`: 0.9-2.0
+
+### Reference Audio Validation
+
+Fish reference audio should reuse the existing upload and storage pipeline
+instead of bypassing it. Add a `fish_s2` entry to `voice_manager`
+`PROVIDER_REQUIREMENTS` with conservative defaults.
+
+Recommended v1 defaults:
+
+- allowed formats: `.wav`, `.mp3`, `.flac`, `.ogg`, `.m4a`, `.opus`
+- conversion target: `wav`
+- sample rate target: `24000`
+- transcript required
+- initial duration envelope: 3-60s
+- user guidance should recommend 10-30s as the high-quality target
+
+Arbitrary raw inline `extra_params.references` payloads should be deferred from
+v1. Supporting only:
+
+- managed references via `reference_id`
+- stored voices via `custom:<voice_id>`
+
+keeps validation, quota enforcement, and user isolation much cleaner.
+
+## Capability Reporting
+
+`fish_s2` should report:
+
+- `provider_name = "Fish Audio S2"`
+- `supports_voice_cloning = true`
+- `supports_streaming = true`
+- `supported_formats = {wav, mp3, pcm}`
+- `default_format = wav`
+
+V1 should not advertise:
+
+- provider-global preset voices
+- `supports_multi_speaker = true`
+
+unless a first-class supported request surface exists for those features.
+
+## Auth and Route Policy
+
+Do not introduce a new Fish-specific privilege scope family in v1.
+
+Instead, mirror the policy posture of the existing voice-management routes:
+
+- same token-scope mode as current audio voice endpoints
+- same quota/counting category where appropriate
+
+This avoids unnecessary privilege-catalog churn and reduces startup validation
+risk while the provider is still new.
+
+## Configuration
+
+Add a `fish_s2` block to the TTS provider config:
+
+```yaml
+providers:
+  fish_s2:
+    enabled: false
+    backend: "native_http"
+    base_url: "http://127.0.0.1:8080"
+    api_key: null
+    timeout: 120
+    verify_api_key_on_init: false
+    model: "s2-pro"
+    sample_rate: 24000
+    max_text_length: 0
+    extra_params:
+      default_chunk_length: 200
+      default_normalize: true
+      default_use_memory_cache: "off"
+```
+
+Notes:
+
+- `backend=local_runtime` remains an internal future shape, not a supported
+  operator-facing mode in v1 docs
+- health verification should prefer `/v1/health`
+- bearer auth should be used when `api_key` is configured
+
+## Error Handling
+
+Map backend failures into existing TTS exceptions:
+
+- 401/403 -> `TTSAuthenticationError`
+- 400 -> `TTSValidationError`
+- 404 managed reference missing -> validation/not-found provider error
+- 429 -> `TTSRateLimitError`
+- network failure -> `TTSNetworkError`
+- timeout -> `TTSTimeoutError`
+- unsupported local backend mode in v1 -> `TTSProviderInitializationError`
+
+Managed reference routes should return user-shaped responses:
+
+- 400 invalid transcript or payload
+- 404 unknown current-user `reference_id`
+- 409 duplicate or conflicting mapping
+- 502/503 backend unavailable
+
+## Testing Plan
+
+### Unit Tests
+
+- registry resolves `fish_s2` and its model aliases
+- request mapping to Fish `/v1/tts`
+- `reference_id` resolves through local `voice_id`
+- `custom:<voice_id>` creates or reuses Fish provider artifacts correctly
+- validation rejects `stream=true` with non-`wav`
+- provider artifact persistence under `provider_artifacts["fish_s2"]`
+
+### Integration Tests
+
+- `/api/v1/audio/speech` with `model=fish_s2`
+- add/list/delete Fish managed references
+- create managed Fish reference from an existing stored voice
+- create managed Fish reference from a fresh upload
+- user A cannot list or delete user B’s Fish references
+- deleting a Fish reference does not delete the underlying local stored voice
+
+### Documentation
+
+Add a Fish S2 setup guide that documents:
+
+- starting the upstream Fish server
+- configuring `fish_s2`
+- WAV-only streaming on the native server backend
+- creating and using managed references
+- using `custom:<voice_id>` with Fish
+
+## Summary
+
+The approved v1 design is intentionally conservative:
+
+- one provider: `fish_s2`
+- one real backend: native Fish HTTP server
+- one logical reference namespace: local `voice_id`
+- one persistence path: existing `voice_manager` metadata
+
+That keeps the design aligned with upstream Fish behavior while fitting the
+current tldw TTS architecture, auth model, and user-isolated voice storage.

--- a/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
+++ b/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
@@ -221,6 +221,11 @@ That means:
   - advertise only preset-speaker `CustomVoice`, or
   - fail configuration validation rather than silently dropping Qwen-only fields
 
+Implementation note as of March 11, 2026:
+
+- the MLX runtime uses `mlx_audio.tts.utils.load_model(...)` for preset-speaker synthesis
+- the remote runtime sends Qwen extension data in `extra_body` using `ref_audio_b64`, `ref_text`, `voice_clone_prompt`, `x_vector_only_mode`, and `description`
+
 ## Configuration
 
 Avoid unnecessary config sprawl. Reuse existing generic provider fields where possible.
@@ -336,4 +341,3 @@ Document a manual Apple Silicon smoke checklist:
 - Remote mode must preserve Qwen-specific semantics or advertise a reduced capability set
 - Capability reporting must become runtime-aware
 - Health and breaker state must carry runtime identity
-

--- a/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
+++ b/Docs/Plans/2026-03-11-qwen3-tts-macos-design.md
@@ -1,0 +1,339 @@
+# Qwen3-TTS On M-Series macOS Design
+
+**Date:** 2026-03-11
+
+## Goal
+
+Add support for `qwen3_tts` on Apple Silicon macOS while preserving one public provider surface in `tldw_server`, and also support users who already run a hosted or sidecar Qwen backend and do not want a duplicate local process.
+
+## Current State
+
+The codebase already contains substantial Qwen3-TTS scaffolding:
+
+- A registered `qwen3_tts` provider in the TTS registry.
+- A `Qwen3TTSAdapter` with model routing, streaming, and voice-clone prompt handling.
+- Provider validation for Qwen-specific request shapes.
+- Voice metadata persistence for `voice_clone_prompt`.
+- Tokenizer endpoints and tests.
+
+However, the current adapter is effectively built around one backend assumption. It does not cleanly separate:
+
+- Linux/CUDA upstream `qwen_tts`
+- Apple Silicon in-process execution
+- Remote OpenAI-compatible sidecar execution
+
+It also currently advertises provider-wide capabilities that are too optimistic for a runtime-split design.
+
+## Design Constraints
+
+### Functional
+
+- Keep one public provider key: `qwen3_tts`.
+- Support three execution modes:
+  - In-process upstream runtime
+  - In-process Apple Silicon runtime
+  - Remote sidecar/hosted runtime
+- Preserve the existing `/api/v1/audio/speech` API shape for callers.
+- Preserve existing Qwen-specific behavior already implemented in the adapter and service layer.
+
+### Scope
+
+Initial Apple Silicon support is intentionally limited:
+
+- `mlx` runtime starts with preset-speaker `CustomVoice` only.
+- It does **not** initially support:
+  - Uploaded `custom:<voice_id>` voices
+  - `Base` model reference-audio cloning
+  - `VoiceDesign`
+  - tokenizer-heavy flows that depend on unavailable runtime support
+
+This wording is important. In the current codebase, uploaded custom voices flow through `Base`-style reference audio and stored prompt metadata, not through preset-speaker `CustomVoice`.
+
+### Non-Goals
+
+- No new public provider names such as `qwen3_tts_mlx`.
+- No promise of full Qwen parity on Apple Silicon in v1.
+- No fake CI claim that proves M-series runtime behavior without Apple Silicon hardware.
+
+## Research Summary
+
+- Official Qwen3-TTS upstream support exists and is current, but published examples are CUDA-oriented and recommend `flash-attn`.
+- PyTorch MPS is a valid Apple Silicon execution substrate, but that alone does not guarantee upstream Qwen runtime maturity on macOS.
+- `mlx-audio` is a practical Apple Silicon path and already exposes Qwen3-TTS models plus an OpenAI-compatible REST API.
+
+Sources:
+
+- [Qwen3-TTS README](https://github.com/QwenLM/Qwen3-TTS)
+- [MLX-Audio README](https://github.com/Blaizzy/mlx-audio)
+- [PyTorch MPS docs](https://docs.pytorch.org/docs/stable/notes/mps.html)
+
+## Recommended Approach
+
+Keep `qwen3_tts` as one logical provider and split execution behind it into runtime backends.
+
+### Why
+
+- Matches the current codebase, which already treats Qwen3-TTS as one provider with one adapter, one config block, one validation surface, and one set of voice metadata rules.
+- Avoids leaking infrastructure choices into public API/provider names.
+- Allows platform-specific truth without forcing callers to integrate against multiple providers.
+
+## Architecture
+
+### Public Surface
+
+The following remain stable:
+
+- Provider key: `qwen3_tts`
+- Registry entry and model family
+- Audio API endpoints
+- Existing voice metadata persistence behavior
+
+### Internal Structure
+
+Refactor the current `Qwen3TTSAdapter` into:
+
+- An orchestration layer that stays responsible for:
+  - request normalization
+  - model aliasing
+  - mode selection
+  - custom voice metadata resolution
+  - Qwen-specific validation hooks
+  - service-compatible `TTSResponse` generation
+- Runtime backends that handle actual execution:
+  - `UpstreamQwenRuntime`
+  - `MlxQwenRuntime`
+  - `RemoteQwenRuntime`
+
+### Runtime Responsibilities
+
+#### `UpstreamQwenRuntime`
+
+- In-process runtime for `qwen_tts`
+- Preferred on Linux/CUDA and any explicitly forced upstream environment
+- Can continue to support the broader Qwen feature set where proven
+
+#### `MlxQwenRuntime`
+
+- In-process Apple Silicon runtime
+- Preferred by `runtime=auto` on `Darwin + arm64`
+- Initial support is intentionally limited to preset-speaker `CustomVoice`
+- Must reject unsupported modes with structured validation errors
+
+#### `RemoteQwenRuntime`
+
+- Used when the user points `qwen3_tts` at an already-hosted backend
+- Keeps the public provider name unchanged
+- Must preserve Qwen-specific semantics rather than silently collapsing to generic OpenAI TTS
+
+## Runtime Selection
+
+Add a provider-level runtime selector under `providers.qwen3_tts`:
+
+- `runtime: auto | upstream | mlx | remote`
+
+Selection rules:
+
+- `auto` on macOS arm64 prefers `mlx`
+- `auto` on Linux/CUDA prefers `upstream`
+- `auto` never silently chooses `remote` unless remote connectivity is explicitly configured
+- Explicit runtime selection always wins
+
+This avoids accidentally choosing an importable but less-stable upstream runtime on Apple Silicon.
+
+## Capability Model
+
+The current capability booleans are too coarse for this feature. The design should retain the existing `TTSCapabilities` envelope but extend the serialized payload for Qwen with runtime-aware metadata.
+
+### Required Capability Fields
+
+Existing fields remain, but Qwen capability serialization should also include:
+
+- `runtime`
+- `supported_modes`
+  - `custom_voice_preset`
+  - `base_clone`
+  - `voice_design`
+- `supports_uploaded_custom_voices`
+- `supports_qwen_voice_clone_prompt`
+- `runtime_notes`
+
+### Initial Runtime Truth Table
+
+#### `upstream`
+
+- `custom_voice_preset`: supported
+- `base_clone`: supported when upstream backend supports it
+- `voice_design`: supported when upstream backend supports it
+- `supports_uploaded_custom_voices`: true via existing `custom:<voice_id>` flow
+
+#### `mlx`
+
+- `custom_voice_preset`: supported
+- `base_clone`: unsupported in v1
+- `voice_design`: unsupported in v1
+- `supports_uploaded_custom_voices`: false in v1
+
+#### `remote`
+
+- Capability truth depends on the remote backend
+- If the remote backend cannot report capabilities, default to conservative values and do not over-advertise support
+
+## Request And Data Flow
+
+### Normal Flow
+
+1. API receives `OpenAISpeechRequest`
+2. `TTSServiceV2` resolves provider `qwen3_tts`
+3. `Qwen3TTSAdapter`:
+   - normalizes request
+   - resolves model/mode
+   - resolves stored voice metadata
+   - selects runtime
+4. Selected runtime validates mode support
+5. Runtime produces PCM or a stream
+6. Existing TTS service logic handles format conversion, history, and persistence
+
+### Uploaded Custom Voice Behavior
+
+Existing `custom:<voice_id>` semantics stay intact for supported runtimes. For `mlx`:
+
+- do not silently degrade uploaded voices into preset speakers
+- fail early with a structured validation error explaining that uploaded custom voices are not supported by the selected runtime
+
+## Remote Runtime Contract
+
+This needs to be explicit. A generic OpenAI-compatible `/audio/speech` request is not sufficient for full Qwen behavior because Qwen clone flows need fields such as:
+
+- `ref_audio`
+- `ref_text`
+- `x_vector_only_mode`
+- `voice_clone_prompt`
+
+### v1 Remote Contract
+
+`RemoteQwenRuntime` must target a **Qwen-extended OpenAI-compatible** backend contract, not a plain generic TTS endpoint.
+
+That means:
+
+- standard OpenAI TTS fields are still used where applicable
+- Qwen-specific fields are passed through using documented request extensions
+- if the remote backend does not support the Qwen extension contract, remote mode must either:
+  - advertise only preset-speaker `CustomVoice`, or
+  - fail configuration validation rather than silently dropping Qwen-only fields
+
+## Configuration
+
+Avoid unnecessary config sprawl. Reuse existing generic provider fields where possible.
+
+### Additions Under `providers.qwen3_tts`
+
+- `runtime`
+- `base_url`
+- `api_key`
+- `mlx_model`
+- `mlx_model_path`
+- `capability_override` only if needed for remote truthing
+
+### Do Not Add Unless Proven Necessary
+
+- separate `remote_base_url`
+- separate `remote_api_key`
+- a nested runtime matrix config
+
+The current provider config model already supports generic `base_url` and `api_key`, and remote mode should reuse that surface.
+
+## Error Handling
+
+Error behavior must distinguish configuration errors, unsupported-mode errors, and runtime failures.
+
+### Expected Cases
+
+- `runtime=mlx` on non-macOS arm64:
+  - provider initialization error with explicit platform message
+- `runtime=upstream` without `qwen_tts` installed:
+  - provider initialization error naming missing dependency
+- `runtime=remote` without usable `base_url`:
+  - provider configuration error
+- `runtime=mlx` with `Base` or `VoiceDesign`:
+  - structured validation error
+- `runtime=mlx` with `voice="custom:<id>"`:
+  - structured validation error explaining uploaded custom voices are unsupported on MLX in v1
+- `runtime=auto` with no viable backend:
+  - initialization error describing which runtimes were attempted
+
+## Health, Metrics, And Circuit Breakers
+
+Public provider identity remains `qwen3_tts`, but operational state must include runtime identity.
+
+### Required Improvement
+
+Namespace runtime-specific operational metadata as:
+
+- `qwen3_tts:upstream`
+- `qwen3_tts:mlx`
+- `qwen3_tts:remote`
+
+This applies to:
+
+- health detail envelopes
+- circuit breaker state
+- runtime-specific metrics/log context
+
+Without this, one failing runtime path can pollute provider-wide state and make debugging misleading.
+
+## Testing Strategy
+
+### Unit Tests
+
+- runtime selection for:
+  - macOS arm64 auto
+  - Linux/CUDA auto
+  - explicit upstream
+  - explicit mlx
+  - explicit remote
+- capability gating for each runtime
+- rejection of unsupported MLX modes
+- rejection of uploaded custom voices on MLX
+- remote request translation of Qwen-specific extension fields
+
+### Integration Tests
+
+- fake upstream backend
+- fake MLX backend
+- fake remote backend
+- provider-level API behavior remains stable for `qwen3_tts`
+- capability payload exposes truthful runtime metadata
+
+### Manual Verification
+
+Document a manual Apple Silicon smoke checklist:
+
+- install/runtime prerequisites
+- minimal preset-speaker request
+- streaming request
+- provider health inspection
+- failure behavior for unsupported `Base` and `VoiceDesign`
+
+## Migration Notes
+
+- No caller-facing provider rename
+- Existing `qwen3_tts` requests remain valid
+- Existing uploaded custom voice flows continue to work only on runtimes that actually support them
+- Capability output becomes more precise, which may slightly change UI/provider-catalog behavior in a good way
+
+## Risks
+
+- The largest product risk is confusing “preset-speaker CustomVoice” with uploaded user voices
+- The largest technical risk is under-defining the remote Qwen extension contract
+- The largest operations risk is failing to namespace runtime-level breaker and health state
+
+## Design Decision Summary
+
+- One provider key: `qwen3_tts`
+- Multiple internal runtimes: `upstream`, `mlx`, `remote`
+- `auto` prefers MLX on Apple Silicon
+- MLX v1 scope is preset-speaker `CustomVoice` only
+- Remote mode must preserve Qwen-specific semantics or advertise a reduced capability set
+- Capability reporting must become runtime-aware
+- Health and breaker state must carry runtime identity
+

--- a/Docs/Plans/2026-03-11-tts-route-speech-playground-design.md
+++ b/Docs/Plans/2026-03-11-tts-route-speech-playground-design.md
@@ -1,0 +1,156 @@
+# `/tts` Route Reuse of Speech Playground Design
+
+**Date:** 2026-03-11
+**Status:** Approved
+**Scope:** Reuse the redesigned Speech Playground for the `/tts` route in both the web UI and extension route layer, without changing `/speech` behavior.
+
+---
+
+## Problem
+
+The current `/tts` route still renders the legacy dedicated `TtsPlaygroundPage`, while the recent TTS redesign work landed in `SpeechPlaygroundPage`.
+
+This causes a visible mismatch:
+
+- `/tts` shows the older UI
+- `/speech` contains the new TTS experience
+- users expect `/tts` to be the dedicated entrypoint into the new TTS UI
+
+The route/component split is currently:
+
+- `apps/packages/ui/src/routes/option-tts.tsx` -> `TtsPlaygroundPage`
+- `apps/packages/ui/src/routes/option-speech.tsx` -> `SpeechPlaygroundPage`
+- `apps/tldw-frontend/pages/tts.tsx` -> shared `@/routes/option-tts`
+
+---
+
+## Decision
+
+`/tts` should reuse `SpeechPlaygroundPage`, but as a dedicated TTS entrypoint rather than a loose alias.
+
+The route must open the shared Speech Playground in TTS-only mode and keep route identity clear. The route should not drift into STT or Round-trip behavior under the `/tts` URL just because the shared page remembers a previous mode.
+
+---
+
+## Architecture
+
+### Route mapping
+
+- Change `apps/packages/ui/src/routes/option-tts.tsx` to render `SpeechPlaygroundPage`
+- Keep `apps/packages/ui/src/routes/option-speech.tsx` rendering the same shared page in unlocked mode
+- Leave `apps/tldw-frontend/pages/tts.tsx` and the extension options entrypoint unchanged, since they already consume the shared route layer
+
+### Source of truth
+
+`SpeechPlaygroundPage` becomes the single active implementation for the redesigned TTS surface.
+
+The old `TtsPlaygroundPage` remains in the tree for now, but is no longer used by `/tts`. Cleanup or deletion is a follow-up task, not part of this route swap.
+
+---
+
+## Route And State Behavior
+
+### Current enum nuance
+
+In the current `SpeechPlaygroundPage` implementation, the mode values do not map to plain-English names:
+
+- `listen` = TTS-only surface
+- `speak` = STT-only surface
+- `roundtrip` = combined Speech Playground
+
+That existing enum should be respected by the route integration unless it is intentionally renamed in a separate refactor.
+
+### Desired behavior
+
+- `/tts` passes a route-level TTS intent into `SpeechPlaygroundPage`
+- that route-level intent maps to the existing `listen` mode
+- `/speech` remains the unlocked route that uses remembered mode state
+- `/tts` must not overwrite the shared remembered mode just by loading
+
+### Locked route semantics
+
+When the page is rendered by `/tts`:
+
+- route-locked TTS mode takes precedence over persisted `speechPlaygroundMode`
+- the top mode selector is hidden
+- attempts to switch into non-TTS modes are ignored by the page
+
+This preserves clean route meaning:
+
+- `/speech` = multi-mode Speech Playground
+- `/tts` = dedicated TTS entry into the same redesigned UI
+
+---
+
+## Component Contract
+
+`SpeechPlaygroundPage` should gain an explicit route-aware prop contract instead of overloading `initialMode`.
+
+Recommended props:
+
+- `lockedMode?: SpeechMode`
+- `hideModeSwitcher?: boolean`
+
+Behavior:
+
+- `/tts` passes `lockedMode="listen"` and `hideModeSwitcher`
+- `/speech` passes neither prop and keeps current unlocked behavior
+
+This separates two concerns cleanly:
+
+- `initialMode` means default selection behavior
+- `lockedMode` means route-enforced behavior
+
+---
+
+## Error Handling And UX Safeguards
+
+- Deep-linking to `/tts` must always land in the redesigned TTS surface, even if local storage previously remembered STT or Round-trip
+- Missing or invalid stored mode must not break `/tts`, because the locked route prop wins
+- If future code tries to call `setMode` while route-locked, the page should stay in the locked mode
+- `/speech` must still expose the mode switcher and remembered-mode behavior exactly as today
+
+---
+
+## Testing Strategy
+
+### Route identity coverage
+
+Update `apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx` to verify:
+
+- `/tts` renders `SpeechPlaygroundPage`
+- `/tts` no longer renders `TtsPlaygroundPage`
+- `/speech` still renders the shared Speech Playground in unlocked mode
+- `/stt` remains unchanged unless intentionally refactored separately
+
+### Speech page coverage
+
+Update `apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx` to verify:
+
+- locked TTS mode hides the mode switcher
+- locked TTS mode suppresses non-TTS regions
+- unlocked mode still renders the normal mode selector
+
+### Regression boundary
+
+No change is required for the Next.js `/tts` page shim unless route-level tests reveal a break in the shared route import.
+
+---
+
+## Non-Goals
+
+- deleting `TtsPlaygroundPage`
+- refactoring `/stt` to use `SpeechPlaygroundPage`
+- renaming the `listen` / `speak` enum values
+- redesigning the `/speech` route
+
+---
+
+## Expected Outcome
+
+After implementation:
+
+- opening `/tts` shows the new Speech Playground TTS UI
+- `/speech` still behaves as the multi-mode page
+- route identity remains explicit and unsurprising
+- extension and web UI both inherit the same fix through the shared route layer

--- a/Docs/Plans/2026-03-11-tts-route-speech-playground-implementation-plan.md
+++ b/Docs/Plans/2026-03-11-tts-route-speech-playground-implementation-plan.md
@@ -1,0 +1,219 @@
+# `/tts` Speech Playground Reuse Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `/tts` reuse the redesigned `SpeechPlaygroundPage` in TTS-only mode instead of rendering the legacy `TtsPlaygroundPage`.
+
+**Architecture:** Repoint the shared `/tts` route to `SpeechPlaygroundPage`, then add an explicit locked-mode contract so the shared page can behave as a dedicated TTS entrypoint without mutating or depending on the remembered multi-mode state used by `/speech`. Keep `/speech` unchanged and leave `TtsPlaygroundPage` in place as an unused follow-up cleanup candidate.
+
+**Tech Stack:** React, TypeScript, React Router shared route layer, Next.js dynamic page shim, Vitest, Testing Library
+
+---
+
+### Task 1: Rewire The `/tts` Route To The Shared Speech Playground
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/option-tts.tsx:1-12`
+- Modify: `apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx:21-62`
+- Reference: `apps/packages/ui/src/routes/option-speech.tsx:1-12`
+- Reference: `apps/tldw-frontend/pages/tts.tsx:1-3`
+
+**Step 1: Write the failing test**
+
+Update the route identity test so `/tts` expects the shared speech page instead of the legacy TTS page. Extend the mock to surface route-lock props.
+
+```tsx
+vi.mock("@/components/Option/Speech/SpeechPlaygroundPage", () => ({
+  __esModule: true,
+  default: ({
+    initialMode,
+    lockedMode,
+    hideModeSwitcher,
+  }: {
+    initialMode?: string
+    lockedMode?: string
+    hideModeSwitcher?: boolean
+  }) => (
+    <div
+      data-testid="speech-playground"
+      data-mode={initialMode ?? "roundtrip"}
+      data-locked-mode={lockedMode ?? ""}
+      data-hide-mode-switcher={hideModeSwitcher ? "true" : "false"}
+    >
+      Speech
+    </div>
+  ),
+}))
+
+it("routes /tts into the shared speech playground locked to TTS mode", () => {
+  render(<OptionTts />)
+  const speech = screen.getByTestId("speech-playground")
+  expect(speech).toHaveAttribute("data-locked-mode", "listen")
+  expect(speech).toHaveAttribute("data-hide-mode-switcher", "true")
+  expect(screen.queryByTestId("tts-playground")).not.toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx`
+
+Expected: FAIL because `OptionTts` still renders `TtsPlaygroundPage`.
+
+**Step 3: Write minimal implementation**
+
+Replace the legacy import in `option-tts.tsx` with the shared page and pass the locked-mode props.
+
+```tsx
+import OptionLayout from "~/components/Layouts/Layout"
+import SpeechPlaygroundPage from "@/components/Option/Speech/SpeechPlaygroundPage"
+
+const OptionTts = () => {
+  return (
+    <OptionLayout>
+      <SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />
+    </OptionLayout>
+  )
+}
+```
+
+Do not change `apps/tldw-frontend/pages/tts.tsx`; it should continue importing the shared route module.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bunx vitest run apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx`
+
+Expected: PASS, with `/tts` now mapped to the shared speech playground and `/speech` still mapped to the unlocked route.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/routes/option-tts.tsx apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx
+git commit -m "refactor(ui): route /tts through shared speech playground"
+```
+
+### Task 2: Add Locked-Mode Support To `SpeechPlaygroundPage`
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx:201-227`
+- Modify: `apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx:1964-2230`
+- Modify: `apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx:258-273`
+
+**Step 1: Write the failing tests**
+
+Add render coverage for both locked and unlocked behavior.
+
+```tsx
+it("hides the mode switcher and STT region when locked to listen mode", () => {
+  render(<SpeechPlaygroundPage lockedMode="listen" hideModeSwitcher />)
+
+  expect(screen.queryByText("Mode")).not.toBeInTheDocument()
+  expect(screen.queryByText("Current transcription model")).not.toBeInTheDocument()
+  expect(screen.getByTestId("tts-provider-strip")).toBeInTheDocument()
+})
+
+it("keeps the mode switcher visible when unlocked", () => {
+  render(<SpeechPlaygroundPage />)
+
+  expect(screen.getByText("Mode")).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx`
+
+Expected: FAIL because `SpeechPlaygroundPage` does not yet accept `lockedMode` or hide the segmented mode picker.
+
+**Step 3: Write minimal implementation**
+
+Add explicit locked-mode props and derive a route-safe effective mode.
+
+```tsx
+type SpeechPlaygroundPageProps = {
+  initialMode?: SpeechMode
+  lockedMode?: SpeechMode
+  hideModeSwitcher?: boolean
+}
+
+const effectiveMode = lockedMode ?? mode
+
+React.useEffect(() => {
+  if (lockedMode) return
+  if (initialMode && mode !== initialMode) {
+    setMode(initialMode)
+  }
+}, [initialMode, lockedMode, mode, setMode])
+
+const handleModeChange = (value: SpeechMode) => {
+  if (lockedMode) return
+  setMode(value)
+}
+```
+
+Use `effectiveMode` instead of `mode` for conditional rendering:
+
+- hide the segmented selector when `hideModeSwitcher` is true
+- gate the STT card with `effectiveMode !== "listen"`
+- gate the TTS card with `effectiveMode !== "speak"`
+
+Do not rename the existing enum values in this task.
+
+**Step 4: Run test to verify it passes**
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx`
+
+Expected: PASS, with `/tts`-style locked rendering suppressing the mode switcher and STT region while unlocked `/speech` still shows the selector.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+git commit -m "feat(ui): support route-locked speech playground mode"
+```
+
+### Task 3: Verify The Shared Entry Point And Guard Against Regressions
+
+**Files:**
+- Verify: `apps/packages/ui/src/routes/option-tts.tsx`
+- Verify: `apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx`
+- Verify: `apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx`
+- Verify: `apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx`
+- Reference only: `apps/tldw-frontend/pages/tts.tsx`
+
+**Step 1: Run the focused route and render suites together**
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx \
+  apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+```
+
+Expected: PASS for both files.
+
+**Step 2: Inspect the working tree**
+
+Run: `git diff -- apps/packages/ui/src/routes/option-tts.tsx apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx`
+
+Expected: only the route reuse, locked-mode logic, and matching tests.
+
+**Step 3: Optional smoke check**
+
+If a local frontend runner is already available, open `/tts` and confirm:
+
+- the new Speech Playground TTS UI is visible
+- the mode switcher is hidden on `/tts`
+- `/speech` still shows the mode switcher
+
+If no runner is available, record that the change was verified by tests only.
+
+**Step 4: Final commit**
+
+```bash
+git add apps/packages/ui/src/routes/option-tts.tsx apps/packages/ui/src/components/Option/Speech/SpeechPlaygroundPage.tsx apps/packages/ui/src/routes/__tests__/option-audio-route-identity.test.tsx apps/packages/ui/src/components/Option/Speech/__tests__/SpeechPlaygroundPage.render.test.tsx
+git commit -m "test(ui): lock /tts onto redesigned speech playground"
+```
+
+**Step 5: Completion note**
+
+Document in the implementation summary that `TtsPlaygroundPage` is intentionally left in place as an unused follow-up cleanup candidate.

--- a/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md
+++ b/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md
@@ -1,0 +1,481 @@
+# Workflows Diagnostics and Improvements Design
+
+Date: 2026-03-11
+Status: Approved
+
+## Summary
+
+Improve the Workflows module with equal weight for workflow authors, operators, and API consumers, while making failed-run diagnosis the first vertical slice. The current runtime already persists substantial execution state, but troubleshooting is still exposed as low-level events, logs, and DB-oriented runbook steps rather than a coherent diagnostics model.
+
+The recommended design adds a structured diagnostics layer on top of the existing run/event/artifact ledger. It introduces explicit step replay capabilities, separates logical step runs from per-attempt retry records, defines a layered failure taxonomy, and exposes a first-class run investigation API plus shared run-inspection UI. The first milestone should also add server-authoritative preflight validation so author-time failures move earlier in the lifecycle.
+
+## Investigated Context
+
+- Runtime and state management already exist in:
+  - `tldw_Server_API/app/core/Workflows/engine.py`
+  - `tldw_Server_API/app/core/DB_Management/Workflows_DB.py`
+- Public API already exposes run summaries, events, artifacts, control, approvals, and DLQ endpoints:
+  - `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+  - `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Existing operational and design docs are present, but they are still largely raw and operator-oriented:
+  - `Docs/Operations/Workflows_Debugging.md`
+  - `Docs/Operations/Workflows_Runbook.md`
+  - `Docs/Design/Workflows.md`
+- Existing workflow editor execution UX is not yet a real server-backed run inspector:
+  - `apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx`
+  - `apps/packages/ui/src/store/workflow-editor.ts`
+
+## User-Confirmed Scope
+
+1. Review the Workflows module and brainstorm improvements with equal weight for authors, operators, and API users.
+2. Prioritize failed-run diagnostics as the first vertical slice.
+3. Allow additive API/schema/model changes and, if necessary, larger model changes.
+4. Pressure-test the design before freezing it, then incorporate revisions.
+
+## Problem Statement
+
+The module has meaningful runtime depth but a weak diagnostics experience.
+
+- Execution evidence is fragmented across `workflow_runs`, `workflow_step_runs`, `workflow_events`, artifacts, logs, and DLQ rows.
+- Retry history is collapsed into mutable step-run state rather than modeled as a first-class attempt ledger.
+- Failure semantics are not authoritative; reason codes, retryability, and remediation hints are inferred inconsistently from free-text errors and event payloads.
+- The primary troubleshooting path is still raw event polling, debug env flags, and DB inspection.
+- The current editor execution UI is local/mock, so there is no shared product-grade run inspector for authors or operators.
+
+## Goals
+
+- Add a coherent failed-run investigation model that answers:
+  - what failed
+  - why it failed
+  - what evidence exists
+  - what next action is safe
+- Keep equal value for three audiences:
+  - workflow authors in the WebUI
+  - operators debugging production runs
+  - API clients automating runs externally
+- Make preflight validation authoritative and server-backed.
+- Preserve existing execution primitives where practical, rather than rewriting the entire engine.
+- Keep the first rollout additive and backward-compatible where possible.
+
+## Non-Goals
+
+- Full orchestration engine redesign for distributed workers or general DAG execution.
+- Replacing the raw event ledger with a diagnostics-only model.
+- Shipping an editor-only diagnostics surface.
+- Persisting unrestricted raw internal exceptions, secrets, or large payload copies as diagnostics.
+
+## Approaches Considered
+
+### 1. Diagnostics Facade Over Existing Surfaces
+
+Add a single aggregated debug endpoint and a lightweight UI that composes existing run, event, and artifact data without deeper data-model changes.
+
+Pros:
+- Fastest path.
+- Lowest migration risk.
+
+Cons:
+- Keeps failure meaning implicit.
+- Leaves retry/attempt history underspecified.
+- Produces a brittle diagnostics layer that still depends on parsing raw events and error strings.
+
+### 2. Structured Diagnostics Layer Beside the Current Runtime
+
+Keep the current run/event/artifact ledger as the source of truth, but add explicit attempt records, failure taxonomy, replay capability metadata, and a first-class investigation API and UI.
+
+Pros:
+- Solves the actual user problem instead of only improving visibility.
+- Reuses most existing runtime behavior.
+- Supports all three audiences with one coherent interpretation layer.
+
+Cons:
+- Requires schema, API, and UI work.
+- Requires careful projection/versioning rules to avoid drift.
+
+### 3. Full Execution Model Redesign
+
+Replace the current model with a more opinionated orchestration plane centered on explicit graph execution, attempts, compensation, and richer lifecycle rules.
+
+Pros:
+- Cleanest long-term architecture.
+
+Cons:
+- Too large for the immediate diagnostics problem.
+- High migration and delivery risk.
+
+## Recommended Approach
+
+Use Approach 2: a structured diagnostics layer beside the current runtime.
+
+This yields the best balance between delivery risk and long-term value. The current engine and persistence model already provide enough operational signal to support a better diagnostics system, but the interpretation layer is missing. The proposed work should refine the existing runtime into a coherent run-investigation product rather than replace it outright.
+
+## Architecture
+
+### 1. Raw Execution Ledger Remains the Source of Truth
+
+Retain the current raw execution entities as authoritative records:
+
+- `workflow_runs`
+- `workflow_step_runs`
+- `workflow_events`
+- `workflow_artifacts`
+- `workflow_webhook_dlq`
+
+These tables remain the execution ledger used for control flow, auditing, and low-level troubleshooting.
+
+### 2. Separate Logical Step Runs From Step Attempts
+
+Current step retries mutate a single `workflow_step_runs.attempt` value in place. That is acceptable for runtime flow control but insufficient for diagnosis.
+
+The revised model should be:
+
+- `workflow_step_runs`
+  - one logical step execution record per step occurrence within a run
+  - stable anchor for routing, approvals, and human-in-the-loop semantics
+- `workflow_step_attempts`
+  - one child row per actual attempt or retry
+  - authoritative ledger for retry history, per-attempt status, timing, evidence, and failure semantics
+
+This split is required to avoid ambiguity in:
+
+- retry-from-step behavior
+- approval and reject flows
+- timeout and retry analysis
+- per-attempt evidence capture
+
+### 3. Add Explicit Replay and Idempotency Capabilities Per Step Type
+
+Safe reruns cannot be inferred from reason code alone. Each step type must declare a small capability contract:
+
+- `replay_safe`
+- `idempotency_strategy`
+- `compensation_supported`
+- `requires_human_review_for_rerun`
+- `evidence_level`
+
+Default behavior for unknown or side-effecting steps is `unsafe`.
+
+Examples:
+
+- `prompt`, `rag_search`, and pure transforms may be replay-safe when inputs are unchanged.
+- `webhook`, `notify`, `mcp_tool`, `kanban`, and ingestion-like steps should default to unsafe or conditional unless explicit idempotency guarantees exist.
+
+### 4. Add a Derived Run Investigation Read Model
+
+Expose a first-class `run investigation` surface that answers the main user questions without replacing the raw ledger.
+
+The investigation model should be computed on demand or stored as a projection with explicit versioning:
+
+- `schema_version`
+- `derived_from_event_seq`
+- `generated_at`
+- stale/rebuild semantics
+
+If projection generation fails, the raw run, attempts, events, and artifacts must remain available.
+
+## Data Model
+
+### `workflow_step_attempts`
+
+Representative fields:
+
+- `attempt_id`
+- `tenant_id`
+- `run_id`
+- `step_run_id`
+- `step_id`
+- `attempt_number`
+- `status`
+- `started_at`
+- `ended_at`
+- `duration_ms`
+- `reason_code_core`
+- `reason_code_detail`
+- `category`
+- `blame_scope`
+- `retryable`
+- `retry_recommendation`
+- `error_summary`
+- `error_detail_redacted`
+- `provider_name`
+- `provider_request_id`
+- `workdir`
+- `stdout_path`
+- `stderr_path`
+- `metadata_json`
+
+### `workflow_run_investigations` (optional materialized projection)
+
+Representative fields:
+
+- `run_id`
+- `schema_version`
+- `derived_from_event_seq`
+- `generated_at`
+- `primary_failure_json`
+- `failed_step_json`
+- `evidence_refs_json`
+- `recommended_actions_json`
+- `stale`
+
+If the projection is materialized, rebuild tooling and migration/version checks are mandatory.
+
+## Failure Semantics
+
+### Layered Taxonomy
+
+Use layered failure semantics instead of a single flat canonical list:
+
+- `reason_code_core`
+  - stable top-level code such as `validation_error`, `policy_blocked`, `provider_timeout`, `runtime_error`
+- `reason_code_detail`
+  - narrower adapter-specific detail such as `template_render_error`, `webhook_blocked_private_ip`, `llm_provider_429`
+- `category`
+  - `user_config`, `external_dependency`, `policy`, `runtime`, `platform`
+- `blame_scope`
+  - `workflow_definition`, `run_input`, `provider`, `system`, `operator_action`
+- `retryable`
+  - boolean
+- `retry_recommendation`
+  - `safe`, `unsafe`, `requires_input_change`, `requires_operator_review`
+
+### Audience-Safe Explanations
+
+Every failed or blocked attempt should support:
+
+- `user_message`
+  - concise, safe explanation for authors and ordinary API callers
+- `operator_message`
+  - more precise remediation-oriented explanation
+- `internal_detail`
+  - privileged raw exception or deep context, if retained at all
+- `suggested_actions`
+  - structured next steps such as `fix_input`, `change_timeout`, `retry_from_step`, `replay_webhook`, `contact_operator`
+
+## Evidence Capture
+
+Evidence must be structured, bounded, and redacted by default.
+
+### Evidence Refs
+
+Prefer typed references and excerpts over duplicating full payloads:
+
+- event refs
+  - exact `event_seq` values
+- attempt refs
+  - specific failed attempt ids
+- artifact refs
+  - stdout, stderr, output, logs, manifests
+- config refs
+  - validation error output, schema path, step config hash or bounded snapshot
+- external refs
+  - provider request id, webhook delivery code, approval record, policy decision id
+
+### Retention and Redaction Rules
+
+Do not persist unrestricted rendered prompts, provider payloads, or secrets in diagnostics records.
+
+The design must include:
+
+- bounded excerpts for stdout/stderr
+- redaction of known secret-bearing fields
+- restricted access to raw deep detail
+- explicit retention windows for per-attempt diagnostics
+
+## API Surface
+
+Retain existing low-level APIs, but add investigation-oriented endpoints:
+
+- `GET /api/v1/workflows/runs/{run_id}/investigation`
+- `GET /api/v1/workflows/runs/{run_id}/steps`
+- `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts`
+- `POST /api/v1/workflows/preflight`
+
+Existing APIs such as:
+
+- `GET /runs/{run_id}`
+- `GET /runs/{run_id}/events`
+- `GET /runs/{run_id}/artifacts`
+- `POST /runs/{run_id}/retry`
+- approval/reject endpoints
+
+remain available as the raw or control surfaces.
+
+### Auth Model
+
+Diagnostic detail must be layered by authorization.
+
+- Base response:
+  - safe summaries, stable reason codes, bounded evidence metadata
+- Elevated operator/admin response:
+  - richer remediation detail, excerpts, provider correlation ids where appropriate
+- Privileged internal detail:
+  - tightly restricted, redacted, and ideally separated from ordinary responses
+
+Do not rely solely on endpoint-level owner/admin gating without field-level response design.
+
+## User Surfaces
+
+### Shared Run Inspector
+
+The first diagnostics UI must be a shared run inspector, not an editor-only feature.
+
+It should include:
+
+- failure summary card
+- step graph or ordered step list with failed node highlighted
+- attempt timeline
+- evidence tabs
+  - logs
+  - artifacts
+  - webhook deliveries
+  - approvals
+- next-action panel
+  - retry
+  - retry from step
+  - inspect config
+  - operator escalation
+
+This shared inspector can then be embedded or linked from the workflow editor.
+
+### Workflow Editor Integration
+
+The editor should not own the diagnostics model. Instead, it should:
+
+- link to the shared run inspector for real runs
+- highlight failed nodes using investigation data
+- show preflight warnings before execution
+
+### Runs Index Improvements
+
+Add run filtering and triage based on structured diagnostics fields:
+
+- `reason_code_core`
+- `category`
+- `blame_scope`
+- `retryable`
+- `workflow_id`
+- `provider_name`
+- stuck age
+
+These filters require explicit denormalization and indexes rather than expensive event scans.
+
+## Preflight Validation
+
+Preflight must be server-authoritative.
+
+Do not implement client-only preflight logic as the main source of truth.
+
+The preflight endpoint should reuse server-side:
+
+- definition schema validation
+- DAG and routing validation
+- template/input resolution where possible
+- capability-based replay/rerun warnings
+- environment and step-compatibility warnings
+
+The UI may still provide immediate local hints, but only the server decides what is valid or dangerous.
+
+## Operational Improvements
+
+The first rollout should also make operations more coherent:
+
+- reason-code-aware dashboards and alerts
+- better stuck-run and retry-exhaustion reporting
+- DLQ and approval evidence linked from the run inspector
+- docs rewritten around investigation flows instead of raw DB spelunking as the default path
+
+## Rollout Plan
+
+### Phase 1: Capability and Attempt Foundation
+
+- Introduce per-step replay/idempotency capability metadata.
+- Add `workflow_step_attempts` and migrations.
+- Preserve current control flow while dual-writing attempt information.
+
+### Phase 2: Failure Taxonomy and Investigation API
+
+- Emit layered failure semantics from engine and adapters.
+- Add investigation service and APIs.
+- Add denormalized fields and indexes needed for triage.
+
+### Phase 3: Shared Run Inspector and Preflight
+
+- Build a shared run inspector UI and data client.
+- Integrate it into the workflow editor.
+- Add server-authoritative preflight UX.
+
+### Phase 4: Docs and Operational Hardening
+
+- Update runbook and debugging docs.
+- Update alerts and dashboards to use reason codes and retryability classes.
+
+## Risks and Mitigations
+
+### Risk: Projection Drift
+
+Mitigation:
+- treat investigation as a derived read model
+- include `schema_version` and `derived_from_event_seq`
+- support rebuild and stale detection
+
+### Risk: Retry Safety Misclassification
+
+Mitigation:
+- do not infer replay safety from reason code alone
+- require explicit step capability declarations
+- default to unsafe
+
+### Risk: Secret Leakage
+
+Mitigation:
+- store evidence refs and excerpts
+- redact known sensitive fields
+- restrict raw internal detail
+- define retention windows
+
+### Risk: UI Built Before Authoritative Data Contract
+
+Mitigation:
+- build investigation API and auth model before editor integration
+- make the shared run inspector the first real UI consumer
+
+## Testing Strategy
+
+### Unit Tests
+
+- step capability contract evaluation
+- attempt record creation and status transitions
+- failure envelope normalization
+- investigation summary generation
+- replay-safety decisioning
+
+### Integration Tests
+
+- failed run produces attempt rows and investigation summary
+- approval/reject flows still anchor correctly on logical step runs
+- retry-from-step respects step replay capabilities
+- preflight returns validation errors and warnings consistent with runtime behavior
+- field-level auth and redaction rules are enforced
+
+### UI Tests
+
+- shared run inspector renders failed-run summary and attempts
+- workflow editor links to or embeds the shared inspector
+- preflight warnings render deterministically
+
+### Operational Verification
+
+- alerts pivot on reason-code-aware metrics
+- debugging docs reflect investigation-first workflows
+- indexes support expected triage queries
+
+## Acceptance Criteria
+
+- Failed runs can be investigated through a first-class API and shared UI without parsing raw events manually.
+- Retry/partial-rerun safety is explicit per step type and defaults to unsafe.
+- Logical step runs and retry attempts are represented as separate entities.
+- Investigation data cannot silently drift from the raw ledger without detection.
+- Diagnostic evidence is bounded, redacted, and authorization-aware.
+- Preflight validation is server-authoritative.
+- Operators, authors, and API consumers all gain usable diagnostics in the first milestone.

--- a/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-implementation-plan.md
+++ b/Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-implementation-plan.md
@@ -1,0 +1,575 @@
+# Workflows Diagnostics and Improvements Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a first-class workflows diagnostics model with explicit replay safety, per-attempt execution history, investigation APIs, a shared run inspector, and server-authoritative preflight validation.
+
+**Architecture:** Keep the current workflows runtime and raw execution ledger in place, but add a structured diagnostics layer beside it. Preserve `workflow_step_runs` as the logical step record, add child `workflow_step_attempts`, derive a `run investigation` view from runs/events/artifacts, and expose that view consistently to the API and shared UI. Build replay safety from explicit step capability metadata rather than inferring it from failures after the fact.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL via `Workflows_DB`, asyncio workflow engine, pytest, React, Zustand, shared UI services, Vitest
+
+---
+
+**Execution Notes**
+
+- Use @using-git-worktrees before implementation so the work happens in an isolated worktree.
+- Follow @test-driven-development for every code task.
+- If tests fail unexpectedly, use @systematic-debugging before changing the implementation approach.
+- Before claiming completion, use @verification-before-completion.
+
+### Task 1: Establish replay capability metadata for step types
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/capabilities.py`
+- Modify: `tldw_Server_API/app/core/Workflows/registry.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py`
+
+**Step 1: Write the failing test**
+
+Create `tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py` with expectations for safe and unsafe step types.
+
+Example:
+
+```python
+from tldw_Server_API.app.core.Workflows.capabilities import get_step_capability
+
+
+def test_webhook_steps_default_to_unsafe_replay():
+    capability = get_step_capability("webhook")
+    assert capability.replay_safe is False
+    assert capability.requires_human_review_for_rerun is True
+
+
+def test_prompt_steps_expose_safe_replay_defaults():
+    capability = get_step_capability("prompt")
+    assert capability.replay_safe is True
+    assert capability.idempotency_strategy == "run_scoped"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+
+Expected: FAIL because the capability module and helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a small capability model and registry helper.
+
+Implementation target:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StepCapability:
+    replay_safe: bool = False
+    idempotency_strategy: str = "none"
+    compensation_supported: bool = False
+    requires_human_review_for_rerun: bool = False
+    evidence_level: str = "standard"
+```
+
+Register per-step defaults in `registry.py`, and extend `/api/v1/workflows/step-types` output so clients can inspect replay semantics without hard-coding them.
+
+**Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/capabilities.py \
+  tldw_Server_API/app/core/Workflows/registry.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py
+git commit -m "feat(workflows): add step replay capabilities"
+```
+
+### Task 2: Add `workflow_step_attempts` schema and DB adapter support
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Workflows_DB.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_db.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py`
+- Test: `tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py`
+
+**Step 1: Write the failing tests**
+
+Add DB-level tests that assert:
+- the new `workflow_step_attempts` table exists in SQLite and PostgreSQL
+- attempt rows can be inserted and listed
+- `workflow_step_runs` remains the logical parent row
+
+Example:
+
+```python
+def test_create_step_attempt_persists_attempt_history(workflows_db):
+    workflows_db.create_step_run(...)
+    attempt_id = workflows_db.create_step_attempt(...)
+    rows = workflows_db.list_step_attempts(run_id="run-1", step_id="step-a")
+    assert rows[0]["attempt_id"] == attempt_id
+    assert rows[0]["attempt_number"] == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_db.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py -k step_attempt -v`
+
+Expected: FAIL because the schema and adapter methods do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add a new table and adapter methods such as:
+
+```sql
+CREATE TABLE IF NOT EXISTS workflow_step_attempts (
+    attempt_id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    step_run_id TEXT NOT NULL,
+    step_id TEXT NOT NULL,
+    attempt_number INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ,
+    ended_at TIMESTAMPTZ,
+    reason_code_core TEXT,
+    reason_code_detail TEXT,
+    retryable BOOLEAN,
+    error_summary TEXT,
+    metadata_json TEXT
+)
+```
+
+Add adapter helpers like:
+- `create_step_attempt(...)`
+- `complete_step_attempt(...)`
+- `list_step_attempts(run_id, step_id=None, step_run_id=None)`
+
+Do not remove or repurpose `workflow_step_runs`.
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_db.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py -k step_attempt -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py -k step_attempt -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Workflows_DB.py \
+  tldw_Server_API/tests/Workflows/test_workflows_db.py \
+  tldw_Server_API/tests/Workflows/test_workflows_postgres_migrations.py \
+  tldw_Server_API/tests/Workflows/test_dual_backend_workflows.py
+git commit -m "feat(workflows): add step attempt persistence"
+```
+
+### Task 3: Emit layered failure semantics and attempt-level engine records
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/failures.py`
+- Modify: `tldw_Server_API/app/core/Workflows/engine.py`
+- Modify: `tldw_Server_API/app/core/Workflows/adapters/_base.py`
+- Test: `tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py`
+- Test: `tldw_Server_API/tests/Workflows/test_workflows_api.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+- each failed attempt gets a `reason_code_core` and `retryable` decision
+- retry loops create multiple attempt rows instead of mutating only a counter
+- unsafe step types do not report safe replay recommendations
+
+Example:
+
+```python
+def test_retrying_step_records_multiple_attempt_rows(workflows_db, engine):
+    run_id = create_retrying_run(...)
+    asyncio.run(engine.start_run(run_id))
+    attempts = workflows_db.list_step_attempts(run_id=run_id, step_id="prompt_1")
+    assert len(attempts) == 2
+    assert attempts[0]["reason_code_core"] == "runtime_error"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+
+Expected: FAIL because the engine does not yet emit attempt rows or layered failure envelopes.
+
+**Step 3: Write minimal implementation**
+
+Create a helper model such as:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailureEnvelope:
+    reason_code_core: str
+    reason_code_detail: str | None
+    category: str
+    blame_scope: str
+    retryable: bool
+    retry_recommendation: str
+    error_summary: str
+```
+
+Update the engine so each loop iteration:
+- creates an attempt row before adapter execution
+- completes that attempt with success, waiting, cancel, or failure state
+- persists failure envelope fields
+- keeps `workflow_step_runs` as the stable parent row for approvals and routing
+
+**Step 4: Run tests to verify they pass**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflows_api.py -k retry -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/failures.py \
+  tldw_Server_API/app/core/Workflows/engine.py \
+  tldw_Server_API/app/core/Workflows/adapters/_base.py \
+  tldw_Server_API/tests/Workflows/test_engine_retry_classifier.py \
+  tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py \
+  tldw_Server_API/tests/Workflows/test_workflows_api.py
+git commit -m "feat(workflows): emit attempt-level failure diagnostics"
+```
+
+### Task 4: Add the run investigation service and API endpoints
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Workflows/investigation.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py`
+
+**Step 1: Write the failing tests**
+
+Add API tests for:
+- `GET /api/v1/workflows/runs/{run_id}/investigation`
+- `GET /api/v1/workflows/runs/{run_id}/steps`
+- `GET /api/v1/workflows/runs/{run_id}/steps/{step_id}/attempts`
+- auth gating between safe summary fields and operator-only detail
+
+Example:
+
+```python
+def test_investigation_endpoint_returns_primary_failure(client, failed_run):
+    resp = client.get(f"/api/v1/workflows/runs/{failed_run}/investigation", headers=auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["primary_failure"]["reason_code_core"] == "runtime_error"
+    assert "recommended_actions" in data
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+
+Expected: FAIL because the service, schemas, and endpoints do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Create a service that assembles investigation data from:
+- `workflow_runs`
+- `workflow_step_runs`
+- `workflow_step_attempts`
+- `workflow_events`
+- artifacts and webhook delivery evidence
+
+Response shape target:
+
+```python
+{
+    "run_id": run_id,
+    "primary_failure": {...},
+    "failed_step": {...},
+    "attempts": [...],
+    "evidence": {...},
+    "recommended_actions": [...]
+}
+```
+
+If you materialize this view, include `schema_version` and `derived_from_event_seq`.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Workflows/investigation.py \
+  tldw_Server_API/app/api/v1/schemas/workflows.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py
+git commit -m "feat(workflows): add investigation APIs"
+```
+
+### Task 5: Add server-authoritative preflight validation
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/workflows.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/workflows.py`
+- Create: `tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert preflight returns:
+- blocking validation errors
+- non-blocking warnings
+- replay safety warnings for unsafe step types
+
+Example:
+
+```python
+def test_preflight_flags_unsafe_replay_steps(client, workflow_definition):
+    resp = client.post("/api/v1/workflows/preflight", json={"definition": workflow_definition}, headers=auth_headers())
+    assert resp.status_code == 200
+    assert resp.json()["warnings"][0]["code"] == "unsafe_replay_step"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+
+Expected: FAIL because the endpoint and schema do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Reuse existing validation helpers instead of creating a second rules engine.
+
+Response shape target:
+
+```python
+{
+    "valid": False,
+    "errors": [{"code": "missing_required_input", "message": "..."}],
+    "warnings": [{"code": "unsafe_replay_step", "message": "..."}]
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/workflows.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py
+git commit -m "feat(workflows): add preflight validation endpoint"
+```
+
+### Task 6: Extend shared UI workflow services and types for diagnostics
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/workflows.ts`
+- Modify: `apps/packages/ui/src/types/workflow-editor.ts`
+- Create: `apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts`
+
+**Step 1: Write the failing tests**
+
+Add service tests for:
+- fetching investigation data
+- fetching step attempts
+- posting preflight requests
+
+Example:
+
+```ts
+it("fetches workflow investigation data", async () => {
+  mockBgRequest.mockResolvedValueOnce({ run_id: "run-1", primary_failure: { reason_code_core: "runtime_error" } })
+  const result = await getWorkflowInvestigation("run-1")
+  expect(result.primary_failure.reason_code_core).toBe("runtime_error")
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+
+Expected: FAIL because the functions and types do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add typed service helpers such as:
+
+```ts
+export const getWorkflowInvestigation = (runId: string) =>
+  bgRequest<WorkflowRunInvestigation>({
+    path: `/api/v1/workflows/runs/${runId}/investigation`,
+    method: "GET"
+  })
+```
+
+Also add typed models for:
+- `WorkflowRunInvestigation`
+- `WorkflowStepAttempt`
+- `WorkflowPreflightResult`
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/workflows.ts \
+  apps/packages/ui/src/types/workflow-editor.ts \
+  apps/packages/ui/src/services/tldw/__tests__/workflows.test.ts
+git commit -m "feat(ui): add workflow diagnostics services"
+```
+
+### Task 7: Build a shared run inspector and embed it in the workflow editor
+
+**Files:**
+- Create: `apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx`
+- Modify: `apps/packages/ui/src/components/Common/Workflow/index.ts`
+- Modify: `apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx`
+- Modify: `apps/packages/ui/src/store/workflow-editor.ts`
+- Create: `apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add component tests that assert the inspector renders:
+- failure summary
+- attempt timeline
+- evidence tabs
+- recommended actions
+
+Example:
+
+```tsx
+it("renders failure summary and attempts", () => {
+  render(<WorkflowRunInspector investigation={investigationFixture} />)
+  expect(screen.getByText("runtime_error")).toBeInTheDocument()
+  expect(screen.getByText("Attempt 2")).toBeInTheDocument()
+  expect(screen.getByRole("tab", { name: /evidence/i })).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+Expected: FAIL because the component does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Build a shared inspector component that accepts typed investigation data and exposes:
+- summary card
+- attempts list
+- evidence tabs
+- next-action panel
+
+Then update `ExecutionPanel.tsx` to open or render that shared component for real run ids instead of only displaying local mock state.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+- `cd apps/packages/ui && bunx vitest run src/components/WorkflowEditor/__tests__/WorkflowEditor.responsive.test.tsx`
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Common/Workflow/WorkflowRunInspector.tsx \
+  apps/packages/ui/src/components/Common/Workflow/index.ts \
+  apps/packages/ui/src/components/WorkflowEditor/ExecutionPanel.tsx \
+  apps/packages/ui/src/store/workflow-editor.ts \
+  apps/packages/ui/src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx
+git commit -m "feat(ui): add shared workflow run inspector"
+```
+
+### Task 8: Update docs, alerts, and final verification
+
+**Files:**
+- Modify: `Docs/Design/Workflows.md`
+- Modify: `Docs/Operations/Workflows_Debugging.md`
+- Modify: `Docs/Operations/Workflows_Runbook.md`
+- Modify: `Docs/Operations/monitoring/alerts/workflows_alerts.yml`
+- Reference: `Docs/Plans/2026-03-11-workflows-diagnostics-and-improvements-design.md`
+
+**Step 1: Write the doc and alert updates**
+
+Document:
+- the new attempt model
+- investigation endpoints
+- preflight endpoint
+- replay safety rules
+- operator workflows for investigation-first triage
+
+Extend alerts or dashboards to key on structured reason codes where possible.
+
+**Step 2: Run targeted verification**
+
+Run:
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_step_capabilities.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_attempt_failures.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_investigation_api.py -v`
+- `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Workflows/test_workflow_preflight_api.py -v`
+- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/workflows.test.ts`
+- `cd apps/packages/ui && bunx vitest run src/components/Common/Workflow/__tests__/WorkflowRunInspector.test.tsx`
+
+Expected: PASS
+
+**Step 3: Run Bandit on the touched backend scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Workflows \
+  tldw_Server_API/app/core/DB_Management/Workflows_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/workflows.py \
+  tldw_Server_API/app/api/v1/schemas/workflows.py \
+  -f json -o /tmp/bandit_workflows_diagnostics.json
+```
+
+Expected: no new findings in changed workflows code.
+
+**Step 4: Review the final diff**
+
+Run: `git diff --stat`
+
+Expected: only workflows diagnostics, UI inspector, docs, and tests are changed.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Design/Workflows.md \
+  Docs/Operations/Workflows_Debugging.md \
+  Docs/Operations/Workflows_Runbook.md \
+  Docs/Operations/monitoring/alerts/workflows_alerts.yml
+git commit -m "docs(workflows): document diagnostics investigation flow"
+```

--- a/Docs/Plans/2026-03-11-workspace-source-folders-and-collections-design.md
+++ b/Docs/Plans/2026-03-11-workspace-source-folders-and-collections-design.md
@@ -1,0 +1,433 @@
+# Workspace Source Folders + Workspace Collections Design
+
+Date: 2026-03-11
+Owner: Codex collaboration session
+Status: Approved (revised after design review)
+
+## Context and Problem
+
+`/workspace-playground` currently has two organization gaps:
+
+- Sources inside a workspace live in one flat `WorkspaceSource[]` list.
+- Saved workspaces are presented as a flat browser with search, pinning, and archive, but no true topical grouping.
+
+This prevents two common research workflows:
+
+1. Organizing sources inside a workspace by nested themes, evidence buckets, or modality-specific subtopics.
+2. Organizing multiple related workspaces under a broader topic while keeping each workspace focused on a narrower question.
+
+The current implementation is also local-first and persistence-heavy, so any design must respect the existing Zustand workspace store, split storage/indexed DB offload, and workspace import/export bundle flow.
+
+## Goals
+
+1. Add nested source folders inside a workspace.
+2. Allow a source to belong to multiple source folders in the same workspace.
+3. Make source folders selectable for grounded chat/output scope, with recursive inclusion of descendant folders.
+4. Add flat workspace collections across saved workspaces.
+5. Allow exactly one collection per workspace in v1.
+6. Keep the design local-first for v1, but shape it so future server-backed sync is straightforward.
+
+## Non-Goals
+
+1. Server-backed sync/storage for folders or collections in v1.
+2. Shared collection overview pages, shared notes, or collection-level RAG behavior.
+3. Collection nesting in v1.
+4. Folder-level exclusion rules in v1.
+5. Auto-generating folders from source type or collections from workspace name/tag.
+6. Sharing, permissions, color systems, or collaborative editing.
+
+## Current Constraints
+
+### Workspace sources are flat
+
+The current workspace state stores:
+
+- `sources: WorkspaceSource[]`
+- `selectedSourceIds: string[]`
+
+There is no existing folder or membership model for workspace sources.
+
+### Saved workspaces are flat and capped
+
+Saved workspaces currently store only:
+
+- `id`
+- `name`
+- `tag`
+- `createdAt`
+- `lastAccessedAt`
+- `sourceCount`
+
+The current store truncates `savedWorkspaces` to `MAX_SAVED_WORKSPACES = 10`. That cap is incompatible with meaningful collection browsing and must change as part of this work.
+
+### Persistence is local-first
+
+Workspace persistence already uses:
+
+- persisted Zustand state
+- split-key storage/indexed DB offload for large payloads
+- quota recovery that evicts heavy snapshot/session payloads
+
+The design should preserve those mechanisms instead of replacing them.
+
+## Design Decision
+
+Use two independent organization systems:
+
+1. **Source folders**
+   - Scoped to a single workspace snapshot.
+   - Nested.
+   - Many-to-many with sources.
+   - Selectable as recursive grounded context.
+
+2. **Workspace collections**
+   - Scoped to the global saved-workspace browser.
+   - Flat in v1.
+   - Exactly one collection per workspace.
+   - Organizational container only.
+
+Use a **local-first, server-ready entity/link model** for both systems so a future backend API can adopt the same shapes without rewriting the client semantics.
+
+## Proposed Data Model
+
+### 1) Source folders
+
+Add two new entities to the workspace snapshot.
+
+#### `WorkspaceSourceFolder`
+
+- `id: string`
+- `workspaceId: string`
+- `name: string`
+- `parentFolderId: string | null`
+- `createdAt: Date`
+- `updatedAt: Date`
+
+#### `WorkspaceSourceFolderMembership`
+
+- `folderId: string`
+- `sourceId: string`
+
+### 2) Workspace collections
+
+Add one global entity plus a collection reference on saved workspace metadata.
+
+#### `WorkspaceCollection`
+
+- `id: string`
+- `name: string`
+- `description: string | null`
+- `createdAt: Date`
+- `updatedAt: Date`
+
+#### `SavedWorkspace` extension
+
+Add:
+
+- `collectionId: string | null`
+
+### 3) Workspace state additions
+
+Add to current workspace snapshot/state:
+
+- `sourceFolders: WorkspaceSourceFolder[]`
+- `sourceFolderMemberships: WorkspaceSourceFolderMembership[]`
+- `selectedSourceFolderIds: string[]`
+- `activeFolderId: string | null`
+
+Add to global workspace list state:
+
+- `workspaceCollections: WorkspaceCollection[]`
+
+## Validation Rules
+
+### Source folders
+
+1. Folder IDs must be unique within the workspace.
+2. A folder cannot parent itself.
+3. A folder cannot move under one of its descendants.
+4. Sibling folder names must be unique under the same parent.
+5. Duplicate `folderId + sourceId` memberships are not allowed.
+
+### Workspace collections
+
+1. Collection IDs must be unique.
+2. Collection names must be unique after trim/case-normalization.
+3. A workspace may reference at most one collection ID.
+
+## Selection Model
+
+The existing direct source selection remains in place. Folder selection is additive, not a replacement.
+
+### State
+
+- `selectedSourceIds`
+  - direct source picks
+- `selectedSourceFolderIds`
+  - folder picks for grounded context
+- `activeFolderId`
+  - browse/filter focus only; does not affect grounded context by itself
+
+### Derived selection
+
+Add a derived selector:
+
+- `effectiveSelectedSourceIds: string[]`
+
+It is the unique set of ready source IDs from:
+
+1. directly selected ready sources
+2. all ready sources reachable from selected folders
+3. all ready sources reachable from descendant folders of selected folders
+
+### Folder recursion rules
+
+Selecting a parent folder includes:
+
+1. sources directly assigned to the folder
+2. sources assigned to every descendant folder at any depth
+
+No exclusion model is included in v1.
+
+### Source selection origin
+
+Each source row should derive one of:
+
+- `direct`
+- `folder`
+- `both`
+- `none`
+
+This is required because a source can be selected through a folder even if its direct checkbox was never toggled.
+
+### Source row interaction rules
+
+1. If a source is `none`, clicking selects it directly.
+2. If a source is `direct`, clicking deselects it directly.
+3. If a source is `folder`, clicking does not remove it from effective context; the UI should make clear it is included via folder.
+4. If a source is `both`, clicking removes only the direct selection; the source remains included via folder.
+
+### Folder checkbox state
+
+Folder checkboxes must be tri-state:
+
+- `unchecked`
+- `checked`
+- `indeterminate`
+
+Tri-state calculations must be based on **unique descendant ready source IDs**, not raw membership row counts, because a source can belong to multiple folders.
+
+## Source Folder UI
+
+### Placement
+
+Add a collapsible source-folder tree above the source list in the Sources pane.
+
+### Folder row behavior
+
+Each folder row should expose:
+
+- expand/collapse
+- context checkbox
+- folder name
+- descendant ready-source count
+- actions:
+  - new subfolder
+  - rename
+  - move
+  - delete
+
+### Folder focus vs context selection
+
+Separate two concepts:
+
+1. **Focus/filter**
+   - clicking the folder name sets `activeFolderId`
+   - source list filters to the focused subtree
+
+2. **Context selection**
+   - clicking the folder checkbox toggles `selectedSourceFolderIds`
+   - grounded chat/output uses `effectiveSelectedSourceIds`
+
+### Membership management
+
+Support both:
+
+1. drag/drop source rows onto folders
+2. source-row and bulk "Add to folders" action
+
+Because membership is many-to-many, users must be able to add a source to several folders without moving it out of previous folders.
+
+### Folder deletion
+
+Deleting a folder:
+
+1. never deletes sources
+2. deletes memberships attached to that folder
+3. reparents child folders to the deleted folder's parent
+4. removes the folder from `selectedSourceFolderIds`
+5. clears `activeFolderId` if that folder was focused
+
+## Workspace Collection UI
+
+### Placement
+
+Collections belong in the workspace browser/header flow, not inside the current workspace panes.
+
+### Browser behavior
+
+The workspace browser should support:
+
+1. create collection
+2. rename collection
+3. delete collection
+4. filter workspaces by collection
+5. grouped display by collection
+6. an `Unassigned` bucket
+7. assign/reassign a workspace to exactly one collection
+
+### Collection deletion
+
+Deleting a collection:
+
+1. never deletes workspaces
+2. sets member workspaces to `collectionId = null`
+3. moves those workspaces into `Unassigned`
+
+### Duplicate/import behavior
+
+1. Duplicated workspaces inherit `collectionId`.
+2. Imported workspaces are placed in `Unassigned`.
+
+Imported workspace bundles must not blindly recreate global collection membership because collections are library-level organization, not intrinsic workspace content.
+
+## Persistence and Migration
+
+### Migration defaults
+
+Existing persisted workspaces must load with:
+
+- `sourceFolders = []`
+- `sourceFolderMemberships = []`
+- `selectedSourceFolderIds = []`
+- `activeFolderId = null`
+- `workspaceCollections = []`
+- `collectionId = null` on all saved workspaces
+
+### Import/export rules
+
+Single-workspace bundle export/import should include:
+
+- source folders
+- source folder memberships
+- selected source folder IDs
+
+Single-workspace bundle export/import should not restore:
+
+- global workspace collection assignments
+- collection definitions
+
+If import data is inconsistent:
+
+1. memberships pointing to missing sources or folders are dropped
+2. folders pointing to missing parents are reparented to root
+3. selected folder IDs pointing to missing folders are dropped
+
+### Saved workspace cap
+
+Replace the current 10-item truncation for saved workspaces in any collection-aware release.
+
+Recommended v1 rule:
+
+- do not truncate saved workspace metadata
+- rely on existing split storage and quota recovery to evict heavy snapshots/chat sessions instead of deleting workspace metadata
+
+## Performance and Selector Architecture
+
+Do not bury all recursive logic inside React components or the giant workspace store body.
+
+Create pure selector/helper utilities for:
+
+- `childrenByFolderId`
+- `sourceIdsByFolderId`
+- `folderIdsBySourceId`
+- descendant folder resolution
+- unique descendant source resolution
+- effective selected source IDs
+- folder tri-state status
+- source selection origin
+
+These selectors should be memoized at the component/store boundary and tested independently.
+
+This is necessary to avoid:
+
+1. duplicate counting bugs
+2. tri-state inconsistencies
+3. unreadable store logic
+4. performance cliffs on medium/large folder trees
+
+## Error Handling and Edge Cases
+
+1. Folders may contain processing/error sources, but only ready sources participate in `effectiveSelectedSourceIds`.
+2. If a selected folder currently resolves to zero ready sources, show that clearly in the UI.
+3. Reject invalid moves that would create cycles.
+4. Reject duplicate memberships silently at the store layer and explicitly in the UI.
+5. Keep undo for folder/collection delete and move operations, consistent with existing source/workspace undo patterns.
+
+## Risks and Mitigations
+
+### Risk: inherited selection feels broken
+
+If a source is selected via folder and the user clicks its checkbox, they may expect it to disappear from context.
+
+Mitigation:
+
+- explicit `direct/folder/both` origin state
+- source-row UI copy that distinguishes direct selection from inherited inclusion
+
+### Risk: collections do not scale
+
+If the 10-workspace cap remains, collections become misleading and lossy.
+
+Mitigation:
+
+- remove saved-workspace truncation as part of this design
+
+### Risk: import/export pollutes library-level organization
+
+If single-workspace bundles restore global collection membership, imports can create invalid or surprising browser organization.
+
+Mitigation:
+
+- do not restore collection membership from workspace bundles
+
+### Risk: duplicate counts and incorrect tri-state
+
+Many-to-many memberships make naive subtree counting wrong.
+
+Mitigation:
+
+- all subtree counts and states must use unique source IDs
+
+## Delivery Staging
+
+Recommended delivery sequence:
+
+1. workspace type/store migration and saved-workspace cap fix
+2. workspace collections in the workspace browser
+3. source-folder data model and pure selectors
+4. source-folder UI and membership editing
+5. effective selection integration with chat/output
+6. import/export updates and regression coverage
+
+This sequence delivers the simpler collection feature first while isolating the higher-risk recursive selection work.
+
+## Success Criteria
+
+1. Users can create nested source folders inside a workspace.
+2. A source can belong to multiple folders.
+3. Selecting a parent folder includes every ready source in descendant folders.
+4. Direct source selection continues to work and is clearly distinguished from folder-derived inclusion.
+5. Users can create flat workspace collections and assign each workspace to exactly one collection.
+6. Workspace collections remain accurate beyond 10 saved workspaces.
+7. Persistence/import/export behaves predictably without corrupting organization metadata.

--- a/Docs/STT-TTS/QWEN3_TTS_SETUP.md
+++ b/Docs/STT-TTS/QWEN3_TTS_SETUP.md
@@ -78,6 +78,7 @@ providers:
       supports_voice_cloning: true
       supports_emotion_control: false
       supported_modes: ["custom_voice_preset", "voice_clone"]
+      supported_voices: ["Cherry", "Ethan"]
       supports_uploaded_custom_voices: false
 ```
 

--- a/Docs/STT-TTS/QWEN3_TTS_SETUP.md
+++ b/Docs/STT-TTS/QWEN3_TTS_SETUP.md
@@ -1,17 +1,42 @@
 # Qwen3-TTS Setup Runbook
 
-This runbook covers installation, configuration, and operational notes for the local Qwen3-TTS adapter.
+This runbook covers installation, configuration, and operational notes for the runtime-aware Qwen3-TTS adapter.
 
-## What You Get
+## Runtime Modes
+
+`qwen3_tts` keeps one public provider key and selects an internal runtime with `providers.qwen3_tts.runtime`.
+
+- `auto`: prefers `mlx` on Apple Silicon macOS and `upstream` elsewhere
+- `upstream`: in-process `qwen_tts`
+- `mlx`: in-process `mlx-audio`
+- `remote`: OpenAI-compatible hosted or sidecar backend
+
+## Capability Matrix
+
+### Upstream
 - CustomVoice (9 named speakers + instruction control)
 - VoiceDesign (prompted voice creation)
 - Base (voice cloning from reference audio)
 - Tokenizer encode/decode endpoints
 
+### MLX v1
+- Preset-speaker synthesis only
+- `stream=true` accepted with buffered fallback chunks
+- Uploaded `custom:<voice_id>` voices rejected
+- `Base` and `VoiceDesign` rejected
+
+### Remote
+- Capabilities depend on the hosted backend
+- Health and capability envelopes default to conservative values until `capability_override` is configured
+
 ## Install Dependencies
 
 ```bash
+# Upstream runtime
 pip install qwen-tts torch soundfile
+
+# Apple Silicon MLX runtime
+pip install mlx mlx-audio
 ```
 
 If the package name differs in your environment, install from the upstream repo instead.
@@ -24,6 +49,7 @@ Edit `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
 providers:
   qwen3_tts:
     enabled: true
+    runtime: "auto"  # auto | upstream | mlx | remote
     model: "auto"  # auto = CustomVoice only
     device: "cuda" # cpu | cuda | mps
     dtype: "float16"
@@ -36,6 +62,24 @@ providers:
 Notes:
 - `auto_download` is false by default. Set true only if you want runtime downloads.
 - `model: "auto"` is valid only for CustomVoice requests.
+- `runtime=mlx` resolves `auto` to preset-speaker synthesis only.
+
+Remote example:
+
+```yaml
+providers:
+  qwen3_tts:
+    enabled: true
+    runtime: "remote"
+    base_url: "http://127.0.0.1:8001/v1/audio/speech"
+    api_key: "${QWEN_REMOTE_API_KEY}"
+    capability_override:
+      supports_streaming: true
+      supports_voice_cloning: true
+      supports_emotion_control: false
+      supported_modes: ["custom_voice_preset", "voice_clone"]
+      supports_uploaded_custom_voices: false
+```
 
 ## Supported Model IDs
 
@@ -65,6 +109,8 @@ TTS models:
 }
 ```
 
+This request shape also works on `runtime=mlx` when `voice` is one of the built-in preset speakers.
+
 ### VoiceDesign (instruction required)
 ```json
 {
@@ -77,6 +123,8 @@ TTS models:
   }
 }
 ```
+
+`VoiceDesign` is available on `upstream` and on `remote` only if the hosted backend supports it.
 
 ### Base Voice Clone (reference audio + optional transcript)
 ```json
@@ -97,6 +145,7 @@ Notes:
 - `extra_params.x_vector_only_mode=true` allows omitting `reference_text` (quality may degrade).
 - `reference_duration_min` (seconds) can be provided to enforce a minimum reference clip duration.
 - Base models enforce a default 3s minimum reference duration when `reference_duration_min` is omitted.
+- `Base` requests are rejected on `runtime=mlx`.
 
 ### Voice Clone Prompt Reuse (optional)
 You may pass a `voice_clone_prompt` to reuse cached prompt embeddings. Accepted formats:
@@ -129,13 +178,28 @@ Tokenizer endpoints require the `audio.tokenizer` scope.
 
 - Streaming defaults to PCM output; MP3/OPUS/AAC are transcoded in real time when available.
 - If real-time transcoding is unavailable, Qwen3 falls back to buffered streaming (collects audio then streams it in chunks).
+- `runtime=mlx` always uses buffered streaming fallback in v1.
 - WAV streaming emits data only on finalize (WAV headers are written at the end).
+
+## Apple Silicon Validation
+
+Run this smoke test on a real M-series Mac to verify `mlx-audio` model and speaker compatibility:
+
+```bash
+source .venv/bin/activate
+TLDW_RUN_QWEN3_MLX_INTEGRATION=1 \
+QWEN3_MLX_MODEL=mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16 \
+python -m pytest tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_mlx_runtime_integration.py -v
+```
 
 ## Troubleshooting
 
 - **Import error: qwen_tts missing**: Install `qwen-tts` or use the upstream repo for your environment.
+- **Import error: mlx_audio missing**: Install `mlx` and `mlx-audio` on Apple Silicon, then set `runtime=mlx`.
 - **Streaming MP3/OPUS/AAC fails**: Ensure `av` is installed (PyAV). Without it, streaming transcoding is disabled.
 - **Base model rejects request**: Base requires `voice_reference`. Use `extra_params.x_vector_only_mode=true` only to skip `reference_text`.
+- **MLX rejects uploaded or Base requests**: `runtime=mlx` supports preset-speaker CustomVoice only in v1.
+- **Remote health/capabilities look too limited**: Add `capability_override` so the hosted backend advertises its real support.
 - **`model="auto"` rejected**: Auto model selection is only for CustomVoice. Set a VoiceDesign/Base model explicitly.
 
 ## Useful Files

--- a/Docs/STT-TTS/TTS-SETUP-GUIDE.md
+++ b/Docs/STT-TTS/TTS-SETUP-GUIDE.md
@@ -105,13 +105,16 @@ Tip (CI/Dev): The test suite sets `TTS_AUTO_DOWNLOAD=0` to avoid network during 
 
 ### Qwen3-TTS Setup
 
-Qwen3-TTS is a local multilingual TTS model family with CustomVoice, VoiceDesign, and Base (voice clone) modes.
+Qwen3-TTS is a runtime-aware multilingual TTS provider with `upstream`, `mlx`, and `remote` execution modes.
 Full runbook: `Docs/STT-TTS/QWEN3_TTS_SETUP.md`.
 
 #### Installation
 ```bash
-# Install the Qwen3-TTS Python package and core dependencies
+# Upstream runtime
 pip install qwen-tts torch soundfile
+
+# Apple Silicon MLX runtime
+pip install mlx mlx-audio
 ```
 
 If the package name differs for your environment, install from the upstream repo instead.
@@ -123,6 +126,7 @@ Enable Qwen3-TTS in `tldw_Server_API/Config_Files/tts_providers_config.yaml`:
 providers:
   qwen3_tts:
     enabled: true
+    runtime: "auto"  # auto | upstream | mlx | remote
     model: "auto"  # or an explicit model id
     device: "cuda" # cpu | cuda | mps
     dtype: "float16"
@@ -177,6 +181,7 @@ Notes:
 - `extra_params.x_vector_only_mode=true` allows omitting `reference_text` (quality may degrade).
 - `reference_duration_min` (seconds) can be provided to enforce a minimum reference clip duration.
 - Base models enforce a default 3s minimum reference duration when `reference_duration_min` is omitted.
+- `runtime=mlx` supports preset-speaker CustomVoice only in v1 and rejects Base/VoiceDesign/uploaded custom voices.
 
 #### Tokenizer API Endpoints
 

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -252,6 +252,7 @@ providers:
     model: "auto"
     model_path: null
     mlx_model: null
+    capability_override: {}  # Remote runtime only; advertise hosted backend support truthfully
     tokenizer_model: "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     device: "cpu"  # "cpu" | "cuda" | "mps"
     dtype: "float32"  # "float16" | "bfloat16" | "float32" (use float16/bfloat16 with cuda/mps)

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -248,6 +248,7 @@ providers:
   # Qwen3-TTS Configuration
   qwen3_tts:
     enabled: false  # Disabled by default (requires model download)
+    runtime: "auto"
     model: "auto"
     model_path: null
     tokenizer_model: "Qwen/Qwen3-TTS-Tokenizer-12Hz"

--- a/tldw_Server_API/Config_Files/tts_providers_config.yaml
+++ b/tldw_Server_API/Config_Files/tts_providers_config.yaml
@@ -251,6 +251,7 @@ providers:
     runtime: "auto"
     model: "auto"
     model_path: null
+    mlx_model: null
     tokenizer_model: "Qwen/Qwen3-TTS-Tokenizer-12Hz"
     device: "cpu"  # "cpu" | "cuda" | "mps"
     dtype: "float32"  # "float16" | "bfloat16" | "float32" (use float16/bfloat16 with cuda/mps)

--- a/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
+++ b/tldw_Server_API/app/api/v1/endpoints/audio/audio_health.py
@@ -13,6 +13,7 @@ from tldw_Server_API.app.api.v1.endpoints.audio.audio_tts import get_tts_service
 from tldw_Server_API.app.core.Audio.error_payloads import _http_error_detail
 from tldw_Server_API.app.core.Audio.transcription_service import _map_openai_audio_model_to_whisper
 from tldw_Server_API.app.core.Logging.log_context import ensure_request_id
+from tldw_Server_API.app.core.TTS.circuit_breaker import build_qwen_runtime_breaker_key
 from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
 from tldw_Server_API.app.core.Utils.pydantic_compat import model_dump_compat
 
@@ -97,10 +98,19 @@ async def get_tts_health(request: Request, tts_service: TTSServiceV2 = Depends(g
                             continue
                         availability = str(raw_entry.get("availability") or "unknown").strip().lower() or "unknown"
                         serialized_caps = _serialize_tts_caps_for_health(tts_service, raw_entry.get("capabilities"))
+                        metadata = {}
+                        if isinstance(serialized_caps, dict):
+                            metadata = dict(serialized_caps.get("metadata") or {})
+                        runtime_name = metadata.get("runtime")
+                        breaker_key = provider_name
+                        if provider_name == "qwen3_tts" and runtime_name:
+                            breaker_key = build_qwen_runtime_breaker_key(provider_name, str(runtime_name))
                         capability_envelopes.append(
                             {
                                 "provider": provider_name,
                                 "availability": availability,
+                                "runtime": runtime_name,
+                                "breaker_key": breaker_key,
                                 "capabilities": serialized_caps,
                             }
                         )
@@ -110,10 +120,15 @@ async def get_tts_health(request: Request, tts_service: TTSServiceV2 = Depends(g
                         if isinstance(current_details, dict):
                             current_details.setdefault("availability", availability)
                             current_details.setdefault("status", availability)
+                            if runtime_name:
+                                current_details.setdefault("runtime", runtime_name)
+                            current_details.setdefault("breaker_key", breaker_key)
                         else:
                             provider_details[provider_name] = {
                                 "status": availability,
                                 "availability": availability,
+                                "runtime": runtime_name,
+                                "breaker_key": breaker_key,
                                 "initialized": False,
                                 "failed": availability == "failed",
                             }

--- a/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
+++ b/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
@@ -279,7 +279,9 @@ performance:
 
 - `runtime=auto` prefers `mlx` on Apple Silicon and `upstream` elsewhere.
 - `runtime=mlx` supports preset-speaker synthesis in v1 and rejects uploaded `custom:<voice_id>` voices, `Base`, and `VoiceDesign`.
+- `runtime=mlx` accepts `stream=true`, but streams buffered fallback chunks after local generation completes.
 - `runtime=remote` reuses the standard provider `base_url` and `api_key` fields.
+- `runtime=remote` advertises only conservative capabilities unless `capability_override` is set.
 - Hosted Qwen backends receive Qwen-specific fields in `extra_body`, including `ref_audio_b64`, `ref_text`, `voice_clone_prompt`, `x_vector_only_mode`, and `description`.
 
 Remote example:
@@ -291,6 +293,12 @@ providers:
     runtime: remote
     base_url: http://127.0.0.1:8001/v1/audio/speech
     api_key: ${QWEN_REMOTE_API_KEY}
+    capability_override:
+      supports_streaming: true
+      supports_voice_cloning: true
+      supports_emotion_control: false
+      supported_modes: [custom_voice_preset, voice_clone]
+      supports_uploaded_custom_voices: false
 ```
 
 ### Apple Silicon Smoke Check
@@ -322,9 +330,17 @@ providers:
    ```
 5. Verify behavior:
    - preset-speaker requests return audio
+   - `stream=true` returns buffered chunks instead of failing validation
    - `custom:<voice_id>` requests fail validation
    - `Base` and `VoiceDesign` requests fail validation on `runtime=mlx`
    - `/api/v1/audio/health` includes runtime metadata such as `qwen3_tts:mlx`
+6. Run the gated MLX integration smoke test:
+   ```bash
+   source .venv/bin/activate
+   TLDW_RUN_QWEN3_MLX_INTEGRATION=1 \
+   QWEN3_MLX_MODEL=mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16 \
+   python -m pytest tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_mlx_runtime_integration.py -v
+   ```
 
 ## Manual GPU Smoke Test (IndexTTS2)
 

--- a/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
+++ b/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
@@ -50,7 +50,7 @@ sudo apt-get install -y \
 brew install ffmpeg espeak git
 
 # For MLX support (Apple Silicon)
-pip install mlx parakeet-mlx
+pip install mlx parakeet-mlx mlx-audio
 ```
 
 #### Windows
@@ -90,7 +90,7 @@ pip install transformers accelerate
 pip install faster-whisper openai-whisper
 
 # For Apple Silicon (MLX)
-pip install mlx parakeet-mlx  # For Parakeet transcription on M1/M2/M3
+pip install mlx parakeet-mlx mlx-audio  # Parakeet transcription + Qwen3-TTS on M1/M2/M3
 ```
 
 ## Configuration
@@ -236,6 +236,15 @@ providers:
     min_reference_duration: 3.0
     max_reference_duration: 30.0
 
+  qwen3_tts:
+    enabled: true
+    runtime: auto              # auto | upstream | mlx | remote
+    model: auto
+    model_path: null
+    mlx_model: mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16
+    device: mps
+    tokenizer_model: Qwen/Qwen3-TTS-Tokenizer-12Hz
+
 > Keep the `voice_mappings.generic.*.index_tts` entries set to `clone_required` so upstream services remember to include voice reference audio with every request.
 
 # Fallback configuration
@@ -264,6 +273,58 @@ performance:
   stream_chunk_size: 4096
   cache_enabled: false
   cache_ttl: 3600
+```
+
+### Qwen3-TTS Runtime Notes
+
+- `runtime=auto` prefers `mlx` on Apple Silicon and `upstream` elsewhere.
+- `runtime=mlx` supports preset-speaker synthesis in v1 and rejects uploaded `custom:<voice_id>` voices, `Base`, and `VoiceDesign`.
+- `runtime=remote` reuses the standard provider `base_url` and `api_key` fields.
+- Hosted Qwen backends receive Qwen-specific fields in `extra_body`, including `ref_audio_b64`, `ref_text`, `voice_clone_prompt`, `x_vector_only_mode`, and `description`.
+
+Remote example:
+
+```yaml
+providers:
+  qwen3_tts:
+    enabled: true
+    runtime: remote
+    base_url: http://127.0.0.1:8001/v1/audio/speech
+    api_key: ${QWEN_REMOTE_API_KEY}
+```
+
+### Apple Silicon Smoke Check
+
+1. Install dependencies:
+   ```bash
+   source .venv/bin/activate
+   pip install mlx mlx-audio
+   ```
+2. Configure the provider:
+   ```yaml
+   providers:
+     qwen3_tts:
+       enabled: true
+       runtime: "mlx"
+       model: "auto"
+       device: "mps"
+   ```
+3. Start the API:
+   ```bash
+   source .venv/bin/activate
+   python -m uvicorn tldw_Server_API.app.main:app --reload
+   ```
+4. Send a preset-speaker request:
+   ```bash
+   curl -X POST http://127.0.0.1:8000/api/v1/audio/speech \
+     -H "Content-Type: application/json" \
+     -d '{"model":"qwen3_tts","input":"hello from Apple Silicon","voice":"Vivian","response_format":"wav","stream":false}'
+   ```
+5. Verify behavior:
+   - preset-speaker requests return audio
+   - `custom:<voice_id>` requests fail validation
+   - `Base` and `VoiceDesign` requests fail validation on `runtime=mlx`
+   - `/api/v1/audio/health` includes runtime metadata such as `qwen3_tts:mlx`
 
 ## Manual GPU Smoke Test (IndexTTS2)
 

--- a/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
+++ b/tldw_Server_API/app/core/TTS/TTS-DEPLOYMENT.md
@@ -298,6 +298,7 @@ providers:
       supports_voice_cloning: true
       supports_emotion_control: false
       supported_modes: [custom_voice_preset, voice_clone]
+      supported_voices: [Cherry, Ethan]
       supports_uploaded_custom_voices: false
 ```
 

--- a/tldw_Server_API/app/core/TTS/TTS-README.md
+++ b/tldw_Server_API/app/core/TTS/TTS-README.md
@@ -33,7 +33,7 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 | **Dia** | Local PyTorch | EN | ✅ (dialogue prompts) | Multi-speaker dialogue specialist |
 | **VibeVoice** | Local PyTorch | 12 | ✅ (Any) | Long-form (90min), spontaneous music |
 | **VibeVoice Realtime** | WS adapter | EN | ❌ | Low-latency streaming (requires realtime backend) |
-| **Qwen3-TTS** | Local PyTorch | Multi (auto/zh/en/ja/ko/de/fr/ru/pt/es/it) | ✅ (CustomVoice) | Multilingual CustomVoice/VoiceDesign/Base |
+| **Qwen3-TTS** | Runtime-aware local/remote | Multi (auto/zh/en/ja/ko/de/fr/ru/pt/es/it) | Runtime-dependent | One provider key with `upstream`, `mlx`, or `remote` execution |
 | **IndexTTS2** | Local PyTorch | EN/zh | ✅ (reference) | Zero-shot cloning, emotion prompts, low-latency streaming |
 | **NeuTTS** | Local (Hybrid) | EN | ✅ (3-15s) | Instant voice cloning, optional GGUF streaming |
 | **Supertonic** | Local ONNX | Varies (model) | ❌ | User-supplied voice styles |
@@ -41,6 +41,54 @@ Developer-oriented details (architecture, provider matrix, configuration, and te
 | **EchoTTS** | Local PyTorch | EN | ✅ (reference) | CUDA-only voice cloning |
 
 \* Current adapter configuration targets English (`tts-1` / `tts-1-hd`). Additional languages depend on OpenAI model availability.
+
+### Qwen3-TTS Runtime Modes
+
+`qwen3_tts` keeps one public provider key and selects an internal runtime with `providers.qwen3_tts.runtime`.
+
+- `auto`: prefers `mlx` on Apple Silicon macOS and `upstream` elsewhere
+- `upstream`: in-process `qwen_tts`
+- `mlx`: in-process `mlx-audio`
+- `remote`: OpenAI-compatible hosted or sidecar backend
+
+MLX v1 scope:
+
+- preset-speaker synthesis only
+- uploaded `custom:<voice_id>` voices are rejected
+- `Base` and `VoiceDesign` requests are rejected
+- stream requests return buffered fallback chunks
+
+Config examples:
+
+```yaml
+providers:
+  qwen3_tts:
+    enabled: true
+    runtime: "mlx"
+    model: "auto"
+    model_path: null
+    mlx_model: "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
+    device: "mps"
+```
+
+```yaml
+providers:
+  qwen3_tts:
+    enabled: true
+    runtime: "remote"
+    base_url: "http://127.0.0.1:8001/v1/audio/speech"
+    api_key: "${QWEN_REMOTE_API_KEY}"
+```
+
+Remote Qwen requests extend the normal OpenAI `/audio/speech` payload through `extra_body` fields:
+
+- `ref_audio_b64`
+- `ref_text`
+- `voice_clone_prompt`
+- `x_vector_only_mode`
+- `description`
+
+See `TTS-DEPLOYMENT.md` for Apple Silicon smoke-test steps.
 
 ### IndexTTS2 Adapter
 

--- a/tldw_Server_API/app/core/TTS/TTS-README.md
+++ b/tldw_Server_API/app/core/TTS/TTS-README.md
@@ -56,7 +56,7 @@ MLX v1 scope:
 - preset-speaker synthesis only
 - uploaded `custom:<voice_id>` voices are rejected
 - `Base` and `VoiceDesign` requests are rejected
-- stream requests return buffered fallback chunks
+- stream requests are accepted and return buffered fallback chunks
 
 Config examples:
 
@@ -78,6 +78,12 @@ providers:
     runtime: "remote"
     base_url: "http://127.0.0.1:8001/v1/audio/speech"
     api_key: "${QWEN_REMOTE_API_KEY}"
+    capability_override:
+      supports_streaming: true
+      supports_voice_cloning: true
+      supports_emotion_control: false
+      supported_modes: ["custom_voice_preset", "voice_clone"]
+      supports_uploaded_custom_voices: false
 ```
 
 Remote Qwen requests extend the normal OpenAI `/audio/speech` payload through `extra_body` fields:
@@ -87,6 +93,8 @@ Remote Qwen requests extend the normal OpenAI `/audio/speech` payload through `e
 - `voice_clone_prompt`
 - `x_vector_only_mode`
 - `description`
+
+Remote capability reporting defaults to conservative values until `capability_override` is set. This keeps `/api/v1/audio/health` and provider metadata aligned with the actual hosted backend.
 
 See `TTS-DEPLOYMENT.md` for Apple Silicon smoke-test steps.
 

--- a/tldw_Server_API/app/core/TTS/TTS-README.md
+++ b/tldw_Server_API/app/core/TTS/TTS-README.md
@@ -83,6 +83,7 @@ providers:
       supports_voice_cloning: true
       supports_emotion_control: false
       supported_modes: ["custom_voice_preset", "voice_clone"]
+      supported_voices: ["Cherry", "Ethan"]
       supports_uploaded_custom_voices: false
 ```
 
@@ -94,7 +95,7 @@ Remote Qwen requests extend the normal OpenAI `/audio/speech` payload through `e
 - `x_vector_only_mode`
 - `description`
 
-Remote capability reporting defaults to conservative values until `capability_override` is set. This keeps `/api/v1/audio/health` and provider metadata aligned with the actual hosted backend.
+Remote capability reporting defaults to conservative values until `capability_override` is set. This keeps `/api/v1/audio/health` and provider metadata aligned with the actual hosted backend. Voice catalogs stay empty unless `capability_override.supported_voices` is provided explicitly.
 
 See `TTS-DEPLOYMENT.md` for Apple Silicon smoke-test steps.
 

--- a/tldw_Server_API/app/core/TTS/adapters/base.py
+++ b/tldw_Server_API/app/core/TTS/adapters/base.py
@@ -76,6 +76,7 @@ class TTSCapabilities:
     latency_ms: Optional[int] = None  # Average latency in milliseconds
     sample_rate: int = 24000
     default_format: AudioFormat = AudioFormat.MP3
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 # Backward-compatibility for tests expecting VoiceSettings
 @dataclass

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_base.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_base.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from .base import TTSCapabilities, TTSRequest, TTSResponse
+
+
+class Qwen3Runtime(Protocol):
+    runtime_name: str
+
+    async def initialize(self) -> bool:
+        ...
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        ...
+
+    async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
+        ...

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -121,7 +121,7 @@ class Qwen3MlxRuntime:
             )
         return speaker
 
-    async def _get_model(self, resolved_model: str):
+    async def _get_model(self, resolved_model: str) -> tuple[object, str]:
         backend_model_id = self._resolve_backend_model_id(resolved_model)
         if self._model is not None and self._model_id == backend_model_id:
             return self._model, backend_model_id

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import importlib
 import platform
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
+
+import numpy as np
 
 from ..tts_exceptions import TTSGenerationError, TTSProviderInitializationError, TTSValidationError
 from .base import AudioFormat, TTSCapabilities, TTSRequest, TTSResponse, VoiceInfo
@@ -15,6 +19,9 @@ class Qwen3MlxRuntime:
 
     def __init__(self, adapter: "Qwen3TTSAdapter") -> None:
         self.adapter = adapter
+        self._load_model = None
+        self._model = None
+        self._model_id: str | None = None
 
     async def initialize(self) -> bool:
         if platform.system() != "Darwin" or platform.machine().lower() != "arm64":
@@ -22,6 +29,14 @@ class Qwen3MlxRuntime:
                 "Qwen3-TTS MLX runtime requires macOS on Apple Silicon",
                 provider=self.adapter.PROVIDER_KEY,
             )
+        try:
+            module = importlib.import_module("mlx_audio.tts.utils")
+            self._load_model = getattr(module, "load_model")
+        except Exception as exc:
+            raise TTSProviderInitializationError(
+                "mlx-audio is required for the Qwen3-TTS MLX runtime",
+                provider=self.adapter.PROVIDER_KEY,
+            ) from exc
         return True
 
     async def get_capabilities(self) -> TTSCapabilities:
@@ -63,10 +78,132 @@ class Qwen3MlxRuntime:
                 provider=self.adapter.PROVIDER_KEY,
             )
 
+    def _resolve_backend_model_id(self, resolved_model: str) -> str:
+        configured_path = str(self.adapter.config.get("model_path") or "").strip()
+        if configured_path:
+            return configured_path
+
+        configured_model = str(self.adapter.config.get("mlx_model") or "").strip()
+        if configured_model:
+            return configured_model
+
+        resolved_key = (resolved_model or "").strip().lower()
+        if "1.7b" in resolved_key:
+            return "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-bf16"
+        return "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
+
+    def _resolve_language(self, request: TTSRequest) -> str:
+        language = self.adapter._resolve_language(request)
+        mapping = {
+            "auto": "English",
+            "en": "English",
+            "zh": "Chinese",
+            "ja": "Japanese",
+            "ko": "Korean",
+            "de": "German",
+            "fr": "French",
+            "ru": "Russian",
+            "pt": "Portuguese",
+            "es": "Spanish",
+            "it": "Italian",
+        }
+        return mapping.get(language, language)
+
+    def _resolve_speaker(self, request: TTSRequest) -> str:
+        speaker = self.adapter._resolve_speaker(request.voice)
+        if not speaker:
+            raise TTSValidationError(
+                "MLX runtime requires a preset Qwen3 speaker",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        return speaker
+
+    def _get_model(self, resolved_model: str):
+        backend_model_id = self._resolve_backend_model_id(resolved_model)
+        if self._model is None or self._model_id != backend_model_id:
+            if self._load_model is None:
+                raise TTSProviderInitializationError(
+                    "mlx-audio backend was not initialized",
+                    provider=self.adapter.PROVIDER_KEY,
+                )
+            self._model = self._load_model(backend_model_id)
+            self._model_id = backend_model_id
+        return self._model, backend_model_id
+
+    def _collect_pcm_audio(self, results: Iterable[object]) -> tuple[np.ndarray, int]:
+        chunks: list[np.ndarray] = []
+        sample_rate = self.adapter.sample_rate
+        for result in results:
+            audio = getattr(result, "audio", None)
+            if audio is None:
+                continue
+            chunk = np.asarray(audio)
+            if chunk.ndim > 1:
+                chunk = chunk.reshape(-1)
+            if chunk.size == 0:
+                continue
+            chunks.append(chunk)
+            rate = getattr(result, "sample_rate", None) or getattr(result, "sampling_rate", None)
+            if rate:
+                sample_rate = int(rate)
+        if not chunks:
+            raise TTSGenerationError(
+                "MLX runtime returned no audio chunks",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        pcm = chunks[0] if len(chunks) == 1 else np.concatenate(chunks)
+        if pcm.dtype != np.int16:
+            pcm = self.adapter._audio_normalizer.normalize(pcm, target_dtype=np.int16)
+        return pcm, sample_rate
+
     async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
         self.validate_mode(request, mode)
-        raise TTSGenerationError(
-            "Qwen3-TTS MLX runtime preset-speaker generation is not implemented yet",
+        model, backend_model_id = self._get_model(resolved_model)
+        speaker = self._resolve_speaker(request)
+        language = self._resolve_language(request)
+
+        try:
+            results = model.generate(
+                text=request.text,
+                voice=speaker,
+                language=language,
+                speed=request.speed,
+            )
+            pcm_audio, sample_rate = self._collect_pcm_audio(results)
+        except Exception as exc:
+            raise TTSGenerationError(
+                "Qwen3-TTS MLX runtime generation failed",
+                provider=self.adapter.PROVIDER_KEY,
+                details={"runtime": self.runtime_name, "model": backend_model_id, "error": str(exc)},
+            ) from exc
+
+        audio_bytes = await self.adapter.convert_audio_format(
+            pcm_audio,
+            source_format=AudioFormat.PCM,
+            target_format=request.format,
+            sample_rate=sample_rate,
+        )
+
+        metadata = {
+            "runtime": self.runtime_name,
+            "backend_model": backend_model_id,
+        }
+        if request.stream:
+            metadata["streaming_fallback"] = "buffered"
+            return TTSResponse(
+                audio_stream=self.adapter._chunk_bytes(audio_bytes),
+                format=request.format,
+                sample_rate=sample_rate,
+                provider=self.adapter.PROVIDER_KEY,
+                model=resolved_model,
+                metadata=metadata,
+            )
+
+        return TTSResponse(
+            audio_content=audio_bytes,
+            format=request.format,
+            sample_rate=sample_rate,
             provider=self.adapter.PROVIDER_KEY,
-            details={"runtime": self.runtime_name, "model": resolved_model},
+            model=resolved_model,
+            metadata=metadata,
         )

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import platform
+from typing import TYPE_CHECKING
+
+from ..tts_exceptions import TTSGenerationError, TTSProviderInitializationError, TTSValidationError
+from .base import AudioFormat, TTSCapabilities, TTSRequest, TTSResponse, VoiceInfo
+
+if TYPE_CHECKING:
+    from .qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+class Qwen3MlxRuntime:
+    runtime_name = "mlx"
+
+    def __init__(self, adapter: "Qwen3TTSAdapter") -> None:
+        self.adapter = adapter
+
+    async def initialize(self) -> bool:
+        if platform.system() != "Darwin" or platform.machine().lower() != "arm64":
+            raise TTSProviderInitializationError(
+                "Qwen3-TTS MLX runtime requires macOS on Apple Silicon",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        return True
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        max_text_length = self.adapter._coerce_int(self.adapter.config.get("max_text_length")) or 5000
+        voices = [VoiceInfo(id=speaker, name=speaker) for speaker in self.adapter.CUSTOMVOICE_SPEAKERS]
+        return TTSCapabilities(
+            provider_name=self.adapter.provider_name,
+            supported_languages=set(self.adapter.SUPPORTED_LANGUAGES),
+            supported_voices=voices,
+            supported_formats={
+                AudioFormat.MP3,
+                AudioFormat.OPUS,
+                AudioFormat.AAC,
+                AudioFormat.WAV,
+                AudioFormat.PCM,
+            },
+            max_text_length=max_text_length,
+            supports_streaming=False,
+            supports_voice_cloning=False,
+            supports_emotion_control=False,
+            sample_rate=self.adapter.sample_rate,
+            default_format=AudioFormat.PCM,
+            metadata={
+                "runtime": self.runtime_name,
+                "supported_modes": ["custom_voice_preset"],
+                "supports_uploaded_custom_voices": False,
+            },
+        )
+
+    def validate_mode(self, request: TTSRequest, mode: str) -> None:
+        if isinstance(request.voice, str) and request.voice.startswith("custom:"):
+            raise TTSValidationError(
+                "Uploaded custom voices are not supported by the MLX runtime in v1",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        if mode in {"voice_clone", "voice_design"}:
+            raise TTSValidationError(
+                f"Mode '{mode}' is not supported by the MLX runtime",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+
+    async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
+        self.validate_mode(request, mode)
+        raise TTSGenerationError(
+            "Qwen3-TTS MLX runtime preset-speaker generation is not implemented yet",
+            provider=self.adapter.PROVIDER_KEY,
+            details={"runtime": self.runtime_name, "model": resolved_model},
+        )

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -112,7 +112,7 @@ class Qwen3MlxRuntime:
 
     def _resolve_speaker(self, request: TTSRequest) -> str:
         speaker = self.adapter._resolve_speaker(request.voice)
-        if not speaker:
+        if not speaker or speaker not in self.adapter.CUSTOMVOICE_SPEAKERS:
             raise TTSValidationError(
                 "MLX runtime requires a preset Qwen3 speaker",
                 provider=self.adapter.PROVIDER_KEY,

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -54,7 +54,7 @@ class Qwen3MlxRuntime:
                 AudioFormat.PCM,
             },
             max_text_length=max_text_length,
-            supports_streaming=False,
+            supports_streaming=True,
             supports_voice_cloning=False,
             supports_emotion_control=False,
             sample_rate=self.adapter.sample_rate,
@@ -63,6 +63,7 @@ class Qwen3MlxRuntime:
                 "runtime": self.runtime_name,
                 "supported_modes": ["custom_voice_preset"],
                 "supports_uploaded_custom_voices": False,
+                "streaming_mode": "buffered_fallback",
             },
         )
 

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import platform
 from collections.abc import Iterable
@@ -22,6 +23,7 @@ class Qwen3MlxRuntime:
         self._load_model = None
         self._model = None
         self._model_id: str | None = None
+        self._model_lock = asyncio.Lock()
 
     async def initialize(self) -> bool:
         if platform.system() != "Darwin" or platform.machine().lower() != "arm64":
@@ -119,17 +121,42 @@ class Qwen3MlxRuntime:
             )
         return speaker
 
-    def _get_model(self, resolved_model: str):
+    async def _get_model(self, resolved_model: str):
         backend_model_id = self._resolve_backend_model_id(resolved_model)
-        if self._model is None or self._model_id != backend_model_id:
-            if self._load_model is None:
-                raise TTSProviderInitializationError(
-                    "mlx-audio backend was not initialized",
-                    provider=self.adapter.PROVIDER_KEY,
-                )
-            self._model = self._load_model(backend_model_id)
-            self._model_id = backend_model_id
+        if self._model is not None and self._model_id == backend_model_id:
+            return self._model, backend_model_id
+        if self._load_model is None:
+            raise TTSProviderInitializationError(
+                "mlx-audio backend was not initialized",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        async with self._model_lock:
+            if self._model is None or self._model_id != backend_model_id:
+                self._model = await asyncio.to_thread(self._load_model, backend_model_id)
+                self._model_id = backend_model_id
         return self._model, backend_model_id
+
+    def _run_generation(
+        self,
+        model: object,
+        *,
+        text: str,
+        speaker: str,
+        language: str,
+        speed: float,
+    ) -> tuple[np.ndarray, int]:
+        if not hasattr(model, "generate"):
+            raise TTSGenerationError(
+                "MLX runtime model does not expose generate()",
+                provider=self.adapter.PROVIDER_KEY,
+            )
+        results = model.generate(
+            text=text,
+            voice=speaker,
+            language=language,
+            speed=speed,
+        )
+        return self._collect_pcm_audio(results)
 
     def _collect_pcm_audio(self, results: Iterable[object]) -> tuple[np.ndarray, int]:
         chunks: list[np.ndarray] = []
@@ -159,18 +186,19 @@ class Qwen3MlxRuntime:
 
     async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
         self.validate_mode(request, mode)
-        model, backend_model_id = self._get_model(resolved_model)
+        model, backend_model_id = await self._get_model(resolved_model)
         speaker = self._resolve_speaker(request)
         language = self._resolve_language(request)
 
         try:
-            results = model.generate(
+            pcm_audio, sample_rate = await asyncio.to_thread(
+                self._run_generation,
+                model,
                 text=request.text,
-                voice=speaker,
+                speaker=speaker,
                 language=language,
                 speed=request.speed,
             )
-            pcm_audio, sample_rate = self._collect_pcm_audio(results)
         except Exception as exc:
             raise TTSGenerationError(
                 "Qwen3-TTS MLX runtime generation failed",

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -37,9 +37,7 @@ class RemoteQwenRuntime:
             self.provider_name = getattr(adapter, "provider_name", self.provider_key)
             self.sample_rate = getattr(adapter, "sample_rate", 24000)
             self.supported_languages = set(getattr(adapter, "SUPPORTED_LANGUAGES", {"en"}))
-            self.supported_voices = [
-                getattr(adapter, "CUSTOMVOICE_SPEAKERS", []),
-            ][0]
+            self.supported_voices: list[str] = []
         else:
             self._adapter = None
             self.config = dict(adapter_or_config or {})
@@ -71,6 +69,19 @@ class RemoteQwenRuntime:
         if isinstance(override, dict):
             return dict(override)
         return {}
+
+    def _resolve_supported_voices(self, override: dict[str, Any]) -> list[str]:
+        configured = override.get("supported_voices")
+        if not isinstance(configured, list):
+            return list(self.supported_voices)
+        voices: list[str] = []
+        for voice in configured:
+            if not isinstance(voice, str):
+                continue
+            normalized = voice.strip()
+            if normalized:
+                voices.append(normalized)
+        return voices
 
     def _is_httpx_exception(self, exc: Exception) -> bool:
         module = getattr(exc.__class__, "__module__", "")
@@ -169,10 +180,11 @@ class RemoteQwenRuntime:
     async def get_capabilities(self) -> TTSCapabilities:
         override = self._capability_override()
         supported_voices = []
-        if self.supported_voices:
+        runtime_supported_voices = self._resolve_supported_voices(override)
+        if runtime_supported_voices:
             from .base import VoiceInfo
 
-            supported_voices = [VoiceInfo(id=voice, name=voice) for voice in self.supported_voices]
+            supported_voices = [VoiceInfo(id=voice, name=voice) for voice in runtime_supported_voices]
         supports_streaming = self._coerce_bool(override.get("supports_streaming"), default=False)
         supports_voice_cloning = self._coerce_bool(override.get("supports_voice_cloning"), default=False)
         supports_emotion_control = self._coerce_bool(override.get("supports_emotion_control"), default=False)

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
 from tldw_Server_API.app.core.http_client import apost
+from tldw_Server_API.app.core.exceptions import NetworkError as CoreNetworkError
+from tldw_Server_API.app.core.exceptions import RetryExhaustedError
 
-from ..tts_exceptions import TTSProviderInitializationError
+from ..tts_exceptions import (
+    TTSError,
+    TTSProviderError,
+    TTSProviderInitializationError,
+    auth_error,
+    network_error,
+    rate_limit_error,
+    timeout_error,
+)
 from ..tts_resource_manager import get_resource_manager
 from .base import AudioFormat, TTSCapabilities, TTSRequest, TTSResponse
 
@@ -42,6 +53,74 @@ class RemoteQwenRuntime:
         self.api_key = str(self.config.get("api_key") or "").strip() or None
         self.client = None
 
+    def _coerce_bool(self, value: Any, default: bool) -> bool:
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"1", "true", "yes", "on"}:
+                return True
+            if lowered in {"0", "false", "no", "off"}:
+                return False
+        return bool(value)
+
+    def _capability_override(self) -> dict[str, Any]:
+        override = self.config.get("capability_override")
+        if isinstance(override, dict):
+            return dict(override)
+        return {}
+
+    def _is_httpx_exception(self, exc: Exception) -> bool:
+        module = getattr(exc.__class__, "__module__", "")
+        return module.startswith("httpx")
+
+    def _is_http_status_error(self, exc: Exception) -> bool:
+        if not self._is_httpx_exception(exc):
+            return False
+        return exc.__class__.__name__ == "HTTPStatusError"
+
+    def _is_timeout_error(self, exc: Exception) -> bool:
+        if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+            return True
+        name = exc.__class__.__name__.lower()
+        return "timeout" in name
+
+    async def _handle_http_status_error(self, exc: Exception) -> None:
+        response = getattr(exc, "response", None)
+        status_code = getattr(response, "status_code", None)
+        headers = getattr(response, "headers", {}) if response is not None else {}
+        error_msg = ""
+        if response is not None:
+            try:
+                error_msg = response.text
+            except Exception:
+                try:
+                    error_msg = response.content.decode()
+                except Exception:
+                    error_msg = ""
+
+        if status_code == 401:
+            raise auth_error(self.provider_key, "Invalid API key")
+        if status_code == 429:
+            retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
+            raise rate_limit_error(
+                self.provider_key,
+                retry_after=int(retry_after) if retry_after else None,
+            )
+        if status_code == 400:
+            raise TTSProviderError(
+                f"Invalid request to remote Qwen backend: {error_msg}",
+                provider=self.provider_key,
+                error_code="BAD_REQUEST",
+            )
+        raise TTSProviderError(
+            f"Remote Qwen API error: {error_msg}",
+            provider=self.provider_key,
+            error_code=str(status_code),
+        )
+
     async def initialize(self) -> bool:
         if not self.base_url:
             raise TTSProviderInitializationError(
@@ -56,11 +135,22 @@ class RemoteQwenRuntime:
         return True
 
     async def get_capabilities(self) -> TTSCapabilities:
+        override = self._capability_override()
         supported_voices = []
         if self.supported_voices:
             from .base import VoiceInfo
 
             supported_voices = [VoiceInfo(id=voice, name=voice) for voice in self.supported_voices]
+        supports_streaming = self._coerce_bool(override.get("supports_streaming"), default=False)
+        supports_voice_cloning = self._coerce_bool(override.get("supports_voice_cloning"), default=False)
+        supports_emotion_control = self._coerce_bool(override.get("supports_emotion_control"), default=False)
+        supported_modes = override.get("supported_modes")
+        if not isinstance(supported_modes, list) or not supported_modes:
+            supported_modes = ["custom_voice_preset"]
+        supports_uploaded_custom_voices = self._coerce_bool(
+            override.get("supports_uploaded_custom_voices"),
+            default=False,
+        )
         return TTSCapabilities(
             provider_name=self.provider_name,
             supported_languages=set(self.supported_languages),
@@ -73,19 +163,15 @@ class RemoteQwenRuntime:
                 AudioFormat.PCM,
             },
             max_text_length=int(self.config.get("max_text_length") or 5000),
-            supports_streaming=True,
-            supports_voice_cloning=True,
-            supports_emotion_control=True,
+            supports_streaming=supports_streaming,
+            supports_voice_cloning=supports_voice_cloning,
+            supports_emotion_control=supports_emotion_control,
             sample_rate=self.sample_rate,
             default_format=AudioFormat.PCM,
             metadata={
                 "runtime": self.runtime_name,
-                "supported_modes": [
-                    "custom_voice_preset",
-                    "uploaded_custom_voice",
-                    "voice_design",
-                ],
-                "supports_uploaded_custom_voices": True,
+                "supported_modes": supported_modes,
+                "supports_uploaded_custom_voices": supports_uploaded_custom_voices,
             },
         )
 
@@ -165,22 +251,37 @@ class RemoteQwenRuntime:
         payload = self._build_payload(request, resolved_model=resolved_model, mode=mode)
         headers = self._build_headers()
 
-        if request.stream:
+        try:
+            if request.stream:
+                return TTSResponse(
+                    audio_stream=self._stream_audio(headers, payload),
+                    format=request.format,
+                    sample_rate=self.sample_rate,
+                    provider=self.provider_key,
+                    model=resolved_model,
+                    metadata={"runtime": self.runtime_name},
+                )
+
+            audio_data = await self._generate_complete(headers, payload)
             return TTSResponse(
-                audio_stream=self._stream_audio(headers, payload),
+                audio_content=audio_data,
                 format=request.format,
                 sample_rate=self.sample_rate,
                 provider=self.provider_key,
                 model=resolved_model,
                 metadata={"runtime": self.runtime_name},
             )
-
-        audio_data = await self._generate_complete(headers, payload)
-        return TTSResponse(
-            audio_content=audio_data,
-            format=request.format,
-            sample_rate=self.sample_rate,
-            provider=self.provider_key,
-            model=resolved_model,
-            metadata={"runtime": self.runtime_name},
-        )
+        except Exception as exc:
+            if self._is_http_status_error(exc):
+                await self._handle_http_status_error(exc)
+            if isinstance(exc, (CoreNetworkError, RetryExhaustedError)) or self._is_httpx_exception(exc):
+                if self._is_timeout_error(exc):
+                    raise timeout_error(self.provider_key, timeout_seconds=int(self.config.get("timeout") or 60)) from exc
+                raise network_error(self.provider_key, exc) from exc
+            if not isinstance(exc, TTSError):
+                raise TTSProviderError(
+                    "Unexpected error in remote Qwen runtime",
+                    provider=self.provider_key,
+                    details={"error": str(exc), "error_type": type(exc).__name__},
+                ) from exc
+            raise

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -1,3 +1,5 @@
+"""Remote Qwen3-TTS runtime backed by an OpenAI-compatible HTTP service."""
+
 from __future__ import annotations
 
 import asyncio
@@ -26,6 +28,8 @@ if TYPE_CHECKING:
 
 
 class RemoteQwenRuntime:
+    """Execute Qwen3-TTS requests against a separately hosted backend."""
+
     runtime_name = "remote"
 
     def __init__(self, adapter_or_config: "Qwen3TTSAdapter | dict[str, Any]") -> None:
@@ -44,7 +48,19 @@ class RemoteQwenRuntime:
             self.provider_key = "qwen3_tts"
             self.provider_name = "Qwen3TTS"
             self.sample_rate = int(self.config.get("sample_rate") or 24000)
-            self.supported_languages = {"auto", "en", "zh", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"}
+            self.supported_languages = {
+                "auto",
+                "en",
+                "zh",
+                "ja",
+                "ko",
+                "de",
+                "fr",
+                "ru",
+                "pt",
+                "es",
+                "it",
+            }
             self.supported_voices = []
 
         self.base_url = str(self.config.get("base_url") or "").strip()

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -7,7 +7,7 @@ import base64
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 
-from tldw_Server_API.app.core.http_client import apost
+from tldw_Server_API.app.core.http_client import RetryPolicy, apost, astream_bytes
 from tldw_Server_API.app.core.exceptions import NetworkError as CoreNetworkError
 from tldw_Server_API.app.core.exceptions import RetryExhaustedError
 
@@ -277,28 +277,28 @@ class RemoteQwenRuntime:
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
 
+    def _build_stream_retry_policy(self) -> RetryPolicy:
+        return RetryPolicy(retry_on_unsafe=True)
+
     async def _stream_audio(
         self,
         headers: dict[str, str],
         payload: dict[str, Any],
     ) -> AsyncGenerator[bytes, None]:
-        response = None
         try:
-            response = await apost(
+            async for chunk in astream_bytes(
+                method="POST",
                 url=self.base_url,
                 client=self.client,
                 headers=headers,
                 json=payload,
-            )
-            response.raise_for_status()
-            async for chunk in response.aiter_bytes(chunk_size=1024):
+                retry=self._build_stream_retry_policy(),
+                chunk_size=1024,
+            ):
                 if chunk:
                     yield chunk
         except Exception as exc:
             await self._raise_remote_error(exc)
-        finally:
-            if response is not None and hasattr(response, "aclose"):
-                await response.aclose()  # type: ignore[func-returns-value]
 
     async def _generate_complete(self, headers: dict[str, str], payload: dict[str, Any]) -> bytes:
         response = await apost(

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import base64
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, Any
+
+from tldw_Server_API.app.core.http_client import apost
+
+from ..tts_exceptions import TTSProviderInitializationError
+from ..tts_resource_manager import get_resource_manager
+from .base import AudioFormat, TTSCapabilities, TTSRequest, TTSResponse
+
+if TYPE_CHECKING:
+    from .qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+class RemoteQwenRuntime:
+    runtime_name = "remote"
+
+    def __init__(self, adapter_or_config: "Qwen3TTSAdapter | dict[str, Any]") -> None:
+        if hasattr(adapter_or_config, "config"):
+            adapter = adapter_or_config
+            self._adapter = adapter
+            self.config = dict(getattr(adapter, "config", {}) or {})
+            self.provider_key = getattr(adapter, "PROVIDER_KEY", "qwen3_tts")
+            self.provider_name = getattr(adapter, "provider_name", self.provider_key)
+            self.sample_rate = getattr(adapter, "sample_rate", 24000)
+            self.supported_languages = set(getattr(adapter, "SUPPORTED_LANGUAGES", {"en"}))
+            self.supported_voices = [
+                getattr(adapter, "CUSTOMVOICE_SPEAKERS", []),
+            ][0]
+        else:
+            self._adapter = None
+            self.config = dict(adapter_or_config or {})
+            self.provider_key = "qwen3_tts"
+            self.provider_name = "Qwen3TTS"
+            self.sample_rate = int(self.config.get("sample_rate") or 24000)
+            self.supported_languages = {"auto", "en", "zh", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"}
+            self.supported_voices = []
+
+        self.base_url = str(self.config.get("base_url") or "").strip()
+        self.api_key = str(self.config.get("api_key") or "").strip() or None
+        self.client = None
+
+    async def initialize(self) -> bool:
+        if not self.base_url:
+            raise TTSProviderInitializationError(
+                "Qwen3-TTS remote runtime requires base_url",
+                provider=self.provider_key,
+            )
+        resource_manager = await get_resource_manager()
+        self.client = await resource_manager.get_http_client(
+            provider=f"{self.provider_key}_{self.runtime_name}",
+            base_url=self.base_url,
+        )
+        return True
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        supported_voices = []
+        if self.supported_voices:
+            from .base import VoiceInfo
+
+            supported_voices = [VoiceInfo(id=voice, name=voice) for voice in self.supported_voices]
+        return TTSCapabilities(
+            provider_name=self.provider_name,
+            supported_languages=set(self.supported_languages),
+            supported_voices=supported_voices,
+            supported_formats={
+                AudioFormat.MP3,
+                AudioFormat.OPUS,
+                AudioFormat.AAC,
+                AudioFormat.WAV,
+                AudioFormat.PCM,
+            },
+            max_text_length=int(self.config.get("max_text_length") or 5000),
+            supports_streaming=True,
+            supports_voice_cloning=True,
+            supports_emotion_control=True,
+            sample_rate=self.sample_rate,
+            default_format=AudioFormat.PCM,
+            metadata={
+                "runtime": self.runtime_name,
+                "supported_modes": [
+                    "custom_voice_preset",
+                    "uploaded_custom_voice",
+                    "voice_design",
+                ],
+                "supports_uploaded_custom_voices": True,
+            },
+        )
+
+    def _build_payload(self, request: TTSRequest, resolved_model: str, mode: str) -> dict[str, Any]:
+        extras = request.extra_params or {}
+        payload: dict[str, Any] = {
+            "model": resolved_model,
+            "input": request.text,
+            "voice": request.voice or "",
+            "response_format": request.format.value,
+            "speed": request.speed,
+            "extra_body": {},
+        }
+
+        language = request.language or extras.get("language")
+        if isinstance(language, str) and language.strip():
+            payload["extra_body"]["language"] = language.strip()
+
+        if mode == "voice_clone":
+            ref_text = (
+                extras.get("reference_text")
+                or extras.get("ref_text")
+                or extras.get("voice_reference_text")
+            )
+            if ref_text:
+                payload["extra_body"]["ref_text"] = ref_text
+            if request.voice_reference:
+                payload["extra_body"]["ref_audio_b64"] = base64.b64encode(request.voice_reference).decode("ascii")
+            if extras.get("x_vector_only_mode") is not None:
+                payload["extra_body"]["x_vector_only_mode"] = extras.get("x_vector_only_mode")
+            if extras.get("voice_clone_prompt") is not None:
+                payload["extra_body"]["voice_clone_prompt"] = extras.get("voice_clone_prompt")
+        elif mode == "voice_design":
+            description = extras.get("description") or extras.get("instruction") or extras.get("instruct")
+            if description:
+                payload["extra_body"]["description"] = description
+
+        return payload
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    async def _stream_audio(
+        self,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+    ) -> AsyncGenerator[bytes, None]:
+        response = await apost(
+            url=self.base_url,
+            client=self.client,
+            headers=headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        try:
+            async for chunk in response.aiter_bytes(chunk_size=1024):
+                if chunk:
+                    yield chunk
+        finally:
+            if hasattr(response, "aclose"):
+                await response.aclose()  # type: ignore[func-returns-value]
+
+    async def _generate_complete(self, headers: dict[str, str], payload: dict[str, Any]) -> bytes:
+        response = await apost(
+            url=self.base_url,
+            client=self.client,
+            headers=headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        return response.content
+
+    async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
+        payload = self._build_payload(request, resolved_model=resolved_model, mode=mode)
+        headers = self._build_headers()
+
+        if request.stream:
+            return TTSResponse(
+                audio_stream=self._stream_audio(headers, payload),
+                format=request.format,
+                sample_rate=self.sample_rate,
+                provider=self.provider_key,
+                model=resolved_model,
+                metadata={"runtime": self.runtime_name},
+            )
+
+        audio_data = await self._generate_complete(headers, payload)
+        return TTSResponse(
+            audio_content=audio_data,
+            format=request.format,
+            sample_rate=self.sample_rate,
+            provider=self.provider_key,
+            model=resolved_model,
+            metadata={"runtime": self.runtime_name},
+        )

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py
@@ -87,6 +87,18 @@ class RemoteQwenRuntime:
         name = exc.__class__.__name__.lower()
         return "timeout" in name
 
+    def _parse_retry_after(self, value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
     async def _handle_http_status_error(self, exc: Exception) -> None:
         response = getattr(exc, "response", None)
         status_code = getattr(response, "status_code", None)
@@ -104,10 +116,12 @@ class RemoteQwenRuntime:
         if status_code == 401:
             raise auth_error(self.provider_key, "Invalid API key")
         if status_code == 429:
-            retry_after = headers.get("retry-after") if isinstance(headers, dict) else None
+            retry_after = None
+            if hasattr(headers, "get"):
+                retry_after = self._parse_retry_after(headers.get("retry-after"))
             raise rate_limit_error(
                 self.provider_key,
-                retry_after=int(retry_after) if retry_after else None,
+                retry_after=retry_after,
             )
         if status_code == 400:
             raise TTSProviderError(
@@ -120,6 +134,24 @@ class RemoteQwenRuntime:
             provider=self.provider_key,
             error_code=str(status_code),
         )
+
+    async def _raise_remote_error(self, exc: Exception) -> None:
+        if self._is_http_status_error(exc):
+            await self._handle_http_status_error(exc)
+        if isinstance(exc, (CoreNetworkError, RetryExhaustedError)) or self._is_httpx_exception(exc):
+            if self._is_timeout_error(exc):
+                raise timeout_error(
+                    self.provider_key,
+                    timeout_seconds=int(self.config.get("timeout") or 60),
+                ) from exc
+            raise network_error(self.provider_key, exc) from exc
+        if not isinstance(exc, TTSError):
+            raise TTSProviderError(
+                "Unexpected error in remote Qwen runtime",
+                provider=self.provider_key,
+                details={"error": str(exc), "error_type": type(exc).__name__},
+            ) from exc
+        raise exc
 
     async def initialize(self) -> bool:
         if not self.base_url:
@@ -222,19 +254,22 @@ class RemoteQwenRuntime:
         headers: dict[str, str],
         payload: dict[str, Any],
     ) -> AsyncGenerator[bytes, None]:
-        response = await apost(
-            url=self.base_url,
-            client=self.client,
-            headers=headers,
-            json=payload,
-        )
-        response.raise_for_status()
+        response = None
         try:
+            response = await apost(
+                url=self.base_url,
+                client=self.client,
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
             async for chunk in response.aiter_bytes(chunk_size=1024):
                 if chunk:
                     yield chunk
+        except Exception as exc:
+            await self._raise_remote_error(exc)
         finally:
-            if hasattr(response, "aclose"):
+            if response is not None and hasattr(response, "aclose"):
                 await response.aclose()  # type: ignore[func-returns-value]
 
     async def _generate_complete(self, headers: dict[str, str], payload: dict[str, Any]) -> bytes:
@@ -272,16 +307,4 @@ class RemoteQwenRuntime:
                 metadata={"runtime": self.runtime_name},
             )
         except Exception as exc:
-            if self._is_http_status_error(exc):
-                await self._handle_http_status_error(exc)
-            if isinstance(exc, (CoreNetworkError, RetryExhaustedError)) or self._is_httpx_exception(exc):
-                if self._is_timeout_error(exc):
-                    raise timeout_error(self.provider_key, timeout_seconds=int(self.config.get("timeout") or 60)) from exc
-                raise network_error(self.provider_key, exc) from exc
-            if not isinstance(exc, TTSError):
-                raise TTSProviderError(
-                    "Unexpected error in remote Qwen runtime",
-                    provider=self.provider_key,
-                    details={"error": str(exc), "error_type": type(exc).__name__},
-                ) from exc
-            raise
+            await self._raise_remote_error(exc)

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_upstream.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_upstream.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import TTSCapabilities, TTSRequest, TTSResponse
+
+if TYPE_CHECKING:
+    from .qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+class Qwen3UpstreamRuntime:
+    runtime_name = "upstream"
+
+    def __init__(self, adapter: "Qwen3TTSAdapter") -> None:
+        self.adapter = adapter
+
+    async def initialize(self) -> bool:
+        return await self.adapter._initialize_upstream_runtime()
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        return await self.adapter._get_upstream_capabilities()
+
+    async def generate(self, request: TTSRequest, resolved_model: str, mode: str) -> TTSResponse:
+        response = await self.adapter._generate_with_upstream_runtime(
+            request=request,
+            resolved_model=resolved_model,
+            mode=mode,
+        )
+        response.metadata.setdefault("runtime", self.runtime_name)
+        return response

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
@@ -195,6 +195,10 @@ class Qwen3TTSAdapter(TTSAdapter):
 
     def _build_runtime(self) -> Qwen3Runtime:
         runtime_name = self._resolve_runtime_name()
+        if runtime_name == "mlx":
+            from .qwen3_runtime_mlx import Qwen3MlxRuntime
+
+            return Qwen3MlxRuntime(self)
         if runtime_name != "upstream":
             logger.warning(
                 f"{self.provider_name}: runtime '{runtime_name}' is not implemented yet; "
@@ -875,6 +879,15 @@ class Qwen3TTSAdapter(TTSAdapter):
             supports_emotion_control=True,
             sample_rate=self.sample_rate,
             default_format=AudioFormat.PCM,
+            metadata={
+                "runtime": "upstream",
+                "supported_modes": [
+                    "custom_voice_preset",
+                    "uploaded_custom_voice",
+                    "voice_design",
+                ],
+                "supports_uploaded_custom_voices": True,
+            },
         )
 
     async def get_capabilities(self) -> TTSCapabilities:

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
@@ -199,6 +199,10 @@ class Qwen3TTSAdapter(TTSAdapter):
             from .qwen3_runtime_mlx import Qwen3MlxRuntime
 
             return Qwen3MlxRuntime(self)
+        if runtime_name == "remote":
+            from .qwen3_runtime_remote import RemoteQwenRuntime
+
+            return RemoteQwenRuntime(self)
         if runtime_name != "upstream":
             logger.warning(
                 f"{self.provider_name}: runtime '{runtime_name}' is not implemented yet; "

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
@@ -42,6 +42,7 @@ from .base import (
     TTSResponse,
     VoiceInfo,
 )
+from .qwen3_runtime_base import Qwen3Runtime
 
 _QWEN3_COERCE_EXCEPTIONS = (
     TypeError,
@@ -172,6 +173,7 @@ class Qwen3TTSAdapter(TTSAdapter):
         self.sample_rate = self._coerce_int(cfg.get("sample_rate")) or 24000
         self._backend = None
         self._backend_module = None
+        self._runtime_impl: Qwen3Runtime | None = None
         self._pipeline_builders: list[tuple[str, Callable[[str], Any]]] = []
         self._pipelines: dict[str, Any] = {}
         self._pipeline_lock = asyncio.Lock()
@@ -190,6 +192,22 @@ class Qwen3TTSAdapter(TTSAdapter):
         if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
             return "mlx"
         return "upstream"
+
+    def _build_runtime(self) -> Qwen3Runtime:
+        runtime_name = self._resolve_runtime_name()
+        if runtime_name != "upstream":
+            logger.warning(
+                f"{self.provider_name}: runtime '{runtime_name}' is not implemented yet; "
+                "falling back to upstream runtime"
+            )
+        from .qwen3_runtime_upstream import Qwen3UpstreamRuntime
+
+        return Qwen3UpstreamRuntime(self)
+
+    def _get_runtime(self) -> Qwen3Runtime:
+        if self._runtime_impl is None:
+            self._runtime_impl = self._build_runtime()
+        return self._runtime_impl
 
     def _coerce_int(self, value: Any) -> int | None:
         try:
@@ -812,8 +830,8 @@ class Qwen3TTSAdapter(TTSAdapter):
                 yield payload[idx:idx + size]
         return _iterator()
 
-    async def initialize(self) -> bool:
-        """Initialize adapter; verify dependency presence."""
+    async def _initialize_upstream_runtime(self) -> bool:
+        """Initialize the upstream qwen_tts runtime."""
         try:
             module = importlib.import_module("qwen_tts")
         except Exception as exc:
@@ -832,7 +850,12 @@ class Qwen3TTSAdapter(TTSAdapter):
         self._backend = module
         return True
 
-    async def get_capabilities(self) -> TTSCapabilities:
+    async def initialize(self) -> bool:
+        """Initialize the selected Qwen3 runtime."""
+        runtime = self._get_runtime()
+        return await runtime.initialize()
+
+    async def _get_upstream_capabilities(self) -> TTSCapabilities:
         max_text_length = self._coerce_int(self.config.get("max_text_length")) or 5000
         voices = [VoiceInfo(id=speaker, name=speaker) for speaker in self.CUSTOMVOICE_SPEAKERS]
         return TTSCapabilities(
@@ -853,6 +876,10 @@ class Qwen3TTSAdapter(TTSAdapter):
             sample_rate=self.sample_rate,
             default_format=AudioFormat.PCM,
         )
+
+    async def get_capabilities(self) -> TTSCapabilities:
+        runtime = self._get_runtime()
+        return await runtime.get_capabilities()
 
     def _is_voice_design_request(self, request: TTSRequest) -> bool:
         voice = request.voice
@@ -1410,15 +1437,13 @@ class Qwen3TTSAdapter(TTSAdapter):
             if cleanup_path:
                 Path(cleanup_path).unlink(missing_ok=True)
 
-    async def generate(self, request: TTSRequest) -> TTSResponse:
-        """Generate speech from text (backend integration required)."""
-        if not await self.ensure_initialized():
-            raise TTSProviderInitializationError(
-                "Qwen3-TTS adapter not initialized",
-                provider=self.PROVIDER_KEY,
-            )
-        resolved_model = self._resolve_model(request)
-        mode = self._resolve_mode(resolved_model)
+    async def _generate_with_upstream_runtime(
+        self,
+        *,
+        request: TTSRequest,
+        resolved_model: str,
+        mode: str,
+    ) -> TTSResponse:
         logger.info(
             f"{self.provider_name}: request model={resolved_model}, mode={mode}, device={self.device}, "
             f"format={request.format.value}, stream={bool(request.stream)}"
@@ -1508,3 +1533,15 @@ class Qwen3TTSAdapter(TTSAdapter):
             provider=self.PROVIDER_KEY,
             model=resolved_model,
         )
+
+    async def generate(self, request: TTSRequest) -> TTSResponse:
+        """Generate speech from text using the selected runtime."""
+        if not await self.ensure_initialized():
+            raise TTSProviderInitializationError(
+                "Qwen3-TTS adapter not initialized",
+                provider=self.PROVIDER_KEY,
+            )
+        resolved_model = self._resolve_model(request)
+        mode = self._resolve_mode(resolved_model)
+        runtime = self._get_runtime()
+        return await runtime.generate(request, resolved_model, mode)

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
@@ -9,6 +9,7 @@ import base64
 import contextlib
 import importlib
 import inspect
+import platform
 import tempfile
 from collections.abc import AsyncGenerator, Iterable
 from pathlib import Path
@@ -158,6 +159,7 @@ class Qwen3TTSAdapter(TTSAdapter):
     def __init__(self, config: dict[str, Any] | None = None):
         super().__init__(config=config)
         cfg = config or {}
+        self.runtime = (cfg.get("runtime") or "auto").strip().lower()
         self.model = (cfg.get("model") or "auto").strip()
         self.model_path = cfg.get("model_path")
         self.tokenizer_model = cfg.get("tokenizer_model") or "Qwen/Qwen3-TTS-Tokenizer-12Hz"
@@ -181,6 +183,13 @@ class Qwen3TTSAdapter(TTSAdapter):
             self.MODEL_BASE_17B.lower(): self.MODEL_BASE_17B,
             self.MODEL_BASE_06B.lower(): self.MODEL_BASE_06B,
         }
+
+    def _resolve_runtime_name(self) -> str:
+        if self.runtime in {"upstream", "mlx", "remote"}:
+            return self.runtime
+        if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
+            return "mlx"
+        return "upstream"
 
     def _coerce_int(self, value: Any) -> int | None:
         try:

--- a/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
+++ b/tldw_Server_API/app/core/TTS/adapters/qwen3_tts_adapter.py
@@ -9,7 +9,6 @@ import base64
 import contextlib
 import importlib
 import inspect
-import platform
 import tempfile
 from collections.abc import AsyncGenerator, Iterable
 from pathlib import Path
@@ -33,7 +32,7 @@ from ..tts_exceptions import (
     TTSStreamingError,
     TTSValidationError,
 )
-from ..utils import parse_bool
+from ..utils import parse_bool, resolve_qwen3_runtime_name
 from .base import (
     AudioFormat,
     TTSAdapter,
@@ -187,11 +186,7 @@ class Qwen3TTSAdapter(TTSAdapter):
         }
 
     def _resolve_runtime_name(self) -> str:
-        if self.runtime in {"upstream", "mlx", "remote"}:
-            return self.runtime
-        if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
-            return "mlx"
-        return "upstream"
+        return resolve_qwen3_runtime_name(self.runtime)
 
     def _build_runtime(self) -> Qwen3Runtime:
         runtime_name = self._resolve_runtime_name()

--- a/tldw_Server_API/app/core/TTS/circuit_breaker.py
+++ b/tldw_Server_API/app/core/TTS/circuit_breaker.py
@@ -360,6 +360,10 @@ class CircuitBreaker:
 CircuitOpenError = TTSCircuitOpenError
 
 
+def build_qwen_runtime_breaker_key(provider_name: str, runtime_name: str) -> str:
+    return f"{provider_name}:{runtime_name}"
+
+
 class CircuitBreakerManager:
     """Manages circuit breakers for all TTS providers."""
 

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -44,6 +44,7 @@ class ProviderConfig(BaseModel):
     runtime: Optional[str] = None
     model: Optional[str] = None
     model_path: Optional[str] = None
+    mlx_model: Optional[str] = None
     device: str = "cpu"
     timeout: int = 60
     max_retries: int = 3

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -41,6 +41,7 @@ class ProviderConfig(BaseModel):
     enabled: bool = False
     api_key: Optional[str] = None
     base_url: Optional[str] = None
+    runtime: Optional[str] = None
     model: Optional[str] = None
     model_path: Optional[str] = None
     device: str = "cpu"

--- a/tldw_Server_API/app/core/TTS/tts_config.py
+++ b/tldw_Server_API/app/core/TTS/tts_config.py
@@ -45,6 +45,7 @@ class ProviderConfig(BaseModel):
     model: Optional[str] = None
     model_path: Optional[str] = None
     mlx_model: Optional[str] = None
+    capability_override: dict[str, Any] = Field(default_factory=dict)
     device: str = "cpu"
     timeout: int = 60
     max_retries: int = 3

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -1257,6 +1257,7 @@ class TTSServiceV2:
         return data
 
     def _resolve_circuit_breaker_key(self, provider_key: str, adapter: Optional[Any] = None) -> str:
+        """Return the circuit-breaker key, namespacing Qwen runtimes when available."""
         if provider_key != "qwen3_tts" or adapter is None:
             return provider_key
 

--- a/tldw_Server_API/app/core/TTS/tts_service_v2.py
+++ b/tldw_Server_API/app/core/TTS/tts_service_v2.py
@@ -39,7 +39,12 @@ from .audio_utils import (
     split_text_into_chunks,
     trim_trailing_silence,
 )
-from .circuit_breaker import CircuitBreakerManager, CircuitOpenError, get_circuit_manager
+from .circuit_breaker import (
+    CircuitBreakerManager,
+    CircuitOpenError,
+    build_qwen_runtime_breaker_key,
+    get_circuit_manager,
+)
 from .realtime_session import (
     BufferedRealtimeSession,
     RealtimeSessionConfig,
@@ -1199,6 +1204,7 @@ class TTSServiceV2:
             fmts = out.get("formats")
             if isinstance(fmts, (set, list, tuple)):
                 out["formats"] = [getattr(f, "value", str(f)) for f in fmts]
+            out["metadata"] = dict(out.get("metadata") or {})
             return out
 
         # Dataclass / object case
@@ -1221,6 +1227,7 @@ class TTSServiceV2:
         except _TTS_NONCRITICAL_EXCEPTIONS:
             data["languages"] = list(languages)
         data["formats"] = [getattr(f, "value", str(f)) for f in formats]
+        data["metadata"] = dict(data.get("metadata") or {})
 
         # Normalize voices (VoiceInfo dataclasses) into plain dicts
         norm_voices: list[dict[str, Any]] = []
@@ -1248,6 +1255,31 @@ class TTSServiceV2:
             data["default_format"] = getattr(df, "value", str(df))
 
         return data
+
+    def _resolve_circuit_breaker_key(self, provider_key: str, adapter: Optional[Any] = None) -> str:
+        if provider_key != "qwen3_tts" or adapter is None:
+            return provider_key
+
+        runtime_name = None
+        runtime_getter = getattr(adapter, "_get_runtime", None)
+        if callable(runtime_getter):
+            try:
+                runtime = runtime_getter()
+                runtime_name = getattr(runtime, "runtime_name", None)
+            except _TTS_NONCRITICAL_EXCEPTIONS:
+                runtime_name = None
+
+        if not runtime_name:
+            runtime_resolver = getattr(adapter, "_resolve_runtime_name", None)
+            if callable(runtime_resolver):
+                try:
+                    runtime_name = runtime_resolver()
+                except _TTS_NONCRITICAL_EXCEPTIONS:
+                    runtime_name = None
+
+        if not runtime_name:
+            return provider_key
+        return build_qwen_runtime_breaker_key(provider_key, str(runtime_name))
 
     async def get_provider_info(self, provider: str) -> dict[str, Any]:
         """Legacy provider information wrapper used by tests."""
@@ -1549,8 +1581,10 @@ class TTSServiceV2:
 
                     # Get circuit breaker if available
                     circuit_breaker = None
+                    breaker_provider_key = provider_key
                     if self.circuit_manager:
-                        circuit_breaker = await self.circuit_manager.get_breaker(provider_key)
+                        breaker_provider_key = self._resolve_circuit_breaker_key(provider_key, adapter)
+                        circuit_breaker = await self.circuit_manager.get_breaker(breaker_provider_key)
 
                     # Generate response (with or without circuit breaker)
                     response: Optional[TTSResponse] = None
@@ -1686,7 +1720,11 @@ class TTSServiceV2:
                                         success=False,
                                         error=error_msg,
                                     )
-                                await self._handle_provider_fallback(request_for_provider, provider_key, error_msg)
+                                await self._handle_provider_fallback(
+                                    request_for_provider,
+                                    breaker_provider_key,
+                                    error_msg,
+                                )
                                 await self._decrement_active_requests(provider_key)
                                 released_active_slot = True
                                 fallback_plan = (self._build_exclude_tokens(adapter), provider_key)

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -4,6 +4,7 @@
 # Imports
 import base64
 import html
+import platform
 import re
 import unicodedata
 from typing import Any, Optional, Union
@@ -354,6 +355,14 @@ class TTSInputValidator:
         except (TypeError, ValueError):
             return None
 
+    def _resolve_qwen3_runtime(self, provider: Optional[str]) -> str:
+        configured = str(self._get_provider_setting(provider, "runtime") or "auto").strip().lower()
+        if configured in {"upstream", "mlx", "remote"}:
+            return configured
+        if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
+            return "mlx"
+        return "upstream"
+
     def _decode_base64_payload(self, payload: str) -> bytes:
         """Decode base64 payload with optional data URL prefix."""
         if "," in payload:
@@ -550,7 +559,7 @@ class TTSInputValidator:
             if provider == "qwen3_tts":
                 model_name = (getattr(request, "model", None) or "").strip().lower()
                 extras = request.extra_params or {}
-                runtime_name = str(self._get_provider_setting(provider, "runtime") or "auto").strip().lower()
+                runtime_name = self._resolve_qwen3_runtime(provider)
                 if runtime_name == "mlx":
                     if request.voice and isinstance(request.voice, str) and request.voice.startswith("custom:"):
                         raise TTSInvalidInputError(

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -550,6 +550,35 @@ class TTSInputValidator:
             if provider == "qwen3_tts":
                 model_name = (getattr(request, "model", None) or "").strip().lower()
                 extras = request.extra_params or {}
+                runtime_name = str(self._get_provider_setting(provider, "runtime") or "auto").strip().lower()
+                if runtime_name == "mlx":
+                    if request.voice and isinstance(request.voice, str) and request.voice.startswith("custom:"):
+                        raise TTSInvalidInputError(
+                            "Uploaded custom voices are not supported by the MLX runtime in v1",
+                            provider=provider,
+                        )
+                    if "voicedesign" in model_name:
+                        raise TTSInvalidInputError(
+                            "Mode 'voice_design' is not supported by the MLX runtime",
+                            provider=provider,
+                        )
+                    clone_requested = bool(
+                        request.voice_reference
+                        or (isinstance(extras, dict) and (
+                            extras.get("reference_text")
+                            or extras.get("ref_text")
+                            or extras.get("voice_reference_text")
+                            or extras.get("x_vector_only_mode")
+                            or extras.get("voice_clone_prompt")
+                        ))
+                        or model_name.endswith("base")
+                        or model_name.endswith("-base")
+                    )
+                    if clone_requested:
+                        raise TTSInvalidInputError(
+                            "Mode 'voice_clone' is not supported by the MLX runtime",
+                            provider=provider,
+                        )
                 if model_name == "auto" or "customvoice" in model_name:
                     if request.voice and isinstance(request.voice, str) and not request.voice.startswith("custom:"):
                         normalized = self._normalize_qwen3_speaker(request.voice)

--- a/tldw_Server_API/app/core/TTS/tts_validation.py
+++ b/tldw_Server_API/app/core/TTS/tts_validation.py
@@ -4,7 +4,6 @@
 # Imports
 import base64
 import html
-import platform
 import re
 import unicodedata
 from typing import Any, Optional, Union
@@ -26,7 +25,7 @@ from .tts_exceptions import (
     TTSValidationError,
     TTSVoiceNotFoundError,
 )
-from .utils import parse_bool
+from .utils import parse_bool, resolve_qwen3_runtime_name
 
 #
 #######################################################################################################################
@@ -356,12 +355,8 @@ class TTSInputValidator:
             return None
 
     def _resolve_qwen3_runtime(self, provider: Optional[str]) -> str:
-        configured = str(self._get_provider_setting(provider, "runtime") or "auto").strip().lower()
-        if configured in {"upstream", "mlx", "remote"}:
-            return configured
-        if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
-            return "mlx"
-        return "upstream"
+        configured = self._get_provider_setting(provider, "runtime")
+        return resolve_qwen3_runtime_name(configured)
 
     def _decode_base64_payload(self, payload: str) -> bytes:
         """Decode base64 payload with optional data URL prefix."""

--- a/tldw_Server_API/app/core/TTS/utils.py
+++ b/tldw_Server_API/app/core/TTS/utils.py
@@ -4,6 +4,7 @@ Utility helpers for TTS modules.
 Currently includes:
 - parse_bool: robust conversion of common string/numeric values to boolean.
 - estimate_max_new_tokens: heuristic sizing for TTS generation.
+- resolve_qwen3_runtime_name: shared Qwen3 runtime selection logic.
 """
 from __future__ import annotations
 
@@ -12,6 +13,7 @@ import hmac
 import json
 import math
 import os
+import platform
 import re
 import unicodedata
 from typing import Any
@@ -88,6 +90,16 @@ def estimate_max_new_tokens(
     if min_tokens < 0:
         min_tokens = 0
     return max(min_tokens, min(est, max_cap))
+
+
+def resolve_qwen3_runtime_name(configured_runtime: Any) -> str:
+    """Resolve the effective Qwen3 runtime for the current host."""
+    normalized = str(configured_runtime or "auto").strip().lower()
+    if normalized in {"upstream", "mlx", "remote"}:
+        return normalized
+    if platform.system() == "Darwin" and platform.machine().lower() == "arm64":
+        return "mlx"
+    return "upstream"
 
 
 def clean_text_for_tts(text: str | None) -> str:

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -26,6 +26,8 @@ import time  # noqa: E402
 from collections.abc import AsyncIterator, Iterable  # noqa: E402
 from contextlib import asynccontextmanager, suppress  # noqa: E402
 from dataclasses import dataclass  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+from email.utils import parsedate_to_datetime  # noqa: E402
 from pathlib import Path  # noqa: E402
 from types import SimpleNamespace  # noqa: E402
 from typing import Any, Protocol, TypedDict  # noqa: E402
@@ -1373,6 +1375,29 @@ def _decorrelated_jitter_sleep(prev: float, base_ms: int, cap_s: int) -> float:
     return sleep
 
 
+def _parse_retry_after_delay_seconds(
+    retry_after: str | None,
+    *,
+    now: datetime | None = None,
+) -> float | None:
+    """Parse Retry-After as delta-seconds or HTTP-date and return seconds to wait."""
+    if not retry_after:
+        return None
+    try:
+        return max(0.0, float(retry_after.strip()))
+    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    try:
+        parsed = parsedate_to_datetime(retry_after.strip())
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        current = now or datetime.now(timezone.utc)
+        return max(0.0, (parsed - current).total_seconds())
+    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+        return None
+
+
 def _should_retry(method: str, status: int | None, exc: Exception | None, policy: RetryPolicy) -> tuple[bool, str]:
     m = method.upper()
     if exc is not None:
@@ -2259,12 +2284,7 @@ async def _afetch_httpx(
                             # Honor Retry-After
                             delay = 0.0
                             if retry.respect_retry_after:
-                                ra = resp.headers.get("retry-after")
-                                if ra:
-                                    try:
-                                        delay = float(ra)
-                                    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                                        delay = 0.0
+                                delay = _parse_retry_after_delay_seconds(resp.headers.get("retry-after")) or 0.0
                             if delay <= 0:
                                 delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                             logger.debug(
@@ -2533,12 +2553,7 @@ async def _afetch_aiohttp(
                     pass
                 delay = 0.0
                 if retry.respect_retry_after:
-                    ra = resp.headers.get("retry-after")
-                    if ra:
-                        try:
-                            delay = float(ra)
-                        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                            delay = 0.0
+                    delay = _parse_retry_after_delay_seconds(resp.headers.get("retry-after")) or 0.0
                 if delay <= 0:
                     delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                 logger.debug(
@@ -2905,12 +2920,7 @@ def _fetch_httpx_response(
                         get_metrics_registry().increment("http_client_retries_total", 1, labels={"reason": rsn})
                     delay = 0.0
                     if retry.respect_retry_after:
-                        ra = resp.headers.get("retry-after")
-                        if ra:
-                            try:
-                                delay = float(ra)
-                            except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                                delay = 0.0
+                        delay = _parse_retry_after_delay_seconds(resp.headers.get("retry-after")) or 0.0
                     if delay <= 0:
                         delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                     logger.debug(
@@ -3259,12 +3269,7 @@ async def _astream_bytes_httpx(
                                 )
                             delay = 0.0
                             if retry.respect_retry_after:
-                                ra = resp.headers.get("retry-after")
-                                if ra:
-                                    try:
-                                        delay = float(ra)
-                                    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                                        delay = 0.0
+                                delay = _parse_retry_after_delay_seconds(resp.headers.get("retry-after")) or 0.0
                             if delay <= 0:
                                 delay = _decorrelated_jitter_sleep(
                                     sleep_s,
@@ -3470,12 +3475,7 @@ async def _astream_bytes_aiohttp(
                                 )
                             delay = 0.0
                             if retry.respect_retry_after:
-                                ra = resp.headers.get("retry-after")
-                                if ra:
-                                    try:
-                                        delay = float(ra)
-                                    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
-                                        delay = 0.0
+                                delay = _parse_retry_after_delay_seconds(resp.headers.get("retry-after")) or 0.0
                             if delay <= 0:
                                 delay = _decorrelated_jitter_sleep(
                                     sleep_s,
@@ -3556,10 +3556,49 @@ async def _astream_bytes_aiohttp(
                 )
                 await asyncio.sleep(delay)
                 sleep_s = delay
+            except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
+                network_exc = NetworkError(e.__class__.__name__)
+                if yielded_any:
+                    _log_outbound_request(
+                        method=method,
+                        url=str(getattr(resp, "url", url)),
+                        status_code=int(getattr(resp, "status", 0) or 0),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=network_exc.__class__.__name__,
+                    )
+                    raise network_exc from e
+                should, rsn = _should_retry(method, None, network_exc, retry)
+                if not should or attempt == attempts:
+                    _log_outbound_request(
+                        method=method,
+                        url=str(getattr(resp, "url", url)),
+                        status_code=0,
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=network_exc.__class__.__name__,
+                    )
+                    raise network_exc from e
+                with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                    get_metrics_registry().increment(
+                        "http_client_retries_total",
+                        1,
+                        labels={"reason": rsn},
+                    )
+                delay = _decorrelated_jitter_sleep(
+                    sleep_s,
+                    retry.backoff_base_ms,
+                    retry.backoff_cap_s,
+                )
+                logger.debug(
+                    f"astream_bytes network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                )
+                await asyncio.sleep(delay)
+                sleep_s = delay
     except asyncio.CancelledError:
         raise
-    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
-        raise NetworkError(e.__class__.__name__) from e
 
 
 async def astream_bytes(

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -458,6 +458,7 @@ class TransportAdapter(Protocol):
         files: Any | None = None,
         timeout: Any | None = None,
         proxies: str | dict[str, str] | None = None,
+        retry: RetryPolicy | None = None,
         chunk_size: int = 65536,
         cert_pinning: dict[str, set[str]] | None = None,
     ) -> AsyncIterator[bytes]: ...
@@ -567,6 +568,7 @@ class HttpxAdapter:
         files: Any | None = None,
         timeout: float | httpx.Timeout | None = None,
         proxies: str | dict[str, str] | None = None,
+        retry: RetryPolicy | None = None,
         chunk_size: int = 65536,
         cert_pinning: dict[str, set[str]] | None = None,
     ) -> AsyncIterator[bytes]:
@@ -581,6 +583,7 @@ class HttpxAdapter:
             files=files,
             timeout=timeout,
             proxies=proxies,
+            retry=retry,
             chunk_size=chunk_size,
             cert_pinning=cert_pinning,
         ):
@@ -673,6 +676,7 @@ class AiohttpAdapter:
         files: Any | None = None,
         timeout: Any | None = None,
         proxies: str | dict[str, str] | None = None,
+        retry: RetryPolicy | None = None,
         chunk_size: int = 65536,
         cert_pinning: dict[str, set[str]] | None = None,
     ) -> AsyncIterator[bytes]:
@@ -687,6 +691,7 @@ class AiohttpAdapter:
             files=files,
             timeout=timeout,
             proxies=proxies,
+            retry=retry,
             chunk_size=chunk_size,
             cert_pinning=cert_pinning,
         ):
@@ -3192,11 +3197,14 @@ async def _astream_bytes_httpx(
     files: Any | None = None,
     timeout: float | httpx.Timeout | None = None,
     proxies: str | dict[str, str] | None = None,
+    retry: RetryPolicy | None = None,
     chunk_size: int = 65536,
     cert_pinning: dict[str, set[str]] | None = None,
 ) -> AsyncIterator[bytes]:
     if httpx is None:  # pragma: no cover
         raise RuntimeError("httpx is not available")  # noqa: TRY003
+    retry = retry or RetryPolicy()
+    _validate_retry_files_seekable(files, retry)
     _validate_egress_or_raise(url)
     _validate_proxies_or_raise(proxies)
 
@@ -3206,80 +3214,180 @@ async def _astream_bytes_httpx(
         ac = _get_httpx_async_client(proxies=proxies)
         need_close = False
 
-    req_headers = _inject_trace_headers(headers)
+    attempts = max(1, retry.attempts)
     t0 = time.time()
     try:
-        # Optional cert pinning
-        try:
-            pins_map = cert_pinning or _get_client_cert_pins(ac)
-            if pins_map:
-                u = httpx.URL(url)
-                if u.scheme.lower() == "https":
-                    host = (u.host or "").lower()
-                    if host in pins_map:
-                        _check_cert_pinning(host, int(u.port or 443), pins_map[host], TLS_MIN_VERSION)
-        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
-            raise NetworkError(e.__class__.__name__) from e
-        async with _httpx_stream_io(
-            client=ac,
-            method=method.upper(),
-            url=url,
-            headers=req_headers,
-            params=params,
-            json=json,
-            data=data,
-            files=files,
-            timeout=timeout,
-            chunk_size=chunk_size,
-        ) as (resp, byte_iter):
-            resp.raise_for_status()
-            timed_iter = _iter_bytes_with_timeouts(byte_iter, timeout)
-            async for chunk in timed_iter:
-                yield chunk
-            # per-request structured log on successful completion
-            _log_outbound_request(
-                method=method,
-                url=resp.request.url,
-                status_code=int(resp.status_code),
-                start_time=t0,
-                attempt=1,
-                last_retry_delay_s=0.0,
-            )
+        sleep_s = 0.0
+        for attempt in range(1, attempts + 1):
+            yielded_any = False
+            req_headers = _inject_trace_headers(headers)
+            resp = None
+            try:
+                try:
+                    pins_map = cert_pinning or _get_client_cert_pins(ac)
+                    if pins_map:
+                        u = httpx.URL(url)
+                        if u.scheme.lower() == "https":
+                            host = (u.host or "").lower()
+                            if host in pins_map:
+                                _check_cert_pinning(host, int(u.port or 443), pins_map[host], TLS_MIN_VERSION)
+                except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
+                    raise NetworkError(e.__class__.__name__) from e
+
+                async with _httpx_stream_io(
+                    client=ac,
+                    method=method.upper(),
+                    url=url,
+                    headers=req_headers,
+                    params=params,
+                    json=json,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                    chunk_size=chunk_size,
+                ) as (resp, byte_iter):
+                    try:
+                        resp.raise_for_status()
+                    except httpx.HTTPStatusError:
+                        should, rsn = _should_retry(method, resp.status_code, None, retry)
+                        if should and attempt < attempts:
+                            with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                                get_metrics_registry().increment(
+                                    "http_client_retries_total",
+                                    1,
+                                    labels={"reason": rsn},
+                                )
+                            delay = 0.0
+                            if retry.respect_retry_after:
+                                ra = resp.headers.get("retry-after")
+                                if ra:
+                                    try:
+                                        delay = float(ra)
+                                    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+                                        delay = 0.0
+                            if delay <= 0:
+                                delay = _decorrelated_jitter_sleep(
+                                    sleep_s,
+                                    retry.backoff_base_ms,
+                                    retry.backoff_cap_s,
+                                )
+                            logger.debug(
+                                f"astream_bytes retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                            )
+                            await asyncio.sleep(delay)
+                            sleep_s = delay
+                            continue
+                        _log_outbound_request(
+                            method=method,
+                            url=resp.request.url,
+                            status_code=int(resp.status_code),
+                            start_time=t0,
+                            attempt=attempt,
+                            last_retry_delay_s=sleep_s,
+                        )
+                        raise
+
+                    timed_iter = _iter_bytes_with_timeouts(byte_iter, timeout)
+                    async for chunk in timed_iter:
+                        if chunk:
+                            yielded_any = True
+                        yield chunk
+                    _log_outbound_request(
+                        method=method,
+                        url=resp.request.url,
+                        status_code=int(resp.status_code),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                    )
+                    return
+            except asyncio.CancelledError:
+                raise
+            except httpx.HTTPStatusError:
+                raise
+            except httpx.HTTPError as e:
+                network_exc = NetworkError(e.__class__.__name__)
+                if yielded_any:
+                    _log_outbound_request(
+                        method=method,
+                        url=url,
+                        status_code=int(getattr(resp, "status_code", 0) or 0),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=network_exc.__class__.__name__,
+                    )
+                    raise network_exc from e
+                should, rsn = _should_retry(method, None, network_exc, retry)
+                if not should or attempt == attempts:
+                    _log_outbound_request(
+                        method=method,
+                        url=url,
+                        status_code=0,
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=network_exc.__class__.__name__,
+                    )
+                    raise network_exc from e
+                with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                    get_metrics_registry().increment(
+                        "http_client_retries_total",
+                        1,
+                        labels={"reason": rsn},
+                    )
+                delay = _decorrelated_jitter_sleep(
+                    sleep_s,
+                    retry.backoff_base_ms,
+                    retry.backoff_cap_s,
+                )
+                logger.debug(
+                    f"astream_bytes network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                )
+                await asyncio.sleep(delay)
+                sleep_s = delay
+            except NetworkError as e:
+                if yielded_any:
+                    _log_outbound_request(
+                        method=method,
+                        url=url,
+                        status_code=int(getattr(resp, "status_code", 0) or 0),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=e.__class__.__name__,
+                    )
+                    raise
+                should, rsn = _should_retry(method, None, e, retry)
+                if not should or attempt == attempts:
+                    _log_outbound_request(
+                        method=method,
+                        url=url,
+                        status_code=0,
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=e.__class__.__name__,
+                    )
+                    raise
+                with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                    get_metrics_registry().increment(
+                        "http_client_retries_total",
+                        1,
+                        labels={"reason": rsn},
+                    )
+                delay = _decorrelated_jitter_sleep(
+                    sleep_s,
+                    retry.backoff_base_ms,
+                    retry.backoff_cap_s,
+                )
+                logger.debug(
+                    f"astream_bytes network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                )
+                await asyncio.sleep(delay)
+                sleep_s = delay
     except asyncio.CancelledError:
         # propagate cancellations cleanly
-        raise
-    except httpx.HTTPStatusError as e:
-        _log_outbound_request(
-            method=method,
-            url=url,
-            status_code=int(getattr(getattr(e, "response", None), "status_code", 0) or 0),
-            start_time=t0,
-            attempt=1,
-            last_retry_delay_s=0.0,
-            exception_class=e.__class__.__name__,
-        )
-        raise
-    except httpx.HTTPError as e:
-        _log_outbound_request(
-            method=method,
-            url=url,
-            status_code=0,
-            start_time=t0,
-            attempt=1,
-            last_retry_delay_s=0.0,
-            exception_class=e.__class__.__name__,
-        )
-        raise NetworkError(e.__class__.__name__) from e
-    except NetworkError as e:
-        _log_outbound_request(
-            method=method,
-            url=url,
-            status_code=0,
-            start_time=t0,
-            attempt=1,
-            last_retry_delay_s=0.0,
-            exception_class=e.__class__.__name__,
-        )
         raise
     finally:
         if need_close:
@@ -3299,88 +3407,158 @@ async def _astream_bytes_aiohttp(
     files: Any | None = None,
     timeout: Any | None = None,
     proxies: str | dict[str, str] | None = None,
+    retry: RetryPolicy | None = None,
     chunk_size: int = 65536,
     cert_pinning: dict[str, set[str]] | None = None,
 ) -> AsyncIterator[bytes]:
     if aiohttp is None:  # pragma: no cover
         raise RuntimeError("aiohttp is not available")  # noqa: TRY003
+    retry = retry or RetryPolicy()
+    _validate_retry_files_seekable(files, retry)
     _validate_egress_or_raise(url)
     _validate_proxies_or_raise(proxies)
 
     session = client or _get_aiohttp_session()
-    req_headers = _inject_trace_headers(headers)
+    attempts = max(1, retry.attempts)
     t0 = time.time()
     try:
-        # Optional cert pinning
-        try:
-            pins_map = cert_pinning or _get_client_cert_pins(session)
-            if pins_map:
-                if httpx is not None:
-                    u = httpx.URL(url)
-                    host = (u.host or "").lower()
-                    port = int(u.port or (443 if (u.scheme or "").lower() == "https" else 80))
-                else:
-                    parsed = urlparse(url)
-                    host = (parsed.hostname or "").lower()
-                    port = parsed.port or (443 if (parsed.scheme or "").lower() == "https" else 80)
-                if host in pins_map:
-                    _check_cert_pinning(host, port, pins_map[host], TLS_MIN_VERSION)
-        except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
-            raise NetworkError(e.__class__.__name__) from e
-        ssl_ctx = _build_ssl_context(ENFORCE_TLS_MIN, TLS_MIN_VERSION)
-        async with _aiohttp_stream_io(
-            session=session,
-            method=method.upper(),
-            url=url,
-            headers=req_headers,
-            params=params,
-            json=json,
-            data=data,
-            files=files,
-            timeout=timeout,
-            proxies=proxies,
-            ssl_override=ssl_ctx,
-            chunk_size=chunk_size,
-        ) as (resp, byte_iter):
-            if resp.status >= 400:
-                await resp.read()
-                raise NetworkError(f"HTTP {resp.status}")  # noqa: TRY003, TRY301
-            timed_iter = _iter_bytes_with_timeouts(byte_iter, timeout)
-            async for chunk in timed_iter:
-                if not chunk:
-                    continue
-                yield chunk
-            _log_outbound_request(
-                method=method,
-                url=str(getattr(resp, "url", url)),
-                status_code=int(resp.status),
-                start_time=t0,
-                attempt=1,
-                last_retry_delay_s=0.0,
-            )
+        sleep_s = 0.0
+        for attempt in range(1, attempts + 1):
+            yielded_any = False
+            resp = None
+            req_headers = _inject_trace_headers(headers)
+            try:
+                try:
+                    pins_map = cert_pinning or _get_client_cert_pins(session)
+                    if pins_map:
+                        if httpx is not None:
+                            u = httpx.URL(url)
+                            host = (u.host or "").lower()
+                            port = int(u.port or (443 if (u.scheme or "").lower() == "https" else 80))
+                        else:
+                            parsed = urlparse(url)
+                            host = (parsed.hostname or "").lower()
+                            port = parsed.port or (443 if (parsed.scheme or "").lower() == "https" else 80)
+                        if host in pins_map:
+                            _check_cert_pinning(host, port, pins_map[host], TLS_MIN_VERSION)
+                except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
+                    raise NetworkError(e.__class__.__name__) from e
+
+                ssl_ctx = _build_ssl_context(ENFORCE_TLS_MIN, TLS_MIN_VERSION)
+                async with _aiohttp_stream_io(
+                    session=session,
+                    method=method.upper(),
+                    url=url,
+                    headers=req_headers,
+                    params=params,
+                    json=json,
+                    data=data,
+                    files=files,
+                    timeout=timeout,
+                    proxies=proxies,
+                    ssl_override=ssl_ctx,
+                    chunk_size=chunk_size,
+                ) as (resp, byte_iter):
+                    if resp.status >= 400:
+                        should, rsn = _should_retry(method, resp.status, None, retry)
+                        if should and attempt < attempts:
+                            with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                                get_metrics_registry().increment(
+                                    "http_client_retries_total",
+                                    1,
+                                    labels={"reason": rsn},
+                                )
+                            delay = 0.0
+                            if retry.respect_retry_after:
+                                ra = resp.headers.get("retry-after")
+                                if ra:
+                                    try:
+                                        delay = float(ra)
+                                    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+                                        delay = 0.0
+                            if delay <= 0:
+                                delay = _decorrelated_jitter_sleep(
+                                    sleep_s,
+                                    retry.backoff_base_ms,
+                                    retry.backoff_cap_s,
+                                )
+                            logger.debug(
+                                f"astream_bytes retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                            )
+                            await asyncio.sleep(delay)
+                            sleep_s = delay
+                            continue
+                        await resp.read()
+                        _log_outbound_request(
+                            method=method,
+                            url=str(getattr(resp, "url", url)),
+                            status_code=int(resp.status),
+                            start_time=t0,
+                            attempt=attempt,
+                            last_retry_delay_s=sleep_s,
+                        )
+                        raise NetworkError(f"HTTP {resp.status}")  # noqa: TRY003
+
+                    timed_iter = _iter_bytes_with_timeouts(byte_iter, timeout)
+                    async for chunk in timed_iter:
+                        if not chunk:
+                            continue
+                        yielded_any = True
+                        yield chunk
+                    _log_outbound_request(
+                        method=method,
+                        url=str(getattr(resp, "url", url)),
+                        status_code=int(resp.status),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                    )
+                    return
+            except asyncio.CancelledError:
+                raise
+            except NetworkError as e:
+                if yielded_any:
+                    _log_outbound_request(
+                        method=method,
+                        url=str(getattr(resp, "url", url)),
+                        status_code=int(getattr(resp, "status", 0) or 0),
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=e.__class__.__name__,
+                    )
+                    raise
+                should, rsn = _should_retry(method, None, e, retry)
+                if not should or attempt == attempts:
+                    _log_outbound_request(
+                        method=method,
+                        url=str(getattr(resp, "url", url)),
+                        status_code=0,
+                        start_time=t0,
+                        attempt=attempt,
+                        last_retry_delay_s=sleep_s,
+                        exception_class=e.__class__.__name__,
+                    )
+                    raise
+                with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
+                    get_metrics_registry().increment(
+                        "http_client_retries_total",
+                        1,
+                        labels={"reason": rsn},
+                    )
+                delay = _decorrelated_jitter_sleep(
+                    sleep_s,
+                    retry.backoff_base_ms,
+                    retry.backoff_cap_s,
+                )
+                logger.debug(
+                    f"astream_bytes network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={url}"
+                )
+                await asyncio.sleep(delay)
+                sleep_s = delay
     except asyncio.CancelledError:
         raise
-    except NetworkError as e:
-        _log_outbound_request(
-            method=method,
-            url=url,
-            status_code=0,
-            start_time=t0,
-            attempt=1,
-            last_retry_delay_s=0.0,
-            exception_class=e.__class__.__name__,
-        )
-        raise
     except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS as e:
-        _log_outbound_request(
-            method=method,
-            url=url,
-            status_code=0,
-            start_time=t0,
-            attempt=1,
-            last_retry_delay_s=0.0,
-            exception_class=e.__class__.__name__,
-        )
         raise NetworkError(e.__class__.__name__) from e
 
 
@@ -3396,6 +3574,7 @@ async def astream_bytes(
     files: Any | None = None,
     timeout: Any | None = None,
     proxies: str | dict[str, str] | None = None,
+    retry: RetryPolicy | None = None,
     chunk_size: int = 65536,
     cert_pinning: dict[str, set[str]] | None = None,
 ) -> AsyncIterator[bytes]:
@@ -3415,6 +3594,7 @@ async def astream_bytes(
         files=files,
         timeout=timeout,
         proxies=proxies,
+        retry=retry,
         chunk_size=chunk_size,
         cert_pinning=cert_pinning,
     ):

--- a/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
+++ b/tldw_Server_API/tests/Infrastructure/test_workflow_concurrency_policy.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+
+PR_STABLE_CONCURRENCY = "${{ github.event.pull_request.number || github.ref }}"
+
+EXPECTED_WORKFLOW_GROUPS = {
+    "ci.yml": f"ci-{PR_STABLE_CONCURRENCY}",
+    "backend-required.yml": f"backend-required-{PR_STABLE_CONCURRENCY}",
+    "coverage-required.yml": f"coverage-required-{PR_STABLE_CONCURRENCY}",
+    "frontend-required.yml": f"frontend-required-{PR_STABLE_CONCURRENCY}",
+    "security-required.yml": f"security-required-{PR_STABLE_CONCURRENCY}",
+    "e2e-required.yml": f"e2e-required-{PR_STABLE_CONCURRENCY}",
+    "frontend-ux-gates.yml": f"frontend-ux-gates-{PR_STABLE_CONCURRENCY}",
+    "pre-commit.yml": f"pre-commit-{PR_STABLE_CONCURRENCY}",
+    "pypi-package.yml": f"pypi-package-{PR_STABLE_CONCURRENCY}",
+    "sbom.yml": f"sbom-{PR_STABLE_CONCURRENCY}",
+}
+
+
+def _load_workflow(name: str) -> dict:
+    with (WORKFLOWS_DIR / name).open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def test_target_workflows_use_pr_stable_concurrency_groups():
+    for filename, expected_group in EXPECTED_WORKFLOW_GROUPS.items():
+        workflow = _load_workflow(filename)
+        concurrency = workflow.get("concurrency")
+
+        assert isinstance(concurrency, dict), f"{filename} is missing a concurrency block"  # nosec B101
+        assert concurrency.get("group") == expected_group  # nosec B101
+        assert concurrency.get("cancel-in-progress") is True  # nosec B101

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_mlx_runtime_integration.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_mlx_runtime_integration.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import platform
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration, pytest.mark.local_llm_service]
+
+
+def _require_qwen3_mlx_model() -> str:
+    if os.getenv("TLDW_RUN_QWEN3_MLX_INTEGRATION") != "1":
+        pytest.skip("TLDW_RUN_QWEN3_MLX_INTEGRATION not set")
+    if platform.system() != "Darwin" or platform.machine().lower() != "arm64":
+        pytest.skip("Qwen3 MLX integration tests run only on Apple Silicon macOS")
+    try:
+        import mlx_audio.tts.utils  # noqa: F401
+    except Exception:
+        pytest.skip("mlx-audio is not installed; skipping Qwen3 MLX integration tests")
+    return os.getenv("QWEN3_MLX_MODEL") or "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
+
+
+@pytest.mark.requires_model
+async def test_qwen3_mlx_streaming_smoke():
+    model_id = _require_qwen3_mlx_model()
+    adapter = Qwen3TTSAdapter(
+        {
+            "runtime": "mlx",
+            "model": "auto",
+            "mlx_model": model_id,
+            "device": "mps",
+        }
+    )
+    try:
+        await adapter.ensure_initialized()
+
+        request = TTSRequest(
+            text="Hello from the Qwen3 MLX integration test.",
+            voice="Vivian",
+            format=AudioFormat.PCM,
+            stream=True,
+        )
+        request.model = "auto"
+
+        response = await adapter.generate(request)
+        chunks = [chunk async for chunk in response.audio_stream if chunk]
+
+        assert chunks
+        assert sum(len(chunk) for chunk in chunks) > 0
+        assert response.metadata["runtime"] == "mlx"
+        assert response.metadata["streaming_fallback"] == "buffered"
+    finally:
+        await adapter.close()

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_runtime_health_envelope.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_runtime_health_envelope.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+import tldw_Server_API.app.api.v1.endpoints.audio.audio_health as audio_health
+import tldw_Server_API.app.core.TTS.adapter_registry as adapter_registry
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSCapabilities
+from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
+
+
+class _FakeRegistry:
+    def list_capabilities(self, include_disabled=True):
+        assert include_disabled is True
+        return [
+            {
+                "provider": "qwen3_tts",
+                "availability": "enabled",
+                "capabilities": TTSCapabilities(
+                    provider_name="Qwen3-TTS",
+                    supported_languages={"en"},
+                    supported_voices=[],
+                    supported_formats={AudioFormat.PCM},
+                    max_text_length=5000,
+                    supports_streaming=False,
+                    metadata={"runtime": "mlx", "supported_modes": ["custom_voice_preset"]},
+                ),
+            }
+        ]
+
+
+class _FakeFactory:
+    def __init__(self):
+        self.registry = _FakeRegistry()
+
+
+class _FakeTTSService:
+    def __init__(self):
+        self._serializer = TTSServiceV2()._serialize_capabilities
+
+    def get_status(self):
+        return {
+            "providers": {
+                "qwen3_tts": {
+                    "status": "enabled",
+                    "availability": "enabled",
+                    "initialized": True,
+                    "failed": False,
+                }
+            },
+            "available": 1,
+            "total_providers": 1,
+            "circuit_breakers": {"qwen3_tts:mlx": {"state": "closed"}},
+        }
+
+    async def get_capabilities(self):
+        return {}
+
+    def _serialize_capabilities(self, caps):
+        return self._serializer(caps)
+
+
+@pytest.mark.asyncio
+async def test_qwen3_runtime_health_envelope_includes_breaker_key(monkeypatch):
+    async def _fake_get_tts_factory():
+        return _FakeFactory()
+
+    monkeypatch.setattr(adapter_registry, "get_tts_factory", _fake_get_tts_factory)
+
+    health = await audio_health.get_tts_health(
+        request=MagicMock(),
+        tts_service=_FakeTTSService(),
+    )
+
+    envelope = health["capabilities_envelope"][0]
+    assert envelope["runtime"] == "mlx"
+    assert envelope["breaker_key"] == "qwen3_tts:mlx"
+    assert health["providers"]["details"]["qwen3_tts"]["breaker_key"] == "qwen3_tts:mlx"

--- a/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_streaming.py
+++ b/tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_streaming.py
@@ -1,3 +1,4 @@
+import importlib.machinery
 import sys
 import types
 
@@ -11,6 +12,11 @@ from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdap
 @pytest.fixture
 def fake_qwen_stream_module(monkeypatch):
     module = types.ModuleType("qwen_tts")
+    fake_torch = types.ModuleType("torch")
+    fake_torch.__spec__ = importlib.machinery.ModuleSpec("torch", loader=None)
+    fake_torch.float16 = "float16"
+    fake_torch.bfloat16 = "bfloat16"
+    fake_torch.float32 = "float32"
 
     class StreamBackend:
         async def stream_custom_voice(self, text, language=None, speaker=None, **_kwargs):
@@ -23,12 +29,13 @@ def fake_qwen_stream_module(monkeypatch):
             return StreamBackend()
 
     module.Qwen3TTS = FakeQwen3TTS
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
     monkeypatch.setitem(sys.modules, "qwen_tts", module)
 
 
 @pytest.mark.asyncio
 async def test_qwen3_streaming_returns_chunks(fake_qwen_stream_module):
-    adapter = Qwen3TTSAdapter({"device": "cpu", "model": "auto"})
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu", "model": "auto"})
     await adapter.ensure_initialized()
 
     request = TTSRequest(

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
@@ -1,7 +1,11 @@
+import sys
+import types
 import platform
 
+import numpy as np
 import pytest
 
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
 
 
@@ -19,3 +23,48 @@ async def test_mlx_runtime_reports_preset_custom_voice_only(monkeypatch):
     assert caps.metadata["supported_modes"] == ["custom_voice_preset"]
     assert caps.metadata["supports_uploaded_custom_voices"] is False
     assert caps.supports_voice_cloning is False
+
+
+@pytest.fixture
+def fake_mlx_audio_module(monkeypatch):
+    mlx_audio_module = types.ModuleType("mlx_audio")
+    mlx_audio_tts_module = types.ModuleType("mlx_audio.tts")
+    mlx_audio_utils_module = types.ModuleType("mlx_audio.tts.utils")
+
+    class _FakeResult:
+        def __init__(self):
+            self.audio = np.zeros(160, dtype=np.float32)
+            self.sample_rate = 24000
+
+    class _FakeModel:
+        def generate(self, **_kwargs):
+            yield _FakeResult()
+
+    mlx_audio_utils_module.load_model = lambda _model_id: _FakeModel()
+
+    monkeypatch.setitem(sys.modules, "mlx_audio", mlx_audio_module)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts", mlx_audio_tts_module)
+    monkeypatch.setitem(sys.modules, "mlx_audio.tts.utils", mlx_audio_utils_module)
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_generates_preset_speaker_audio(fake_mlx_audio_module, monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+
+    request = TTSRequest(
+        text="hello",
+        voice="Vivian",
+        format=AudioFormat.PCM,
+        stream=False,
+    )
+    request.model = "auto"
+
+    response = await adapter.generate(request)
+
+    assert response.audio_content
+    assert response.metadata["runtime"] == "mlx"

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
@@ -23,6 +23,7 @@ async def test_mlx_runtime_reports_preset_custom_voice_only(monkeypatch):
     assert caps.metadata["supported_modes"] == ["custom_voice_preset"]
     assert caps.metadata["supports_uploaded_custom_voices"] is False
     assert caps.supports_voice_cloning is False
+    assert caps.supports_streaming is True
 
 
 @pytest.fixture
@@ -68,3 +69,28 @@ async def test_mlx_runtime_generates_preset_speaker_audio(fake_mlx_audio_module,
 
     assert response.audio_content
     assert response.metadata["runtime"] == "mlx"
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_stream_request_uses_buffered_fallback(fake_mlx_audio_module, monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+
+    request = TTSRequest(
+        text="hello",
+        voice="Vivian",
+        format=AudioFormat.PCM,
+        stream=True,
+    )
+    request.model = "auto"
+
+    response = await adapter.generate(request)
+    chunks = [chunk async for chunk in response.audio_stream]
+
+    assert chunks
+    assert response.metadata["runtime"] == "mlx"
+    assert response.metadata["streaming_fallback"] == "buffered"

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
@@ -7,6 +7,7 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
 
 
 @pytest.mark.asyncio
@@ -69,6 +70,27 @@ async def test_mlx_runtime_generates_preset_speaker_audio(fake_mlx_audio_module,
 
     assert response.audio_content
     assert response.metadata["runtime"] == "mlx"
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_rejects_unknown_non_custom_voice(fake_mlx_audio_module, monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+
+    request = TTSRequest(
+        text="hello",
+        voice="not-a-real-speaker",
+        format=AudioFormat.PCM,
+        stream=False,
+    )
+    request.model = "auto"
+
+    with pytest.raises(TTSValidationError):
+        await adapter.generate(request)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
@@ -1,6 +1,7 @@
+import asyncio
+import platform
 import sys
 import types
-import platform
 
 import numpy as np
 import pytest
@@ -32,6 +33,7 @@ def fake_mlx_audio_module(monkeypatch):
     mlx_audio_module = types.ModuleType("mlx_audio")
     mlx_audio_tts_module = types.ModuleType("mlx_audio.tts")
     mlx_audio_utils_module = types.ModuleType("mlx_audio.tts.utils")
+    load_calls = {"count": 0}
 
     class _FakeResult:
         def __init__(self):
@@ -42,11 +44,16 @@ def fake_mlx_audio_module(monkeypatch):
         def generate(self, **_kwargs):
             yield _FakeResult()
 
-    mlx_audio_utils_module.load_model = lambda _model_id: _FakeModel()
+    def fake_load_model(_model_id):
+        load_calls["count"] += 1
+        return _FakeModel()
+
+    mlx_audio_utils_module.load_model = fake_load_model
 
     monkeypatch.setitem(sys.modules, "mlx_audio", mlx_audio_module)
     monkeypatch.setitem(sys.modules, "mlx_audio.tts", mlx_audio_tts_module)
     monkeypatch.setitem(sys.modules, "mlx_audio.tts.utils", mlx_audio_utils_module)
+    return load_calls
 
 
 @pytest.mark.asyncio
@@ -70,6 +77,58 @@ async def test_mlx_runtime_generates_preset_speaker_audio(fake_mlx_audio_module,
 
     assert response.audio_content
     assert response.metadata["runtime"] == "mlx"
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_offloads_model_load_and_generation(fake_mlx_audio_module, monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    to_thread_calls = []
+
+    async def fake_to_thread(func, *args, **kwargs):
+        to_thread_calls.append(func.__name__)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+
+    request = TTSRequest(
+        text="hello",
+        voice="Vivian",
+        format=AudioFormat.PCM,
+        stream=False,
+    )
+    request.model = "auto"
+
+    await adapter.generate(request)
+
+    assert to_thread_calls == ["fake_load_model", "_run_generation"]
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_serializes_concurrent_model_loads(fake_mlx_audio_module, monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    async def fake_to_thread(func, *args, **kwargs):
+        await asyncio.sleep(0)
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+    runtime = adapter._get_runtime()
+
+    models = await asyncio.gather(runtime._get_model("auto"), runtime._get_model("auto"))
+
+    assert models[0][0] is models[1][0]
+    assert fake_mlx_audio_module["count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py
@@ -1,0 +1,21 @@
+import platform
+
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+@pytest.mark.asyncio
+async def test_mlx_runtime_reports_preset_custom_voice_only(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter({"runtime": "mlx", "device": "mps"})
+
+    await adapter.ensure_initialized()
+    caps = await adapter.get_capabilities()
+
+    assert caps.metadata["runtime"] == "mlx"
+    assert caps.metadata["supported_modes"] == ["custom_voice_preset"]
+    assert caps.metadata["supports_uploaded_custom_voices"] is False
+    assert caps.supports_voice_cloning is False

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+from types import SimpleNamespace
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote import RemoteQwenRuntime
@@ -49,6 +50,24 @@ async def test_remote_runtime_capabilities_default_to_conservative_values():
 
 
 @pytest.mark.asyncio
+async def test_remote_runtime_does_not_advertise_local_speakers_by_default():
+    runtime = RemoteQwenRuntime(
+        SimpleNamespace(
+            config={"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"},
+            PROVIDER_KEY="qwen3_tts",
+            provider_name="Qwen3TTS",
+            sample_rate=24000,
+            SUPPORTED_LANGUAGES={"en"},
+            CUSTOMVOICE_SPEAKERS=["Cherry", "Ethan"],
+        )
+    )
+
+    caps = await runtime.get_capabilities()
+
+    assert caps.supported_voices == []
+
+
+@pytest.mark.asyncio
 async def test_remote_runtime_capabilities_allow_override():
     runtime = RemoteQwenRuntime(
         {
@@ -59,6 +78,7 @@ async def test_remote_runtime_capabilities_allow_override():
                 "supports_voice_cloning": True,
                 "supports_emotion_control": True,
                 "supported_modes": ["custom_voice_preset", "uploaded_custom_voice"],
+                "supported_voices": ["Cherry", "Ethan"],
                 "supports_uploaded_custom_voices": True,
             },
         }
@@ -69,6 +89,7 @@ async def test_remote_runtime_capabilities_allow_override():
     assert caps.supports_streaming is True
     assert caps.supports_voice_cloning is True
     assert caps.supports_emotion_control is True
+    assert [voice.id for voice in caps.supported_voices] == ["Cherry", "Ethan"]
     assert caps.metadata["supported_modes"] == ["custom_voice_preset", "uploaded_custom_voice"]
     assert caps.metadata["supports_uploaded_custom_voices"] is True
 

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote import RemoteQwenRuntime
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_maps_qwen_clone_fields_into_extended_payload():
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(
+        text="hello",
+        format=AudioFormat.PCM,
+        voice_reference=b"VOICE_BYTES",
+        extra_params={"reference_text": "ref", "voice_clone_prompt": "UFJPTVBU"},
+    )
+
+    payload = runtime._build_payload(
+        request,
+        resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+        mode="voice_clone",
+    )
+
+    assert payload["extra_body"]["ref_text"] == "ref"
+    assert payload["extra_body"]["voice_clone_prompt"] == "UFJPTVBU"

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
@@ -3,7 +3,11 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote import RemoteQwenRuntime
-from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError, TTSTimeoutError
+from tldw_Server_API.app.core.TTS.tts_exceptions import (
+    TTSAuthenticationError,
+    TTSRateLimitError,
+    TTSTimeoutError,
+)
 import tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote as remote_runtime_mod
 
 
@@ -100,3 +104,100 @@ async def test_remote_runtime_maps_timeout_to_tts_timeout_error(monkeypatch):
 
     with pytest.raises(TTSTimeoutError):
         await runtime.generate(request, resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", mode="custom_voice")
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_stream_maps_http_401_to_auth_error(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=True)
+
+    async def fake_apost(**_kwargs):
+        req = httpx.Request("POST", "http://127.0.0.1:8001/v1/audio/speech")
+        return httpx.Response(401, request=req, content=b'{"error":"bad key"}')
+
+    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+
+    response = await runtime.generate(
+        request,
+        resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+        mode="custom_voice",
+    )
+
+    with pytest.raises(TTSAuthenticationError):
+        [chunk async for chunk in response.audio_stream]
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_stream_maps_iterator_timeout_to_tts_timeout_error(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=True)
+
+    class _FakeStreamResponse:
+        status_code = 200
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+        async def aiter_bytes(self, chunk_size=1024):
+            _ = chunk_size
+            raise httpx.ReadTimeout("timed out during stream")
+            yield b""  # pragma: no cover
+
+        async def aclose(self):
+            return None
+
+    async def fake_apost(**_kwargs):
+        return _FakeStreamResponse()
+
+    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+
+    response = await runtime.generate(
+        request,
+        resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+        mode="custom_voice",
+    )
+
+    with pytest.raises(TTSTimeoutError):
+        [chunk async for chunk in response.audio_stream]
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_maps_http_429_date_retry_after_to_rate_limit_error(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=False)
+
+    async def fake_apost(**_kwargs):
+        req = httpx.Request("POST", "http://127.0.0.1:8001/v1/audio/speech")
+        return httpx.Response(
+            429,
+            request=req,
+            headers={"retry-after": "Wed, 21 Oct 2015 07:28:00 GMT"},
+            content=b'{"error":"rate limited"}',
+        )
+
+    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+
+    with pytest.raises(TTSRateLimitError) as exc:
+        await runtime.generate(
+            request,
+            resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+            mode="custom_voice",
+        )
+
+    assert exc.value.retry_after is None
+
+
+def test_remote_runtime_retry_after_parser_ignores_http_date():
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+
+    assert runtime._parse_retry_after("120") == 120
+    assert runtime._parse_retry_after(" Wed, 21 Oct 2015 07:28:00 GMT ") is None

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
@@ -134,11 +134,13 @@ async def test_remote_runtime_stream_maps_http_401_to_auth_error(monkeypatch):
     )
     request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=True)
 
-    async def fake_apost(**_kwargs):
+    async def fake_astream_bytes(**_kwargs):
         req = httpx.Request("POST", "http://127.0.0.1:8001/v1/audio/speech")
-        return httpx.Response(401, request=req, content=b'{"error":"bad key"}')
+        response = httpx.Response(401, request=req, content=b'{"error":"bad key"}')
+        raise httpx.HTTPStatusError("401", request=req, response=response)
+        yield b""  # pragma: no cover
 
-    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+    monkeypatch.setattr(remote_runtime_mod, "astream_bytes", fake_astream_bytes)
 
     response = await runtime.generate(
         request,
@@ -151,31 +153,49 @@ async def test_remote_runtime_stream_maps_http_401_to_auth_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_remote_runtime_stream_uses_astream_bytes_with_retry_policy(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=True)
+    captured = {}
+
+    async def fake_astream_bytes(**kwargs):
+        captured.update(kwargs)
+        yield b"chunk-one"
+
+    async def fail_if_apost_used(**_kwargs):
+        raise AssertionError("streaming path should use astream_bytes")
+
+    monkeypatch.setattr(remote_runtime_mod, "astream_bytes", fake_astream_bytes, raising=False)
+    monkeypatch.setattr(remote_runtime_mod, "apost", fail_if_apost_used)
+
+    response = await runtime.generate(
+        request,
+        resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
+        mode="custom_voice",
+    )
+    chunks = [chunk async for chunk in response.audio_stream]
+
+    assert chunks == [b"chunk-one"]
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://127.0.0.1:8001/v1/audio/speech"
+    assert captured["retry"].retry_on_unsafe is True
+    assert captured["retry"].attempts >= 2
+
+
+@pytest.mark.asyncio
 async def test_remote_runtime_stream_maps_iterator_timeout_to_tts_timeout_error(monkeypatch):
     runtime = RemoteQwenRuntime(
         {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
     )
     request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=True)
 
-    class _FakeStreamResponse:
-        status_code = 200
-        headers = {}
+    async def fake_astream_bytes(**_kwargs):
+        raise httpx.ReadTimeout("timed out during stream")
+        yield b""  # pragma: no cover
 
-        def raise_for_status(self):
-            return None
-
-        async def aiter_bytes(self, chunk_size=1024):
-            _ = chunk_size
-            raise httpx.ReadTimeout("timed out during stream")
-            yield b""  # pragma: no cover
-
-        async def aclose(self):
-            return None
-
-    async def fake_apost(**_kwargs):
-        return _FakeStreamResponse()
-
-    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+    monkeypatch.setattr(remote_runtime_mod, "astream_bytes", fake_astream_bytes)
 
     response = await runtime.generate(
         request,

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py
@@ -1,7 +1,10 @@
+import httpx
 import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote import RemoteQwenRuntime
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSAuthenticationError, TTSTimeoutError
+import tldw_Server_API.app.core.TTS.adapters.qwen3_runtime_remote as remote_runtime_mod
 
 
 @pytest.mark.asyncio
@@ -24,3 +27,76 @@ async def test_remote_runtime_maps_qwen_clone_fields_into_extended_payload():
 
     assert payload["extra_body"]["ref_text"] == "ref"
     assert payload["extra_body"]["voice_clone_prompt"] == "UFJPTVBU"
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_capabilities_default_to_conservative_values():
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+
+    caps = await runtime.get_capabilities()
+
+    assert caps.supports_streaming is False
+    assert caps.supports_voice_cloning is False
+    assert caps.supports_emotion_control is False
+    assert caps.metadata["supported_modes"] == ["custom_voice_preset"]
+    assert caps.metadata["supports_uploaded_custom_voices"] is False
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_capabilities_allow_override():
+    runtime = RemoteQwenRuntime(
+        {
+            "base_url": "http://127.0.0.1:8001/v1/audio/speech",
+            "api_key": "test-key",
+            "capability_override": {
+                "supports_streaming": True,
+                "supports_voice_cloning": True,
+                "supports_emotion_control": True,
+                "supported_modes": ["custom_voice_preset", "uploaded_custom_voice"],
+                "supports_uploaded_custom_voices": True,
+            },
+        }
+    )
+
+    caps = await runtime.get_capabilities()
+
+    assert caps.supports_streaming is True
+    assert caps.supports_voice_cloning is True
+    assert caps.supports_emotion_control is True
+    assert caps.metadata["supported_modes"] == ["custom_voice_preset", "uploaded_custom_voice"]
+    assert caps.metadata["supports_uploaded_custom_voices"] is True
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_maps_http_401_to_auth_error(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=False)
+
+    async def fake_apost(**_kwargs):
+        req = httpx.Request("POST", "http://127.0.0.1:8001/v1/audio/speech")
+        return httpx.Response(401, request=req, content=b'{"error":"bad key"}')
+
+    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+
+    with pytest.raises(TTSAuthenticationError):
+        await runtime.generate(request, resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", mode="custom_voice")
+
+
+@pytest.mark.asyncio
+async def test_remote_runtime_maps_timeout_to_tts_timeout_error(monkeypatch):
+    runtime = RemoteQwenRuntime(
+        {"base_url": "http://127.0.0.1:8001/v1/audio/speech", "api_key": "test-key"}
+    )
+    request = TTSRequest(text="hello", format=AudioFormat.PCM, stream=False)
+
+    async def fake_apost(**_kwargs):
+        raise httpx.ReadTimeout("timed out")
+
+    monkeypatch.setattr(remote_runtime_mod, "apost", fake_apost)
+
+    with pytest.raises(TTSTimeoutError):
+        await runtime.generate(request, resolved_model="Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice", mode="custom_voice")

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_runtime_selection.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_runtime_selection.py
@@ -1,0 +1,26 @@
+import platform
+
+from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+def test_runtime_auto_prefers_mlx_on_macos_arm64(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter({"runtime": "auto"})
+
+    assert adapter._resolve_runtime_name() == "mlx"
+
+
+def test_runtime_explicit_remote_wins_over_platform(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+
+    adapter = Qwen3TTSAdapter(
+        {
+            "runtime": "remote",
+            "base_url": "http://127.0.0.1:8000/v1/audio/speech",
+        }
+    )
+
+    assert adapter._resolve_runtime_name() == "remote"

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_runtime_selection.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_runtime_selection.py
@@ -1,6 +1,18 @@
 import platform
 
+import tldw_Server_API.app.core.TTS.utils as tts_utils
 from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+def test_shared_runtime_resolver_exists_and_prefers_mlx_on_macos_arm64(monkeypatch):
+    monkeypatch.setattr(platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(tts_utils, "platform", platform, raising=False)
+
+    helper = getattr(tts_utils, "resolve_qwen3_runtime_name", None)
+
+    assert helper is not None
+    assert helper("auto") == "mlx"
 
 
 def test_runtime_auto_prefers_mlx_on_macos_arm64(monkeypatch):

--- a/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_upstream_runtime.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_upstream_runtime.py
@@ -1,0 +1,47 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.adapters.qwen3_tts_adapter import Qwen3TTSAdapter
+
+
+class _FakeBackend:
+    def generate_custom_voice(self, text, language=None, speaker=None, instruct=None, **_kwargs):
+        return np.zeros(160, dtype=np.float32)
+
+
+@pytest.fixture
+def fake_qwen_module(monkeypatch):
+    module = types.ModuleType("qwen_tts")
+
+    class FakeQwen3TTS:
+        @classmethod
+        def from_pretrained(cls, model_id, **_kwargs):
+            return _FakeBackend()
+
+    module.Qwen3TTS = FakeQwen3TTS
+    monkeypatch.setitem(sys.modules, "qwen_tts", module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_upstream_runtime_handles_existing_custom_voice_flow(fake_qwen_module, monkeypatch):
+    adapter = Qwen3TTSAdapter({"runtime": "upstream", "device": "cpu"})
+    monkeypatch.setattr(adapter, "_resolve_torch_dtype", lambda: "float32")
+    await adapter.ensure_initialized()
+
+    request = TTSRequest(
+        text="hello",
+        voice="Vivian",
+        format=AudioFormat.PCM,
+        stream=False,
+    )
+    request.model = "auto"
+
+    response = await adapter.generate(request)
+
+    assert response.audio_content
+    assert response.metadata["runtime"] == "upstream"

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_qwen3_capabilities_runtime_metadata.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_qwen3_capabilities_runtime_metadata.py
@@ -1,0 +1,24 @@
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSCapabilities
+from tldw_Server_API.app.core.TTS.tts_service_v2 import TTSServiceV2
+from tldw_Server_API.app.core.TTS.circuit_breaker import build_qwen_runtime_breaker_key
+
+
+def test_qwen3_capability_payload_includes_runtime_metadata():
+    caps = TTSCapabilities(
+        provider_name="Qwen3-TTS",
+        supported_languages={"en"},
+        supported_voices=[],
+        supported_formats={AudioFormat.PCM},
+        max_text_length=5000,
+        supports_streaming=True,
+        metadata={"runtime": "mlx", "supported_modes": ["custom_voice_preset"]},
+    )
+
+    serialized = TTSServiceV2()._serialize_capabilities(caps)
+
+    assert serialized["metadata"]["runtime"] == "mlx"
+
+
+def test_runtime_breaker_key_is_namespaced():
+    key = build_qwen_runtime_breaker_key("qwen3_tts", "mlx")
+    assert key == "qwen3_tts:mlx"

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
@@ -2,6 +2,7 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+import tldw_Server_API.app.core.TTS.tts_validation as tts_validation_mod
 from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
 
 
@@ -19,6 +20,28 @@ def test_mlx_runtime_rejects_uploaded_custom_voice_request():
             request,
             provider="qwen3_tts",
             config={"providers": {"qwen3_tts": {"runtime": "mlx"}}},
+        )
+
+    assert "uploaded custom voices" in str(exc.value).lower()
+
+
+@pytest.mark.unit
+def test_runtime_auto_on_apple_silicon_rejects_uploaded_custom_voice_request(monkeypatch):
+    monkeypatch.setattr(tts_validation_mod.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(tts_validation_mod.platform, "machine", lambda: "arm64")
+
+    request = TTSRequest(
+        text="hello",
+        voice="custom:voice-1",
+        format=AudioFormat.MP3,
+    )
+    request.model = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(
+            request,
+            provider="qwen3_tts",
+            config={"providers": {"qwen3_tts": {"runtime": "auto"}}},
         )
 
     assert "uploaded custom voices" in str(exc.value).lower()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
+from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
+from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
+
+
+@pytest.mark.unit
+def test_mlx_runtime_rejects_uploaded_custom_voice_request():
+    request = TTSRequest(
+        text="hello",
+        voice="custom:voice-1",
+        format=AudioFormat.MP3,
+    )
+    request.model = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
+
+    with pytest.raises(TTSValidationError) as exc:
+        validate_tts_request(
+            request,
+            provider="qwen3_tts",
+            config={"providers": {"qwen3_tts": {"runtime": "mlx"}}},
+        )
+
+    assert "uploaded custom voices" in str(exc.value).lower()

--- a/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
+++ b/tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py
@@ -2,7 +2,7 @@ import pytest
 
 from tldw_Server_API.app.core.TTS.adapters.base import AudioFormat, TTSRequest
 from tldw_Server_API.app.core.TTS.tts_exceptions import TTSValidationError
-import tldw_Server_API.app.core.TTS.tts_validation as tts_validation_mod
+import tldw_Server_API.app.core.TTS.utils as tts_utils
 from tldw_Server_API.app.core.TTS.tts_validation import validate_tts_request
 
 
@@ -27,8 +27,8 @@ def test_mlx_runtime_rejects_uploaded_custom_voice_request():
 
 @pytest.mark.unit
 def test_runtime_auto_on_apple_silicon_rejects_uploaded_custom_voice_request(monkeypatch):
-    monkeypatch.setattr(tts_validation_mod.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(tts_validation_mod.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(tts_utils.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(tts_utils.platform, "machine", lambda: "arm64")
 
     request = TTSRequest(
         text="hello",

--- a/tldw_Server_API/tests/http_client/test_http_client_retry_after.py
+++ b/tldw_Server_API/tests/http_client/test_http_client_retry_after.py
@@ -1,5 +1,7 @@
 import pytest
 import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 
 
 pytestmark = pytest.mark.unit
@@ -14,6 +16,17 @@ def _has_httpx():
 
 
 requires_httpx = pytest.mark.skipif(not _has_httpx(), reason="httpx not installed")
+
+
+def test_parse_retry_after_delay_seconds_accepts_http_date():
+    from tldw_Server_API.app.core.http_client import _parse_retry_after_delay_seconds
+
+    now = datetime(2026, 3, 11, 20, 0, 0, tzinfo=timezone.utc)
+    retry_after = format_datetime(now + timedelta(seconds=5), usegmt=True)
+
+    delay = _parse_retry_after_delay_seconds(retry_after, now=now)
+
+    assert delay == pytest.approx(5.0, abs=1e-6)
 
 
 @requires_httpx

--- a/tldw_Server_API/tests/http_client/test_http_client_stream_timeouts.py
+++ b/tldw_Server_API/tests/http_client/test_http_client_stream_timeouts.py
@@ -1,5 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +28,16 @@ class StreamResponse:
 
     def raise_for_status(self) -> None:
         return None
+
+
+class AioStreamResponse:
+    def __init__(self, url: str, status: int = 200, headers: dict[str, str] | None = None) -> None:
+        self.status = status
+        self.url = url
+        self.headers = headers or {}
+
+    async def read(self) -> bytes:
+        return b""
 
 
 @requires_httpx
@@ -60,6 +72,94 @@ async def test_stream_bytes_retries_http_503_before_first_chunk_httpx(monkeypatc
 
     chunks = []
     async for chunk in hc.astream_bytes(
+        method="POST",
+        url="http://93.184.216.34/stream",
+        client=object(),
+        retry=hc.RetryPolicy(attempts=2, retry_on_unsafe=True),
+    ):
+        chunks.append(chunk)
+
+    assert calls["n"] == 2
+    assert chunks == [b"ok"]
+
+
+@requires_httpx
+@pytest.mark.asyncio
+async def test_stream_bytes_honors_date_form_retry_after_before_first_chunk_httpx(monkeypatch):
+    from tldw_Server_API.app.core import http_client as hc
+    import httpx
+
+    calls = {"n": 0}
+    delays: list[float] = []
+    retry_after = format_datetime(datetime.now(timezone.utc) + timedelta(seconds=5), usegmt=True)
+
+    async def fake_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    @asynccontextmanager
+    async def fake_httpx_stream_io(**_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            request = httpx.Request("POST", "http://93.184.216.34/stream")
+            response = httpx.Response(
+                503,
+                request=request,
+                headers={"Retry-After": retry_after},
+            )
+
+            async def iter_bytes():
+                if False:  # pragma: no cover
+                    yield b""
+
+            yield response, iter_bytes()
+            return
+
+        async def iter_bytes():
+            yield b"ok"
+
+        resp = StreamResponse("http://93.184.216.34/stream")
+        yield resp, iter_bytes()
+
+    monkeypatch.setattr(hc, "_httpx_stream_io", fake_httpx_stream_io)
+    monkeypatch.setattr(hc.asyncio, "sleep", fake_sleep)
+
+    chunks = []
+    async for chunk in hc.astream_bytes(
+        method="POST",
+        url="http://93.184.216.34/stream",
+        client=object(),
+        retry=hc.RetryPolicy(attempts=2, retry_on_unsafe=True),
+    ):
+        chunks.append(chunk)
+
+    assert calls["n"] == 2
+    assert chunks == [b"ok"]
+    assert len(delays) == 1
+    assert delays[0] >= 3.0
+
+
+@pytest.mark.asyncio
+async def test_stream_bytes_retries_aiohttp_transport_error_before_first_chunk(monkeypatch):
+    from tldw_Server_API.app.core import http_client as hc
+
+    calls = {"n": 0}
+
+    @asynccontextmanager
+    async def fake_aiohttp_stream_io(**_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("socket reset")
+
+        async def iter_bytes():
+            yield b"ok"
+
+        yield AioStreamResponse("http://93.184.216.34/stream"), iter_bytes()
+
+    monkeypatch.setattr(hc, "aiohttp", object())
+    monkeypatch.setattr(hc, "_aiohttp_stream_io", fake_aiohttp_stream_io)
+
+    chunks = []
+    async for chunk in hc._astream_bytes_aiohttp(
         method="POST",
         url="http://93.184.216.34/stream",
         client=object(),

--- a/tldw_Server_API/tests/http_client/test_http_client_stream_timeouts.py
+++ b/tldw_Server_API/tests/http_client/test_http_client_stream_timeouts.py
@@ -30,6 +30,84 @@ class StreamResponse:
 
 @requires_httpx
 @pytest.mark.asyncio
+async def test_stream_bytes_retries_http_503_before_first_chunk_httpx(monkeypatch):
+    from tldw_Server_API.app.core import http_client as hc
+    import httpx
+
+    calls = {"n": 0}
+
+    @asynccontextmanager
+    async def fake_httpx_stream_io(**_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            request = httpx.Request("POST", "http://93.184.216.34/stream")
+            response = httpx.Response(503, request=request)
+
+            async def iter_bytes():
+                if False:  # pragma: no cover
+                    yield b""
+
+            yield response, iter_bytes()
+            return
+
+        async def iter_bytes():
+            yield b"ok"
+
+        resp = StreamResponse("http://93.184.216.34/stream")
+        yield resp, iter_bytes()
+
+    monkeypatch.setattr(hc, "_httpx_stream_io", fake_httpx_stream_io)
+
+    chunks = []
+    async for chunk in hc.astream_bytes(
+        method="POST",
+        url="http://93.184.216.34/stream",
+        client=object(),
+        retry=hc.RetryPolicy(attempts=2, retry_on_unsafe=True),
+    ):
+        chunks.append(chunk)
+
+    assert calls["n"] == 2
+    assert chunks == [b"ok"]
+
+
+@requires_httpx
+@pytest.mark.asyncio
+async def test_stream_bytes_does_not_retry_after_first_chunk_httpx(monkeypatch):
+    from tldw_Server_API.app.core import http_client as hc
+
+    calls = {"n": 0}
+
+    @asynccontextmanager
+    async def fake_httpx_stream_io(**_kwargs):
+        calls["n"] += 1
+
+        async def iter_bytes():
+            yield b"first"
+            raise hc.NetworkError("stream dropped")
+
+        resp = StreamResponse("http://93.184.216.34/stream")
+        yield resp, iter_bytes()
+
+    monkeypatch.setattr(hc, "_httpx_stream_io", fake_httpx_stream_io)
+
+    chunks = []
+    with pytest.raises(hc.NetworkError) as exc:
+        async for chunk in hc.astream_bytes(
+            method="POST",
+            url="http://93.184.216.34/stream",
+            client=object(),
+            retry=hc.RetryPolicy(attempts=2, retry_on_unsafe=True),
+        ):
+            chunks.append(chunk)
+
+    assert calls["n"] == 1
+    assert chunks == [b"first"]
+    assert "stream dropped" in str(exc.value)
+
+
+@requires_httpx
+@pytest.mark.asyncio
 async def test_stream_bytes_first_byte_timeout_httpx(monkeypatch):
     from tldw_Server_API.app.core import http_client as hc
 


### PR DESCRIPTION
## Summary
- Keep `qwen3_tts` as one provider while routing execution to `upstream`, `mlx`, or `remote` runtimes.
- Add Apple Silicon MLX preset-speaker generation, runtime-aware capabilities and health metadata, and remote Qwen payload and error normalization.
- Document runtime configuration and add focused unit/integration coverage, including a gated Apple Silicon smoke test.

## Test Plan
- `source .venv/bin/activate && LOGURU_LEVEL=ERROR python -m pytest tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_mlx_runtime.py tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_remote_runtime.py tldw_Server_API/tests/TTS_NEW/unit/test_tts_validation_qwen3_mlx.py tldw_Server_API/tests/TTS_NEW/unit/adapters/test_qwen3_runtime_selection.py tldw_Server_API/tests/TTS_NEW/unit/test_qwen3_capabilities_runtime_metadata.py tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_runtime_health_envelope.py tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_streaming.py tldw_Server_API/tests/TTS_NEW/integration/test_qwen3_mlx_runtime_integration.py -q --tb=short`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_mlx.py tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py tldw_Server_API/app/core/TTS/tts_validation.py tldw_Server_API/app/core/TTS/tts_config.py -f json -o /tmp/bandit_qwen3_review_followup.json`
- `source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/TTS/adapters/qwen3_runtime_remote.py -f json -o /tmp/bandit_qwen3_remote_stream_fix.json`