### PR TITLE
Presentation Studio render and UX audit follow-ups

### DIFF
--- a/Docs/Plans/2026-03-13-presentation-studio-bootstrap-fix-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-bootstrap-fix-implementation-plan.md
@@ -1,0 +1,29 @@
+# Presentation Studio Bootstrap Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Unblock Presentation Studio project creation and initial detail loading in the WebUI.
+
+**Architecture:** Keep the fix local to the Presentation Studio bootstrap layer. Make `/presentation-studio/new` strict-mode-safe by sharing the in-flight create request across effect replays, and make `/presentation-studio/:projectId` clear loading state independently of lifecycle cleanup ordering so successful loads cannot strand the page on a loading banner.
+
+**Tech Stack:** React, Zustand, Vitest, Testing Library, Playwright.
+
+---
+
+## Stage 1: Reproduce The Broken Bootstrap States
+**Goal**: Lock the known regressions into tests before changing runtime code.
+**Success Criteria**: There is a failing unit regression for strict-mode new-project creation, and a failing verification path for detail bootstrap.
+**Tests**: `vitest` targeted Presentation Studio page tests; existing focused Playwright audit as integration evidence.
+**Status**: In Progress
+
+## Stage 2: Fix New And Detail Bootstrap Lifecycles
+**Goal**: Make PresentationStudioPage resilient to React strict mode and rerender timing.
+**Success Criteria**: Successful create redirects to detail and successful detail fetch exits the loading state reliably.
+**Tests**: Re-run targeted Vitest suite.
+**Status**: Not Started
+
+## Stage 3: Verify In Browser
+**Goal**: Confirm the real WebUI no longer strands users on “Creating presentation…” or “Loading presentation…”.
+**Success Criteria**: The focused Playwright Presentation Studio audit reaches the editor instead of the loading banners.
+**Tests**: `bunx playwright test e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line`
+**Status**: Not Started

--- a/Docs/Plans/2026-03-13-presentation-studio-drag-ordering-pass-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-drag-ordering-pass-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Define the focused UX pass
+**Goal**: Limit this pass to drag-and-drop slide ordering in the Presentation Studio rail.
+**Success Criteria**: The scope stays within store reorder support, sortable rail items, and browser verification.
+**Tests**: N/A
+**Status**: Complete
+
+## Stage 2: Add regression coverage for drag ordering
+**Goal**: Add tests for direct reorder state changes and visible drag handles.
+**Success Criteria**: Tests fail before implementation and cover store reorder behavior plus slide-rail affordances.
+**Tests**: Vitest store/component tests for `reorderSlides` and drag-handle rendering.
+**Status**: Complete
+
+## Stage 3: Implement drag-and-drop ordering
+**Goal**: Add sortable slide cards using the repo's existing `@dnd-kit/react` pattern while keeping button-based reorder fallback controls.
+**Success Criteria**: Users can drag slide cards to reorder them, and the selected slide/order updates correctly.
+**Tests**: Existing and new Vitest tests, plus Playwright browser verification.
+**Status**: Complete
+
+## Stage 4: Verify with targeted tests and browser audit
+**Goal**: Confirm drag ordering works without regressing the working editor and responsive layout.
+**Success Criteria**: Targeted Vitest suite passes and the Presentation Studio Playwright flow verifies reordered slides in the browser.
+**Tests**: `bunx vitest run ...`, `bunx playwright test e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line`
+**Status**: Complete

--- a/Docs/Plans/2026-03-13-presentation-studio-persistence-export-timing-transition-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-persistence-export-timing-transition-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Lock Down The Contract
+**Goal**: Add regression coverage for Presentation Studio timing/transition metadata across create, patch, export, and version flows.
+**Success Criteria**: Tests prove slide `metadata.studio.transition`, `timing_mode`, and `manual_duration_ms` survive persistence and JSON export in canonical form.
+**Tests**: `python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py -k studio`
+**Status**: Complete
+
+## Stage 2: Normalize At The API Boundary
+**Goal**: Canonicalize Presentation Studio slide metadata in the Slides API before saving or returning presentations.
+**Success Criteria**: Missing/invalid timing-transition fields are normalized consistently with the editor and renderer contract; images validation still works.
+**Tests**: `python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py -k studio`
+**Status**: Complete
+
+## Stage 3: Align WebUI Create Paths
+**Goal**: Ensure new WebUI and extension-created projects send explicit studio defaults so first-save/export behavior matches the UI.
+**Success Criteria**: Newly created decks persist explicit transition/timing defaults without waiting for a later autosave.
+**Tests**: `bunx vitest run src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx`
+**Status**: Complete
+
+## Stage 4: Verify And Close
+**Goal**: Run the smallest relevant backend/frontend regressions plus Bandit on touched production backend code.
+**Success Criteria**: Targeted tests pass and Bandit reports zero findings for touched backend production files.
+**Tests**: `python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py tldw_Server_API/tests/Slides/test_presentation_rendering.py -q`, `bunx vitest run ...`, `python -m bandit -r tldw_Server_API/app/api/v1/endpoints/slides.py`
+**Status**: Complete

--- a/Docs/Plans/2026-03-13-presentation-studio-playwright-ux-audit-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-playwright-ux-audit-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Audit Setup
+**Goal**: Prepare an isolated audit workflow for Presentation Studio on latest `origin/dev`.
+**Success Criteria**: Clean worktree confirmed, target route/components identified, and a focused audit path chosen.
+**Tests**: Verify Presentation Studio routes/components exist and Playwright can target them.
+**Status**: Complete
+
+## Stage 2: Focused Playwright Coverage
+**Goal**: Add a dedicated Playwright spec that exercises Presentation Studio project creation and captures audit artifacts.
+**Success Criteria**: A deterministic spec opens `/presentation-studio/new`, reaches the editor route, and stores screenshots/diagnostics for review.
+**Tests**: Run the new Playwright spec locally against the dev server/backend.
+**Status**: In Progress
+
+## Stage 3: Live UX Validation
+**Goal**: Run the app locally and collect evidence from the real UI on desktop and mobile viewports.
+**Success Criteria**: Backend/frontend start successfully, the spec passes, and audit artifacts are generated.
+**Tests**: Execute the focused Playwright test and inspect resulting screenshots/logs.
+**Status**: Not Started
+
+## Stage 4: Heuristic Review
+**Goal**: Evaluate the captured UI against Nielsen Norman Group heuristics and identify concrete UX improvements.
+**Success Criteria**: Findings are prioritized, tied to evidence from the audit, and translated into actionable design recommendations.
+**Tests**: Manual review of screenshots, captured diagnostics, and relevant component code.
+**Status**: Not Started

--- a/Docs/Plans/2026-03-13-presentation-studio-readiness-ux-pass-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-readiness-ux-pass-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Define the focused UX pass
+**Goal**: Limit this pass to richer slide readiness detail and publish-prep explanations.
+**Success Criteria**: The scope stays within UI/helper changes for issue reasons, duration visibility, and clearer deck readiness status.
+**Tests**: N/A
+**Status**: Complete
+
+## Stage 2: Add regression coverage for readiness explanations
+**Goal**: Add tests for duration formatting, issue summaries, and richer current-slide/deck-readiness content.
+**Success Criteria**: Tests fail before implementation and cover both helper logic and visible UI copy.
+**Tests**: Vitest unit/component tests for readiness helpers and media rail text.
+**Status**: Complete
+
+## Stage 3: Implement readiness detail and publish-prep improvements
+**Goal**: Add explicit missing/stale/failed reasons, narration duration visibility, and clearer deck-level status summaries.
+**Success Criteria**: Users can tell why a slide is blocked and whether narration timing is known without inferring from raw status badges.
+**Tests**: Existing and new Vitest tests.
+**Status**: Complete
+
+## Stage 4: Verify with targeted tests and Playwright audit
+**Goal**: Confirm the new readiness copy does not regress the working create/load and responsive flows.
+**Success Criteria**: Targeted Vitest suite passes and the Presentation Studio Playwright audit passes.
+**Tests**: `bunx vitest run ...`, `bunx playwright test e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line`
+**Status**: Complete

--- a/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-design.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-design.md
@@ -1,0 +1,144 @@
+# Presentation Studio Render Timing And Transitions Design
+
+## Overview
+
+This design makes the Presentation Studio timing and transition controls real in exported video. The current UI supports slide-level transition presets and manual timing, but the backend renderer still treats every slide as a still-image segment and concatenates them with hard cuts.
+
+The revised render pipeline keeps the existing slide-frame generation and asset materialization model, but changes how durations and final assembly are resolved:
+
+- manual timing can extend a narrated slide without trimming narration
+- non-cut transitions render after each slide's effective duration without overlapping narration
+- all-cut decks stay on the cheap concat path
+- decks with real transitions switch to a filtered final video assembly path
+
+## Constraints From Current Backend
+
+The current renderer has four constraints that shape the implementation:
+
+1. Audio-backed segments currently stop at narration end.
+   - `_build_segment_command()` uses `-shortest` whenever an audio track exists.
+   - Manual timing padding therefore requires explicit audio padding plus `-t <effective_duration>`.
+
+2. Final assembly is currently concat-copy only.
+   - `_build_concat_command()` uses the concat demuxer with `-c copy`.
+   - Any `xfade` transition requires a filtered final encode instead of concat-copy.
+
+3. Runtime is currently a plain sum of slide durations.
+   - That is insufficient once visual overlap enters the pipeline.
+
+4. Audio duration is metadata-first.
+   - `_estimate_slide_duration_seconds()` trusts `audio.duration_ms` and then falls back straight to a notes heuristic.
+   - If an audio asset exists but metadata duration is absent or stale, the renderer should probe the actual asset duration before using the heuristic.
+
+## Timing Semantics
+
+Effective slide duration resolves in this order:
+
+1. If a slide has a narration asset and a valid `audio.duration_ms`, use that audio duration.
+2. If a slide has a narration asset but metadata duration is missing, probe the materialized asset duration with `ffprobe`.
+3. If `timing_mode` is `manual`, final effective duration is `max(audio_duration, manual_duration)`.
+4. If there is no usable narration duration, fall back to the existing speaker-notes word-count estimate.
+
+Manual timing never trims narration. It only extends a slide with additional hold time.
+
+## Transition Semantics
+
+Supported UI presets map to backend transitions as follows:
+
+- `cut` -> hard cut
+- `fade` -> `xfade=fade`
+- `wipe` -> `xfade=wipeleft`
+- `zoom` -> `xfade=zoomin`
+
+Transition duration is a single backend constant for v1, likely `0.75s`.
+
+Transitions are visual-only in v1. Audio remains sequential and non-overlapping.
+
+Each non-cut transition begins after the outgoing slide's effective duration. To make that work with `xfade` without shortening the deck runtime, the renderer extends the outgoing visual clip by one transition-duration hold buffer. The overlap then happens inside that extra visual-only buffer instead of inside the authored slide duration.
+
+This yields three useful properties:
+
+- narration never overlaps with incoming-slide visuals
+- manual timing remains the real hold duration before the next slide starts appearing
+- final deck runtime still matches the sum of authored slide durations
+
+## Render Pipeline
+
+The renderer splits into two execution paths.
+
+### Path A: All Boundaries Resolve To `cut`
+
+Keep the current segment-first architecture:
+
+- render one frame per slide
+- materialize one audio asset per slide if present
+- build one media segment per slide
+- concatenate segments into the final output
+
+The key change is narrated segment generation:
+
+- when audio is present, use padded audio plus explicit `-t <effective_duration>`
+- use `apad` so manual timing can extend the segment past narration end
+- avoid relying on `-shortest` for narrated slides
+
+This path preserves the current cheap concat behavior for the common case of hard cuts.
+
+### Path B: At Least One Boundary Resolves To A Real Transition
+
+Replace concat-copy final assembly with a filtered final encode.
+
+The pipeline becomes:
+
+1. Render one still-video source per slide at its effective duration.
+2. Build the video timeline with chained `xfade` transitions.
+3. Build the audio timeline separately from padded sequential slide audio clips.
+4. Mux final video and audio into the requested format.
+
+To preserve overall runtime while using `xfade`, each slide that transitions out visually gets an extra video-only hold buffer equal to the transition duration. The xfade offset is placed at the outgoing slide's effective end, so the overlap occurs inside that added hold buffer and the final deck runtime still matches the sum of effective slide durations.
+
+Audio stays sequential:
+
+- narration plays once, from the start of its slide
+- manual timing longer than narration pads with silence
+- no `acrossfade`
+
+This makes the export match the authored timing model without creating overlapping speech.
+
+## Runtime And Timeout Semantics
+
+Timeout budgeting must use resolved final runtime, not a naive sum from the old segment model.
+
+For all-cut decks:
+
+- final runtime is the sum of effective slide durations
+
+For transitioned decks:
+
+- final runtime is still the sum of effective slide durations
+- outgoing slides receive extra visual hold to absorb the xfade overlap
+- timeout should be based on that final runtime, not on intermediate buffered clip lengths alone
+
+## Failure Behavior
+
+- invalid or missing transition metadata falls back to `fade`
+- invalid manual duration falls back to auto timing
+- missing `audio.duration_ms` on a slide with narration triggers asset-duration probing
+- if duration probing fails, the renderer falls back to the existing notes heuristic
+- if filtered transition assembly fails, the render fails explicitly rather than silently producing the wrong output
+
+## Testing Strategy
+
+The implementation should stay TDD-first and extend the existing Slides render tests.
+
+Required coverage:
+
+- duration resolution with metadata and `ffprobe` fallback
+- manual timing padding for narrated slides
+- transition mapping from UI preset to ffmpeg filter name
+- transitioned deck runtime preserving the sum of effective slide durations
+- transition mapping from UI preset to ffmpeg filter name
+- cut-only decks still using the concat path
+- transitioned decks using filtered final video assembly
+- timeout/runtime math using resolved deck runtime
+
+The first implementation pass should stay command-generation focused. It is enough to prove that the renderer chooses the correct path, computes the correct durations, and emits the correct ffmpeg arguments without requiring a full end-to-end video-content assertion.

--- a/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-design.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-design.md
@@ -136,7 +136,6 @@ Required coverage:
 - manual timing padding for narrated slides
 - transition mapping from UI preset to ffmpeg filter name
 - transitioned deck runtime preserving the sum of effective slide durations
-- transition mapping from UI preset to ffmpeg filter name
 - cut-only decks still using the concat path
 - transitioned decks using filtered final video assembly
 - timeout/runtime math using resolved deck runtime

--- a/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-implementation-plan.md
@@ -26,7 +26,7 @@ Add tests that expect helper behavior for:
 
 **Step 2: Run test to verify it fails**
 
-Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "timing or transition" -v`
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "timing or transition" -v`
 
 Expected: FAIL because the helpers do not exist yet.
 
@@ -62,7 +62,7 @@ Add a render test expecting narrated slides with longer manual timing to emit a 
 
 **Step 2: Run test to verify it fails**
 
-Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "padding or cut_only" -v`
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "padding or cut_only" -v`
 
 Expected: FAIL because segment commands still rely on `-shortest`.
 
@@ -99,7 +99,7 @@ Add a render test expecting:
 
 **Step 2: Run test to verify it fails**
 
-Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "transitioned or filter_complex" -v`
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "transitioned or filter_complex" -v`
 
 Expected: FAIL because final assembly still always uses concat-copy.
 
@@ -132,7 +132,7 @@ git commit -m "feat: add presentation render transition assembly"
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/tests/Slides/test_presentation_render_jobs.py -v
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/tests/Slides/test_presentation_render_jobs.py -v
 ```
 
 Expected: PASS for all affected Slides render tests.
@@ -142,7 +142,7 @@ Expected: PASS for all affected Slides render tests.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -v
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -v
 ```
 
 Expected: PASS with no render regressions.
