### PR TITLE
Expand companion capture for bulk imports

### DIFF
--- a/Docs/Plans/2026-03-12-companion-capture-expansion-design.md
+++ b/Docs/Plans/2026-03-12-companion-capture-expansion-design.md
@@ -1,0 +1,387 @@
+Date: 2026-03-12
+Status: Designed
+
+# Companion Capture Expansion Design
+
+## Summary
+
+This design activates the deferred companion capture-expansion slice after the foundation, quality/trust-controls, and proactive-polish milestones.
+
+The goal is not to broaden companion in every direction. It is to extend the existing explicit-capture model into a small set of lower-risk bulk and import flows that already map well onto the current companion activity ledger.
+
+This milestone stays intentionally narrow:
+
+- `notes/import`
+- `notes/bulk`
+- `watchlists/sources/import`
+- `watchlists/sources/bulk`
+
+## Goal
+
+Extend explicit companion capture into selected bulk/import flows so that successful imported or bulk-created user content becomes usable by existing companion derivations, reflections, and conversation context.
+
+## Non-Goals
+
+This milestone does not include:
+
+- `chatbooks/import`
+- restore semantics beyond what endpoints already do today
+- ledger entries for duplicates, skips, validation failures, or row-level errors
+- new import-specific event families
+- passive or hidden capture
+- a new storage path outside personalization
+
+## Product Rules
+
+The user already approved these rules during design review:
+
+- capture stays explicit and per-item
+- only rows that actually changed state are eligible for companion activity
+- existing event families are reused
+- import and bulk origins are distinguished through provenance and surface metadata
+- restore semantics remain out of scope for this slice unless the endpoint already restores
+
+## Reviewed Current State
+
+The current companion system already has:
+
+- per-user consent gating through personalization profiles
+- an explicit companion activity ledger in `PersonalizationDB`
+- existing event families for notes and watchlist sources
+- downstream consumers that already understand those event families
+
+The current import and bulk flows already exist:
+
+- notes import supports create, skip, overwrite, and create-copy flows
+- notes bulk creates notes and returns hydrated created-note payloads
+- watchlists OPML import creates or skips sources
+- watchlists bulk create creates rows or returns per-entry errors
+
+These flows are explicit user actions already, so they fit the companion model.
+
+## Design Review Adjustments
+
+Before approving this milestone, the design was tightened around several real implementation risks found in the current code.
+
+### Bulk companion insert must be conflict-tolerant
+
+`PersonalizationDB.insert_companion_activity_events_bulk(...)` currently inserts the whole batch in one transaction without duplicate handling.
+
+That is too brittle for this slice because a single dedupe conflict can invalidate the whole companion write batch.
+
+This milestone therefore requires either:
+
+- conflict-tolerant bulk insert behavior, or
+- prefiltering against existing dedupe keys before insert
+
+The behavioral requirement is fixed even if the implementation choice varies:
+
+- companion capture remains best-effort
+- one duplicate must not fail the whole bulk/import companion write
+
+### `watchlists/sources/bulk` must prove that a row was newly created
+
+The current watchlists DB helper is idempotent on unique URL conflict and can return an existing row from `create_source(...)`.
+
+That means the endpoint's current `status="created"` response is not strong enough to drive companion capture by itself.
+
+This milestone therefore requires explicit actual-change detection for `watchlists/sources/bulk`.
+
+Valid options:
+
+- extend the DB helper to report whether the insert was new
+- add a conservative pre-check that only emits companion activity when a create is known to have changed state
+
+The design requirement is:
+
+- no `watchlist_source_created` companion event may be emitted unless the code can prove the row was newly created
+
+### `notes/import` must reread the final note row
+
+The current notes import path does not end with a hydrated post-write note object in either create or overwrite mode.
+
+That is not sufficient for reliable companion event construction because existing note companion events use:
+
+- final version
+- final timestamps
+- final compact metadata
+- keyword/tag state where available
+
+This milestone therefore requires a post-write reread for successful `notes/import` create and overwrite rows before building companion events.
+
+### Capture must be success-branch local
+
+Companion writes must happen inside the actual success branches that performed the create or update, not from the final response summary.
+
+This avoids mapping drift where:
+
+- a route reports `created` for an idempotent no-op
+- a route classifies a failure as `skipped`
+- future response formats stop matching actual DB effects
+
+### Shared adapter should batch payloads, not loop over single-event helpers
+
+The existing `record_*` helpers open personalization storage and check consent one event at a time.
+
+That is fine for single-resource CRUD routes, but not ideal for bulk/import flows.
+
+This milestone therefore introduces a shared adapter layer that:
+
+- builds normalized event payloads
+- performs consent gating once
+- writes through a conflict-tolerant bulk path
+
+## Recommended Approach
+
+Recommended approach: shared bulk/import companion adapter.
+
+Why this is the right fit:
+
+- it keeps the milestone low-risk
+- it avoids four one-off endpoint-specific companion implementations
+- it preserves the existing companion activity model
+- it keeps provenance and metadata normalization in one place
+
+Rejected alternatives:
+
+- endpoint-local hand-written capture logic in all four handlers
+  - simpler to start, but more drift and duplication
+- post-import reconciliation from response payloads
+  - too easy to mismatch actual DB changes
+
+## Architecture
+
+### Core principle
+
+Do not introduce a second bulk-import-specific companion pipeline.
+
+Bulk/import routes should continue to:
+
+- perform parsing
+- perform validation
+- perform DB writes
+- build their normal API responses
+
+The companion system should continue to:
+
+- reuse existing event families
+- write into personalization storage
+- honor existing per-user consent gates
+
+### New layer
+
+Add a shared companion bulk/import adapter in the personalization layer.
+
+Responsibilities:
+
+- map successful row outcomes to existing event families
+- attach import-specific provenance and surfaces
+- build compact metadata payloads
+- perform a single consent check per request
+- execute conflict-tolerant bulk writes
+
+Endpoints remain responsible for:
+
+- identifying successful create/update branches
+- rereading final objects where needed
+- passing normalized row outcomes into the adapter
+
+## Event Model
+
+### Event families
+
+Reuse existing families:
+
+- `note_created`
+- `note_updated`
+- `watchlist_source_created`
+- `watchlist_source_updated` only if a current in-scope flow already performs a real update
+
+This milestone does not add:
+
+- `note_imported`
+- `bulk_note_created`
+- `watchlist_source_imported`
+- any other import-specific event family
+
+### Provenance and surfaces
+
+Differentiate origin through surface and provenance instead of event type.
+
+Surfaces:
+
+- `api.notes.import`
+- `api.notes.bulk`
+- `api.watchlists.sources.import`
+- `api.watchlists.sources.bulk`
+
+Provenance routes:
+
+- `/api/v1/notes/import`
+- `/api/v1/notes/bulk`
+- `/api/v1/watchlists/sources/import`
+- `/api/v1/watchlists/sources/bulk`
+
+Provenance actions should reflect origin-specific behavior while preserving the existing event families:
+
+- `import_create`
+- `import_overwrite`
+- `bulk_create`
+
+If a future in-scope route performs a real update rather than a create, its provenance action should be similarly explicit.
+
+## Per-Surface Behavior
+
+### `notes/import`
+
+Successful outcomes:
+
+- imported new note -> emit `note_created`
+- overwrite of existing note -> emit `note_updated`
+- create-copy retry that succeeds -> emit `note_created`
+
+No companion activity for:
+
+- skipped duplicates
+- parse failures
+- validation failures
+- row-level exceptions
+
+Implementation rule:
+
+- reread the final note row after successful create or overwrite before building companion activity
+
+### `notes/bulk`
+
+Successful outcomes:
+
+- created note -> emit `note_created`
+
+No companion activity for:
+
+- per-row failures
+- rejected rows
+
+Implementation note:
+
+- this route already rereads the created note row, so it can pass hydrated notes into the shared adapter
+
+### `watchlists/sources/import`
+
+Successful outcomes:
+
+- newly created source -> emit `watchlist_source_created`
+
+No companion activity for:
+
+- duplicate-source skips
+- missing URL rows
+- invalid YouTube RSS rows
+- create failures
+
+Implementation note:
+
+- capture must happen only in the actual create branch
+
+### `watchlists/sources/bulk`
+
+Successful outcomes:
+
+- newly created source -> emit `watchlist_source_created`
+
+No companion activity for:
+
+- per-entry validation errors
+- create failures
+- idempotent returns of existing sources
+
+Implementation rule:
+
+- this route must establish whether the row was newly created before emitting any companion event
+
+## Metadata Rules
+
+### Note metadata
+
+Imported and bulk note metadata should stay consistent with current note activity:
+
+- `title`
+- `content_preview`
+- `version`
+- `conversation_id`
+- `message_id`
+
+Where available after reread or existing hydration:
+
+- keyword-derived tags
+- import-relevant `changed_fields` for overwrite paths
+
+### Watchlist source metadata
+
+Imported and bulk source metadata should stay consistent with current watchlist source activity:
+
+- `name`
+- `url`
+- `source_type`
+- `active`
+- `status`
+- `group_ids`
+- `settings_keys`
+
+Where available:
+
+- normalized tags
+
+## Consent And Failure Policy
+
+Consent behavior remains unchanged:
+
+- if personalization/companion is not enabled for the user, import and bulk actions still succeed
+- companion activity is simply not recorded
+
+Failure behavior for this milestone:
+
+- companion capture is best-effort
+- companion write failure must not fail the import or bulk operation
+- failures should be logged at debug or warning level with enough context to diagnose drift
+
+This is the right tradeoff for this slice because the import/bulk action is the primary user intent, while companion capture is secondary enrichment.
+
+## Testing Strategy
+
+Backend coverage should include:
+
+- adapter unit tests for event payload construction
+- adapter tests for conflict-tolerant duplicate handling
+- notes import integration tests covering:
+  - create -> `note_created`
+  - overwrite -> `note_updated`
+  - skip -> no event
+  - consent-disabled import -> no companion event and unchanged response counts
+- notes bulk integration tests covering:
+  - success row -> `note_created`
+  - failed row -> no event
+- watchlists OPML import integration tests covering:
+  - create -> `watchlist_source_created`
+  - duplicate skip -> no event
+- watchlists bulk integration tests covering:
+  - real create -> `watchlist_source_created`
+  - duplicate/idempotent existing-row case -> no event
+  - validation error -> no event
+
+Verification should also include:
+
+- targeted existing regression tests for notes and watchlists bulk/import responses
+- Bandit on touched backend scope
+- `git diff --check`
+
+## Milestone Outcome
+
+When this milestone is complete:
+
+- explicit bulk/import actions feed the existing companion system
+- companion derivations and reflections gain more useful raw activity without new hidden capture
+- provenance remains clear about where each event came from
+- the ledger stays cleaner because duplicates, skips, and errors are excluded
+
+This keeps the companion system broader, but still disciplined.

