### PR TITLE
feat(admin-ui): make byok validation and retention preview authoritative

### DIFF
--- a/Docs/Plans/2026-03-12-admin-ui-byok-retention-authoritative-design.md
+++ b/Docs/Plans/2026-03-12-admin-ui-byok-retention-authoritative-design.md
@@ -1,0 +1,272 @@
+# Admin UI BYOK Validation And Retention Preview Authoritative Design
+
+**Date:** 2026-03-12
+**Status:** Approved
+**Branch:** `codex/admin-ui-byok-retention-authoritative`
+
+## Goal
+
+Close the remaining two production-readiness gaps in the admin UI by:
+
+- replacing the BYOK dashboard's placeholder validation/telemetry path with authoritative backend-backed validation runs and shared history
+- replacing the retention-policy impact estimate fallback with a real backend dry-run preview that must be used before destructive saves
+
+## Problem Summary
+
+Two admin surfaces on current `dev` still fall short of truthful production behavior:
+
+1. `admin-ui/app/byok/page.tsx` still labels part of the page as placeholder telemetry and explicitly hides batch validation until backend support exists.
+2. `admin-ui/components/data-ops/RetentionPoliciesSection.tsx` falls back to a locally estimated impact preview when the backend preview route is unavailable.
+
+These are not cosmetic gaps:
+
+- BYOK operators cannot authoritatively validate key health at scale or rely on shared validation history.
+- Retention-policy changes are destructive, but the current UI can still display a non-authoritative estimate and keep the preview/save workflow alive.
+
+## Current Backend Constraints
+
+### BYOK
+
+The backend already has:
+
+- admin BYOK endpoints for listing, testing, upserting, and deleting keys
+- metrics that expose BYOK resolution and missing-credential counts
+- audit logs that can support recent admin activity views
+
+The backend does **not** currently expose:
+
+- a batch validation run model
+- a shared validation history/status API
+- a Jobs-backed validation worker
+
+### Retention
+
+The backend already has:
+
+- `GET /admin/retention-policies`
+- `PUT /admin/retention-policies/{policy_key}`
+- service logic that validates retention-policy ranges and applies overrides
+
+The backend does **not** currently expose:
+
+- `POST /admin/retention-policies/{policy_key}/preview`
+- an authoritative count of affected rows/files before a policy change
+- a way to bind a reviewed preview to the later destructive save
+
+## Chosen Architecture
+
+### 1. Dedicated BYOK validation-run model
+
+Add a control-plane `byok_validation_runs` table in AuthNZ-backed admin persistence.
+
+Each run stores:
+
+- `id`
+- `status` as `queued | running | complete | failed`
+- `org_id` nullable
+- `provider` nullable
+- `keys_checked`
+- `valid_count`
+- `invalid_count`
+- `error_count`
+- `requested_by_user_id`
+- `requested_by_label`
+- `job_id`
+- `scope_summary`
+- `error_message`
+- `created_at`
+- `started_at`
+- `completed_at`
+
+Runs store only aggregate/redacted results. They do **not** persist raw key material, provider credential payloads, or verbose per-key error blobs.
+
+### 2. Jobs-backed BYOK batch validation
+
+Use Jobs because this is an admin-visible operational workflow that needs durable shared status/history.
+
+Flow:
+
+1. The UI creates a validation run through a new admin BYOK endpoint.
+2. Backend validates scope and active-run exclusivity.
+3. Backend records the run and enqueues a Jobs task.
+4. The worker scans the targeted keys, performs provider validation with conservative concurrency, and updates the run row with aggregate counts.
+5. The UI polls run detail/history until a terminal state is reached.
+
+V1 allows at most one active validation run globally. This keeps provider traffic predictable and prevents confusing overlapping histories.
+
+### 3. Narrower authoritative telemetry promise for BYOK
+
+V1 does **not** try to invent perfect historical observability for every BYOK card.
+
+Instead:
+
+- the validation sweep and recent validation history become authoritative
+- existing metrics-backed and audit-backed cards remain only if their source is already real
+- cards that would still overpromise after this work are renamed or removed rather than left as placeholders
+
+If the current “Key Activity” card still reflects only partial data after implementation, it should be renamed to something narrower such as recent validation activity or recent admin key events.
+
+### 4. Backend retention dry-run preview
+
+Add:
+
+- `POST /api/v1/admin/retention-policies/{policy_key}/preview`
+
+The preview response returns authoritative counts for the proposed change:
+
+- `policy_key`
+- `current_days`
+- `new_days`
+- `counts.audit_log_entries`
+- `counts.job_records`
+- `counts.backup_files`
+- `preview_signature`
+- `expires_at`
+
+The preview uses the same auth/scope rules and validation path as the eventual update endpoint.
+
+### 5. Preview/save binding for retention
+
+The retention save flow needs a backend binding between the reviewed preview and the later destructive update.
+
+V1 uses a signed, time-bounded preview token/signature:
+
+- preview computes a `preview_signature` over `policy_key`, `current_days`, `new_days`, actor identity, and a freshness window
+- `PUT /admin/retention-policies/{policy_key}` accepts `preview_signature`
+- backend verifies the signature before applying the update
+
+This prevents saving a different value from the one the operator previewed, and avoids introducing another stateful server-side draft store.
+
+## API Design
+
+### BYOK
+
+Add endpoints under the existing admin BYOK surface:
+
+- `POST /api/v1/admin/byok/validation-runs`
+- `GET /api/v1/admin/byok/validation-runs`
+- `GET /api/v1/admin/byok/validation-runs/{run_id}`
+
+Create request fields:
+
+- `org_id` optional
+- `provider` optional
+
+Create semantics:
+
+- require BYOK to be enabled
+- preserve admin/org scope enforcement
+- reject when another validation run is active
+- create run row and enqueue worker job
+
+Read semantics:
+
+- list/detail return aggregate counts, timestamps, status, scope summary, and any bounded failure message
+
+### Retention
+
+Add:
+
+- `POST /api/v1/admin/retention-policies/{policy_key}/preview`
+
+Extend:
+
+- `PUT /api/v1/admin/retention-policies/{policy_key}`
+
+Update request fields become:
+
+- `days`
+- `preview_signature`
+
+Update semantics:
+
+- reject missing or invalid signature
+- reject expired signature
+- reject mismatched policy/current/new values
+- then apply the existing retention update logic
+
+## UI Design
+
+### BYOK page
+
+Replace the current placeholder validation framing in `admin-ui/app/byok/page.tsx` with:
+
+- a `Run validation sweep` control
+- latest validation-run status
+- recent validation history
+- aggregate counts from the selected run
+
+Keep the existing per-key admin actions:
+
+- add/update shared key
+- test shared key
+- revoke/delete key
+
+The page should no longer say validation sweep support is hidden. It should instead show:
+
+- current run state when a run exists
+- a truthful empty state when no runs have been created yet
+
+### Retention policies
+
+Keep the existing preview-before-save workflow, but make it authoritative:
+
+- `Preview impact` must call the backend preview endpoint
+- preview failure shows an error and leaves save disabled
+- no local estimate fallback remains
+- save requires:
+  - a successful backend preview for the exact value
+  - a matching backend `preview_signature`
+  - the destructive confirmation checkbox
+
+The preview row should no longer mention “estimated locally.”
+
+## Failure Semantics
+
+### BYOK
+
+- create failure: no fake history row, no success toast
+- worker failure: run is marked `failed`, bounded error message stored on the run
+- reload during execution: page rediscovers run state from backend history/detail
+
+### Retention
+
+- preview failure: no estimate fallback, save remains disabled
+- update failure after successful preview: current form value remains in memory, preview stays valid while the value is unchanged and the signature has not expired
+- changed value after preview: previous signature is invalidated client-side and the operator must preview again
+
+## Security And Safety Constraints
+
+- BYOK validation runs never store secrets or raw credential fields
+- provider-side validation errors are redacted before persistence
+- validation worker uses bounded concurrency per provider
+- only one active BYOK validation run exists at a time in v1
+- retention preview and update use the same auth/scope rules
+- retention update fails closed without a valid backend preview signature
+
+## Deferred / Out Of Scope For V1
+
+- detailed persisted per-key BYOK validation result tables
+- multi-run BYOK concurrency beyond the single active run
+- historical reconstruction of all BYOK activity before validation runs existed
+- retention preview for datasets not already represented by current cleanup logic
+
+## Testing Strategy
+
+### Backend
+
+- repo tests for BYOK validation runs
+- service/API tests for BYOK run create/list/detail and active-run exclusivity
+- worker tests for BYOK status transitions and aggregate result recording
+- retention preview endpoint tests for valid preview, invalid range, unknown policy, and preview-signature verification
+
+### Frontend
+
+- BYOK page tests for creating/polling validation runs and rendering real history
+- retention section tests for backend-only preview and preview-signature-bound save
+
+### Verification
+
+- targeted pytest for the new BYOK and retention backend slices
+- targeted vitest for `admin-ui/app/byok/page.tsx` and `RetentionPoliciesSection.tsx`
+- Bandit on touched backend files

--- a/Docs/Plans/2026-03-12-admin-ui-byok-retention-authoritative-implementation-plan.md
+++ b/Docs/Plans/2026-03-12-admin-ui-byok-retention-authoritative-implementation-plan.md
@@ -1,0 +1,414 @@
+# Admin UI BYOK Validation And Retention Preview Authoritative Hardening Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the BYOK dashboard's placeholder validation flow with authoritative Jobs-backed validation runs, and replace retention-policy local impact estimates with a backend dry-run preview bound to destructive saves.
+
+**Architecture:** Add AuthNZ-backed BYOK validation-run persistence, admin endpoints, and a Jobs worker for shared validation status/history. Add a backend retention preview endpoint that returns authoritative counts plus a signed preview token, then require that token on the existing retention update path. Update the admin UI to use those real backend flows and remove placeholder/estimated fallbacks.
+
+**Tech Stack:** FastAPI, Pydantic, AuthNZ SQLite/Postgres repos, Jobs manager/worker patterns, Next.js/React, Vitest, pytest, Bandit.
+
+---
+
+### Task 1: Add BYOK validation-run persistence
+
+**Files:**
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/core/AuthNZ/migrations.py`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py`
+- Create: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py`
+
+**Step 1: Write the failing repo tests**
+
+Add tests for:
+- creating a validation run with scope, requester, and status metadata
+- listing runs newest-first
+- updating a run to `running`, `complete`, and `failed`
+- enforcing one active run at a time
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py -q
+```
+
+Expected: FAIL because the repo/table do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- additive SQLite migration for `byok_validation_runs`
+- matching Postgres ensure helper
+- repo methods:
+  - `create_run(...)`
+  - `list_runs(...)`
+  - `get_run(...)`
+  - `mark_running(...)`
+  - `mark_complete(...)`
+  - `mark_failed(...)`
+  - `has_active_run(...)`
+
+Persist aggregate counts only. Do not persist secrets or detailed provider error payloads.
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/AuthNZ/migrations.py \
+  tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py \
+  tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py \
+  tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py
+git commit -m "feat(byok): add validation run persistence"
+```
+
+### Task 2: Add BYOK validation service and schemas
+
+**Files:**
+- Create: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_byok_validation_service.py`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/schemas/user_keys.py`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py`
+
+**Step 1: Write the failing service tests**
+
+Cover:
+- create validation run with org/provider filters
+- reject create when BYOK is disabled
+- reject create when another validation run is active
+- compute and persist a `scope_summary`
+- redact persisted error summaries
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py -q
+```
+
+Expected: FAIL because service and schemas do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- request/response models for BYOK validation-run create/list/detail
+- service helpers for:
+  - scope validation
+  - active-run exclusion
+  - bounded provider-summary error formatting
+  - list/detail orchestration
+
+Use existing BYOK repos and scope-enforcement patterns already used by `admin_byok_service.py`.
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/admin_byok_validation_service.py \
+  tldw_Server_API/app/api/v1/schemas/user_keys.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py
+git commit -m "feat(byok): add validation service"
+```
+
+### Task 3: Add BYOK validation admin endpoints
+
+**Files:**
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py`
+
+**Step 1: Write the failing API tests**
+
+Cover:
+- `POST /api/v1/admin/byok/validation-runs`
+- `GET /api/v1/admin/byok/validation-runs`
+- `GET /api/v1/admin/byok/validation-runs/{id}`
+- active-run conflict returns `409`
+- org scope enforcement is preserved
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py -q
+```
+
+Expected: FAIL because the routes are missing.
+
+**Step 3: Write minimal implementation**
+
+Wire:
+- create/list/detail endpoints into `admin_byok.py`
+- service calls
+- clear error mapping for disabled BYOK, conflict, and invalid scope
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+git commit -m "feat(byok): add validation admin endpoints"
+```
+
+### Task 4: Add Jobs-backed BYOK validation worker
+
+**Files:**
+- Create: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/main.py`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py`
+
+**Step 1: Write the failing worker tests**
+
+Cover:
+- queued run becomes running then complete
+- failed provider validation marks run failed with redacted summary
+- worker records aggregate counts only
+- provider validation uses bounded concurrency
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py -q
+```
+
+Expected: FAIL because the worker and enqueue path do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Use the admin maintenance-rotation and backup worker patterns as references.
+
+Add:
+- worker handler that loads a run by id
+- validation scan over the targeted keys
+- bounded per-provider concurrency
+- status transitions and aggregate summary recording
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py
+git commit -m "feat(byok): add jobs-backed validation worker"
+```
+
+### Task 5: Add authoritative retention preview backend contract
+
+**Files:**
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_data_ops_service.py`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/schemas/admin_schemas.py`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py`
+
+**Step 1: Write the failing backend tests**
+
+Cover:
+- preview returns authoritative counts and a `preview_signature`
+- unknown policy returns `404`
+- invalid range returns `400`
+- update rejects missing or invalid preview signature
+- update accepts a valid signature for the exact previewed values
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py -q
+```
+
+Expected: FAIL because preview endpoint/signature handling do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- preview response schema
+- `POST /admin/retention-policies/{policy_key}/preview`
+- backend count calculation for audit logs, job records, and backup files
+- signed `preview_signature` generation and verification
+- update endpoint requirement for a valid signature
+
+Use the existing retention validation path so preview and update share the same range and policy rules.
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/admin_data_ops_service.py \
+  tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py \
+  tldw_Server_API/app/api/v1/schemas/admin_schemas.py \
+  tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py
+git commit -m "feat(retention): add authoritative preview contract"
+```
+
+### Task 6: Replace the BYOK page placeholder validation flow
+
+**Files:**
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/app/byok/page.tsx`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/lib/api-client.ts`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/types/index.ts`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/app/byok/__tests__/page.test.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Cover:
+- `Run validation sweep` creates a backend run and polls until terminal
+- validation history renders from backend data
+- placeholder validation copy is removed
+- no fake success state appears when create fails
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui
+bunx vitest run app/byok/__tests__/page.test.tsx
+```
+
+Expected: FAIL because the page still hides validation sweep and renders placeholder-only copy.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- create/list/detail client methods for BYOK validation runs
+- page state for active run polling and recent run history
+- truthful telemetry/history labels based on backend data
+
+Do not add client-side synthetic histories.
+
+**Step 4: Run test to verify it passes**
+
+Run the same vitest command.
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/app/byok/page.tsx \
+  admin-ui/lib/api-client.ts \
+  admin-ui/types/index.ts \
+  admin-ui/app/byok/__tests__/page.test.tsx
+git commit -m "feat(admin-ui): add authoritative byok validation flow"
+```
+
+### Task 7: Replace retention local-estimate fallback
+
+**Files:**
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/components/data-ops/RetentionPoliciesSection.tsx`
+- Modify: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/lib/api-client.ts`
+- Test: `/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui/components/data-ops/RetentionPoliciesSection.test.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Cover:
+- preview success requires backend response and stores the returned signature
+- preview failure shows error and does not render an estimated preview row
+- save request includes the returned `preview_signature`
+- changing the days input invalidates the existing preview/signature
+
+**Step 2: Run test to verify it fails**
+
+Run:
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui
+bunx vitest run components/data-ops/RetentionPoliciesSection.test.tsx
+```
+
+Expected: FAIL because the component still falls back to a local estimate and the update call does not send a signature.
+
+**Step 3: Write minimal implementation**
+
+Remove:
+- local estimate fallback
+- “estimated locally” messaging
+
+Add:
+- preview-signature handling
+- save request payload with `preview_signature`
+- strict preview-required gating tied to the current input value
+
+**Step 4: Run test to verify it passes**
+
+Run the same vitest command.
+
+**Step 5: Commit**
+
+```bash
+git add admin-ui/components/data-ops/RetentionPoliciesSection.tsx \
+  admin-ui/lib/api-client.ts \
+  admin-ui/components/data-ops/RetentionPoliciesSection.test.tsx
+git commit -m "feat(admin-ui): require authoritative retention preview"
+```
+
+### Task 8: Run verification and request review
+
+**Files:**
+- Modify if needed: touched files only
+
+**Step 1: Run backend verification**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py \
+  tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py \
+  tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py -q
+```
+
+Expected: all pass.
+
+**Step 2: Run frontend verification**
+
+Run:
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui
+bunx vitest run app/byok/__tests__/page.test.tsx components/data-ops/RetentionPoliciesSection.test.tsx
+bun run typecheck
+bunx eslint app/byok/page.tsx components/data-ops/RetentionPoliciesSection.tsx lib/api-client.ts
+```
+
+Expected: all pass.
+
+**Step 3: Run security verification**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py \
+  tldw_Server_API/app/services/admin_byok_validation_service.py \
+  tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py \
+  tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py \
+  tldw_Server_API/app/services/admin_data_ops_service.py \
+  tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py \
+  tldw_Server_API/app/api/v1/schemas/admin_schemas.py \
+  -f json -o /tmp/bandit_admin_ui_byok_retention_authoritative.json
+```
+
+Expected: no new findings in touched code.
+
+**Step 4: Request code review**
+
+Use the `requesting-code-review` skill against the completed branch before opening or merging a PR.
+
+**Step 5: Commit any final review-driven fixes**
+
+```bash
+git add <touched files>
+git commit -m "fix(admin-ui): address byok and retention review feedback"
+```

--- a/admin-ui/app/byok/__tests__/page.test.tsx
+++ b/admin-ui/app/byok/__tests__/page.test.tsx
@@ -60,6 +60,9 @@ vi.mock('@/lib/api-client', () => ({
     refreshOpenAIOAuth: vi.fn(),
     disconnectOpenAIOAuth: vi.fn(),
     switchOpenAICredentialSource: vi.fn(),
+    createByokValidationRun: vi.fn(),
+    getByokValidationRuns: vi.fn(),
+    getByokValidationRun: vi.fn(),
   },
 }));
 
@@ -78,9 +81,31 @@ type ApiMock = {
   refreshOpenAIOAuth: ReturnType<typeof vi.fn>;
   disconnectOpenAIOAuth: ReturnType<typeof vi.fn>;
   switchOpenAICredentialSource: ReturnType<typeof vi.fn>;
+  createByokValidationRun: ReturnType<typeof vi.fn>;
+  getByokValidationRuns: ReturnType<typeof vi.fn>;
+  getByokValidationRun: ReturnType<typeof vi.fn>;
 };
 
 const apiMock = api as unknown as ApiMock;