@@ -152,7 +152,7 @@ Expected: PASS with no render regressions.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/presentation-studio-ux-audit/tldw_Server_API/app/core/Slides/presentation_rendering.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/presentation-studio-ux-audit/tldw_Server_API/tests/Slides/test_presentation_rendering.py -f json -o /tmp/bandit_presentation_render_timing_transitions.json
+source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Slides/presentation_rendering.py tldw_Server_API/tests/Slides/test_presentation_rendering.py -f json -o /tmp/bandit_presentation_render_timing_transitions.json
 ```
 
 Expected: `0` findings in touched code.

--- a/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-implementation-plan.md
@@ -1,0 +1,165 @@
+# Presentation Studio Render Timing And Transitions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Presentation Studio video exports honor manual slide timing and supported transition presets in the backend renderer.
+
+**Architecture:** Extend the Slides renderer with explicit timing-resolution helpers, keep a cut-only concat path for simple decks, and add a filtered final video assembly path for eligible visual transitions. Audio remains sequential and non-overlapping; manual timing only pads narration with silence and never trims it.
+
+**Tech Stack:** Python, ffmpeg/ffprobe, pytest, FastAPI Slides render pipeline
+
+---
+
+### Task 1: Add failing tests for timing resolution helpers
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Slides/test_presentation_rendering.py`
+- Modify: `tldw_Server_API/app/core/Slides/presentation_rendering.py`
+
+**Step 1: Write the failing test**
+
+Add tests that expect helper behavior for:
+- audio duration from metadata
+- audio duration from probed asset when metadata is missing
+- effective duration using `max(audio_duration, manual_duration)`
+- transition mapping from slide metadata to ffmpeg filter selection
+
+**Step 2: Run test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "timing or transition" -v`
+
+Expected: FAIL because the helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add small helpers in `presentation_rendering.py` for:
+- studio metadata normalization
+- audio-duration resolution
+- effective-duration resolution
+- transition filter mapping
+- transition eligibility resolution
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command and expect PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/app/core/Slides/presentation_rendering.py
+git commit -m "test: add presentation render timing resolution coverage"
+```
+
+### Task 2: Add failing tests for narrated slide padding in cut-only renders
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Slides/test_presentation_rendering.py`
+- Modify: `tldw_Server_API/app/core/Slides/presentation_rendering.py`
+
+**Step 1: Write the failing test**
+
+Add a render test expecting narrated slides with longer manual timing to emit a segment command that pads audio and uses explicit effective duration instead of ending at narration length.
+
+**Step 2: Run test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "padding or cut_only" -v`
+
+Expected: FAIL because segment commands still rely on `-shortest`.
+
+**Step 3: Write minimal implementation**
+
+Adjust segment command generation so:
+- silent slides keep the existing synthetic-audio path
+- narrated slides can use `apad` and `-t <effective_duration>`
+- cut-only decks remain concat-based
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command and expect PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/app/core/Slides/presentation_rendering.py
+git commit -m "feat: pad narrated presentation slides for manual timing"
+```
+
+### Task 3: Add failing tests for transitioned deck assembly
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Slides/test_presentation_rendering.py`
+- Modify: `tldw_Server_API/app/core/Slides/presentation_rendering.py`
+
+**Step 1: Write the failing test**
+
+Add a render test expecting:
+- `cut`-only decks to keep concat final assembly
+- decks with `wipe` or `zoom` boundaries to use filtered final video assembly instead of concat-copy
+- transitioned decks to preserve total authored runtime by using an outgoing visual hold buffer
+
+**Step 2: Run test to verify it fails**
+
+Run: `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py -k "transitioned or filter_complex" -v`
+
+Expected: FAIL because final assembly still always uses concat-copy.
+
+**Step 3: Write minimal implementation**
+
+Add:
+- a filtered final video assembly command builder
+- sequential audio assembly for transitioned decks
+- path selection logic choosing concat vs filtered assembly
+
+**Step 4: Run test to verify it passes**
+
+Run the same pytest command and expect PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/app/core/Slides/presentation_rendering.py
+git commit -m "feat: add presentation render transition assembly"
+```
+
+### Task 4: Verify Slides render endpoints and job flow stay green
+
+**Files:**
+- Test: `tldw_Server_API/tests/Slides/test_presentation_rendering.py`
+- Test: `tldw_Server_API/tests/Slides/test_presentation_render_jobs.py`
+
+**Step 1: Run targeted backend verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides/test_presentation_rendering.py tldw_Server_API/tests/Slides/test_presentation_render_jobs.py -v
+```
+
+Expected: PASS for all affected Slides render tests.
+
+**Step 2: Run broader Slides regression**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Slides -v
+```
+
+Expected: PASS with no render regressions.
+
+**Step 3: Run Bandit on touched backend scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/presentation-studio-ux-audit/tldw_Server_API/app/core/Slides/presentation_rendering.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/presentation-studio-ux-audit/tldw_Server_API/tests/Slides/test_presentation_rendering.py -f json -o /tmp/bandit_presentation_render_timing_transitions.json
+```
+
+Expected: `0` findings in touched code.
+
+**Step 4: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Slides/presentation_rendering.py tldw_Server_API/tests/Slides/test_presentation_rendering.py Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-design.md Docs/Plans/2026-03-13-presentation-studio-render-timing-transitions-implementation-plan.md
+git commit -m "feat: wire presentation render timing and transitions"
+```

--- a/Docs/Plans/2026-03-13-presentation-studio-sequence-ux-pass-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-sequence-ux-pass-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Define the focused UX pass
+**Goal**: Limit this pass to sequence editing controls and clearer slide-level publish readiness cues.
+**Success Criteria**: The scope stays within store/UI changes for slide movement and progress visibility.
+**Tests**: N/A
+**Status**: Complete
+
+## Stage 2: Add regression coverage for sequence editing and progress cues
+**Goal**: Add tests for reordering slides and surfacing ready-versus-needs-attention states in the rail.
+**Success Criteria**: Tests fail before implementation and cover both the store transition and visible UI cues.
+**Tests**: Vitest store/component tests for move-up/down behavior and progress labels.
+**Status**: Complete
+
+## Stage 3: Implement sequence editing and slide progress improvements
+**Goal**: Add move earlier/later controls, update slide ordering, and show explicit ready/attention cues in the rail.
+**Success Criteria**: Users can reorder slides without drag/drop, selected-slide controls respect boundaries, and the rail shows which slides are render-ready.
+**Tests**: Existing and new Vitest tests.
+**Status**: Complete
+
+## Stage 4: Verify with targeted tests and Playwright audit
+**Goal**: Confirm the next UX pass preserves the working create/load flow and improved responsive layout.
+**Success Criteria**: Targeted Vitest suite passes and the Presentation Studio Playwright audit passes.
+**Tests**: `bunx vitest run ...`, `bunx playwright test e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line`
+**Status**: Complete

--- a/Docs/Plans/2026-03-13-presentation-studio-transition-timing-controls-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-transition-timing-controls-plan.md
@@ -1,0 +1,35 @@
+# Presentation Studio Transition And Timing Controls Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add slide-level transition presets and timing controls so Presentation Studio can show effective slide duration beyond narration-only timing.
+
+**Architecture:** Extend `metadata.studio` with a small, typed timing model and transition preset. Keep narration-derived timing as the default, then layer a manual duration override on top for UX control without changing backend contracts.
+
+**Tech Stack:** React, Zustand, Vitest, Playwright
+
+---
+
+## Stage 1: Define Slide Timing Metadata
+**Goal**: Add normalized transition and timing fields to the Presentation Studio store.
+**Success Criteria**: Blank, loaded, duplicated, and merged slides all preserve a stable `transition`, `timing_mode`, and optional `manual_duration_ms`.
+**Tests**: Store tests for normalization and manual-duration updates.
+**Status**: Not Started
+
+## Stage 2: Add Failing UX Tests
+**Goal**: Describe the new editor and readiness behavior in tests before implementation.
+**Success Criteria**: Tests fail because the UI does not yet show transition/timing controls or effective duration messaging.
+**Tests**: `PresentationStudioPage.test.tsx`, `presentationStudioReadiness.test.ts`, `presentation-studio.store.test.tsx`
+**Status**: Not Started
+
+## Stage 3: Implement Editor And Readiness UI
+**Goal**: Add the transition/timing panel and surface effective duration in editor, rail, and readiness summaries.
+**Success Criteria**: Selected slide can switch transition preset, toggle auto/manual timing, and show the resulting duration consistently.
+**Tests**: Targeted Vitest suite passes.
+**Status**: Not Started
+
+## Stage 4: Verify Browser Flow
+**Goal**: Confirm the new controls work in the real UI without regressing the prior create/load or overflow fixes.
+**Success Criteria**: Playwright audit passes and still reports successful create/detail flow with no mobile overflow.
+**Tests**: `e2e/ux-audit/presentation-studio.spec.ts`
+**Status**: Not Started

--- a/Docs/Plans/2026-03-13-presentation-studio-ux-layout-pass-plan.md
+++ b/Docs/Plans/2026-03-13-presentation-studio-ux-layout-pass-plan.md
@@ -1,0 +1,23 @@
+## Stage 1: Define the focused UX pass
+**Goal**: Limit this pass to responsive layout and presentation-editor information architecture improvements.
+**Success Criteria**: Clear scope for mobile/layout fixes, slide controls, and task-oriented panel changes.
+**Tests**: N/A
+**Status**: Complete
+
+## Stage 2: Add regression coverage for the targeted UX improvements
+**Goal**: Add tests for new slide-management actions and the updated editor/media presentation.
+**Success Criteria**: Tests fail before implementation and cover the new user-facing behavior.
+**Tests**: Vitest component/store tests for duplicate/delete actions and task-oriented UI copy.
+**Status**: Complete
+
+## Stage 3: Implement the responsive Presentation Studio UX improvements
+**Goal**: Update the workspace, slide rail, editor pane, and media rail to improve mobile behavior and editing clarity.
+**Success Criteria**: Mobile layout stacks cleanly, slide controls are available, preview/guidance UI is visible, and technical metadata is de-emphasized.
+**Tests**: Existing and new Vitest tests.
+**Status**: Complete
+
+## Stage 4: Verify with targeted tests and Playwright audit
+**Goal**: Confirm the new UX does not regress the create/load flows and improves the audited editor state.
+**Success Criteria**: Targeted Vitest suite passes and the Presentation Studio Playwright audit passes.
+**Tests**: `bunx vitest run ...`, `bunx playwright test e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line`
+**Status**: Complete

--- a/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
+++ b/apps/packages/ui/src/components/Layouts/ChatHeader.tsx
@@ -272,7 +272,7 @@ export function ChatHeader({
               type="button"
               onClick={startTemporaryChat}
               aria-label={t("playground:header.newTemporaryChat", "Temporary chat (not saved)") as string}
-              className={`inline-flex items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text ${focusRingClasses}`}
+              className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
               title={t("playground:header.newTemporaryChat", "Temporary chat (not saved)")}
             >
               {t("playground:header.temporaryShort", "Temp")}
@@ -283,7 +283,7 @@ export function ChatHeader({
               type="button"
               onClick={startCharacterChat}
               aria-label={t("playground:header.newCharacterChat", "Character chat") as string}
-              className={`inline-flex items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text ${focusRingClasses}`}
+              className={`hidden items-center justify-center rounded-md px-2 py-1.5 text-[11px] font-medium text-text-muted hover:bg-surface2 hover:text-text sm:inline-flex ${focusRingClasses}`}
               title={t("playground:header.newCharacterChat", "Character chat")}
             >
               {t("playground:header.characterShort", "Character")}

--- a/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
+++ b/apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx
@@ -149,6 +149,24 @@ describe("ChatHeader shortcut toggle", () => {
     expect(props.onStartCharacterChat).toHaveBeenCalledTimes(1)
   })
 
+  it("hides temporary and character quick actions below the small breakpoint", () => {
+    const props = createProps()
+    render(<ChatHeader {...props} />)
+
+    expect(
+      screen.getByRole("button", { name: "Temporary chat (not saved)" }).className
+    ).toContain("hidden")
+    expect(
+      screen.getByRole("button", { name: "Temporary chat (not saved)" }).className
+    ).toContain("sm:inline-flex")
+    expect(screen.getByRole("button", { name: "Character chat" }).className).toContain(
+      "hidden"
+    )
+    expect(screen.getByRole("button", { name: "Character chat" }).className).toContain(
+      "sm:inline-flex"
+    )
+  })
+
   it("shows mode badges for temporary and active character", () => {
     const props = createProps({
       temporaryChat: true,

--- a/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/ExtensionStartPanel.tsx
@@ -182,6 +182,9 @@ export const ExtensionStartPanel: React.FC = () => {
     const metadata: Record<string, unknown> = {
       studio: {
         slideId,
+        transition: "fade",
+        timing_mode: "auto",
+        manual_duration_ms: null,
         audio: { status: "missing" },
         image: { status: imageSeed ? "ready" : "missing" }
       }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/MediaRail.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/MediaRail.tsx
@@ -1,5 +1,11 @@
 import React from "react"
 
+import { Badge } from "@/components/ui/primitives/Badge"
+import {
+  deriveDeckReadiness,
+  describeSlideReadiness
+} from "./presentationStudioReadiness"
+import { PresentationStudioStatusBadge } from "./PresentationStudioStatusBadge"
 import { usePresentationStudioStore } from "@/store/presentation-studio"
 
 type MediaRailProps = {
@@ -12,39 +18,186 @@ export const MediaRail: React.FC<MediaRailProps> = ({ canRender }) => {
   const autosaveState = usePresentationStudioStore((state) => state.autosaveState)
   const etag = usePresentationStudioStore((state) => state.etag)
   const slide = slides.find((entry) => entry.metadata.studio.slideId === selectedSlideId) || null
+  const currentReadiness = slide ? describeSlideReadiness(slide) : null
+  const deckReadiness = deriveDeckReadiness(slides)
+  const readyToRender =
+    canRender && slides.length > 0 && deckReadiness.readySlides === slides.length
+  const nextSteps = [
+    ...(currentReadiness?.issues || []),
+    !canRender
+      ? "Video rendering is disabled on this server, so export remains limited to draft editing."
+      : null
+  ].filter(Boolean) as string[]
 
   return (
     <aside
-      className="flex min-h-[320px] flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4"
+      className="flex min-h-[320px] min-w-0 flex-col gap-4 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
       data-testid="presentation-studio-media-rail"
     >
       <div>
         <h2 className="text-lg font-semibold text-slate-900">Media & Publish</h2>
-        <p className="text-sm text-slate-500">Track per-slide media state and render readiness.</p>
+        <p className="text-sm text-slate-500">
+          Keep the selected slide production-ready and watch overall deck readiness.
+        </p>
       </div>
 
-      <dl className="grid grid-cols-1 gap-3 text-sm text-slate-600">
-        <div>
-          <dt className="font-medium text-slate-800">Audio status</dt>
-          <dd>{slide?.metadata.studio.audio.status || "missing"}</dd>
+      <section className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-base font-semibold text-slate-900">Current slide</h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge size="sm" variant="secondary">
+              {slide?.title || "Untitled slide"}
+            </Badge>
+            {currentReadiness ? (
+              <Badge size="sm" variant={currentReadiness.isReady ? "success" : "warning"}>
+                {currentReadiness.summaryLabel}
+              </Badge>
+            ) : null}
+          </div>
         </div>
-        <div>
-          <dt className="font-medium text-slate-800">Image status</dt>
-          <dd>{slide?.metadata.studio.image.status || "missing"}</dd>
+        <dl className="mt-4 space-y-3 text-sm text-slate-600">
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Audio status</dt>
+            <dd>
+              <PresentationStudioStatusBadge status={slide?.metadata.studio.audio.status} />
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Image status</dt>
+            <dd>
+              <PresentationStudioStatusBadge status={slide?.metadata.studio.image.status} />
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Video render</dt>
+            <dd>
+              <Badge size="sm" variant={canRender ? "success" : "secondary"}>
+                {canRender ? "available" : "unavailable"}
+              </Badge>
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Narration timing</dt>
+            <dd className="text-right text-sm text-slate-600">
+              {currentReadiness?.narrationTiming || "Unknown until audio is generated"}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Transition</dt>
+            <dd className="text-right text-sm text-slate-600">
+              {currentReadiness?.transitionLabel || "Fade"}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="font-medium text-slate-800">Effective duration</dt>
+            <dd className="text-right text-sm text-slate-600">
+              {currentReadiness?.effectiveTiming || "Unknown until audio is generated"}
+            </dd>
+          </div>
+        </dl>
+        {currentReadiness && currentReadiness.issues.length > 0 ? (
+          <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-white p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Blocking issues
+            </p>
+            <ul className="mt-2 space-y-2 text-sm text-slate-600">
+              {currentReadiness.issues.map((issue) => (
+                <li key={issue}>{issue}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4">
+        <h3 className="text-base font-semibold text-slate-900">Deck readiness</h3>
+        <p className="mt-1 text-sm text-slate-500">
+          {readyToRender
+            ? "Every slide has image and narration assets staged for rendering."
+            : "Resolve missing or stale slide media before you publish a narrated video."}
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Ready slides
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900">
+              {deckReadiness.readySlides}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Slides needing images
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900">
+              {deckReadiness.slidesMissingImages}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Slides missing narration
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900">
+              {deckReadiness.slidesMissingNarration}
+            </p>
+          </div>
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Slides with stale narration
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-slate-900">
+              {deckReadiness.slidesWithStaleNarration}
+            </p>
+          </div>
         </div>
-        <div>
-          <dt className="font-medium text-slate-800">Autosave</dt>
-          <dd>{autosaveState}</dd>
+        <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Estimated narration length
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">
+            {deckReadiness.totalNarrationDuration}
+          </p>
         </div>
-        <div>
-          <dt className="font-medium text-slate-800">ETag</dt>
-          <dd>{etag || "unsaved"}</dd>
+        <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Estimated deck runtime
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">
+            {deckReadiness.totalDeckDuration}
+          </p>
         </div>
-        <div>
-          <dt className="font-medium text-slate-800">Video render</dt>
-          <dd>{canRender ? "available" : "unavailable"}</dd>
+        <div className="mt-4 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            Next up
+          </p>
+          <ul className="mt-2 space-y-2 text-sm text-slate-600">
+            {nextSteps.length > 0 ? (
+              nextSteps.map((step) => <li key={step}>{step}</li>)
+            ) : (
+              <li>Ready to render once slide media is complete.</li>
+            )}
+          </ul>
         </div>
-      </dl>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4">
+        <h3 className="text-base font-semibold text-slate-900">Draft sync</h3>
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium text-slate-800">Autosave</p>
+            <p className="text-sm text-slate-500">Persist the current project draft.</p>
+          </div>
+          <Badge size="sm" variant={autosaveState === "error" ? "danger" : autosaveState === "saving" ? "info" : "secondary"}>
+            {autosaveState}
+          </Badge>
+        </div>
+        <div className="mt-4 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+            ETag
+          </p>
+          <p className="mt-2 break-all text-sm text-slate-600">{etag || "unsaved"}</p>
+        </div>
+      </section>
     </aside>
   )
 }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
@@ -69,6 +69,9 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
             metadata: {
               studio: {
                 slideId: blankSlideId,
+                transition: "fade",
+                timing_mode: "auto",
+                manual_duration_ms: null,
                 audio: { status: "missing" },
                 image: { status: "missing" }
               }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioPage.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { useNavigate } from "react-router-dom"
 
 import { ProjectWorkspace } from "./ProjectWorkspace"
-import { tldwClient } from "@/services/tldw/TldwApiClient"
+import { tldwClient, type PresentationStudioRecord } from "@/services/tldw/TldwApiClient"
 import { useServerCapabilities } from "@/hooks/useServerCapabilities"
 import { useServerOnline } from "@/hooks/useServerOnline"
 import { usePresentationStudioStore } from "@/store/presentation-studio"
@@ -22,6 +22,11 @@ const createBlankSlideId = (): string =>
   globalThis.crypto?.randomUUID?.() ||
   `slide-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`
 
+type InFlightProjectRequest = {
+  projectId: string | null
+  promise: Promise<PresentationStudioRecord>
+}
+
 export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
   mode = "index",
   projectId = null
@@ -35,75 +40,76 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
   const currentProjectId = usePresentationStudioStore((state) => state.projectId)
   const [isProjectLoading, setIsProjectLoading] = React.useState(mode === "new")
   const [loadError, setLoadError] = React.useState<string | null>(null)
-  const newProjectStartedRef = React.useRef(false)
+  const createRequestRef = React.useRef<InFlightProjectRequest | null>(null)
+  const detailRequestRef = React.useRef<InFlightProjectRequest | null>(null)
 
   React.useEffect(() => {
     if (mode !== "new") {
       return
     }
-    if (newProjectStartedRef.current) {
-      return
-    }
-    newProjectStartedRef.current = true
-    let active = true
+    let cancelled = false
     setIsProjectLoading(true)
     setLoadError(null)
-    const blankSlideId = createBlankSlideId()
-
-    void tldwClient
-      .createPresentation({
-        title: "Untitled Presentation",
-        description: null,
-        theme: "black",
-        studio_data: {
-          origin: "blank",
-          entry_surface: "webui_new"
-        },
-        slides: [
-          {
-            order: 0,
-            layout: "title",
-            title: "Title slide",
-            content: "",
-            speaker_notes: "",
-            metadata: {
-              studio: {
-                slideId: blankSlideId,
-                transition: "fade",
-                timing_mode: "auto",
-                manual_duration_ms: null,
-                audio: { status: "missing" },
-                image: { status: "missing" }
+    if (!createRequestRef.current) {
+      const blankSlideId = createBlankSlideId()
+      createRequestRef.current = {
+        projectId: null,
+        promise: tldwClient.createPresentation({
+          title: "Untitled Presentation",
+          description: null,
+          theme: "black",
+          studio_data: {
+            origin: "blank",
+            entry_surface: "webui_new"
+          },
+          slides: [
+            {
+              order: 0,
+              layout: "title",
+              title: "Title slide",
+              content: "",
+              speaker_notes: "",
+              metadata: {
+                studio: {
+                  slideId: blankSlideId,
+                  transition: "fade",
+                  timing_mode: "auto",
+                  manual_duration_ms: null,
+                  audio: { status: "missing" },
+                  image: { status: "missing" }
+                }
               }
             }
-          }
-        ]
-      })
+          ]
+        })
+      }
+    }
+
+    void createRequestRef.current.promise
       .then((project) => {
-        if (!active) {
+        if (cancelled) {
           return
         }
+        setIsProjectLoading(false)
         loadProject(project, {
           etag: formatEtag(project.version)
         })
         navigate(`/presentation-studio/${project.id}`, {
           replace: true
         })
+        createRequestRef.current = null
       })
       .catch((error) => {
-        if (!active) {
+        if (cancelled) {
           return
         }
+        createRequestRef.current = null
         setLoadError(toErrorMessage(error))
-      })
-      .finally(() => {
-        if (active) {
-          setIsProjectLoading(false)
-        }
+        setIsProjectLoading(false)
       })
 
     return () => {
-      active = false
+      cancelled = true
     }
   }, [loadProject, mode, navigate])
 
@@ -112,34 +118,40 @@ export const PresentationStudioPage: React.FC<PresentationStudioPageProps> = ({
       return
     }
     if (currentProjectId === projectId) {
+      setIsProjectLoading(false)
       return
     }
-    let active = true
+    let cancelled = false
     setIsProjectLoading(true)
     setLoadError(null)
-    void tldwClient
-      .getPresentation(projectId)
+    if (!detailRequestRef.current || detailRequestRef.current.projectId !== projectId) {
+      detailRequestRef.current = {
+        projectId,
+        promise: tldwClient.getPresentation(projectId)
+      }
+    }
+
+    void detailRequestRef.current.promise
       .then((project) => {
-        if (!active) {
+        if (cancelled) {
           return
         }
+        setIsProjectLoading(false)
         loadProject(project, {
           etag: formatEtag(project.version)
         })
+        detailRequestRef.current = null
       })
       .catch((error) => {
-        if (!active) {
+        if (cancelled) {
           return
         }
+        detailRequestRef.current = null
         setLoadError(toErrorMessage(error))
-      })
-      .finally(() => {
-        if (active) {
-          setIsProjectLoading(false)
-        }
+        setIsProjectLoading(false)
       })
     return () => {
-      active = false
+      cancelled = true
     }
   }, [currentProjectId, loadProject, mode, projectId])
 

--- a/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/PresentationStudioStatusBadge.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+
+import { Badge } from "@/components/ui/primitives/Badge"
+import { cn } from "@/libs/utils"
+import type { PresentationStudioAssetStatus } from "@/store/presentation-studio"
+
+type PresentationStudioStatusBadgeProps = {
+  status: PresentationStudioAssetStatus | null | undefined
+  className?: string
+}
+
+const STATUS_VARIANTS: Record<
+  PresentationStudioAssetStatus,
+  React.ComponentProps<typeof Badge>["variant"]
+> = {
+  missing: "secondary",
+  ready: "success",
+  stale: "warning",
+  generating: "info",
+  failed: "danger"
+}
+
+export const PresentationStudioStatusBadge: React.FC<
+  PresentationStudioStatusBadgeProps
+> = ({ status, className }) => {
+  const normalized = status || "missing"
+
+  return (
+    <Badge
+      className={cn("capitalize", className)}
+      dot
+      size="sm"
+      variant={STATUS_VARIANTS[normalized]}
+    >
+      {normalized}
+    </Badge>
+  )
+}

--- a/apps/packages/ui/src/components/Option/PresentationStudio/ProjectWorkspace.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/ProjectWorkspace.tsx
@@ -13,10 +13,16 @@ export const ProjectWorkspace: React.FC<ProjectWorkspaceProps> = ({ canRender })
   usePresentationStudioAutosave()
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)_280px]">
-      <SlideRail />
-      <SlideEditorPane />
-      <MediaRail canRender={canRender} />
+    <div className="grid min-w-0 gap-4 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+      <div className="min-w-0">
+        <SlideRail />
+      </div>
+      <div className="min-w-0">
+        <SlideEditorPane />
+      </div>
+      <div className="min-w-0">
+        <MediaRail canRender={canRender} />
+      </div>
     </div>
   )
 }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/SlideEditorPane.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/SlideEditorPane.tsx
@@ -1,17 +1,31 @@
 import React from "react"
 
+import { Badge } from "@/components/ui/primitives/Badge"
+import { PresentationStudioStatusBadge } from "./PresentationStudioStatusBadge"
+import { describeSlideReadiness } from "./presentationStudioReadiness"
 import { usePresentationStudioStore } from "@/store/presentation-studio"
+
+const transitionOptions = [
+  { value: "fade", label: "Fade" },
+  { value: "cut", label: "Cut" },
+  { value: "wipe", label: "Wipe" },
+  { value: "zoom", label: "Zoom" }
+] as const
 
 export const SlideEditorPane: React.FC = () => {
   const slides = usePresentationStudioStore((state) => state.slides)
   const selectedSlideId = usePresentationStudioStore((state) => state.selectedSlideId)
   const updateSlide = usePresentationStudioStore((state) => state.updateSlide)
   const slide = slides.find((entry) => entry.metadata.studio.slideId === selectedSlideId) || null
+  const slideIndex = slide
+    ? slides.findIndex((entry) => entry.metadata.studio.slideId === slide.metadata.studio.slideId)
+    : -1
+  const readiness = slide ? describeSlideReadiness(slide) : null
 
   if (!slide) {
     return (
       <section
-        className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6"
+        className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-6"
         data-testid="presentation-studio-slide-editor"
       >
         <p className="text-sm text-slate-500">Select a slide to edit its content.</p>
@@ -21,48 +35,231 @@ export const SlideEditorPane: React.FC = () => {
 
   return (
     <section
-      className="flex min-h-[320px] flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4"
+      className="flex min-h-[320px] min-w-0 flex-col gap-5 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
       data-testid="presentation-studio-slide-editor"
     >
-      <div>
-        <h2 className="text-lg font-semibold text-slate-900">Slide Editor</h2>
-        <p className="text-sm text-slate-500">Structured fields for the current slide.</p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Slide Editor</h2>
+          <p className="text-sm text-slate-500">
+            Shape what appears on the slide and what the narration will say.
+          </p>
+        </div>
+        <Badge size="sm" variant="secondary">
+          Slide {slideIndex + 1} of {slides.length}
+        </Badge>
       </div>
 
-      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-        Slide title
-        <input
-          className="rounded-md border border-slate-300 px-3 py-2"
-          onChange={(event) =>
-            updateSlide(slide.metadata.studio.slideId, { title: event.target.value })
-          }
-          value={slide.title || ""}
-        />
-      </label>
+      <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="min-w-0 space-y-4">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+            <h3 className="text-base font-semibold text-slate-900">On-slide copy</h3>
+            <p className="mt-1 text-sm text-slate-500">
+              This text is visible on the slide itself.
+            </p>
+            <div className="mt-4 space-y-4">
+              <label className="flex min-w-0 flex-col gap-2 text-sm font-medium text-slate-700">
+                Slide title
+                <input
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2"
+                  onChange={(event) =>
+                    updateSlide(slide.metadata.studio.slideId, { title: event.target.value })
+                  }
+                  value={slide.title || ""}
+                />
+              </label>
 
-      <label className="flex flex-1 flex-col gap-2 text-sm font-medium text-slate-700">
-        Slide content
-        <textarea
-          className="min-h-[120px] rounded-md border border-slate-300 px-3 py-2"
-          onChange={(event) =>
-            updateSlide(slide.metadata.studio.slideId, { content: event.target.value })
-          }
-          value={slide.content}
-        />
-      </label>
+              <label className="flex min-w-0 flex-1 flex-col gap-2 text-sm font-medium text-slate-700">
+                Slide content
+                <textarea
+                  className="min-h-[140px] w-full rounded-lg border border-slate-300 px-3 py-2"
+                  onChange={(event) =>
+                    updateSlide(slide.metadata.studio.slideId, { content: event.target.value })
+                  }
+                  value={slide.content}
+                />
+              </label>
+            </div>
+          </div>
 
-      <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-        Narration script
-        <textarea
-          className="min-h-[100px] rounded-md border border-slate-300 px-3 py-2"
-          onChange={(event) =>
-            updateSlide(slide.metadata.studio.slideId, {
-              speaker_notes: event.target.value
-            })
-          }
-          value={slide.speaker_notes || ""}
-        />
-      </label>
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <h3 className="text-base font-semibold text-slate-900">Narration</h3>
+            <p className="mt-1 text-sm text-slate-500">
+              This script is spoken in the generated narration audio.
+            </p>
+            <label className="mt-4 flex min-w-0 flex-col gap-2 text-sm font-medium text-slate-700">
+              Narration script
+              <textarea
+                className="min-h-[140px] w-full rounded-lg border border-slate-300 px-3 py-2"
+                onChange={(event) =>
+                  updateSlide(slide.metadata.studio.slideId, {
+                    speaker_notes: event.target.value
+                  })
+                }
+                value={slide.speaker_notes || ""}
+              />
+            </label>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white p-4">
+            <h3 className="text-base font-semibold text-slate-900">Transitions & timing</h3>
+            <p className="mt-1 text-sm text-slate-500">
+              Choose how this slide enters and whether timing follows narration or a manual hold.
+            </p>
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="flex min-w-0 flex-col gap-2 text-sm font-medium text-slate-700">
+                Transition
+                <select
+                  aria-label="Transition"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2"
+                  onChange={(event) =>
+                    updateSlide(slide.metadata.studio.slideId, {
+                      metadata: {
+                        studio: {
+                          transition: event.target.value
+                        }
+                      }
+                    })
+                  }
+                  value={slide.metadata.studio.transition}
+                >
+                  {transitionOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="flex min-w-0 flex-col gap-2 text-sm font-medium text-slate-700">
+                Duration mode
+                <select
+                  aria-label="Duration mode"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2"
+                  onChange={(event) =>
+                    updateSlide(slide.metadata.studio.slideId, {
+                      metadata: {
+                        studio: {
+                          timing_mode: event.target.value
+                        }
+                      }
+                    })
+                  }
+                  value={slide.metadata.studio.timing_mode}
+                >
+                  <option value="auto">Auto from narration</option>
+                  <option value="manual">Manual hold</option>
+                </select>
+              </label>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+              <label className="flex min-w-0 flex-col gap-2 text-sm font-medium text-slate-700">
+                Manual duration (seconds)
+                <input
+                  aria-label="Manual duration (seconds)"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+                  disabled={slide.metadata.studio.timing_mode !== "manual"}
+                  min={1}
+                  onChange={(event) =>
+                    updateSlide(slide.metadata.studio.slideId, {
+                      metadata: {
+                        studio: {
+                          manual_duration_ms:
+                            event.target.value.trim().length > 0
+                              ? Math.round(Number(event.target.value) * 1000)
+                              : null
+                        }
+                      }
+                    })
+                  }
+                  step={1}
+                  type="number"
+                  value={
+                    slide.metadata.studio.manual_duration_ms
+                      ? String(Math.round(slide.metadata.studio.manual_duration_ms / 1000))
+                      : ""
+                  }
+                />
+              </label>
+
+              <Badge size="sm" variant="info">
+                Effective duration: {readiness?.effectiveTiming || "Unknown"}
+              </Badge>
+            </div>
+
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  Active transition
+                </p>
+                <p className="mt-2 text-sm font-semibold text-slate-900">
+                  {readiness?.transitionLabel || "Fade"}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  Narration timing
+                </p>
+                <p className="mt-2 text-sm font-semibold text-slate-900">
+                  {readiness?.narrationTiming || "Unknown until audio is generated"}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <aside className="min-w-0 rounded-[28px] bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.22),_transparent_45%),linear-gradient(180deg,_#0f172a_0%,_#111827_100%)] p-4 text-white shadow-inner">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <h3 className="text-base font-semibold">Preview</h3>
+              <p className="text-sm text-slate-300">How this slide reads at a glance.</p>
+            </div>
+            <Badge className="bg-white/10 text-white" size="sm" variant="info">
+              {slide.layout}
+            </Badge>
+          </div>
+
+          <div className="mt-4 rounded-[24px] border border-white/10 bg-white/10 p-4">
+            <div className="rounded-2xl border border-dashed border-white/20 bg-black/10 px-4 py-6 text-sm text-slate-300">
+              {slide.metadata.studio.image.status === "ready"
+                ? "Visual ready for this slide."
+                : "Add or generate an image to support this moment."}
+            </div>
+            <h4 className="mt-4 text-lg font-semibold text-white">
+              {slide.title || "Untitled slide"}
+            </h4>
+            <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">
+              {slide.content || "Write the key point that should remain visible while narration plays."}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <PresentationStudioStatusBadge
+                className="bg-white/10 text-white"
+                status={slide.metadata.studio.image.status}
+              />
+              <PresentationStudioStatusBadge
+                className="bg-white/10 text-white"
+                status={slide.metadata.studio.audio.status}
+              />
+              <Badge className="bg-white/10 text-white" size="sm" variant="info">
+                {readiness?.transitionLabel || "Fade"}
+              </Badge>
+              <Badge className="bg-white/10 text-white" size="sm" variant="info">
+                {readiness?.effectiveTiming || "Unknown"}
+              </Badge>
+            </div>
+          </div>
+
+          <div className="mt-4 rounded-2xl border border-white/10 bg-black/10 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-300">
+              Spoken summary
+            </p>
+            <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-slate-200">
+              {slide.speaker_notes || "Narration will appear here once you write the spoken script."}
+            </p>
+          </div>
+        </aside>
+      </div>
     </section>
   )
 }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/SlideRail.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/SlideRail.tsx
@@ -1,25 +1,201 @@
-import React from "react"
+import React, { useCallback } from "react"
+import { GripVertical } from "lucide-react"
+import { DragDropProvider, type DragDropEvents } from "@dnd-kit/react"
+import { useSortable } from "@dnd-kit/react/sortable"
+import { closestCenter } from "@dnd-kit/collision"
 
-import { usePresentationStudioStore } from "@/store/presentation-studio"
+import { Badge } from "@/components/ui/primitives/Badge"
+import {
+  deriveDeckReadiness,
+  describeSlideReadiness
+} from "./presentationStudioReadiness"
+import { PresentationStudioStatusBadge } from "./PresentationStudioStatusBadge"
+import { usePresentationStudioStore, type PresentationStudioEditorSlide } from "@/store/presentation-studio"
+
+type DragEndEvent = Parameters<DragDropEvents["dragend"]>[0]
+
+type SortableSlideCardProps = {
+  slide: PresentationStudioEditorSlide
+  index: number
+  isActive: boolean
+  onSelect: (slideId: string) => void
+}
+
+const SortableSlideCard: React.FC<SortableSlideCardProps> = ({
+  slide,
+  index,
+  isActive,
+  onSelect
+}) => {
+  const readiness = describeSlideReadiness(slide)
+  const {
+    ref,
+    handleRef,
+    isDragging
+  } = useSortable({
+    id: slide.metadata.studio.slideId,
+    index,
+    collisionDetector: closestCenter
+  })
+
+  return (
+    <div
+      ref={ref}
+      className={`min-w-0 rounded-2xl border transition ${
+        isActive
+          ? "border-slate-900 bg-slate-950 text-white shadow-sm"
+          : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+      }`}
+      data-testid="presentation-studio-slide-card"
+      data-slide-id={slide.metadata.studio.slideId}
+      style={{ opacity: isDragging ? 0.5 : 1 }}
+    >
+      <div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-3 px-3 py-4">
+        <button
+          ref={handleRef}
+          aria-label={`Drag to reorder slide ${index + 1}`}
+          className={`mt-1 flex h-8 w-8 items-center justify-center rounded-lg border transition ${
+            isActive
+              ? "border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+              : "border-slate-200 bg-slate-50 text-slate-500 hover:border-slate-300 hover:text-slate-700"
+          } cursor-grab active:cursor-grabbing`}
+          data-testid="presentation-studio-slide-handle"
+          title={`Drag to reorder slide ${index + 1}`}
+          type="button"
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+
+        <button
+          className="min-w-0 text-left"
+          onClick={() => onSelect(slide.metadata.studio.slideId)}
+          type="button"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={`text-xs font-semibold uppercase tracking-[0.16em] ${
+                isActive ? "text-slate-300" : "text-slate-500"
+              }`}
+            >
+              Slide {index + 1}
+            </span>
+            <Badge
+              className={isActive ? "bg-white/10 text-white" : ""}
+              size="sm"
+              variant={isActive ? "info" : "secondary"}
+            >
+              {slide.layout}
+            </Badge>
+          </div>
+          <div
+            className={`mt-3 text-sm font-semibold ${
+              isActive ? "text-white" : "text-slate-900"
+            }`}
+          >
+            {slide.title || "Untitled slide"}
+          </div>
+          <div
+            className={`mt-2 line-clamp-2 text-xs ${
+              isActive ? "text-slate-200" : "text-slate-500"
+            }`}
+          >
+            {slide.content || "Add concise on-slide copy for this step of the story."}
+          </div>
+          <div
+            className={`mt-2 line-clamp-2 text-[11px] ${
+              isActive ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            {readiness.isReady
+              ? `${readiness.transitionLabel} transition · ${readiness.effectiveTiming}`
+              : readiness.issues[0]}
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Badge size="sm" variant={readiness.isReady ? "success" : "warning"}>
+              {readiness.summaryLabel}
+            </Badge>
+            <Badge size="sm" variant="secondary">
+              {readiness.transitionLabel}
+            </Badge>
+            <PresentationStudioStatusBadge status={slide.metadata.studio.audio.status} />
+            <PresentationStudioStatusBadge status={slide.metadata.studio.image.status} />
+          </div>
+        </button>
+      </div>
+    </div>
+  )
+}
 
 export const SlideRail: React.FC = () => {
   const slides = usePresentationStudioStore((state) => state.slides)
   const selectedSlideId = usePresentationStudioStore((state) => state.selectedSlideId)
   const selectSlide = usePresentationStudioStore((state) => state.selectSlide)
   const addSlide = usePresentationStudioStore((state) => state.addSlide)
+  const duplicateSlide = usePresentationStudioStore((state) => state.duplicateSlide)
+  const removeSlide = usePresentationStudioStore((state) => state.removeSlide)
+  const moveSlide = usePresentationStudioStore((state) => state.moveSlide)
+  const reorderSlides = usePresentationStudioStore((state) => state.reorderSlides)
+  const selectedSlide =
+    slides.find((slide) => slide.metadata.studio.slideId === selectedSlideId) || null
+  const selectedIndex = selectedSlide
+    ? slides.findIndex(
+        (slide) => slide.metadata.studio.slideId === selectedSlide.metadata.studio.slideId
+      )
+    : -1
+  const deckReadiness = deriveDeckReadiness(slides)
+  const readySlideCount = deckReadiness.readySlides
+  const needsAttentionCount = slides.length - readySlideCount
+  const canMoveEarlier = selectedIndex > 0
+  const canMoveLater = selectedIndex > -1 && selectedIndex < slides.length - 1
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (event.canceled) {
+        return
+      }
+
+      const sourceId = event.operation.source?.id
+      const targetId = event.operation.target?.id
+      if (!sourceId || !targetId || sourceId === targetId) {
+        return
+      }
+
+      const fromIndex = slides.findIndex(
+        (slide) => slide.metadata.studio.slideId === sourceId
+      )
+      const toIndex = slides.findIndex((slide) => slide.metadata.studio.slideId === targetId)
+      if (fromIndex === -1 || toIndex === -1) {
+        return
+      }
+
+      reorderSlides(fromIndex, toIndex)
+    },
+    [reorderSlides, slides]
+  )
 
   return (
     <aside
-      className="flex min-h-[320px] flex-col gap-4 rounded-xl border border-slate-200 bg-white p-4"
+      className="flex min-h-[320px] min-w-0 flex-col gap-4 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
       data-testid="presentation-studio-slide-rail"
     >
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-slate-900">Slides</h2>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-semibold text-slate-900">Slides</h2>
+            <Badge size="sm" variant="secondary">
+              {slides.length} total
+            </Badge>
+            <Badge size="sm" variant="success">
+              {readySlideCount} ready
+            </Badge>
+            <Badge size="sm" variant="warning">
+              {needsAttentionCount} need attention
+            </Badge>
+          </div>
           <p className="text-sm text-slate-500">Arrange and edit your sequence.</p>
         </div>
         <button
-          className="rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700"
+          className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
           onClick={() => addSlide()}
           type="button"
         >
@@ -27,31 +203,63 @@ export const SlideRail: React.FC = () => {
         </button>
       </div>
 
-      <div className="flex flex-col gap-2">
-        {slides.map((slide) => {
-          const slideId = slide.metadata.studio.slideId
-          const isActive = slideId === selectedSlideId
-          return (
-            <button
-              key={slideId}
-              className={`rounded-lg border px-3 py-3 text-left ${
-                isActive
-                  ? "border-slate-900 bg-slate-50"
-                  : "border-slate-200 bg-white text-slate-700"
-              }`}
-              onClick={() => selectSlide(slideId)}
-              type="button"
-            >
-              <div className="text-xs uppercase tracking-wide text-slate-400">
-                {slide.layout}
-              </div>
-              <div className="mt-1 text-sm font-medium text-slate-900">
-                {slide.title || "Untitled slide"}
-              </div>
-            </button>
-          )
-        })}
-      </div>
+      {selectedSlide ? (
+        <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50 p-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+              Selected slide
+            </p>
+            <p className="truncate text-sm font-semibold text-slate-900">
+              {selectedSlide.title || "Untitled slide"}
+            </p>
+          </div>
+          <button
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+            disabled={!canMoveEarlier}
+            onClick={() => moveSlide(selectedSlide.metadata.studio.slideId, "earlier")}
+            type="button"
+          >
+            Move earlier
+          </button>
+          <button
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+            disabled={!canMoveLater}
+            onClick={() => moveSlide(selectedSlide.metadata.studio.slideId, "later")}
+            type="button"
+          >
+            Move later
+          </button>
+          <button
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+            onClick={() => duplicateSlide(selectedSlide.metadata.studio.slideId)}
+            type="button"
+          >
+            Duplicate slide
+          </button>
+          <button
+            className="rounded-lg border border-rose-200 px-3 py-2 text-sm font-medium text-rose-700 transition hover:border-rose-300 hover:text-rose-800 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+            disabled={slides.length <= 1}
+            onClick={() => removeSlide(selectedSlide.metadata.studio.slideId)}
+            type="button"
+          >
+            Delete slide
+          </button>
+        </div>
+      ) : null}
+
+      <DragDropProvider onDragEnd={handleDragEnd}>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+          {slides.map((slide, index) => (
+            <SortableSlideCard
+              key={slide.metadata.studio.slideId}
+              index={index}
+              isActive={slide.metadata.studio.slideId === selectedSlideId}
+              onSelect={selectSlide}
+              slide={slide}
+            />
+          ))}
+        </div>
+      </DragDropProvider>
     </aside>
   )
 }

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioBootstrap.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioBootstrap.test.tsx
@@ -1,0 +1,172 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PresentationStudioPage } from "../PresentationStudioPage"
+import { usePresentationStudioStore } from "@/store/presentation-studio"
+
+const onlineMocks = vi.hoisted(() => ({
+  useServerOnline: vi.fn()
+}))
+
+const capabilityMocks = vi.hoisted(() => ({
+  useServerCapabilities: vi.fn()
+}))
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn()
+}))
+
+const clientMocks = vi.hoisted(() => ({
+  createPresentation: vi.fn(),
+  getPresentation: vi.fn()
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => onlineMocks.useServerOnline()
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => capabilityMocks.useServerCapabilities()
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return {
+    ...actual,
+    useNavigate: () => routerMocks.navigate
+  }
+})
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    createPresentation: (...args: unknown[]) => clientMocks.createPresentation(...args),
+    getPresentation: (...args: unknown[]) => clientMocks.getPresentation(...args)
+  }
+}))
+
+describe("PresentationStudioPage bootstrap", () => {
+  beforeEach(() => {
+    usePresentationStudioStore.getState().reset()
+    routerMocks.navigate.mockReset()
+    clientMocks.createPresentation.mockReset()
+    clientMocks.getPresentation.mockReset()
+    onlineMocks.useServerOnline.mockReturnValue(true)
+    capabilityMocks.useServerCapabilities.mockReturnValue({
+      loading: false,
+      capabilities: {
+        hasSlides: true,
+        hasPresentationStudio: true,
+        hasPresentationRender: true
+      }
+    })
+  })
+
+  it("creates a blank project only once in strict mode", async () => {
+    let resolveCreate: ((value: any) => void) | null = null
+    clientMocks.createPresentation.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      })
+    )
+
+    render(
+      <React.StrictMode>
+        <PresentationStudioPage mode="new" />
+      </React.StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(clientMocks.createPresentation).toHaveBeenCalledTimes(1)
+    })
+
+    resolveCreate?.({
+      id: "presentation-strict",
+      title: "Untitled Presentation",
+      description: null,
+      theme: "black",
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Title slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: "slide-strict",
+              transition: "fade",
+              timing_mode: "auto",
+              manual_duration_ms: null,
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ],
+      studio_data: { origin: "blank" },
+      created_at: "2026-03-13T00:00:00Z",
+      last_modified: "2026-03-13T00:00:00Z",
+      deleted: false,
+      client_id: "1",
+      version: 1
+    })
+
+    await waitFor(() => {
+      expect(routerMocks.navigate).toHaveBeenCalledWith(
+        "/presentation-studio/presentation-strict",
+        {
+          replace: true
+        }
+      )
+    })
+  })
+
+  it("leaves the loading state after a detail fetch resolves", async () => {
+    clientMocks.getPresentation.mockResolvedValue({
+      id: "presentation-load",
+      title: "Loaded Presentation",
+      description: null,
+      theme: "black",
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Loaded slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: "slide-load",
+              transition: "fade",
+              timing_mode: "auto",
+              manual_duration_ms: null,
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ],
+      studio_data: { origin: "blank" },
+      created_at: "2026-03-13T00:00:00Z",
+      last_modified: "2026-03-13T00:00:00Z",
+      deleted: false,
+      client_id: "1",
+      version: 1
+    })
+
+    render(
+      <React.StrictMode>
+        <PresentationStudioPage mode="detail" projectId="presentation-load" />
+      </React.StrictMode>
+    )
+
+    expect(screen.getByText("Loading presentation…")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presentation-studio-slide-rail")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText("Loading presentation…")).not.toBeInTheDocument()
+  })
+})

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioCreatePayload.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioCreatePayload.test.tsx
@@ -1,0 +1,114 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PresentationStudioPage } from "../PresentationStudioPage"
+import { usePresentationStudioStore } from "@/store/presentation-studio"
+
+const onlineMocks = vi.hoisted(() => ({
+  useServerOnline: vi.fn()
+}))
+
+const capabilityMocks = vi.hoisted(() => ({
+  useServerCapabilities: vi.fn()
+}))
+
+const routerMocks = vi.hoisted(() => ({
+  navigate: vi.fn()
+}))
+
+const clientMocks = vi.hoisted(() => ({
+  createPresentation: vi.fn()
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => onlineMocks.useServerOnline()
+}))
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => capabilityMocks.useServerCapabilities()
+}))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return {
+    ...actual,
+    useNavigate: () => routerMocks.navigate
+  }
+})
+
+vi.mock("@/services/tldw/TldwApiClient", () => ({
+  tldwClient: {
+    createPresentation: (...args: unknown[]) => clientMocks.createPresentation(...args)
+  }
+}))
+
+describe("PresentationStudioPage create payload", () => {
+  beforeEach(() => {
+    usePresentationStudioStore.getState().reset()
+    routerMocks.navigate.mockReset()
+    clientMocks.createPresentation.mockReset()
+    onlineMocks.useServerOnline.mockReturnValue(true)
+    capabilityMocks.useServerCapabilities.mockReturnValue({
+      loading: false,
+      capabilities: {
+        hasSlides: true,
+        hasPresentationStudio: true,
+        hasPresentationRender: true
+      }
+    })
+  })
+
+  it("sends explicit slide timing and transition defaults for new projects", async () => {
+    clientMocks.createPresentation.mockResolvedValue({
+      id: "presentation-1",
+      title: "Untitled Presentation",
+      description: null,
+      theme: "black",
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Title slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: "slide-1",
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ],
+      studio_data: { origin: "blank" },
+      created_at: "2026-03-13T00:00:00Z",
+      last_modified: "2026-03-13T00:00:00Z",
+      deleted: false,
+      client_id: "1",
+      version: 1
+    })
+
+    render(<PresentationStudioPage mode="new" />)
+
+    await waitFor(() => {
+      expect(clientMocks.createPresentation).toHaveBeenCalledTimes(1)
+    })
+
+    expect(clientMocks.createPresentation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slides: [
+          expect.objectContaining({
+            metadata: {
+              studio: expect.objectContaining({
+                transition: "fade",
+                timing_mode: "auto",
+                manual_duration_ms: null
+              })
+            }
+          })
+        ]
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { PresentationStudioPage } from "../PresentationStudioPage"
@@ -101,13 +101,125 @@ describe("PresentationStudioPage", () => {
       expect.objectContaining({
         title: "Untitled Presentation",
         theme: "black",
-        studio_data: { origin: "blank", entry_surface: "webui_new" }
+        studio_data: { origin: "blank", entry_surface: "webui_new" },
+        slides: [
+          expect.objectContaining({
+            metadata: {
+              studio: expect.objectContaining({
+                transition: "fade",
+                timing_mode: "auto",
+                manual_duration_ms: null
+              })
+            }
+          })
+        ]
       })
     )
     expect(routerMocks.navigate).toHaveBeenCalledWith("/presentation-studio/presentation-1", {
       replace: true
     })
     expect(usePresentationStudioStore.getState().projectId).toBe("presentation-1")
+  })
+
+  it("completes blank project creation in strict mode", async () => {
+    let resolveCreate: ((value: any) => void) | null = null
+    clientMocks.createPresentation.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve
+      })
+    )
+
+    render(
+      <React.StrictMode>
+        <PresentationStudioPage mode="new" />
+      </React.StrictMode>
+    )
+
+    await waitFor(() => {
+      expect(clientMocks.createPresentation).toHaveBeenCalledTimes(1)
+    })
+
+    resolveCreate?.({
+      id: "presentation-strict",
+      title: "Untitled Presentation",
+      description: null,
+      theme: "black",
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Title slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: "slide-strict",
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ],
+      studio_data: { origin: "blank" },
+      created_at: "2026-03-13T00:00:00Z",
+      last_modified: "2026-03-13T00:00:00Z",
+      deleted: false,
+      client_id: "1",
+      version: 1
+    })
+
+    await waitFor(() => {
+      expect(routerMocks.navigate).toHaveBeenCalledWith(
+        "/presentation-studio/presentation-strict",
+        {
+          replace: true
+        }
+      )
+    })
+  })
+
+  it("loads a detail project and leaves the loading state", async () => {
+    clientMocks.getPresentation.mockResolvedValue({
+      id: "presentation-load",
+      title: "Loaded Presentation",
+      description: null,
+      theme: "black",
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Loaded slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: "slide-load",
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ],
+      studio_data: { origin: "blank" },
+      created_at: "2026-03-13T00:00:00Z",
+      last_modified: "2026-03-13T00:00:00Z",
+      deleted: false,
+      client_id: "1",
+      version: 1
+    })
+
+    render(
+      <React.StrictMode>
+        <PresentationStudioPage mode="detail" projectId="presentation-load" />
+      </React.StrictMode>
+    )
+
+    expect(screen.getByText("Loading presentation…")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByTestId("presentation-studio-slide-rail")).toBeInTheDocument()
+    })
+    expect(screen.queryByText("Loading presentation…")).not.toBeInTheDocument()
   })
 
   it("shows stale audio and ready image badges for seeded slide media state", () => {
@@ -145,9 +257,189 @@ describe("PresentationStudioPage", () => {
 
     render(<PresentationStudioPage mode="detail" projectId="presentation-1" />)
 
-    expect(screen.getByText("Audio status")).toBeInTheDocument()
-    expect(screen.getByText("stale")).toBeInTheDocument()
-    expect(screen.getByText("Image status")).toBeInTheDocument()
-    expect(screen.getByText("ready")).toBeInTheDocument()
+    const mediaRail = screen.getByTestId("presentation-studio-media-rail")
+    expect(within(mediaRail).getByText("Audio status")).toBeInTheDocument()
+    expect(within(mediaRail).getByText("Image status")).toBeInTheDocument()
+    expect(within(mediaRail).getAllByText("stale").length).toBeGreaterThan(0)
+    expect(within(mediaRail).getAllByText("ready").length).toBeGreaterThan(0)
+  })
+
+  it("explains readiness issues and narration timing for the selected slide", () => {
+    usePresentationStudioStore.getState().loadProject(
+      {
+        id: "presentation-readiness",
+        title: "Readiness deck",
+        description: null,
+        theme: "black",
+        slides: [
+          {
+            order: 0,
+            layout: "content",
+            title: "Problem framing",
+            content: "Summarize the core problem.",
+            speaker_notes: "Open with the core problem.",
+            metadata: {
+              studio: {
+                slideId: "slide-readiness",
+                audio: { status: "stale", duration_ms: 92_000 },
+                image: { status: "missing" }
+              }
+            }
+          }
+        ],
+        studio_data: { origin: "blank" },
+        created_at: "2026-03-13T00:00:00Z",
+        last_modified: "2026-03-13T00:00:00Z",
+        deleted: false,
+        client_id: "1",
+        version: 3
+      },
+      { etag: 'W/"v3"' }
+    )
+
+    render(<PresentationStudioPage mode="detail" projectId="presentation-readiness" />)
+
+    const mediaRail = screen.getByTestId("presentation-studio-media-rail")
+    expect(within(mediaRail).getByText("Narration timing")).toBeInTheDocument()
+    expect(within(mediaRail).getAllByText("1m 32s").length).toBeGreaterThan(0)
+    expect(
+      within(mediaRail).getAllByText("Refresh narration to match the latest script changes.")
+        .length
+    ).toBeGreaterThan(0)
+    expect(
+      within(mediaRail).getAllByText("Add or generate a slide image before publishing.").length
+    ).toBeGreaterThan(0)
+    expect(within(mediaRail).getByText("Slides with stale narration")).toBeInTheDocument()
+    expect(within(mediaRail).getByText("Estimated narration length")).toBeInTheDocument()
+  })
+
+  it("surfaces task-oriented editing guidance and slide controls for the active slide", () => {
+    usePresentationStudioStore.getState().loadProject(
+      {
+        id: "presentation-ux",
+        title: "Narrated deck",
+        description: null,
+        theme: "black",
+        slides: [
+          {
+            order: 0,
+            layout: "content",
+            title: "Intro",
+            content: "Frame the talk in a single sentence.",
+            speaker_notes: "Set up the presentation.",
+            metadata: {
+              studio: {
+                slideId: "slide-ux-1",
+                audio: { status: "ready", asset_ref: "output:1" },
+                image: { status: "ready", asset_ref: "output:2" }
+              }
+            }
+          },
+          {
+            order: 1,
+            layout: "content",
+            title: "Problem framing",
+            content: "Summarize the core problem, constraints, and target audience.",
+            speaker_notes:
+              "Open with the core problem, then explain who the presentation is for.",
+            metadata: {
+              studio: {
+                slideId: "slide-ux-2",
+                audio: { status: "stale" },
+                image: { status: "missing" }
+              }
+            }
+          }
+        ],
+        studio_data: { origin: "blank" },
+        created_at: "2026-03-13T00:00:00Z",
+        last_modified: "2026-03-13T00:00:00Z",
+        deleted: false,
+        client_id: "1",
+        version: 2
+      },
+      { etag: 'W/"v2"' }
+    )
+    usePresentationStudioStore.getState().selectSlide("slide-ux-2")
+
+    render(<PresentationStudioPage mode="detail" projectId="presentation-ux" />)
+
+    expect(screen.getByRole("button", { name: "Duplicate slide" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Move earlier" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Move later" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Delete slide" })).toBeEnabled()
+    expect(screen.getByRole("heading", { name: "On-slide copy" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Narration" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Preview" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Deck readiness" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Draft sync" })).toBeInTheDocument()
+    expect(screen.getAllByText("Ready to render").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Needs attention").length).toBeGreaterThan(0)
+    expect(
+      screen.getByRole("button", { name: "Drag to reorder slide 1" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Drag to reorder slide 2" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("This text is visible on the slide itself.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("This script is spoken in the generated narration audio.")
+    ).toBeInTheDocument()
+  })
+
+  it("lets the editor configure transition and manual slide timing", () => {
+    usePresentationStudioStore.getState().loadProject(
+      {
+        id: "presentation-timing",
+        title: "Timed deck",
+        description: null,
+        theme: "black",
+        slides: [
+          {
+            order: 0,
+            layout: "content",
+            title: "Intro",
+            content: "Frame the opening.",
+            speaker_notes: "Open the deck.",
+            metadata: {
+              studio: {
+                slideId: "slide-timing",
+                audio: { status: "ready", duration_ms: 18_000, asset_ref: "output:1" },
+                image: { status: "ready", asset_ref: "output:2" }
+              }
+            }
+          }
+        ],
+        studio_data: { origin: "blank" },
+        created_at: "2026-03-13T00:00:00Z",
+        last_modified: "2026-03-13T00:00:00Z",
+        deleted: false,
+        client_id: "1",
+        version: 2
+      },
+      { etag: 'W/"v2"' }
+    )
+
+    render(<PresentationStudioPage mode="detail" projectId="presentation-timing" />)
+
+    expect(screen.getByRole("heading", { name: "Transitions & timing" })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("Transition"), {
+      target: { value: "wipe" }
+    })
+    fireEvent.change(screen.getByLabelText("Duration mode"), {
+      target: { value: "manual" }
+    })
+    fireEvent.change(screen.getByLabelText("Manual duration (seconds)"), {
+      target: { value: "45" }
+    })
+
+    const mediaRail = screen.getByTestId("presentation-studio-media-rail")
+    expect(within(mediaRail).getByText("Transition")).toBeInTheDocument()
+    expect(within(mediaRail).getByText("Wipe")).toBeInTheDocument()
+    expect(within(mediaRail).getByText("Effective duration")).toBeInTheDocument()
+    expect(within(mediaRail).getAllByText("45s").length).toBeGreaterThan(0)
   })
 })

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
@@ -197,4 +197,46 @@ describe("presentation studio store", () => {
     expect(slide?.metadata?.studio?.timing_mode).toBe("manual")
     expect(slide?.metadata?.studio?.manual_duration_ms).toBe(45_000)
   })
+
+  it("keeps manual timing selected while the duration is being authored", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sampleProject)
+
+    store.updateSlide("slide-1", {
+      metadata: {
+        studio: {
+          timing_mode: "manual"
+        }
+      }
+    })
+
+    const slide = usePresentationStudioStore.getState().slides[0]
+    expect(slide?.metadata?.studio?.timing_mode).toBe("manual")
+    expect(slide?.metadata?.studio?.manual_duration_ms).toBeNull()
+  })
+
+  it("switches back to auto timing when manual duration is cleared", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sampleProject)
+
+    store.updateSlide("slide-1", {
+      metadata: {
+        studio: {
+          timing_mode: "manual",
+          manual_duration_ms: 45_000
+        }
+      }
+    })
+    store.updateSlide("slide-1", {
+      metadata: {
+        studio: {
+          manual_duration_ms: null
+        }
+      }
+    })
+
+    const slide = usePresentationStudioStore.getState().slides[0]
+    expect(slide?.metadata?.studio?.manual_duration_ms).toBeNull()
+    expect(slide?.metadata?.studio?.timing_mode).toBe("auto")
+  })
 })

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx
@@ -40,9 +40,65 @@ const sampleProject = {
   version: 1
 } as const
 