--- a/Docs/Plans/2026-03-12-companion-capture-expansion-implementation-plan.md
+++ b/Docs/Plans/2026-03-12-companion-capture-expansion-implementation-plan.md
@@ -1,0 +1,669 @@
+# Companion Capture Expansion Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Status:** Planned on 2026-03-12
+
+**Goal:** Extend explicit companion capture into lower-risk notes and watchlists bulk/import flows without creating new event families or hidden tracking behavior.
+
+**Architecture:** Add a shared personalization-layer bulk/import adapter that builds existing companion activity events from actual successful create/update branches, performs a single consent check, and writes through a conflict-tolerant bulk path. Keep endpoint ownership of parsing and DB writes, require post-write rereads where final object state is needed, and only emit events when the route can prove state changed.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/WAL (`PersonalizationDB`), existing notes/watchlists DB helpers, pytest, Bandit.
+
+**Shell Convention:** Command snippets below assume `PROJECT_ROOT` points at the repository root. If it is not already set, run `PROJECT_ROOT="$(pwd)"` from the repo root before executing them.
+
+---
+
+### Task 1: Add Conflict-Tolerant Companion Bulk Insert Support
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Personalization_DB.py`
+- Test: `tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_insert_companion_activity_events_bulk_skips_duplicate_dedupe_keys(personalization_db):
+    personalization_db.update_profile("1", enabled=1)
+    events = [
+        {
+            "event_type": "note_created",
+            "source_type": "note",
+            "source_id": "n1",
+            "surface": "api.notes.import",
+            "dedupe_key": "notes.create:n1",
+            "provenance": {"capture_mode": "explicit"},
+            "metadata": {"title": "One"},
+        },
+        {
+            "event_type": "note_created",
+            "source_type": "note",
+            "source_id": "n1",
+            "surface": "api.notes.import",
+            "dedupe_key": "notes.create:n1",
+            "provenance": {"capture_mode": "explicit"},
+            "metadata": {"title": "One duplicate"},
+        },
+    ]
+
+    inserted = personalization_db.insert_companion_activity_events_bulk(user_id="1", events=events)
+
+    assert len(inserted) == 1
+    rows, total = personalization_db.list_companion_activity_events("1", limit=10)
+    assert total == 1
+
+
+def test_insert_companion_activity_events_bulk_keeps_unique_rows_when_one_conflicts(personalization_db):
+    personalization_db.update_profile("1", enabled=1)
+    personalization_db.insert_companion_activity_event(
+        user_id="1",
+        event_type="note_created",
+        source_type="note",
+        source_id="n1",
+        surface="api.notes.import",
+        dedupe_key="notes.create:n1",
+        provenance={"capture_mode": "explicit"},
+        metadata={"title": "Existing"},
+    )
+
+    inserted = personalization_db.insert_companion_activity_events_bulk(
+        user_id="1",
+        events=[
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n1",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n1",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Duplicate"},
+            },
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n2",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n2",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Fresh"},
+            },
+        ],
+    )
+
+    assert len(inserted) == 1
+    rows, total = personalization_db.list_companion_activity_events("1", limit=10)
+    assert total == 2
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py -k "bulk_skips_duplicate or one_conflicts"
+```
+
+Expected: FAIL because the current bulk insert path is all-or-nothing on duplicate dedupe keys.
+
+**Step 3: Write minimal implementation**
+
+- Update `insert_companion_activity_events_bulk(...)` in `Personalization_DB.py` so one duplicate does not fail the whole batch.
+- Accept either implementation:
+  - prefiltering existing dedupe keys before insert, or
+  - per-row conflict-tolerant inserts inside one transaction.
+- Preserve current return semantics by returning only inserted event IDs.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/DB_Management/Personalization_DB.py \
+  tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+git commit -m "feat: make companion bulk activity inserts conflict tolerant"
+```
+
+### Task 2: Add Shared Companion Bulk/Import Event Builders
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Personalization/companion_activity.py`
+- Test: `tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_build_note_import_created_activity_uses_import_surface_and_route():
+    note = {
+        "id": "note-1",
+        "title": "Imported note",
+        "content": "Imported content",
+        "version": 1,
+        "created_at": "2026-03-12T00:00:00+00:00",
+        "last_modified": "2026-03-12T00:00:00+00:00",
+        "keywords": [{"keyword": "import"}],
+    }
+
+    payload = build_note_bulk_import_activity(
+        note=note,
+        operation="import_create",
+        route="/api/v1/notes/import",
+        surface="api.notes.import",
+    )
+
+    assert payload["event_type"] == "note_created"
+    assert payload["surface"] == "api.notes.import"
+    assert payload["provenance"]["route"] == "/api/v1/notes/import"
+    assert payload["provenance"]["action"] == "import_create"
+
+
+def test_build_watchlist_source_bulk_activity_uses_bulk_surface_and_route():
+    source = {
+        "id": 12,
+        "name": "Bulk source",
+        "url": "https://example.com/feed.xml",
+        "source_type": "rss",
+        "active": True,
+        "status": None,
+        "group_ids": [2],
+        "tags": ["feeds"],
+        "created_at": "2026-03-12T00:00:00+00:00",
+        "updated_at": "2026-03-12T00:00:00+00:00",
+    }
+
+    payload = build_watchlist_source_bulk_import_activity(
+        source=source,
+        operation="bulk_create",
+        route="/api/v1/watchlists/sources/bulk",
+        surface="api.watchlists.sources.bulk",
+    )
+
+    assert payload["event_type"] == "watchlist_source_created"
+    assert payload["surface"] == "api.watchlists.sources.bulk"
+    assert payload["provenance"]["action"] == "bulk_create"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py -k "import_surface_and_route or bulk_surface_and_route"
+```
+
+Expected: FAIL because shared bulk/import event builders do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+- Add helper builders in `companion_activity.py` for:
+  - notes import/bulk create payloads
+  - notes import overwrite payloads
+  - watchlist source import/bulk create payloads
+- Reuse existing metadata helpers and event families.
+- Keep provenance origin-specific:
+  - `import_create`
+  - `import_overwrite`
+  - `bulk_create`
+- Do not write to the DB in these helpers; only build event payloads.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Personalization/companion_activity.py \
+  tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+git commit -m "feat: add companion bulk import activity builders"
+```
+
+### Task 3: Add Notes Import Companion Capture With Post-Write Rereads
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/notes.py`
+- Test: `tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py`
+- Test: `tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_notes_import_create_records_companion_note_created(client, personalization_db):
+    response = client.post(
+        "/api/v1/notes/import",
+        json={
+            "duplicate_strategy": "create_copy",
+            "items": [
+                {
+                    "file_name": "note.json",
+                    "format": "json",
+                    "content": "{\"title\": \"Imported Note\", \"content\": \"Body\", \"keywords\": [\"alpha\"]}",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("333", limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "note_created"
+    assert events[0]["surface"] == "api.notes.import"
+    assert events[0]["provenance"]["action"] == "import_create"
+
+
+def test_notes_import_overwrite_records_companion_note_updated(client, personalization_db):
+    note_id = seed_note(client, title="Original", content="Before")
+
+    response = client.post(
+        "/api/v1/notes/import",
+        json={
+            "duplicate_strategy": "overwrite",
+            "items": [
+                {
+                    "file_name": "note.json",
+                    "format": "json",
+                    "content": f"{{\"id\": \"{note_id}\", \"title\": \"Updated\", \"content\": \"After\"}}",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    events, _ = personalization_db.list_companion_activity_events("333", limit=10)
+    updated = next(event for event in events if event["event_type"] == "note_updated")
+    assert updated["source_id"] == note_id
+    assert updated["surface"] == "api.notes.import"
+    assert updated["provenance"]["action"] == "import_overwrite"
+    assert updated["metadata"]["changed_fields"] == ["content", "title"]
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py -k "import"
+```
+
+Expected: FAIL because `notes/import` does not record companion activity yet.
+
+**Step 3: Write minimal implementation**
+
+- In `notes.py`, collect successful import-create and import-overwrite rows inside their actual success branches.
+- After each successful create or overwrite, reread the final note row with `db.get_note_by_id(...)`.
+- For overwrite paths, compute the patch fields used by the companion builder.
+- After processing a file or request, send the built events through the shared bulk/import adapter.
+- Keep skips and failures out of the companion ledger.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/notes.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+git commit -m "feat: capture companion activity for notes import"
+```
+
+### Task 4: Add Notes Bulk Companion Capture
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/notes.py`
+- Test: `tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py`
+- Test: `tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_notes_bulk_success_rows_record_companion_activity(client, personalization_db):
+    response = client.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {"title": "Bulk One", "content": "One"},
+                {"title": "Bulk Two", "content": "Two"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("333", limit=10)
+    assert total == 2
+    assert all(event["event_type"] == "note_created" for event in events)
+    assert all(event["surface"] == "api.notes.bulk" for event in events)
+    assert all(event["provenance"]["action"] == "bulk_create" for event in events)
+
+
+def test_notes_bulk_failed_rows_do_not_record_companion_activity(client, personalization_db):
+    response = client.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {"title": "Bulk Good", "content": "Good"},
+                {"content": "Missing title and no auto title"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("333", limit=10)
+    assert total == 1
+    assert events[0]["metadata"]["title"] == "Bulk Good"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py -k "bulk"
+```
+
+Expected: FAIL because `notes/bulk` does not record companion activity yet.
+
+**Step 3: Write minimal implementation**
+
+- Reuse the already hydrated created note rows returned inside `notes/bulk`.
+- Build `note_created` companion payloads only for successful rows.
+- Batch write those payloads after the bulk loop finishes.
+- Leave all existing API result counting and per-row error reporting unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/notes.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py
+git commit -m "feat: capture companion activity for notes bulk create"
+```
+
+### Task 5: Add Watchlists OPML Import Companion Capture
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_watchlists_sources_import_created_rows_record_companion_activity(client, personalization_db, opml_bytes):
+    response = client.post(
+        "/api/v1/watchlists/sources/import",
+        files={"file": ("feeds.opml", opml_bytes, "text/xml")},
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("906", limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "watchlist_source_created"
+    assert events[0]["surface"] == "api.watchlists.sources.import"
+    assert events[0]["provenance"]["action"] == "import_create"
+
+
+def test_watchlists_sources_import_duplicate_skip_does_not_record_companion_activity(client, personalization_db, opml_bytes):
+    client.post("/api/v1/watchlists/sources/import", files={"file": ("feeds.opml", opml_bytes, "text/xml")})
+
+    response = client.post(
+        "/api/v1/watchlists/sources/import",
+        files={"file": ("feeds.opml", opml_bytes, "text/xml")},
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("906", limit=20)
+    assert total == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_watchlists_api.py -k "sources_import"
+```
+
+Expected: FAIL because the OPML import route does not record companion activity yet.
+
+**Step 3: Write minimal implementation**
+
+- In `watchlists.py`, build companion payloads only inside the actual create branch of `/sources/import`.
+- Do not derive companion writes from final `items` response rows.
+- Batch write after the import loop completes.
+- Leave skipped duplicate and invalid-row behavior unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/watchlists.py \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+git commit -m "feat: capture companion activity for watchlists opml import"
+```
+
+### Task 6: Add Watchlists Bulk Companion Capture With Actual-Create Detection
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Watchlists_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_watchlists_api.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_watchlists_bulk_new_source_records_companion_activity(client, personalization_db):
+    response = client.post(
+        "/api/v1/watchlists/sources/bulk",
+        json={"sources": [{"name": "Feed A", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("906", limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "watchlist_source_created"
+    assert events[0]["surface"] == "api.watchlists.sources.bulk"
+    assert events[0]["provenance"]["action"] == "bulk_create"
+
+
+def test_watchlists_bulk_idempotent_existing_source_does_not_record_companion_activity(client, personalization_db):
+    client.post(
+        "/api/v1/watchlists/sources/bulk",
+        json={"sources": [{"name": "Feed A", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+    )
+
+    response = client.post(
+        "/api/v1/watchlists/sources/bulk",
+        json={"sources": [{"name": "Feed A Again", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+    )
+
+    assert response.status_code == 200
+    events, total = personalization_db.list_companion_activity_events("906", limit=20)
+    assert total == 1
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_watchlists_api.py -k "bulk"
+```
+
+Expected: FAIL because the bulk route does not capture companion activity and cannot yet distinguish real creates from idempotent existing-row returns.
+
+**Step 3: Write minimal implementation**
+
+- Extend `Watchlists_DB.create_source(...)` to expose whether a source was newly created.
+- Update `/sources/bulk` to use that signal and only build companion payloads for real creates.
+- Preserve current API behavior unless a safer response clarification is needed for tests.
+- Keep validation errors and idempotent existing-source rows out of the companion ledger.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/DB_Management/Watchlists_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/watchlists.py \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_watchlists_api.py
+git commit -m "feat: capture companion activity for watchlists bulk create"
+```
+
+### Task 7: Add Consent-Gated Bulk Adapter Wiring And End-to-End Verification
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Personalization/companion_activity.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/notes.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/watchlists.py`
+- Test: `tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py`
+- Test: `tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_notes_import_succeeds_without_companion_when_profile_disabled(client, personalization_db):
+    personalization_db.update_profile("333", enabled=0)
+
+    response = client.post(
+        "/api/v1/notes/import",
+        json={
+            "duplicate_strategy": "create_copy",
+            "items": [{"file_name": "note.md", "format": "markdown", "content": "# Title\n\nBody"}],
+        },
+    )
+
+    assert response.status_code == 200
+    _, total = personalization_db.list_companion_activity_events("333", limit=10)
+    assert total == 0
+
+
+def test_watchlists_bulk_succeeds_without_companion_when_profile_disabled(client, personalization_db):
+    personalization_db.update_profile("906", enabled=0)
+
+    response = client.post(
+        "/api/v1/watchlists/sources/bulk",
+        json={"sources": [{"name": "Feed A", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+    )
+
+    assert response.status_code == 200
+    _, total = personalization_db.list_companion_activity_events("906", limit=10)
+    assert total == 0
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py -k "profile_disabled"
+```
+
+Expected: FAIL until the shared adapter is wired with one consent check and no-op behavior when the profile is not enabled.
+
+**Step 3: Write minimal implementation**
+
+- Add a shared write helper in `companion_activity.py` for bulk/import event payloads that:
+  - opens personalization storage once
+  - checks profile consent once
+  - writes through the conflict-tolerant bulk insert path
+  - logs and returns cleanly on companion-side failure
+- Use that helper from the updated notes and watchlists handlers.
+- Keep import/bulk response payloads and counters unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run the same pytest command from Step 2.
+
+Expected: PASS
+
+**Step 5: Run focused verification**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m pytest -v \
+  tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_watchlists_api.py \
+  tldw_Server_API/tests/Watchlists/test_youtube_normalization_more.py -k "bulk or import"
+```
+
+Expected: PASS
+
+**Step 6: Run security and diff verification**
+
+Run:
+
+```bash
+source "$PROJECT_ROOT/.venv/bin/activate" && python -m bandit -r \
+  tldw_Server_API/app/core/Personalization/companion_activity.py \
+  tldw_Server_API/app/core/DB_Management/Personalization_DB.py \
+  tldw_Server_API/app/core/DB_Management/Watchlists_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/notes.py \
+  tldw_Server_API/app/api/v1/endpoints/watchlists.py
+git diff --check
+```
+
+Expected:
+
+- Bandit reports no new findings in touched code
+- `git diff --check` is clean
+
+**Step 7: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Personalization/companion_activity.py \
+  tldw_Server_API/app/api/v1/endpoints/notes.py \
+  tldw_Server_API/app/api/v1/endpoints/watchlists.py \
+  tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py \
+  tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py
+git commit -m "feat: wire consent gated companion bulk import capture"
+```

--- a/Docs/Plans/2026-03-12-companion-capture-expansion-placeholder.md
+++ b/Docs/Plans/2026-03-12-companion-capture-expansion-placeholder.md
@@ -1,0 +1,47 @@
+Date: 2026-03-12
+Status: Activated And Planned
+
+# Companion Capture Expansion Placeholder
+
+## Purpose
+
+Reserve the next companion breadth-oriented slice and record that it has now been upgraded into a reviewed design plus implementation plan.
+
+## Current State
+
+This placeholder is no longer just a deferred reminder.
+
+It is now backed by:
+
+- `Docs/Plans/2026-03-12-companion-capture-expansion-design.md`
+- `Docs/Plans/2026-03-12-companion-capture-expansion-implementation-plan.md`
+
+## Activated Scope
+
+This activated slice is intentionally narrow and lower risk:
+
+- `notes/import`
+- `notes/bulk`
+- `watchlists/sources/import`
+- `watchlists/sources/bulk`
+
+Rules locked in by design review:
+
+- per-item explicit companion capture only
+- only rows that actually changed state are eligible
+- reuse existing event families
+- import/bulk origin is represented through provenance and surface metadata
+- skips, duplicates, and row-level errors stay out of the companion ledger
+
+## Deferred Items That Still Remain Deferred
+
+Not part of this slice:
+
+- `chatbooks/import`
+- restore semantics beyond current endpoint behavior
+- new import-specific companion event families
+- broader extension or adjacent-system capture families outside these four routes
+
+## Deliverable Expectation
+
+The next time this area is executed, it should follow the reviewed implementation plan rather than reopening scope from scratch.

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -824,6 +824,29 @@ def _sync_note_keywords(db: CharactersRAGDB, note_id: str, keywords: list[str]) 
     }
 
 
+def _build_import_note_companion_event(
+    *,
+    db: CharactersRAGDB,
+    note_id: str | int,
+    operation: str,
+    patch: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Reload an imported note and build a stable companion activity payload."""
+    reloaded_note = db.get_note_by_id(str(note_id))
+    if not reloaded_note:
+        raise CharactersRAGDBError(
+            f"Imported {str(operation).replace('_', ' ')} note could not be reloaded."
+        )
+    reloaded_note = _attach_keywords_inline(db, reloaded_note)
+    return build_note_bulk_import_activity(
+        note=reloaded_note,
+        operation=operation,
+        route="/api/v1/notes/import",
+        surface="api.notes.import",
+        patch=patch,
+    )
+
+
 def _normalize_keyword_tokens(tokens: Optional[list[str]]) -> list[str]:
     if not tokens:
         return []
@@ -1663,16 +1686,11 @@ async def import_notes(
                                 note_id=str(imported_id),
                                 keywords=parsed_note.get("keywords", []),
                             )
-                        updated_note = db.get_note_by_id(str(imported_id))
-                        if not updated_note:
-                            raise CharactersRAGDBError("Imported overwrite note could not be reloaded.")  # noqa: TRY003
-                        updated_note = _attach_keywords_inline(db, updated_note)
                         companion_events.append(
-                            build_note_bulk_import_activity(
-                                note=updated_note,
+                            _build_import_note_companion_event(
+                                db=db,
+                                note_id=str(imported_id),
                                 operation="import_overwrite",
-                                route="/api/v1/notes/import",
-                                surface="api.notes.import",
                                 patch=update_patch,
                             )
                         )
@@ -1693,16 +1711,11 @@ async def import_notes(
                             note_id=str(created_note_id),
                             keywords=parsed_note.get("keywords", []),
                         )
-                    created_note = db.get_note_by_id(str(created_note_id))
-                    if not created_note:
-                        raise CharactersRAGDBError("Imported note could not be reloaded.")  # noqa: TRY003
-                    created_note = _attach_keywords_inline(db, created_note)
                     companion_events.append(
-                        build_note_bulk_import_activity(
-                            note=created_note,
+                        _build_import_note_companion_event(
+                            db=db,
+                            note_id=str(created_note_id),
                             operation="import_create",
-                            route="/api/v1/notes/import",
-                            surface="api.notes.import",
                         )
                     )
                     file_result.created_count += 1
@@ -1724,16 +1737,11 @@ async def import_notes(
                                     note_id=str(created_note_id),
                                     keywords=parsed_note.get("keywords", []),
                                 )
-                            created_note = db.get_note_by_id(str(created_note_id))
-                            if not created_note:
-                                raise CharactersRAGDBError("Imported create-copy note could not be reloaded.")  # noqa: TRY003
-                            created_note = _attach_keywords_inline(db, created_note)
                             companion_events.append(
-                                build_note_bulk_import_activity(
-                                    note=created_note,
+                                _build_import_note_companion_event(
+                                    db=db,
+                                    note_id=str(created_note_id),
                                     operation="import_create",
-                                    route="/api/v1/notes/import",
-                                    surface="api.notes.import",
                                 )
                             )
                             file_result.created_count += 1
@@ -1755,7 +1763,8 @@ async def import_notes(
             totals["failed_count"] += file_result.failed_count
             files.append(file_result)
 
-        record_companion_activity_events_bulk(
+        await _run_db_call(
+            record_companion_activity_events_bulk,
             user_id=current_user.id,
             events=companion_events,
         )
@@ -3609,7 +3618,8 @@ async def bulk_create_notes(
             results.append(NoteBulkCreateItemResult(success=False, error=str(e)))
             failed += 1
 
-    record_companion_activity_events_bulk(
+    await _run_db_call(
+        record_companion_activity_events_bulk,
         user_id=current_user.id,
         events=companion_events,
     )

--- a/tldw_Server_API/app/api/v1/endpoints/notes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/notes.py
@@ -98,6 +98,8 @@ from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Utils.Utils import sanitize_filename
 from tldw_Server_API.app.core.Monitoring.topic_monitoring_service import get_topic_monitoring_service
 from tldw_Server_API.app.core.Personalization import (
+    build_note_bulk_import_activity,
+    record_companion_activity_events_bulk,
     record_note_created,
     record_note_deleted,
     record_note_restored,
@@ -1604,6 +1606,7 @@ async def import_notes(
             "skipped_count": 0,
             "failed_count": 0,
         }
+        companion_events: list[dict[str, Any]] = []
 
         for item in payload.items:
             file_result = NotesImportFileResult(
@@ -1644,13 +1647,14 @@ async def import_notes(
                         continue
 
                     if existing_note and payload.duplicate_strategy == "overwrite":
+                        update_patch = {
+                            "title": parsed_note["title"],
+                            "content": parsed_note["content"],
+                        }
                         expected_version = int(existing_note.get("version", 1))
                         db.update_note(
                             note_id=str(imported_id),
-                            update_data={
-                                "title": parsed_note["title"],
-                                "content": parsed_note["content"],
-                            },
+                            update_data=update_patch,
                             expected_version=expected_version,
                         )
                         if parsed_note.get("keywords_provided"):
@@ -1659,6 +1663,19 @@ async def import_notes(
                                 note_id=str(imported_id),
                                 keywords=parsed_note.get("keywords", []),
                             )
+                        updated_note = db.get_note_by_id(str(imported_id))
+                        if not updated_note:
+                            raise CharactersRAGDBError("Imported overwrite note could not be reloaded.")  # noqa: TRY003
+                        updated_note = _attach_keywords_inline(db, updated_note)
+                        companion_events.append(
+                            build_note_bulk_import_activity(
+                                note=updated_note,
+                                operation="import_overwrite",
+                                route="/api/v1/notes/import",
+                                surface="api.notes.import",
+                                patch=update_patch,
+                            )
+                        )
                         file_result.updated_count += 1
                         continue
 
@@ -1676,6 +1693,18 @@ async def import_notes(
                             note_id=str(created_note_id),
                             keywords=parsed_note.get("keywords", []),
                         )
+                    created_note = db.get_note_by_id(str(created_note_id))
+                    if not created_note:
+                        raise CharactersRAGDBError("Imported note could not be reloaded.")  # noqa: TRY003
+                    created_note = _attach_keywords_inline(db, created_note)
+                    companion_events.append(
+                        build_note_bulk_import_activity(
+                            note=created_note,
+                            operation="import_create",
+                            route="/api/v1/notes/import",
+                            surface="api.notes.import",
+                        )
+                    )
                     file_result.created_count += 1
                 except ConflictError as conflict_err:
                     # If "create_copy" still conflicts (for example, stale imported ID edge case),
@@ -1695,6 +1724,18 @@ async def import_notes(
                                     note_id=str(created_note_id),
                                     keywords=parsed_note.get("keywords", []),
                                 )
+                            created_note = db.get_note_by_id(str(created_note_id))
+                            if not created_note:
+                                raise CharactersRAGDBError("Imported create-copy note could not be reloaded.")  # noqa: TRY003
+                            created_note = _attach_keywords_inline(db, created_note)
+                            companion_events.append(
+                                build_note_bulk_import_activity(
+                                    note=created_note,
+                                    operation="import_create",
+                                    route="/api/v1/notes/import",
+                                    surface="api.notes.import",
+                                )
+                            )
                             file_result.created_count += 1
                             continue
                         except _NOTES_NONCRITICAL_EXCEPTIONS as retry_err:
@@ -1714,6 +1755,10 @@ async def import_notes(
             totals["failed_count"] += file_result.failed_count
             files.append(file_result)
 
+        record_companion_activity_events_bulk(
+            user_id=current_user.id,
+            events=companion_events,
+        )
         return NotesImportResponse(files=files, **totals)
     except HTTPException:
         raise
@@ -3457,6 +3502,7 @@ async def bulk_create_notes(
         current_user: User = Depends(get_request_user)
 ):
     results: list[NoteBulkCreateItemResult] = []
+    companion_events: list[dict[str, Any]] = []
     created = 0
     failed = 0
     # Enforce centralized per-request rate limit (notes.bulk_create)
@@ -3548,6 +3594,14 @@ async def bulk_create_notes(
             if not nd:
                 raise CharactersRAGDBError("Created note could not be retrieved.")
             nd = _attach_keywords_inline(db, nd)
+            companion_events.append(
+                build_note_bulk_import_activity(
+                    note=nd,
+                    operation="bulk_create",
+                    route="/api/v1/notes/bulk",
+                    surface="api.notes.bulk",
+                )
+            )
             results.append(NoteBulkCreateItemResult(success=True, note=nd))
             created += 1
         except _NOTES_NONCRITICAL_EXCEPTIONS as e:
@@ -3555,6 +3609,10 @@ async def bulk_create_notes(
             results.append(NoteBulkCreateItemResult(success=False, error=str(e)))
             failed += 1
 
+    record_companion_activity_events_bulk(
+        user_id=current_user.id,
+        events=companion_events,
+    )
     response_payload = NoteBulkCreateResponse(results=results, created_count=created, failed_count=failed)
     response_status = status.HTTP_200_OK if failed == 0 else status.HTTP_207_MULTI_STATUS
     return JSONResponse(content=jsonable_encoder(response_payload), status_code=response_status)

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -1671,7 +1671,11 @@ async def import_sources_opml(
         except (*_WATCHLISTS_NONCRITICAL_EXCEPTIONS, _DatabaseError) as exc:
             items.append(SourcesImportItem(url=url_str, name=e.name, status="skipped", error=str(exc)))
             skipped += 1
-    record_companion_activity_events_bulk(user_id=current_user.id, events=companion_events)
+    await asyncio.to_thread(
+        record_companion_activity_events_bulk,
+        user_id=current_user.id,
+        events=companion_events,
+    )
     return SourcesImportResponse(items=items, total=(created + skipped + errors), created=created, skipped=skipped, errors=errors)
 
 
@@ -2414,7 +2418,11 @@ async def bulk_create_sources(
             )
             errors_count += 1
 
-    record_companion_activity_events_bulk(user_id=current_user.id, events=companion_events)
+    await asyncio.to_thread(
+        record_companion_activity_events_bulk,
+        user_id=current_user.id,
+        events=companion_events,
+    )
     return SourcesBulkCreateResponse(
         items=items,
         total=len(items),

--- a/tldw_Server_API/app/api/v1/endpoints/watchlists.py
+++ b/tldw_Server_API/app/api/v1/endpoints/watchlists.py
@@ -64,6 +64,8 @@ from tldw_Server_API.app.core.DB_Management.scope_context import get_scope as _g
 from tldw_Server_API.app.core.DB_Management.Watchlists_DB import WatchlistsDatabase
 from tldw_Server_API.app.core.exceptions import TemplateValidationError
 from tldw_Server_API.app.core.Personalization.companion_activity import (
+    build_watchlist_source_bulk_import_activity,
+    record_companion_activity_events_bulk,
     record_watchlist_item_updated,
     record_watchlist_source_created,
     record_watchlist_source_deleted,
@@ -1618,6 +1620,7 @@ async def import_sources_opml(
     if group_id is not None:
         _validate_group_ids(db, [group_id])
     items: list[SourcesImportItem] = []
+    companion_events: list[dict[str, Any]] = []
     created = skipped = errors = 0
     default_tags = tags or []
     for e in entries:
@@ -1655,11 +1658,20 @@ async def import_sources_opml(
                 tags=default_tags,
                 group_ids=([group_id] if group_id else []),
             )
+            companion_events.append(
+                build_watchlist_source_bulk_import_activity(
+                    source=row,
+                    operation="import_create",
+                    route="/api/v1/watchlists/sources/import",
+                    surface="api.watchlists.sources.import",
+                )
+            )
             items.append(SourcesImportItem(url=url_str, name=row.name, id=row.id, status="created"))
             created += 1
         except (*_WATCHLISTS_NONCRITICAL_EXCEPTIONS, _DatabaseError) as exc:
             items.append(SourcesImportItem(url=url_str, name=e.name, status="skipped", error=str(exc)))
             skipped += 1
+    record_companion_activity_events_bulk(user_id=current_user.id, events=companion_events)
     return SourcesImportResponse(items=items, total=(created + skipped + errors), created=created, skipped=skipped, errors=errors)
 
 
@@ -2257,6 +2269,7 @@ async def bulk_create_sources(
     db = Depends(get_watchlists_db_for_user),
 ):
     items: list[SourcesBulkCreateItem] = []
+    companion_events: list[dict[str, Any]] = []
     created_count = 0
     errors_count = 0
     for s in payload.sources:
@@ -2368,6 +2381,15 @@ async def bulk_create_sources(
                 tags=s.tags or [],
                 group_ids=s.group_ids or [],
             )
+            if getattr(row, "was_created", False):
+                companion_events.append(
+                    build_watchlist_source_bulk_import_activity(
+                        source=row,
+                        operation="bulk_create",
+                        route="/api/v1/watchlists/sources/bulk",
+                        surface="api.watchlists.sources.bulk",
+                    )
+                )
             # Echo request name for stable per-entry mapping, even on idempotent creates
             items.append(
                 SourcesBulkCreateItem(
@@ -2392,6 +2414,7 @@ async def bulk_create_sources(
             )
             errors_count += 1
 
+    record_companion_activity_events_bulk(user_id=current_user.id, events=companion_events)
     return SourcesBulkCreateResponse(
         items=items,
         total=len(items),

--- a/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
@@ -710,37 +710,67 @@ class PersonalizationDB:
         user_id: str,
         events: list[dict[str, Any]],
     ) -> list[str]:
-        """Insert multiple companion activity events in a single transaction."""
+        """Insert multiple companion activity events in a single transaction.
+
+        Duplicate dedupe keys are skipped so one conflict does not fail the
+        entire batch.
+        """
         if not events:
             return []
 
         import uuid
 
         self.get_or_create_profile(user_id)
-        rows: list[tuple[Any, ...]] = []
-        event_ids: list[str] = []
-        for event in events:
-            event_id = uuid.uuid4().hex
-            event_ids.append(event_id)
-            rows.append(
-                (
-                    event_id,
-                    str(user_id),
-                    str(event["event_type"]),
-                    str(event["source_type"]),
-                    str(event["source_id"]),
-                    str(event["surface"]),
-                    str(event["dedupe_key"]),
-                    json.dumps(event.get("tags")) if event.get("tags") is not None else None,
-                    json.dumps(event.get("provenance") or {}),
-                    json.dumps(event.get("metadata")) if event.get("metadata") is not None else None,
-                    _utcnow_iso(),
-                )
-            )
-
         with self._lock:
             conn = self._connect()
             try:
+                existing_dedupe_keys: set[str] = set()
+                dedupe_keys = [
+                    str(event.get("dedupe_key"))
+                    for event in events
+                    if str(event.get("dedupe_key", "")).strip()
+                ]
+                if dedupe_keys:
+                    placeholders = ", ".join(["?"] * len(dedupe_keys))
+                    existing_rows = conn.execute(
+                        f"""
+                        SELECT dedupe_key
+                        FROM companion_activity_events
+                        WHERE user_id = ? AND dedupe_key IN ({placeholders})
+                        """,  # nosec B608
+                        (str(user_id), *dedupe_keys),
+                    ).fetchall()
+                    existing_dedupe_keys = {str(row["dedupe_key"]) for row in existing_rows}
+
+                rows: list[tuple[Any, ...]] = []
+                event_ids: list[str] = []
+                seen_dedupe_keys: set[str] = set(existing_dedupe_keys)
+                for event in events:
+                    dedupe_key = str(event["dedupe_key"])
+                    if dedupe_key in seen_dedupe_keys:
+                        continue
+                    seen_dedupe_keys.add(dedupe_key)
+                    event_id = uuid.uuid4().hex
+                    event_ids.append(event_id)
+                    rows.append(
+                        (
+                            event_id,
+                            str(user_id),
+                            str(event["event_type"]),
+                            str(event["source_type"]),
+                            str(event["source_id"]),
+                            str(event["surface"]),
+                            dedupe_key,
+                            json.dumps(event.get("tags")) if event.get("tags") is not None else None,
+                            json.dumps(event.get("provenance") or {}),
+                            json.dumps(event.get("metadata")) if event.get("metadata") is not None else None,
+                            _utcnow_iso(),
+                        )
+                    )
+
+                if not rows:
+                    return []
+
                 conn.executemany(
                     """
                     INSERT INTO companion_activity_events (

--- a/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Personalization_DB.py
@@ -743,7 +743,6 @@ class PersonalizationDB:
                     existing_dedupe_keys = {str(row["dedupe_key"]) for row in existing_rows}
 
                 rows: list[tuple[Any, ...]] = []
-                event_ids: list[str] = []
                 seen_dedupe_keys: set[str] = set(existing_dedupe_keys)
                 for event in events:
                     dedupe_key = str(event["dedupe_key"])
@@ -751,7 +750,6 @@ class PersonalizationDB:
                         continue
                     seen_dedupe_keys.add(dedupe_key)
                     event_id = uuid.uuid4().hex
-                    event_ids.append(event_id)
                     rows.append(
                         (
                             event_id,
@@ -771,16 +769,20 @@ class PersonalizationDB:
                 if not rows:
                     return []
 
-                conn.executemany(
-                    """
-                    INSERT INTO companion_activity_events (
-                        id, user_id, event_type, source_type, source_id, surface,
-                        dedupe_key, tags, provenance_json, metadata_json, created_at
+                event_ids: list[str] = []
+                for row in rows:
+                    cursor = conn.execute(
+                        """
+                        INSERT OR IGNORE INTO companion_activity_events (
+                            id, user_id, event_type, source_type, source_id, surface,
+                            dedupe_key, tags, provenance_json, metadata_json, created_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        row,
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    rows,
-                )
+                    if cursor.rowcount == 1:
+                        event_ids.append(str(row[0]))
                 conn.commit()
                 return event_ids
             finally:

--- a/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/Watchlists_DB.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import sqlite3
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -60,6 +61,7 @@ _WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS = (
     AttributeError,
     ConnectionError,
     TimeoutError,
+    sqlite3.IntegrityError,
     json.JSONDecodeError,
 )
 
@@ -87,6 +89,7 @@ class SourceRow:
     created_at: str
     updated_at: str
     tags: list[str]
+    was_created: bool = False
 
 
 @dataclass
@@ -932,12 +935,14 @@ class WatchlistsDatabase:
         now = _utcnow_iso()
         # Try insert; if UNIQUE(user_id,url) violates, fetch existing id and proceed idempotently
         sid: int | None = None
+        created_new = False
         try:
             res = self._execute_insert(
                 "INSERT INTO sources (user_id, name, url, source_type, active, settings_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (self.user_id, name, url, source_type, 1 if active else 0, settings_json, now, now),
             )
             sid = self._extract_lastrowid(res)
+            created_new = True
         except (*_WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS, _DatabaseError):
             # Look up existing source for idempotency
             try:
@@ -952,7 +957,7 @@ class WatchlistsDatabase:
             except (*_WATCHLISTS_DB_NONCRITICAL_EXCEPTIONS, _DatabaseError):
                 raise
         if sid is None:
-            raise RuntimeError("failed_to_create_or_lookup_source")
+                raise RuntimeError("failed_to_create_or_lookup_source")
         if tags:
             tag_ids = self.ensure_tag_ids(tags)
             for tid in tag_ids:
@@ -979,7 +984,9 @@ class WatchlistsDatabase:
                         "INSERT INTO source_groups (source_id, group_id) SELECT ?, ? WHERE NOT EXISTS (SELECT 1 FROM source_groups WHERE source_id = ? AND group_id = ?)",
                         (sid, gid, sid, gid),
                     )
-        return self.get_source(sid)
+        row = self.get_source(sid)
+        row.was_created = created_new
+        return row
 
     def get_source_by_url(self, url: str) -> SourceRow | None:
         row = self.backend.execute(

--- a/tldw_Server_API/app/core/Personalization/__init__.py
+++ b/tldw_Server_API/app/core/Personalization/__init__.py
@@ -1,7 +1,10 @@
 """Personalization helpers and adapter utilities."""
 
 from tldw_Server_API.app.core.Personalization.companion_activity import (
+    build_note_bulk_import_activity,
+    build_watchlist_source_bulk_import_activity,
     record_companion_activity,
+    record_companion_activity_events_bulk,
     record_note_created,
     record_note_deleted,
     record_note_restored,
@@ -33,8 +36,11 @@ from tldw_Server_API.app.core.Personalization.companion_derivations import deriv
 
 __all__ = [
     "record_companion_activity",
+    "record_companion_activity_events_bulk",
     "load_companion_context",
     "derive_companion_knowledge_cards",
+    "build_note_bulk_import_activity",
+    "build_watchlist_source_bulk_import_activity",
     "record_note_created",
     "record_note_deleted",
     "record_note_restored",

--- a/tldw_Server_API/app/core/Personalization/companion_activity.py
+++ b/tldw_Server_API/app/core/Personalization/companion_activity.py
@@ -105,10 +105,15 @@ def record_companion_activity_events_bulk(
     user_id: str | int | None,
     events: list[dict[str, Any]],
 ) -> list[str]:
-    """Persist explicit companion activity events in bulk when the user opted in."""
+    """Persist explicit companion activity events in bulk when the user opted in.
+
+    This helper performs synchronous DB I/O and should be wrapped in
+    ``asyncio.to_thread`` from async request handlers.
+    """
     if user_id is None or not is_personalization_enabled() or not events:
         return []
 
+    normalized_user_id = str(user_id or "").strip() or None
     try:
         db, normalized_user_id = _open_db_for_user(user_id)
         if not _profile_opted_in(db, normalized_user_id):
@@ -125,7 +130,20 @@ def record_companion_activity_events_bulk(
             events=safe_events,
         )
     except Exception as exc:
-        logger.debug("companion activity bulk capture skipped: {}", exc)
+        sample_event_types = [str(event.get("event_type", "")) for event in events[:3]]
+        sample_dedupe_keys = [
+            str(event.get("dedupe_key", ""))
+            for event in events[:3]
+            if str(event.get("dedupe_key", "")).strip()
+        ]
+        logger.warning(
+            "companion activity bulk capture skipped for user={} batch_size={} sample_event_types={} sample_dedupe_keys={} error={}",
+            normalized_user_id or str(user_id or ""),
+            len(events),
+            sample_event_types,
+            sample_dedupe_keys,
+            exc,
+        )
         return []
 
 

--- a/tldw_Server_API/app/core/Personalization/companion_activity.py
+++ b/tldw_Server_API/app/core/Personalization/companion_activity.py
@@ -100,6 +100,35 @@ def record_companion_activity(
         return None
 
 
+def record_companion_activity_events_bulk(
+    *,
+    user_id: str | int | None,
+    events: list[dict[str, Any]],
+) -> list[str]:
+    """Persist explicit companion activity events in bulk when the user opted in."""
+    if user_id is None or not is_personalization_enabled() or not events:
+        return []
+
+    try:
+        db, normalized_user_id = _open_db_for_user(user_id)
+        if not _profile_opted_in(db, normalized_user_id):
+            return []
+        safe_events: list[dict[str, Any]] = []
+        for event in events:
+            safe_event = dict(event)
+            safe_provenance = dict(safe_event.get("provenance") or {})
+            safe_provenance.setdefault("capture_mode", "explicit")
+            safe_event["provenance"] = safe_provenance
+            safe_events.append(safe_event)
+        return db.insert_companion_activity_events_bulk(
+            user_id=normalized_user_id,
+            events=safe_events,
+        )
+    except Exception as exc:
+        logger.debug("companion activity bulk capture skipped: {}", exc)
+        return []
+
+
 def _truncate_text(value: str | None, *, max_length: int) -> str | None:
     if value is None:
         return None
@@ -471,6 +500,58 @@ def _note_timestamp(note: Any, *, prefer_created: bool = False) -> str | None:
     return _value(note, "last_modified") or _value(note, "updated_at") or _value(note, "created_at")
 
 
+def build_note_bulk_import_activity(
+    *,
+    note: Any,
+    operation: str,
+    route: str,
+    surface: str,
+    patch: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a note companion activity payload for explicit bulk/import flows."""
+    normalized_operation = str(operation or "").strip().lower()
+    note_id = str(_value(note, "id"))
+    if normalized_operation in {"import_create", "bulk_create"}:
+        source_timestamp = _note_timestamp(note, prefer_created=True)
+        return {
+            "event_type": "note_created",
+            "source_type": "note",
+            "source_id": note_id,
+            "surface": surface,
+            "dedupe_key": f"notes.create:{note_id}",
+            "tags": _note_tags(note),
+            "provenance": _explicit_provenance(
+                route=route,
+                action=normalized_operation,
+                source_timestamp=source_timestamp,
+            ),
+            "metadata": _note_metadata(note),
+        }
+    if normalized_operation == "import_overwrite":
+        source_timestamp = _note_timestamp(note)
+        version = _value(note, "version")
+        fingerprint = _payload_fingerprint(patch)
+        changed_fields = sorted(str(key) for key in dict(patch or {}).keys())
+        return {
+            "event_type": "note_updated",
+            "source_type": "note",
+            "source_id": note_id,
+            "surface": surface,
+            "dedupe_key": f"notes.update:{note_id}:{version or source_timestamp or 'na'}:{fingerprint}",
+            "tags": _note_tags(note),
+            "provenance": _explicit_provenance(
+                route=route,
+                action=normalized_operation,
+                source_timestamp=source_timestamp,
+            ),
+            "metadata": {
+                **_note_metadata(note),
+                "changed_fields": changed_fields,
+            },
+        }
+    raise ValueError(f"unsupported note bulk/import operation: {operation}")
+
+
 def record_note_created(*, user_id: str | int | None, note: Any) -> str | None:
     note_id = str(_value(note, "id"))
     source_timestamp = _note_timestamp(note, prefer_created=True)
@@ -777,6 +858,58 @@ def _watchlist_source_metadata(source: Any) -> dict[str, Any]:
 
 def _watchlist_source_timestamp(source: Any) -> str | None:
     return _value(source, "updated_at") or _value(source, "created_at")
+
+
+def build_watchlist_source_bulk_import_activity(
+    *,
+    source: Any,
+    operation: str,
+    route: str,
+    surface: str,
+    patch: dict[str, Any] | None = None,
+    event_timestamp: str | None = None,
+) -> dict[str, Any]:
+    """Build a watchlist source companion activity payload for bulk/import flows."""
+    normalized_operation = str(operation or "").strip().lower()
+    source_id = str(_value(source, "id"))
+    if normalized_operation in {"import_create", "bulk_create"}:
+        source_timestamp = event_timestamp or _watchlist_source_timestamp(source)
+        return {
+            "event_type": "watchlist_source_created",
+            "source_type": "watchlist_source",
+            "source_id": source_id,
+            "surface": surface,
+            "dedupe_key": f"watchlists.source.create:{source_id}",
+            "tags": list(_value(source, "tags") or []),
+            "provenance": _explicit_provenance(
+                route=route,
+                action=normalized_operation,
+                source_timestamp=source_timestamp,
+            ),
+            "metadata": _watchlist_source_metadata(source),
+        }
+    if normalized_operation == "import_update":
+        source_timestamp = event_timestamp or _watchlist_source_timestamp(source)
+        fingerprint = _payload_fingerprint(patch)
+        changed_fields = sorted(str(key) for key in dict(patch or {}).keys())
+        return {
+            "event_type": "watchlist_source_updated",
+            "source_type": "watchlist_source",
+            "source_id": source_id,
+            "surface": surface,
+            "dedupe_key": f"watchlists.source.update:{source_id}:{source_timestamp or 'na'}:{fingerprint}",
+            "tags": list(_value(source, "tags") or []),
+            "provenance": _explicit_provenance(
+                route=route,
+                action=normalized_operation,
+                source_timestamp=source_timestamp,
+            ),
+            "metadata": {
+                **_watchlist_source_metadata(source),
+                "changed_fields": changed_fields,
+            },
+        }
+    raise ValueError(f"unsupported watchlist source bulk/import operation: {operation}")
 
 
 def record_watchlist_source_created(

--- a/tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py
+++ b/tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py
@@ -160,3 +160,111 @@ def test_note_delete_and_restore_record_companion_activity(notes_client_with_com
     assert restored_event["metadata"]["title"] == "Recoverable Note"
     assert restored_event["metadata"]["version"] == restored["version"]
     assert restored_event["metadata"]["deleted"] is False
+
+
+def test_notes_import_create_records_companion_note_created(notes_client_with_companion_opt_in):
+    client, personalization_db = notes_client_with_companion_opt_in
+
+    response = client.post(
+        "/api/v1/notes/import",
+        json={
+            "duplicate_strategy": "create_copy",
+            "items": [
+                {
+                    "file_name": "note.json",
+                    "format": "json",
+                    "content": "{\"title\": \"Imported Note\", \"content\": \"Body\", \"keywords\": [\"alpha\"]}",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events(str(TEST_USER_ID), limit=10)
+    assert total == 1
+    event = events[0]
+    assert event["event_type"] == "note_created"
+    assert event["surface"] == "api.notes.import"
+    assert event["provenance"]["route"] == "/api/v1/notes/import"
+    assert event["provenance"]["action"] == "import_create"
+    assert event["tags"] == ["alpha"]
+
+
+def test_notes_import_overwrite_records_companion_note_updated(notes_client_with_companion_opt_in):
+    client, personalization_db = notes_client_with_companion_opt_in
+
+    create_resp = client.post(
+        "/api/v1/notes/",
+        json={
+            "title": "Original",
+            "content": "Before",
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    note_id = create_resp.json()["id"]
+
+    response = client.post(
+        "/api/v1/notes/import",
+        json={
+            "duplicate_strategy": "overwrite",
+            "items": [
+                {
+                    "file_name": "note.json",
+                    "format": "json",
+                    "content": f"{{\"id\": \"{note_id}\", \"title\": \"Updated\", \"content\": \"After\"}}",
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events(str(TEST_USER_ID), limit=10)
+    assert total == 2
+    updated = next(event for event in events if event["event_type"] == "note_updated")
+    assert updated["source_id"] == note_id
+    assert updated["surface"] == "api.notes.import"
+    assert updated["provenance"]["route"] == "/api/v1/notes/import"
+    assert updated["provenance"]["action"] == "import_overwrite"
+    assert updated["metadata"]["changed_fields"] == ["content", "title"]
+
+
+def test_notes_bulk_success_rows_record_companion_activity(notes_client_with_companion_opt_in):
+    client, personalization_db = notes_client_with_companion_opt_in
+
+    response = client.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {"title": "Bulk One", "content": "One"},
+                {"title": "Bulk Two", "content": "Two"},
+            ]
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events(str(TEST_USER_ID), limit=10)
+    assert total == 2
+    assert all(event["event_type"] == "note_created" for event in events)
+    assert all(event["surface"] == "api.notes.bulk" for event in events)
+    assert all(event["provenance"]["route"] == "/api/v1/notes/bulk" for event in events)
+    assert all(event["provenance"]["action"] == "bulk_create" for event in events)
+
+
+def test_notes_bulk_failed_rows_do_not_record_companion_activity(notes_client_with_companion_opt_in):
+    client, personalization_db = notes_client_with_companion_opt_in
+
+    response = client.post(
+        "/api/v1/notes/bulk",
+        json={
+            "notes": [
+                {"title": "Bulk Good", "content": "Good"},
+                {"content": "Missing title and no auto title"},
+            ]
+        },
+    )
+
+    assert response.status_code == 207, response.text
+    events, total = personalization_db.list_companion_activity_events(str(TEST_USER_ID), limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "note_created"
+    assert events[0]["metadata"]["title"] == "Bulk Good"

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import sqlite3
+from typing import Any
 
 import pytest
 
@@ -164,6 +166,82 @@ def test_insert_companion_activity_events_bulk_keeps_unique_rows_when_one_confli
                 "dedupe_key": "notes.create:n1",
                 "provenance": {"capture_mode": "explicit"},
                 "metadata": {"title": "Duplicate"},
+            },
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n2",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n2",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Fresh"},
+            },
+        ],
+    )
+
+    assert len(inserted) == 1
+    rows, total = db.list_companion_activity_events(user_id, limit=10)
+    assert total == 2
+    source_ids = {row["source_id"] for row in rows}
+    assert source_ids == {"n1", "n2"}
+
+
+def test_insert_companion_activity_events_bulk_keeps_unique_rows_when_conflict_appears_at_insert_time(
+    companion_db_env,
+    monkeypatch,
+):
+    user_id = "77-bulk-race"
+    db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(user_id)))
+    db.update_profile(user_id, enabled=1)
+    real_connect = db._connect
+
+    class _RaceInjectingConnection:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+            self._injected = False
+
+        def execute(self, sql: str, params: tuple[Any, ...] = ()) -> Any:
+            normalized_sql = " ".join(sql.split()).upper()
+            if (
+                normalized_sql.startswith("INSERT")
+                and "COMPANION_ACTIVITY_EVENTS" in normalized_sql
+                and len(params) >= 7
+                and str(params[6]) == "notes.create:n1"
+                and not self._injected
+            ):
+                self._injected = True
+                competing = sqlite3.connect(db.db_path, timeout=10, isolation_level=None)
+                try:
+                    competing.execute("PRAGMA journal_mode=WAL")
+                    competing.execute("PRAGMA foreign_keys=ON")
+                    competing.execute("PRAGMA busy_timeout=5000")
+                    competing.execute(sql, params)
+                    competing.commit()
+                finally:
+                    competing.close()
+            return self._inner.execute(sql, params)
+
+        def executemany(self, sql: str, seq_of_params: Any) -> Any:
+            for row in seq_of_params:
+                self.execute(sql, row)
+            return None
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+    monkeypatch.setattr(db, "_connect", lambda: _RaceInjectingConnection(real_connect()))
+
+    inserted = db.insert_companion_activity_events_bulk(
+        user_id=user_id,
+        events=[
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n1",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n1",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Conflicted"},
             },
             {
                 "event_type": "note_created",

--- a/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
+++ b/tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
@@ -5,6 +5,8 @@ import pytest
 from tldw_Server_API.app.core.DB_Management.Personalization_DB import PersonalizationDB
 from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
 from tldw_Server_API.app.core.Personalization.companion_activity import (
+    build_note_bulk_import_activity,
+    build_watchlist_source_bulk_import_activity,
     record_companion_activity,
     record_note_created,
     record_note_deleted,
@@ -99,6 +101,146 @@ def test_record_companion_activity_requires_opt_in_and_dedupes(companion_db_env)
     assert duplicate is None
     _, total_after_duplicate = db.list_companion_activity_events(user_id)
     assert total_after_duplicate == 1
+
+
+def test_insert_companion_activity_events_bulk_skips_duplicate_dedupe_keys(companion_db_env):
+    user_id = "77-bulk"
+    db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(user_id)))
+    db.update_profile(user_id, enabled=1)
+
+    inserted = db.insert_companion_activity_events_bulk(
+        user_id=user_id,
+        events=[
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n1",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n1",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "One"},
+            },
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n1",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n1",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "One duplicate"},
+            },
+        ],
+    )
+
+    assert len(inserted) == 1
+    rows, total = db.list_companion_activity_events(user_id, limit=10)
+    assert total == 1
+    assert rows[0]["source_id"] == "n1"
+
+
+def test_insert_companion_activity_events_bulk_keeps_unique_rows_when_one_conflicts(companion_db_env):
+    user_id = "77-bulk-existing"
+    db = PersonalizationDB(str(DatabasePaths.get_personalization_db_path(user_id)))
+    db.update_profile(user_id, enabled=1)
+    db.insert_companion_activity_event(
+        user_id=user_id,
+        event_type="note_created",
+        source_type="note",
+        source_id="n1",
+        surface="api.notes.import",
+        dedupe_key="notes.create:n1",
+        provenance={"capture_mode": "explicit"},
+        metadata={"title": "Existing"},
+    )
+
+    inserted = db.insert_companion_activity_events_bulk(
+        user_id=user_id,
+        events=[
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n1",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n1",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Duplicate"},
+            },
+            {
+                "event_type": "note_created",
+                "source_type": "note",
+                "source_id": "n2",
+                "surface": "api.notes.import",
+                "dedupe_key": "notes.create:n2",
+                "provenance": {"capture_mode": "explicit"},
+                "metadata": {"title": "Fresh"},
+            },
+        ],
+    )
+
+    assert len(inserted) == 1
+    rows, total = db.list_companion_activity_events(user_id, limit=10)
+    assert total == 2
+    source_ids = {row["source_id"] for row in rows}
+    assert source_ids == {"n1", "n2"}
+
+
+def test_build_note_import_created_activity_uses_import_surface_and_route():
+    note = {
+        "id": "note-1",
+        "title": "Imported note",
+        "content": "Imported content",
+        "version": 1,
+        "created_at": "2026-03-12T00:00:00+00:00",
+        "last_modified": "2026-03-12T00:00:00+00:00",
+        "keywords": [{"keyword": "import"}],
+    }
+
+    payload = build_note_bulk_import_activity(
+        note=note,
+        operation="import_create",
+        route="/api/v1/notes/import",
+        surface="api.notes.import",
+    )
+
+    assert payload["event_type"] == "note_created"
+    assert payload["source_type"] == "note"
+    assert payload["source_id"] == "note-1"
+    assert payload["surface"] == "api.notes.import"
+    assert payload["provenance"]["route"] == "/api/v1/notes/import"
+    assert payload["provenance"]["action"] == "import_create"
+    assert payload["metadata"]["title"] == "Imported note"
+    assert payload["tags"] == ["import"]
+
+
+def test_build_watchlist_source_bulk_activity_uses_bulk_surface_and_route():
+    source = {
+        "id": 12,
+        "name": "Bulk source",
+        "url": "https://example.com/feed.xml",
+        "source_type": "rss",
+        "active": True,
+        "status": None,
+        "group_ids": [2],
+        "tags": ["feeds"],
+        "created_at": "2026-03-12T00:00:00+00:00",
+        "updated_at": "2026-03-12T00:00:00+00:00",
+    }
+
+    payload = build_watchlist_source_bulk_import_activity(
+        source=source,
+        operation="bulk_create",
+        route="/api/v1/watchlists/sources/bulk",
+        surface="api.watchlists.sources.bulk",
+    )
+
+    assert payload["event_type"] == "watchlist_source_created"
+    assert payload["source_type"] == "watchlist_source"
+    assert payload["source_id"] == "12"
+    assert payload["surface"] == "api.watchlists.sources.bulk"
+    assert payload["provenance"]["route"] == "/api/v1/watchlists/sources/bulk"
+    assert payload["provenance"]["action"] == "bulk_create"
+    assert payload["metadata"]["name"] == "Bulk source"
+    assert payload["tags"] == ["feeds"]
 
 
 def test_note_activity_adapters_capture_compact_metadata(companion_db_env):

--- a/tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py
+++ b/tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py
@@ -226,3 +226,93 @@ def test_watchlist_item_run_and_flag_updates_record_companion_events(watchlists_
         event["provenance"]["route"] == f"/api/v1/watchlists/items/{item_id}"
         for event in item_updated_events
     )
+
+
+def test_watchlists_sources_import_created_rows_record_companion_activity(watchlists_app):
+    app, personalization_db = watchlists_app
+    opml_bytes = b"""<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Example Feed" title="Example Feed" type="rss" xmlUrl="https://example.com/feed.xml" />
+  </body>
+</opml>
+"""
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/watchlists/sources/import",
+            files={"file": ("feeds.opml", opml_bytes, "text/xml")},
+        )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events("906", limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "watchlist_source_created"
+    assert events[0]["surface"] == "api.watchlists.sources.import"
+    assert events[0]["provenance"]["route"] == "/api/v1/watchlists/sources/import"
+    assert events[0]["provenance"]["action"] == "import_create"
+
+
+def test_watchlists_sources_import_duplicate_skip_does_not_record_companion_activity(watchlists_app):
+    app, personalization_db = watchlists_app
+    opml_bytes = b"""<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Example Feed" title="Example Feed" type="rss" xmlUrl="https://example.com/feed.xml" />
+  </body>
+</opml>
+"""
+
+    with TestClient(app) as client:
+        first_response = client.post(
+            "/api/v1/watchlists/sources/import",
+            files={"file": ("feeds.opml", opml_bytes, "text/xml")},
+        )
+        assert first_response.status_code == 200, first_response.text
+
+        response = client.post(
+            "/api/v1/watchlists/sources/import",
+            files={"file": ("feeds.opml", opml_bytes, "text/xml")},
+        )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events("906", limit=20)
+    assert total == 1
+
+
+def test_watchlists_bulk_new_source_records_companion_activity(watchlists_app):
+    app, personalization_db = watchlists_app
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/watchlists/sources/bulk",
+            json={"sources": [{"name": "Feed A", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+        )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events("906", limit=10)
+    assert total == 1
+    assert events[0]["event_type"] == "watchlist_source_created"
+    assert events[0]["surface"] == "api.watchlists.sources.bulk"
+    assert events[0]["provenance"]["route"] == "/api/v1/watchlists/sources/bulk"
+    assert events[0]["provenance"]["action"] == "bulk_create"
+
+
+def test_watchlists_bulk_idempotent_existing_source_does_not_record_companion_activity(watchlists_app):
+    app, personalization_db = watchlists_app
+
+    with TestClient(app) as client:
+        first_response = client.post(
+            "/api/v1/watchlists/sources/bulk",
+            json={"sources": [{"name": "Feed A", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+        )
+        assert first_response.status_code == 200, first_response.text
+
+        response = client.post(
+            "/api/v1/watchlists/sources/bulk",
+            json={"sources": [{"name": "Feed A Again", "url": "https://example.com/a.xml", "source_type": "rss"}]},
+        )
+
+    assert response.status_code == 200, response.text
+    events, total = personalization_db.list_companion_activity_events("906", limit=20)
+    assert total == 1


### PR DESCRIPTION
## Summary
- add conflict-tolerant bulk companion activity inserts and shared bulk/import activity builders
- record explicit companion activity for successful notes import and notes bulk create rows with post-write rereads for stable metadata
- record explicit companion activity for watchlists OPML import and watchlists bulk source creation only when a new source was actually created, plus include the capture-expansion design and plan docs

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Notes_NEW/integration/test_companion_notes_activity_bridge.py tldw_Server_API/tests/Watchlists/test_companion_watchlists_activity_bridge.py tldw_Server_API/tests/Personalization/test_companion_activity_adapters.py
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -q tldw_Server_API/tests/Watchlists/test_opml_api.py tldw_Server_API/tests/Watchlists/test_opml_edge_cases.py tldw_Server_API/tests/Watchlists/test_opml_nested.py tldw_Server_API/tests/Watchlists/test_youtube_normalization_more.py tldw_Server_API/tests/Watchlists/test_youtube_url_validation.py tldw_Server_API/tests/Watchlists/test_watchlists_api.py tldw_Server_API/tests/Notes_NEW/integration/test_notes_api.py -k "import or bulk"
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/endpoints/notes.py tldw_Server_API/app/api/v1/endpoints/watchlists.py tldw_Server_API/app/core/DB_Management/Personalization_DB.py tldw_Server_API/app/core/DB_Management/Watchlists_DB.py tldw_Server_API/app/core/Personalization/companion_activity.py -f json -o /tmp/bandit_companion_capture_expansion.json