+
+const completedValidationRun = {
+  id: 'run-1',
+  status: 'complete',
+  org_id: null,
+  provider: 'openai',
+  keys_checked: 12,
+  valid_count: 10,
+  invalid_count: 1,
+  error_count: 1,
+  requested_by_user_id: 1,
+  requested_by_label: 'alice',
+  job_id: 'job-1',
+  scope_summary: 'All orgs • provider=openai',
+  error_message: null,
+  created_at: '2026-03-12T12:00:00Z',
+  started_at: '2026-03-12T12:00:05Z',
+  completed_at: '2026-03-12T12:00:15Z',
+} as const;
 
 beforeEach(() => {
   toastSuccessMock.mockClear();
@@ -111,6 +136,14 @@ beforeEach(() => {
     auth_source: 'oauth',
     updated_at: new Date().toISOString(),
   });
+  apiMock.createByokValidationRun.mockResolvedValue(completedValidationRun);
+  apiMock.getByokValidationRuns.mockResolvedValue({
+    items: [completedValidationRun],
+    total: 1,
+    limit: 20,
+    offset: 0,
+  });
+  apiMock.getByokValidationRun.mockResolvedValue(completedValidationRun);
 
   apiMock.getUsersPage.mockResolvedValue({
     items: [
@@ -155,7 +188,7 @@ afterEach(() => {
 });
 
 describe('ByokDashboardPage', () => {
-  it('renders per-user BYOK usage with user+provider aggregation', async () => {
+  it('renders per-user BYOK usage with backend-backed validation history', async () => {
     render(<ByokDashboardPage />);
 
     expect(await screen.findByText('Per-User BYOK Usage')).toBeInTheDocument();
@@ -178,10 +211,14 @@ describe('ByokDashboardPage', () => {
     expect(within(bobRow as HTMLElement).getByText('50')).toBeInTheDocument();
     expect(within(bobRow as HTMLElement).getByText(/\$0\.5/)).toBeInTheDocument();
 
+    expect(await screen.findByRole('button', { name: /run validation sweep/i })).toBeInTheDocument();
+    expect(screen.getByText('All orgs • provider=openai')).toBeInTheDocument();
+    expect(screen.getByText('12 checked • 10 valid • 1 invalid • 1 errors')).toBeInTheDocument();
     expect(
-      screen.getByText('Validation sweep control is hidden until backend batch validation support is available.')
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /validation sweep/i })).not.toBeInTheDocument();
+      screen.queryByText('Validation sweep control is hidden until backend batch validation support is available.')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Placeholder telemetry views/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Key Activity (Placeholder)')).not.toBeInTheDocument();
   });
 
   it('starts OpenAI OAuth connect flow from the BYOK card', async () => {
@@ -201,5 +238,85 @@ describe('ByokDashboardPage', () => {
       );
     });
     openSpy.mockRestore();
+  });
+
+  it('creates a validation sweep and polls until terminal state', async () => {
+    apiMock.getByokValidationRuns.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+    apiMock.createByokValidationRun.mockResolvedValue({
+      ...completedValidationRun,
+      id: 'run-2',
+      status: 'queued',
+      started_at: null,
+      completed_at: null,
+      keys_checked: null,
+      valid_count: null,
+      invalid_count: null,
+      error_count: null,
+      job_id: null,
+    });
+    apiMock.getByokValidationRun
+      .mockResolvedValueOnce({
+        ...completedValidationRun,
+        id: 'run-2',
+        status: 'running',
+        started_at: '2026-03-12T12:00:10Z',
+        completed_at: null,
+        keys_checked: null,
+        valid_count: null,
+        invalid_count: null,
+        error_count: null,
+        job_id: 'job-2',
+      })
+      .mockResolvedValueOnce({
+        ...completedValidationRun,
+        id: 'run-2',
+        job_id: 'job-2',
+      });
+
+    render(<ByokDashboardPage />);
+
+    expect(screen.getByText('BYOK Dashboards')).toBeInTheDocument();
+    const runSweepButton = await screen.findByRole('button', { name: /run validation sweep/i });
+    await waitFor(() => expect(runSweepButton).not.toBeDisabled());
+    fireEvent.click(runSweepButton);
+
+    await waitFor(() => {
+      expect(apiMock.createByokValidationRun).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(apiMock.getByokValidationRun).toHaveBeenCalledWith('run-2');
+      expect(screen.getByText('Complete')).toBeInTheDocument();
+      expect(screen.getByText('12 checked • 10 valid • 1 invalid • 1 errors')).toBeInTheDocument();
+      expect(toastSuccessMock).toHaveBeenCalled();
+    }, { timeout: 5000 });
+  }, 10000);
+
+  it('does not create fake validation history when create fails', async () => {
+    apiMock.getByokValidationRuns.mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+    apiMock.createByokValidationRun.mockRejectedValue(new Error('sweep failed'));
+
+    render(<ByokDashboardPage />);
+
+    expect(screen.getByText('BYOK Dashboards')).toBeInTheDocument();
+    const runSweepButton = await screen.findByRole('button', { name: /run validation sweep/i });
+    await waitFor(() => expect(runSweepButton).not.toBeDisabled());
+    fireEvent.click(runSweepButton);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('Validation sweep failed', 'sweep failed');
+    });
+    expect(screen.getByText('No validation runs yet.')).toBeInTheDocument();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
   });
 });

--- a/admin-ui/app/byok/page.tsx
+++ b/admin-ui/app/byok/page.tsx
@@ -11,13 +11,13 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { useOrgContext } from '@/components/OrgContextSwitcher';
 import { useToast } from '@/components/ui/toast';
 import { ApiError, api } from '@/lib/api-client';
-import type { AuditLog } from '@/types';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select } from '@/components/ui/select';
 import { useConfirm } from '@/components/ui/confirm-dialog';
 import { KeyRound, RefreshCw, Plus, Trash2, Send, Server, X } from 'lucide-react';
 import { AccessibleIconButton } from '@/components/ui/accessible-icon-button';
+import type { AuditLog, ByokValidationRunItem } from '@/types';
 
 type SharedProviderKey = {
   scope_type: 'org' | 'team';
@@ -73,6 +73,8 @@ type OpenAIOAuthStatus = {
   expires_at?: string | null;
   scope?: string | null;
 };
+
+const VALIDATION_POLL_INTERVAL_MS = 2_000;
 
 const SOURCE_LABELS: Record<string, string> = {
   user: 'User',
@@ -151,6 +153,22 @@ const formatUsd = (value: number) => new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 }).format(value);
 
+const sortValidationRuns = (runs: ByokValidationRunItem[]) =>
+  [...runs].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+
+const isActiveValidationRun = (run: ByokValidationRunItem) =>
+  run.status === 'queued' || run.status === 'running';
+
+const formatValidationStatus = (status: ByokValidationRunItem['status']) =>
+  status.charAt(0).toUpperCase() + status.slice(1);
+
+const formatValidationCounts = (run: ByokValidationRunItem) => {
+  if (run.keys_checked === null || run.keys_checked === undefined) {
+    return 'Awaiting validation results.';
+  }
+  return `${formatCount(run.keys_checked)} checked • ${formatCount(run.valid_count ?? 0)} valid • ${formatCount(run.invalid_count ?? 0)} invalid • ${formatCount(run.error_count ?? 0)} errors`;
+};
+
 const PROVIDER_OPTIONS = [
   'openai',
   'anthropic',
@@ -175,17 +193,21 @@ export default function ByokDashboardPage() {
   const [resolutionBySource, setResolutionBySource] = useState<Record<string, number>>({});
   const [resolutionByProvider, setResolutionByProvider] = useState<Record<string, number>>({});
   const [missingByProvider, setMissingByProvider] = useState<Record<string, number>>({});
-  const [missingByOperation, setMissingByOperation] = useState<Record<string, number>>({});
   const [auditEntries, setAuditEntries] = useState<AuditLog[]>([]);
   const [auditError, setAuditError] = useState<string | null>(null);
   const [auditLoading, setAuditLoading] = useState(false);
   const [byokUsageRows, setByokUsageRows] = useState<ByokUserUsageRow[]>([]);
   const [byokUsageLoading, setByokUsageLoading] = useState(false);
   const [byokUsageError, setByokUsageError] = useState<string | null>(null);
+  const [validationRuns, setValidationRuns] = useState<ByokValidationRunItem[]>([]);
+  const [validationLoading, setValidationLoading] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [validationCreating, setValidationCreating] = useState(false);
   const [openAIOAuthStatus, setOpenAIOAuthStatus] = useState<OpenAIOAuthStatus | null>(null);
   const [openAIOAuthLoading, setOpenAIOAuthLoading] = useState(false);
   const [openAIOAuthError, setOpenAIOAuthError] = useState<string | null>(null);
   const [openAIOAuthAction, setOpenAIOAuthAction] = useState<string | null>(null);
+  const validationToastRunIdRef = useRef<string | null>(null);
 
   // Shared Provider Keys
   const [sharedKeys, setSharedKeys] = useState<SharedProviderKey[]>([]);
@@ -223,18 +245,14 @@ export default function ByokDashboardPage() {
       });
 
       const missingProviderTotals: Record<string, number> = {};
-      const missingOperationTotals: Record<string, number> = {};
       missingSamples.forEach((sample) => {
         const provider = sample.labels.provider || 'unknown';
-        const operation = sample.labels.operation || 'unknown';
         missingProviderTotals[provider] = (missingProviderTotals[provider] || 0) + sample.value;
-        missingOperationTotals[operation] = (missingOperationTotals[operation] || 0) + sample.value;
       });
 
       setResolutionBySource(sourceTotals);
       setResolutionByProvider(providerTotals);
       setMissingByProvider(missingProviderTotals);
-      setMissingByOperation(missingOperationTotals);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load metrics.';
       setMetricsError(message);
@@ -400,6 +418,66 @@ export default function ByokDashboardPage() {
       setByokUsageLoading(false);
     }
   }, [selectedOrg?.id]);
+
+  const loadValidationRuns = useCallback(async () => {
+    setValidationLoading(true);
+    setValidationError(null);
+    try {
+      const response = await api.getByokValidationRuns({ limit: 10, offset: 0 });
+      setValidationRuns(sortValidationRuns(Array.isArray(response.items) ? response.items : []));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load BYOK validation history.';
+      setValidationError(message);
+    } finally {
+      setValidationLoading(false);
+    }
+  }, []);
+
+  const pollValidationRun = useCallback(async (runId: string) => {
+    try {
+      const run = await api.getByokValidationRun(runId);
+      setValidationRuns((current) => sortValidationRuns([
+        run,
+        ...current.filter((item) => item.id !== run.id),
+      ]));
+      if (!isActiveValidationRun(run) && validationToastRunIdRef.current === runId) {
+        validationToastRunIdRef.current = null;
+        if (run.status === 'complete') {
+          toastSuccess('Validation sweep complete', 'BYOK validation sweep finished successfully.');
+        } else {
+          showError('Validation sweep failed', run.error_message || 'BYOK validation sweep failed.');
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to refresh BYOK validation run.';
+      setValidationError(message);
+      if (validationToastRunIdRef.current === runId) {
+        validationToastRunIdRef.current = null;
+        showError('Validation sweep failed', message);
+      }
+    }
+  }, [showError, toastSuccess]);
+
+  const handleRunValidationSweep = useCallback(async () => {
+    setValidationCreating(true);
+    setValidationError(null);
+    try {
+      const run = await api.createByokValidationRun(
+        selectedOrg?.id ? { org_id: selectedOrg.id } : {}
+      );
+      validationToastRunIdRef.current = run.id;
+      setValidationRuns((current) => sortValidationRuns([
+        run,
+        ...current.filter((item) => item.id !== run.id),
+      ]));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start BYOK validation sweep.';
+      setValidationError(message);
+      showError('Validation sweep failed', message);
+    } finally {
+      setValidationCreating(false);
+    }
+  }, [selectedOrg?.id, showError]);
 
   const loadSharedKeys = useCallback(async () => {
     const requestId = sharedKeysRequestIdRef.current + 1;
@@ -619,8 +697,9 @@ export default function ByokDashboardPage() {
     loadAudit();
     loadSharedKeys();
     loadByokUsage();
+    loadValidationRuns();
     loadOpenAIOAuthStatus();
-  }, [loadMetrics, loadAudit, loadSharedKeys, loadByokUsage, loadOpenAIOAuthStatus]);
+  }, [loadMetrics, loadAudit, loadSharedKeys, loadByokUsage, loadValidationRuns, loadOpenAIOAuthStatus]);
 
   const summaryCards = useMemo(() => {
     const byokTotal = sumValues(
@@ -663,11 +742,15 @@ export default function ByokDashboardPage() {
       .slice(0, 5);
   }, [missingByProvider]);
 
-  const missingTopOperations = useMemo(() => {
-    return Object.entries(missingByOperation)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5);
-  }, [missingByOperation]);
+  const latestValidationRun = useMemo(
+    () => validationRuns[0] ?? null,
+    [validationRuns]
+  );
+
+  const activeValidationRun = useMemo(
+    () => validationRuns.find((run) => isActiveValidationRun(run)) ?? null,
+    [validationRuns]
+  );
 
   const openAIOAuthStatusLabel = useMemo(() => {
     if (!openAIOAuthStatus) return 'Not connected';
@@ -676,6 +759,18 @@ export default function ByokDashboardPage() {
     if (openAIOAuthStatus.connected) return 'Connected';
     return 'Not connected';
   }, [openAIOAuthStatus]);
+
+  useEffect(() => {
+    if (!activeValidationRun) {
+      return undefined;
+    }
+    const timer = window.setTimeout(() => {
+      void pollValidationRun(activeValidationRun.id);
+    }, VALIDATION_POLL_INTERVAL_MS);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [activeValidationRun, pollValidationRun]);
 
   return (
     <PermissionGuard variant="route" requireAuth role="admin">
@@ -688,7 +783,7 @@ export default function ByokDashboardPage() {
                 <h1 className="text-2xl font-semibold">BYOK Dashboards</h1>
               </div>
               <p className="text-sm text-muted-foreground">
-                Placeholder telemetry views for BYOK adoption, resolution mix, and key activity.
+                Operational dashboards for BYOK adoption, validation sweeps, and recent admin key activity.
               </p>
               {selectedOrg && (
                 <div className="mt-1 text-xs text-muted-foreground">
@@ -822,23 +917,68 @@ export default function ByokDashboardPage() {
 
             <Card>
               <CardHeader>
-                <CardTitle className="text-base">Key Validation</CardTitle>
-                <CardDescription>Recent validation results and errors.</CardDescription>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-base">Key Validation</CardTitle>
+                    <CardDescription>Run an authoritative validation sweep and review recent validation history.</CardDescription>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={loadValidationRuns}
+                      disabled={validationLoading || validationCreating}
+                    >
+                      <RefreshCw className="mr-2 h-4 w-4" />
+                      {validationLoading ? 'Refreshing…' : 'Refresh history'}
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={handleRunValidationSweep}
+                      disabled={validationLoading || validationCreating}
+                    >
+                      <Send className="mr-2 h-4 w-4" />
+                      {validationCreating ? 'Starting…' : 'Run validation sweep'}
+                    </Button>
+                  </div>
+                </div>
               </CardHeader>
               <CardContent className="space-y-2 text-sm text-muted-foreground">
-                {missingTopOperations.length === 0 ? (
-                  <div className="rounded-md border px-3 py-2">No validation events yet.</div>
-                ) : (
-                  missingTopOperations.map(([operation, count]) => (
-                    <div key={operation} className="flex items-center justify-between rounded-md border px-3 py-2">
-                      <span>{operation}</span>
-                      <span>{formatCount(count)}</span>
-                    </div>
-                  ))
+                {validationError && (
+                  <Alert variant="destructive">
+                    <AlertDescription>{validationError}</AlertDescription>
+                  </Alert>
                 )}
-                <div className="rounded-md border px-3 py-2 text-xs text-muted-foreground">
-                  Validation sweep control is hidden until backend batch validation support is available.
-                </div>
+                {latestValidationRun ? (
+                  <div className="rounded-md border px-3 py-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="font-medium text-foreground">{latestValidationRun.scope_summary}</div>
+                      <Badge variant={latestValidationRun.status === 'complete' ? 'default' : 'outline'}>
+                        {formatValidationStatus(latestValidationRun.status)}
+                      </Badge>
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {formatValidationCounts(latestValidationRun)}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Requested by {latestValidationRun.requested_by_label || 'Unknown'} • {new Date(latestValidationRun.created_at).toLocaleString()}
+                    </div>
+                    {latestValidationRun.error_message && (
+                      <div className="mt-1 text-xs text-red-600">{latestValidationRun.error_message}</div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="rounded-md border px-3 py-2">No validation runs yet.</div>
+                )}
+                {validationRuns.slice(1, 4).map((run) => (
+                  <div key={run.id} className="rounded-md border px-3 py-2">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-medium text-foreground">{run.scope_summary}</span>
+                      <Badge variant="outline">{formatValidationStatus(run.status)}</Badge>
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">{formatValidationCounts(run)}</div>
+                  </div>
+                ))}
               </CardContent>
             </Card>
           </div>
@@ -1092,8 +1232,8 @@ export default function ByokDashboardPage() {
 
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">Key Activity (Placeholder)</CardTitle>
-              <CardDescription>Audit events matching BYOK-related actions (when emitted).</CardDescription>
+              <CardTitle className="text-base">BYOK Audit Activity</CardTitle>
+              <CardDescription>Recent BYOK-related audit events captured by the backend.</CardDescription>
             </CardHeader>
             <CardContent>
               {auditError && (

--- a/admin-ui/components/data-ops/RetentionPoliciesSection.test.tsx
+++ b/admin-ui/components/data-ops/RetentionPoliciesSection.test.tsx
@@ -45,11 +45,16 @@ beforeEach(() => {
     ],
   });
   apiMock.previewRetentionPolicyImpact.mockResolvedValue({
-    estimate: {
+    key: 'audit_logs',
+    current_days: 90,
+    new_days: 30,
+    counts: {
       audit_log_entries: 125,
       job_records: 60,
       backup_files: 8,
     },
+    preview_signature: 'preview-sig-123',
+    notes: [],
   });
   apiMock.updateRetentionPolicy.mockResolvedValue({ status: 'ok' });
 });
@@ -60,7 +65,7 @@ afterEach(() => {
 });
 
 describe('RetentionPoliciesSection', () => {
-  it('renders impact preview text with parsed counts', async () => {
+  it('renders backend preview text and removes local-estimate messaging', async () => {
     const user = userEvent.setup();
     render(<RetentionPoliciesSection refreshSignal={0} />);
 
@@ -75,9 +80,10 @@ describe('RetentionPoliciesSection', () => {
     expect(previewText.textContent).toContain('125 audit log entries');
     expect(previewText.textContent).toContain('60 job records');
     expect(previewText.textContent).toContain('8 backup files');
+    expect(screen.queryByText(/estimated locally/i)).not.toBeInTheDocument();
   });
 
-  it('requires acknowledgment checkbox before save is enabled', async () => {
+  it('requires acknowledgment and sends preview signature on save', async () => {
     const user = userEvent.setup();
     render(<RetentionPoliciesSection refreshSignal={0} />);
 
@@ -100,7 +106,51 @@ describe('RetentionPoliciesSection', () => {
     await user.click(saveButton);
 
     await waitFor(() => {
-      expect(apiMock.updateRetentionPolicy).toHaveBeenCalledWith('audit_logs', { days: 30 });
+      expect(apiMock.updateRetentionPolicy).toHaveBeenCalledWith('audit_logs', {
+        days: 30,
+        preview_signature: 'preview-sig-123',
+      });
     });
+  });
+
+  it('shows an error and no preview row when backend preview fails', async () => {
+    const user = userEvent.setup();
+    apiMock.previewRetentionPolicyImpact.mockRejectedValue(new Error('preview failed'));
+
+    render(<RetentionPoliciesSection refreshSignal={0} />);
+
+    const daysInput = await screen.findByDisplayValue('90');
+    await user.clear(daysInput);
+    await user.type(daysInput, '30');
+    await user.click(screen.getByRole('button', { name: 'Preview impact' }));
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('Preview failed', 'preview failed');
+    });
+    expect(screen.queryByTestId('retention-preview-row-audit_logs')).not.toBeInTheDocument();
+    expect(screen.queryByText(/estimated locally/i)).not.toBeInTheDocument();
+  });
+
+  it('invalidates the preview when the days value changes', async () => {
+    const user = userEvent.setup();
+    render(<RetentionPoliciesSection refreshSignal={0} />);
+
+    const daysInput = await screen.findByDisplayValue('90');
+    await user.clear(daysInput);
+    await user.type(daysInput, '30');
+    await user.click(screen.getByRole('button', { name: 'Preview impact' }));
+    await screen.findByTestId('retention-preview-row-audit_logs');
+
+    await user.click(screen.getByLabelText(/I understand this change can permanently delete historical data/i));
+    const saveButton = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    await waitFor(() => {
+      expect(saveButton.disabled).toBe(false);
+    });
+
+    await user.clear(daysInput);
+    await user.type(daysInput, '45');
+
+    expect(screen.queryByTestId('retention-preview-row-audit_logs')).not.toBeInTheDocument();
+    expect(saveButton.disabled).toBe(true);
   });
 });

--- a/admin-ui/components/data-ops/RetentionPoliciesSection.tsx
+++ b/admin-ui/components/data-ops/RetentionPoliciesSection.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useToast } from '@/components/ui/toast';
 import { api } from '@/lib/api-client';
-import type { RetentionPolicy } from '@/types';
+import type { RetentionPolicy, RetentionPolicyPreviewResponse } from '@/types';
 import { AlertTriangle, ShieldCheck } from 'lucide-react';
 
 type RetentionPoliciesSectionProps = {
@@ -26,7 +26,8 @@ type RetentionImpactPreview = {
   currentDays: number;
   newDays: number;
   counts: RetentionImpactCounts;
-  source: 'backend' | 'estimate';
+  previewSignature: string;
+  notes: string[];
 };
 
 const toNonNegativeNumber = (value: unknown): number | null => {
@@ -69,23 +70,6 @@ const parseImpactCounts = (payload: unknown): RetentionImpactCounts => {
     auditLogEntries: readCount(['audit_log_entries', 'audit_logs', 'audit_entries', 'audit_count']),
     jobRecords: readCount(['job_records', 'jobs', 'job_count']),
     backupFiles: readCount(['backup_files', 'backups', 'backup_count']),
-  };
-};
-
-const estimateImpactCounts = (policyKey: string, currentDays: number, newDays: number): RetentionImpactCounts => {
-  const daysReduced = Math.max(0, currentDays - newDays);
-  if (daysReduced === 0) return { auditLogEntries: 0, jobRecords: 0, backupFiles: 0 };
-
-  const key = policyKey.toLowerCase();
-  const scale = Math.max(1, Math.ceil(daysReduced / 7));
-  const auditWeight = key.includes('audit') || key.includes('log') ? 95 : 25;
-  const jobWeight = key.includes('job') ? 70 : 18;
-  const backupWeight = key.includes('backup') ? 22 : 6;
-
-  return {
-    auditLogEntries: daysReduced * auditWeight * scale,
-    jobRecords: daysReduced * jobWeight * scale,
-    backupFiles: daysReduced * backupWeight * scale,
   };
 };
 
@@ -147,28 +131,28 @@ export const RetentionPoliciesSection = ({ refreshSignal }: RetentionPoliciesSec
         current_days: currentDays,
         days,
       });
-      const counts = parseImpactCounts(previewResponse);
+      const typedPreview = previewResponse as RetentionPolicyPreviewResponse;
+      const counts = parseImpactCounts(typedPreview.counts);
+      if (!typedPreview.preview_signature?.trim()) {
+        throw new Error('Backend retention preview did not return a preview signature.');
+      }
       setPolicyPreviews((prev) => ({
         ...prev,
         [policy.key]: {
-          currentDays,
-          newDays: days,
+          currentDays: typedPreview.current_days,
+          newDays: typedPreview.new_days,
           counts,
-          source: 'backend',
+          previewSignature: typedPreview.preview_signature,
+          notes: Array.isArray(typedPreview.notes) ? typedPreview.notes : [],
         },
       }));
       setPolicyPreviewAcknowledged((prev) => ({ ...prev, [policy.key]: false }));
-    } catch {
-      setPolicyPreviews((prev) => ({
-        ...prev,
-        [policy.key]: {
-          currentDays,
-          newDays: days,
-          counts: estimateImpactCounts(policy.key, currentDays, days),
-          source: 'estimate',
-        },
-      }));
-      setPolicyPreviewAcknowledged((prev) => ({ ...prev, [policy.key]: false }));
+    } catch (err: unknown) {
+      clearPolicyPreview(policy.key);
+      const message = err instanceof Error && err.message
+        ? err.message
+        : 'Failed to preview retention policy impact';
+      showError('Preview failed', message);
     } finally {
       setPolicyPreviewLoading((prev) => ({ ...prev, [policy.key]: false }));
     }
@@ -193,7 +177,10 @@ export const RetentionPoliciesSection = ({ refreshSignal }: RetentionPoliciesSec
 
     setPolicySaving((prev) => ({ ...prev, [policy.key]: true }));
     try {
-      await api.updateRetentionPolicy(policy.key, { days: value });
+      await api.updateRetentionPolicy(policy.key, {
+        days: value,
+        preview_signature: preview.previewSignature,
+      });
       success('Retention updated', `${policy.key} set to ${value} days.`);
       setPolicyEdits((prev) => {
         const next = { ...prev };
@@ -321,11 +308,11 @@ export const RetentionPoliciesSection = ({ refreshSignal }: RetentionPoliciesSec
                               {previewCurrent.counts.auditLogEntries} audit log entries, {previewCurrent.counts.jobRecords}{' '}
                               job records, {previewCurrent.counts.backupFiles} backup files.
                             </p>
-                            {previewCurrent.source === 'estimate' && (
-                              <p className="text-xs text-muted-foreground">
-                                Preview is estimated locally because backend dry-run preview is unavailable.
+                            {previewCurrent.notes.map((note) => (
+                              <p key={note} className="text-xs text-muted-foreground">
+                                {note}
                               </p>
-                            )}
+                            ))}
                             <label
                               htmlFor={`retention-preview-ack-${policy.key}`}
                               className="flex items-start gap-2 text-sm"

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -9,6 +9,9 @@ import type {
   BackupScheduleListResponse,
   BackupScheduleMutationResponse,
   BackupsResponse,
+  ByokValidationRunCreateRequest,
+  ByokValidationRunItem,
+  ByokValidationRunListResponse,
   EffectivePermissionsResponse,
   FeatureRegistryEntry,
   IncidentItem,
@@ -920,6 +923,19 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  createByokValidationRun: (data: ByokValidationRunCreateRequest) =>
+    requestJson<ByokValidationRunItem>('/admin/byok/validation-runs', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  getByokValidationRuns: (params?: { limit?: number; offset?: number }) => {
+    const queryString = buildQueryString(params);
+    return requestJson<ByokValidationRunListResponse>(
+      `/admin/byok/validation-runs${queryString ? `?${queryString}` : ''}`
+    );
+  },
+  getByokValidationRun: (runId: string) =>
+    requestJson<ByokValidationRunItem>(`/admin/byok/validation-runs/${encodeURIComponent(runId)}`),
 
   // ============================================
   // Security Health

--- a/admin-ui/lib/api-client.ts
+++ b/admin-ui/lib/api-client.ts
@@ -29,6 +29,7 @@ import type {
   ProviderSecret,
   RegistrationCode,
   RetentionPoliciesResponse,
+  RetentionPolicyPreviewResponse,
   SecurityAlertStatus,
   SecurityHealthData,
   Subscription,
@@ -499,7 +500,7 @@ export const api = {
     }),
   getRetentionPolicies: () => requestJson<RetentionPoliciesResponse>('/admin/retention-policies'),
   previewRetentionPolicyImpact: (policyKey: string, data: Record<string, unknown>) =>
-    requestJson(`/admin/retention-policies/${encodeURIComponent(policyKey)}/preview`, {
+    requestJson<RetentionPolicyPreviewResponse>(`/admin/retention-policies/${encodeURIComponent(policyKey)}/preview`, {
       method: 'POST',
       body: JSON.stringify(data),
     }),

--- a/admin-ui/types/index.ts
+++ b/admin-ui/types/index.ts
@@ -272,6 +272,21 @@ export interface RetentionPoliciesResponse {
   policies: RetentionPolicy[];
 }
 
+export interface RetentionPolicyPreviewCounts {
+  audit_log_entries: number;
+  job_records: number;
+  backup_files: number;
+}
+
+export interface RetentionPolicyPreviewResponse {
+  key: string;
+  current_days: number;
+  new_days: number;
+  counts: RetentionPolicyPreviewCounts;
+  preview_signature: string;
+  notes: string[];
+}
+
 export interface ProviderSecret {
   provider: string;
   created_at: string;

--- a/admin-ui/types/index.ts
+++ b/admin-ui/types/index.ts
@@ -231,6 +231,37 @@ export interface MaintenanceRotationRunCreateResponse {
   item: MaintenanceRotationRunItem;
 }
 
+export interface ByokValidationRunItem {
+  id: string;
+  status: 'queued' | 'running' | 'complete' | 'failed';
+  org_id?: number | null;
+  provider?: string | null;
+  keys_checked?: number | null;
+  valid_count?: number | null;
+  invalid_count?: number | null;
+  error_count?: number | null;
+  requested_by_user_id?: number | null;
+  requested_by_label?: string | null;
+  job_id?: string | null;
+  scope_summary: string;
+  error_message?: string | null;
+  created_at: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+export interface ByokValidationRunListResponse {
+  items: ByokValidationRunItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ByokValidationRunCreateRequest {
+  org_id?: number;
+  provider?: string;
+}
+
 export interface RetentionPolicy {
   key: string;
   days?: number | null;

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Literal, Protocol
+from typing import Annotated, Any, Literal, Protocol
 
-from fastapi import APIRouter, Depends, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
@@ -75,6 +75,15 @@ async def get_admin_byok_validation_service(
 ) -> AdminByokValidationServiceProtocol:
     """Build the admin BYOK validation service for dependency injection."""
     return AdminByokValidationService(repo=repo)
+
+
+def get_byok_validation_job_enqueuer() -> Callable[[dict[str, Any]], Awaitable[str]]:
+    """Return the callable used to enqueue BYOK validation Jobs."""
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        enqueue_byok_validation_run,
+    )
+
+    return enqueue_byok_validation_run
 
 
 @router.get(
@@ -177,15 +186,28 @@ async def admin_delete_shared_byok_key(
 async def admin_create_byok_validation_run(
     payload: ByokValidationRunCreateRequest,
     principal: AuthPrincipal = Depends(get_auth_principal),
+    repo: AuthnzByokValidationRunsRepo = Depends(_get_byok_validation_runs_repo),
     service: AdminByokValidationServiceProtocol = Depends(get_admin_byok_validation_service),
+    enqueue_run: Callable[[dict[str, Any]], Awaitable[str]] = Depends(get_byok_validation_job_enqueuer),
 ) -> ByokValidationRunItem:
     """Create an authoritative BYOK validation run."""
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        byok_validation_worker_enabled,
+    )
+
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    if not byok_validation_worker_enabled():
+        raise HTTPException(status_code=503, detail="byok_validation_worker_unavailable")
     item = await service.create_run(
         principal,
         org_id=payload.org_id,
         provider=payload.provider,
     )
+    try:
+        await enqueue_run(item)
+    except Exception as exc:
+        await repo.mark_failed(str(item["id"]), error_message="enqueue_failed")
+        raise HTTPException(status_code=503, detail="byok_validation_enqueue_failed") from exc
     return ByokValidationRunItem(**item)
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
@@ -28,6 +28,11 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
     AuthnzByokValidationRunsRepo,
 )
+from tldw_Server_API.app.core.exceptions import (
+    ByokValidationActiveRunError,
+    ByokValidationDisabledError,
+    ByokValidationRunNotFoundError,
+)
 from tldw_Server_API.app.services import admin_byok_service
 from tldw_Server_API.app.services.admin_byok_validation_service import (
     AdminByokValidationService,
@@ -198,11 +203,16 @@ async def admin_create_byok_validation_run(
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
     if not byok_validation_worker_enabled():
         raise HTTPException(status_code=503, detail="byok_validation_worker_unavailable")
-    item = await service.create_run(
-        principal,
-        org_id=payload.org_id,
-        provider=payload.provider,
-    )
+    try:
+        item = await service.create_run(
+            principal,
+            org_id=payload.org_id,
+            provider=payload.provider,
+        )
+    except ByokValidationDisabledError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ByokValidationActiveRunError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     try:
         await enqueue_run(item)
     except Exception as exc:
@@ -243,5 +253,8 @@ async def admin_get_byok_validation_run(
 ) -> ByokValidationRunItem:
     """Return one authoritative BYOK validation run by id."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    item = await service.get_run(run_id)
+    try:
+        item = await service.get_run(run_id)
+    except ByokValidationRunNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     return ByokValidationRunItem(**item)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Literal, Protocol
 
 from fastapi import APIRouter, Depends, Query, Response, status
 
@@ -13,16 +14,67 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
 )
 from tldw_Server_API.app.api.v1.schemas.user_keys import (
     AdminUserKeysResponse,
+    ByokValidationRunCreateRequest,
+    ByokValidationRunItem,
+    ByokValidationRunListResponse,
     SharedProviderKeyResponse,
     SharedProviderKeysResponse,
     SharedProviderKeyTestRequest,
     SharedProviderKeyTestResponse,
     SharedProviderKeyUpsertRequest,
 )
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+    AuthnzByokValidationRunsRepo,
+)
 from tldw_Server_API.app.services import admin_byok_service
+from tldw_Server_API.app.services.admin_byok_validation_service import (
+    AdminByokValidationService,
+)
 
 router = APIRouter()
+
+
+class AdminByokValidationServiceProtocol(Protocol):
+    """Protocol for admin BYOK validation service dependency overrides."""
+
+    async def create_run(
+        self,
+        principal: AuthPrincipal,
+        *,
+        org_id: int | None,
+        provider: str | None,
+    ) -> dict[str, object]:
+        ...
+
+    async def list_runs(self, *, limit: int, offset: int) -> tuple[list[dict[str, object]], int]:
+        ...
+
+    async def get_run(self, run_id: str) -> dict[str, object]:
+        ...
+
+
+def _get_ensure_sqlite_authnz_ready_if_test_mode() -> Callable[[], Awaitable[None]]:
+    """Return the AuthNZ test-mode readiness hook."""
+    from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
+
+    return admin_mod._ensure_sqlite_authnz_ready_if_test_mode
+
+
+async def _get_byok_validation_runs_repo() -> AuthnzByokValidationRunsRepo:
+    """Build the BYOK validation runs repository from the shared AuthNZ pool."""
+    pool = await get_db_pool()
+    repo = AuthnzByokValidationRunsRepo(pool)
+    await repo.ensure_schema()
+    return repo
+
+
+async def get_admin_byok_validation_service(
+    repo: AuthnzByokValidationRunsRepo = Depends(_get_byok_validation_runs_repo),
+) -> AdminByokValidationServiceProtocol:
+    """Build the admin BYOK validation service for dependency injection."""
+    return AdminByokValidationService(repo=repo)
 
 
 @router.get(
@@ -115,3 +167,59 @@ async def admin_delete_shared_byok_key(
     """Delete a shared BYOK key for a given scope and provider."""
     await admin_byok_service.delete_shared_key(principal, scope_type, scope_id, provider)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/byok/validation-runs",
+    response_model=ByokValidationRunItem,
+    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+)
+async def admin_create_byok_validation_run(
+    payload: ByokValidationRunCreateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    service: AdminByokValidationServiceProtocol = Depends(get_admin_byok_validation_service),
+) -> ByokValidationRunItem:
+    """Create an authoritative BYOK validation run."""
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    item = await service.create_run(
+        principal,
+        org_id=payload.org_id,
+        provider=payload.provider,
+    )
+    return ByokValidationRunItem(**item)
+
+
+@router.get(
+    "/byok/validation-runs",
+    response_model=ByokValidationRunListResponse,
+    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+)
+async def admin_list_byok_validation_runs(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    service: AdminByokValidationServiceProtocol = Depends(get_admin_byok_validation_service),
+) -> ByokValidationRunListResponse:
+    """List authoritative BYOK validation runs newest-first."""
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    items, total = await service.list_runs(limit=limit, offset=offset)
+    return ByokValidationRunListResponse(
+        items=[ByokValidationRunItem(**item) for item in items],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get(
+    "/byok/validation-runs/{run_id}",
+    response_model=ByokValidationRunItem,
+    dependencies=[Depends(require_roles("admin")), Depends(check_rate_limit)],
+)
+async def admin_get_byok_validation_run(
+    run_id: str,
+    service: AdminByokValidationServiceProtocol = Depends(get_admin_byok_validation_service),
+) -> ByokValidationRunItem:
+    """Return one authoritative BYOK validation run by id."""
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    item = await service.get_run(run_id)
+    return ByokValidationRunItem(**item)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -739,7 +739,12 @@ async def preview_retention_policy(
             raise HTTPException(status_code=409, detail="stale_current_days") from exc
         raise HTTPException(status_code=400, detail="invalid_retention_preview") from exc
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
-        logger.error(f"Failed to preview retention policy: {exc}")
+        logger.error(
+            "Failed to preview retention policy: policy_key={} principal_id={} error={}",
+            policy_key,
+            principal.principal_id,
+            exc,
+        )
         raise HTTPException(status_code=500, detail="Failed to preview retention policy") from exc
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py
@@ -27,6 +27,8 @@ from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     DataSubjectRequestPreviewResponse,
     RetentionPoliciesResponse,
     RetentionPolicy,
+    RetentionPolicyPreviewRequest,
+    RetentionPolicyPreviewResponse,
     RetentionPolicyUpdateRequest,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -39,8 +41,11 @@ from tldw_Server_API.app.services.admin_data_ops_service import (
     create_backup_snapshot as svc_create_backup_snapshot,
     list_backup_items as svc_list_backup_items,
     list_retention_policies as svc_list_retention_policies,
+    preview_retention_policy as svc_preview_retention_policy,
     restore_backup_snapshot as svc_restore_backup_snapshot,
+    build_retention_preview_signature as svc_build_retention_preview_signature,
     update_retention_policy as svc_update_retention_policy,
+    verify_retention_preview_signature as svc_verify_retention_preview_signature,
 )
 from tldw_Server_API.app.services.admin_data_subject_requests_service import (
     list_data_subject_requests as svc_list_data_subject_requests,
@@ -705,6 +710,39 @@ async def list_retention_policies(
         raise HTTPException(status_code=500, detail="Failed to list retention policies") from exc
 
 
+@router.post("/retention-policies/{policy_key}/preview", response_model=RetentionPolicyPreviewResponse)
+async def preview_retention_policy(
+    policy_key: str,
+    payload: RetentionPolicyPreviewRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> RetentionPolicyPreviewResponse:
+    try:
+        preview = await svc_preview_retention_policy(
+            policy_key=policy_key,
+            current_days=payload.current_days,
+            days=payload.days,
+        )
+        signature = svc_build_retention_preview_signature(
+            principal=principal,
+            policy_key=policy_key,
+            current_days=int(preview["current_days"]),
+            new_days=int(preview["new_days"]),
+        )
+        return RetentionPolicyPreviewResponse(**preview, preview_signature=signature)
+    except ValueError as exc:
+        detail = str(exc)
+        if detail == "unknown_policy":
+            raise HTTPException(status_code=404, detail="unknown_policy") from exc
+        if detail == "invalid_range":
+            raise HTTPException(status_code=400, detail="invalid_range") from exc
+        if detail == "stale_current_days":
+            raise HTTPException(status_code=409, detail="stale_current_days") from exc
+        raise HTTPException(status_code=400, detail="invalid_retention_preview") from exc
+    except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error(f"Failed to preview retention policy: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to preview retention policy") from exc
+
+
 @router.put("/retention-policies/{policy_key}", response_model=RetentionPolicy)
 async def update_retention_policy(
     policy_key: str,
@@ -713,6 +751,12 @@ async def update_retention_policy(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> RetentionPolicy:
     try:
+        await svc_verify_retention_preview_signature(
+            principal=principal,
+            policy_key=policy_key,
+            days=payload.days,
+            preview_signature=payload.preview_signature,
+        )
         updated = await svc_update_retention_policy(policy_key, payload.days)
         await _emit_admin_audit_event(
             request,
@@ -731,6 +775,8 @@ async def update_retention_policy(
             raise HTTPException(status_code=404, detail="unknown_policy") from exc
         if detail == "invalid_range":
             raise HTTPException(status_code=400, detail="invalid_range") from exc
+        if detail in {"preview_signature_required", "invalid_preview_signature", "expired_preview_signature"}:
+            raise HTTPException(status_code=400, detail=detail) from exc
         raise HTTPException(status_code=400, detail="invalid_retention_update") from exc
     except _DATA_OPS_NONCRITICAL_EXCEPTIONS as exc:
         logger.error(f"Failed to update retention policy: {exc}")

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -665,6 +665,39 @@ class RetentionPoliciesResponse(BaseModel):
 class RetentionPolicyUpdateRequest(BaseModel):
     """Request to update a retention policy."""
     days: int = Field(..., ge=1, le=3650)
+    preview_signature: str | None = Field(default=None, min_length=1, max_length=2048)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RetentionPolicyPreviewRequest(BaseModel):
+    """Request to preview the impact of a retention policy change."""
+
+    current_days: int = Field(..., ge=1, le=3650)
+    days: int = Field(..., ge=1, le=3650)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RetentionPolicyPreviewCounts(BaseModel):
+    """Authoritative count summary for a retention policy preview."""
+
+    audit_log_entries: NonNegativeInt = 0
+    job_records: NonNegativeInt = 0
+    backup_files: NonNegativeInt = 0
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RetentionPolicyPreviewResponse(BaseModel):
+    """Response for an authoritative retention policy preview."""
+
+    key: str
+    current_days: int = Field(..., ge=1, le=3650)
+    new_days: int = Field(..., ge=1, le=3650)
+    counts: RetentionPolicyPreviewCounts
+    preview_signature: str = Field(..., min_length=1, max_length=2048)
+    notes: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/user_keys.py
+++ b/tldw_Server_API/app/api/v1/schemas/user_keys.py
@@ -165,3 +165,34 @@ class OpenAICredentialSourceSwitchResponse(BaseModel):
     provider: Literal["openai"] = "openai"
     auth_source: Literal["api_key", "oauth"]
     updated_at: datetime
+
+
+class ByokValidationRunCreateRequest(BaseModel):
+    org_id: int | None = None
+    provider: str | None = None
+
+
+class ByokValidationRunItem(BaseModel):
+    id: str
+    status: Literal["queued", "running", "complete", "failed"]
+    org_id: int | None = None
+    provider: str | None = None
+    keys_checked: int | None = None
+    valid_count: int | None = None
+    invalid_count: int | None = None
+    error_count: int | None = None
+    requested_by_user_id: int | None = None
+    requested_by_label: str | None = None
+    job_id: str | None = None
+    scope_summary: str
+    error_message: str | None = None
+    created_at: datetime
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class ByokValidationRunListResponse(BaseModel):
+    items: list[ByokValidationRunItem]
+    total: int
+    limit: int
+    offset: int

--- a/tldw_Server_API/app/api/v1/schemas/user_keys.py
+++ b/tldw_Server_API/app/api/v1/schemas/user_keys.py
@@ -168,11 +168,15 @@ class OpenAICredentialSourceSwitchResponse(BaseModel):
 
 
 class ByokValidationRunCreateRequest(BaseModel):
+    """Request to create a shared authoritative BYOK validation run."""
+
     org_id: int | None = None
     provider: str | None = None
 
 
 class ByokValidationRunItem(BaseModel):
+    """Persisted BYOK validation run item returned to the admin UI."""
+
     id: str
     status: Literal["queued", "running", "complete", "failed"]
     org_id: int | None = None
@@ -192,6 +196,8 @@ class ByokValidationRunItem(BaseModel):
 
 
 class ByokValidationRunListResponse(BaseModel):
+    """Paginated list response for authoritative BYOK validation runs."""
+
     items: list[ByokValidationRunItem]
     total: int
     limit: int

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -3316,6 +3316,56 @@ def rollback_067_drop_maintenance_rotation_runs_table(conn: sqlite3.Connection) 
     logger.info("Rollback 067: Dropped maintenance rotation runs table")
 
 
+def migration_068_create_byok_validation_runs_table(conn: sqlite3.Connection) -> None:
+    """Create BYOK validation run persistence table (SQLite)."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS byok_validation_runs (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            org_id INTEGER,
+            provider TEXT,
+            keys_checked INTEGER,
+            valid_count INTEGER,
+            invalid_count INTEGER,
+            error_count INTEGER,
+            requested_by_user_id INTEGER,
+            requested_by_label TEXT,
+            job_id TEXT,
+            scope_summary TEXT NOT NULL,
+            error_message TEXT,
+            created_at TIMESTAMP NOT NULL,
+            started_at TIMESTAMP,
+            completed_at TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_byok_validation_runs_active
+        ON byok_validation_runs((1))
+        WHERE status IN ('queued', 'running')
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_created_at "
+        "ON byok_validation_runs(created_at)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_status "
+        "ON byok_validation_runs(status)"
+    )
+    conn.commit()
+    logger.info("Migration 068: Created BYOK validation runs table")
+
+
+def rollback_068_drop_byok_validation_runs_table(conn: sqlite3.Connection) -> None:
+    """Drop BYOK validation run persistence table (SQLite rollback)."""
+    conn.execute("DROP TABLE IF EXISTS byok_validation_runs")
+    conn.commit()
+    logger.info("Rollback 068: Dropped BYOK validation runs table")
+
+
 def migration_041_add_llm_provider_overrides(conn: sqlite3.Connection) -> None:
     """Add llm_provider_overrides table for runtime provider overrides."""
     logger.info("Migration 041: START llm_provider_overrides table")
@@ -3764,6 +3814,12 @@ def get_authnz_migrations() -> list[Migration]:
             "Create maintenance rotation runs table",
             migration_067_create_maintenance_rotation_runs_table,
             rollback_067_drop_maintenance_rotation_runs_table,
+        ),
+        Migration(
+            68,
+            "Create BYOK validation runs table",
+            migration_068_create_byok_validation_runs_table,
+            rollback_068_drop_byok_validation_runs_table,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1895,6 +1895,50 @@ _CREATE_MAINTENANCE_ROTATION_RUNS_TABLES = [
     ),
 ]
 
+_CREATE_BYOK_VALIDATION_RUNS_TABLES = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS byok_validation_runs (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            org_id INTEGER NULL,
+            provider TEXT NULL,
+            keys_checked INTEGER NULL,
+            valid_count INTEGER NULL,
+            invalid_count INTEGER NULL,
+            error_count INTEGER NULL,
+            requested_by_user_id INTEGER NULL,
+            requested_by_label TEXT NULL,
+            job_id TEXT NULL,
+            scope_summary TEXT NOT NULL,
+            error_message TEXT NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            started_at TIMESTAMPTZ NULL,
+            completed_at TIMESTAMPTZ NULL
+        )
+        """,
+        (),
+    ),
+    (
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_byok_validation_runs_active
+        ON byok_validation_runs((1))
+        WHERE status IN ('queued', 'running')
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_created_at "
+        "ON byok_validation_runs(created_at)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_status "
+        "ON byok_validation_runs(status)",
+        (),
+    ),
+]
+
 
 async def ensure_tool_catalogs_tables_pg(pool: DatabasePool | None = None) -> bool:
     """Ensure tool catalogs tables exist on PostgreSQL backends.
@@ -1965,6 +2009,30 @@ async def ensure_maintenance_rotation_runs_table_pg(pool: DatabasePool | None = 
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL maintenance rotation runs table: {exc}")
+        return False
+
+
+async def ensure_byok_validation_runs_table_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure BYOK validation run tables exist on PostgreSQL backends."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+        try:
+            await ensure_authnz_core_tables_pg(db_pool)
+        except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(
+                f"PG ensure authnz core tables before BYOK validation runs failed: {exc}"
+            )
+        for sql, params in _CREATE_BYOK_VALIDATION_RUNS_TABLES:
+            try:
+                await db_pool.execute(sql, *params)
+            except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug(f"PG ensure BYOK validation run DDL failed: {exc}")
+        logger.info("Ensured PostgreSQL BYOK validation runs table (idempotent)")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL BYOK validation runs table: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone as dt_timezone
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+_SQLITE_BYOK_VALIDATION_RUNS_DDL = (
+    """
+    CREATE TABLE IF NOT EXISTS byok_validation_runs (
+        id TEXT PRIMARY KEY,
+        status TEXT NOT NULL,
+        org_id INTEGER,
+        provider TEXT,
+        keys_checked INTEGER,
+        valid_count INTEGER,
+        invalid_count INTEGER,
+        error_count INTEGER,
+        requested_by_user_id INTEGER,
+        requested_by_label TEXT,
+        job_id TEXT,
+        scope_summary TEXT NOT NULL,
+        error_message TEXT,
+        created_at TIMESTAMP NOT NULL,
+        started_at TIMESTAMP,
+        completed_at TIMESTAMP
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_byok_validation_runs_active
+    ON byok_validation_runs((1))
+    WHERE status IN ('queued', 'running')
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_created_at ON byok_validation_runs(created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_byok_validation_runs_status ON byok_validation_runs(status)",
+)
+
+
+@dataclass
+class AuthnzByokValidationRunsRepo:
+    """Repository for authoritative BYOK validation run records."""
+
+    db_pool: DatabasePool
+
+    def _is_postgres_backend(self) -> bool:
+        """Return True when the underlying DatabasePool is using PostgreSQL."""
+        return bool(getattr(self.db_pool, "pool", None))
+
+    async def ensure_schema(self) -> None:
+        """Ensure BYOK validation run tables exist for the active backend."""
+        try:
+            if self._is_postgres_backend():
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_byok_validation_runs_table_pg,
+                )
+
+                ok = await ensure_byok_validation_runs_table_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL BYOK validation runs schema ensure failed")
+                return
+
+            for statement in _SQLITE_BYOK_VALIDATION_RUNS_DDL:
+                await self.db_pool.execute(statement)
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.ensure_schema failed")
+            raise
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        """Normalize backend-specific row objects to plain JSON-friendly dicts."""
+        if isinstance(row, dict):
+            data = dict(row)
+        else:
+            try:
+                keys = row.keys()
+                data = {key: row[key] for key in keys}
+            except Exception:
+                data = dict(row)
+
+        for text_id_field in ("id", "job_id"):
+            if data.get(text_id_field) is not None:
+                data[text_id_field] = str(data[text_id_field])
+
+        for int_field in (
+            "org_id",
+            "keys_checked",
+            "valid_count",
+            "invalid_count",
+            "error_count",
+            "requested_by_user_id",
+        ):
+            if data.get(int_field) is not None:
+                try:
+                    data[int_field] = int(data[int_field])
+                except (TypeError, ValueError):
+                    pass
+
+        for ts_field in ("created_at", "started_at", "completed_at"):
+            value = data.get(ts_field)
+            if isinstance(value, datetime):
+                data[ts_field] = value.isoformat()
+
+        return data
+
+    @staticmethod
+    def _command_touched_rows(result: Any) -> bool:
+        """Return True when an UPDATE command affected at least one row."""
+        if isinstance(result, str):
+            parts = result.split()
+            if parts and parts[-1].isdigit():
+                return int(parts[-1]) > 0
+            return True
+        rowcount = getattr(result, "rowcount", None)
+        if isinstance(rowcount, int):
+            return rowcount != 0
+        return True
+
+    def _normalize_timestamp(self, value: str | None) -> str | datetime | None:
+        """Normalize timestamps for the active backend."""
+        if value is None:
+            return None
+        parsed = datetime.fromisoformat(value)
+        if self._is_postgres_backend():
+            return parsed
+        return parsed.isoformat()
+
+    async def create_run(
+        self,
+        *,
+        org_id: int | None,
+        provider: str | None,
+        requested_by_user_id: int | None,
+        requested_by_label: str | None,
+        scope_summary: str,
+    ) -> dict[str, Any]:
+        """Persist a new BYOK validation run and return the stored record."""
+        run_id = str(uuid4())
+        now = datetime.now(dt_timezone.utc)
+        created_at = now if self._is_postgres_backend() else now.isoformat()
+        try:
+            await self.db_pool.execute(
+                """
+                INSERT INTO byok_validation_runs (
+                    id, status, org_id, provider, keys_checked, valid_count, invalid_count,
+                    error_count, requested_by_user_id, requested_by_label, job_id,
+                    scope_summary, error_message, created_at, started_at, completed_at
+                ) VALUES (?, 'queued', ?, ?, NULL, NULL, NULL, NULL, ?, ?, NULL, ?, NULL, ?, NULL, NULL)
+                """,
+                (
+                    run_id,
+                    org_id,
+                    provider,
+                    requested_by_user_id,
+                    requested_by_label,
+                    scope_summary,
+                    created_at,
+                ),
+            )
+            row = await self.get_run(run_id)
+            return row or {}
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.create_run failed")
+            raise
+
+    async def get_run(self, run_id: str) -> dict[str, Any] | None:
+        """Fetch a BYOK validation run by id."""
+        try:
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, status, org_id, provider, keys_checked, valid_count, invalid_count,
+                       error_count, requested_by_user_id, requested_by_label, job_id,
+                       scope_summary, error_message, created_at, started_at, completed_at
+                FROM byok_validation_runs
+                WHERE id = ?
+                """,
+                (run_id,),
+            )
+            return self._row_to_dict(row) if row else None
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.get_run failed")
+            raise
+
+    async def list_runs(self, *, limit: int, offset: int) -> tuple[list[dict[str, Any]], int]:
+        """List BYOK validation runs newest-first with total count."""
+        try:
+            rows = await self.db_pool.fetchall(
+                """
+                SELECT id, status, org_id, provider, keys_checked, valid_count, invalid_count,
+                       error_count, requested_by_user_id, requested_by_label, job_id,
+                       scope_summary, error_message, created_at, started_at, completed_at
+                FROM byok_validation_runs
+                ORDER BY created_at DESC, id DESC
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            )
+            count_row = await self.db_pool.fetchone(
+                "SELECT COUNT(*) AS total FROM byok_validation_runs"
+            )
+            total = 0
+            if count_row is not None:
+                try:
+                    total = int(count_row["total"])
+                except Exception:
+                    total = int(list(count_row)[0])
+            return [self._row_to_dict(row) for row in rows], total
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.list_runs failed")
+            raise
+
+    async def mark_running(self, run_id: str, *, job_id: str | None) -> dict[str, Any] | None:
+        """Mark a run as running and attach a job id."""
+        started_at = self._normalize_timestamp(datetime.now(dt_timezone.utc).isoformat())
+        try:
+            result = await self.db_pool.execute(
+                """
+                UPDATE byok_validation_runs
+                SET status = 'running',
+                    job_id = ?,
+                    started_at = COALESCE(started_at, ?)
+                WHERE id = ?
+                """,
+                (job_id, started_at, run_id),
+            )
+            if not self._command_touched_rows(result):
+                return None
+            return await self.get_run(run_id)
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.mark_running failed")
+            raise
+
+    async def mark_complete(
+        self,
+        run_id: str,
+        *,
+        keys_checked: int,
+        valid_count: int,
+        invalid_count: int,
+        error_count: int,
+    ) -> dict[str, Any] | None:
+        """Mark a run complete and persist aggregate counts."""
+        completed_at = self._normalize_timestamp(datetime.now(dt_timezone.utc).isoformat())
+        try:
+            result = await self.db_pool.execute(
+                """
+                UPDATE byok_validation_runs
+                SET status = 'complete',
+                    keys_checked = ?,
+                    valid_count = ?,
+                    invalid_count = ?,
+                    error_count = ?,
+                    completed_at = ?
+                WHERE id = ?
+                """,
+                (keys_checked, valid_count, invalid_count, error_count, completed_at, run_id),
+            )
+            if not self._command_touched_rows(result):
+                return None
+            return await self.get_run(run_id)
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.mark_complete failed")
+            raise
+
+    async def mark_failed(self, run_id: str, *, error_message: str) -> dict[str, Any] | None:
+        """Mark a run failed and persist a bounded error message."""
+        completed_at = self._normalize_timestamp(datetime.now(dt_timezone.utc).isoformat())
+        try:
+            result = await self.db_pool.execute(
+                """
+                UPDATE byok_validation_runs
+                SET status = 'failed',
+                    error_message = ?,
+                    completed_at = ?
+                WHERE id = ?
+                """,
+                (error_message, completed_at, run_id),
+            )
+            if not self._command_touched_rows(result):
+                return None
+            return await self.get_run(run_id)
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.mark_failed failed")
+            raise
+
+    async def has_active_run(self) -> bool:
+        """Return True when any BYOK validation run is queued or running."""
+        try:
+            row = await self.db_pool.fetchone(
+                """
+                SELECT 1
+                FROM byok_validation_runs
+                WHERE status IN ('queued', 'running')
+                LIMIT 1
+                """
+            )
+            return row is not None
+        except Exception:
+            logger.error("AuthnzByokValidationRunsRepo.has_active_run failed")
+            raise

--- a/tldw_Server_API/app/core/DB_Management/admin_retention_preview_counts.py
+++ b/tldw_Server_API/app/core/DB_Management/admin_retention_preview_counts.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+
+async def count_retention_window(
+    *,
+    table: str,
+    column: str,
+    older_than: datetime | str,
+    not_older_than: datetime | str,
+    is_date_column: bool = False,
+) -> int:
+    """Count rows in one retention window for a known table/column pair."""
+    db_pool = await get_db_pool()
+    is_postgres = bool(getattr(db_pool, "pool", None))
+
+    if isinstance(older_than, datetime):
+        older_than_param: Any = older_than.replace(tzinfo=None) if is_postgres else older_than.isoformat()
+    else:
+        older_than_param = older_than
+    if isinstance(not_older_than, datetime):
+        not_older_than_param: Any = (
+            not_older_than.replace(tzinfo=None) if is_postgres else not_older_than.isoformat()
+        )
+    else:
+        not_older_than_param = not_older_than
+
+    if is_postgres:
+        cast = "::date" if is_date_column else ""
+        query = (
+            f"SELECT COUNT(*) FROM {table} "  # nosec B608
+            f"WHERE {column}{cast} < $1 AND {column}{cast} >= $2"  # nosec B608
+        )
+        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
+    elif is_date_column:
+        query = (
+            f"SELECT COUNT(*) FROM {table} "  # nosec B608
+            f"WHERE DATE({column}) < DATE(?) AND DATE({column}) >= DATE(?)"  # nosec B608
+        )
+        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
+    else:
+        query = (
+            f"SELECT COUNT(*) FROM {table} "  # nosec B608
+            f"WHERE datetime({column}) < datetime(?) AND datetime({column}) >= datetime(?)"  # nosec B608
+        )
+        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
+    return int(total or 0)

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -173,6 +173,22 @@ class InvalidRetentionRangeError(AdminDataOpsError):
     """Raised when a retention policy update is out of range."""
 
 
+class ByokValidationError(AdminDataOpsError):
+    """Base exception for admin BYOK validation run errors."""
+
+
+class ByokValidationDisabledError(ByokValidationError):
+    """Raised when BYOK validation is disabled for the current deployment."""
+
+
+class ByokValidationActiveRunError(ByokValidationError):
+    """Raised when another BYOK validation run is already active."""
+
+
+class ByokValidationRunNotFoundError(ByokValidationError):
+    """Raised when a BYOK validation run id cannot be resolved."""
+
+
 class BundleError(AdminDataOpsError):
     """Base exception for backup bundle operations."""
 

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -2670,6 +2670,26 @@ async def lifespan(app: FastAPI):
     except _STARTUP_GUARD_EXCEPTIONS as e:
         logger.warning(f"Failed to start Admin backup Jobs worker: {e}")
 
+    # Admin BYOK validation Jobs worker
+    try:
+        if _sidecar_mode:
+            logger.info("Admin BYOK validation Jobs worker disabled in sidecar mode")
+        else:
+            from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+                start_admin_byok_validation_jobs_worker,
+            )
+
+            admin_byok_validation_jobs_task = await start_admin_byok_validation_jobs_worker()
+            if admin_byok_validation_jobs_task:
+                logger.info("Admin BYOK validation Jobs worker started")
+            else:
+                logger.info(
+                    "Admin BYOK validation Jobs worker disabled "
+                    "(ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED != true)"
+                )
+    except _STARTUP_GUARD_EXCEPTIONS as e:
+        logger.warning(f"Failed to start Admin BYOK validation Jobs worker: {e}")
+
     # Admin maintenance rotation Jobs worker
     try:
         if _sidecar_mode:

--- a/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
+++ b/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from json import JSONDecodeError
 import os
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, Protocol, TypedDict
 
 from loguru import logger
 
@@ -21,13 +23,85 @@ from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
 from tldw_Server_API.app.core.testing import env_flag_enabled
 from tldw_Server_API.app.services import admin_byok_service, admin_orgs_service
-from tldw_Server_API.app.services.admin_byok_validation_service import (
-    AdminByokValidationService,
-)
 
 
 BYOK_VALIDATION_DOMAIN = "byok"
 BYOK_VALIDATION_JOB_TYPE = "validation_sweep"
+
+
+class ByokValidationCandidate(TypedDict, total=False):
+    """One concrete BYOK credential candidate to validate."""
+
+    provider: str
+    api_key: str
+    credential_fields: dict[str, Any] | None
+    source: str
+    scope_type: str
+    scope_id: int
+    user_id: int
+
+
+@dataclass(frozen=True)
+class CandidateLoadResult:
+    """Candidates plus the number of skipped records encountered while loading."""
+
+    candidates: list[ByokValidationCandidate]
+    error_count: int = 0
+
+
+class SharedByokRepoProtocol(Protocol):
+    """Subset of shared BYOK repo behavior used by validation loading."""
+
+    async def list_secrets(
+        self,
+        *,
+        scope_type: str | None = None,
+        scope_id: int | None = None,
+        provider: str | None = None,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    async def fetch_secret(
+        self,
+        scope_type: str,
+        scope_id: int,
+        provider: str,
+    ) -> dict[str, Any] | None:
+        ...
+
+
+class UserByokRepoProtocol(Protocol):
+    """Subset of per-user BYOK repo behavior used by validation loading."""
+
+    async def list_secrets_for_user(self, user_id: int) -> list[dict[str, Any]]:
+        ...
+
+    async def fetch_secret_for_user(self, user_id: int, provider: str) -> dict[str, Any] | None:
+        ...
+
+
+class ValidationRunsRepoProtocol(Protocol):
+    """Subset of run-repo behavior required by the Jobs worker."""
+
+    async def get_run(self, run_id: str) -> dict[str, Any] | None:
+        ...
+
+    async def mark_running(self, run_id: str, *, job_id: str | None) -> dict[str, Any]:
+        ...
+
+    async def mark_complete(
+        self,
+        run_id: str,
+        *,
+        keys_checked: int,
+        valid_count: int,
+        invalid_count: int,
+        error_count: int,
+    ) -> dict[str, Any]:
+        ...
+
+    async def mark_failed(self, run_id: str, *, error_message: str) -> dict[str, Any]:
+        ...
 
 
 def byok_validation_queue() -> str:
@@ -50,7 +124,7 @@ def build_byok_validation_idempotency_key(*, run_id: str) -> str:
     return f"byok-validation:{run_id}"
 
 
-async def _get_repo():
+async def _get_repo() -> ValidationRunsRepoProtocol:
     """Build the BYOK validation run repository for worker execution."""
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
     from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
@@ -105,10 +179,11 @@ async def _load_team_scoped_shared_candidates(
     *,
     org_id: int,
     provider: str | None,
-    shared_repo,
-) -> list[dict[str, Any]]:
+    shared_repo: SharedByokRepoProtocol,
+) -> CandidateLoadResult:
     """Load team-scoped shared key candidates for one organization."""
-    items: list[dict[str, Any]] = []
+    items: list[ByokValidationCandidate] = []
+    error_count = 0
     offset = 0
     limit = 200
     while True:
@@ -126,7 +201,17 @@ async def _load_team_scoped_shared_candidates(
                 full_row = await shared_repo.fetch_secret("team", team_id, str(row["provider"]))
                 if not full_row or not full_row.get("encrypted_blob"):
                     continue
-                payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                try:
+                    payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                except (JSONDecodeError, TypeError, ValueError) as exc:
+                    error_count += 1
+                    logger.warning(
+                        "Skipping unreadable BYOK validation candidate: provider={} source=shared scope_type=team scope_id={} error_type={}",
+                        row["provider"],
+                        team_id,
+                        type(exc).__name__,
+                    )
+                    continue
                 items.append(
                     {
                         "provider": str(row["provider"]),
@@ -140,19 +225,20 @@ async def _load_team_scoped_shared_candidates(
         if len(teams) < limit:
             break
         offset += limit
-    return items
+    return CandidateLoadResult(candidates=items, error_count=error_count)
 
 
-async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[str, Any]]:
+async def load_default_validation_candidates(run: dict[str, Any]) -> CandidateLoadResult:
     """Load shared and per-user BYOK validation candidates for one run scope."""
     provider = str(run.get("provider") or "").strip() or None
     org_id = int(run["org_id"]) if run.get("org_id") is not None else None
 
-    shared_repo = await admin_byok_service.get_shared_byok_repo()
-    user_repo = await admin_byok_service.get_user_byok_repo()
+    shared_repo: SharedByokRepoProtocol = await admin_byok_service.get_shared_byok_repo()
+    user_repo: UserByokRepoProtocol = await admin_byok_service.get_user_byok_repo()
     users_repo = await AuthnzUsersRepo.from_pool()
 
-    candidates: list[dict[str, Any]] = []
+    candidates: list[ByokValidationCandidate] = []
+    error_count = 0
 
     if org_id is not None:
         shared_rows = await shared_repo.list_secrets(
@@ -160,14 +246,14 @@ async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[s
             scope_id=org_id,
             provider=provider,
         )
-        team_rows = await _load_team_scoped_shared_candidates(
+        team_load_result = await _load_team_scoped_shared_candidates(
             org_id=org_id,
             provider=provider,
             shared_repo=shared_repo,
         )
     else:
         shared_rows = await shared_repo.list_secrets(provider=provider)
-        team_rows = []
+        team_load_result = CandidateLoadResult(candidates=[], error_count=0)
 
     for row in shared_rows:
         scope_type = str(row["scope_type"])
@@ -175,7 +261,18 @@ async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[s
         full_row = await shared_repo.fetch_secret(scope_type, scope_id, str(row["provider"]))
         if not full_row or not full_row.get("encrypted_blob"):
             continue
-        payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+        try:
+            payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+        except (JSONDecodeError, TypeError, ValueError) as exc:
+            error_count += 1
+            logger.warning(
+                "Skipping unreadable BYOK validation candidate: provider={} source=shared scope_type={} scope_id={} error_type={}",
+                row["provider"],
+                scope_type,
+                scope_id,
+                type(exc).__name__,
+            )
+            continue
         candidates.append(
             {
                 "provider": str(row["provider"]),
@@ -186,7 +283,8 @@ async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[s
                 "scope_id": scope_id,
             }
         )
-    candidates.extend(team_rows)
+    candidates.extend(team_load_result.candidates)
+    error_count += team_load_result.error_count
 
     offset = 0
     limit = 200
@@ -208,7 +306,17 @@ async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[s
                 full_row = await user_repo.fetch_secret_for_user(user_id, row_provider)
                 if not full_row or not full_row.get("encrypted_blob"):
                     continue
-                payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                try:
+                    payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                except (JSONDecodeError, TypeError, ValueError) as exc:
+                    error_count += 1
+                    logger.warning(
+                        "Skipping unreadable BYOK validation candidate: provider={} source=user user_id={} error_type={}",
+                        row_provider,
+                        user_id,
+                        type(exc).__name__,
+                    )
+                    continue
                 candidates.append(
                     {
                         "provider": row_provider,
@@ -222,20 +330,45 @@ async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[s
         if offset >= total:
             break
 
-    return candidates
+    return CandidateLoadResult(candidates=candidates, error_count=error_count)
+
+
+def _normalize_candidate_load_result(
+    load_result: CandidateLoadResult | list[ByokValidationCandidate],
+) -> CandidateLoadResult:
+    """Normalize legacy loader outputs into the worker's structured load result."""
+    if isinstance(load_result, CandidateLoadResult):
+        return load_result
+    return CandidateLoadResult(candidates=load_result, error_count=0)
 
 
 async def _run_validation_scan(
-    candidates: list[dict[str, Any]],
+    candidates: list[ByokValidationCandidate],
     *,
     test_provider_credentials_fn: Callable[..., Awaitable[Any]],
+    initial_error_count: int = 0,
+    max_workers: int | None = None,
     per_provider_limit: int | None = None,
 ) -> dict[str, int]:
     """Validate candidate credentials with bounded concurrency per provider."""
+    if not candidates:
+        return {
+            "keys_checked": 0,
+            "valid_count": 0,
+            "invalid_count": 0,
+            "error_count": initial_error_count,
+        }
+
     provider_limit = per_provider_limit or _per_provider_limit()
     semaphores: dict[str, asyncio.Semaphore] = {}
+    counts = {
+        "keys_checked": len(candidates),
+        "valid_count": 0,
+        "invalid_count": 0,
+        "error_count": initial_error_count,
+    }
 
-    async def _validate_candidate(candidate: dict[str, Any]) -> str:
+    async def _validate_candidate(candidate: ByokValidationCandidate) -> str:
         provider = str(candidate["provider"])
         semaphore = semaphores.setdefault(provider, asyncio.Semaphore(provider_limit))
         async with semaphore:
@@ -250,20 +383,53 @@ async def _run_validation_scan(
             except (ChatAuthenticationError, ChatBadRequestError):
                 return "invalid"
 
-    results = await asyncio.gather(*[_validate_candidate(candidate) for candidate in candidates])
-    return {
-        "keys_checked": len(candidates),
-        "valid_count": sum(1 for status in results if status == "valid"),
-        "invalid_count": sum(1 for status in results if status == "invalid"),
-        "error_count": 0,
-    }
+    queue: asyncio.Queue[ByokValidationCandidate | None] = asyncio.Queue()
+    for candidate in candidates:
+        queue.put_nowait(candidate)
+
+    provider_count = len({str(candidate["provider"]) for candidate in candidates})
+    worker_count = min(
+        len(candidates),
+        max(1, max_workers or (provider_limit * max(1, provider_count))),
+    )
+    for _ in range(worker_count):
+        queue.put_nowait(None)
+
+    async def _worker() -> None:
+        while True:
+            candidate = await queue.get()
+            try:
+                if candidate is None:
+                    return
+                status = await _validate_candidate(candidate)
+                if status == "valid":
+                    counts["valid_count"] += 1
+                else:
+                    counts["invalid_count"] += 1
+            finally:
+                queue.task_done()
+
+    tasks = [asyncio.create_task(_worker()) for _ in range(worker_count)]
+    try:
+        await asyncio.gather(*tasks)
+    except Exception:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+
+    return counts
 
 
 async def handle_byok_validation_job(
     job: dict[str, Any],
     *,
-    repo=None,
-    candidate_loader: Callable[[dict[str, Any]], Awaitable[list[dict[str, Any]]]] | None = None,
+    repo: ValidationRunsRepoProtocol | None = None,
+    candidate_loader: Callable[
+        [dict[str, Any]],
+        Awaitable[CandidateLoadResult | list[ByokValidationCandidate]],
+    ]
+    | None = None,
     test_provider_credentials_fn: Callable[..., Awaitable[Any]] | None = None,
 ) -> dict[str, Any]:
     """Execute one authoritative BYOK validation run from the Jobs queue."""
@@ -286,10 +452,11 @@ async def handle_byok_validation_job(
     validator = test_provider_credentials_fn or test_provider_credentials
 
     try:
-        candidates = await loader(run)
+        load_result = _normalize_candidate_load_result(await loader(run))
         summary = await _run_validation_scan(
-            candidates,
+            load_result.candidates,
             test_provider_credentials_fn=validator,
+            initial_error_count=load_result.error_count,
         )
     except Exception as exc:
         await repo.mark_failed(run_id, error_message=_redact_validation_failure(exc))

--- a/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
+++ b/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    decrypt_byok_payload,
+    loads_envelope,
+)
+from tldw_Server_API.app.core.Chat.Chat_Deps import (
+    ChatAuthenticationError,
+    ChatBadRequestError,
+    ChatProviderError,
+)
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Jobs.worker_sdk import WorkerConfig, WorkerSDK
+from tldw_Server_API.app.core.testing import env_flag_enabled
+from tldw_Server_API.app.services import admin_byok_service, admin_orgs_service
+from tldw_Server_API.app.services.admin_byok_validation_service import (
+    AdminByokValidationService,
+)
+
+
+BYOK_VALIDATION_DOMAIN = "byok"
+BYOK_VALIDATION_JOB_TYPE = "validation_sweep"
+
+
+def byok_validation_queue() -> str:
+    """Return the Jobs queue used for authoritative BYOK validation runs."""
+    return (os.getenv("ADMIN_BYOK_VALIDATION_JOBS_QUEUE") or "default").strip() or "default"
+
+
+def byok_validation_worker_enabled() -> bool:
+    """Return True when the authoritative BYOK validation worker is enabled."""
+    return env_flag_enabled("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED")
+
+
+def build_byok_validation_job_payload(*, run_id: str) -> dict[str, Any]:
+    """Build the opaque Jobs payload for one BYOK validation run."""
+    return {"run_id": str(run_id)}
+
+
+def build_byok_validation_idempotency_key(*, run_id: str) -> str:
+    """Return the Jobs idempotency key for one BYOK validation run enqueue."""
+    return f"byok-validation:{run_id}"
+
+
+async def _get_repo():
+    """Build the BYOK validation run repository for worker execution."""
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+        AuthnzByokValidationRunsRepo,
+    )
+
+    pool = await get_db_pool()
+    repo = AuthnzByokValidationRunsRepo(pool)
+    await repo.ensure_schema()
+    return repo
+
+
+def _per_provider_limit() -> int:
+    """Return the max concurrent validation calls per provider."""
+    raw_value = (os.getenv("ADMIN_BYOK_VALIDATION_PER_PROVIDER_CONCURRENCY") or "2").strip()
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        return 2
+
+
+def _redact_validation_failure(exc: Exception) -> str:
+    """Return a bounded redacted summary for a failed validation run."""
+    if isinstance(exc, ChatAuthenticationError | ChatBadRequestError):
+        return "invalid_credentials"
+    if isinstance(exc, ChatProviderError):
+        return "provider_validation_failed"
+    return "provider_validation_failed"
+
+
+async def enqueue_byok_validation_run(
+    run: dict[str, Any],
+    *,
+    job_manager: JobManager | None = None,
+) -> str:
+    """Enqueue one authoritative BYOK validation run into Jobs."""
+    jobs = job_manager or JobManager()
+    job = jobs.create_job(
+        domain=BYOK_VALIDATION_DOMAIN,
+        queue=byok_validation_queue(),
+        job_type=BYOK_VALIDATION_JOB_TYPE,
+        payload=build_byok_validation_job_payload(run_id=str(run["id"])),
+        owner_user_id=(
+            str(run["requested_by_user_id"]) if run.get("requested_by_user_id") is not None else None
+        ),
+        idempotency_key=build_byok_validation_idempotency_key(run_id=str(run["id"])),
+    )
+    return str(job.get("id"))
+
+
+async def _load_team_scoped_shared_candidates(
+    *,
+    org_id: int,
+    provider: str | None,
+    shared_repo,
+) -> list[dict[str, Any]]:
+    """Load team-scoped shared key candidates for one organization."""
+    items: list[dict[str, Any]] = []
+    offset = 0
+    limit = 200
+    while True:
+        teams = await admin_orgs_service.list_teams_by_org(org_id, limit=limit, offset=offset)
+        if not teams:
+            break
+        for team in teams:
+            team_id = int(team["id"])
+            team_rows = await shared_repo.list_secrets(
+                scope_type="team",
+                scope_id=team_id,
+                provider=provider,
+            )
+            for row in team_rows:
+                full_row = await shared_repo.fetch_secret("team", team_id, str(row["provider"]))
+                if not full_row or not full_row.get("encrypted_blob"):
+                    continue
+                payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                items.append(
+                    {
+                        "provider": str(row["provider"]),
+                        "api_key": payload["api_key"],
+                        "credential_fields": payload.get("credential_fields"),
+                        "source": "shared",
+                        "scope_type": "team",
+                        "scope_id": team_id,
+                    }
+                )
+        if len(teams) < limit:
+            break
+        offset += limit
+    return items
+
+
+async def load_default_validation_candidates(run: dict[str, Any]) -> list[dict[str, Any]]:
+    """Load shared and per-user BYOK validation candidates for one run scope."""
+    provider = str(run.get("provider") or "").strip() or None
+    org_id = int(run["org_id"]) if run.get("org_id") is not None else None
+
+    shared_repo = await admin_byok_service.get_shared_byok_repo()
+    user_repo = await admin_byok_service.get_user_byok_repo()
+    users_repo = await AuthnzUsersRepo.from_pool()
+
+    candidates: list[dict[str, Any]] = []
+
+    if org_id is not None:
+        shared_rows = await shared_repo.list_secrets(
+            scope_type="org",
+            scope_id=org_id,
+            provider=provider,
+        )
+        team_rows = await _load_team_scoped_shared_candidates(
+            org_id=org_id,
+            provider=provider,
+            shared_repo=shared_repo,
+        )
+    else:
+        shared_rows = await shared_repo.list_secrets(provider=provider)
+        team_rows = []
+
+    for row in shared_rows:
+        scope_type = str(row["scope_type"])
+        scope_id = int(row["scope_id"])
+        full_row = await shared_repo.fetch_secret(scope_type, scope_id, str(row["provider"]))
+        if not full_row or not full_row.get("encrypted_blob"):
+            continue
+        payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+        candidates.append(
+            {
+                "provider": str(row["provider"]),
+                "api_key": payload["api_key"],
+                "credential_fields": payload.get("credential_fields"),
+                "source": "shared",
+                "scope_type": scope_type,
+                "scope_id": scope_id,
+            }
+        )
+    candidates.extend(team_rows)
+
+    offset = 0
+    limit = 200
+    while True:
+        users, total = await users_repo.list_users(
+            offset=offset,
+            limit=limit,
+            org_ids=[org_id] if org_id is not None else None,
+        )
+        if not users:
+            break
+        for user in users:
+            user_id = int(user["id"])
+            user_rows = await user_repo.list_secrets_for_user(user_id)
+            for row in user_rows:
+                row_provider = str(row["provider"])
+                if provider is not None and row_provider != provider:
+                    continue
+                full_row = await user_repo.fetch_secret_for_user(user_id, row_provider)
+                if not full_row or not full_row.get("encrypted_blob"):
+                    continue
+                payload = decrypt_byok_payload(loads_envelope(str(full_row["encrypted_blob"])))
+                candidates.append(
+                    {
+                        "provider": row_provider,
+                        "api_key": payload["api_key"],
+                        "credential_fields": payload.get("credential_fields"),
+                        "source": "user",
+                        "user_id": user_id,
+                    }
+                )
+        offset += limit
+        if offset >= total:
+            break
+
+    return candidates
+
+
+async def _run_validation_scan(
+    candidates: list[dict[str, Any]],
+    *,
+    test_provider_credentials_fn: Callable[..., Awaitable[Any]],
+    per_provider_limit: int | None = None,
+) -> dict[str, int]:
+    """Validate candidate credentials with bounded concurrency per provider."""
+    provider_limit = per_provider_limit or _per_provider_limit()
+    semaphores: dict[str, asyncio.Semaphore] = {}
+
+    async def _validate_candidate(candidate: dict[str, Any]) -> str:
+        provider = str(candidate["provider"])
+        semaphore = semaphores.setdefault(provider, asyncio.Semaphore(provider_limit))
+        async with semaphore:
+            try:
+                await test_provider_credentials_fn(
+                    provider=provider,
+                    api_key=str(candidate["api_key"]),
+                    credential_fields=candidate.get("credential_fields"),
+                    model=None,
+                )
+                return "valid"
+            except (ChatAuthenticationError, ChatBadRequestError):
+                return "invalid"
+
+    results = await asyncio.gather(*[_validate_candidate(candidate) for candidate in candidates])
+    return {
+        "keys_checked": len(candidates),
+        "valid_count": sum(1 for status in results if status == "valid"),
+        "invalid_count": sum(1 for status in results if status == "invalid"),
+        "error_count": 0,
+    }
+
+
+async def handle_byok_validation_job(
+    job: dict[str, Any],
+    *,
+    repo=None,
+    candidate_loader: Callable[[dict[str, Any]], Awaitable[list[dict[str, Any]]]] | None = None,
+    test_provider_credentials_fn: Callable[..., Awaitable[Any]] | None = None,
+) -> dict[str, Any]:
+    """Execute one authoritative BYOK validation run from the Jobs queue."""
+    from tldw_Server_API.app.core.AuthNZ.byok_testing import test_provider_credentials
+
+    payload = job.get("payload") or {}
+    run_id = str(payload.get("run_id") or "").strip()
+    if not run_id:
+        raise ValueError("missing_run_id")
+
+    repo = repo or await _get_repo()
+    run = await repo.get_run(run_id)
+    if not run:
+        raise ValueError("missing_run")
+
+    job_id = str(job.get("id")) if job.get("id") is not None else None
+    await repo.mark_running(run_id, job_id=job_id)
+
+    loader = candidate_loader or load_default_validation_candidates
+    validator = test_provider_credentials_fn or test_provider_credentials
+
+    try:
+        candidates = await loader(run)
+        summary = await _run_validation_scan(
+            candidates,
+            test_provider_credentials_fn=validator,
+        )
+    except Exception as exc:
+        await repo.mark_failed(run_id, error_message=_redact_validation_failure(exc))
+        raise
+
+    await repo.mark_complete(
+        run_id,
+        keys_checked=int(summary["keys_checked"]),
+        valid_count=int(summary["valid_count"]),
+        invalid_count=int(summary["invalid_count"]),
+        error_count=int(summary["error_count"]),
+    )
+
+    logger.info(
+        "BYOK validation job completed: run_id={} job_id={} keys_checked={} valid={} invalid={} errors={}",
+        run_id,
+        job_id,
+        summary["keys_checked"],
+        summary["valid_count"],
+        summary["invalid_count"],
+        summary["error_count"],
+    )
+    return {
+        "status": "complete",
+        "run_id": run_id,
+        "job_id": job_id,
+        "keys_checked": int(summary["keys_checked"]),
+        "valid_count": int(summary["valid_count"]),
+        "invalid_count": int(summary["invalid_count"]),
+        "error_count": int(summary["error_count"]),
+    }
+
+
+async def run_admin_byok_validation_jobs_worker() -> None:
+    """Run the WorkerSDK loop for authoritative BYOK validation jobs."""
+    worker_id = (
+        os.getenv("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ID") or f"admin-byok-validation-{os.getpid()}"
+    ).strip()
+    cfg = WorkerConfig(
+        domain=BYOK_VALIDATION_DOMAIN,
+        queue=byok_validation_queue(),
+        worker_id=worker_id,
+    )
+    jm = JobManager()
+    sdk = WorkerSDK(jm, cfg)
+    logger.info(
+        "Admin BYOK validation Jobs worker starting: queue={} worker_id={}",
+        cfg.queue,
+        worker_id,
+    )
+    await sdk.run(handler=handle_byok_validation_job)
+
+
+async def start_admin_byok_validation_jobs_worker() -> asyncio.Task | None:
+    """Start the BYOK validation Jobs worker when explicitly enabled."""
+    if not byok_validation_worker_enabled():
+        return None
+    return asyncio.create_task(
+        run_admin_byok_validation_jobs_worker(),
+        name="admin_byok_validation_jobs_worker",
+    )
+
+
+__all__ = [
+    "BYOK_VALIDATION_DOMAIN",
+    "BYOK_VALIDATION_JOB_TYPE",
+    "_run_validation_scan",
+    "build_byok_validation_idempotency_key",
+    "build_byok_validation_job_payload",
+    "byok_validation_queue",
+    "byok_validation_worker_enabled",
+    "enqueue_byok_validation_run",
+    "handle_byok_validation_job",
+    "load_default_validation_candidates",
+    "run_admin_byok_validation_jobs_worker",
+    "start_admin_byok_validation_jobs_worker",
+]

--- a/tldw_Server_API/app/services/admin_byok_validation_service.py
+++ b/tldw_Server_API/app/services/admin_byok_validation_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi import HTTPException, status
+
+from tldw_Server_API.app.core.AuthNZ.byok_helpers import is_byok_enabled
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+    AuthnzByokValidationRunsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import normalize_provider_name
+from tldw_Server_API.app.services import admin_scope_service
+
+
+def _requested_by_label(principal: AuthPrincipal) -> str | None:
+    """Return a stable operator label for persisted validation runs."""
+    return principal.email or principal.username or principal.subject
+
+
+@dataclass
+class AdminByokValidationService:
+    """Service layer for authoritative admin BYOK validation runs."""
+
+    repo: AuthnzByokValidationRunsRepo
+
+    async def create_run(
+        self,
+        principal: AuthPrincipal,
+        *,
+        org_id: int | None,
+        provider: str | None,
+    ) -> dict[str, object]:
+        """Validate create inputs, enforce scope, and persist a queued validation run."""
+        if not is_byok_enabled():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="BYOK is disabled in this deployment",
+            )
+
+        if org_id is not None:
+            await admin_scope_service.enforce_admin_org_access(principal, org_id, require_admin=True)
+
+        provider_norm = normalize_provider_name(provider) if provider else None
+
+        if await self.repo.has_active_run():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="active_validation_run_exists",
+            )
+
+        try:
+            return await self.repo.create_run(
+                org_id=org_id,
+                provider=provider_norm,
+                requested_by_user_id=principal.user_id,
+                requested_by_label=_requested_by_label(principal),
+                scope_summary=self._scope_summary(org_id=org_id, provider=provider_norm),
+            )
+        except Exception as exc:
+            if "idx_byok_validation_runs_active" in str(exc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="active_validation_run_exists",
+                ) from exc
+            raise
+
+    async def list_runs(self, *, limit: int, offset: int) -> tuple[list[dict[str, object]], int]:
+        """Return queued and historical BYOK validation runs."""
+        return await self.repo.list_runs(limit=limit, offset=offset)
+
+    async def get_run(self, run_id: str) -> dict[str, object]:
+        """Return a BYOK validation run by id or raise 404 when absent."""
+        item = await self.repo.get_run(run_id)
+        if item is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="byok_validation_run_not_found")
+        return item
+
+    @staticmethod
+    def _scope_summary(*, org_id: int | None, provider: str | None) -> str:
+        """Return the persisted human-readable scope summary."""
+        parts: list[str] = []
+        if org_id is not None:
+            parts.append(f"org={org_id}")
+        else:
+            parts.append("global")
+        if provider is not None:
+            parts.append(f"provider={provider}")
+        return ", ".join(parts)

--- a/tldw_Server_API/app/services/admin_byok_validation_service.py
+++ b/tldw_Server_API/app/services/admin_byok_validation_service.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from fastapi import HTTPException, status
-
 from tldw_Server_API.app.core.AuthNZ.byok_helpers import is_byok_enabled
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
     AuthnzByokValidationRunsRepo,
 )
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import normalize_provider_name
+from tldw_Server_API.app.core.exceptions import (
+    ByokValidationActiveRunError,
+    ByokValidationDisabledError,
+    ByokValidationRunNotFoundError,
+)
 from tldw_Server_API.app.services import admin_scope_service
 
 
@@ -33,10 +36,7 @@ class AdminByokValidationService:
     ) -> dict[str, object]:
         """Validate create inputs, enforce scope, and persist a queued validation run."""
         if not is_byok_enabled():
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="BYOK is disabled in this deployment",
-            )
+            raise ByokValidationDisabledError("BYOK is disabled in this deployment")
 
         if org_id is not None:
             await admin_scope_service.enforce_admin_org_access(principal, org_id, require_admin=True)
@@ -44,10 +44,7 @@ class AdminByokValidationService:
         provider_norm = normalize_provider_name(provider) if provider else None
 
         if await self.repo.has_active_run():
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="active_validation_run_exists",
-            )
+            raise ByokValidationActiveRunError("active_validation_run_exists")
 
         try:
             return await self.repo.create_run(
@@ -59,10 +56,7 @@ class AdminByokValidationService:
             )
         except Exception as exc:
             if "idx_byok_validation_runs_active" in str(exc):
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="active_validation_run_exists",
-                ) from exc
+                raise ByokValidationActiveRunError("active_validation_run_exists") from exc
             raise
 
     async def list_runs(self, *, limit: int, offset: int) -> tuple[list[dict[str, object]], int]:
@@ -73,7 +67,7 @@ class AdminByokValidationService:
         """Return a BYOK validation run by id or raise 404 when absent."""
         item = await self.repo.get_run(run_id)
         if item is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="byok_validation_run_not_found")
+            raise ByokValidationRunNotFoundError("byok_validation_run_not_found")
         return item
 
     @staticmethod

--- a/tldw_Server_API/app/services/admin_data_ops_service.py
+++ b/tldw_Server_API/app/services/admin_data_ops_service.py
@@ -66,7 +66,7 @@ DATASET_DB_RESOLVERS = {
 }
 _BACKUP_DATASETS = frozenset([*DATASET_DB_RESOLVERS.keys(), "authnz"])
 _BACKUP_EXTENSIONS = (".db", ".sqlib", ".dump")
-_RETENTION_PREVIEW_TOKEN_VERSION = "v1"
+_RETENTION_PREVIEW_SCHEMA_VERSION = "v1"
 
 
 def _backup_base_dir() -> str:
@@ -375,7 +375,7 @@ def _retention_preview_secret() -> bytes:
     if not secret_seed:
         raise RuntimeError("preview_signature_secret_unavailable")
     pepper = getattr(settings, "API_KEY_PEPPER", None) or ""
-    material = f"{secret_seed}|{pepper}|retention-preview|{_RETENTION_PREVIEW_TOKEN_VERSION}"
+    material = f"{secret_seed}|{pepper}|retention-preview|{_RETENTION_PREVIEW_SCHEMA_VERSION}"
     return hashlib.sha256(material.encode("utf-8")).digest()
 
 
@@ -388,7 +388,7 @@ def build_retention_preview_signature(
 ) -> str:
     expires_at = int((datetime.now(timezone.utc) + timedelta(seconds=_retention_preview_ttl_seconds())).timestamp())
     payload = {
-        "v": _RETENTION_PREVIEW_TOKEN_VERSION,
+        "v": _RETENTION_PREVIEW_SCHEMA_VERSION,
         "p": policy_key,
         "c": int(current_days),
         "n": int(new_days),
@@ -433,7 +433,7 @@ async def verify_retention_preview_signature(
     if not preview_signature:
         raise InvalidRetentionRangeError("preview_signature_required")
     payload = _decode_retention_preview_signature(preview_signature)
-    if payload.get("v") != _RETENTION_PREVIEW_TOKEN_VERSION:
+    if payload.get("v") != _RETENTION_PREVIEW_SCHEMA_VERSION:
         raise InvalidRetentionRangeError("invalid_preview_signature")
     expires_at = int(payload.get("e") or 0)
     if expires_at < int(datetime.now(timezone.utc).timestamp()):

--- a/tldw_Server_API/app/services/admin_data_ops_service.py
+++ b/tldw_Server_API/app/services/admin_data_ops_service.py
@@ -27,6 +27,9 @@ from tldw_Server_API.app.core.AuthNZ.retention_policies import (
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType, DatabaseConfig
+from tldw_Server_API.app.core.DB_Management.admin_retention_preview_counts import (
+    count_retention_window,
+)
 from tldw_Server_API.app.core.DB_Management.DB_Backups import (
     create_backup,
     create_incremental_backup,
@@ -449,50 +452,6 @@ async def verify_retention_preview_signature(
         raise InvalidRetentionRangeError("invalid_preview_signature")
 
 
-async def _count_retention_window(
-    *,
-    table: str,
-    column: str,
-    older_than: datetime | str,
-    not_older_than: datetime | str,
-    is_date_column: bool = False,
-) -> int:
-    db_pool = await get_db_pool()
-    is_postgres = bool(getattr(db_pool, "pool", None))
-
-    if isinstance(older_than, datetime):
-        older_than_param: Any = older_than.replace(tzinfo=None) if is_postgres else older_than.isoformat()
-    else:
-        older_than_param = older_than
-    if isinstance(not_older_than, datetime):
-        not_older_than_param: Any = (
-            not_older_than.replace(tzinfo=None) if is_postgres else not_older_than.isoformat()
-        )
-    else:
-        not_older_than_param = not_older_than
-
-    if is_postgres:
-        cast = "::date" if is_date_column else ""
-        query = (
-            f"SELECT COUNT(*) FROM {table} "  # nosec B608
-            f"WHERE {column}{cast} < $1 AND {column}{cast} >= $2"  # nosec B608
-        )
-        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
-    else:
-        comparator = f"DATE({column})" if is_date_column else f"datetime({column})"
-        query = (
-            f"SELECT COUNT(*) FROM {table} "  # nosec B608
-            f"WHERE {comparator} < datetime(?) AND {comparator} >= datetime(?)"  # nosec B608
-        )
-        if is_date_column:
-            query = (
-                f"SELECT COUNT(*) FROM {table} "  # nosec B608
-                f"WHERE DATE({column}) < DATE(?) AND DATE({column}) >= DATE(?)"  # nosec B608
-            )
-        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
-    return int(total or 0)
-
-
 async def preview_retention_policy(
     *,
     policy_key: str,
@@ -516,28 +475,28 @@ async def preview_retention_policy(
         older_than = datetime.now(timezone.utc) - timedelta(days=effective_days)
         not_older_than = datetime.now(timezone.utc) - timedelta(days=actual_current_days)
         if policy_key == "audit_logs":
-            counts["audit_log_entries"] = await _count_retention_window(
+            counts["audit_log_entries"] = await count_retention_window(
                 table="audit_logs",
                 column="created_at",
                 older_than=older_than,
                 not_older_than=not_older_than,
             )
         elif policy_key == "usage_logs":
-            counts["job_records"] = await _count_retention_window(
+            counts["job_records"] = await count_retention_window(
                 table="usage_log",
                 column="ts",
                 older_than=older_than,
                 not_older_than=not_older_than,
             )
         elif policy_key == "llm_usage_logs":
-            counts["job_records"] = await _count_retention_window(
+            counts["job_records"] = await count_retention_window(
                 table="llm_usage_log",
                 column="ts",
                 older_than=older_than,
                 not_older_than=not_older_than,
             )
         elif policy_key == "usage_daily":
-            counts["job_records"] = await _count_retention_window(
+            counts["job_records"] = await count_retention_window(
                 table="usage_daily",
                 column="day",
                 older_than=(datetime.now(timezone.utc) - timedelta(days=effective_days)).date().isoformat(),
@@ -545,7 +504,7 @@ async def preview_retention_policy(
                 is_date_column=True,
             )
         elif policy_key == "llm_usage_daily":
-            counts["job_records"] = await _count_retention_window(
+            counts["job_records"] = await count_retention_window(
                 table="llm_usage_daily",
                 column="day",
                 older_than=(datetime.now(timezone.utc) - timedelta(days=effective_days)).date().isoformat(),
@@ -553,7 +512,7 @@ async def preview_retention_policy(
                 is_date_column=True,
             )
         elif policy_key in {"privilege_snapshots", "privilege_snapshots_weekly"}:
-            counts["job_records"] = await _count_retention_window(
+            counts["job_records"] = await count_retention_window(
                 table="privilege_snapshots",
                 column="generated_at",
                 older_than=older_than,

--- a/tldw_Server_API/app/services/admin_data_ops_service.py
+++ b/tldw_Server_API/app/services/admin_data_ops_service.py
@@ -2,24 +2,29 @@
 # Description: Admin data operations helpers (backups, retention policies, exports)
 from __future__ import annotations
 
+import base64
 import csv
+import hashlib
+import hmac
 import io
 import json
 import os
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
 from urllib.parse import urlparse
 
 from loguru import logger
 
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.retention_policies import (
     RETENTION_POLICIES,
     apply_retention_overrides,
     upsert_retention_override,
 )
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 from tldw_Server_API.app.core.DB_Management.backends.base import BackendType, DatabaseConfig
 from tldw_Server_API.app.core.DB_Management.DB_Backups import (
@@ -61,6 +66,7 @@ DATASET_DB_RESOLVERS = {
 }
 _BACKUP_DATASETS = frozenset([*DATASET_DB_RESOLVERS.keys(), "authnz"])
 _BACKUP_EXTENSIONS = (".db", ".sqlib", ".dump")
+_RETENTION_PREVIEW_TOKEN_VERSION = "v1"
 
 
 def _backup_base_dir() -> str:
@@ -314,24 +320,261 @@ async def list_retention_policies() -> list[dict[str, Any]]:
     return policies
 
 
-async def update_retention_policy(policy_key: str, days: int) -> dict[str, Any]:
+def _resolve_retention_policy_meta(policy_key: str) -> dict[str, Any]:
     meta = RETENTION_POLICIES.get(policy_key)
     if not meta:
         raise InvalidRetentionPolicyError("unknown_policy")
+    return meta
+
+
+def _validate_requested_retention_days(policy_key: str, days: int) -> tuple[dict[str, Any], int]:
+    meta = _resolve_retention_policy_meta(policy_key)
     min_val = int(meta["min"])
     max_val = int(meta["max"])
     if days < min_val or days > max_val:
         raise InvalidRetentionRangeError("invalid_range")
+    return meta, int(days)
 
+
+async def _current_retention_days(policy_key: str) -> int:
+    meta = _resolve_retention_policy_meta(policy_key)
     settings = get_settings()
-    effective_days = int(days)
+    await apply_retention_overrides(settings)
+    value = getattr(settings, meta["attr"], None)
+    return int(value) if value is not None else 0
+
+
+def _effective_retention_days(policy_key: str, requested_days: int) -> int:
+    effective_days = int(requested_days)
     if policy_key == "privilege_snapshots_weekly":
+        settings = get_settings()
         try:
-            primary = int(getattr(settings, RETENTION_POLICIES["privilege_snapshots"]["attr"]))
-            if effective_days < primary:
-                effective_days = primary
+            primary_days = int(getattr(settings, RETENTION_POLICIES["privilege_snapshots"]["attr"]))
+            if effective_days < primary_days:
+                effective_days = primary_days
         except Exception as retention_floor_error:
             logger.debug("Failed to apply privilege snapshot retention floor", exc_info=retention_floor_error)
+    return effective_days
+
+
+def _retention_preview_ttl_seconds() -> int:
+    raw_value = (os.getenv("ADMIN_RETENTION_PREVIEW_TTL_SECONDS") or "900").strip()
+    try:
+        return max(60, int(raw_value))
+    except ValueError:
+        return 900
+
+
+def _retention_preview_secret() -> bytes:
+    settings = get_settings()
+    secret_seed = (
+        getattr(settings, "JWT_SECRET_KEY", None)
+        or getattr(settings, "SINGLE_USER_API_KEY", None)
+        or os.getenv("JWT_SECRET_TEST_KEY")
+    )
+    if not secret_seed:
+        raise RuntimeError("preview_signature_secret_unavailable")
+    pepper = getattr(settings, "API_KEY_PEPPER", None) or ""
+    material = f"{secret_seed}|{pepper}|retention-preview|{_RETENTION_PREVIEW_TOKEN_VERSION}"
+    return hashlib.sha256(material.encode("utf-8")).digest()
+
+
+def build_retention_preview_signature(
+    *,
+    principal: AuthPrincipal,
+    policy_key: str,
+    current_days: int,
+    new_days: int,
+) -> str:
+    expires_at = int((datetime.now(timezone.utc) + timedelta(seconds=_retention_preview_ttl_seconds())).timestamp())
+    payload = {
+        "v": _RETENTION_PREVIEW_TOKEN_VERSION,
+        "p": policy_key,
+        "c": int(current_days),
+        "n": int(new_days),
+        "a": principal.principal_id,
+        "e": expires_at,
+    }
+    body = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii").rstrip("=")
+    digest = hmac.new(_retention_preview_secret(), body.encode("utf-8"), hashlib.sha256).hexdigest()
+    return f"{body}.{digest}"
+
+
+def _decode_retention_preview_signature(signature: str) -> dict[str, Any]:
+    try:
+        body, digest = str(signature).split(".", 1)
+    except ValueError as exc:
+        raise InvalidRetentionRangeError("invalid_preview_signature") from exc
+
+    expected = hmac.new(_retention_preview_secret(), body.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(digest, expected):
+        raise InvalidRetentionRangeError("invalid_preview_signature")
+
+    padded = body + "=" * (-len(body) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        payload = json.loads(decoded.decode("utf-8"))
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise InvalidRetentionRangeError("invalid_preview_signature") from exc
+    if not isinstance(payload, dict):
+        raise InvalidRetentionRangeError("invalid_preview_signature")
+    return payload
+
+
+async def verify_retention_preview_signature(
+    *,
+    principal: AuthPrincipal,
+    policy_key: str,
+    days: int,
+    preview_signature: str | None,
+) -> None:
+    if not preview_signature:
+        raise InvalidRetentionRangeError("preview_signature_required")
+    payload = _decode_retention_preview_signature(preview_signature)
+    if payload.get("v") != _RETENTION_PREVIEW_TOKEN_VERSION:
+        raise InvalidRetentionRangeError("invalid_preview_signature")
+    expires_at = int(payload.get("e") or 0)
+    if expires_at < int(datetime.now(timezone.utc).timestamp()):
+        raise InvalidRetentionRangeError("expired_preview_signature")
+    actual_current_days = await _current_retention_days(policy_key)
+    effective_days = _effective_retention_days(policy_key, days)
+    if (
+        payload.get("p") != policy_key
+        or int(payload.get("c") or -1) != actual_current_days
+        or int(payload.get("n") or -1) != effective_days
+        or payload.get("a") != principal.principal_id
+    ):
+        raise InvalidRetentionRangeError("invalid_preview_signature")
+
+
+async def _count_retention_window(
+    *,
+    table: str,
+    column: str,
+    older_than: datetime | str,
+    not_older_than: datetime | str,
+    is_date_column: bool = False,
+) -> int:
+    db_pool = await get_db_pool()
+    is_postgres = bool(getattr(db_pool, "pool", None))
+
+    if isinstance(older_than, datetime):
+        older_than_param: Any = older_than.replace(tzinfo=None) if is_postgres else older_than.isoformat()
+    else:
+        older_than_param = older_than
+    if isinstance(not_older_than, datetime):
+        not_older_than_param: Any = (
+            not_older_than.replace(tzinfo=None) if is_postgres else not_older_than.isoformat()
+        )
+    else:
+        not_older_than_param = not_older_than
+
+    if is_postgres:
+        cast = "::date" if is_date_column else ""
+        query = (
+            f"SELECT COUNT(*) FROM {table} "  # nosec B608
+            f"WHERE {column}{cast} < $1 AND {column}{cast} >= $2"  # nosec B608
+        )
+        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
+    else:
+        comparator = f"DATE({column})" if is_date_column else f"datetime({column})"
+        query = (
+            f"SELECT COUNT(*) FROM {table} "  # nosec B608
+            f"WHERE {comparator} < datetime(?) AND {comparator} >= datetime(?)"  # nosec B608
+        )
+        if is_date_column:
+            query = (
+                f"SELECT COUNT(*) FROM {table} "  # nosec B608
+                f"WHERE DATE({column}) < DATE(?) AND DATE({column}) >= DATE(?)"  # nosec B608
+            )
+        total = await db_pool.fetchval(query, older_than_param, not_older_than_param)
+    return int(total or 0)
+
+
+async def preview_retention_policy(
+    *,
+    policy_key: str,
+    current_days: int,
+    days: int,
+) -> dict[str, Any]:
+    _, requested_days = _validate_requested_retention_days(policy_key, days)
+    actual_current_days = await _current_retention_days(policy_key)
+    if int(current_days) != actual_current_days:
+        raise InvalidRetentionRangeError("stale_current_days")
+
+    effective_days = _effective_retention_days(policy_key, requested_days)
+    counts = {
+        "audit_log_entries": 0,
+        "job_records": 0,
+        "backup_files": 0,
+    }
+    notes: list[str] = []
+
+    if effective_days < actual_current_days:
+        older_than = datetime.now(timezone.utc) - timedelta(days=effective_days)
+        not_older_than = datetime.now(timezone.utc) - timedelta(days=actual_current_days)
+        if policy_key == "audit_logs":
+            counts["audit_log_entries"] = await _count_retention_window(
+                table="audit_logs",
+                column="created_at",
+                older_than=older_than,
+                not_older_than=not_older_than,
+            )
+        elif policy_key == "usage_logs":
+            counts["job_records"] = await _count_retention_window(
+                table="usage_log",
+                column="ts",
+                older_than=older_than,
+                not_older_than=not_older_than,
+            )
+        elif policy_key == "llm_usage_logs":
+            counts["job_records"] = await _count_retention_window(
+                table="llm_usage_log",
+                column="ts",
+                older_than=older_than,
+                not_older_than=not_older_than,
+            )
+        elif policy_key == "usage_daily":
+            counts["job_records"] = await _count_retention_window(
+                table="usage_daily",
+                column="day",
+                older_than=(datetime.now(timezone.utc) - timedelta(days=effective_days)).date().isoformat(),
+                not_older_than=(datetime.now(timezone.utc) - timedelta(days=actual_current_days)).date().isoformat(),
+                is_date_column=True,
+            )
+        elif policy_key == "llm_usage_daily":
+            counts["job_records"] = await _count_retention_window(
+                table="llm_usage_daily",
+                column="day",
+                older_than=(datetime.now(timezone.utc) - timedelta(days=effective_days)).date().isoformat(),
+                not_older_than=(datetime.now(timezone.utc) - timedelta(days=actual_current_days)).date().isoformat(),
+                is_date_column=True,
+            )
+        elif policy_key in {"privilege_snapshots", "privilege_snapshots_weekly"}:
+            counts["job_records"] = await _count_retention_window(
+                table="privilege_snapshots",
+                column="generated_at",
+                older_than=older_than,
+                not_older_than=not_older_than,
+            )
+        else:
+            notes.append("No additional backend preview counts are modeled for this policy.")
+
+    return {
+        "key": policy_key,
+        "current_days": actual_current_days,
+        "new_days": effective_days,
+        "counts": counts,
+        "notes": notes,
+    }
+
+
+async def update_retention_policy(policy_key: str, days: int) -> dict[str, Any]:
+    meta, requested_days = _validate_requested_retention_days(policy_key, days)
+    settings = get_settings()
+    effective_days = _effective_retention_days(policy_key, requested_days)
     await upsert_retention_override(policy_key, effective_days)
     setattr(settings, meta["attr"], effective_days)
 

--- a/tldw_Server_API/app/services/admin_settings_service.py
+++ b/tldw_Server_API/app/services/admin_settings_service.py
@@ -45,9 +45,13 @@ async def get_notes_title_settings() -> dict[str, Any]:
     try:
         llm_enabled = bool(app_settings.get("NOTES_TITLE_LLM_ENABLED", False))
         default_strategy = str(app_settings.get("NOTES_TITLE_DEFAULT_STRATEGY", "heuristic")).lower()
+        effective_strategy = (
+            default_strategy if llm_enabled or default_strategy == "heuristic" else "heuristic"
+        )
         return {
             "llm_enabled": llm_enabled,
             "default_strategy": default_strategy,
+            "effective_strategy": effective_strategy,
             "strategies": ["heuristic", "llm", "llm_fallback"],
         }
     except Exception as exc:

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
@@ -18,6 +18,7 @@ def _setup_env(monkeypatch, *, user_db_base: str) -> None:
     auth_db_path = Path(user_db_base).parent / "users_test_byok_validation_api.db"
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{auth_db_path}")
     monkeypatch.setenv("TEST_MODE", "true")
+    monkeypatch.setenv("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED", "true")
 
 
 @dataclass
@@ -105,6 +106,10 @@ class _ConflictByokValidationService(_FakeByokValidationService):
         raise HTTPException(status_code=409, detail="active_validation_run_exists")
 
 
+async def _noop_enqueue_run(item):
+    return "job-1"
+
+
 @pytest.mark.asyncio
 async def test_admin_byok_validation_create_list_and_detail_roundtrip(monkeypatch, tmp_path) -> None:
     _setup_env(monkeypatch, user_db_base=str(tmp_path / "user_dbs"))
@@ -113,6 +118,7 @@ async def test_admin_byok_validation_create_list_and_detail_roundtrip(monkeypatc
 
     service = _FakeByokValidationService()
     app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = lambda: service
+    app.dependency_overrides[admin_byok.get_byok_validation_job_enqueuer] = lambda: _noop_enqueue_run
 
     headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
 
@@ -151,6 +157,7 @@ async def test_admin_byok_validation_create_maps_active_run_conflict(monkeypatch
     app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = (
         lambda: _ConflictByokValidationService()
     )
+    app.dependency_overrides[admin_byok.get_byok_validation_job_enqueuer] = lambda: _noop_enqueue_run
 
     headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
 
@@ -175,6 +182,7 @@ async def test_admin_byok_validation_detail_returns_not_found(monkeypatch, tmp_p
     app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = (
         lambda: _FakeByokValidationService()
     )
+    app.dependency_overrides[admin_byok.get_byok_validation_job_enqueuer] = lambda: _noop_enqueue_run
 
     headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
 
@@ -183,5 +191,31 @@ async def test_admin_byok_validation_detail_returns_not_found(monkeypatch, tmp_p
             response = client.get("/api/v1/admin/byok/validation-runs/missing")
             assert response.status_code == 404, response.text
             assert response.json()["detail"] == "byok_validation_run_not_found"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_byok_validation_create_fails_closed_when_worker_is_disabled(monkeypatch, tmp_path) -> None:
+    _setup_env(monkeypatch, user_db_base=str(tmp_path / "user_dbs"))
+    monkeypatch.delenv("ADMIN_BYOK_VALIDATION_JOBS_WORKER_ENABLED", raising=False)
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_byok
+
+    service = _FakeByokValidationService()
+    app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = lambda: service
+    app.dependency_overrides[admin_byok.get_byok_validation_job_enqueuer] = lambda: _noop_enqueue_run
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    try:
+        with TestClient(app, headers=headers) as client:
+            response = client.post(
+                "/api/v1/admin/byok/validation-runs",
+                json={"org_id": 42, "provider": "openai"},
+            )
+            assert response.status_code == 503, response.text
+            assert response.json()["detail"] == "byok_validation_worker_unavailable"
+            assert service.created_calls == []
     finally:
         app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
@@ -5,10 +5,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from tldw_Server_API.app.main import app
+from tldw_Server_API.app.core.exceptions import (
+    ByokValidationActiveRunError,
+    ByokValidationRunNotFoundError,
+)
 
 
 def _setup_env(monkeypatch, *, user_db_base: str) -> None:
@@ -79,7 +82,7 @@ class _FakeByokValidationService:
 
     async def get_run(self, run_id: str):
         if run_id != "run-1":
-            raise HTTPException(status_code=404, detail="byok_validation_run_not_found")
+            raise ByokValidationRunNotFoundError("byok_validation_run_not_found")
         return {
             "id": "run-1",
             "status": "complete",
@@ -103,7 +106,7 @@ class _FakeByokValidationService:
 @dataclass
 class _ConflictByokValidationService(_FakeByokValidationService):
     async def create_run(self, principal, *, org_id: int | None, provider: str | None):
-        raise HTTPException(status_code=409, detail="active_validation_run_exists")
+        raise ByokValidationActiveRunError("active_validation_run_exists")
 
 
 async def _noop_enqueue_run(item):

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _setup_env(monkeypatch, *, user_db_base: str) -> None:
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "unit-test-api-key")
+    monkeypatch.setenv("USER_DB_BASE_DIR", user_db_base)
+    auth_db_path = Path(user_db_base).parent / "users_test_byok_validation_api.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{auth_db_path}")
+    monkeypatch.setenv("TEST_MODE", "true")
+
+
+@dataclass
+class _FakeByokValidationService:
+    created_calls: list[dict] = field(default_factory=list)
+
+    async def create_run(self, principal, *, org_id: int | None, provider: str | None):
+        self.created_calls.append(
+            {
+                "principal": principal,
+                "org_id": org_id,
+                "provider": provider,
+            }
+        )
+        return {
+            "id": "run-1",
+            "status": "queued",
+            "org_id": org_id,
+            "provider": provider,
+            "keys_checked": None,
+            "valid_count": None,
+            "invalid_count": None,
+            "error_count": None,
+            "requested_by_user_id": principal.user_id,
+            "requested_by_label": principal.email,
+            "job_id": None,
+            "scope_summary": "org=42, provider=openai",
+            "error_message": None,
+            "created_at": "2026-03-12T20:00:00+00:00",
+            "started_at": None,
+            "completed_at": None,
+        }
+
+    async def list_runs(self, *, limit: int, offset: int):
+        return (
+            [
+                {
+                    "id": "run-1",
+                    "status": "complete",
+                    "org_id": 42,
+                    "provider": "openai",
+                    "keys_checked": 5,
+                    "valid_count": 4,
+                    "invalid_count": 1,
+                    "error_count": 0,
+                    "requested_by_user_id": 1,
+                    "requested_by_label": "ops-admin@example.com",
+                    "job_id": "job-1",
+                    "scope_summary": "org=42, provider=openai",
+                    "error_message": None,
+                    "created_at": "2026-03-12T20:00:00+00:00",
+                    "started_at": "2026-03-12T20:00:05+00:00",
+                    "completed_at": "2026-03-12T20:00:15+00:00",
+                }
+            ],
+            1,
+        )
+
+    async def get_run(self, run_id: str):
+        if run_id != "run-1":
+            raise HTTPException(status_code=404, detail="byok_validation_run_not_found")
+        return {
+            "id": "run-1",
+            "status": "complete",
+            "org_id": 42,
+            "provider": "openai",
+            "keys_checked": 5,
+            "valid_count": 4,
+            "invalid_count": 1,
+            "error_count": 0,
+            "requested_by_user_id": 1,
+            "requested_by_label": "ops-admin@example.com",
+            "job_id": "job-1",
+            "scope_summary": "org=42, provider=openai",
+            "error_message": None,
+            "created_at": "2026-03-12T20:00:00+00:00",
+            "started_at": "2026-03-12T20:00:05+00:00",
+            "completed_at": "2026-03-12T20:00:15+00:00",
+        }
+
+
+@dataclass
+class _ConflictByokValidationService(_FakeByokValidationService):
+    async def create_run(self, principal, *, org_id: int | None, provider: str | None):
+        raise HTTPException(status_code=409, detail="active_validation_run_exists")
+
+
+@pytest.mark.asyncio
+async def test_admin_byok_validation_create_list_and_detail_roundtrip(monkeypatch, tmp_path) -> None:
+    _setup_env(monkeypatch, user_db_base=str(tmp_path / "user_dbs"))
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_byok
+
+    service = _FakeByokValidationService()
+    app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = lambda: service
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    try:
+        with TestClient(app, headers=headers) as client:
+            create_resp = client.post(
+                "/api/v1/admin/byok/validation-runs",
+                json={"org_id": 42, "provider": "openai"},
+            )
+            assert create_resp.status_code == 200, create_resp.text
+            created = create_resp.json()
+            assert created["id"] == "run-1"
+            assert service.created_calls[0]["org_id"] == 42
+            assert service.created_calls[0]["provider"] == "openai"
+
+            list_resp = client.get("/api/v1/admin/byok/validation-runs?limit=25&offset=0")
+            assert list_resp.status_code == 200, list_resp.text
+            listed = list_resp.json()
+            assert listed["total"] == 1
+            assert listed["items"][0]["id"] == "run-1"
+
+            detail_resp = client.get("/api/v1/admin/byok/validation-runs/run-1")
+            assert detail_resp.status_code == 200, detail_resp.text
+            assert detail_resp.json()["id"] == "run-1"
+            assert detail_resp.json()["keys_checked"] == 5
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_byok_validation_create_maps_active_run_conflict(monkeypatch, tmp_path) -> None:
+    _setup_env(monkeypatch, user_db_base=str(tmp_path / "user_dbs"))
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_byok
+
+    app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = (
+        lambda: _ConflictByokValidationService()
+    )
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    try:
+        with TestClient(app, headers=headers) as client:
+            response = client.post(
+                "/api/v1/admin/byok/validation-runs",
+                json={"org_id": 42, "provider": "openai"},
+            )
+            assert response.status_code == 409, response.text
+            assert response.json()["detail"] == "active_validation_run_exists"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_admin_byok_validation_detail_returns_not_found(monkeypatch, tmp_path) -> None:
+    _setup_env(monkeypatch, user_db_base=str(tmp_path / "user_dbs"))
+
+    from tldw_Server_API.app.api.v1.endpoints.admin import admin_byok
+
+    app.dependency_overrides[admin_byok.get_admin_byok_validation_service] = (
+        lambda: _FakeByokValidationService()
+    )
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    try:
+        with TestClient(app, headers=headers) as client:
+            response = client.get("/api/v1/admin/byok/validation-runs/missing")
+            assert response.status_code == 404, response.text
+            assert response.json()["detail"] == "byok_validation_run_not_found"
+    finally:
+        app.dependency_overrides.clear()

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.core.Chat.Chat_Deps import ChatAuthenticationError
+
+
+@dataclass
+class _FakeValidationRunsRepo:
+    run: dict[str, object]
+    running_calls: list[tuple[str, str | None]] = field(default_factory=list)
+    complete_calls: list[dict[str, int]] = field(default_factory=list)
+    failed_calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def get_run(self, run_id: str):
+        if self.run.get("id") != run_id:
+            return None
+        return dict(self.run)
+
+    async def mark_running(self, run_id: str, *, job_id: str | None):
+        self.running_calls.append((run_id, job_id))
+        updated = dict(self.run)
+        updated["status"] = "running"
+        updated["job_id"] = job_id
+        return updated
+
+    async def mark_complete(
+        self,
+        run_id: str,
+        *,
+        keys_checked: int,
+        valid_count: int,
+        invalid_count: int,
+        error_count: int,
+    ):
+        self.complete_calls.append(
+            {
+                "keys_checked": keys_checked,
+                "valid_count": valid_count,
+                "invalid_count": invalid_count,
+                "error_count": error_count,
+            }
+        )
+        updated = dict(self.run)
+        updated["status"] = "complete"
+        updated["keys_checked"] = keys_checked
+        updated["valid_count"] = valid_count
+        updated["invalid_count"] = invalid_count
+        updated["error_count"] = error_count
+        return updated
+
+    async def mark_failed(self, run_id: str, *, error_message: str):
+        self.failed_calls.append((run_id, error_message))
+        updated = dict(self.run)
+        updated["status"] = "failed"
+        updated["error_message"] = error_message
+        return updated
+
+
+@pytest.mark.asyncio
+async def test_handle_byok_validation_job_marks_running_and_complete() -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        handle_byok_validation_job,
+    )
+
+    repo = _FakeValidationRunsRepo(
+        run={
+            "id": "run-1",
+            "status": "queued",
+            "org_id": 42,
+            "provider": None,
+        }
+    )
+
+    async def _load_candidates(run: dict[str, object]) -> list[dict[str, object]]:
+        assert run["id"] == "run-1"
+        return [
+            {"provider": "openai", "api_key": "valid-openai-1", "credential_fields": None},
+            {"provider": "openai", "api_key": "invalid-openai-2", "credential_fields": None},
+            {"provider": "anthropic", "api_key": "valid-anthropic-1", "credential_fields": None},
+        ]
+
+    async def _validate(*, provider: str, api_key: str, credential_fields=None, model=None):
+        if api_key.startswith("invalid-"):
+            raise ChatAuthenticationError(message="rejected", provider=provider)
+        return "ok"
+
+    result = await handle_byok_validation_job(
+        {"id": "job-1", "payload": {"run_id": "run-1"}},
+        repo=repo,
+        candidate_loader=_load_candidates,
+        test_provider_credentials_fn=_validate,
+    )
+
+    assert repo.running_calls == [("run-1", "job-1")]
+    assert repo.complete_calls == [
+        {
+            "keys_checked": 3,
+            "valid_count": 2,
+            "invalid_count": 1,
+            "error_count": 0,
+        }
+    ]
+    assert repo.failed_calls == []
+    assert result["status"] == "complete"
+    assert result["keys_checked"] == 3
+    assert result["valid_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_handle_byok_validation_job_marks_failed_with_redacted_summary() -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        handle_byok_validation_job,
+    )
+
+    repo = _FakeValidationRunsRepo(
+        run={
+            "id": "run-1",
+            "status": "queued",
+            "org_id": None,
+            "provider": "openai",
+        }
+    )
+
+    async def _load_candidates(run: dict[str, object]) -> list[dict[str, object]]:
+        return [{"provider": "openai", "api_key": "valid-openai-1", "credential_fields": None}]
+
+    async def _validate(*, provider: str, api_key: str, credential_fields=None, model=None):
+        raise RuntimeError("openai returned 503 with secret-like raw payload")
+
+    with pytest.raises(RuntimeError):
+        await handle_byok_validation_job(
+            {"id": "job-9", "payload": {"run_id": "run-1"}},
+            repo=repo,
+            candidate_loader=_load_candidates,
+            test_provider_credentials_fn=_validate,
+        )
+
+    assert repo.complete_calls == []
+    assert repo.failed_calls == [("run-1", "provider_validation_failed")]
+
+
+@pytest.mark.asyncio
+async def test_run_validation_scan_uses_bounded_per_provider_concurrency() -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import _run_validation_scan
+
+    current_by_provider: dict[str, int] = {}
+    max_by_provider: dict[str, int] = {}
+
+    async def _validate(*, provider: str, api_key: str, credential_fields=None, model=None):
+        current_by_provider[provider] = current_by_provider.get(provider, 0) + 1
+        max_by_provider[provider] = max(max_by_provider.get(provider, 0), current_by_provider[provider])
+        await asyncio.sleep(0.01)
+        current_by_provider[provider] -= 1
+        return "ok"
+
+    candidates = [
+        {"provider": "openai", "api_key": "valid-1", "credential_fields": None},
+        {"provider": "openai", "api_key": "valid-2", "credential_fields": None},
+        {"provider": "openai", "api_key": "valid-3", "credential_fields": None},
+        {"provider": "anthropic", "api_key": "valid-4", "credential_fields": None},
+    ]
+
+    summary = await _run_validation_scan(
+        candidates,
+        test_provider_credentials_fn=_validate,
+        per_provider_limit=2,
+    )
+
+    assert summary["keys_checked"] == 4
+    assert summary["valid_count"] == 4
+    assert summary["invalid_count"] == 0
+    assert summary["error_count"] == 0
+    assert max_by_provider["openai"] <= 2
+
+
+@pytest.mark.asyncio
+async def test_handle_byok_validation_job_raises_for_missing_run() -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        handle_byok_validation_job,
+    )
+
+    repo = _FakeValidationRunsRepo(run={"id": "other-run"})
+
+    with pytest.raises(ValueError, match="missing_run"):
+        await handle_byok_validation_job(
+            {"id": "job-7", "payload": {"run_id": "run-1"}},
+            repo=repo,
+        )

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py
@@ -64,6 +64,7 @@ class _FakeValidationRunsRepo:
 @pytest.mark.asyncio
 async def test_handle_byok_validation_job_marks_running_and_complete() -> None:
     from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        CandidateLoadResult,
         handle_byok_validation_job,
     )
 
@@ -76,13 +77,16 @@ async def test_handle_byok_validation_job_marks_running_and_complete() -> None:
         }
     )
 
-    async def _load_candidates(run: dict[str, object]) -> list[dict[str, object]]:
+    async def _load_candidates(run: dict[str, object]) -> CandidateLoadResult:
         assert run["id"] == "run-1"
-        return [
-            {"provider": "openai", "api_key": "valid-openai-1", "credential_fields": None},
-            {"provider": "openai", "api_key": "invalid-openai-2", "credential_fields": None},
-            {"provider": "anthropic", "api_key": "valid-anthropic-1", "credential_fields": None},
-        ]
+        return CandidateLoadResult(
+            candidates=[
+                {"provider": "openai", "api_key": "valid-openai-1", "credential_fields": None},
+                {"provider": "openai", "api_key": "invalid-openai-2", "credential_fields": None},
+                {"provider": "anthropic", "api_key": "valid-anthropic-1", "credential_fields": None},
+            ],
+            error_count=1,
+        )
 
     async def _validate(*, provider: str, api_key: str, credential_fields=None, model=None):
         if api_key.startswith("invalid-"):
@@ -102,13 +106,14 @@ async def test_handle_byok_validation_job_marks_running_and_complete() -> None:
             "keys_checked": 3,
             "valid_count": 2,
             "invalid_count": 1,
-            "error_count": 0,
+            "error_count": 1,
         }
     ]
     assert repo.failed_calls == []
     assert result["status"] == "complete"
     assert result["keys_checked"] == 3
     assert result["valid_count"] == 2
+    assert result["error_count"] == 1
 
 
 @pytest.mark.asyncio
@@ -176,6 +181,68 @@ async def test_run_validation_scan_uses_bounded_per_provider_concurrency() -> No
     assert summary["invalid_count"] == 0
     assert summary["error_count"] == 0
     assert max_by_provider["openai"] <= 2
+
+
+@pytest.mark.asyncio
+async def test_load_default_validation_candidates_skips_unreadable_secrets(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_jobs_worker import (
+        load_default_validation_candidates,
+    )
+
+    class _SharedRepo:
+        async def list_secrets(self, **kwargs):
+            return [
+                {"scope_type": "org", "scope_id": 42, "provider": "openai"},
+            ]
+
+        async def fetch_secret(self, scope_type: str, scope_id: int, provider: str):
+            return {"encrypted_blob": "broken"}
+
+    class _UserRepo:
+        async def list_secrets_for_user(self, user_id: int):
+            return []
+
+        async def fetch_secret_for_user(self, user_id: int, provider: str):
+            return None
+
+    class _UsersRepo:
+        async def list_users(self, *, offset: int, limit: int, org_ids=None):
+            return [], 0
+
+    async def _get_shared_repo():
+        return _SharedRepo()
+
+    async def _get_user_repo():
+        return _UserRepo()
+
+    async def _from_pool():
+        return _UsersRepo()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_jobs_worker.admin_byok_service.get_shared_byok_repo",
+        _get_shared_repo,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_jobs_worker.admin_byok_service.get_user_byok_repo",
+        _get_user_repo,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_jobs_worker.AuthnzUsersRepo.from_pool",
+        _from_pool,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_jobs_worker.loads_envelope",
+        lambda encrypted_blob: encrypted_blob,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_jobs_worker.decrypt_byok_payload",
+        lambda envelope: (_ for _ in ()).throw(ValueError("broken secret")),
+    )
+
+    result = await load_default_validation_candidates({"org_id": None, "provider": None})
+
+    assert result.candidates == []
+    assert result.error_count == 1
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+@dataclass
+class _RecordingRepo:
+    created_payload: dict | None = None
+
+    async def has_active_run(self) -> bool:
+        return False
+
+    async def create_run(self, **kwargs):
+        self.created_payload = dict(kwargs)
+        return {
+            "id": "run-1",
+            "status": "queued",
+            "org_id": kwargs["org_id"],
+            "provider": kwargs["provider"],
+            "keys_checked": None,
+            "valid_count": None,
+            "invalid_count": None,
+            "error_count": None,
+            "requested_by_user_id": kwargs["requested_by_user_id"],
+            "requested_by_label": kwargs["requested_by_label"],
+            "job_id": None,
+            "scope_summary": kwargs["scope_summary"],
+            "error_message": None,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "started_at": None,
+            "completed_at": None,
+        }
+
+    async def list_runs(self, *, limit: int, offset: int):
+        return [], 0
+
+    async def get_run(self, run_id: str):
+        return None
+
+
+@dataclass
+class _ActiveRunRepo(_RecordingRepo):
+    async def has_active_run(self) -> bool:
+        return True
+
+
+@dataclass
+class _DuplicateRunRepo(_RecordingRepo):
+    async def create_run(self, **kwargs):
+        raise RuntimeError("duplicate key value violates unique constraint idx_byok_validation_runs_active")
+
+
+def _platform_admin_principal() -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=7,
+        username="ops-admin",
+        email="ops-admin@example.com",
+        roles=["admin"],
+        permissions=["*"],
+        is_admin=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_validation_run_persists_scope_summary(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    repo = _RecordingRepo()
+    service = AdminByokValidationService(repo=repo)
+    principal = _platform_admin_principal()
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.is_byok_enabled",
+        lambda: True,
+    )
+
+    created = await service.create_run(
+        principal,
+        org_id=42,
+        provider=" OpenAI ",
+    )
+
+    assert created["status"] == "queued"
+    assert repo.created_payload is not None
+    assert repo.created_payload["org_id"] == 42
+    assert repo.created_payload["provider"] == "openai"
+    assert repo.created_payload["requested_by_user_id"] == 7
+    assert repo.created_payload["requested_by_label"] == "ops-admin@example.com"
+    assert repo.created_payload["scope_summary"] == "org=42, provider=openai"
+
+
+@pytest.mark.asyncio
+async def test_create_validation_run_rejects_when_byok_disabled(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    service = AdminByokValidationService(repo=_RecordingRepo())
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.is_byok_enabled",
+        lambda: False,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "BYOK is disabled in this deployment"
+
+
+@pytest.mark.asyncio
+async def test_create_validation_run_enforces_org_scope(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    calls: list[int] = []
+
+    async def _record_org_access(principal, org_id: int, *, require_admin: bool = True) -> None:
+        calls.append(org_id)
+        assert require_admin is True
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.is_byok_enabled",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.admin_scope_service.enforce_admin_org_access",
+        _record_org_access,
+    )
+
+    service = AdminByokValidationService(repo=_RecordingRepo())
+    await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
+
+    assert calls == [42]
+
+
+@pytest.mark.asyncio
+async def test_create_validation_run_rejects_when_another_run_is_active(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.is_byok_enabled",
+        lambda: True,
+    )
+
+    service = AdminByokValidationService(repo=_ActiveRunRepo())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "active_validation_run_exists"
+
+
+@pytest.mark.asyncio
+async def test_create_validation_run_maps_unique_index_race_to_conflict(monkeypatch) -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.services.admin_byok_validation_service.is_byok_enabled",
+        lambda: True,
+    )
+
+    service = AdminByokValidationService(repo=_DuplicateRunRepo())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "active_validation_run_exists"

--- a/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py
@@ -4,9 +4,12 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import pytest
-from fastapi import HTTPException
-
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.exceptions import (
+    ByokValidationActiveRunError,
+    ByokValidationDisabledError,
+    ByokValidationRunNotFoundError,
+)
 
 
 @dataclass
@@ -111,11 +114,10 @@ async def test_create_validation_run_rejects_when_byok_disabled(monkeypatch) -> 
         lambda: False,
     )
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ByokValidationDisabledError) as exc_info:
         await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
 
-    assert exc_info.value.status_code == 403
-    assert exc_info.value.detail == "BYOK is disabled in this deployment"
+    assert str(exc_info.value) == "BYOK is disabled in this deployment"
 
 
 @pytest.mark.asyncio
@@ -158,11 +160,10 @@ async def test_create_validation_run_rejects_when_another_run_is_active(monkeypa
 
     service = AdminByokValidationService(repo=_ActiveRunRepo())
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ByokValidationActiveRunError) as exc_info:
         await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == "active_validation_run_exists"
+    assert str(exc_info.value) == "active_validation_run_exists"
 
 
 @pytest.mark.asyncio
@@ -178,8 +179,21 @@ async def test_create_validation_run_maps_unique_index_race_to_conflict(monkeypa
 
     service = AdminByokValidationService(repo=_DuplicateRunRepo())
 
-    with pytest.raises(HTTPException) as exc_info:
+    with pytest.raises(ByokValidationActiveRunError) as exc_info:
         await service.create_run(_platform_admin_principal(), org_id=42, provider="openai")
 
-    assert exc_info.value.status_code == 409
-    assert exc_info.value.detail == "active_validation_run_exists"
+    assert str(exc_info.value) == "active_validation_run_exists"
+
+
+@pytest.mark.asyncio
+async def test_get_run_raises_not_found_when_missing() -> None:
+    from tldw_Server_API.app.services.admin_byok_validation_service import (
+        AdminByokValidationService,
+    )
+
+    service = AdminByokValidationService(repo=_RecordingRepo())
+
+    with pytest.raises(ByokValidationRunNotFoundError) as exc_info:
+        await service.get_run("missing-run")
+
+    assert str(exc_info.value) == "byok_validation_run_not_found"

--- a/tldw_Server_API/tests/Admin/test_admin_split_openapi_contract.py
+++ b/tldw_Server_API/tests/Admin/test_admin_split_openapi_contract.py
@@ -50,6 +50,7 @@ EXPECTED_SPLIT_ADMIN_OPERATIONS: set[tuple[str, str]] = {
     ("POST", "/api/v1/admin/backup-schedules/{schedule_id}/resume"),
     ("DELETE", "/api/v1/admin/backup-schedules/{schedule_id}"),
     ("GET", "/api/v1/admin/retention-policies"),
+    ("POST", "/api/v1/admin/retention-policies/{policy_key}/preview"),
     ("PUT", "/api/v1/admin/retention-policies/{policy_key}"),
     ("GET", "/api/v1/admin/maintenance"),
     ("PUT", "/api/v1/admin/maintenance"),

--- a/tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py
+++ b/tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_byok_validation_runs_repo_sqlite_roundtrip(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+        AuthnzByokValidationRunsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = AuthnzByokValidationRunsRepo(pool)
+    await repo.ensure_schema()
+
+    created = await repo.create_run(
+        org_id=42,
+        provider="openai",
+        requested_by_user_id=7,
+        requested_by_label="ops-admin@example.com",
+        scope_summary="org=42, provider=openai",
+    )
+
+    assert created["status"] == "queued"
+    assert created["org_id"] == 42
+    assert created["provider"] == "openai"
+    assert created["keys_checked"] is None
+    assert created["valid_count"] is None
+    assert created["invalid_count"] is None
+    assert created["error_count"] is None
+    assert created["requested_by_user_id"] == 7
+    assert created["requested_by_label"] == "ops-admin@example.com"
+    assert created["job_id"] is None
+    assert created["scope_summary"] == "org=42, provider=openai"
+    assert created["error_message"] is None
+    assert created["started_at"] is None
+    assert created["completed_at"] is None
+
+    fetched = await repo.get_run(str(created["id"]))
+    assert fetched is not None
+    assert fetched["id"] == created["id"]
+    assert fetched["created_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_byok_validation_runs_repo_sqlite_lists_newest_first_and_updates_status(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+        AuthnzByokValidationRunsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = AuthnzByokValidationRunsRepo(pool)
+    await repo.ensure_schema()
+
+    first = await repo.create_run(
+        org_id=42,
+        provider="openai",
+        requested_by_user_id=9,
+        requested_by_label="first-admin@example.com",
+        scope_summary="org=42, provider=openai",
+    )
+
+    await repo.mark_running(str(first["id"]), job_id="job-byok-openai")
+    await repo.mark_complete(
+        str(first["id"]),
+        keys_checked=14,
+        valid_count=11,
+        invalid_count=2,
+        error_count=1,
+    )
+
+    second = await repo.create_run(
+        org_id=None,
+        provider=None,
+        requested_by_user_id=11,
+        requested_by_label="second-admin@example.com",
+        scope_summary="global",
+    )
+    await repo.mark_running(str(second["id"]), job_id="job-byok-global")
+    await repo.mark_failed(str(second["id"]), error_message="validation worker failed")
+
+    listed, total = await repo.list_runs(limit=20, offset=0)
+    assert total == 2
+    assert [row["id"] for row in listed] == [second["id"], first["id"]]
+
+    first_fetched = await repo.get_run(str(first["id"]))
+    assert first_fetched is not None
+    assert first_fetched["status"] == "complete"
+    assert first_fetched["job_id"] == "job-byok-openai"
+    assert first_fetched["keys_checked"] == 14
+    assert first_fetched["valid_count"] == 11
+    assert first_fetched["invalid_count"] == 2
+    assert first_fetched["error_count"] == 1
+    assert first_fetched["started_at"] is not None
+    assert first_fetched["completed_at"] is not None
+
+    second_fetched = await repo.get_run(str(second["id"]))
+    assert second_fetched is not None
+    assert second_fetched["status"] == "failed"
+    assert second_fetched["job_id"] == "job-byok-global"
+    assert second_fetched["error_message"] == "validation worker failed"
+    assert second_fetched["started_at"] is not None
+    assert second_fetched["completed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_byok_validation_runs_repo_sqlite_enforces_single_active_run(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.byok_validation_runs_repo import (
+        AuthnzByokValidationRunsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = AuthnzByokValidationRunsRepo(pool)
+    await repo.ensure_schema()
+
+    first_run = await repo.create_run(
+        org_id=42,
+        provider="openai",
+        requested_by_user_id=5,
+        requested_by_label="ops@example.com",
+        scope_summary="org=42, provider=openai",
+    )
+
+    assert await repo.has_active_run() is True
+
+    with pytest.raises(Exception):
+        await repo.create_run(
+            org_id=84,
+            provider="anthropic",
+            requested_by_user_id=6,
+            requested_by_label="other-ops@example.com",
+            scope_summary="org=84, provider=anthropic",
+        )
+
+    await repo.mark_running(str(first_run["id"]), job_id="job-byok-active")
+    assert await repo.has_active_run() is True
+
+    await repo.mark_complete(
+        str(first_run["id"]),
+        keys_checked=8,
+        valid_count=8,
+        invalid_count=0,
+        error_count=0,
+    )
+    assert await repo.has_active_run() is False
+
+    replacement = await repo.create_run(
+        org_id=84,
+        provider="anthropic",
+        requested_by_user_id=6,
+        requested_by_label="other-ops@example.com",
+        scope_summary="org=84, provider=anthropic",
+    )
+
+    assert replacement["id"] != first_run["id"]
+    assert replacement["status"] == "queued"

--- a/tldw_Server_API/tests/Admin/test_data_ops.py
+++ b/tldw_Server_API/tests/Admin/test_data_ops.py
@@ -124,10 +124,19 @@ async def test_admin_retention_policy_update(tmp_path):
             (policy["key"] for policy in policies if policy.get("key") == "audit_logs"),
             policies[0]["key"],
         )
+        current_days = next((policy["days"] for policy in policies if policy.get("key") == target), None)
+        assert isinstance(current_days, int)
+
+        preview_resp = client.post(
+            f"/api/v1/admin/retention-policies/{target}/preview",
+            json={"current_days": current_days, "days": 180},
+        )
+        assert preview_resp.status_code == 200, preview_resp.text
+        preview_signature = preview_resp.json()["preview_signature"]
 
         update_resp = client.put(
             f"/api/v1/admin/retention-policies/{target}",
-            json={"days": 180},
+            json={"days": 180, "preview_signature": preview_signature},
         )
         assert update_resp.status_code == 200, update_resp.text
         payload = update_resp.json()

--- a/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py
+++ b/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.main import app
+
+
+def _setup_env(tmp_path) -> None:
+    os.environ["AUTH_MODE"] = "single_user"
+    os.environ["SINGLE_USER_API_KEY"] = "unit-test-api-key"
+    os.environ["DATABASE_URL"] = f"sqlite:///{tmp_path / 'users_test_retention_preview.db'}"
+    os.environ["TLDW_DB_ALLOWED_BASE_DIRS"] = str(tmp_path)
+    os.environ["TLDW_DB_BACKUP_PATH"] = str(tmp_path / "backups")
+    os.environ["USER_DB_BASE_DIR"] = str(tmp_path / "user_dbs")
+
+
+async def _seed_audit_log_preview_data() -> int:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
+
+    pool = await get_db_pool()
+    username = "retention_preview_user"
+    email = "retention_preview_user@example.com"
+    if await is_postgres_backend():
+        await pool.execute(
+            """
+            INSERT INTO users (uuid, username, email, password_hash, is_active)
+            VALUES ($1,$2,$3,$4,1)
+            ON CONFLICT (username) DO NOTHING
+            """,
+            str(uuid.uuid4()),
+            username,
+            email,
+            "x",
+        )
+    else:
+        await pool.execute(
+            "INSERT OR IGNORE INTO users (uuid, username, email, password_hash, is_active) VALUES (?,?,?,?,1)",
+            str(uuid.uuid4()),
+            username,
+            email,
+            "x",
+        )
+    user_id = await pool.fetchval("SELECT id FROM users WHERE username = ?", username)
+
+    now = datetime.now(timezone.utc)
+    stale_created_at = (now - timedelta(days=120)).isoformat()
+    fresh_created_at = (now - timedelta(days=10)).isoformat()
+    await pool.execute(
+        """
+        INSERT INTO audit_logs (user_id, action, resource_type, resource_id, ip_address, details, created_at)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+        int(user_id),
+        "retention.preview.old",
+        "audit",
+        1,
+        "127.0.0.1",
+        '{"ok": true}',
+        stale_created_at,
+    )
+    await pool.execute(
+        """
+        INSERT INTO audit_logs (user_id, action, resource_type, resource_id, ip_address, details, created_at)
+        VALUES (?,?,?,?,?,?,?)
+        """,
+        int(user_id),
+        "retention.preview.fresh",
+        "audit",
+        2,
+        "127.0.0.1",
+        '{"ok": true}',
+        fresh_created_at,
+    )
+    return int(user_id)
+
+
+@pytest.mark.asyncio
+async def test_retention_preview_returns_authoritative_counts_and_signature(tmp_path) -> None:
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+    await reset_session_manager()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        await _seed_audit_log_preview_data()
+
+        response = client.post(
+            "/api/v1/admin/retention-policies/audit_logs/preview",
+            json={"current_days": 180, "days": 90},
+        )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["key"] == "audit_logs"
+        assert payload["current_days"] == 180
+        assert payload["new_days"] == 90
+        assert payload["counts"]["audit_log_entries"] == 1
+        assert payload["counts"]["job_records"] == 0
+        assert payload["counts"]["backup_files"] == 0
+        assert isinstance(payload["preview_signature"], str)
+        assert payload["preview_signature"]
+
+
+@pytest.mark.asyncio
+async def test_retention_preview_returns_unknown_policy_and_invalid_range(tmp_path) -> None:
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+    await reset_session_manager()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        unknown_resp = client.post(
+            "/api/v1/admin/retention-policies/missing_policy/preview",
+            json={"current_days": 180, "days": 90},
+        )
+        assert unknown_resp.status_code == 404, unknown_resp.text
+        assert unknown_resp.json()["detail"] == "unknown_policy"
+
+        invalid_resp = client.post(
+            "/api/v1/admin/retention-policies/audit_logs/preview",
+            json={"current_days": 180, "days": 1},
+        )
+        assert invalid_resp.status_code == 400, invalid_resp.text
+        assert invalid_resp.json()["detail"] == "invalid_range"
+
+
+@pytest.mark.asyncio
+async def test_retention_update_requires_valid_preview_signature(tmp_path) -> None:
+    _setup_env(tmp_path)
+
+    from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.session_manager import reset_session_manager
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    await reset_db_pool()
+    reset_settings()
+    await reset_session_manager()
+
+    headers = {"X-API-KEY": os.environ["SINGLE_USER_API_KEY"]}
+
+    with TestClient(app, headers=headers) as client:
+        await _seed_audit_log_preview_data()
+
+        missing_resp = client.put(
+            "/api/v1/admin/retention-policies/audit_logs",
+            json={"days": 90},
+        )
+        assert missing_resp.status_code == 400, missing_resp.text
+        assert missing_resp.json()["detail"] == "preview_signature_required"
+
+        invalid_resp = client.put(
+            "/api/v1/admin/retention-policies/audit_logs",
+            json={"days": 90, "preview_signature": "not-a-real-signature"},
+        )
+        assert invalid_resp.status_code == 400, invalid_resp.text
+        assert invalid_resp.json()["detail"] == "invalid_preview_signature"
+
+        preview_resp = client.post(
+            "/api/v1/admin/retention-policies/audit_logs/preview",
+            json={"current_days": 180, "days": 90},
+        )
+        assert preview_resp.status_code == 200, preview_resp.text
+        preview_signature = preview_resp.json()["preview_signature"]
+
+        update_resp = client.put(
+            "/api/v1/admin/retention-policies/audit_logs",
+            json={"days": 90, "preview_signature": preview_signature},
+        )
+        assert update_resp.status_code == 200, update_resp.text
+        assert update_resp.json()["key"] == "audit_logs"
+        assert update_resp.json()["days"] == 90

--- a/tldw_Server_API/tests/integration/test_admin_notes_title_settings.py
+++ b/tldw_Server_API/tests/integration/test_admin_notes_title_settings.py
@@ -8,6 +8,7 @@ def test_get_and_set_notes_title_settings(client_user_only: TestClient):
     data = r.json()
     assert "llm_enabled" in data
     assert data["default_strategy"] in ["heuristic", "llm", "llm_fallback"]
+    assert data["effective_strategy"] in ["heuristic", "llm", "llm_fallback"]
 
     # Toggle values
     r2 = client_user_only.post(
@@ -18,6 +19,7 @@ def test_get_and_set_notes_title_settings(client_user_only: TestClient):
     new = r2.json()
     assert new["llm_enabled"] is True
     assert new["default_strategy"] == "llm_fallback"
+    assert new["effective_strategy"] == "llm_fallback"
 
     # Invalid strategy
     r3 = client_user_only.post(


### PR DESCRIPTION
## Summary
- add authoritative Jobs-backed admin BYOK validation runs with shared history and status
- replace the BYOK page placeholder validation flow with real run-backed UI and polling
- replace retention-policy local impact estimates with backend preview signatures required for save

## Test Plan
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_byok_validation_runs_repo.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_service.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_api.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_admin_byok_validation_jobs.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/tests/Admin/test_retention_policy_preview_api.py -q
- [x] cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui && bunx vitest run app/byok/__tests__/page.test.tsx components/data-ops/RetentionPoliciesSection.test.tsx
- [x] cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui && bun run typecheck
- [x] cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/admin-ui && bunx eslint app/byok/page.tsx app/byok/__tests__/page.test.tsx components/data-ops/RetentionPoliciesSection.tsx components/data-ops/RetentionPoliciesSection.test.tsx lib/api-client.ts types/index.ts
- [x] source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/core/AuthNZ/repos/byok_validation_runs_repo.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_byok_validation_service.py /Users/macbook-dev/Documents/GitHub/tldw_Server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_byok_validation_jobs_worker.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/endpoints/admin/admin_byok.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/services/admin_data_ops_service.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/endpoints/admin/admin_data_ops.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/admin-ui-byok-retention-authoritative/tldw_Server_API/app/api/v1/schemas/admin_schemas.py -f json -o /tmp/bandit_admin_ui_byok_retention_authoritative.json