+const sequenceProject = {
+  ...sampleProject,
+  slides: [
+    sampleProject.slides[0],
+    {
+      order: 1,
+      layout: "content",
+      title: "Problem",
+      content: "Explain the current gap.",
+      speaker_notes: "Describe the pain point.",
+      metadata: {
+        studio: {
+          slideId: "slide-2",
+          audio: {
+            status: "stale"
+          },
+          image: {
+            status: "missing"
+          }
+        }
+      }
+    },
+    {
+      order: 2,
+      layout: "content",
+      title: "Outcome",
+      content: "Describe the result.",
+      speaker_notes: "Close with the value.",
+      metadata: {
+        studio: {
+          slideId: "slide-3",
+          audio: {
+            status: "ready",
+            asset_ref: "output:3"
+          },
+          image: {
+            status: "ready",
+            asset_ref: "output:4"
+          }
+        }
+      }
+    }
+  ]
+} as const
+
 describe("presentation studio store", () => {
   beforeEach(() => {
     usePresentationStudioStore.getState().reset()
+  })
+
+  it("initializes blank slides with default transition and auto timing", () => {
+    const store = usePresentationStudioStore.getState()
+
+    store.initializeBlankProject()
+
+    const slide = usePresentationStudioStore.getState().slides[0]
+    expect(slide?.metadata?.studio?.transition).toBe("fade")
+    expect(slide?.metadata?.studio?.timing_mode).toBe("auto")
+    expect(slide?.metadata?.studio?.manual_duration_ms).toBeNull()
   })
 
   it("marks audio stale when speaker_notes change", () => {
@@ -53,5 +109,92 @@ describe("presentation studio store", () => {
     expect(usePresentationStudioStore.getState().slides[0]?.metadata?.studio?.audio?.status).toBe(
       "stale"
     )
+  })
+
+  it("duplicates and removes slides while preserving selection and order", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sampleProject)
+
+    store.duplicateSlide("slide-1")
+
+    const duplicatedSlides = usePresentationStudioStore.getState().slides
+    expect(duplicatedSlides).toHaveLength(2)
+    expect(duplicatedSlides.map((slide) => slide.order)).toEqual([0, 1])
+    expect(duplicatedSlides[1]?.title).toBe("Intro copy")
+    expect(duplicatedSlides[1]?.metadata?.studio?.slideId).not.toBe("slide-1")
+    expect(usePresentationStudioStore.getState().selectedSlideId).toBe(
+      duplicatedSlides[1]?.metadata?.studio?.slideId
+    )
+
+    store.removeSlide(duplicatedSlides[1]!.metadata.studio.slideId)
+
+    const remainingSlides = usePresentationStudioStore.getState().slides
+    expect(remainingSlides).toHaveLength(1)
+    expect(remainingSlides[0]?.metadata?.studio?.slideId).toBe("slide-1")
+    expect(usePresentationStudioStore.getState().selectedSlideId).toBe("slide-1")
+  })
+
+  it("moves slides earlier and later while keeping selection on the moved slide", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sequenceProject)
+    store.selectSlide("slide-2")
+
+    store.moveSlide("slide-2", "earlier")
+
+    let slides = usePresentationStudioStore.getState().slides
+    expect(slides.map((slide) => slide.metadata.studio.slideId)).toEqual([
+      "slide-2",
+      "slide-1",
+      "slide-3"
+    ])
+    expect(slides.map((slide) => slide.order)).toEqual([0, 1, 2])
+    expect(usePresentationStudioStore.getState().selectedSlideId).toBe("slide-2")
+
+    store.moveSlide("slide-2", "later")
+    store.moveSlide("slide-2", "later")
+
+    slides = usePresentationStudioStore.getState().slides
+    expect(slides.map((slide) => slide.metadata.studio.slideId)).toEqual([
+      "slide-1",
+      "slide-3",
+      "slide-2"
+    ])
+    expect(slides.map((slide) => slide.order)).toEqual([0, 1, 2])
+    expect(usePresentationStudioStore.getState().selectedSlideId).toBe("slide-2")
+  })
+
+  it("reorders slides directly between arbitrary indexes", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sequenceProject)
+
+    store.reorderSlides(0, 2)
+
+    const slides = usePresentationStudioStore.getState().slides
+    expect(slides.map((slide) => slide.metadata.studio.slideId)).toEqual([
+      "slide-2",
+      "slide-3",
+      "slide-1"
+    ])
+    expect(slides.map((slide) => slide.order)).toEqual([0, 1, 2])
+  })
+
+  it("preserves manual timing and transition metadata on slide updates", () => {
+    const store = usePresentationStudioStore.getState()
+    store.loadProject(sampleProject)
+
+    store.updateSlide("slide-1", {
+      metadata: {
+        studio: {
+          transition: "wipe",
+          timing_mode: "manual",
+          manual_duration_ms: 45_000
+        }
+      }
+    })
+
+    const slide = usePresentationStudioStore.getState().slides[0]
+    expect(slide?.metadata?.studio?.transition).toBe("wipe")
+    expect(slide?.metadata?.studio?.timing_mode).toBe("manual")
+    expect(slide?.metadata?.studio?.manual_duration_ms).toBe(45_000)
   })
 })

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentationStudioReadiness.test.ts
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentationStudioReadiness.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  deriveDeckReadiness,
+  describeSlideReadiness,
+  formatNarrationDuration
+} from "../presentationStudioReadiness"
+import type { PresentationStudioEditorSlide } from "@/store/presentation-studio"
+
+const createSlide = (
+  overrides: Partial<PresentationStudioEditorSlide> & {
+    metadata?: Record<string, any>
+  }
+): PresentationStudioEditorSlide => ({
+  order: 0,
+  layout: "content",
+  title: "Slide",
+  content: "Content",
+  speaker_notes: "Narration",
+  metadata: {
+    studio: {
+      slideId: "slide-1",
+      audio: {
+        status: "missing"
+      },
+      image: {
+        status: "missing"
+      }
+    }
+  },
+  ...overrides
+})
+
+describe("presentationStudioReadiness", () => {
+  it("formats narration duration for short and long clips", () => {
+    expect(formatNarrationDuration(18_000)).toBe("18s")
+    expect(formatNarrationDuration(92_000)).toBe("1m 32s")
+    expect(formatNarrationDuration(null)).toBe("Unknown until audio is generated")
+  })
+
+  it("describes slide readiness issues and narration timing", () => {
+    const readiness = describeSlideReadiness(
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-1",
+            audio: {
+              status: "stale",
+              duration_ms: 92_000
+            },
+            image: {
+              status: "missing"
+            }
+          }
+        }
+      })
+    )
+
+    expect(readiness.summaryLabel).toBe("Needs attention")
+    expect(readiness.narrationTiming).toBe("1m 32s")
+    expect(readiness.issues).toEqual([
+      "Refresh narration to match the latest script changes.",
+      "Add or generate a slide image before publishing."
+    ])
+  })
+
+  it("prefers manual slide timing over narration duration when present", () => {
+    const readiness = describeSlideReadiness(
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-manual",
+            transition: "wipe",
+            timing_mode: "manual",
+            manual_duration_ms: 45_000,
+            audio: { status: "ready", duration_ms: 18_000, asset_ref: "output:1" },
+            image: { status: "ready", asset_ref: "output:2" }
+          }
+        }
+      })
+    )
+
+    expect((readiness as any).effectiveTiming).toBe("45s")
+    expect((readiness as any).transitionLabel).toBe("Wipe")
+  })
+
+  it("summarizes deck readiness counts", () => {
+    const deckReadiness = deriveDeckReadiness([
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-ready",
+            audio: { status: "ready", duration_ms: 18_000, asset_ref: "output:1" },
+            image: { status: "ready", asset_ref: "output:2" }
+          }
+        }
+      }),
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-stale",
+            audio: { status: "stale", duration_ms: 32_000 },
+            image: { status: "ready", asset_ref: "output:3" }
+          }
+        }
+      }),
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-missing",
+            audio: { status: "missing" },
+            image: { status: "missing" }
+          }
+        }
+      })
+    ])
+
+    expect(deckReadiness.readySlides).toBe(1)
+    expect(deckReadiness.slidesMissingImages).toBe(1)
+    expect(deckReadiness.slidesWithStaleNarration).toBe(1)
+    expect(deckReadiness.slidesMissingNarration).toBe(1)
+    expect(deckReadiness.totalNarrationDuration).toBe("50s")
+  })
+
+  it("summarizes total deck runtime using manual timing overrides", () => {
+    const deckReadiness = deriveDeckReadiness([
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-auto",
+            timing_mode: "auto",
+            audio: { status: "ready", duration_ms: 18_000, asset_ref: "output:1" },
+            image: { status: "ready", asset_ref: "output:2" }
+          }
+        }
+      }),
+      createSlide({
+        metadata: {
+          studio: {
+            slideId: "slide-manual",
+            timing_mode: "manual",
+            manual_duration_ms: 45_000,
+            audio: { status: "ready", duration_ms: 12_000, asset_ref: "output:3" },
+            image: { status: "ready", asset_ref: "output:4" }
+          }
+        }
+      })
+    ])
+
+    expect((deckReadiness as any).totalDeckDuration).toBe("1m 3s")
+  })
+})

--- a/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentationStudioReadiness.test.ts
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentationStudioReadiness.test.ts
@@ -64,7 +64,7 @@ describe("presentationStudioReadiness", () => {
     ])
   })
 
-  it("prefers manual slide timing over narration duration when present", () => {
+  it("uses the longer of manual timing and narration duration", () => {
     const readiness = describeSlideReadiness(
       createSlide({
         metadata: {
@@ -73,14 +73,14 @@ describe("presentationStudioReadiness", () => {
             transition: "wipe",
             timing_mode: "manual",
             manual_duration_ms: 45_000,
-            audio: { status: "ready", duration_ms: 18_000, asset_ref: "output:1" },
+            audio: { status: "ready", duration_ms: 60_000, asset_ref: "output:1" },
             image: { status: "ready", asset_ref: "output:2" }
           }
         }
       })
     )
 
-    expect((readiness as any).effectiveTiming).toBe("45s")
+    expect((readiness as any).effectiveTiming).toBe("1m 0s")
     expect((readiness as any).transitionLabel).toBe("Wipe")
   })
 

--- a/apps/packages/ui/src/components/Option/PresentationStudio/presentationStudioReadiness.ts
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/presentationStudioReadiness.ts
@@ -1,0 +1,159 @@
+import type { PresentationStudioEditorSlide } from "@/store/presentation-studio"
+
+type SlideReadinessDescription = {
+  isReady: boolean
+  summaryLabel: "Ready to render" | "Needs attention"
+  issues: string[]
+  narrationTiming: string
+  effectiveTiming: string
+  transitionLabel: string
+}
+
+type DeckReadinessSummary = {
+  readySlides: number
+  slidesMissingImages: number
+  slidesMissingNarration: number
+  slidesWithStaleNarration: number
+  totalNarrationDuration: string
+  totalDeckDuration: string
+}
+
+const formatSeconds = (value: number): string => `${value}s`
+const transitionLabels = {
+  fade: "Fade",
+  cut: "Cut",
+  wipe: "Wipe",
+  zoom: "Zoom"
+} as const
+
+export const formatNarrationDuration = (durationMs: number | null | undefined): string => {
+  if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs <= 0) {
+    return "Unknown until audio is generated"
+  }
+
+  const totalSeconds = Math.round(durationMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  if (minutes <= 0) {
+    return formatSeconds(totalSeconds)
+  }
+
+  return `${minutes}m ${formatSeconds(seconds)}`
+}
+
+export const getEffectiveSlideDurationMs = (
+  slide: PresentationStudioEditorSlide
+): number | null => {
+  if (
+    slide.metadata.studio.timing_mode === "manual" &&
+    typeof slide.metadata.studio.manual_duration_ms === "number" &&
+    slide.metadata.studio.manual_duration_ms > 0
+  ) {
+    return slide.metadata.studio.manual_duration_ms
+  }
+
+  return typeof slide.metadata.studio.audio.duration_ms === "number" &&
+    slide.metadata.studio.audio.duration_ms > 0
+    ? slide.metadata.studio.audio.duration_ms
+    : null
+}
+
+export const formatTransitionLabel = (
+  transition: PresentationStudioEditorSlide["metadata"]["studio"]["transition"]
+): string => transitionLabels[transition] || "Fade"
+
+export const describeSlideReadiness = (
+  slide: PresentationStudioEditorSlide
+): SlideReadinessDescription => {
+  const issues: string[] = []
+  const audioStatus = slide.metadata.studio.audio.status
+  const imageStatus = slide.metadata.studio.image.status
+
+  if (audioStatus === "missing") {
+    issues.push("Generate narration audio to estimate timing and publish this slide.")
+  } else if (audioStatus === "stale") {
+    issues.push("Refresh narration to match the latest script changes.")
+  } else if (audioStatus === "failed") {
+    issues.push("Retry narration generation after the previous audio run failed.")
+  } else if (audioStatus === "generating") {
+    issues.push("Narration is still generating for this slide.")
+  }
+
+  if (imageStatus === "missing") {
+    issues.push("Add or generate a slide image before publishing.")
+  } else if (imageStatus === "failed") {
+    issues.push("Retry image generation or upload a replacement image.")
+  } else if (imageStatus === "generating") {
+    issues.push("Image generation is still in progress for this slide.")
+  }
+
+  if (
+    slide.metadata.studio.timing_mode === "manual" &&
+    (!slide.metadata.studio.manual_duration_ms || slide.metadata.studio.manual_duration_ms <= 0)
+  ) {
+    issues.push("Set a manual duration or switch back to auto timing.")
+  }
+
+  const isReady = issues.length === 0
+  const effectiveDurationMs = getEffectiveSlideDurationMs(slide)
+
+  return {
+    isReady,
+    summaryLabel: isReady ? "Ready to render" : "Needs attention",
+    issues,
+    narrationTiming: formatNarrationDuration(slide.metadata.studio.audio.duration_ms),
+    effectiveTiming: formatNarrationDuration(effectiveDurationMs),
+    transitionLabel: formatTransitionLabel(slide.metadata.studio.transition)
+  }
+}
+
+export const deriveDeckReadiness = (
+  slides: PresentationStudioEditorSlide[]
+): DeckReadinessSummary => {
+  const summary = slides.reduce(
+    (accumulator, slide) => {
+      const readiness = describeSlideReadiness(slide)
+      if (readiness.isReady) {
+        accumulator.readySlides += 1
+      }
+      if (slide.metadata.studio.image.status !== "ready") {
+        accumulator.slidesMissingImages += 1
+      }
+      if (slide.metadata.studio.audio.status === "missing") {
+        accumulator.slidesMissingNarration += 1
+      }
+      if (slide.metadata.studio.audio.status === "stale") {
+        accumulator.slidesWithStaleNarration += 1
+      }
+      if (
+        typeof slide.metadata.studio.audio.duration_ms === "number" &&
+        slide.metadata.studio.audio.duration_ms > 0
+      ) {
+        accumulator.totalNarrationMs += slide.metadata.studio.audio.duration_ms
+      }
+      const effectiveDurationMs = getEffectiveSlideDurationMs(slide)
+      if (typeof effectiveDurationMs === "number" && effectiveDurationMs > 0) {
+        accumulator.totalDeckMs += effectiveDurationMs
+      }
+      return accumulator
+    },
+    {
+      readySlides: 0,
+      slidesMissingImages: 0,
+      slidesMissingNarration: 0,
+      slidesWithStaleNarration: 0,
+      totalNarrationMs: 0,
+      totalDeckMs: 0
+    }
+  )
+
+  return {
+    readySlides: summary.readySlides,
+    slidesMissingImages: summary.slidesMissingImages,
+    slidesMissingNarration: summary.slidesMissingNarration,
+    slidesWithStaleNarration: summary.slidesWithStaleNarration,
+    totalNarrationDuration: formatNarrationDuration(summary.totalNarrationMs || null),
+    totalDeckDuration: formatNarrationDuration(summary.totalDeckMs || null)
+  }
+}

--- a/apps/packages/ui/src/components/Option/PresentationStudio/presentationStudioReadiness.ts
+++ b/apps/packages/ui/src/components/Option/PresentationStudio/presentationStudioReadiness.ts
@@ -45,18 +45,23 @@ export const formatNarrationDuration = (durationMs: number | null | undefined): 
 export const getEffectiveSlideDurationMs = (
   slide: PresentationStudioEditorSlide
 ): number | null => {
+  const audioDurationMs =
+    typeof slide.metadata.studio.audio.duration_ms === "number" &&
+    slide.metadata.studio.audio.duration_ms > 0
+      ? slide.metadata.studio.audio.duration_ms
+      : null
+
   if (
     slide.metadata.studio.timing_mode === "manual" &&
     typeof slide.metadata.studio.manual_duration_ms === "number" &&
     slide.metadata.studio.manual_duration_ms > 0
   ) {
-    return slide.metadata.studio.manual_duration_ms
+    return audioDurationMs
+      ? Math.max(audioDurationMs, slide.metadata.studio.manual_duration_ms)
+      : slide.metadata.studio.manual_duration_ms
   }
 
-  return typeof slide.metadata.studio.audio.duration_ms === "number" &&
-    slide.metadata.studio.audio.duration_ms > 0
-    ? slide.metadata.studio.audio.duration_ms
-    : null
+  return audioDurationMs
 }
 
 export const formatTransitionLabel = (

--- a/apps/packages/ui/src/store/presentation-studio.tsx
+++ b/apps/packages/ui/src/store/presentation-studio.tsx
@@ -147,6 +147,18 @@ const normalizeTimingMode = (
     : fallback
 }
 
+const resolveTimingMode = (
+  candidate: unknown,
+  manualDurationMs: number | null,
+  fallback: PresentationStudioTimingMode = "auto"
+): PresentationStudioTimingMode => {
+  if (!manualDurationMs) {
+    return "auto"
+  }
+
+  return normalizeTimingMode(candidate, fallback === "manual" ? "manual" : "auto")
+}
+
 const normalizeSlide = (
   slide: Partial<PresentationStudioSlide> & { metadata?: Record<string, any> },
   order: number
@@ -172,8 +184,9 @@ const normalizeSlide = (
       ? studio.slideId
       : createSlideId()
   const manualDurationMs = normalizeManualDuration(studio.manual_duration_ms)
-  const timingMode = normalizeTimingMode(
+  const timingMode = resolveTimingMode(
     studio.timing_mode,
+    manualDurationMs,
     manualDurationMs ? "manual" : "auto"
   )
 
@@ -290,8 +303,9 @@ const mergeSlideMetadata = (
         localStudio.transition ?? remoteStudio.transition,
         normalizeTransition(remoteStudio.transition)
       ),
-      timing_mode: normalizeTimingMode(
+      timing_mode: resolveTimingMode(
         localStudio.timing_mode ?? remoteStudio.timing_mode,
+        mergedManualDurationMs,
         mergedManualDurationMs ? "manual" : "auto"
       ),
       manual_duration_ms: mergedManualDurationMs,
@@ -618,6 +632,9 @@ export const usePresentationStudioStore = createWithEqualityFn<PresentationStudi
             studioUpdates &&
               Object.prototype.hasOwnProperty.call(studioUpdates, "manual_duration_ms")
           )
+          const hasTimingModeUpdate = Boolean(
+            studioUpdates && Object.prototype.hasOwnProperty.call(studioUpdates, "timing_mode")
+          )
           const nextManualDurationMs = hasManualDurationUpdate
             ? normalizeManualDuration(studioUpdates?.manual_duration_ms)
             : slide.metadata.studio.manual_duration_ms
@@ -625,10 +642,16 @@ export const usePresentationStudioStore = createWithEqualityFn<PresentationStudi
             studioUpdates?.transition,
             slide.metadata.studio.transition
           )
-          const nextTimingMode = normalizeTimingMode(
-            studioUpdates?.timing_mode,
-            nextManualDurationMs ? "manual" : slide.metadata.studio.timing_mode
-          )
+          const nextTimingMode = hasTimingModeUpdate
+            ? normalizeTimingMode(
+                studioUpdates?.timing_mode,
+                nextManualDurationMs ? "manual" : "auto"
+              )
+            : hasManualDurationUpdate
+              ? nextManualDurationMs
+                ? "manual"
+                : "auto"
+              : slide.metadata.studio.timing_mode
           const nextMetadata =
             updates.metadata && typeof updates.metadata === "object"
               ? {

--- a/apps/packages/ui/src/store/presentation-studio.tsx
+++ b/apps/packages/ui/src/store/presentation-studio.tsx
@@ -12,8 +12,14 @@ export type PresentationStudioAssetStatus =
   | "generating"
   | "failed"
 
+export type PresentationStudioTransition = "fade" | "cut" | "wipe" | "zoom"
+export type PresentationStudioTimingMode = "auto" | "manual"
+
 export type PresentationStudioSlideStudioMeta = {
   slideId: string
+  transition: PresentationStudioTransition
+  timing_mode: PresentationStudioTimingMode
+  manual_duration_ms: number | null
   audio: {
     status: PresentationStudioAssetStatus
     asset_ref?: string | null
@@ -41,6 +47,7 @@ export type PresentationStudioPatchPayload = {
 }
 
 type AutosaveState = "idle" | "saving" | "error"
+type SlideMoveDirection = "earlier" | "later"
 
 type PresentationStudioStore = {
   projectId: string | null
@@ -68,6 +75,10 @@ type PresentationStudioStore = {
   }) => void
   selectSlide: (slideId: string) => void
   addSlide: () => void
+  duplicateSlide: (slideId: string) => void
+  removeSlide: (slideId: string) => void
+  moveSlide: (slideId: string, direction: SlideMoveDirection) => void
+  reorderSlides: (fromIndex: number, toIndex: number) => void
   updateSlide: (
     slideId: string,
     updates: Partial<PresentationStudioEditorSlide>
@@ -97,6 +108,45 @@ const normalizeAssetStatus = (
     : fallback
 }
 
+const normalizeTransition = (
+  candidate: unknown,
+  fallback: PresentationStudioTransition = "fade"
+): PresentationStudioTransition => {
+  const normalized = String(candidate || "").trim().toLowerCase()
+  return ["fade", "cut", "wipe", "zoom"].includes(normalized)
+    ? (normalized as PresentationStudioTransition)
+    : fallback
+}
+
+const normalizeManualDuration = (candidate: unknown): number | null => {
+  if (candidate === null || candidate === undefined || candidate === "") {
+    return null
+  }
+
+  const numericValue =
+    typeof candidate === "number"
+      ? candidate
+      : typeof candidate === "string"
+        ? Number(candidate)
+        : NaN
+
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return null
+  }
+
+  return Math.round(numericValue)
+}
+
+const normalizeTimingMode = (
+  candidate: unknown,
+  fallback: PresentationStudioTimingMode = "auto"
+): PresentationStudioTimingMode => {
+  const normalized = String(candidate || "").trim().toLowerCase()
+  return ["auto", "manual"].includes(normalized)
+    ? (normalized as PresentationStudioTimingMode)
+    : fallback
+}
+
 const normalizeSlide = (
   slide: Partial<PresentationStudioSlide> & { metadata?: Record<string, any> },
   order: number
@@ -121,6 +171,11 @@ const normalizeSlide = (
     typeof studio.slideId === "string" && studio.slideId.trim().length > 0
       ? studio.slideId
       : createSlideId()
+  const manualDurationMs = normalizeManualDuration(studio.manual_duration_ms)
+  const timingMode = normalizeTimingMode(
+    studio.timing_mode,
+    manualDurationMs ? "manual" : "auto"
+  )
 
   return {
     order,
@@ -133,6 +188,9 @@ const normalizeSlide = (
       studio: {
         ...studio,
         slideId,
+        transition: normalizeTransition(studio.transition),
+        timing_mode: timingMode,
+        manual_duration_ms: manualDurationMs,
         audio: {
           ...audioState,
           status: normalizeAssetStatus(
@@ -187,6 +245,14 @@ const mergeSlideMetadata = (
     local.studio && typeof local.studio === "object" && !Array.isArray(local.studio)
       ? local.studio
       : {}
+  const remoteManualDurationMs = normalizeManualDuration(remoteStudio.manual_duration_ms)
+  const localHasManualDuration = Object.prototype.hasOwnProperty.call(
+    localStudio,
+    "manual_duration_ms"
+  )
+  const mergedManualDurationMs = localHasManualDuration
+    ? normalizeManualDuration(localStudio.manual_duration_ms)
+    : remoteManualDurationMs
   const remoteAudio =
     remoteStudio.audio && typeof remoteStudio.audio === "object" && !Array.isArray(remoteStudio.audio)
       ? remoteStudio.audio
@@ -220,6 +286,15 @@ const mergeSlideMetadata = (
           : typeof remoteStudio.slideId === "string" && remoteStudio.slideId.trim().length > 0
             ? remoteStudio.slideId
             : createSlideId(),
+      transition: normalizeTransition(
+        localStudio.transition ?? remoteStudio.transition,
+        normalizeTransition(remoteStudio.transition)
+      ),
+      timing_mode: normalizeTimingMode(
+        localStudio.timing_mode ?? remoteStudio.timing_mode,
+        mergedManualDurationMs ? "manual" : "auto"
+      ),
+      manual_duration_ms: mergedManualDurationMs,
       audio: {
         ...remoteAudio,
         ...localAudio,
@@ -315,6 +390,32 @@ const createBlankSlide = (order: number): PresentationStudioEditorSlide =>
     order
   )
 
+const createDuplicatedSlide = (
+  slide: PresentationStudioEditorSlide,
+  order: number
+): PresentationStudioEditorSlide =>
+  normalizeSlide(
+    {
+      ...slide,
+      order,
+      title: slide.title ? `${slide.title} copy` : `Slide ${order + 1}`,
+      metadata: {
+        ...slide.metadata,
+        studio: {
+          ...slide.metadata.studio,
+          slideId: createSlideId(),
+          audio: {
+            ...slide.metadata.studio.audio
+          },
+          image: {
+            ...slide.metadata.studio.image
+          }
+        }
+      }
+    },
+    order
+  )
+
 const createInitialState = () => ({
   projectId: null,
   title: "Untitled Presentation",
@@ -391,12 +492,143 @@ export const usePresentationStudioStore = createWithEqualityFn<PresentationStudi
         }
       }),
 
+    duplicateSlide: (slideId) =>
+      set((state) => {
+        const sourceIndex = state.slides.findIndex(
+          (slide) => slide.metadata.studio.slideId === slideId
+        )
+        if (sourceIndex === -1) {
+          return state
+        }
+        const duplicate = createDuplicatedSlide(state.slides[sourceIndex]!, sourceIndex + 1)
+        const slides = [
+          ...state.slides.slice(0, sourceIndex + 1),
+          duplicate,
+          ...state.slides.slice(sourceIndex + 1)
+        ].map((slide, index) => ({
+          ...slide,
+          order: index
+        }))
+
+        return {
+          slides,
+          selectedSlideId: duplicate.metadata.studio.slideId,
+          isDirty: true
+        }
+      }),
+
+    removeSlide: (slideId) =>
+      set((state) => {
+        if (state.slides.length <= 1) {
+          return state
+        }
+        const sourceIndex = state.slides.findIndex(
+          (slide) => slide.metadata.studio.slideId === slideId
+        )
+        if (sourceIndex === -1) {
+          return state
+        }
+        const slides = state.slides
+          .filter((slide) => slide.metadata.studio.slideId !== slideId)
+          .map((slide, index) => ({
+            ...slide,
+            order: index
+          }))
+        const nextSelectedSlideId =
+          state.selectedSlideId === slideId
+            ? slides[Math.max(0, sourceIndex - 1)]?.metadata.studio.slideId ||
+              slides[0]?.metadata.studio.slideId ||
+              null
+            : state.selectedSlideId
+
+        return {
+          slides,
+          selectedSlideId: nextSelectedSlideId,
+          isDirty: true
+        }
+      }),
+
+    moveSlide: (slideId, direction) =>
+      set((state) => {
+        const sourceIndex = state.slides.findIndex(
+          (slide) => slide.metadata.studio.slideId === slideId
+        )
+        if (sourceIndex === -1) {
+          return state
+        }
+
+        const targetIndex = direction === "earlier" ? sourceIndex - 1 : sourceIndex + 1
+        if (targetIndex < 0 || targetIndex >= state.slides.length) {
+          return state
+        }
+
+        const slides = [...state.slides]
+        const [movedSlide] = slides.splice(sourceIndex, 1)
+        slides.splice(targetIndex, 0, movedSlide!)
+
+        return {
+          slides: slides.map((slide, index) => ({
+            ...slide,
+            order: index
+          })),
+          selectedSlideId: slideId,
+          isDirty: true
+        }
+      }),
+
+    reorderSlides: (fromIndex, toIndex) =>
+      set((state) => {
+        if (
+          fromIndex < 0 ||
+          toIndex < 0 ||
+          fromIndex >= state.slides.length ||
+          toIndex >= state.slides.length ||
+          fromIndex === toIndex
+        ) {
+          return state
+        }
+
+        const slides = [...state.slides]
+        const [movedSlide] = slides.splice(fromIndex, 1)
+        slides.splice(toIndex, 0, movedSlide!)
+
+        return {
+          slides: slides.map((slide, index) => ({
+            ...slide,
+            order: index
+          })),
+          selectedSlideId: movedSlide?.metadata.studio.slideId || state.selectedSlideId,
+          isDirty: true
+        }
+      }),
+
     updateSlide: (slideId, updates) =>
       set((state) => {
         const slides = state.slides.map((slide, index) => {
           if (slide.metadata.studio.slideId !== slideId) {
             return slide
           }
+          const studioUpdates =
+            updates.metadata?.studio &&
+            typeof updates.metadata.studio === "object" &&
+            !Array.isArray(updates.metadata.studio)
+              ? updates.metadata.studio
+              : null
+          const hasManualDurationUpdate = Boolean(
+            studioUpdates &&
+              Object.prototype.hasOwnProperty.call(studioUpdates, "manual_duration_ms")
+          )
+          const nextManualDurationMs = hasManualDurationUpdate
+            ? normalizeManualDuration(studioUpdates?.manual_duration_ms)
+            : slide.metadata.studio.manual_duration_ms
+          const nextTransition = normalizeTransition(
+            studioUpdates?.transition,
+            slide.metadata.studio.transition
+          )
+          const nextTimingMode = normalizeTimingMode(
+            studioUpdates?.timing_mode,
+            nextManualDurationMs ? "manual" : slide.metadata.studio.timing_mode
+          )
           const nextMetadata =
             updates.metadata && typeof updates.metadata === "object"
               ? {
@@ -404,7 +636,36 @@ export const usePresentationStudioStore = createWithEqualityFn<PresentationStudi
                   ...updates.metadata,
                   studio: {
                     ...slide.metadata.studio,
-                    ...(updates.metadata.studio || {})
+                    ...(studioUpdates || {}),
+                    transition: nextTransition,
+                    timing_mode: nextTimingMode,
+                    manual_duration_ms: nextManualDurationMs,
+                    audio: studioUpdates?.audio
+                      ? {
+                          ...slide.metadata.studio.audio,
+                          ...studioUpdates.audio,
+                          status: normalizeAssetStatus(
+                            studioUpdates.audio.status ?? slide.metadata.studio.audio.status,
+                            studioUpdates.audio.asset_ref ||
+                              slide.metadata.studio.audio.asset_ref
+                              ? "ready"
+                              : "missing"
+                          )
+                        }
+                      : slide.metadata.studio.audio,
+                    image: studioUpdates?.image
+                      ? {
+                          ...slide.metadata.studio.image,
+                          ...studioUpdates.image,
+                          status: normalizeAssetStatus(
+                            studioUpdates.image.status ?? slide.metadata.studio.image.status,
+                            studioUpdates.image.asset_ref ||
+                              slide.metadata.studio.image.asset_ref
+                              ? "ready"
+                              : "missing"
+                          )
+                        }
+                      : slide.metadata.studio.image
                   }
                 }
               : slide.metadata

--- a/apps/tldw-frontend/e2e/ux-audit/presentation-studio.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/presentation-studio.spec.ts
@@ -1,0 +1,434 @@
+import * as fs from "fs"
+import * as path from "path"
+
+import type { Page } from "@playwright/test"
+import { dismissModals, fetchWithApiKey, waitForConnection } from "../utils/helpers"
+import {
+  classifySmokeIssues,
+  getCriticalIssues,
+  test,
+  expect,
+  seedAuth,
+  type DiagnosticsData
+} from "../smoke/smoke.setup"
+
+const AUDIT_ROOT = path.resolve(__dirname, "../../output/playwright/presentation-studio-ux-audit")
+const SCREENSHOTS_DIR = path.join(AUDIT_ROOT, "screenshots")
+const DATA_DIR = path.join(AUDIT_ROOT, "data")
+
+type ViewportConfig = {
+  key: "desktop" | "mobile"
+  width: number
+  height: number
+}
+
+type PresentationStudioAuditData = {
+  route: string
+  finalUrl: string
+  redirected: boolean
+  httpStatus: number | null
+  timestamp: string
+  newFlow: {
+    succeeded: boolean
+    finalUrl: string
+    screenshot: string | null
+    visibleText: string | null
+  }
+  detailFlow: {
+    editorVisible: boolean
+    finalUrl: string
+    screenshot: string | null
+    visibleText: string | null
+    lastRequestError: string | null
+    requestErrors: string | null
+  }
+  screenshots: Record<string, string>
+  diagnostics: {
+    pageErrors: DiagnosticsData["pageErrors"]
+    unexpectedConsoleErrors: ReturnType<typeof classifySmokeIssues>["unexpectedConsoleErrors"]
+    unexpectedRequestFailures: ReturnType<typeof classifySmokeIssues>["unexpectedRequestFailures"]
+    allowlistedConsoleErrors: Array<{ text: string; ruleId: string }>
+    allowlistedRequestFailures: Array<{ url: string; ruleId: string }>
+  }
+  performance: {
+    domContentLoaded: number | null
+    firstContentfulPaint: number | null
+    resourceCount: number
+  }
+  accessibility: {
+    headingStructure: string[]
+    landmarkCount: number
+    imagesWithoutAlt: number
+    focusableElements: number
+  }
+  uiSnapshot: {
+    slideCount: number
+    slideTitles: string[]
+    selectedSlideTitle: string | null
+    buttonLabels: string[]
+    fieldLabels: string[]
+    statusSummary: string[]
+    horizontalOverflow: Record<string, boolean>
+    overflowOffenders: Record<string, string[]>
+  }
+}
+
+const VIEWPORTS: ViewportConfig[] = [
+  { key: "desktop", width: 1440, height: 900 },
+  { key: "mobile", width: 390, height: 844 }
+]
+
+fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true })
+fs.mkdirSync(DATA_DIR, { recursive: true })
+
+const setLightMode = async (page: Page) => {
+  await page.evaluate(() => {
+    document.documentElement.classList.remove("dark")
+    document.documentElement.classList.add("light")
+  })
+}
+
+const captureViewportState = async (
+  page: Page,
+  viewport: ViewportConfig
+): Promise<{
+  screenshot: string
+  hasHorizontalOverflow: boolean
+  overflowOffenders: string[]
+}> => {
+  await page.setViewportSize({ width: viewport.width, height: viewport.height })
+  await setLightMode(page)
+  await page.waitForTimeout(500)
+
+  const screenshotName = `presentation-studio-${viewport.key}.png`
+  const screenshotPath = path.join(SCREENSHOTS_DIR, screenshotName)
+  await page.screenshot({ path: screenshotPath, fullPage: true })
+
+  const { hasHorizontalOverflow, overflowOffenders } = await page.evaluate(() => {
+    const scrollingRoot = document.scrollingElement || document.documentElement
+    const offenders = Array.from(document.querySelectorAll("body *"))
+      .map((element) => {
+        const rect = element.getBoundingClientRect()
+        if (rect.right <= window.innerWidth + 1 && rect.left >= -1) {
+          return null
+        }
+        const htmlElement = element as HTMLElement
+        const className =
+          typeof htmlElement.className === "string" ? htmlElement.className.trim() : ""
+        const testId = htmlElement.dataset?.testid
+
+        return `${htmlElement.tagName.toLowerCase()}${testId ? `[data-testid="${testId}"]` : ""}${className ? `.${className.replace(/\s+/g, ".")}` : ""} (${Math.round(rect.left)}-${Math.round(rect.right)})`
+      })
+      .filter(Boolean)
+      .slice(0, 10) as string[]
+
+    return {
+      hasHorizontalOverflow: scrollingRoot.scrollWidth > window.innerWidth + 1,
+      overflowOffenders: offenders
+    }
+  })
+
+  return {
+    screenshot: screenshotName,
+    hasHorizontalOverflow,
+    overflowOffenders
+  }
+}
+
+const collectSnapshot = async (page: Page) =>
+  page.evaluate(() => {
+    const slideButtons = Array.from(
+      document.querySelectorAll("[data-testid='presentation-studio-slide-card']")
+    )
+    const slideTitles = slideButtons
+      .map((button) => button.textContent?.trim() || "")
+      .filter(Boolean)
+    const selectedSlideTitle =
+      document.querySelector(
+        "[data-testid='presentation-studio-slide-card'].border-slate-900 .mt-3.text-sm.font-semibold"
+      )
+        ?.textContent
+        ?.trim() || null
+    const buttonLabels = Array.from(document.querySelectorAll("button"))
+      .map((button) => button.textContent?.trim() || "")
+      .filter(Boolean)
+    const fieldLabels = Array.from(document.querySelectorAll("label"))
+      .map((label) => label.textContent?.trim() || "")
+      .filter(Boolean)
+    const statusSummary = Array.from(
+      document.querySelectorAll("[data-testid='presentation-studio-media-rail'] dt, [data-testid='presentation-studio-media-rail'] dd")
+    )
+      .map((node) => node.textContent?.trim() || "")
+      .filter(Boolean)
+
+    return {
+      slideCount: slideTitles.length,
+      slideTitles,
+      selectedSlideTitle,
+      buttonLabels,
+      fieldLabels,
+      statusSummary
+    }
+  })
+
+const writeAuditData = (data: PresentationStudioAuditData) => {
+  fs.writeFileSync(
+    path.join(DATA_DIR, "presentation-studio.json"),
+    `${JSON.stringify(data, null, 2)}\n`,
+    "utf8"
+  )
+}
+
+const createSeedProject = async () => {
+  const serverUrl = process.env.TLDW_SERVER_URL || "http://127.0.0.1:8000"
+  const apiKey = process.env.TLDW_API_KEY || "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+  const uniqueId = Date.now()
+  const response = await fetchWithApiKey(`${serverUrl}/api/v1/slides/presentations`, apiKey, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      title: `Presentation Studio Audit ${uniqueId}`,
+      description: null,
+      theme: "black",
+      studio_data: {
+        origin: "blank",
+        entry_surface: "playwright_audit"
+      },
+      slides: [
+        {
+          order: 0,
+          layout: "title",
+          title: "Title slide",
+          content: "",
+          speaker_notes: "",
+          metadata: {
+            studio: {
+              slideId: `audit-slide-${uniqueId}`,
+              audio: { status: "missing" },
+              image: { status: "missing" }
+            }
+          }
+        }
+      ]
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`seed_project_failed_${response.status}`)
+  }
+
+  return (await response.json()) as { id: string }
+}
+
+test.describe("Presentation Studio UX Audit", () => {
+  test("captures Presentation Studio creation flow for heuristic review", async ({
+    page,
+    diagnostics
+  }) => {
+    test.setTimeout(120_000)
+
+    await seedAuth(page)
+
+    const response = await page.goto("/presentation-studio/new", {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000
+    })
+    await waitForConnection(page, 30_000)
+
+    let newFlowSucceeded = false
+    try {
+      await page.waitForFunction(
+        () => {
+          const pathname = window.location.pathname
+          return /^\/presentation-studio\/[^/]+$/.test(pathname) && pathname !== "/presentation-studio/new"
+        },
+        undefined,
+        { timeout: 20_000 }
+      )
+      newFlowSucceeded = true
+    } catch {
+      newFlowSucceeded = false
+    }
+
+    let newFlowScreenshot: string | null = null
+    let newFlowVisibleText: string | null = null
+    if (!newFlowSucceeded) {
+      newFlowScreenshot = "presentation-studio-new-flow-stuck.png"
+      await setLightMode(page)
+      await page.screenshot({
+        path: path.join(SCREENSHOTS_DIR, newFlowScreenshot),
+        fullPage: true
+      })
+      newFlowVisibleText = await page.locator("main").textContent()
+
+      const seededProject = await createSeedProject()
+      await page.goto(`/presentation-studio/${seededProject.id}`, {
+        waitUntil: "domcontentloaded",
+        timeout: 30_000
+      })
+    }
+
+    await dismissModals(page)
+    await page.waitForTimeout(1500)
+
+    const slideRail = page.getByTestId("presentation-studio-slide-rail")
+    let editorVisible = false
+    try {
+      await slideRail.waitFor({ state: "visible", timeout: 15_000 })
+      editorVisible = true
+    } catch {
+      editorVisible = false
+    }
+
+    let detailFlowScreenshot: string | null = null
+    let detailFlowVisibleText: string | null = null
+    if (editorVisible) {
+      await expect(page.getByTestId("presentation-studio-slide-editor")).toBeVisible()
+      await expect(page.getByTestId("presentation-studio-media-rail")).toBeVisible()
+
+      await page.getByRole("button", { name: "Add slide" }).click()
+      await expect(page.getByTestId("presentation-studio-slide-card")).toHaveCount(2)
+
+      await page.getByLabel("Slide title").fill("Problem framing")
+      await page
+        .getByLabel("Slide content")
+        .fill("Summarize the core problem, constraints, and target audience.")
+      await page
+        .getByLabel("Narration script")
+        .fill("Open with the core problem, then explain who the presentation is for.")
+      await page.getByLabel("Transition").selectOption("wipe")
+      await page.getByLabel("Duration mode").selectOption("manual")
+      await page.getByLabel("Manual duration (seconds)").fill("45")
+
+      await expect(page.getByTestId("presentation-studio-media-rail")).toContainText("Wipe")
+      await expect(page.getByTestId("presentation-studio-media-rail")).toContainText(
+        "Effective duration"
+      )
+      await expect(page.getByTestId("presentation-studio-media-rail")).toContainText("45s")
+
+      const firstHandle = page.getByTestId("presentation-studio-slide-handle").nth(0)
+      const secondCard = page.getByTestId("presentation-studio-slide-card").nth(1)
+      const firstHandleBox = await firstHandle.boundingBox()
+      const secondCardBox = await secondCard.boundingBox()
+
+      if (firstHandleBox && secondCardBox) {
+        await page.mouse.move(
+          firstHandleBox.x + firstHandleBox.width / 2,
+          firstHandleBox.y + firstHandleBox.height / 2
+        )
+        await page.mouse.down()
+        await page.mouse.move(
+          secondCardBox.x + secondCardBox.width / 2,
+          secondCardBox.y + secondCardBox.height / 2,
+          { steps: 12 }
+        )
+        await page.mouse.up()
+      }
+
+      await expect(page.getByTestId("presentation-studio-slide-card").nth(0)).toContainText(
+        "Problem framing"
+      )
+
+      await page.waitForTimeout(1800)
+    } else {
+      detailFlowScreenshot = "presentation-studio-detail-loading.png"
+      await setLightMode(page)
+      await page.screenshot({
+        path: path.join(SCREENSHOTS_DIR, detailFlowScreenshot),
+        fullPage: true
+      })
+      detailFlowVisibleText = await page.locator("main").textContent()
+    }
+
+    const requestErrorState = await page.evaluate(() => ({
+      lastRequestError: localStorage.getItem("__tldwLastRequestError"),
+      requestErrors: localStorage.getItem("__tldwRequestErrors")
+    }))
+
+    const screenshots: Record<string, string> = {}
+    const overflowByViewport: Record<string, boolean> = {}
+    const overflowOffenders: Record<string, string[]> = {}
+    for (const viewport of VIEWPORTS) {
+      const artifact = await captureViewportState(page, viewport)
+      screenshots[viewport.key] = artifact.screenshot
+      overflowByViewport[viewport.key] = artifact.hasHorizontalOverflow
+      overflowOffenders[viewport.key] = artifact.overflowOffenders
+    }
+
+    const criticalIssues = getCriticalIssues(diagnostics)
+    const classified = classifySmokeIssues("/presentation-studio/[projectId]", criticalIssues)
+
+    const performance = await page.evaluate(() => {
+      const navigation = performance.getEntriesByType("navigation")[0] as
+        | PerformanceNavigationTiming
+        | undefined
+      const paint = performance.getEntriesByType("paint")
+      const fcp = paint.find((entry) => entry.name === "first-contentful-paint")
+      return {
+        domContentLoaded: navigation?.domContentLoadedEventEnd ?? null,
+        firstContentfulPaint: fcp?.startTime ?? null,
+        resourceCount: performance.getEntriesByType("resource").length
+      }
+    })
+
+    const accessibility = await page.evaluate(() => ({
+      headingStructure: Array.from(document.querySelectorAll("h1, h2, h3, h4, h5, h6")).map(
+        (heading) => heading.tagName.toLowerCase()
+      ),
+      landmarkCount: document.querySelectorAll(
+        "main, nav, header, footer, aside, [role='main'], [role='navigation'], [role='banner'], [role='contentinfo'], [role='complementary']"
+      ).length,
+      imagesWithoutAlt: document.querySelectorAll("img:not([alt])").length,
+      focusableElements: document.querySelectorAll(
+        "a[href], button, input, select, textarea, [tabindex]:not([tabindex='-1'])"
+      ).length
+    }))
+
+    const snapshot = await collectSnapshot(page)
+
+    writeAuditData({
+      route: "/presentation-studio/new",
+      finalUrl: page.url(),
+      redirected: page.url().includes("/presentation-studio/") && !page.url().endsWith("/new"),
+      httpStatus: response?.status() ?? null,
+      timestamp: new Date().toISOString(),
+      newFlow: {
+        succeeded: newFlowSucceeded,
+        finalUrl: newFlowSucceeded ? page.url() : page.url(),
+        screenshot: newFlowScreenshot,
+        visibleText: newFlowVisibleText
+      },
+      detailFlow: {
+        editorVisible,
+        finalUrl: page.url(),
+        screenshot: detailFlowScreenshot,
+        visibleText: detailFlowVisibleText,
+        lastRequestError: requestErrorState.lastRequestError,
+        requestErrors: requestErrorState.requestErrors
+      },
+      screenshots,
+      diagnostics: {
+        pageErrors: classified.pageErrors,
+        unexpectedConsoleErrors: classified.unexpectedConsoleErrors,
+        unexpectedRequestFailures: classified.unexpectedRequestFailures,
+        allowlistedConsoleErrors: classified.allowlistedConsoleErrors.map((entry) => ({
+          text: entry.entry.text,
+          ruleId: entry.rule.id
+        })),
+        allowlistedRequestFailures: classified.allowlistedRequestFailures.map((entry) => ({
+          url: entry.entry.url,
+          ruleId: entry.rule.id
+        }))
+      },
+      performance,
+      accessibility,
+      uiSnapshot: {
+        ...snapshot,
+        horizontalOverflow: overflowByViewport,
+        overflowOffenders
+      }
+    })
+  })
+})

--- a/apps/tldw-frontend/e2e/ux-audit/presentation-studio.spec.ts
+++ b/apps/tldw-frontend/e2e/ux-audit/presentation-studio.spec.ts
@@ -88,6 +88,17 @@ const setLightMode = async (page: Page) => {
   })
 }
 
+const waitForStablePaint = async (page: Page) => {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve())
+        })
+      })
+  )
+}
+
 const captureViewportState = async (
   page: Page,
   viewport: ViewportConfig
@@ -98,7 +109,7 @@ const captureViewportState = async (
 }> => {
   await page.setViewportSize({ width: viewport.width, height: viewport.height })
   await setLightMode(page)
-  await page.waitForTimeout(500)
+  await waitForStablePaint(page)
 
   const screenshotName = `presentation-studio-${viewport.key}.png`
   const screenshotPath = path.join(SCREENSHOTS_DIR, screenshotName)
@@ -181,7 +192,10 @@ const writeAuditData = (data: PresentationStudioAuditData) => {
 
 const createSeedProject = async () => {
   const serverUrl = process.env.TLDW_SERVER_URL || "http://127.0.0.1:8000"
-  const apiKey = process.env.TLDW_API_KEY || "THIS-IS-A-SECURE-KEY-123-FAKE-KEY"
+  const apiKey = process.env.TLDW_API_KEY
+  if (!apiKey) {
+    throw new Error("presentation_studio_audit_requires_tldw_api_key")
+  }
   const uniqueId = Date.now()
   const response = await fetchWithApiKey(`${serverUrl}/api/v1/slides/presentations`, apiKey, {
     method: "POST",
@@ -271,7 +285,6 @@ test.describe("Presentation Studio UX Audit", () => {
     }
 
     await dismissModals(page)
-    await page.waitForTimeout(1500)
 
     const slideRail = page.getByTestId("presentation-studio-slide-rail")
     let editorVisible = false
@@ -330,8 +343,7 @@ test.describe("Presentation Studio UX Audit", () => {
       await expect(page.getByTestId("presentation-studio-slide-card").nth(0)).toContainText(
         "Problem framing"
       )
-
-      await page.waitForTimeout(1800)
+      await expect(page.getByLabel("Slide title")).toHaveValue("Problem framing")
     } else {
       detailFlowScreenshot = "presentation-studio-detail-loading.png"
       await setLightMode(page)

--- a/tldw_Server_API/app/api/v1/endpoints/slides.py
+++ b/tldw_Server_API/app/api/v1/endpoints/slides.py
@@ -148,6 +148,9 @@ _SLIDES_NONCRITICAL_EXCEPTIONS = (
     json.JSONDecodeError,
 )
 
+_PRESENTATION_STUDIO_TRANSITIONS = {"fade", "cut", "wipe", "zoom"}
+_PRESENTATION_STUDIO_TIMING_MODES = {"auto", "manual"}
+
 
 def _parse_etag(raw: str | None) -> int:
     if not raw:
@@ -204,6 +207,50 @@ def _slide_from_obj(obj: Any) -> Slide:
     return Slide.parse_obj(obj)
 
 
+def _normalize_presentation_studio_transition(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized if normalized in _PRESENTATION_STUDIO_TRANSITIONS else "fade"
+
+
+def _normalize_presentation_studio_manual_duration_ms(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric_value <= 0:
+        return None
+    return int(round(numeric_value))
+
+
+def _normalize_presentation_studio_timing_mode(value: Any, *, has_manual_duration: bool) -> str:
+    normalized = str(value or "").strip().lower()
+    if normalized not in _PRESENTATION_STUDIO_TIMING_MODES:
+        return "manual" if has_manual_duration else "auto"
+    if normalized == "manual" and not has_manual_duration:
+        return "auto"
+    return normalized
+
+
+def _normalize_slide_studio_metadata(metadata: dict[str, Any]) -> None:
+    studio = metadata.get("studio")
+    if studio is None:
+        return
+    if not isinstance(studio, dict):
+        raise HTTPException(status_code=422, detail="slide_studio_metadata_invalid")
+
+    manual_duration_ms = _normalize_presentation_studio_manual_duration_ms(
+        studio.get("manual_duration_ms")
+    )
+    studio["transition"] = _normalize_presentation_studio_transition(studio.get("transition"))
+    studio["manual_duration_ms"] = manual_duration_ms
+    studio["timing_mode"] = _normalize_presentation_studio_timing_mode(
+        studio.get("timing_mode"),
+        has_manual_duration=manual_duration_ms is not None,
+    )
+
+
 def _normalize_slides(slides: list[Slide]) -> list[Slide]:
     orders = [slide.order for slide in slides]
     if any(order < 0 for order in orders):
@@ -217,6 +264,7 @@ def _normalize_slides(slides: list[Slide]) -> list[Slide]:
             slide.metadata = {}
         if not isinstance(slide.metadata, dict):
             raise HTTPException(status_code=422, detail="slide_metadata_invalid")
+        _normalize_slide_studio_metadata(slide.metadata)
         _validate_slide_images(slide.metadata)
     return ordered
 

--- a/tldw_Server_API/app/core/Slides/presentation_rendering.py
+++ b/tldw_Server_API/app/core/Slides/presentation_rendering.py
@@ -261,7 +261,25 @@ def _probe_media_duration_seconds(media_path: Path) -> float | None:
             stderr=subprocess.PIPE,
             timeout=_DEFAULT_FFPROBE_TIMEOUT_SECONDS,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    except FileNotFoundError:
+        logger.warning("ffprobe duration probe failed for {}: ffprobe executable is unavailable", media_path)
+        return None
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "ffprobe duration probe failed for {}: {} timed out after {} seconds",
+            media_path,
+            exc.cmd,
+            exc.timeout,
+        )
+        return None
+    except subprocess.CalledProcessError as exc:
+        stderr_text = (exc.stderr or b"").decode("utf-8", "ignore").strip()
+        logger.warning(
+            "ffprobe duration probe failed for {}: exit code {}{}",
+            media_path,
+            exc.returncode,
+            f" ({stderr_text})" if stderr_text else "",
+        )
         return None
 
     try:
@@ -736,12 +754,12 @@ def _build_transition_video_command(
             boundary_transition = boundary_transitions[index - 1]
             output_label = f"v{index}"
             next_label = f"{index}:v"
+            cumulative_offset += effective_durations_seconds[index - 1]
             if boundary_transition == "cut":
                 filter_parts.append(
                     f"[{current_label}][{next_label}]concat=n=2:v=1:a=0[{output_label}]"
                 )
             else:
-                cumulative_offset += effective_durations_seconds[index - 1]
                 filter_parts.append(
                     f"[{current_label}][{next_label}]xfade=transition={boundary_transition}:duration={_TRANSITION_DURATION_SECONDS:.2f}:offset={cumulative_offset:.2f}[{output_label}]"
                 )

--- a/tldw_Server_API/app/core/Slides/presentation_rendering.py
+++ b/tldw_Server_API/app/core/Slides/presentation_rendering.py
@@ -31,6 +31,14 @@ _TEXT_COLOR = "#f8fafc"
 _MUTED_TEXT_COLOR = "#cbd5e1"
 _ACCENT_COLOR = "#38bdf8"
 _DEFAULT_FFMPEG_TIMEOUT_SECONDS = 120
+_DEFAULT_FFPROBE_TIMEOUT_SECONDS = 30
+_TRANSITION_DURATION_SECONDS = 0.75
+_TRANSITION_FILTERS = {
+    "cut": "cut",
+    "fade": "fade",
+    "wipe": "wipeleft",
+    "zoom": "zoomin",
+}
 
 
 class PresentationRenderError(RuntimeError):
@@ -62,6 +70,15 @@ class PresentationRenderSnapshot:
     theme: str
     slides: list[dict[str, Any]]
     studio_data: dict[str, Any] | None
+
+
+@dataclass
+class _PreparedSlideRender:
+    slide: dict[str, Any]
+    frame_path: Path
+    audio_path: Path | None
+    audio_duration_seconds: float | None
+    effective_duration_seconds: float
 
 
 def load_presentation_render_snapshot(
@@ -143,6 +160,23 @@ def _resolve_ffmpeg_path() -> str:
     raise PresentationRenderError("presentation_render_ffmpeg_unavailable")
 
 
+def _resolve_ffprobe_path() -> str | None:
+    env_path = (os.getenv("FFPROBE_PATH") or "").strip()
+    if env_path:
+        return env_path
+
+    ffmpeg_env_path = (os.getenv("FFMPEG_PATH") or "").strip()
+    if ffmpeg_env_path:
+        sibling = Path(ffmpeg_env_path).with_name("ffprobe")
+        if sibling.exists():
+            return str(sibling)
+
+    ffprobe_path = shutil.which("ffprobe")
+    if ffprobe_path:
+        return ffprobe_path
+    return None
+
+
 def _resolve_ffmpeg_timeout_seconds(*, expected_duration_seconds: float) -> int:
     override = (os.getenv("PRESENTATION_RENDER_FFMPEG_TIMEOUT_SECONDS") or "").strip()
     if override:
@@ -194,6 +228,49 @@ def _slide_studio_metadata(slide: dict[str, Any]) -> dict[str, Any]:
     if isinstance(studio, dict):
         return studio
     return {}
+
+
+def _duration_seconds_from_ms(value: Any) -> float | None:
+    if not isinstance(value, (int, float)):
+        return None
+    if value <= 0:
+        return None
+    return float(value) / 1000.0
+
+
+def _probe_media_duration_seconds(media_path: Path) -> float | None:
+    ffprobe_path = _resolve_ffprobe_path()
+    if ffprobe_path is None or not media_path.exists():
+        return None
+
+    command = [
+        ffprobe_path,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(media_path),
+    ]
+    try:
+        completed = subprocess.run(  # nosec B603
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=_DEFAULT_FFPROBE_TIMEOUT_SECONDS,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+    try:
+        duration_seconds = float((completed.stdout or b"").decode("utf-8", "ignore").strip())
+    except ValueError:
+        return None
+    if duration_seconds <= 0:
+        return None
+    return duration_seconds
 
 
 def _decode_data_b64(data_b64: str, *, error_code: str) -> bytes:
@@ -302,13 +379,7 @@ def _materialize_slide_audio(
     return audio_path
 
 
-def _estimate_slide_duration_seconds(slide: dict[str, Any]) -> float:
-    audio = _slide_studio_metadata(slide).get("audio")
-    if isinstance(audio, dict):
-        duration_ms = audio.get("duration_ms")
-        if isinstance(duration_ms, (int, float)) and duration_ms > 0:
-            return max(1.0, float(duration_ms) / 1000.0)
-
+def _estimate_slide_duration_from_notes_seconds(slide: dict[str, Any]) -> float:
     notes = str(slide.get("speaker_notes") or "").strip()
     if not notes:
         return 3.0
@@ -316,6 +387,56 @@ def _estimate_slide_duration_seconds(slide: dict[str, Any]) -> float:
     if words <= 0:
         return 3.0
     return max(3.0, min(20.0, round(words / 2.6, 2)))
+
+
+def _resolve_slide_audio_duration_seconds(
+    slide: dict[str, Any],
+    *,
+    audio_path: Path | None,
+) -> float | None:
+    audio = _slide_studio_metadata(slide).get("audio")
+    if not isinstance(audio, dict):
+        return None
+
+    metadata_duration_seconds = _duration_seconds_from_ms(audio.get("duration_ms"))
+    if metadata_duration_seconds is not None:
+        return max(1.0, metadata_duration_seconds)
+
+    if audio_path is None:
+        return None
+
+    probed_duration_seconds = _probe_media_duration_seconds(audio_path)
+    if probed_duration_seconds is None:
+        return None
+    return max(1.0, probed_duration_seconds)
+
+
+def _resolve_effective_slide_duration_seconds(
+    slide: dict[str, Any],
+    *,
+    audio_duration_seconds: float | None,
+) -> float:
+    studio = _slide_studio_metadata(slide)
+    timing_mode = str(studio.get("timing_mode") or "").strip().lower()
+    manual_duration_seconds = _duration_seconds_from_ms(studio.get("manual_duration_ms"))
+
+    if timing_mode == "manual" and manual_duration_seconds is not None:
+        if audio_duration_seconds is not None:
+            return max(audio_duration_seconds, manual_duration_seconds)
+        return manual_duration_seconds
+
+    if audio_duration_seconds is not None:
+        return audio_duration_seconds
+
+    return _estimate_slide_duration_from_notes_seconds(slide)
+
+
+def _resolve_slide_transition_filter(slide: dict[str, Any]) -> str:
+    studio = _slide_studio_metadata(slide)
+    if "transition" not in studio or not str(studio.get("transition") or "").strip():
+        return "cut"
+    transition_name = str(studio.get("transition") or "fade").strip().lower()
+    return _TRANSITION_FILTERS.get(transition_name, "fade")
 
 
 def _load_font(size: int) -> ImageFont.ImageFont:
@@ -451,11 +572,11 @@ def _build_segment_command(
         str(frame_path),
     ]
     if audio_path is not None:
-        command.extend(["-i", str(audio_path)])
+        command.extend(["-i", str(audio_path), "-af", "apad"])
     else:
-        command.extend(["-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo", "-t", f"{duration_seconds:.2f}"])
+        command.extend(["-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo"])
 
-    command.extend(["-shortest", "-r", "30", "-tune", "stillimage"])
+    command.extend(["-r", "30", "-tune", "stillimage", "-t", f"{duration_seconds:.2f}"])
     if output_format == "mp4":
         command.extend(
             [
@@ -484,6 +605,57 @@ def _build_segment_command(
     return command
 
 
+def _build_visual_segment_command(
+    *,
+    ffmpeg_path: str,
+    frame_path: Path,
+    duration_seconds: float,
+    output_path: Path,
+    output_format: str,
+) -> list[str]:
+    command = [
+        ffmpeg_path,
+        "-y",
+        "-loop",
+        "1",
+        "-framerate",
+        "30",
+        "-t",
+        f"{duration_seconds:.2f}",
+        "-i",
+        str(frame_path),
+        "-an",
+    ]
+    if output_format == "mp4":
+        command.extend(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
+    else:
+        command.extend(["-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "35"])
+    command.append(str(output_path))
+    return command
+
+
+def _build_audio_segment_command(
+    *,
+    ffmpeg_path: str,
+    audio_path: Path | None,
+    duration_seconds: float,
+    output_path: Path,
+    output_format: str,
+) -> list[str]:
+    command = [ffmpeg_path, "-y"]
+    if audio_path is not None:
+        command.extend(["-i", str(audio_path), "-af", "apad"])
+    else:
+        command.extend(["-f", "lavfi", "-i", "anullsrc=r=48000:cl=stereo"])
+    command.extend(["-t", f"{duration_seconds:.2f}"])
+    if output_format == "mp4":
+        command.extend(["-c:a", "aac"])
+    else:
+        command.extend(["-c:a", "libopus"])
+    command.append(str(output_path))
+    return command
+
+
 def _build_concat_command(
     *,
     ffmpeg_path: str,
@@ -501,6 +673,107 @@ def _build_concat_command(
         "-i",
         str(concat_list_path),
         "-c",
+        "copy",
+    ]
+    if output_format == "mp4":
+        command.extend(["-movflags", "+faststart"])
+    command.append(str(output_path))
+    return command
+
+
+def _build_audio_concat_command(
+    *,
+    ffmpeg_path: str,
+    audio_paths: list[Path],
+    output_path: Path,
+    output_format: str,
+) -> list[str]:
+    if len(audio_paths) == 1:
+        command = [ffmpeg_path, "-y", "-i", str(audio_paths[0]), "-c", "copy"]
+        command.append(str(output_path))
+        return command
+
+    command = [ffmpeg_path, "-y"]
+    for audio_path in audio_paths:
+        command.extend(["-i", str(audio_path)])
+    filter_inputs = "".join(f"[{index}:a]" for index in range(len(audio_paths)))
+    command.extend(
+        [
+            "-filter_complex",
+            f"{filter_inputs}concat=n={len(audio_paths)}:v=0:a=1[aout]",
+            "-map",
+            "[aout]",
+        ]
+    )
+    if output_format == "mp4":
+        command.extend(["-c:a", "aac"])
+    else:
+        command.extend(["-c:a", "libopus"])
+    command.append(str(output_path))
+    return command
+
+
+def _build_transition_video_command(
+    *,
+    ffmpeg_path: str,
+    video_paths: list[Path],
+    effective_durations_seconds: list[float],
+    boundary_transitions: list[str],
+    output_path: Path,
+    output_format: str,
+) -> list[str]:
+    command = [ffmpeg_path, "-y"]
+    for video_path in video_paths:
+        command.extend(["-i", str(video_path)])
+
+    if len(video_paths) == 1:
+        command.extend(["-map", "0:v:0"])
+    else:
+        filter_parts: list[str] = []
+        current_label = "0:v"
+        cumulative_offset = 0.0
+        for index in range(1, len(video_paths)):
+            boundary_transition = boundary_transitions[index - 1]
+            output_label = f"v{index}"
+            next_label = f"{index}:v"
+            if boundary_transition == "cut":
+                filter_parts.append(
+                    f"[{current_label}][{next_label}]concat=n=2:v=1:a=0[{output_label}]"
+                )
+            else:
+                cumulative_offset += effective_durations_seconds[index - 1]
+                filter_parts.append(
+                    f"[{current_label}][{next_label}]xfade=transition={boundary_transition}:duration={_TRANSITION_DURATION_SECONDS:.2f}:offset={cumulative_offset:.2f}[{output_label}]"
+                )
+            current_label = output_label
+        command.extend(["-filter_complex", ";".join(filter_parts), "-map", f"[{current_label}]"])
+
+    if output_format == "mp4":
+        command.extend(["-c:v", "libx264", "-pix_fmt", "yuv420p"])
+    else:
+        command.extend(["-c:v", "libvpx-vp9", "-b:v", "0", "-crf", "35"])
+    command.append(str(output_path))
+    return command
+
+
+def _build_mux_command(
+    *,
+    ffmpeg_path: str,
+    video_path: Path,
+    audio_path: Path,
+    output_path: Path,
+    output_format: str,
+) -> list[str]:
+    command = [
+        ffmpeg_path,
+        "-y",
+        "-i",
+        str(video_path),
+        "-i",
+        str(audio_path),
+        "-c:v",
+        "copy",
+        "-c:a",
         "copy",
     ]
     if output_format == "mp4":
@@ -550,8 +823,7 @@ def render_presentation_video(
     with tempfile.TemporaryDirectory(prefix="presentation-render-") as temp_dir_str:
         temp_dir = Path(temp_dir_str)
         with _collections_db_context(user_id=user_id, collections_db=collections_db) as asset_db:
-            segment_paths: list[Path] = []
-            total_expected_duration_seconds = 0.0
+            prepared_slides: list[_PreparedSlideRender] = []
             for slide_index, slide in enumerate(render_slides):
                 frame_path = temp_dir / f"slide-{slide_index:03d}.png"
                 _render_slide_frame(
@@ -567,14 +839,42 @@ def render_presentation_video(
                     collections_db=asset_db,
                     user_id=user_id,
                 )
+                audio_duration_seconds = _resolve_slide_audio_duration_seconds(
+                    slide,
+                    audio_path=audio_path,
+                )
+                slide_duration_seconds = _resolve_effective_slide_duration_seconds(
+                    slide,
+                    audio_duration_seconds=audio_duration_seconds,
+                )
+                prepared_slides.append(
+                    _PreparedSlideRender(
+                        slide=slide,
+                        frame_path=frame_path,
+                        audio_path=audio_path,
+                        audio_duration_seconds=audio_duration_seconds,
+                        effective_duration_seconds=slide_duration_seconds,
+                    )
+                )
+
+        boundary_transitions = [
+            _resolve_slide_transition_filter(prepared.slide)
+            for prepared in prepared_slides[1:]
+        ]
+        has_visual_transitions = any(transition != "cut" for transition in boundary_transitions)
+        total_expected_duration_seconds = sum(
+            prepared.effective_duration_seconds for prepared in prepared_slides
+        )
+
+        if not has_visual_transitions:
+            segment_paths: list[Path] = []
+            for slide_index, prepared in enumerate(prepared_slides):
                 segment_path = temp_dir / f"segment-{slide_index:03d}.{normalized_format}"
-                slide_duration_seconds = _estimate_slide_duration_seconds(slide)
-                total_expected_duration_seconds += slide_duration_seconds
                 command = _build_segment_command(
                     ffmpeg_path=ffmpeg_path,
-                    frame_path=frame_path,
-                    audio_path=audio_path,
-                    duration_seconds=slide_duration_seconds,
+                    frame_path=prepared.frame_path,
+                    audio_path=prepared.audio_path,
+                    duration_seconds=prepared.effective_duration_seconds,
                     segment_path=segment_path,
                     output_format=normalized_format,
                 )
@@ -582,29 +882,124 @@ def render_presentation_video(
                     command,
                     output_path=segment_path,
                     timeout_seconds=_resolve_ffmpeg_timeout_seconds(
-                        expected_duration_seconds=slide_duration_seconds,
+                        expected_duration_seconds=prepared.effective_duration_seconds,
                     ),
                 )
                 segment_paths.append(segment_path)
+            concat_list_path = temp_dir / "segments.txt"
+            concat_list_path.write_text(
+                "\n".join(f"file '{segment_path.as_posix()}'" for segment_path in segment_paths),
+                encoding="utf-8",
+            )
+            concat_command = _build_concat_command(
+                ffmpeg_path=ffmpeg_path,
+                concat_list_path=concat_list_path,
+                output_path=output_path,
+                output_format=normalized_format,
+            )
+            _run_ffmpeg_command(
+                concat_command,
+                output_path=output_path,
+                timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                    expected_duration_seconds=total_expected_duration_seconds,
+                ),
+            )
+        else:
+            visual_paths: list[Path] = []
+            audio_paths: list[Path] = []
+            audio_extension = ".m4a" if normalized_format == "mp4" else ".webm"
 
-        concat_list_path = temp_dir / "segments.txt"
-        concat_list_path.write_text(
-            "\n".join(f"file '{segment_path.as_posix()}'" for segment_path in segment_paths),
-            encoding="utf-8",
-        )
-        concat_command = _build_concat_command(
-            ffmpeg_path=ffmpeg_path,
-            concat_list_path=concat_list_path,
-            output_path=output_path,
-            output_format=normalized_format,
-        )
-        _run_ffmpeg_command(
-            concat_command,
-            output_path=output_path,
-            timeout_seconds=_resolve_ffmpeg_timeout_seconds(
-                expected_duration_seconds=total_expected_duration_seconds,
-            ),
-        )
+            for slide_index, prepared in enumerate(prepared_slides):
+                outgoing_transition = (
+                    boundary_transitions[slide_index]
+                    if slide_index < len(boundary_transitions)
+                    else "cut"
+                )
+                visual_duration_seconds = prepared.effective_duration_seconds + (
+                    _TRANSITION_DURATION_SECONDS if outgoing_transition != "cut" else 0.0
+                )
+                visual_path = temp_dir / f"visual-{slide_index:03d}.{normalized_format}"
+                visual_command = _build_visual_segment_command(
+                    ffmpeg_path=ffmpeg_path,
+                    frame_path=prepared.frame_path,
+                    duration_seconds=visual_duration_seconds,
+                    output_path=visual_path,
+                    output_format=normalized_format,
+                )
+                _run_ffmpeg_command(
+                    visual_command,
+                    output_path=visual_path,
+                    timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                        expected_duration_seconds=visual_duration_seconds,
+                    ),
+                )
+                visual_paths.append(visual_path)
+
+                audio_segment_path = temp_dir / f"audio-{slide_index:03d}{audio_extension}"
+                audio_command = _build_audio_segment_command(
+                    ffmpeg_path=ffmpeg_path,
+                    audio_path=prepared.audio_path,
+                    duration_seconds=prepared.effective_duration_seconds,
+                    output_path=audio_segment_path,
+                    output_format=normalized_format,
+                )
+                _run_ffmpeg_command(
+                    audio_command,
+                    output_path=audio_segment_path,
+                    timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                        expected_duration_seconds=prepared.effective_duration_seconds,
+                    ),
+                )
+                audio_paths.append(audio_segment_path)
+
+            transitioned_video_path = temp_dir / f"transitioned-video.{normalized_format}"
+            transitioned_video_command = _build_transition_video_command(
+                ffmpeg_path=ffmpeg_path,
+                video_paths=visual_paths,
+                effective_durations_seconds=[
+                    prepared.effective_duration_seconds for prepared in prepared_slides
+                ],
+                boundary_transitions=boundary_transitions,
+                output_path=transitioned_video_path,
+                output_format=normalized_format,
+            )
+            _run_ffmpeg_command(
+                transitioned_video_command,
+                output_path=transitioned_video_path,
+                timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                    expected_duration_seconds=total_expected_duration_seconds,
+                ),
+            )
+
+            concatenated_audio_path = temp_dir / f"transitioned-audio{audio_extension}"
+            audio_concat_command = _build_audio_concat_command(
+                ffmpeg_path=ffmpeg_path,
+                audio_paths=audio_paths,
+                output_path=concatenated_audio_path,
+                output_format=normalized_format,
+            )
+            _run_ffmpeg_command(
+                audio_concat_command,
+                output_path=concatenated_audio_path,
+                timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                    expected_duration_seconds=total_expected_duration_seconds,
+                ),
+            )
+
+            mux_command = _build_mux_command(
+                ffmpeg_path=ffmpeg_path,
+                video_path=transitioned_video_path,
+                audio_path=concatenated_audio_path,
+                output_path=output_path,
+                output_format=normalized_format,
+            )
+            _run_ffmpeg_command(
+                mux_command,
+                output_path=output_path,
+                timeout_seconds=_resolve_ffmpeg_timeout_seconds(
+                    expected_duration_seconds=total_expected_duration_seconds,
+                ),
+            )
 
     return PresentationRenderResult(
         output_format=normalized_format,

--- a/tldw_Server_API/tests/Slides/test_presentation_rendering.py
+++ b/tldw_Server_API/tests/Slides/test_presentation_rendering.py
@@ -7,6 +7,8 @@ from PIL import Image, ImageChops
 from tldw_Server_API.app.core.Slides.presentation_rendering import (
     PresentationRenderError,
     _TRANSITION_DURATION_SECONDS,
+    _build_transition_video_command,
+    _probe_media_duration_seconds,
     _resolve_effective_slide_duration_seconds,
     _resolve_ffmpeg_timeout_seconds,
     _resolve_slide_audio_duration_seconds,
@@ -82,6 +84,30 @@ def test_resolve_slide_audio_duration_prefers_metadata_and_probes_asset_when_nee
     )
 
 
+def test_probe_media_duration_logs_ffprobe_failures(monkeypatch, tmp_path):
+    media_path = tmp_path / "slide.wav"
+    media_path.write_bytes(b"audio")
+    logged_messages: list[str] = []
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._resolve_ffprobe_path",
+        lambda: "/usr/bin/ffprobe",
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired("ffprobe", 5)),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering.logger.warning",
+        lambda message, *args: logged_messages.append(message.format(*args)),
+    )
+
+    assert _probe_media_duration_seconds(media_path) is None
+    assert logged_messages == [
+        f"ffprobe duration probe failed for {media_path}: ffprobe timed out after 5 seconds"
+    ]
+
+
 def test_resolve_effective_slide_duration_and_transition_filter():
     slide = {
         "speaker_notes": "Short narration",
@@ -97,6 +123,30 @@ def test_resolve_effective_slide_duration_and_transition_filter():
     assert _resolve_effective_slide_duration_seconds(slide, audio_duration_seconds=18.0) == 45.0
     assert _resolve_slide_transition_filter(slide) == "wipeleft"
     assert _resolve_slide_transition_filter({"metadata": {"studio": {"transition": "unknown"}}}) == "fade"
+
+
+def test_build_transition_video_command_offsets_xfade_after_prior_cut_boundaries(tmp_path):
+    command = _build_transition_video_command(
+        ffmpeg_path="/usr/bin/ffmpeg",
+        video_paths=[
+            tmp_path / "slide-0.mp4",
+            tmp_path / "slide-1.mp4",
+            tmp_path / "slide-2.mp4",
+        ],
+        effective_durations_seconds=[5.0, 4.0, 6.0],
+        boundary_transitions=["cut", "wipeleft"],
+        output_path=tmp_path / "transitioned.mp4",
+        output_format="mp4",
+    )
+
+    filter_index = command.index("-filter_complex") + 1
+    filter_complex = command[filter_index]
+
+    assert "concat=n=2:v=1:a=0" in filter_complex
+    assert (
+        f"xfade=transition=wipeleft:duration={_TRANSITION_DURATION_SECONDS:.2f}:offset=9.00"
+        in filter_complex
+    )
 
 
 def test_render_presentation_video_builds_slide_segments_from_visuals_and_audio(tmp_path, monkeypatch):

--- a/tldw_Server_API/tests/Slides/test_presentation_rendering.py
+++ b/tldw_Server_API/tests/Slides/test_presentation_rendering.py
@@ -6,7 +6,11 @@ from PIL import Image, ImageChops
 
 from tldw_Server_API.app.core.Slides.presentation_rendering import (
     PresentationRenderError,
+    _TRANSITION_DURATION_SECONDS,
+    _resolve_effective_slide_duration_seconds,
     _resolve_ffmpeg_timeout_seconds,
+    _resolve_slide_audio_duration_seconds,
+    _resolve_slide_transition_filter,
     _render_slide_frame,
     _run_ffmpeg_command,
     render_presentation_video,
@@ -34,6 +38,65 @@ def test_render_slide_frame_draws_slide_text_content(tmp_path):
     background = Image.new("RGB", rendered.size, "#0f172a")
 
     assert ImageChops.difference(rendered, background).getbbox() is not None
+
+
+def test_resolve_slide_audio_duration_prefers_metadata_and_probes_asset_when_needed(monkeypatch, tmp_path):
+    audio_path = tmp_path / "slide.wav"
+    audio_path.write_bytes(b"audio")
+
+    assert (
+        _resolve_slide_audio_duration_seconds(
+            {
+                "metadata": {
+                    "studio": {
+                        "audio": {
+                            "duration_ms": 18_000
+                        }
+                    }
+                }
+            },
+            audio_path=None,
+        )
+        == 18.0
+    )
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._probe_media_duration_seconds",
+        lambda path: 12.5 if path == audio_path else None,
+    )
+
+    assert (
+        _resolve_slide_audio_duration_seconds(
+            {
+                "metadata": {
+                    "studio": {
+                        "audio": {
+                            "asset_ref": "output:1"
+                        }
+                    }
+                }
+            },
+            audio_path=audio_path,
+        )
+        == 12.5
+    )
+
+
+def test_resolve_effective_slide_duration_and_transition_filter():
+    slide = {
+        "speaker_notes": "Short narration",
+        "metadata": {
+            "studio": {
+                "transition": "wipe",
+                "timing_mode": "manual",
+                "manual_duration_ms": 45_000,
+            }
+        },
+    }
+
+    assert _resolve_effective_slide_duration_seconds(slide, audio_duration_seconds=18.0) == 45.0
+    assert _resolve_slide_transition_filter(slide) == "wipeleft"
+    assert _resolve_slide_transition_filter({"metadata": {"studio": {"transition": "unknown"}}}) == "fade"
 
 
 def test_render_presentation_video_builds_slide_segments_from_visuals_and_audio(tmp_path, monkeypatch):
@@ -124,6 +187,157 @@ def test_render_presentation_video_builds_slide_segments_from_visuals_and_audio(
     assert result.storage_path.endswith(".mp4")
     assert result.output_path.exists()
     assert result.byte_size == len(b"video-bytes")
+
+
+def test_render_presentation_video_pads_narrated_cut_only_segments_to_manual_duration(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._resolve_ffmpeg_path",
+        lambda: "/usr/bin/ffmpeg",
+    )
+    captured_commands: list[list[str]] = []
+    audio_path = tmp_path / "slide-0.wav"
+    audio_path.write_bytes(b"audio-bytes")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._render_slide_frame",
+        lambda slide, *, output_path, collections_db, user_id: output_path.write_bytes(b"png"),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._materialize_slide_audio",
+        lambda slide, *, temp_dir, slide_index, collections_db, user_id: audio_path,
+    )
+
+    def _fake_run_ffmpeg(command: list[str], *, output_path: Path, timeout_seconds: int | None = None) -> None:
+        captured_commands.append(command)
+        output_path.write_bytes(b"video-bytes")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._run_ffmpeg_command",
+        _fake_run_ffmpeg,
+    )
+
+    render_presentation_video(
+        presentation_id="pres_cut",
+        presentation_version=1,
+        title="Deck",
+        slides=[
+            {
+                "order": 0,
+                "layout": "content",
+                "title": "Manual timing",
+                "content": "Opening",
+                "speaker_notes": "Narration",
+                "metadata": {
+                    "studio": {
+                        "timing_mode": "manual",
+                        "manual_duration_ms": 45_000,
+                        "audio": {
+                            "duration_ms": 18_000,
+                            "asset_ref": "output:1",
+                        },
+                    }
+                },
+            }
+        ],
+        output_format="mp4",
+        output_dir=tmp_path,
+        collections_db=object(),
+        user_id=7,
+    )
+
+    assert len(captured_commands) == 2
+    segment_command = captured_commands[0]
+    assert str(audio_path) in segment_command
+    assert "-af" in segment_command
+    assert "apad" in segment_command
+    assert "-shortest" not in segment_command
+    duration_index = segment_command.index("-t") + 1
+    assert segment_command[duration_index] == "45.00"
+    assert "concat" in captured_commands[1]
+
+
+def test_render_presentation_video_uses_filtered_transition_assembly_for_transitioned_decks(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._resolve_ffmpeg_path",
+        lambda: "/usr/bin/ffmpeg",
+    )
+    captured_commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._render_slide_frame",
+        lambda slide, *, output_path, collections_db, user_id: output_path.write_bytes(b"png"),
+    )
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._materialize_slide_audio",
+        lambda slide, *, temp_dir, slide_index, collections_db, user_id: None,
+    )
+
+    def _fake_run_ffmpeg(command: list[str], *, output_path: Path, timeout_seconds: int | None = None) -> None:
+        captured_commands.append(command)
+        output_path.write_bytes(b"video-bytes")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Slides.presentation_rendering._run_ffmpeg_command",
+        _fake_run_ffmpeg,
+    )
+
+    render_presentation_video(
+        presentation_id="pres_transition",
+        presentation_version=1,
+        title="Deck",
+        slides=[
+            {
+                "order": 0,
+                "layout": "content",
+                "title": "Intro",
+                "content": "First",
+                "speaker_notes": "",
+                "metadata": {
+                    "studio": {
+                        "timing_mode": "manual",
+                        "manual_duration_ms": 5_000,
+                        "transition": "cut",
+                    }
+                },
+            },
+            {
+                "order": 1,
+                "layout": "content",
+                "title": "Next",
+                "content": "Second",
+                "speaker_notes": "",
+                "metadata": {
+                    "studio": {
+                        "timing_mode": "manual",
+                        "manual_duration_ms": 4_000,
+                        "transition": "wipe",
+                    }
+                },
+            },
+        ],
+        output_format="mp4",
+        output_dir=tmp_path,
+    )
+
+    assert len(captured_commands) > 4
+    assert not any("concat" in command and "copy" in command for command in captured_commands)
+    transition_commands = [
+        command
+        for command in captured_commands
+        if "-filter_complex" in command and any("xfade=transition=wipeleft" in part for part in command)
+    ]
+    assert transition_commands
+    visual_segment_commands = [
+        command for command in captured_commands if "-loop" in command and "-an" in command
+    ]
+    assert visual_segment_commands
+    first_visual = visual_segment_commands[0]
+    duration_index = first_visual.index("-t") + 1
+    assert first_visual[duration_index] == f"{5.0 + _TRANSITION_DURATION_SECONDS:.2f}"
 
 
 def test_render_presentation_video_rejects_unsupported_format(tmp_path):

--- a/tldw_Server_API/tests/Slides/test_slides_api.py
+++ b/tldw_Server_API/tests/Slides/test_slides_api.py
@@ -364,6 +364,53 @@ def test_slides_create_and_export_json(slides_client):
     assert exported["studio_data"] == payload["studio_data"]
 
 
+def test_slides_create_canonicalizes_presentation_studio_slide_metadata(slides_client):
+    payload = {
+        "title": "Deck",
+        "description": None,
+        "theme": "black",
+        "studio_data": {
+            "origin": "blank",
+        },
+        "slides": [
+            {
+                "order": 0,
+                "layout": "title",
+                "title": "Deck",
+                "content": "",
+                "speaker_notes": "",
+                "metadata": {
+                    "studio": {
+                        "slideId": "slide-1",
+                        "audio": {"status": "missing"},
+                        "image": {"status": "missing"},
+                    }
+                },
+            }
+        ],
+        "custom_css": None,
+    }
+
+    resp = slides_client.post("/api/v1/slides/presentations", json=payload)
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    studio = data["slides"][0]["metadata"]["studio"]
+    assert studio["slideId"] == "slide-1"
+    assert studio["transition"] == "fade"
+    assert studio["timing_mode"] == "auto"
+    assert studio["manual_duration_ms"] is None
+    assert studio["audio"]["status"] == "missing"
+    assert studio["image"]["status"] == "missing"
+
+    export_resp = slides_client.get(f"/api/v1/slides/presentations/{data['id']}/export?format=json")
+    assert export_resp.status_code == 200
+    exported = export_resp.json()
+    exported_studio = exported["slides"][0]["metadata"]["studio"]
+    assert exported_studio["transition"] == "fade"
+    assert exported_studio["timing_mode"] == "auto"
+    assert exported_studio["manual_duration_ms"] is None
+
+
 def test_slides_create_rejects_invalid_image(slides_client):
     payload = {
         "title": "Deck",
@@ -745,6 +792,94 @@ def test_slides_versions_and_restore(slides_client):
     assert restore_resp.status_code == 200
     assert restore_resp.json()["title"] == "Deck"
     assert restore_resp.json()["studio_data"] == payload["studio_data"]
+
+
+def test_slides_patch_persists_presentation_studio_timing_and_transition_metadata(slides_client):
+    create_resp = slides_client.post(
+        "/api/v1/slides/presentations",
+        json={
+            "title": "Deck",
+            "description": None,
+            "theme": "black",
+            "studio_data": {"origin": "blank"},
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "content",
+                    "title": "Slide",
+                    "content": "Body",
+                    "speaker_notes": "Narration",
+                    "metadata": {
+                        "studio": {
+                            "slideId": "slide-1",
+                            "audio": {"status": "ready", "duration_ms": 12000},
+                            "image": {"status": "ready"},
+                        }
+                    },
+                }
+            ],
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    presentation_id = create_resp.json()["id"]
+    etag = create_resp.headers["ETag"]
+
+    patch_resp = slides_client.patch(
+        f"/api/v1/slides/presentations/{presentation_id}",
+        json={
+            "slides": [
+                {
+                    "order": 0,
+                    "layout": "content",
+                    "title": "Slide",
+                    "content": "Body",
+                    "speaker_notes": "Narration",
+                    "metadata": {
+                        "studio": {
+                            "slideId": "slide-1",
+                            "transition": "wipe",
+                            "timing_mode": "manual",
+                            "manual_duration_ms": 45000,
+                            "audio": {"status": "ready", "duration_ms": 12000},
+                            "image": {"status": "ready"},
+                        }
+                    },
+                }
+            ]
+        },
+        headers={"If-Match": etag},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    patched = patch_resp.json()
+    patched_studio = patched["slides"][0]["metadata"]["studio"]
+    assert patched_studio["transition"] == "wipe"
+    assert patched_studio["timing_mode"] == "manual"
+    assert patched_studio["manual_duration_ms"] == 45000
+    new_etag = patch_resp.headers["ETag"]
+
+    version_resp = slides_client.get(f"/api/v1/slides/presentations/{presentation_id}/versions/1")
+    assert version_resp.status_code == 200
+    version_studio = version_resp.json()["slides"][0]["metadata"]["studio"]
+    assert version_studio["transition"] == "fade"
+    assert version_studio["timing_mode"] == "auto"
+    assert version_studio["manual_duration_ms"] is None
+
+    restore_resp = slides_client.post(
+        f"/api/v1/slides/presentations/{presentation_id}/versions/1/restore",
+        headers={"If-Match": new_etag},
+    )
+    assert restore_resp.status_code == 200
+    restored_studio = restore_resp.json()["slides"][0]["metadata"]["studio"]
+    assert restored_studio["transition"] == "fade"
+    assert restored_studio["timing_mode"] == "auto"
+    assert restored_studio["manual_duration_ms"] is None
+
+    export_resp = slides_client.get(f"/api/v1/slides/presentations/{presentation_id}/export?format=json")
+    assert export_resp.status_code == 200
+    exported_studio = export_resp.json()["slides"][0]["metadata"]["studio"]
+    assert exported_studio["transition"] == "fade"
+    assert exported_studio["timing_mode"] == "auto"
+    assert exported_studio["manual_duration_ms"] is None
 
 def test_slides_generate_from_prompt_uses_stubbed_llm(slides_client, monkeypatch):
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- wire Presentation Studio timing and transition metadata through Slides persistence, export, and video rendering
- add focused WebUI fixes for explicit slide defaults and stable bootstrap/detail loading
- ship the editor UX audit pass: slide sequencing controls, readiness/status cues, timing controls, mobile overflow fix, and Playwright coverage

## Test Plan
- [x] python -m pytest tldw_Server_API/tests/Slides/test_slides_api.py tldw_Server_API/tests/Slides/test_presentation_rendering.py -q
- [x] python -m bandit -r tldw_Server_API/app/api/v1/endpoints/slides.py tldw_Server_API/app/core/Slides/presentation_rendering.py -f json -o /tmp/bandit_presentation_studio_persistence_export.json
- [x] bunx vitest run apps/packages/ui/src/components/Layouts/__tests__/ChatHeader.test.tsx apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioPage.test.tsx apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentation-studio.store.test.tsx apps/packages/ui/src/components/Option/PresentationStudio/__tests__/presentationStudioReadiness.test.ts apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioBootstrap.test.tsx apps/packages/ui/src/components/Option/PresentationStudio/__tests__/PresentationStudioCreatePayload.test.tsx
- [x] TLDW_WEB_URL=http://localhost:3100 TLDW_WEB_CMD="bun run dev -- -p 3100" TLDW_SERVER_URL=http://127.0.0.1:8000 TLDW_API_KEY=THIS-IS-A-SECURE-KEY-123-FAKE-KEY bunx playwright test apps/tldw-frontend/e2e/ux-audit/presentation-studio.spec.ts --project=chromium --reporter=line