### PR TITLE
feat(flashcards): add study assistant and scheduler follow-ups

### DIFF
--- a/Docs/Plans/2026-03-13-assistant-conflict-recovery-ux-design.md
+++ b/Docs/Plans/2026-03-13-assistant-conflict-recovery-ux-design.md
@@ -1,0 +1,126 @@
+# Assistant Conflict Recovery UX Design
+
+## Goal
+
+Make flashcard study-assistant and quiz-remediation assistant threads recover cleanly from `409` thread-version conflicts instead of collapsing into a generic unavailable state.
+
+## Scope
+
+This slice only covers assistant conflict recovery UX.
+
+In scope:
+- Flashcard study assistant in review
+- Quiz remediation assistant
+- Conflict-specific retry and reload behavior
+
+Out of scope:
+- Server-side remediation conversion persistence
+- Scheduler settings during deck creation/edit flows
+- Backend API changes unless implementation reveals a missing response detail
+
+## Current State
+
+The backend already supports optimistic concurrency with `expected_thread_version`. The flashcards and quizzes assistant hooks attach the cached thread version automatically when callers do not provide one. On conflict, the backend returns `409`.
+
+The UI still treats these failures as generic assistant outages:
+- [FlashcardStudyAssistantPanel.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx)
+- [ReviewTab.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx)
+- [QuizRemediationPanel.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx)
+
+That loses user momentum and hides the actual recovery path.
+
+## Recommended Approach
+
+Keep the backend contract unchanged and solve this at the panel boundary.
+
+`FlashcardStudyAssistantPanel` becomes the shared recovery surface for both flashcards and quiz remediation. It will:
+- detect `409` conflicts from `onRespond`
+- refetch the latest assistant context through a new `onReloadContext` prop
+- preserve the attempted request locally
+- render a conflict-specific banner with retry/reload actions
+
+`ReviewTab` and `QuizRemediationPanel` will remain thin coordinators. They will pass the query `refetch` function down to the panel and keep their existing mutation usage.
+
+## Data Flow
+
+### Normal send
+
+1. User triggers quick action, follow-up, or transcript fact-check.
+2. Panel calls `onRespond(request)`.
+3. Existing mutation updates the assistant query cache.
+4. Panel clears any transient conflict state.
+
+### Conflict send
+
+1. User triggers a send.
+2. `onRespond(request)` throws an error with HTTP status `409`.
+3. Panel stores the attempted request as `pendingRequest`.
+4. Panel calls `onReloadContext()`.
+5. Query refetches the latest thread and version.
+6. Panel shows a conflict banner while leaving the refreshed thread visible.
+7. User chooses:
+   - `Reload latest`: clear `pendingRequest`, keep refreshed thread
+   - `Retry my message`: resend `pendingRequest`
+   - transcript-specific retry: same resend path, different label
+
+The retry request should not manually set a new version in the panel. The existing mutation hooks already read the refreshed thread version from the query cache and will attach it automatically.
+
+## UI Behavior
+
+### Flashcards
+
+The study assistant panel stays open during conflicts. The latest thread remains visible. The user sees:
+- a conflict banner stating the conversation changed elsewhere
+- `Reload latest`
+- `Retry my message` or `Retry transcript review`, depending on the preserved request
+
+### Quiz remediation
+
+The remediation panel uses the same assistant surface, so it should recover in place with the same behavior. It should not collapse back to the results list or lose the active question focus.
+
+### Error boundaries
+
+Conflict state is separate from generic errors:
+- `409` becomes recoverable conflict UX
+- all other failures continue to show the existing generic assistant-unavailable messaging
+
+## State Model
+
+`FlashcardStudyAssistantPanel` will own:
+- `assistantError`
+- `pendingConflictRequest`
+- `isConflictRecovering`
+
+Where:
+- `pendingConflictRequest` is the exact failed `StudyAssistantRespondRequest`
+- `isConflictRecovering` covers the refetch/reload action state
+
+This state resets when:
+- `cardUuid` changes
+- the user clicks `Reload latest`
+- a retry succeeds
+
+## Testing
+
+Frontend coverage should prove:
+- flashcard assistant `409` refetches and shows conflict-specific recovery actions
+- quiz remediation `409` preserves the active question and pending request
+- `Reload latest` clears the pending request without resending
+- transcript/fact-check conflicts preserve transcript payload and use the transcript-specific retry label
+- non-409 failures still show the generic unavailable path
+
+Primary test files:
+- [ReviewTab.assistant.test.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx)
+- [ResultsTab.remediation.test.tsx](/Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx)
+
+## Risks
+
+- The panel must not duplicate or fight the optimistic cache updates already done in the hooks.
+- Reload/retry must stay local to the active assistant thread and avoid broad invalidations.
+- The retry path should preserve request payloads exactly, especially `voice_transcript` fact-check messages.
+
+## Follow-on Slices
+
+After this slice:
+1. Server-side remediation conversion state
+2. Scheduler settings in deck creation/edit flows

--- a/Docs/Plans/2026-03-13-assistant-conflict-recovery-ux-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-assistant-conflict-recovery-ux-implementation-plan.md
@@ -1,0 +1,216 @@
+# Assistant Conflict Recovery UX Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make flashcard and quiz assistant threads recover gracefully from `409` version conflicts by reloading the latest thread, preserving the failed request, and offering explicit retry actions.
+
+**Architecture:** Keep the backend contract unchanged. Add conflict recovery state to the shared `FlashcardStudyAssistantPanel`, pass query `refetch` handlers from the flashcards and quiz surfaces, and prove the behavior with end-to-end UI tests on both surfaces.
+
+**Tech Stack:** React, TanStack Query, Vitest, Ant Design, existing flashcards/quizzes assistant hooks
+
+---
+
+### Task 1: Add failing flashcard-assistant conflict tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+- a `409` assistant send refetches context and shows a conflict-specific banner
+- `Retry my message` resends the preserved request
+- transcript fact-check conflicts use a transcript-specific retry label and preserve the transcript payload
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+```
+
+Expected: the new conflict-recovery assertions fail because the panel only shows the generic unavailable state.
+
+**Step 3: Commit the failing-test checkpoint**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+git commit -m "test(flashcards): add assistant conflict recovery coverage"
+```
+
+### Task 2: Implement shared assistant conflict recovery in the panel
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx`
+
+**Step 1: Add the minimal panel API and conflict state**
+
+Extend the panel with:
+- `onReloadContext: () => Promise<unknown>`
+- local conflict state for the pending request and reload status
+- helpers to detect `409` responses
+
+**Step 2: Implement the minimal conflict UX**
+
+When `onRespond` throws a `409`:
+- store the failed `StudyAssistantRespondRequest`
+- call `onReloadContext`
+- render the conflict banner and recovery buttons
+
+Keep non-409 errors on the existing generic error path.
+
+**Step 3: Wire the flashcard review surface**
+
+Pass `assistantQuery.refetch` from `ReviewTab` into the panel.
+
+**Step 4: Run the flashcard tests**
+
+Run:
+
+```bash
+bunx vitest run src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+```
+
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+git commit -m "fix(flashcards): recover assistant threads after conflict"
+```
+
+### Task 3: Add failing quiz-remediation conflict tests
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add tests that prove:
+- remediation assistant `409` keeps the active question in place
+- the panel reloads the latest thread and shows conflict recovery actions
+- `Reload latest` clears the pending request without resending
+
+**Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+bunx vitest run src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: FAIL because the remediation flow still treats the conflict like a generic assistant failure.
+
+**Step 3: Commit the failing-test checkpoint**
+
+```bash
+git add apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+git commit -m "test(quiz): add remediation assistant conflict coverage"
+```
+
+### Task 4: Wire quiz remediation into the shared recovery path
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts`
+
+**Step 1: Pass context reload to the shared panel**
+
+Use `assistantQuery.refetch` in `QuizRemediationPanel` and pass it to `FlashcardStudyAssistantPanel`.
+
+**Step 2: Keep mutation behavior compatible with conflict retry**
+
+Do not rewrite the mutation flow. Preserve the existing hook behavior where it pulls `expected_thread_version` from the refreshed query cache. Only make sure the query refetch path is reachable and clean.
+
+**Step 3: Run the quiz remediation tests**
+
+Run:
+
+```bash
+bunx vitest run src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+git commit -m "fix(quiz): recover remediation assistant conflicts"
+```
+
+### Task 5: Run the focused regression matrix
+
+**Files:**
+- Verify only
+
+**Step 1: Run the focused matrix**
+
+Run:
+
+```bash
+bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
+```
+
+Expected: PASS
+
+**Step 2: Run an adjacent spot-check**
+
+Run:
+
+```bash
+bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.analytics-summary.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+```
+
+Expected: PASS
+
+**Step 3: Check formatting cleanliness**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output
+
+**Step 4: Commit any follow-up fixes**
+
+```bash
+git add <touched files>
+git commit -m "test(ui): verify assistant conflict recovery slice"
+```
+
+### Task 6: Update docs
+
+**Files:**
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+
+**Step 1: Document the new recovery behavior**
+
+Add a short note that assistant conflicts reload the latest thread and offer retry instead of failing generically.
+
+**Step 2: Run a focused docs/link sanity check**
+
+Run:
+
+```bash
+bunx vitest run src/components/Flashcards/constants/__tests__/help-links.test.ts
+```
+
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+git commit -m "docs(flashcards): document assistant conflict recovery"
+```

--- a/Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-design.md
+++ b/Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-design.md
@@ -1,0 +1,270 @@
+# Scheduler Settings In Deck Creation Flows Design
+
+Date: 2026-03-13  
+Status: Approved
+
+## Summary
+
+This slice extends scheduler configuration from the dedicated `Scheduler` tab into deck-creation flows.
+
+The goal is to let users choose scheduler behavior when they create new flashcard decks, instead of creating decks with implicit defaults and fixing them later.
+
+The design covers:
+
+- explicit inline deck creation in the flashcard create drawer
+- flashcards import/generate/image-occlusion deck creation from the target-deck selector
+- quiz remediation deck creation when converting missed questions into flashcards
+
+It does not replace the existing `Scheduler` tab. That tab remains the full editor for existing decks.
+
+## Current Baseline
+
+The backend already supports scheduler settings on deck create and deck update.
+
+The current UI gap is that most deck-creation flows either:
+
+- create a deck with name only, or
+- silently auto-create a deck with backend defaults
+
+Relevant code anchors:
+
+- `apps/packages/ui/src/services/flashcards.ts`
+- `apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts`
+- `apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts`
+- `apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx`
+- `apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx`
+- `apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx`
+- `apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx`
+- `apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx`
+- `apps/packages/ui/src/services/quizzes.ts`
+- `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+- `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+- `tldw_Server_API/app/api/v1/schemas/quizzes.py`
+- `tldw_Server_API/app/api/v1/endpoints/quizzes.py`
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+## Product Decision
+
+Use one shared scheduler-creation editor across deck-creation flows.
+
+Do not embed the full `Scheduler` tab in each creation surface.
+
+Do not limit creation-time scheduler control to presets only.
+
+Do not leave quiz remediation as a default-only exception.
+
+This gives users the best outcome because:
+
+- new decks can start with the right scheduler immediately
+- all major deck-creation surfaces behave consistently
+- the existing `Scheduler` tab remains the one place for deep edits after creation
+
+## Recommended Approach
+
+Add a shared compact scheduler editor for creation flows and reuse the existing scheduler draft utilities.
+
+The creation flows should all support:
+
+- deck name
+- preset selection
+- scheduler summary
+- optional advanced custom settings
+
+The shared editor should be used by:
+
+- flashcard create drawer inline new-deck flow
+- structured import target deck selector
+- generated-cards target deck selector
+- image-occlusion target deck selector
+- quiz remediation "create new deck" modal path
+
+The `Scheduler` tab remains the edit surface for existing decks.
+
+## Scope Clarification
+
+This slice includes both flashcards and quiz remediation deck creation.
+
+It does not add a new standalone deck-management modal.
+
+It does not add scheduler editing for already-selected decks inside each flow. Existing decks stay read-only in these surfaces, with a visible scheduler summary and a pointer to the `Scheduler` tab.
+
+## Shared Scheduler Editor
+
+Extract a reusable embeddable scheduler editor instead of reusing `SchedulerTab` directly.
+
+New shared pieces:
+
+- `DeckSchedulerSettingsEditor`
+- `useDeckSchedulerDraft`
+
+The shared hook should wrap:
+
+- `createSchedulerDraft`
+- `validateSchedulerDraft`
+- preset application
+- reset-to-defaults
+- draft/error state
+
+The shared component should support a compact creation mode:
+
+- preset selector
+- summary preview
+- optional advanced editor accordion
+
+It should reuse the same field labels, validation rules, and preset behavior as the existing `Scheduler` tab so the UI cannot drift.
+
+## Create-Deck Contract
+
+The frontend create-deck contract should be tightened to use a full scheduler settings object when the field is present.
+
+V1 decision:
+
+- `useCreateDeckMutation()` accepts `scheduler_settings?: DeckSchedulerSettings`
+- creation flows must submit fully validated scheduler settings
+- do not send partial scheduler payloads from create flows
+
+This matches the backend model more closely and removes ambiguity about which side is responsible for default-filling.
+
+## Flashcards Create Drawer
+
+The inline `Create new deck` path in `FlashcardCreateDrawer.tsx` should expand from name-only creation to:
+
+- deck name
+- scheduler preset selector
+- compact scheduler summary
+- advanced scheduler settings when expanded
+
+Behavior:
+
+- validation must happen before calling create
+- successful create selects the new deck in the flashcard form
+- cancel must clear both deck-name and scheduler draft state
+
+## Import, Generate, And Image-Occlusion Flows
+
+The current import/generate/image-occlusion tabs only auto-create a deck when no decks exist.
+
+That is not enough for this slice.
+
+V1 decision:
+
+- add a `__new__` option to target-deck selectors in:
+  - structured import
+  - generated cards
+  - image occlusion
+- when `__new__` is selected, render a new-deck configuration block inline
+- the configuration block contains:
+  - deck name
+  - preset selector
+  - scheduler summary
+  - optional advanced scheduler editor
+
+This lets users create a new deck with scheduler settings even when other decks already exist.
+
+### Selector State Rules
+
+The existing "default to first deck" effects must become sentinel-aware.
+
+Rules:
+
+- initial default may still select the first existing deck
+- once the user chooses `__new__`, the selector state must not be overwritten by the auto-default effect
+- deck creation block state must persist while `__new__` remains selected
+- switching back to an existing deck hides the creation block without mutating the chosen existing deck
+
+These rules are required to avoid clobbering user intent.
+
+## Quiz Remediation Deck Creation
+
+Quiz remediation already supports `target_deck_id` or `create_deck_name`.
+
+This slice extends that creation path so a new remediation deck can also receive scheduler settings.
+
+Request extension:
+
+- `create_deck_scheduler_settings?: DeckSchedulerSettings | null`
+
+Rules:
+
+- only valid when `create_deck_name` is provided
+- ignored or rejected when `target_deck_id` is used
+- create-deck scheduler settings are applied only to the newly created deck
+
+UI behavior in `ResultsTab.tsx`:
+
+- when the user chooses `Create new deck`, render the same shared scheduler creation block below the deck-name input
+- when an existing deck is selected, show a read-only scheduler summary for that deck
+
+This keeps remediation deck creation consistent with the flashcards surfaces.
+
+## Existing Deck Visibility
+
+When an existing deck is selected in any creation surface, show:
+
+- a short scheduler summary
+- lightweight text pointing to the `Scheduler` tab for edits
+
+V1 should not allow inline editing of existing deck scheduler settings in these creation flows.
+
+That keeps the scope focused and avoids mixing create-time and edit-time concerns.
+
+## Validation And Error Handling
+
+Validation should remain local to the creation surface until the user submits.
+
+Behavior:
+
+- invalid scheduler drafts block deck creation
+- create-flow validation errors stay local to that flow
+- deck-create request errors still use the existing mutation error path
+- remediation create-deck errors should stay in the remediation modal and not clear selection state
+
+## Backend Changes
+
+Flashcards create-deck backend already supports scheduler settings, so no flashcards API change is required.
+
+Quiz remediation does require a small backend extension:
+
+- add `create_deck_scheduler_settings` to the remediation convert request schema
+- thread it through the remediation convert endpoint and DB helper
+- pass those settings into the deck creation call when `create_deck_name` is used
+
+No other scheduler backend behavior changes are needed in this slice.
+
+## Testing Strategy
+
+Frontend tests should cover:
+
+- `useCreateDeckMutation` forwarding full scheduler settings
+- flashcard create drawer inline deck creation with scheduler settings
+- structured import `__new__` deck creation with scheduler settings
+- generated cards `__new__` deck creation with scheduler settings
+- image occlusion `__new__` deck creation with scheduler settings
+- quiz remediation `Create new deck` with scheduler settings
+- selector sentinel state not being overwritten by default-deck effects
+- existing deck scheduler summary rendering in each creation surface
+
+Backend tests should cover:
+
+- remediation convert request accepting `create_deck_scheduler_settings`
+- remediation-created decks storing the provided scheduler settings
+- rejecting invalid create-deck scheduler payloads through existing schema validation
+
+## Non-Goals
+
+This slice does not include:
+
+- inline editing of existing deck scheduler settings in create/import flows
+- a new dedicated deck-management modal
+- changing deck scheduler settings from the quiz side after deck creation
+- changing flashcards routing or the `Scheduler` tab architecture
+
+## Success Criteria
+
+This slice is complete when:
+
+- all supported new-deck flows can create a deck with explicit scheduler settings
+- import/generate/image-occlusion flows support `Create new deck` even when decks already exist
+- quiz remediation can create a new deck with scheduler settings
+- existing selected decks show a scheduler summary without becoming editable in-place
+- the UI submits full validated scheduler settings instead of partial create payloads

--- a/Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-implementation-plan.md
@@ -1,0 +1,341 @@
+# Scheduler Settings In Deck Creation Flows Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Extend scheduler configuration into deck-creation flows across flashcards and quiz remediation, including explicit inline deck creation, selector-driven `Create new deck` flows, and quiz-owned remediation deck creation.
+
+**Architecture:** Extract a shared scheduler draft/editor for creation surfaces, tighten the create-deck mutation to submit full scheduler settings, add `__new__` deck-selector support to import/generate/image-occlusion flows, and extend quiz remediation deck creation to accept scheduler settings when creating a new deck.
+
+**Tech Stack:** React, TanStack Query, Ant Design, TypeScript, FastAPI, Pydantic, SQLite/PostgreSQL via `CharactersRAGDB`, Vitest, pytest, Bandit.
+
+---
+
+### Task 1: Extract Shared Scheduler Draft And Creation Editor Primitives
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts`
+- Create: `apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts`
+- Create: `apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add UI tests for:
+
+- preset selection updating the scheduler summary
+- advanced field edits producing validated full settings
+- reset-to-defaults restoring baseline settings
+- validation errors staying local to the editor
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+```
+
+Expected: FAIL because the shared editor and hook do not exist.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `useDeckSchedulerDraft`
+- `DeckSchedulerSettingsEditor`
+
+Requirements:
+
+- compact creation-mode layout
+- preset selector
+- summary preview
+- optional advanced section
+- full-settings validation output
+
+Keep the implementation free of deck version/conflict logic from `SchedulerTab`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+```
+
+Expected: PASS.
+
+### Task 2: Tighten Deck-Creation Mutation Contract And Reuse It In Flashcards Create Drawer
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/flashcards.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+- `useCreateDeckMutation` forwarding full `scheduler_settings`
+- inline create-deck flow submitting deck name plus scheduler settings
+- cancel clearing inline scheduler draft state
+- existing deck selection remaining unchanged until successful create
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run \
+  src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx \
+  src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
+```
+
+Expected: FAIL because the mutation does not forward scheduler settings and the drawer has no scheduler editor.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+
+- `createDeck()` type tightened to full `DeckSchedulerSettings` when present
+- `useCreateDeckMutation()` accepting `scheduler_settings`
+- `FlashcardCreateDrawer` inline new-deck flow using the shared scheduler editor
+
+Also add a read-only scheduler summary when an existing deck is selected.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command from Step 2.
+
+Expected: PASS.
+
+### Task 3: Add `Create New Deck` Selector Flows To Structured Import, Generated Cards, And Image Occlusion
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx`
+- Create: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+
+- structured import selector supports `__new__`
+- generated cards selector supports `__new__`
+- image occlusion selector supports `__new__`
+- selecting `__new__` shows deck-name plus scheduler editor
+- the default-first-deck effect does not overwrite the `__new__` sentinel
+- save/import creates a deck with scheduler settings and then saves cards into it
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
+```
+
+Expected: FAIL because those selectors do not yet support `__new__`.
+
+**Step 3: Write minimal implementation**
+
+In each flow:
+
+- add `__new__` selector option
+- add local new-deck config state
+- add deck name plus shared scheduler editor block
+- make the auto-default effects sentinel-aware
+- pass validated scheduler settings into `useCreateDeckMutation()`
+
+Also show a read-only scheduler summary for existing selected decks.
+
+**Step 4: Run test to verify it passes**
+
+Run the same command from Step 2.
+
+Expected: PASS.
+
+### Task 4: Extend Quiz Remediation Deck Creation To Accept Scheduler Settings
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/quizzes.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/quizzes.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py`
+- Modify: `apps/packages/ui/src/services/quizzes.ts`
+- Modify: `apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts`
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add backend and frontend tests for:
+
+- remediation convert request accepting `create_deck_scheduler_settings`
+- remediation-created deck storing those scheduler settings
+- remediation UI showing the shared scheduler editor when `Create new deck` is selected
+- remediation UI forwarding scheduler settings with `create_deck_name`
+- existing selected remediation deck showing a scheduler summary
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py \
+  -k "remediation_conversion" -v
+```
+
+And:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: FAIL because the remediation request and UI do not yet carry scheduler settings.
+
+**Step 3: Write minimal implementation**
+
+Backend:
+
+- add `create_deck_scheduler_settings` to the remediation convert request schema
+- validate it only with `create_deck_name`
+- pass it into the remediation conversion helper
+- use it when calling deck creation
+
+Frontend:
+
+- extend quiz service/hook types
+- render the shared scheduler editor when `Create new deck` is selected
+- submit full validated scheduler settings with remediation conversion
+- show read-only scheduler summary for existing selected decks
+
+**Step 4: Run test to verify it passes**
+
+Run the same commands from Step 2.
+
+Expected: PASS.
+
+### Task 5: Update Docs And Run End-To-End Verification
+
+**Files:**
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- choosing scheduler settings during deck creation
+- `Create new deck` in import/generate/image-occlusion flows
+- remediation deck creation with scheduler settings
+- using the `Scheduler` tab for later edits
+
+**Step 2: Run frontend verification matrix**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run \
+  src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx \
+  src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx \
+  src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Run backend verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py \
+  -k "remediation_conversion" -v
+```
+
+Expected: PASS.
+
+**Step 4: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/endpoints/quizzes.py \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/schemas/quizzes.py \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  -f json -o /tmp/bandit_scheduler_creation_flows.json
+```
+
+Expected: either no new findings or only pre-existing findings outside the new slice.
+
+**Step 5: Run diff hygiene**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux diff --check
+```
+
+Expected: clean.
+
+### Task 6: Final Review And Commit
+
+**Step 1: Review the diff**
+
+Check for:
+
+- any selector-state regressions from `__new__`
+- duplicated scheduler validation logic
+- any path still creating decks without explicit scheduler handling
+- any remediation path drift between deck create and conversion request
+
+**Step 2: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add \
+  Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md \
+  Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-design.md \
+  Docs/Plans/2026-03-13-scheduler-settings-deck-creation-flows-implementation-plan.md \
+  apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx \
+  apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx \
+  apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx \
+  apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts \
+  apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts \
+  apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx \
+  apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx \
+  apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx \
+  apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx \
+  apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts \
+  apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx \
+  apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx \
+  apps/packages/ui/src/services/flashcards.ts \
+  apps/packages/ui/src/services/quizzes.ts \
+  apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts \
+  tldw_Server_API/app/api/v1/endpoints/quizzes.py \
+  tldw_Server_API/app/api/v1/schemas/quizzes.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(flashcards): add scheduler settings to deck creation flows"
+```
+
+Success means the branch has one consistent scheduler-creation experience across flashcards and quiz remediation.

--- a/Docs/Plans/2026-03-13-server-side-remediation-conversion-state-design.md
+++ b/Docs/Plans/2026-03-13-server-side-remediation-conversion-state-design.md
@@ -1,0 +1,302 @@
+# Server-Side Remediation Conversion State Design
+
+Date: 2026-03-13  
+Status: Approved
+
+## Summary
+
+This slice replaces browser-only remediation conversion tracking in quiz results with durable server-side state.
+
+The goal is to make "already converted" and "study linked cards" reliable across reloads, browsers, and devices without coupling quiz state to incidental flashcard search or session storage.
+
+The design keeps one active remediation conversion per missed question, preserves earlier conversions as `superseded`, and moves conversion ownership into a quiz endpoint that creates decks, creates flashcards, and records remediation state in one flow.
+
+## Current Baseline
+
+The existing remediation flow is split between UI state and flashcard creation:
+
+- `ResultsTab.tsx` stores converted missed-question flags in session storage
+- `ResultsTab.tsx` stores one deck per attempt in session storage for flashcard-study handoff
+- `ResultsTab.tsx` creates a new deck in the client when needed
+- `ResultsTab.tsx` bulk-creates flashcards directly through the flashcards API
+- `QuizRemediationPanel.tsx` treats conversion state as a simple `alreadyConverted: boolean`
+
+Relevant code anchors:
+
+- `apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx`
+- `apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx`
+- `apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts`
+- `apps/packages/ui/src/services/quizzes.ts`
+- `apps/packages/ui/src/services/tldw/quiz-flashcards-handoff.ts`
+- `apps/packages/ui/src/components/Flashcards/FlashcardsManager.tsx`
+- `apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx`
+- `tldw_Server_API/app/api/v1/endpoints/quizzes.py`
+- `tldw_Server_API/app/api/v1/schemas/quizzes.py`
+- `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+- `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+## Product Decision
+
+Use a dedicated remediation-conversion record owned by the quiz domain.
+
+Do not derive conversion state from flashcards alone.
+
+Do not store remediation conversion history as JSON inside quiz attempts.
+
+This gives users the most reliable experience because:
+
+- conversion state survives session loss
+- conversion state is explicit and queryable
+- active versus superseded history is first-class
+- linked-deck and linked-card metadata can be shown without recomputing from flashcard search
+
+## Recommended Approach
+
+Add a new quiz-owned remediation conversion model and endpoint surface:
+
+- `GET /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions`
+- `POST /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert`
+
+`POST .../convert` owns the full conversion action:
+
+- validate the attempt and selected question IDs
+- validate that each question belongs to the attempt and was missed in a completed submission
+- optionally create a new destination deck
+- create the flashcards
+- supersede previous active remediation rows when explicitly requested
+- insert new active remediation records
+- return per-question results and linked flashcard UUIDs
+
+This removes the current "create flashcards first, then mark session state" split that can drift.
+
+## Data Model
+
+Add a new table:
+
+- `quiz_remediation_conversions`
+
+Suggested columns:
+
+- `id`
+- `attempt_id`
+- `quiz_id`
+- `question_id`
+- `status` with `active | superseded`
+- `superseded_by_id`
+- `target_deck_id`
+- `target_deck_name_snapshot`
+- `flashcard_count`
+- `flashcard_uuids_json`
+- `source_ref_id`
+- `created_at`
+- `last_modified`
+- `client_id`
+- `version`
+
+Rules:
+
+- one `active` row per `attempt_id + question_id`
+- `Convert again anyway` creates a new active row and marks the previous active row `superseded`
+- superseded rows remain queryable for history and auditability
+- linked flashcards are stored by UUID, not internal numeric ID
+
+Indexing:
+
+- `(attempt_id)`
+- `(attempt_id, question_id)`
+- partial unique index for one active row per `(attempt_id, question_id)`
+
+The stored `source_ref_id` should remain aligned with flashcards:
+
+- `quiz-attempt:{attempt_id}:question:{question_id}`
+
+## API Surface
+
+### Read
+
+`GET /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions`
+
+Returns:
+
+- `attempt_id`
+- per-question active remediation summary
+- optional `superseded_count`
+- optional `orphaned` indicator when linked flashcards no longer exist
+
+The read model should be question-centric because the results surface is already organized around missed questions.
+
+### Convert
+
+`POST /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert`
+
+Request:
+
+- `question_ids: number[]`
+- exactly one of:
+  - `target_deck_id`
+  - `create_deck_name`
+- `replace_active: boolean`
+
+Response:
+
+- per-question results with `created | already_exists | superseded_and_created | failed`
+- active conversion summary when successful
+- created flashcard UUIDs
+- structured error details for mixed-result handling
+
+If `replace_active=false` and an active conversion already exists, the endpoint should return an `already_exists` result for that question instead of silently overwriting it.
+
+## Validation Rules
+
+The server must enforce remediation eligibility instead of trusting the UI.
+
+For each requested question:
+
+- attempt exists
+- attempt belongs to the current user
+- attempt has been completed
+- question ID exists in the attempt snapshot
+- the question has a graded answer
+- the graded answer was incorrect
+
+This prevents direct API callers from creating remediation records for correct, missing, or unsubmitted questions.
+
+## Deck Creation Ownership
+
+The convert endpoint must support the current "create new deck" workflow directly.
+
+Do not require the client to create the deck before calling conversion.
+
+Reason:
+
+- avoids empty orphan decks if conversion later fails
+- keeps remediation conversion atomic from the user's perspective
+- removes one more client-only side effect from `ResultsTab`
+
+V1 request semantics:
+
+- `target_deck_id` for existing deck conversion
+- `create_deck_name` for new deck conversion
+
+Reject requests that provide both or neither.
+
+## Dedupe Policy
+
+The current UI dedupes missed questions with identical prompt and correct answer before flashcard creation.
+
+That behavior conflicts with a per-question conversion record unless it is made explicit.
+
+V1 decision:
+
+- preserve the current flashcard dedupe behavior
+- allow multiple question-level remediation records to reference the same created flashcard UUID set
+
+This keeps user-visible card creation behavior stable while still making remediation history question-specific.
+
+Consequences:
+
+- `flashcard_count` is the count of linked created cards for that question's active conversion
+- two question records may point at the same UUID array
+- the conversion response should make that explicit so the UI does not assume one new card per missed question
+
+## Handoff To Flashcards Study
+
+The current handoff assumes one deck per attempt. That is no longer always true.
+
+V1 handoff rule:
+
+- if all active remediation conversions for the attempt point to the same live deck, keep the existing deck-filtered `Study linked cards` behavior
+- if active conversions span multiple decks, hand off using `quiz_id` and `attempt_id` only, without a deck filter
+
+This avoids picking an arbitrary deck and keeps the CTA usable without changing flashcards routing in this slice.
+
+The deck-specific chip shown beside each missed question should come from the active remediation conversion summary.
+
+## Orphaned And Stale Conversion State
+
+A dedicated remediation record can outlive its linked flashcards.
+
+V1 behavior:
+
+- on read, if every linked flashcard UUID is missing or deleted, mark the active remediation conversion summary as `orphaned`
+- orphaned conversions remain in history but should not block a fresh conversion
+- the UI should surface orphaned conversions as stale and allow a normal reconvert without forcing `replace_active=true`
+
+This keeps the remediation state honest after later flashcard deletion.
+
+## UI Behavior
+
+`ResultsTab` should stop using session storage for remediation conversion state.
+
+Instead it should:
+
+- fetch remediation state for the selected attempt
+- derive `alreadyConverted`, deck labels, and stale/orphaned state from the server response
+- default "Create remediation flashcards" to only not-yet-active or orphaned missed questions
+- show explicit `Convert again anyway` when active conversions already exist
+
+`QuizRemediationPanel` should remain question-centric but gain richer status text:
+
+- `Not converted`
+- `Converted`
+- `Converted in deck X`
+- `Superseded history exists`
+- `Linked cards were deleted`
+
+The global "Study linked cards" CTA should follow the multi-deck handoff rule above.
+
+## Backend Implementation Notes
+
+Prefer one DB helper that performs the conversion flow inside a single transaction:
+
+- load and validate attempt/question eligibility
+- create a deck when needed
+- create flashcards
+- supersede old active records when requested
+- insert new active remediation rows
+- return per-question results
+
+If the flashcard creation helper cannot be reused transactionally without unsafe duplication, the acceptable fallback is:
+
+- keep the convert endpoint orchestration in one request
+- use compensating deletion if remediation-row persistence fails after card creation
+
+The transactional path is preferred.
+
+## Testing
+
+Backend tests should cover:
+
+- reading remediation state for one attempt
+- converting fresh missed questions
+- rejecting correct or ungraded questions
+- rejecting conversion on incomplete attempts
+- creating a new deck inside conversion
+- mixed-result bulk convert with fresh and already-converted questions
+- `replace_active=true` superseding the old active row
+- deduped card creation while preserving per-question remediation rows
+- orphaned conversion read behavior after linked-card deletion
+- user isolation
+
+Frontend tests should cover:
+
+- no more session-storage remediation state reads or writes
+- results tab loading server-backed remediation state
+- already-converted questions excluded by default
+- `Convert again anyway` sending `replace_active=true`
+- active deck label rendering
+- multi-deck handoff dropping the deck filter
+- single-deck handoff keeping the deck filter
+- orphaned conversion rows showing stale state and allowing reconvert
+
+## Non-Scope
+
+This slice does not add:
+
+- full remediation conversion history browsing UI
+- server-driven dedupe explanation UI
+- automatic sync from flashcard edits back into remediation records
+- migration of old session-storage conversion data
+
+The goal is durable server truth for future attempts, not historical recovery from browser-local state.

--- a/Docs/Plans/2026-03-13-server-side-remediation-conversion-state-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-server-side-remediation-conversion-state-implementation-plan.md
@@ -1,0 +1,476 @@
+# Server-Side Remediation Conversion State Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace browser-only missed-question remediation conversion tracking with a quiz-owned server-side conversion model that creates decks, creates remediation flashcards, preserves superseded history, and drives results-tab status plus flashcards-study handoff.
+
+**Architecture:** Add a dedicated remediation-conversion table and DB helper in ChaChaNotes, expose quiz endpoints for reading and converting missed-question remediation state, and update the quiz results UI to consume server-backed conversion summaries instead of session storage. Keep flashcard identity linked by UUID and preserve the existing card dedupe behavior by allowing multiple question-level conversion rows to reference the same created card UUIDs.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL via `CharactersRAGDB`, React, TanStack Query, Ant Design, Vitest, pytest, Bandit.
+
+---
+
+### Task 1: Add Remediation Conversion Schemas And DB Storage
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/quizzes.py`
+- Create: `tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py`
+
+**Step 1: Write the failing tests**
+
+Add DB tests for:
+
+- creating an active remediation conversion row
+- enforcing one active row per `attempt_id + question_id`
+- superseding the old active row
+- storing `flashcard_uuids_json`
+- reading active rows and superseded counts
+
+Example test shape:
+
+```python
+def test_create_active_remediation_conversion(chacha_db, completed_attempt_id):
+    row = chacha_db.create_quiz_remediation_conversion(
+        attempt_id=completed_attempt_id,
+        quiz_id=7,
+        question_id=12,
+        target_deck_id=3,
+        target_deck_name_snapshot="Renal Deck",
+        flashcard_uuids=["card-a"],
+        source_ref_id="quiz-attempt:101:question:12",
+    )
+    assert row["status"] == "active"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py -v
+```
+
+Expected: FAIL because the table, helper methods, and schemas do not exist.
+
+**Step 3: Write minimal implementation**
+
+In `ChaChaNotes_DB.py`:
+
+- bump schema version
+- add `quiz_remediation_conversions`
+- add indexes
+- add active-row uniqueness enforcement
+- add DB helpers for:
+  - create conversion row
+  - supersede active row
+  - list active conversions for an attempt
+  - count superseded history
+
+In `schemas/quizzes.py` add models for:
+
+- remediation conversion summary
+- remediation conversion list response
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/schemas/quizzes.py tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(quizzes): add remediation conversion persistence"
+```
+
+### Task 2: Add Attempt Validation And Conversion Orchestration Helpers
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/quizzes.py`
+- Create: `tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py`
+
+**Step 1: Write the failing tests**
+
+Add service-level DB tests for:
+
+- rejecting incomplete attempts
+- rejecting question IDs not present in the attempt snapshot
+- rejecting questions that were answered correctly
+- accepting only missed questions
+- preserving the current flashcard dedupe behavior while allowing multiple question records to point to the same UUID set
+- creating a deck inside conversion when `create_deck_name` is provided
+- marking old active rows `superseded` when `replace_active=True`
+
+Example test shape:
+
+```python
+def test_convert_missed_questions_rejects_correct_answers(chacha_db, completed_attempt_id):
+    with pytest.raises(InputError):
+        chacha_db.convert_quiz_remediation_questions(
+            attempt_id=completed_attempt_id,
+            question_ids=[11],
+            target_deck_id=3,
+            replace_active=False,
+        )
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py -v
+```
+
+Expected: FAIL because the orchestration helper and validation rules do not exist.
+
+**Step 3: Write minimal implementation**
+
+In `ChaChaNotes_DB.py` implement one helper such as:
+
+- `convert_quiz_remediation_questions(...)`
+
+Behavior:
+
+- load attempt and graded answers
+- validate user ownership through existing DB access pattern
+- validate completion and missed-question eligibility
+- accept exactly one of `target_deck_id` or `create_deck_name`
+- create deck when requested
+- build flashcard payloads using existing remediation text shape
+- preserve current text-answer dedupe behavior
+- bulk create flashcards
+- write remediation conversion rows
+- supersede old actives when requested
+- return mixed per-question results plus created card UUIDs
+
+In `schemas/quizzes.py` add:
+
+- convert request model
+- per-question convert result model
+- convert response model
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/schemas/quizzes.py tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(quizzes): add remediation conversion orchestration"
+```
+
+### Task 3: Expose Quiz Remediation Conversion Endpoints
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/quizzes.py`
+- Modify: `tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py`
+
+**Step 1: Write the failing tests**
+
+Add endpoint tests for:
+
+- `GET /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions`
+- `POST /api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert`
+- `create_deck_name` path
+- `replace_active=false` returning `already_exists`
+- `replace_active=true` returning `superseded_and_created`
+- mixed result responses
+- orphaned active conversions being marked in read responses after linked flashcards are deleted
+
+Example test shape:
+
+```python
+def test_convert_remediation_questions_creates_new_deck(client, auth_headers, completed_attempt_id):
+    response = client.post(
+        f"/api/v1/quizzes/attempts/{completed_attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": [12, 13],
+            "create_deck_name": "Quiz 7 - Missed Questions",
+            "replace_active": False,
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["results"][0]["status"] == "created"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py -k "remediation_conversion" -v
+```
+
+Expected: FAIL because the routes do not exist.
+
+**Step 3: Write minimal implementation**
+
+In `quizzes.py` add:
+
+- `GET /attempts/{attempt_id}/remediation-conversions`
+- `POST /attempts/{attempt_id}/remediation-conversions/convert`
+
+Implementation notes:
+
+- keep all remediation conversion behavior in the quiz domain
+- translate DB/domain errors into `400`, `404`, or `409` as appropriate
+- return mixed per-question results without failing the entire request on one conflict
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py -k "remediation_conversion" -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add tldw_Server_API/app/api/v1/endpoints/quizzes.py tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(quizzes): add remediation conversion endpoints"
+```
+
+### Task 4: Add Quiz Service And Hook Support For Server-Backed Remediation State
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/quizzes.ts`
+- Modify: `apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts`
+- Create: `apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationConversionQueries.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add hook/service tests for:
+
+- loading attempt remediation conversions
+- converting with `target_deck_id`
+- converting with `create_deck_name`
+- retrying with `replace_active=true`
+- invalidating and refreshing attempt remediation state after conversion
+
+Example test shape:
+
+```tsx
+it("passes replace_active when converting again", async () => {
+  await mutation.mutateAsync({
+    attemptId: 101,
+    payload: {
+      question_ids: [12],
+      target_deck_id: 3,
+      replace_active: true
+    }
+  })
+  expect(api.convertAttemptRemediationQuestions).toHaveBeenCalled()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Quiz/hooks/__tests__/useQuizRemediationConversionQueries.test.tsx
+```
+
+Expected: FAIL because the service methods and hooks do not exist.
+
+**Step 3: Write minimal implementation**
+
+In `quizzes.ts` add:
+
+- remediation conversion summary types
+- convert request/response types
+- read and convert API client helpers
+
+In `useQuizQueries.ts` add:
+
+- `useAttemptRemediationConversionsQuery`
+- `useConvertAttemptRemediationQuestionsMutation`
+
+Invalidate:
+
+- attempt remediation query for the active attempt
+- any quiz results data paths that need refreshed deck/conversion state
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Quiz/hooks/__tests__/useQuizRemediationConversionQueries.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add apps/packages/ui/src/services/quizzes.ts apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationConversionQueries.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(ui): add quiz remediation conversion queries"
+```
+
+### Task 5: Replace Session Storage In Results And Remediation UI
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add or update tests for:
+
+- results tab marks already-converted missed questions from server data
+- no remediation conversion session-storage keys are read or written
+- convert action uses the new quiz endpoint instead of direct flashcard bulk-create
+- `Convert again anyway` resubmits with `replace_active=true`
+- deck labels render from active remediation records
+- orphaned conversions show stale state and allow reconvert
+
+Example test shape:
+
+```tsx
+it("removes session storage remediation tracking", async () => {
+  const getItemSpy = vi.spyOn(window.sessionStorage, "getItem")
+  render(<ResultsTab />)
+  expect(getItemSpy).not.toHaveBeenCalledWith("quiz-results-missed-flashcards-v1")
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+```
+
+Expected: FAIL because the UI still uses session storage and the flashcards bulk-create hook directly.
+
+**Step 3: Write minimal implementation**
+
+In `ResultsTab.tsx`:
+
+- remove remediation conversion session-storage helpers and state
+- fetch remediation conversion summaries for the selected attempt
+- route flashcard creation through the new quiz convert mutation
+- preserve existing results-filter session-storage behavior
+- implement explicit `Convert again anyway` confirmation for active conversions
+- compute flashcards-study handoff:
+  - keep deck filter when all active conversions share one live deck
+  - omit deck filter when active conversions span multiple decks
+
+In `QuizRemediationPanel.tsx`:
+
+- replace `alreadyConverted: boolean`-only display with richer status text
+- surface deck labels and stale/orphaned state
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "feat(ui): move remediation conversion state to server"
+```
+
+### Task 6: Update Docs And Run Verification
+
+**Files:**
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+
+**Step 1: Update docs**
+
+Document:
+
+- remediation conversion state is now server-backed
+- "Convert again anyway" creates a new active conversion and keeps previous history as superseded
+- "Study linked cards" may span multiple decks and therefore may omit the deck filter
+
+**Step 2: Run backend regression**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py \
+  tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py \
+  tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py -k "remediation_conversion" -v
+```
+
+Expected: PASS.
+
+**Step 3: Run frontend regression**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/apps/packages/ui
+bunx vitest run \
+  src/components/Quiz/hooks/__tests__/useQuizRemediationConversionQueries.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx \
+  src/components/Flashcards/__tests__/FlashcardsManager.consistency.test.tsx
+```
+
+Expected: PASS.
+
+**Step 4: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/endpoints/quizzes.py \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/schemas/quizzes.py \
+  /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  -f json -o /tmp/bandit_remediation_conversion_state.json
+```
+
+Expected: no new findings in the touched remediation code.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux add Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux commit -m "docs(quizzes): document server-backed remediation conversions"
+```

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -30,6 +30,21 @@ Why the 8 KB field limit did not increase:
 5. Use `Manage` when you want to inspect queue state on expanded cards or document rows while cleaning up a deck.
 6. Repeat daily. The scheduler adjusts next due dates from your ratings.
 
+## Study Assistant Conflict Recovery
+
+The flashcard study assistant and quiz remediation assistant now recover cleanly if the same thread changes in another tab or client.
+
+What happens on a thread version conflict:
+
+- The latest assistant thread is reloaded automatically.
+- Your pending question or transcript is preserved instead of being dropped.
+- The panel shows `Reload latest` and retry actions so you can continue without reopening the card or results view.
+
+Retry labels:
+
+- Text questions use `Retry my message`.
+- Voice transcript fact-checks use `Retry transcript review`.
+
 ## Scheduler Tab
 
 Open `Scheduler` from the top-level Flashcards tabs to edit deck-level review policy.

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -84,6 +84,34 @@ Important behavior:
 - Unsaved scheduler drafts are guarded when you switch decks or leave the `Scheduler` tab.
 - If another client updates the same deck first, the tab shows `Reload latest` and `Reapply my draft` actions.
 
+## Scheduler Settings During Deck Creation
+
+You can now set scheduler policy at deck-creation time instead of creating the deck first and fixing it later.
+
+Flashcards creation flows:
+
+- `Manage` manual card creation
+- `Transfer` structured Q&A preview save
+- `Transfer` generated flashcards save
+- `Transfer` image occlusion save
+
+How it works:
+
+- Existing deck selectors now include `Create new deck`.
+- Choosing that option opens a deck-name field plus the same scheduler preset/editor used by the scheduler UI.
+- Existing decks remain read-only in those flows and show a compact scheduler summary instead.
+- New decks created there start with exactly the scheduler settings you selected.
+
+Quiz remediation:
+
+- `Results` → `Create Flashcards from Missed Questions` also supports `Create new deck`.
+- The remediation modal lets you set scheduler settings for the new deck before conversion runs.
+- If you choose an existing deck, the modal shows that deck's scheduler summary.
+
+Later edits:
+
+- If you need to change a deck after creation, open the `Scheduler` tab and edit that deck there.
+
 ## Queue States
 
 Queue-state badges now appear on the active card in `Study`, on expanded cards in `Manage`, and on document-mode rows.

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -45,6 +45,22 @@ Retry labels:
 - Text questions use `Retry my message`.
 - Voice transcript fact-checks use `Retry transcript review`.
 
+## Quiz Remediation Conversion State
+
+Quiz-results remediation flashcards now use server-backed conversion records instead of browser-only session state.
+
+What changed:
+
+- `Already converted` status survives reloads, browser changes, and new devices.
+- Each missed question keeps one active remediation conversion plus any superseded history.
+- `Convert Again Anyway` creates a fresh active conversion and leaves the older one in history as `superseded`.
+- If linked remediation cards were deleted later, the quiz results view marks that conversion as stale and lets you reconvert normally.
+
+`Study Linked Cards` behavior:
+
+- If all active remediation conversions for an attempt point to the same live deck, the handoff keeps that deck filter.
+- If conversions span multiple decks, the handoff still opens Flashcards study for the quiz attempt, but without a deck filter.
+
 ## Scheduler Tab
 
 Open `Scheduler` from the top-level Flashcards tabs to edit deck-level review policy.

--- a/apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx
@@ -1,0 +1,191 @@
+import React from "react"
+import { Button, Checkbox, Input, Typography } from "antd"
+import { useTranslation } from "react-i18next"
+
+import type {
+  SchedulerPresetId,
+  SchedulerSettingsDraft,
+  SchedulerValidationErrors
+} from "../utils/scheduler-settings"
+import { SCHEDULER_PRESETS } from "../utils/scheduler-settings"
+
+const { Text } = Typography
+
+type DeckSchedulerSettingsEditorProps = {
+  draft: SchedulerSettingsDraft
+  errors: SchedulerValidationErrors
+  summary: string | null
+  onFieldChange: <K extends keyof SchedulerSettingsDraft>(
+    field: K,
+    value: SchedulerSettingsDraft[K]
+  ) => void
+  onApplyPreset: (presetId: SchedulerPresetId) => void
+  onResetDefaults: () => void
+  advancedDefaultOpen?: boolean
+}
+
+type SchedulerFieldConfig = {
+  key: Exclude<keyof SchedulerSettingsDraft, "enable_fuzz">
+  label: string
+  placeholder?: string
+  testId: string
+}
+
+const ADVANCED_FIELDS: SchedulerFieldConfig[] = [
+  {
+    key: "new_steps_minutes",
+    label: "New steps (minutes)",
+    placeholder: "1, 10",
+    testId: "deck-scheduler-editor-field-new-steps"
+  },
+  {
+    key: "relearn_steps_minutes",
+    label: "Relearn steps (minutes)",
+    placeholder: "10",
+    testId: "deck-scheduler-editor-field-relearn-steps"
+  },
+  {
+    key: "graduating_interval_days",
+    label: "Graduating interval (days)",
+    testId: "deck-scheduler-editor-field-graduating-interval"
+  },
+  {
+    key: "easy_interval_days",
+    label: "Easy interval (days)",
+    testId: "deck-scheduler-editor-field-easy-interval"
+  },
+  {
+    key: "easy_bonus",
+    label: "Easy bonus",
+    testId: "deck-scheduler-editor-field-easy-bonus"
+  },
+  {
+    key: "interval_modifier",
+    label: "Interval modifier",
+    testId: "deck-scheduler-editor-field-interval-modifier"
+  },
+  {
+    key: "max_interval_days",
+    label: "Max interval (days)",
+    testId: "deck-scheduler-editor-field-max-interval"
+  },
+  {
+    key: "leech_threshold",
+    label: "Leech threshold",
+    testId: "deck-scheduler-editor-field-leech-threshold"
+  }
+]
+
+export const DeckSchedulerSettingsEditor: React.FC<DeckSchedulerSettingsEditorProps> = ({
+  draft,
+  errors,
+  summary,
+  onFieldChange,
+  onApplyPreset,
+  onResetDefaults,
+  advancedDefaultOpen = false
+}) => {
+  const { t } = useTranslation(["option", "common"])
+  const [advancedOpen, setAdvancedOpen] = React.useState(advancedDefaultOpen)
+
+  const renderFieldError = (field: keyof SchedulerValidationErrors) => {
+    const error = errors[field]
+    if (!error) return null
+    return (
+      <Text type="danger" className="text-xs">
+        {error}
+      </Text>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Text strong>
+          {t("option:flashcards.schedulerPresets", { defaultValue: "Presets" })}
+        </Text>
+        <div className="flex flex-wrap gap-2">
+          {SCHEDULER_PRESETS.map((preset) => (
+            <Button
+              key={preset.id}
+              size="small"
+              onClick={() => onApplyPreset(preset.id)}
+              data-testid={`deck-scheduler-editor-preset-${preset.id}`}
+            >
+              {preset.label}
+            </Button>
+          ))}
+          <Button
+            size="small"
+            onClick={onResetDefaults}
+            data-testid="deck-scheduler-editor-reset"
+          >
+            {t("option:flashcards.schedulerResetAction", {
+              defaultValue: "Reset to defaults"
+            })}
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded border border-border bg-muted/20 p-3">
+        <Text
+          type={summary ? "secondary" : "danger"}
+          data-testid="deck-scheduler-editor-summary"
+        >
+          {summary ??
+            t("option:flashcards.schedulerDraftInvalid", {
+              defaultValue: "Draft has validation errors."
+            })}
+        </Text>
+      </div>
+
+      <div>
+        <Button
+          type="text"
+          size="small"
+          onClick={() => setAdvancedOpen((current) => !current)}
+          data-testid="deck-scheduler-editor-toggle-advanced"
+        >
+          {advancedOpen
+            ? t("option:flashcards.hideAdvancedScheduler", {
+                defaultValue: "Hide advanced settings"
+              })
+            : t("option:flashcards.showAdvancedScheduler", {
+                defaultValue: "Customize scheduler"
+              })}
+        </Button>
+      </div>
+
+      {advancedOpen && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {ADVANCED_FIELDS.map((field) => (
+            <label key={field.key} className="flex flex-col gap-1">
+              <Text strong>{field.label}</Text>
+              <Input
+                value={draft[field.key]}
+                onChange={(event) => onFieldChange(field.key, event.target.value)}
+                placeholder={field.placeholder}
+                data-testid={field.testId}
+              />
+              {renderFieldError(field.key as keyof SchedulerValidationErrors)}
+            </label>
+          ))}
+
+          <div className="md:col-span-2">
+            <Checkbox
+              checked={draft.enable_fuzz}
+              onChange={(event) => onFieldChange("enable_fuzz", event.target.checked)}
+              data-testid="deck-scheduler-editor-field-enable-fuzz"
+            >
+              {t("option:flashcards.schedulerEnableFuzz", {
+                defaultValue: "Enable review fuzz"
+              })}
+            </Checkbox>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default DeckSchedulerSettingsEditor

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -24,6 +24,7 @@ import {
 import { FLASHCARDS_DRAWER_WIDTH_PX } from "../constants"
 import { MarkdownWithBoundary } from "./MarkdownWithBoundary"
 import { FlashcardImageInsertButton } from "./FlashcardImageInsertButton"
+import { DeckSchedulerSettingsEditor } from "./DeckSchedulerSettingsEditor"
 import { normalizeFlashcardTemplateFields } from "../utils/template-helpers"
 import {
   getSelectionFromElement,
@@ -37,6 +38,8 @@ import {
   getUtf8ByteLength
 } from "../utils/field-byte-limit"
 import type { FlashcardCreate, Deck } from "@/services/flashcards"
+import { useDeckSchedulerDraft } from "../hooks/useDeckSchedulerDraft"
+import { formatSchedulerSummary } from "../utils/scheduler-settings"
 
 const { Text } = Typography
 const CLOZE_PATTERN = /\{\{c\d+::[\s\S]+?\}\}/
@@ -84,6 +87,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
   const selectedModelType = Form.useWatch("model_type", form) as
     | FlashcardModelType
     | undefined
+  const selectedDeckId = Form.useWatch("deck_id", form) as number | undefined
   const [showPreview, setShowPreview] = React.useState(false)
   const frontPreview = useDebouncedFormField(form, "front")
   const backPreview = useDebouncedFormField(form, "back")
@@ -117,11 +121,16 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
   // Inline deck creation state
   const [showInlineCreate, setShowInlineCreate] = React.useState(false)
   const [inlineDeckName, setInlineDeckName] = React.useState("")
+  const inlineSchedulerDraft = useDeckSchedulerDraft()
 
   // Queries and mutations - use props if provided, otherwise fetch
   const decksQuery = useDecksQuery({ enabled: !propDecks })
   const decks = propDecks ?? decksQuery.data ?? []
   const decksLoading = propDecksLoading ?? decksQuery.isLoading
+  const selectedDeck = React.useMemo(
+    () => decks.find((deck) => deck.id === selectedDeckId) ?? null,
+    [decks, selectedDeckId]
+  )
 
   const createMutation = useCreateFlashcardMutation()
   const createDeckMutation = useCreateDeckMutation()
@@ -187,8 +196,9 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
       setShowPreview(false)
       setShowInlineCreate(false)
       setInlineDeckName("")
+      inlineSchedulerDraft.resetToDefaults()
     }
-  }, [open, form])
+  }, [form, inlineSchedulerDraft.resetToDefaults, open])
 
   // Create new deck (inline)
   const handleInlineCreateDeck = async () => {
@@ -201,12 +211,16 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
         )
         return
       }
+      const schedulerSettings = inlineSchedulerDraft.getValidatedSettings()
+      if (!schedulerSettings) return
       const deck = await createDeckMutation.mutateAsync({
-        name: inlineDeckName.trim()
+        name: inlineDeckName.trim(),
+        scheduler_settings: schedulerSettings
       })
       message.success(t("common:created", { defaultValue: "Created" }))
       setShowInlineCreate(false)
       setInlineDeckName("")
+      inlineSchedulerDraft.resetToDefaults()
       form.setFieldsValue({ deck_id: deck.id })
     } catch (e: unknown) {
       const errorMessage =
@@ -381,41 +395,68 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
               />
             </Form.Item>
           ) : (
-            <div className="flex items-center gap-2">
-              <Input
-                placeholder={t("option:flashcards.newDeckNamePlaceholder", {
-                  defaultValue: "New deck name"
-                })}
-                value={inlineDeckName}
-                onChange={(e) => setInlineDeckName(e.target.value)}
-                className="flex-1"
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleInlineCreateDeck()
-                  if (e.key === "Escape") {
+            <>
+              <div className="flex items-center gap-2">
+                <Input
+                  placeholder={t("option:flashcards.newDeckNamePlaceholder", {
+                    defaultValue: "New deck name"
+                  })}
+                  value={inlineDeckName}
+                  onChange={(e) => setInlineDeckName(e.target.value)}
+                  className="flex-1"
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleInlineCreateDeck()
+                    if (e.key === "Escape") {
+                      setShowInlineCreate(false)
+                      setInlineDeckName("")
+                      inlineSchedulerDraft.resetToDefaults()
+                    }
+                  }}
+                />
+              </div>
+              <DeckSchedulerSettingsEditor
+                draft={inlineSchedulerDraft.draft}
+                errors={inlineSchedulerDraft.errors}
+                summary={inlineSchedulerDraft.summary}
+                onFieldChange={inlineSchedulerDraft.updateField}
+                onApplyPreset={inlineSchedulerDraft.applyPreset}
+                onResetDefaults={inlineSchedulerDraft.resetToDefaults}
+              />
+              <div className="flex items-center gap-2">
+                <Button
+                  type="primary"
+                  size="small"
+                  onClick={handleInlineCreateDeck}
+                  loading={createDeckMutation.isPending}
+                  data-testid="flashcards-inline-create-deck-submit"
+                >
+                  {t("common:create", { defaultValue: "Create" })}
+                </Button>
+                <Button
+                  size="small"
+                  data-testid="flashcards-inline-create-deck-cancel"
+                  onClick={() => {
                     setShowInlineCreate(false)
                     setInlineDeckName("")
-                  }
-                }}
-              />
-              <Button
-                type="primary"
-                size="small"
-                onClick={handleInlineCreateDeck}
-                loading={createDeckMutation.isPending}
-              >
-                {t("common:create", { defaultValue: "Create" })}
-              </Button>
-              <Button
-                size="small"
-                onClick={() => {
-                  setShowInlineCreate(false)
-                  setInlineDeckName("")
-                }}
-              >
-                {t("common:cancel", { defaultValue: "Cancel" })}
-              </Button>
-            </div>
+                    inlineSchedulerDraft.resetToDefaults()
+                  }}
+                >
+                  {t("common:cancel", { defaultValue: "Cancel" })}
+                </Button>
+              </div>
+              <Text type="secondary" className="block text-xs">
+                {t("option:flashcards.schedulerTabRedirectHint", {
+                  defaultValue: "Use the Scheduler tab later if you want to refine this deck further."
+                })}
+              </Text>
+            </>
+          )}
+
+          {!showInlineCreate && selectedDeck && (
+            <Text type="secondary" className="block text-xs -mt-2 mb-3">
+              {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+            </Text>
           )}
 
           {/* Card template */}

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardStudyAssistantPanel.tsx
@@ -6,6 +6,7 @@ import { useSpeechRecognition } from "@/hooks/useSpeechRecognition"
 import { useTTS } from "@/hooks/useTTS"
 import type {
   StudyAssistantAction,
+  StudyAssistantContextResponse,
   StudyAssistantMessage,
   StudyAssistantRespondRequest
 } from "@/services/flashcards"
@@ -24,13 +25,50 @@ const DEFAULT_ACTIONS: StudyAssistantAction[] = [
 
 interface FlashcardStudyAssistantPanelProps {
   cardUuid: string
+  threadVersion?: number | null
   messages: StudyAssistantMessage[]
   availableActions?: StudyAssistantAction[] | null
   isLoading?: boolean
   isError?: boolean
   isResponding?: boolean
+  onReloadContext?: () => Promise<unknown>
   onRespond: (request: StudyAssistantRespondRequest) => Promise<unknown>
+  autoSubmitRequest?: {
+    token: number
+    request: StudyAssistantRespondRequest
+  } | null
 }
+
+type SubmitOutcome = "success" | "conflict" | "error"
+
+const hasStudyAssistantContextShape = (value: unknown): value is StudyAssistantContextResponse =>
+  typeof value === "object" &&
+  value !== null &&
+  "thread" in value &&
+  "messages" in value &&
+  "available_actions" in value
+
+const extractStudyAssistantContext = (value: unknown): StudyAssistantContextResponse | null => {
+  if (hasStudyAssistantContextShape(value)) {
+    return value
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "data" in value &&
+    hasStudyAssistantContextShape((value as { data?: unknown }).data)
+  ) {
+    return (value as { data: StudyAssistantContextResponse }).data
+  }
+  return null
+}
+
+const isConflictError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "response" in error &&
+  typeof (error as { response?: { status?: unknown } }).response?.status === "number" &&
+  (error as { response?: { status?: number } }).response?.status === 409
 
 const ACTION_LABELS: Record<StudyAssistantAction, string> = {
   explain: "Explain",
@@ -42,12 +80,15 @@ const ACTION_LABELS: Record<StudyAssistantAction, string> = {
 
 export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanelProps> = ({
   cardUuid,
+  threadVersion = null,
   messages,
   availableActions,
   isLoading = false,
   isError = false,
   isResponding = false,
-  onRespond
+  onReloadContext,
+  onRespond,
+  autoSubmitRequest = null
 }) => {
   const { t } = useTranslation(["option", "common"])
   const { speak, isSpeaking } = useTTS()
@@ -60,48 +101,109 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
     resetTranscript
   } = useSpeechRecognition()
   const [assistantError, setAssistantError] = React.useState<string | null>(null)
+  const [conflictRequest, setConflictRequest] = React.useState<StudyAssistantRespondRequest | null>(null)
+  const [isConflictRecovering, setIsConflictRecovering] = React.useState(false)
+  const [reloadedContext, setReloadedContext] = React.useState<StudyAssistantContextResponse | null>(null)
   const [followUpText, setFollowUpText] = React.useState("")
   const [factCheckTranscript, setFactCheckTranscript] = React.useState("")
   const [factCheckOpen, setFactCheckOpen] = React.useState(false)
+  const lastAutoSubmitTokenRef = React.useRef<number | null>(null)
+  const resetTranscriptRef = React.useRef(resetTranscript)
 
-  const resolvedActions = React.useMemo(
-    () =>
-      Array.from(
-        new Set((availableActions && availableActions.length ? availableActions : DEFAULT_ACTIONS))
-      ),
-    [availableActions]
-  )
+  React.useEffect(() => {
+    resetTranscriptRef.current = resetTranscript
+  }, [resetTranscript])
+
+  const activeContextOverride = React.useMemo(() => {
+    if (!reloadedContext) return null
+    if (threadVersion == null) return reloadedContext
+    return reloadedContext.thread.version > threadVersion ? reloadedContext : null
+  }, [reloadedContext, threadVersion])
+
+  const displayedMessages = activeContextOverride?.messages ?? messages
+  const resolvedActions = React.useMemo(() => {
+    const sourceActions = activeContextOverride?.available_actions ?? availableActions
+    return Array.from(new Set((sourceActions && sourceActions.length ? sourceActions : DEFAULT_ACTIONS)))
+  }, [activeContextOverride?.available_actions, availableActions])
 
   React.useEffect(() => {
     setAssistantError(null)
+    setConflictRequest(null)
+    setIsConflictRecovering(false)
+    setReloadedContext(null)
     setFollowUpText("")
     setFactCheckTranscript("")
     setFactCheckOpen(false)
-    resetTranscript()
-  }, [cardUuid, resetTranscript])
+    resetTranscriptRef.current()
+  }, [cardUuid])
+
+  React.useEffect(() => {
+    if (!reloadedContext || threadVersion == null) return
+    if (threadVersion >= reloadedContext.thread.version) {
+      setReloadedContext(null)
+    }
+  }, [reloadedContext, threadVersion])
 
   React.useEffect(() => {
     if (!factCheckOpen || !isListening) return
     setFactCheckTranscript(transcript)
   }, [factCheckOpen, isListening, transcript])
 
+  const reloadLatestContext = React.useCallback(async () => {
+    if (!onReloadContext) return true
+    setIsConflictRecovering(true)
+    try {
+      const refreshed = await onReloadContext()
+      const latestContext = extractStudyAssistantContext(refreshed)
+      if (latestContext) {
+        setReloadedContext(latestContext)
+      }
+      return true
+    } catch {
+      setAssistantError(
+        t("option:flashcards.studyAssistantUnavailable", {
+          defaultValue: "Study assistant unavailable"
+        })
+      )
+      return false
+    } finally {
+      setIsConflictRecovering(false)
+    }
+  }, [onReloadContext, t])
+
   const submitRequest = React.useCallback(
-    async (request: StudyAssistantRespondRequest) => {
+    async (request: StudyAssistantRespondRequest): Promise<SubmitOutcome> => {
       try {
         setAssistantError(null)
+        setConflictRequest(null)
         await onRespond(request)
-        return true
-      } catch {
+        return "success"
+      } catch (error) {
+        if (isConflictError(error)) {
+          setConflictRequest(request)
+          const reloaded = await reloadLatestContext()
+          if (!reloaded) {
+            return "error"
+          }
+          return "conflict"
+        }
         setAssistantError(
           t("option:flashcards.studyAssistantUnavailable", {
             defaultValue: "Study assistant unavailable"
           })
         )
-        return false
+        return "error"
       }
     },
-    [onRespond, t]
+    [onRespond, reloadLatestContext, t]
   )
+
+  React.useEffect(() => {
+    if (!autoSubmitRequest) return
+    if (lastAutoSubmitTokenRef.current === autoSubmitRequest.token) return
+    lastAutoSubmitTokenRef.current = autoSubmitRequest.token
+    void submitRequest(autoSubmitRequest.request)
+  }, [autoSubmitRequest, submitRequest])
 
   const handleQuickAction = React.useCallback(
     async (action: StudyAssistantAction) => {
@@ -125,12 +227,12 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
     const action: StudyAssistantAction = resolvedActions.includes("follow_up")
       ? "follow_up"
       : "freeform"
-    const succeeded = await submitRequest({
+    const outcome = await submitRequest({
       action,
       message: trimmed,
       input_modality: "text"
     })
-    if (succeeded) {
+    if (outcome === "success") {
       setFollowUpText("")
     }
   }, [followUpText, resolvedActions, submitRequest])
@@ -138,12 +240,12 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
   const handleSubmitFactCheck = React.useCallback(async () => {
     const trimmed = factCheckTranscript.trim()
     if (!trimmed) return
-    const succeeded = await submitRequest({
+    const outcome = await submitRequest({
       action: "fact_check",
       message: trimmed,
       input_modality: "voice_transcript"
     })
-    if (!succeeded) return
+    if (outcome !== "success") return
     if (isListening) {
       stop()
     }
@@ -168,6 +270,29 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
     },
     [speak]
   )
+
+  const handleReloadLatest = React.useCallback(async () => {
+    const reloaded = await reloadLatestContext()
+    if (!reloaded) return
+    setConflictRequest(null)
+  }, [reloadLatestContext])
+
+  const handleRetryConflict = React.useCallback(async () => {
+    if (!conflictRequest) return
+    await submitRequest(conflictRequest)
+  }, [conflictRequest, submitRequest])
+
+  const retryLabel = React.useMemo(() => {
+    if (!conflictRequest) return null
+    if (conflictRequest.input_modality === "voice_transcript") {
+      return t("option:flashcards.studyAssistantRetryTranscript", {
+        defaultValue: "Retry transcript review"
+      })
+    }
+    return t("option:flashcards.studyAssistantRetryMessage", {
+      defaultValue: "Retry my message"
+    })
+  }, [conflictRequest, t])
 
   return (
     <Card
@@ -197,11 +322,44 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
             }
           />
         )}
+        {conflictRequest && (
+          <div className="rounded border border-amber-300 bg-amber-50 p-3">
+            <div className="font-medium">
+              {t("option:flashcards.studyAssistantConflictTitle", {
+                defaultValue: "Conversation changed elsewhere."
+              })}
+            </div>
+            <div className="text-sm text-text-muted">
+              {t("option:flashcards.studyAssistantConflictDescription", {
+                defaultValue: "Reload the latest thread or retry your request against the updated conversation."
+              })}
+            </div>
+            <Space className="mt-3">
+              <Button
+                size="small"
+                onClick={() => void handleReloadLatest()}
+                loading={isConflictRecovering}
+              >
+                {t("option:flashcards.studyAssistantReloadLatest", {
+                  defaultValue: "Reload latest"
+                })}
+              </Button>
+              <Button
+                size="small"
+                type="primary"
+                onClick={() => void handleRetryConflict()}
+                loading={isResponding}
+              >
+                {retryLabel}
+              </Button>
+            </Space>
+          </div>
+        )}
         <div className="flex flex-wrap gap-2">
           {resolvedActions.includes("explain") && (
             <Button
               onClick={() => void handleQuickAction("explain")}
-              loading={isResponding}
+              loading={isResponding || isConflictRecovering}
               icon={<Lightbulb className="size-4" />}
             >
               {t("option:flashcards.studyAssistantExplain", {
@@ -212,7 +370,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
           {resolvedActions.includes("mnemonic") && (
             <Button
               onClick={() => void handleQuickAction("mnemonic")}
-              loading={isResponding}
+              loading={isResponding || isConflictRecovering}
             >
               {t("option:flashcards.studyAssistantMnemonic", {
                 defaultValue: ACTION_LABELS.mnemonic
@@ -222,7 +380,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
           {supported && resolvedActions.includes("fact_check") && (
             <Button
               onClick={() => void handleQuickAction("fact_check")}
-              loading={isResponding}
+              loading={isResponding || isConflictRecovering}
             >
               {t("option:flashcards.studyAssistantFactCheck", {
                 defaultValue: ACTION_LABELS.fact_check
@@ -235,7 +393,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
             transcript={factCheckTranscript}
             isListening={isListening}
             supported={supported}
-            isSubmitting={isResponding}
+            isSubmitting={isResponding || isConflictRecovering}
             onTranscriptChange={setFactCheckTranscript}
             onStartListening={() => start()}
             onStopListening={stop}
@@ -266,7 +424,7 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
                 <Button
                   type="primary"
                   icon={<MessageSquareText className="size-4" />}
-                  loading={isResponding}
+                  loading={isResponding || isConflictRecovering}
                   disabled={!followUpText.trim()}
                   onClick={() => void handleSubmitFollowUp()}
                 >
@@ -290,9 +448,9 @@ export const FlashcardStudyAssistantPanel: React.FC<FlashcardStudyAssistantPanel
                 defaultValue: "Loading assistant history..."
               })}
             </Text>
-          ) : messages.length ? (
+          ) : displayedMessages.length ? (
             <div className="flex flex-col gap-3">
-              {messages.map((message) => (
+              {displayedMessages.map((message) => (
                 <div
                   key={message.id}
                   className="rounded border border-border bg-surface p-3"

--- a/apps/packages/ui/src/components/Flashcards/components/NewDeckConfigurationFields.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/NewDeckConfigurationFields.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { Input, Typography } from "antd"
+import { useTranslation } from "react-i18next"
+
+import { DeckSchedulerSettingsEditor } from "./DeckSchedulerSettingsEditor"
+import type { DeckSchedulerDraftState } from "../hooks/useDeckSchedulerDraft"
+
+const { Text } = Typography
+
+type NewDeckConfigurationFieldsProps = {
+  deckName: string
+  onDeckNameChange: (value: string) => void
+  schedulerDraft: DeckSchedulerDraftState
+  nameTestId: string
+  hint?: string | null
+}
+
+export const NewDeckConfigurationFields: React.FC<NewDeckConfigurationFieldsProps> = ({
+  deckName,
+  onDeckNameChange,
+  schedulerDraft,
+  nameTestId,
+  hint = null
+}) => {
+  const { t } = useTranslation(["option"])
+
+  return (
+    <div className="space-y-3 rounded border border-border bg-muted/10 p-3">
+      <label className="flex flex-col gap-1">
+        <Text strong>
+          {t("option:flashcards.newDeckNameLabel", {
+            defaultValue: "New deck name"
+          })}
+        </Text>
+        <Input
+          value={deckName}
+          onChange={(event) => onDeckNameChange(event.target.value)}
+          placeholder={t("option:flashcards.newDeckNamePlaceholder", {
+            defaultValue: "New deck name"
+          })}
+          data-testid={nameTestId}
+        />
+      </label>
+
+      <DeckSchedulerSettingsEditor
+        draft={schedulerDraft.draft}
+        errors={schedulerDraft.errors}
+        summary={schedulerDraft.summary}
+        onFieldChange={schedulerDraft.updateField}
+        onApplyPreset={schedulerDraft.applyPreset}
+        onResetDefaults={schedulerDraft.resetToDefaults}
+      />
+
+      {hint ? (
+        <Text type="secondary" className="block text-xs">
+          {hint}
+        </Text>
+      ) : null}
+    </div>
+  )
+}
+
+export default NewDeckConfigurationFields

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
@@ -1,0 +1,122 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { DeckSchedulerSettingsEditor } from "../DeckSchedulerSettingsEditor"
+import { useDeckSchedulerDraft } from "../../hooks/useDeckSchedulerDraft"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+            [key: string]: unknown
+          }
+    ) => {
+      const interpolate = (
+        template: string,
+        values?: {
+          [key: string]: unknown
+        }
+      ) =>
+        template.replace(/\{\{\s*([^\s}]+)\s*\}\}/g, (_match, token: string) => {
+          const value = values?.[token]
+          return value == null ? "" : String(value)
+        })
+
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) {
+        return interpolate(defaultValueOrOptions.defaultValue, defaultValueOrOptions)
+      }
+      return key
+    }
+  })
+}))
+
+const Harness = () => {
+  const schedulerDraft = useDeckSchedulerDraft()
+  const [validatedJson, setValidatedJson] = React.useState("")
+
+  return (
+    <div>
+      <DeckSchedulerSettingsEditor
+        draft={schedulerDraft.draft}
+        errors={schedulerDraft.errors}
+        summary={schedulerDraft.summary}
+        onFieldChange={schedulerDraft.updateField}
+        onApplyPreset={schedulerDraft.applyPreset}
+        onResetDefaults={schedulerDraft.resetToDefaults}
+      />
+      <button
+        type="button"
+        onClick={() => {
+          const settings = schedulerDraft.getValidatedSettings()
+          setValidatedJson(settings ? JSON.stringify(settings) : "")
+        }}
+      >
+        Validate draft
+      </button>
+      <output data-testid="deck-scheduler-editor-validated-json">{validatedJson}</output>
+    </div>
+  )
+}
+
+describe("DeckSchedulerSettingsEditor", () => {
+  it("updates the summary when a preset is selected", () => {
+    render(<Harness />)
+
+    expect(screen.getByTestId("deck-scheduler-editor-summary")).toHaveTextContent(
+      "1m,10m -> 1d / easy 4d / leech 8 / fuzz off"
+    )
+
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+
+    expect(screen.getByTestId("deck-scheduler-editor-summary")).toHaveTextContent(
+      "1m,5m,15m -> 1d / easy 3d / leech 10 / fuzz off"
+    )
+  })
+
+  it("validates advanced edits into a full scheduler settings object", () => {
+    render(<Harness />)
+
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-toggle-advanced"))
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
+      target: { value: "12" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: /validate draft/i }))
+
+    expect(screen.getByTestId("deck-scheduler-editor-validated-json")).toHaveTextContent(
+      '"leech_threshold":12'
+    )
+    expect(screen.getByTestId("deck-scheduler-editor-validated-json")).toHaveTextContent(
+      '"new_steps_minutes":[1,10]'
+    )
+  })
+
+  it("resets back to defaults after changes", () => {
+    render(<Harness />)
+
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-conservative_review"))
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-reset"))
+
+    expect(screen.getByTestId("deck-scheduler-editor-summary")).toHaveTextContent(
+      "1m,10m -> 1d / easy 4d / leech 8 / fuzz off"
+    )
+  })
+
+  it("keeps validation errors local to the editor", () => {
+    render(<Harness />)
+
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-toggle-advanced"))
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
+      target: { value: "0" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: /validate draft/i }))
+
+    expect(screen.getByText(/leech threshold must be >= 1/i)).toBeInTheDocument()
+    expect(screen.getByTestId("deck-scheduler-editor-validated-json")).toHaveTextContent("")
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { FlashcardCreateDrawer } from "../FlashcardCreateDrawer"
 import { useCreateDeckMutation, useCreateFlashcardMutation, useDecksQuery } from "../../hooks"
+import type { DeckSchedulerSettings } from "@/services/flashcards"
 
 const uploadFlashcardAsset = vi.hoisted(() => vi.fn())
 
@@ -81,10 +82,33 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
 }
 
 describe("FlashcardCreateDrawer image insertion", () => {
+  const createDeckMutateAsync = vi.fn()
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(useDecksQuery).mockReturnValue({
-      data: [],
+      data: [
+        {
+          id: 1,
+          name: "Biology",
+          description: null,
+          deleted: false,
+          client_id: "test",
+          version: 1,
+          scheduler_settings_json: null,
+          scheduler_settings: {
+            new_steps_minutes: [1, 10],
+            relearn_steps_minutes: [10],
+            graduating_interval_days: 1,
+            easy_interval_days: 4,
+            easy_bonus: 1.3,
+            interval_modifier: 1,
+            max_interval_days: 36500,
+            leech_threshold: 8,
+            enable_fuzz: false
+          }
+        }
+      ],
       isLoading: false
     } as any)
     vi.mocked(useCreateFlashcardMutation).mockReturnValue({
@@ -92,9 +116,10 @@ describe("FlashcardCreateDrawer image insertion", () => {
       isPending: false
     } as any)
     vi.mocked(useCreateDeckMutation).mockReturnValue({
-      mutateAsync: vi.fn(),
+      mutateAsync: createDeckMutateAsync,
       isPending: false
     } as any)
+    createDeckMutateAsync.mockReset()
   })
 
   it("inserts an uploaded image snippet into the front field at the cursor", async () => {
@@ -124,5 +149,52 @@ describe("FlashcardCreateDrawer image insertion", () => {
         "Alpha ![Slide](flashcard-asset://asset-1)Omega"
       )
     })
+  })
+
+  it("creates an inline deck with scheduler settings and selects it in the form", async () => {
+    const createdDeckSettings: DeckSchedulerSettings = {
+      new_steps_minutes: [1, 5, 15],
+      relearn_steps_minutes: [10],
+      graduating_interval_days: 1,
+      easy_interval_days: 3,
+      easy_bonus: 1.15,
+      interval_modifier: 0.9,
+      max_interval_days: 3650,
+      leech_threshold: 10,
+      enable_fuzz: false
+    }
+    createDeckMutateAsync.mockResolvedValue({
+      id: 7,
+      name: "New deck",
+      description: null,
+      deleted: false,
+      client_id: "test",
+      version: 1,
+      scheduler_settings_json: JSON.stringify(createdDeckSettings),
+      scheduler_settings: createdDeckSettings
+    })
+
+    render(<FlashcardCreateDrawer open onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.mouseDown(screen.getByLabelText("Deck"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+
+    fireEvent.change(screen.getByPlaceholderText("New deck name"), {
+      target: { value: "New deck" }
+    })
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+    fireEvent.click(screen.getByTestId("flashcards-inline-create-deck-submit"))
+
+    await waitFor(() =>
+      expect(createDeckMutateAsync).toHaveBeenCalledWith({
+        name: "New deck",
+        scheduler_settings: createdDeckSettings
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("New deck name")).not.toBeInTheDocument()
+    })
+    expect(screen.getByTitle("7")).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import { act, renderHook } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useCreateDeckMutation } from "../useFlashcardQueries"
+import { createDeck, type DeckSchedulerSettings } from "@/services/flashcards"
+
+vi.mock("@/hooks/useServerCapabilities", () => ({
+  useServerCapabilities: () => ({
+    capabilities: { hasFlashcards: true },
+    loading: false
+  })
+}))
+
+vi.mock("@/hooks/useServerOnline", () => ({
+  useServerOnline: () => true
+}))
+
+vi.mock("@/services/flashcards", async () => {
+  const actual = await vi.importActual<typeof import("@/services/flashcards")>(
+    "@/services/flashcards"
+  )
+  const noopAsync = vi.fn()
+  return {
+    ...actual,
+    listDecks: noopAsync,
+    listFlashcards: noopAsync,
+    createFlashcard: noopAsync,
+    createFlashcardsBulk: noopAsync,
+    updateFlashcardsBulk: noopAsync,
+    createDeck: vi.fn(),
+    updateDeck: noopAsync,
+    updateFlashcard: noopAsync,
+    deleteFlashcard: noopAsync,
+    resetFlashcardScheduling: noopAsync,
+    reviewFlashcard: noopAsync,
+    getNextReviewCard: noopAsync,
+    getFlashcardAssistant: noopAsync,
+    respondFlashcardAssistant: noopAsync,
+    generateFlashcards: noopAsync,
+    getFlashcard: noopAsync,
+    importFlashcards: noopAsync,
+    previewStructuredQaImport: noopAsync,
+    importFlashcardsJson: noopAsync,
+    importFlashcardsApkg: noopAsync,
+    getFlashcardsAnalyticsSummary: noopAsync,
+    exportFlashcards: noopAsync,
+    exportFlashcardsFile: noopAsync,
+    getFlashcardsImportLimits: noopAsync
+  }
+})
+
+const schedulerSettings: DeckSchedulerSettings = {
+  new_steps_minutes: [1, 5, 15],
+  relearn_steps_minutes: [10],
+  graduating_interval_days: 1,
+  easy_interval_days: 3,
+  easy_bonus: 1.15,
+  interval_modifier: 0.9,
+  max_interval_days: 3650,
+  leech_threshold: 10,
+  enable_fuzz: false
+}
+
+const buildWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+describe("useCreateDeckMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("forwards full scheduler settings when creating a deck", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    })
+
+    vi.mocked(createDeck).mockResolvedValue({
+      id: 9,
+      name: "Biology Basics",
+      description: null,
+      deleted: false,
+      client_id: "test-client",
+      version: 1,
+      created_at: "2026-03-13T08:00:00Z",
+      last_modified: "2026-03-13T08:00:00Z",
+      scheduler_settings_json: JSON.stringify(schedulerSettings),
+      scheduler_settings: schedulerSettings
+    })
+
+    const { result } = renderHook(() => useCreateDeckMutation(), {
+      wrapper: buildWrapper(queryClient)
+    })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "  Biology Basics  ",
+        description: "  Intro deck  ",
+        scheduler_settings: schedulerSettings
+      })
+    })
+
+    expect(createDeck).toHaveBeenCalledWith({
+      name: "Biology Basics",
+      description: "Intro deck",
+      scheduler_settings: schedulerSettings
+    })
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts
@@ -1,0 +1,97 @@
+import React from "react"
+
+import type { DeckSchedulerSettings } from "@/services/flashcards"
+import type {
+  SchedulerPresetId,
+  SchedulerSettingsDraft,
+  SchedulerValidationErrors
+} from "../utils/scheduler-settings"
+import {
+  DEFAULT_SCHEDULER_SETTINGS,
+  applySchedulerPreset,
+  copySchedulerSettings,
+  createSchedulerDraft,
+  formatSchedulerSummary,
+  validateSchedulerDraft
+} from "../utils/scheduler-settings"
+
+export type DeckSchedulerDraftState = {
+  draft: SchedulerSettingsDraft
+  errors: SchedulerValidationErrors
+  summary: string | null
+  updateField: <K extends keyof SchedulerSettingsDraft>(
+    field: K,
+    value: SchedulerSettingsDraft[K]
+  ) => void
+  applyPreset: (presetId: SchedulerPresetId) => void
+  resetToDefaults: () => void
+  replaceDraft: (settings: DeckSchedulerSettings) => void
+  getValidatedSettings: () => DeckSchedulerSettings | null
+  clearErrors: () => void
+}
+
+export const useDeckSchedulerDraft = (
+  initialSettings: DeckSchedulerSettings = DEFAULT_SCHEDULER_SETTINGS
+): DeckSchedulerDraftState => {
+  const [draft, setDraft] = React.useState<SchedulerSettingsDraft>(() =>
+    createSchedulerDraft(copySchedulerSettings(initialSettings))
+  )
+  const [errors, setErrors] = React.useState<SchedulerValidationErrors>({})
+
+  const replaceDraft = React.useCallback((settings: DeckSchedulerSettings) => {
+    setDraft(createSchedulerDraft(copySchedulerSettings(settings)))
+    setErrors({})
+  }, [])
+
+  const updateField = React.useCallback(
+    <K extends keyof SchedulerSettingsDraft>(field: K, value: SchedulerSettingsDraft[K]) => {
+      setDraft((current) => ({ ...current, [field]: value }))
+      setErrors((current) => {
+        if (!current[field as keyof SchedulerValidationErrors]) return current
+        const next = { ...current }
+        delete next[field as keyof SchedulerValidationErrors]
+        return next
+      })
+    },
+    []
+  )
+
+  const applyPreset = React.useCallback((presetId: SchedulerPresetId) => {
+    setDraft(createSchedulerDraft(applySchedulerPreset(presetId)))
+    setErrors({})
+  }, [])
+
+  const resetToDefaults = React.useCallback(() => {
+    setDraft(createSchedulerDraft(DEFAULT_SCHEDULER_SETTINGS))
+    setErrors({})
+  }, [])
+
+  const getValidatedSettings = React.useCallback(() => {
+    const parsed = validateSchedulerDraft(draft)
+    setErrors(parsed.errors)
+    return parsed.settings
+  }, [draft])
+
+  const clearErrors = React.useCallback(() => {
+    setErrors({})
+  }, [])
+
+  const summary = React.useMemo(() => {
+    const parsed = validateSchedulerDraft(draft)
+    return parsed.settings ? formatSchedulerSummary(parsed.settings) : null
+  }, [draft])
+
+  return {
+    draft,
+    errors,
+    summary,
+    updateField,
+    applyPreset,
+    resetToDefaults,
+    replaceDraft,
+    getValidatedSettings,
+    clearErrors
+  }
+}
+
+export default useDeckSchedulerDraft

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -454,8 +454,16 @@ export function useCreateDeckMutation() {
 
   return useMutation({
     mutationKey: ["flashcards:deck:create"],
-    mutationFn: (params: { name: string; description?: string }) =>
-      createDeck({ name: params.name.trim(), description: params.description?.trim() || undefined }),
+    mutationFn: (params: {
+      name: string
+      description?: string
+      scheduler_settings?: Deck["scheduler_settings"]
+    }) =>
+      createDeck({
+        name: params.name.trim(),
+        description: params.description?.trim() || undefined,
+        scheduler_settings: params.scheduler_settings
+      }),
     onSuccess: () => {
       invalidateFlashcardsQueries(qc)
     },

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
@@ -18,6 +18,9 @@ import {
   useCreateFlashcardsBulkMutation,
   useDecksQuery
 } from "../hooks"
+import { useDeckSchedulerDraft } from "../hooks/useDeckSchedulerDraft"
+import { NewDeckConfigurationFields } from "../components/NewDeckConfigurationFields"
+import { formatSchedulerSummary } from "../utils/scheduler-settings"
 import { generateImageOcclusionAssets } from "../utils/image-occlusion-canvas"
 import { ImageOcclusionPanel, type ImageOcclusionRegion } from "./ImageOcclusionPanel"
 
@@ -27,6 +30,8 @@ const OCCLUSION_UNDO_SECONDS = 30
 const OCCLUSION_UNDO_CHUNK_SIZE = 50
 const IMAGE_OCCLUSION_SYSTEM_TAG = "image-occlusion"
 const MAX_OCCLUSION_REGIONS = 25
+const NEW_DECK_OPTION_VALUE = "__new__" as const
+type DeckSelectionValue = number | typeof NEW_DECK_OPTION_VALUE | null | undefined
 
 type TransferActionStatus = "success" | "warning" | "error"
 
@@ -125,6 +130,7 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
   const decksQuery = useDecksQuery()
   const createDeckMutation = useCreateDeckMutation()
   const createBulkMutation = useCreateFlashcardsBulkMutation()
+  const decks = decksQuery.data || []
 
   const [panelState, setPanelState] = React.useState<ImageOcclusionPanelState>({
     sourceFile: null,
@@ -132,31 +138,81 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
     regions: [],
     selectedRegionId: null
   })
-  const [targetDeckId, setTargetDeckId] = React.useState<number | null | undefined>(undefined)
+  const [targetDeckId, setTargetDeckId] = React.useState<DeckSelectionValue>(undefined)
+  const [newDeckName, setNewDeckName] = React.useState(() =>
+    t("option:flashcards.occlusionDeckName", {
+      defaultValue: "Image Occlusion"
+    })
+  )
   const [tagsInput, setTagsInput] = React.useState("")
   const [drafts, setDrafts] = React.useState<ImageOcclusionDraft[]>([])
   const [error, setError] = React.useState<string | null>(null)
   const [isGenerating, setIsGenerating] = React.useState(false)
   const [isSaving, setIsSaving] = React.useState(false)
+  const schedulerDraft = useDeckSchedulerDraft()
+  const selectedDeck = React.useMemo(
+    () => (typeof targetDeckId === "number" ? decks.find((deck) => deck.id === targetDeckId) ?? null : null),
+    [decks, targetDeckId]
+  )
+  const deckOptions = React.useMemo(
+    () => [
+      ...decks.map((deck: Deck) => ({
+        label: deck.name,
+        value: deck.id
+      })),
+      {
+        label: t("option:flashcards.createNewDeck", {
+          defaultValue: "Create new deck"
+        }),
+        value: NEW_DECK_OPTION_VALUE
+      }
+    ],
+    [decks, t]
+  )
 
   React.useEffect(() => {
     if (targetDeckId != null) return
-    if ((decksQuery.data || []).length > 0) {
-      setTargetDeckId((decksQuery.data || [])[0].id)
+    if (decks.length > 0) {
+      setTargetDeckId(decks[0].id)
+      return
     }
-  }, [decksQuery.data, targetDeckId])
+    setTargetDeckId(NEW_DECK_OPTION_VALUE)
+  }, [decks, targetDeckId])
 
   const resolveTargetDeckId = React.useCallback(async (): Promise<number> => {
-    if (targetDeckId != null) return targetDeckId
-    if ((decksQuery.data || []).length > 0) return (decksQuery.data || [])[0].id
-    const createdDeck = await createDeckMutation.mutateAsync({
-      name: t("option:flashcards.occlusionDeckName", {
-        defaultValue: "Image Occlusion"
+    if (typeof targetDeckId === "number") return targetDeckId
+    if (targetDeckId === undefined && decks.length > 0) return decks[0].id
+    if (targetDeckId === NEW_DECK_OPTION_VALUE || (targetDeckId == null && decks.length === 0)) {
+      const name = newDeckName.trim()
+      if (!name) {
+        throw new Error(
+          t("option:flashcards.newDeckNameRequired", {
+            defaultValue: "Enter a deck name."
+          })
+        )
+      }
+      const schedulerSettings = schedulerDraft.getValidatedSettings()
+      if (!schedulerSettings) {
+        throw new Error(
+          t("option:flashcards.schedulerDraftInvalid", {
+            defaultValue: "Draft has validation errors."
+          })
+        )
+      }
+      const createdDeck = await createDeckMutation.mutateAsync({
+        name,
+        scheduler_settings: schedulerSettings
       })
-    })
-    setTargetDeckId(createdDeck.id)
-    return createdDeck.id
-  }, [createDeckMutation, decksQuery.data, t, targetDeckId])
+      setTargetDeckId(createdDeck.id)
+      return createdDeck.id
+    }
+    if (targetDeckId == null && decks.length > 0) return decks[0].id
+    throw new Error(
+      t("option:flashcards.newDeckNameRequired", {
+        defaultValue: "Enter a deck name."
+      })
+    )
+  }, [createDeckMutation, decks, newDeckName, schedulerDraft, t, targetDeckId])
 
   const updateDraft = React.useCallback((id: string, patch: Partial<ImageOcclusionDraft>) => {
     setDrafts((current) =>
@@ -398,14 +454,27 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
           <Select
             allowClear
             value={targetDeckId ?? undefined}
-            onChange={setTargetDeckId}
+            onChange={(value) => setTargetDeckId((value as DeckSelectionValue) ?? null)}
             data-testid="flashcards-occlusion-deck"
-            options={(decksQuery.data || []).map((deck: Deck) => ({
-              label: deck.name,
-              value: deck.id
-            }))}
+            options={deckOptions}
           />
         </Form.Item>
+        {targetDeckId === NEW_DECK_OPTION_VALUE ? (
+          <NewDeckConfigurationFields
+            deckName={newDeckName}
+            onDeckNameChange={setNewDeckName}
+            schedulerDraft={schedulerDraft}
+            nameTestId="flashcards-occlusion-new-deck-name"
+          />
+        ) : selectedDeck?.scheduler_settings ? (
+          <Text
+            type="secondary"
+            className="block text-xs -mt-2 mb-2"
+            data-testid="flashcards-occlusion-selected-deck-summary"
+          >
+            {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+          </Text>
+        ) : null}
         <Form.Item
           label={t("option:flashcards.tags", { defaultValue: "Tags" })}
           className="!mb-2"

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -18,6 +18,7 @@ import { useAntdMessage } from "@/hooks/useAntdMessage"
 import { useUndoNotification } from "@/hooks/useUndoNotification"
 import { processInChunks } from "@/utils/chunk-processing"
 import { ImageOcclusionTransferPanel } from "./ImageOcclusionTransferPanel"
+import { NewDeckConfigurationFields } from "../components/NewDeckConfigurationFields"
 import {
   useCreateDeckMutation,
   useCreateFlashcardMutation,
@@ -31,8 +32,10 @@ import {
   usePreviewStructuredQaImportMutation
 } from "../hooks"
 import { getUtf8ByteLength } from "../utils/field-byte-limit"
+import { useDeckSchedulerDraft } from "../hooks/useDeckSchedulerDraft"
 import { FileDropZone } from "../components"
 import { FLASHCARDS_HELP_LINKS } from "../constants"
+import { formatSchedulerSummary } from "../utils/scheduler-settings"
 import {
   deleteFlashcard,
   exportFlashcards,
@@ -111,6 +114,8 @@ const LARGE_IMPORT_CONFIRM_THRESHOLD_ROWS = 300
 const LARGE_IMPORT_CONFIRM_THRESHOLD_APKG_BYTES = 5 * 1024 * 1024
 const APKG_ESTIMATED_BYTES_PER_CARD = 4096
 const SUPPORTED_DELIMITERS: SupportedDelimiter[] = ["\t", ",", ";", "|"]
+const NEW_DECK_OPTION_VALUE = "__new__" as const
+type DeckSelectionValue = number | typeof NEW_DECK_OPTION_VALUE | null | undefined
 const IMPORT_HELP_ANCHORS = {
   columns: "flashcards-import-help-columns",
   delimiter: "flashcards-import-help-delimiter",
@@ -385,6 +390,7 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
   const importJsonMutation = useImportFlashcardsJsonMutation()
   const importApkgMutation = useImportFlashcardsApkgMutation()
   const previewStructuredMutation = usePreviewStructuredQaImportMutation()
+  const decks = decksQuery.data || []
 
   const [content, setContent] = React.useState("")
   const [importMode, setImportMode] = React.useState<ImportMode>("delimited")
@@ -396,13 +402,40 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
   const [structuredPreviewErrors, setStructuredPreviewErrors] = React.useState<
     FlashcardsImportError[]
   >([])
-  const [structuredTargetDeckId, setStructuredTargetDeckId] = React.useState<
-    number | null | undefined
-  >(undefined)
+  const [structuredTargetDeckId, setStructuredTargetDeckId] =
+    React.useState<DeckSelectionValue>(undefined)
+  const [structuredNewDeckName, setStructuredNewDeckName] = React.useState(() =>
+    t("option:flashcards.structuredImportDeckName", {
+      defaultValue: "Structured Import"
+    })
+  )
   const [confirmLargeImportOpen, setConfirmLargeImportOpen] = React.useState(false)
   const [importHelpActiveKeys, setImportHelpActiveKeys] = React.useState<string[]>([
     "columns"
   ])
+  const structuredSchedulerDraft = useDeckSchedulerDraft()
+  const structuredSelectedDeck = React.useMemo(
+    () =>
+      typeof structuredTargetDeckId === "number"
+        ? decks.find((deck) => deck.id === structuredTargetDeckId) ?? null
+        : null,
+    [decks, structuredTargetDeckId]
+  )
+  const structuredDeckOptions = React.useMemo(
+    () => [
+      ...decks.map((deck) => ({
+        label: deck.name,
+        value: deck.id
+      })),
+      {
+        label: t("option:flashcards.createNewDeck", {
+          defaultValue: "Create new deck"
+        }),
+        value: NEW_DECK_OPTION_VALUE
+      }
+    ],
+    [decks, t]
+  )
 
   const selectedDelimiterLabel = React.useMemo(() => {
     if (delimiter === "\t") {
@@ -419,10 +452,12 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
 
   React.useEffect(() => {
     if (structuredTargetDeckId !== undefined) return
-    if ((decksQuery.data || []).length > 0) {
-      setStructuredTargetDeckId((decksQuery.data || [])[0].id)
+    if (decks.length > 0) {
+      setStructuredTargetDeckId(decks[0].id)
+      return
     }
-  }, [decksQuery.data, structuredTargetDeckId])
+    setStructuredTargetDeckId(NEW_DECK_OPTION_VALUE)
+  }, [decks, structuredTargetDeckId])
 
   const structuredMaxFieldLength = React.useMemo(() => {
     const rawValue = limitsQuery.data?.max_field_length
@@ -444,17 +479,52 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
 
   const resolveStructuredTargetDeckId = React.useCallback(async (): Promise<number> => {
     if (typeof structuredTargetDeckId === "number") return structuredTargetDeckId
-    if (structuredTargetDeckId === undefined && (decksQuery.data || []).length > 0) {
-      return (decksQuery.data || [])[0].id
+    if (structuredTargetDeckId === undefined && decks.length > 0) {
+      return decks[0].id
     }
-    const createdDeck = await createDeckMutation.mutateAsync({
-      name: t("option:flashcards.structuredImportDeckName", {
-        defaultValue: "Structured Import"
+    if (
+      structuredTargetDeckId === NEW_DECK_OPTION_VALUE ||
+      (structuredTargetDeckId == null && decks.length === 0)
+    ) {
+      const name = structuredNewDeckName.trim()
+      if (!name) {
+        throw new Error(
+          t("option:flashcards.newDeckNameRequired", {
+            defaultValue: "Enter a deck name."
+          })
+        )
+      }
+      const schedulerSettings = structuredSchedulerDraft.getValidatedSettings()
+      if (!schedulerSettings) {
+        throw new Error(
+          t("option:flashcards.schedulerDraftInvalid", {
+            defaultValue: "Draft has validation errors."
+          })
+        )
+      }
+      const createdDeck = await createDeckMutation.mutateAsync({
+        name,
+        scheduler_settings: schedulerSettings
       })
-    })
-    setStructuredTargetDeckId(createdDeck.id)
-    return createdDeck.id
-  }, [createDeckMutation, decksQuery.data, structuredTargetDeckId, t])
+      setStructuredTargetDeckId(createdDeck.id)
+      return createdDeck.id
+    }
+    if (structuredTargetDeckId == null && decks.length > 0) {
+      return decks[0].id
+    }
+    throw new Error(
+      t("option:flashcards.newDeckNameRequired", {
+        defaultValue: "Enter a deck name."
+      })
+    )
+  }, [
+    createDeckMutation,
+    decks,
+    structuredNewDeckName,
+    structuredSchedulerDraft,
+    structuredTargetDeckId,
+    t
+  ])
 
   const scrollToImportHelp = React.useCallback((anchorId?: string) => {
     if (!anchorId || typeof document === "undefined") return
@@ -1224,15 +1294,28 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
                   allowClear
                   value={structuredTargetDeckId ?? undefined}
                   onChange={(value) => {
-                    setStructuredTargetDeckId(value ?? null)
+                    setStructuredTargetDeckId((value as DeckSelectionValue) ?? null)
                   }}
-                  options={(decksQuery.data || []).map((deck) => ({
-                    label: deck.name,
-                    value: deck.id
-                  }))}
+                  options={structuredDeckOptions}
                   data-testid="flashcards-structured-target-deck"
                 />
               </Form.Item>
+              {structuredTargetDeckId === NEW_DECK_OPTION_VALUE ? (
+                <NewDeckConfigurationFields
+                  deckName={structuredNewDeckName}
+                  onDeckNameChange={setStructuredNewDeckName}
+                  schedulerDraft={structuredSchedulerDraft}
+                  nameTestId="flashcards-structured-new-deck-name"
+                />
+              ) : structuredSelectedDeck?.scheduler_settings ? (
+                <Text
+                  type="secondary"
+                  className="block text-xs"
+                  data-testid="flashcards-structured-selected-deck-summary"
+                >
+                  {formatSchedulerSummary(structuredSelectedDeck.scheduler_settings)}
+                </Text>
+              ) : null}
               <Button
                 type="primary"
                 onClick={() => void handleStructuredPreview()}
@@ -1895,6 +1978,7 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
   const generateMutation = useGenerateFlashcardsMutation()
   const createMutation = useCreateFlashcardMutation()
   const createDeckMutation = useCreateDeckMutation()
+  const decks = decksQuery.data || []
 
   const sourceContext = React.useMemo<GenerateSourceContext | null>(() => {
     if (!initialIntent) return null
@@ -1919,17 +2003,44 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
   const [provider, setProvider] = React.useState("")
   const [model, setModel] = React.useState("")
   const [focusTopicsInput, setFocusTopicsInput] = React.useState("")
-  const [targetDeckId, setTargetDeckId] = React.useState<number | null | undefined>(undefined)
+  const [targetDeckId, setTargetDeckId] = React.useState<DeckSelectionValue>(undefined)
+  const [newDeckName, setNewDeckName] = React.useState(() =>
+    t("option:flashcards.generatedDeckName", {
+      defaultValue: "Generated Flashcards"
+    })
+  )
   const [generatedCards, setGeneratedCards] = React.useState<GeneratedCardDraft[]>([])
   const [generationError, setGenerationError] = React.useState<string | null>(null)
   const [isSaving, setIsSaving] = React.useState(false)
+  const generatedDeckSchedulerDraft = useDeckSchedulerDraft()
+  const selectedDeck = React.useMemo(
+    () => (typeof targetDeckId === "number" ? decks.find((deck) => deck.id === targetDeckId) ?? null : null),
+    [decks, targetDeckId]
+  )
+  const deckOptions = React.useMemo(
+    () => [
+      ...decks.map((deck) => ({
+        label: deck.name,
+        value: deck.id
+      })),
+      {
+        label: t("option:flashcards.createNewDeck", {
+          defaultValue: "Create new deck"
+        }),
+        value: NEW_DECK_OPTION_VALUE
+      }
+    ],
+    [decks, t]
+  )
 
   React.useEffect(() => {
     if (targetDeckId != null) return
-    if ((decksQuery.data || []).length > 0) {
-      setTargetDeckId((decksQuery.data || [])[0].id)
+    if (decks.length > 0) {
+      setTargetDeckId(decks[0].id)
+      return
     }
-  }, [decksQuery.data, targetDeckId])
+    setTargetDeckId(NEW_DECK_OPTION_VALUE)
+  }, [decks, targetDeckId])
 
   const updateGeneratedCard = React.useCallback(
     (id: string, patch: Partial<GeneratedCardDraft>) => {
@@ -2013,16 +2124,39 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
   ])
 
   const resolveTargetDeckId = React.useCallback(async (): Promise<number> => {
-    if (targetDeckId != null) return targetDeckId
-    if ((decksQuery.data || []).length > 0) return (decksQuery.data || [])[0].id
-    const createdDeck = await createDeckMutation.mutateAsync({
-      name: t("option:flashcards.generatedDeckName", {
-        defaultValue: "Generated Flashcards"
+    if (typeof targetDeckId === "number") return targetDeckId
+    if (targetDeckId === undefined && decks.length > 0) return decks[0].id
+    if (targetDeckId === NEW_DECK_OPTION_VALUE || (targetDeckId == null && decks.length === 0)) {
+      const name = newDeckName.trim()
+      if (!name) {
+        throw new Error(
+          t("option:flashcards.newDeckNameRequired", {
+            defaultValue: "Enter a deck name."
+          })
+        )
+      }
+      const schedulerSettings = generatedDeckSchedulerDraft.getValidatedSettings()
+      if (!schedulerSettings) {
+        throw new Error(
+          t("option:flashcards.schedulerDraftInvalid", {
+            defaultValue: "Draft has validation errors."
+          })
+        )
+      }
+      const createdDeck = await createDeckMutation.mutateAsync({
+        name,
+        scheduler_settings: schedulerSettings
       })
-    })
-    setTargetDeckId(createdDeck.id)
-    return createdDeck.id
-  }, [createDeckMutation, decksQuery.data, t, targetDeckId])
+      setTargetDeckId(createdDeck.id)
+      return createdDeck.id
+    }
+    if (targetDeckId == null && decks.length > 0) return decks[0].id
+    throw new Error(
+      t("option:flashcards.newDeckNameRequired", {
+        defaultValue: "Enter a deck name."
+      })
+    )
+  }, [createDeckMutation, decks, generatedDeckSchedulerDraft, newDeckName, t, targetDeckId])
 
   const handleSaveGeneratedCards = React.useCallback(async () => {
     if (generatedCards.length === 0) return
@@ -2217,14 +2351,27 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
           <Select
             allowClear
             value={targetDeckId ?? undefined}
-            onChange={setTargetDeckId}
+            onChange={(value) => setTargetDeckId((value as DeckSelectionValue) ?? null)}
             data-testid="flashcards-generate-deck"
-            options={(decksQuery.data || []).map((deck) => ({
-              label: deck.name,
-              value: deck.id
-            }))}
+            options={deckOptions}
           />
         </Form.Item>
+        {targetDeckId === NEW_DECK_OPTION_VALUE ? (
+          <NewDeckConfigurationFields
+            deckName={newDeckName}
+            onDeckNameChange={setNewDeckName}
+            schedulerDraft={generatedDeckSchedulerDraft}
+            nameTestId="flashcards-generate-new-deck-name"
+          />
+        ) : selectedDeck?.scheduler_settings ? (
+          <Text
+            type="secondary"
+            className="block text-xs -mt-2 mb-2"
+            data-testid="flashcards-generate-selected-deck-summary"
+          >
+            {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+          </Text>
+        ) : null}
         <Form.Item
           label={t("option:flashcards.generateProvider", {
             defaultValue: "Provider (optional)"

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -976,11 +976,13 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
 
             <FlashcardStudyAssistantPanel
               cardUuid={activeCard.uuid}
+              threadVersion={assistantQuery.data?.thread.version ?? null}
               messages={assistantQuery.data?.messages ?? []}
               availableActions={assistantQuery.data?.available_actions ?? null}
               isLoading={assistantQuery.isLoading}
               isError={assistantQuery.isError}
               isResponding={assistantRespondMutation.isPending}
+              onReloadContext={() => assistantQuery.refetch()}
               onRespond={handleAssistantRespond}
             />
 

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
@@ -18,13 +18,15 @@ const {
   generateImageOcclusionAssetsMock,
   uploadFlashcardAssetMock,
   createBulkMutateAsync,
-  invalidateQueriesMock
+  invalidateQueriesMock,
+  createDeckMutateAsync
 } = vi.hoisted(() => ({
   showUndoNotificationMock: vi.fn(),
   generateImageOcclusionAssetsMock: vi.fn(),
   uploadFlashcardAssetMock: vi.fn(),
   createBulkMutateAsync: vi.fn(),
-  invalidateQueriesMock: vi.fn().mockResolvedValue(undefined)
+  invalidateQueriesMock: vi.fn().mockResolvedValue(undefined),
+  createDeckMutateAsync: vi.fn()
 }))
 
 vi.mock("@tanstack/react-query", async () => {
@@ -72,7 +74,7 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("../../hooks", () => ({
   useCreateDeckMutation: vi.fn(() => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: createDeckMutateAsync,
     isPending: false
   })),
   useCreateFlashcardsBulkMutation: vi.fn(() => ({
@@ -148,6 +150,7 @@ vi.mock("@/services/flashcard-assets", () => ({
 describe("ImageOcclusionTransferPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    createDeckMutateAsync.mockReset()
     generateImageOcclusionAssetsMock.mockResolvedValue({
       source: {
         blob: new Blob(["source"], { type: "image/webp" }),
@@ -236,5 +239,54 @@ describe("ImageOcclusionTransferPanel", () => {
         }
       ])
     })
+  })
+
+  it("creates a new occlusion deck with scheduler settings from the selector flow", async () => {
+    const fastAcquisitionSettings = {
+      new_steps_minutes: [1, 5, 15],
+      relearn_steps_minutes: [10],
+      graduating_interval_days: 1,
+      easy_interval_days: 3,
+      easy_bonus: 1.15,
+      interval_modifier: 0.9,
+      max_interval_days: 3650,
+      leech_threshold: 10,
+      enable_fuzz: false
+    }
+    createDeckMutateAsync.mockResolvedValue({
+      id: 9,
+      name: "Occlusion deck",
+      description: null,
+      deleted: false,
+      client_id: "test",
+      version: 1,
+      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
+      scheduler_settings: fastAcquisitionSettings
+    })
+
+    render(<ImageOcclusionTransferPanel />)
+
+    fireEvent.mouseDown(screen.getByTestId("flashcards-occlusion-deck"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+    fireEvent.change(screen.getByTestId("flashcards-occlusion-new-deck-name"), {
+      target: { value: "Occlusion deck" }
+    })
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+
+    fireEvent.click(screen.getByTestId("mock-occlusion-panel-load"))
+    fireEvent.click(screen.getByTestId("flashcards-occlusion-generate-button"))
+
+    await waitFor(() => {
+      expect(uploadFlashcardAssetMock).toHaveBeenCalledTimes(3)
+    })
+
+    fireEvent.click(await screen.findByTestId("flashcards-occlusion-save-button"))
+
+    await waitFor(() =>
+      expect(createDeckMutateAsync).toHaveBeenCalledWith({
+        name: "Occlusion deck",
+        scheduler_settings: fastAcquisitionSettings
+      })
+    )
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx
@@ -1,0 +1,309 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ImportExportTab } from "../ImportExportTab"
+import {
+  useCreateDeckMutation,
+  useCreateFlashcardMutation,
+  useCreateFlashcardsBulkMutation,
+  useDecksQuery,
+  useGenerateFlashcardsMutation,
+  useImportFlashcardsApkgMutation,
+  useImportFlashcardsJsonMutation,
+  useImportFlashcardsMutation,
+  useImportLimitsQuery,
+  usePreviewStructuredQaImportMutation
+} from "../../hooks"
+import type { DeckSchedulerSettings } from "@/services/flashcards"
+
+const messageSpies = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+  loading: vi.fn(),
+  open: vi.fn(),
+  destroy: vi.fn()
+}
+
+const createDeckMutateAsync = vi.hoisted(() => vi.fn())
+const createCardMutateAsync = vi.hoisted(() => vi.fn())
+const createBulkMutateAsync = vi.hoisted(() => vi.fn())
+const generateMutateAsync = vi.hoisted(() => vi.fn())
+const previewStructuredMutateAsync = vi.hoisted(() => vi.fn())
+const invalidateQueriesMock = vi.hoisted(() => vi.fn())
+const useQueryMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query")
+  return {
+    ...actual,
+    useQuery: useQueryMock,
+    useQueryClient: () => ({
+      invalidateQueries: invalidateQueriesMock
+    })
+  }
+})
+
+vi.mock("@/hooks/useAntdMessage", () => ({
+  useAntdMessage: () => messageSpies
+}))
+
+vi.mock("@/hooks/useUndoNotification", () => ({
+  useUndoNotification: () => ({
+    showUndoNotification: vi.fn()
+  })
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) {
+        return defaultValueOrOptions.defaultValue.replace(
+          /\{\{(\w+)\}\}/g,
+          (_match, token: string) =>
+            String((defaultValueOrOptions as Record<string, unknown>)[token] ?? `{{${token}}}`)
+        )
+      }
+      return key
+    }
+  })
+}))
+
+vi.mock("../../hooks", () => ({
+  useCreateDeckMutation: vi.fn(),
+  useCreateFlashcardMutation: vi.fn(),
+  useCreateFlashcardsBulkMutation: vi.fn(),
+  useDecksQuery: vi.fn(),
+  useGenerateFlashcardsMutation: vi.fn(),
+  useImportFlashcardsMutation: vi.fn(),
+  useImportFlashcardsApkgMutation: vi.fn(),
+  useImportFlashcardsJsonMutation: vi.fn(),
+  useImportLimitsQuery: vi.fn(),
+  usePreviewStructuredQaImportMutation: vi.fn()
+}))
+
+if (!(globalThis as any).ResizeObserver) {
+  ;(globalThis as any).ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
+if (!(Element.prototype as any).scrollIntoView) {
+  ;(Element.prototype as any).scrollIntoView = vi.fn()
+}
+
+const fastAcquisitionSettings: DeckSchedulerSettings = {
+  new_steps_minutes: [1, 5, 15],
+  relearn_steps_minutes: [10],
+  graduating_interval_days: 1,
+  easy_interval_days: 3,
+  easy_bonus: 1.15,
+  interval_modifier: 0.9,
+  max_interval_days: 3650,
+  leech_threshold: 10,
+  enable_fuzz: false
+}
+
+describe("ImportExportTab deck creation flows", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    createDeckMutateAsync.mockReset()
+    createCardMutateAsync.mockReset()
+    createBulkMutateAsync.mockReset()
+    generateMutateAsync.mockReset()
+    previewStructuredMutateAsync.mockReset()
+    useQueryMock.mockReturnValue({
+      data: 0,
+      isLoading: false
+    } as any)
+
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name: "Biology",
+          description: null,
+          deleted: false,
+          client_id: "test",
+          version: 1,
+          scheduler_settings_json: null,
+          scheduler_settings: {
+            new_steps_minutes: [1, 10],
+            relearn_steps_minutes: [10],
+            graduating_interval_days: 1,
+            easy_interval_days: 4,
+            easy_bonus: 1.3,
+            interval_modifier: 1,
+            max_interval_days: 36500,
+            leech_threshold: 8,
+            enable_fuzz: false
+          }
+        }
+      ],
+      isLoading: false
+    } as any)
+    vi.mocked(useCreateDeckMutation).mockReturnValue({
+      mutateAsync: createDeckMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
+      mutateAsync: createCardMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: createBulkMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useGenerateFlashcardsMutation).mockReturnValue({
+      mutateAsync: generateMutateAsync,
+      isPending: false
+    } as any)
+    vi.mocked(useImportFlashcardsMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useImportFlashcardsJsonMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useImportFlashcardsApkgMutation).mockReturnValue({
+      mutateAsync: vi.fn(),
+      isPending: false
+    } as any)
+    vi.mocked(useImportLimitsQuery).mockReturnValue({
+      data: null
+    } as any)
+    vi.mocked(usePreviewStructuredQaImportMutation).mockReturnValue({
+      mutateAsync: previewStructuredMutateAsync,
+      isPending: false
+    } as any)
+  })
+
+  it("creates a new structured-import deck with scheduler settings from the selector flow", async () => {
+    createDeckMutateAsync.mockResolvedValue({
+      id: 11,
+      name: "Structured deck",
+      description: null,
+      deleted: false,
+      client_id: "test",
+      version: 1,
+      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
+      scheduler_settings: fastAcquisitionSettings
+    })
+    previewStructuredMutateAsync.mockResolvedValue({
+      drafts: [
+        {
+          front: "Question",
+          back: "Answer",
+          line_start: 1,
+          line_end: 2,
+          notes: null,
+          extra: null,
+          tags: []
+        }
+      ],
+      errors: [],
+      detected_format: "qa_labels",
+      skipped_blocks: 0
+    })
+    createBulkMutateAsync.mockResolvedValue({
+      items: [{ uuid: "card-1", deck_id: 11 }],
+      count: 1,
+      total: 1,
+      errors: []
+    })
+
+    render(<ImportExportTab />)
+
+    fireEvent.mouseDown(screen.getByTestId("flashcards-import-format"))
+    fireEvent.click(await screen.findByText("Structured Q&A"))
+
+    fireEvent.mouseDown(screen.getByTestId("flashcards-structured-target-deck"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+    fireEvent.change(screen.getByTestId("flashcards-structured-new-deck-name"), {
+      target: { value: "Structured deck" }
+    })
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+
+    fireEvent.change(screen.getByTestId("flashcards-import-textarea"), {
+      target: { value: "Q: Question\nA: Answer" }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-structured-preview-button"))
+
+    await waitFor(() => {
+      expect(previewStructuredMutateAsync).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(await screen.findByTestId("flashcards-structured-save-button"))
+
+    await waitFor(() =>
+      expect(createDeckMutateAsync).toHaveBeenCalledWith({
+        name: "Structured deck",
+        scheduler_settings: fastAcquisitionSettings
+      })
+    )
+  })
+
+  it("creates a new generated-cards deck with scheduler settings from the selector flow", async () => {
+    createDeckMutateAsync.mockResolvedValue({
+      id: 12,
+      name: "Generated deck",
+      description: null,
+      deleted: false,
+      client_id: "test",
+      version: 1,
+      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
+      scheduler_settings: fastAcquisitionSettings
+    })
+    generateMutateAsync.mockResolvedValue({
+      flashcards: [
+        {
+          front: "Generated front",
+          back: "Generated back",
+          tags: ["tag-1"],
+          model_type: "basic"
+        }
+      ],
+      count: 1
+    })
+    createCardMutateAsync.mockResolvedValue({})
+
+    render(<ImportExportTab />)
+
+    fireEvent.mouseDown(screen.getByTestId("flashcards-generate-deck"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+    fireEvent.change(screen.getByTestId("flashcards-generate-new-deck-name"), {
+      target: { value: "Generated deck" }
+    })
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+
+    fireEvent.change(screen.getByTestId("flashcards-generate-text"), {
+      target: { value: "Photosynthesis notes..." }
+    })
+    fireEvent.click(screen.getByTestId("flashcards-generate-button"))
+
+    await waitFor(() => {
+      expect(generateMutateAsync).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(await screen.findByTestId("flashcards-generate-save-button"))
+
+    await waitFor(() =>
+      expect(createDeckMutateAsync).toHaveBeenCalledWith({
+        name: "Generated deck",
+        scheduler_settings: fastAcquisitionSettings
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx
@@ -32,6 +32,7 @@ const messageSpies = {
 
 const assistantMutateAsync = vi.fn()
 const speakMock = vi.fn()
+const assistantRefetchMock = vi.fn()
 const speechRecognitionState = {
   supported: true,
   isListening: false,
@@ -118,11 +119,14 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
 }
 
 describe("ReviewTab study assistant panel", () => {
+  let assistantQueryState: any
+
   beforeEach(() => {
     vi.clearAllMocks()
     speechRecognitionState.supported = true
     speechRecognitionState.isListening = false
     speechRecognitionState.transcript = ""
+    assistantRefetchMock.mockReset()
 
     vi.mocked(useDecksQuery).mockReturnValue({
       data: [{ id: 1, name: "Biology" }],
@@ -180,7 +184,7 @@ describe("ReviewTab study assistant panel", () => {
     } as any)
     vi.mocked(useHasCardsQuery).mockReturnValue({ data: true } as any)
     vi.mocked(useNextDueQuery).mockReturnValue({ data: null } as any)
-    vi.mocked(useFlashcardAssistantQuery).mockReturnValue({
+    assistantQueryState = {
       data: {
         thread: {
           id: 9,
@@ -217,7 +221,46 @@ describe("ReviewTab study assistant panel", () => {
       },
       isLoading: false,
       isError: false
-    } as any)
+    }
+    assistantRefetchMock.mockImplementation(async () => {
+      const nextMessageId = 12 + (assistantQueryState.data?.messages?.length ?? 1)
+      assistantQueryState = {
+        ...assistantQueryState,
+        data: {
+          ...assistantQueryState.data,
+          thread: {
+            ...assistantQueryState.data.thread,
+            version: 2,
+            message_count: 2
+          },
+          messages: [
+            ...(assistantQueryState.data?.messages ?? []),
+            {
+              id: nextMessageId,
+              thread_id: 9,
+              role: "assistant",
+              action_type: "follow_up",
+              input_modality: "text",
+              content: "Fresh thread update",
+              structured_payload: {},
+              context_snapshot: {},
+              provider: "openai",
+              model: "gpt-5",
+              created_at: "2026-03-13T08:05:00Z",
+              client_id: "test"
+            }
+          ]
+        }
+      }
+      return assistantQueryState
+    })
+    vi.mocked(useFlashcardAssistantQuery).mockImplementation(
+      () =>
+        ({
+          ...assistantQueryState,
+          refetch: assistantRefetchMock
+        }) as any
+    )
     vi.mocked(useFlashcardAssistantRespondMutation).mockReturnValue({
       mutateAsync: assistantMutateAsync,
       isPending: false
@@ -310,5 +353,86 @@ describe("ReviewTab study assistant panel", () => {
       expect(screen.getByText("Study assistant unavailable")).toBeInTheDocument()
     })
     expect(screen.getByTestId("flashcards-review-show-answer")).toBeInTheDocument()
+  })
+
+  it("reloads the latest thread and offers retry actions after a conflict", async () => {
+    assistantMutateAsync
+      .mockRejectedValueOnce(Object.assign(new Error("Version mismatch"), { response: { status: 409 } }))
+      .mockResolvedValueOnce({
+        assistant_message: { content: "Retried explanation" }
+      })
+    renderReviewTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "Explain" }))
+
+    await waitFor(() => {
+      expect(assistantRefetchMock).toHaveBeenCalled()
+      expect(screen.getByText("Fresh thread update")).toBeInTheDocument()
+      expect(screen.getByText("Conversation changed elsewhere.")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Retry my message" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry my message" }))
+
+    await waitFor(() => {
+      expect(assistantMutateAsync).toHaveBeenNthCalledWith(2, {
+        cardUuid: "card-1",
+        request: { action: "explain" }
+      })
+    })
+  })
+
+  it("clears the pending request when reloading the latest thread", async () => {
+    assistantMutateAsync.mockRejectedValueOnce(
+      Object.assign(new Error("Version mismatch"), { response: { status: 409 } })
+    )
+    renderReviewTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "Explain" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Reload latest/i })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Retry my message" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /Reload latest/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Retry my message" })).not.toBeInTheDocument()
+    })
+    expect(assistantMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves transcript fact-check requests across conflict recovery", async () => {
+    assistantMutateAsync
+      .mockRejectedValueOnce(Object.assign(new Error("Version mismatch"), { response: { status: 409 } }))
+      .mockResolvedValueOnce({
+        assistant_message: { content: "Retried fact-check" }
+      })
+    renderReviewTab()
+
+    fireEvent.click(screen.getByRole("button", { name: "Fact-check me" }))
+    fireEvent.change(screen.getByLabelText("Transcript"), {
+      target: { value: "I think the glomerulus filters blood." }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send fact-check" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Conversation changed elsewhere.")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Retry transcript review" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry transcript review" }))
+
+    await waitFor(() => {
+      expect(assistantMutateAsync).toHaveBeenNthCalledWith(2, {
+        cardUuid: "card-1",
+        request: {
+          action: "fact_check",
+          message: "I think the glomerulus filters blood.",
+          input_modality: "voice_transcript"
+        }
+      })
+    })
   })
 })

--- a/apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx
+++ b/apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx
@@ -49,6 +49,11 @@ export const QuizRemediationPanel: React.FC<QuizRemediationPanelProps> = ({
   const [activeQuestionId, setActiveQuestionId] = React.useState<number | null>(
     () => missedQuestionEntries[0]?.questionId ?? null
   )
+  const [assistantAutoRequest, setAssistantAutoRequest] = React.useState<{
+    token: number
+    request: StudyAssistantRespondRequest
+  } | null>(null)
+  const assistantAutoRequestTokenRef = React.useRef(0)
 
   React.useEffect(() => {
     if (missedQuestionEntries.length === 0) {
@@ -84,13 +89,13 @@ export const QuizRemediationPanel: React.FC<QuizRemediationPanelProps> = ({
   const handleExplainQuestion = React.useCallback(
     async (questionId: number) => {
       setActiveQuestionId(questionId)
-      await assistantRespondMutation.mutateAsync({
-        attemptId,
-        questionId,
+      assistantAutoRequestTokenRef.current += 1
+      setAssistantAutoRequest({
+        token: assistantAutoRequestTokenRef.current,
         request: { action: "explain" }
       })
     },
-    [assistantRespondMutation, attemptId]
+    []
   )
 
   const handleAssistantRespond = React.useCallback(
@@ -270,12 +275,15 @@ export const QuizRemediationPanel: React.FC<QuizRemediationPanelProps> = ({
             </div>
             <FlashcardStudyAssistantPanel
               cardUuid={`quiz-attempt-${attemptId}-question-${activeQuestion.questionId}`}
+              threadVersion={assistantQuery.data?.thread.version ?? null}
               messages={assistantQuery.data?.messages ?? []}
               availableActions={assistantQuery.data?.available_actions ?? [...DEFAULT_AVAILABLE_ACTIONS]}
               isLoading={assistantQuery.isLoading}
               isError={assistantQuery.isError}
               isResponding={assistantRespondMutation.isPending}
+              onReloadContext={() => assistantQuery.refetch()}
               onRespond={handleAssistantRespond}
+              autoSubmitRequest={assistantAutoRequest}
             />
           </div>
         ) : null}

--- a/apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx
+++ b/apps/packages/ui/src/components/Quiz/components/QuizRemediationPanel.tsx
@@ -18,6 +18,10 @@ export type MissedQuestionEntry = {
   userAnswerText: string
   explanation: string | null
   alreadyConverted: boolean
+  orphaned: boolean
+  convertedDeckName: string | null
+  linkedFlashcardCount: number
+  hasSupersededHistory: boolean
 }
 
 interface QuizRemediationPanelProps {
@@ -194,10 +198,28 @@ export const QuizRemediationPanel: React.FC<QuizRemediationPanelProps> = ({
                           {t("option:quiz.yourAnswer", { defaultValue: "Your answer" })}:{" "}
                           {entry.userAnswerText}
                         </div>
-                        {entry.alreadyConverted && (
+                        {entry.orphaned ? (
+                          <div className="pl-6 text-xs text-warning">
+                            {t("option:quiz.linkedCardsDeleted", {
+                              defaultValue: "Linked cards were deleted. Convert again to recreate them."
+                            })}
+                          </div>
+                        ) : entry.alreadyConverted ? (
                           <div className="pl-6 text-xs text-text-subtle">
-                            {t("option:quiz.alreadyConvertedRemediation", {
-                              defaultValue: "Remediation flashcards already exist for this miss."
+                            {entry.convertedDeckName
+                              ? t("option:quiz.alreadyConvertedDeckLabel", {
+                                  defaultValue: "Converted in deck {{deckName}}.",
+                                  deckName: entry.convertedDeckName
+                                })
+                              : t("option:quiz.alreadyConvertedRemediation", {
+                                  defaultValue: "Remediation flashcards already exist for this miss."
+                                })}
+                          </div>
+                        ) : null}
+                        {entry.hasSupersededHistory && (
+                          <div className="pl-6 text-xs text-text-subtle">
+                            {t("option:quiz.supersededRemediationHistory", {
+                              defaultValue: "Superseded remediation history exists for this question."
                             })}
                           </div>
                         )}

--- a/apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationQueries.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationQueries.test.tsx
@@ -1,10 +1,18 @@
 import React from "react"
-import { act, renderHook } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { useGenerateRemediationQuizMutation } from "../useQuizQueries"
-import { generateRemediationQuiz } from "@/services/quizzes"
+import {
+  useAttemptRemediationConversionsQuery,
+  useConvertAttemptRemediationQuestionsMutation,
+  useGenerateRemediationQuizMutation
+} from "../useQuizQueries"
+import {
+  convertAttemptRemediationQuestions,
+  generateRemediationQuiz,
+  listAttemptRemediationConversions
+} from "@/services/quizzes"
 
 vi.mock("@/hooks/useServerCapabilities", () => ({
   useServerCapabilities: () => ({
@@ -23,6 +31,87 @@ vi.mock("@/services/quizzes", async () => {
   )
   return {
     ...actual,
+    listAttemptRemediationConversions: vi.fn(async () => ({
+      attempt_id: 301,
+      items: [
+        {
+          id: 71,
+          attempt_id: 301,
+          quiz_id: 21,
+          question_id: 12,
+          status: "active",
+          orphaned: false,
+          target_deck_id: 9,
+          target_deck_name_snapshot: "Renal Recovery",
+          flashcard_count: 1,
+          flashcard_uuids_json: ["fc-1"],
+          source_ref_id: "quiz-attempt:301:question:12",
+          created_at: "2026-03-13T09:00:00Z",
+          last_modified: "2026-03-13T09:00:00Z",
+          client_id: "test-client",
+          version: 1
+        }
+      ],
+      count: 1,
+      superseded_count: 0
+    })),
+    convertAttemptRemediationQuestions: vi.fn(async () => ({
+      attempt_id: 301,
+      quiz_id: 21,
+      target_deck: {
+        id: 9,
+        name: "Renal Recovery"
+      },
+      results: [
+        {
+          question_id: 12,
+          status: "already_exists",
+          conversion: {
+            id: 71,
+            attempt_id: 301,
+            quiz_id: 21,
+            question_id: 12,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 9,
+            target_deck_name_snapshot: "Renal Recovery",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-1"],
+            source_ref_id: "quiz-attempt:301:question:12",
+            created_at: "2026-03-13T09:00:00Z",
+            last_modified: "2026-03-13T09:00:00Z",
+            client_id: "test-client",
+            version: 1
+          },
+          flashcard_uuids: ["fc-1"],
+          error: null
+        },
+        {
+          question_id: 19,
+          status: "created",
+          conversion: {
+            id: 72,
+            attempt_id: 301,
+            quiz_id: 21,
+            question_id: 19,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 9,
+            target_deck_name_snapshot: "Renal Recovery",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-2"],
+            source_ref_id: "quiz-attempt:301:question:19",
+            created_at: "2026-03-13T09:05:00Z",
+            last_modified: "2026-03-13T09:05:00Z",
+            client_id: "test-client",
+            version: 1
+          },
+          flashcard_uuids: ["fc-2"],
+          error: null
+        }
+      ],
+      created_flashcard_uuids: ["fc-2"]
+    })),
     generateRemediationQuiz: vi.fn(async () => ({
       quiz: {
         id: 21,
@@ -85,6 +174,87 @@ describe("useGenerateRemediationQuizMutation", () => {
       difficulty: "medium",
       focus_topics: ["renal"],
       workspace_tag: "workspace:med-school"
+    })
+  })
+
+  it("loads server-backed remediation conversion state for an attempt", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    })
+
+    const { result } = renderHook(
+      () => useAttemptRemediationConversionsQuery(301),
+      { wrapper: buildWrapper(queryClient) }
+    )
+
+    await waitFor(() => {
+      expect(result.current.data?.items).toHaveLength(1)
+    })
+
+    expect(listAttemptRemediationConversions).toHaveBeenCalledWith(301, expect.any(Object))
+    expect(result.current.data?.items[0]?.target_deck_name_snapshot).toBe("Renal Recovery")
+  })
+
+  it("converts remediation questions through the quiz-owned conversion endpoint", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false }
+      }
+    })
+
+    queryClient.setQueryData(["quizzes:attempt:remediation-conversions", 301], {
+      attempt_id: 301,
+      items: [
+        {
+          id: 71,
+          attempt_id: 301,
+          quiz_id: 21,
+          question_id: 12,
+          status: "active",
+          orphaned: false,
+          target_deck_id: 9,
+          target_deck_name_snapshot: "Renal Recovery",
+          flashcard_count: 1,
+          flashcard_uuids_json: ["fc-1"],
+          source_ref_id: "quiz-attempt:301:question:12",
+          created_at: "2026-03-13T09:00:00Z",
+          last_modified: "2026-03-13T09:00:00Z",
+          client_id: "test-client",
+          version: 1
+        }
+      ],
+      count: 1,
+      superseded_count: 0
+    })
+
+    const { result } = renderHook(
+      () => useConvertAttemptRemediationQuestionsMutation(),
+      { wrapper: buildWrapper(queryClient) }
+    )
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        attemptId: 301,
+        request: {
+          question_ids: [12, 19],
+          target_deck_id: 9
+        }
+      })
+    })
+
+    expect(convertAttemptRemediationQuestions).toHaveBeenCalledWith(301, {
+      question_ids: [12, 19],
+      target_deck_id: 9
+    }, undefined)
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<any>(["quizzes:attempt:remediation-conversions", 301])
+      expect(cached?.items).toHaveLength(2)
+      expect(cached?.items.some((item: any) => item.question_id === 19)).toBe(true)
     })
   })
 })

--- a/apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationQueries.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/hooks/__tests__/useQuizRemediationQueries.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/services/quizzes", async () => {
           question_id: 12,
           status: "active",
           orphaned: false,
+          superseded_count: 1,
           target_deck_id: 9,
           target_deck_name_snapshot: "Renal Recovery",
           flashcard_count: 1,
@@ -53,7 +54,7 @@ vi.mock("@/services/quizzes", async () => {
         }
       ],
       count: 1,
-      superseded_count: 0
+      superseded_count: 1
     })),
     convertAttemptRemediationQuestions: vi.fn(async () => ({
       attempt_id: 301,
@@ -73,6 +74,7 @@ vi.mock("@/services/quizzes", async () => {
             question_id: 12,
             status: "active",
             orphaned: false,
+            superseded_count: 1,
             target_deck_id: 9,
             target_deck_name_snapshot: "Renal Recovery",
             flashcard_count: 1,
@@ -87,16 +89,17 @@ vi.mock("@/services/quizzes", async () => {
           error: null
         },
         {
-          question_id: 19,
-          status: "created",
-          conversion: {
-            id: 72,
-            attempt_id: 301,
-            quiz_id: 21,
             question_id: 19,
-            status: "active",
-            orphaned: false,
-            target_deck_id: 9,
+            status: "created",
+            conversion: {
+              id: 72,
+              attempt_id: 301,
+              quiz_id: 21,
+              question_id: 19,
+              status: "active",
+              orphaned: false,
+              superseded_count: 0,
+              target_deck_id: 9,
             target_deck_name_snapshot: "Renal Recovery",
             flashcard_count: 1,
             flashcard_uuids_json: ["fc-2"],
@@ -216,6 +219,7 @@ describe("useGenerateRemediationQuizMutation", () => {
           question_id: 12,
           status: "active",
           orphaned: false,
+          superseded_count: 1,
           target_deck_id: 9,
           target_deck_name_snapshot: "Renal Recovery",
           flashcard_count: 1,
@@ -228,7 +232,7 @@ describe("useGenerateRemediationQuizMutation", () => {
         }
       ],
       count: 1,
-      superseded_count: 0
+      superseded_count: 1
     })
 
     const { result } = renderHook(
@@ -255,6 +259,10 @@ describe("useGenerateRemediationQuizMutation", () => {
       const cached = queryClient.getQueryData<any>(["quizzes:attempt:remediation-conversions", 301])
       expect(cached?.items).toHaveLength(2)
       expect(cached?.items.some((item: any) => item.question_id === 19)).toBe(true)
+      expect(cached?.superseded_count).toBe(1)
+      expect(
+        cached?.items.find((item: any) => item.question_id === 12)?.superseded_count
+      ).toBe(1)
     })
   })
 })

--- a/apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts
+++ b/apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts
@@ -13,6 +13,8 @@ import {
   submitAttempt,
   listAttempts,
   getAttempt,
+  listAttemptRemediationConversions,
+  convertAttemptRemediationQuestions,
   getQuizAttemptQuestionAssistant,
   generateQuiz,
   generateRemediationQuiz,
@@ -27,6 +29,9 @@ import {
   type QuestionType,
   type QuizGenerateRequest,
   type QuizRemediationGenerateRequest,
+  type QuizRemediationConvertRequest,
+  type QuizRemediationConvertResponse,
+  type QuizRemediationConversionListResponse,
   type QuizAnswerInput,
   type QuizListParams,
   type AttemptListParams,
@@ -454,6 +459,21 @@ export function useAttemptQuery(
   })
 }
 
+export function useAttemptRemediationConversionsQuery(
+  attemptId: number | null | undefined,
+  options?: UseQuizQueriesOptions
+) {
+  const { quizzesEnabled } = useQuizzesEnabled()
+
+  return useQuery({
+    queryKey: ["quizzes:attempt:remediation-conversions", attemptId ?? null],
+    queryFn: ({ signal }) => listAttemptRemediationConversions(attemptId!, { signal }),
+    enabled: (options?.enabled ?? quizzesEnabled) && attemptId != null,
+    staleTime: ATTEMPT_QUERY_STALE_TIME_MS,
+    refetchOnWindowFocus: false
+  })
+}
+
 export function useQuizAttemptQuestionAssistantQuery(
   attemptId: number | null | undefined,
   questionId: number | null | undefined,
@@ -517,6 +537,58 @@ export function useQuizAttemptQuestionAssistantRespondMutation() {
     },
     onError: (error) => {
       console.error("Failed to respond with quiz question assistant:", error)
+    }
+  })
+}
+
+export function useConvertAttemptRemediationQuestionsMutation() {
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationKey: ["quizzes:attempt:remediation-convert"],
+    mutationFn: (params: {
+      attemptId: number
+      request: QuizRemediationConvertRequest
+      signal?: AbortSignal
+    }) => (
+      convertAttemptRemediationQuestions(
+        params.attemptId,
+        params.request,
+        params.signal ? { signal: params.signal } : undefined
+      )
+    ),
+    onSuccess: (response: QuizRemediationConvertResponse, variables) => {
+      qc.setQueryData<QuizRemediationConversionListResponse | undefined>(
+        ["quizzes:attempt:remediation-conversions", variables.attemptId],
+        (current) => {
+          if (!current) return current
+
+          const nextItems = current.items
+            .filter((item) => {
+              const incomingQuestionIds = new Set(response.results.map((result) => result.question_id))
+              if (!incomingQuestionIds.has(item.question_id)) return true
+              return item.status !== "active"
+            })
+
+          response.results.forEach((result) => {
+            if (result.conversion) {
+              nextItems.push(result.conversion)
+            }
+          })
+
+          const supersededCount = nextItems.filter((item) => item.status === "superseded").length
+          return {
+            attempt_id: current.attempt_id,
+            items: nextItems,
+            count: nextItems.length,
+            superseded_count: supersededCount
+          }
+        }
+      )
+      qc.invalidateQueries({
+        queryKey: ["quizzes:attempt:remediation-conversions", variables.attemptId],
+        refetchType: "active"
+      })
     }
   })
 }

--- a/apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts
+++ b/apps/packages/ui/src/components/Quiz/hooks/useQuizQueries.ts
@@ -558,6 +558,7 @@ export function useConvertAttemptRemediationQuestionsMutation() {
       )
     ),
     onSuccess: (response: QuizRemediationConvertResponse, variables) => {
+      qc.invalidateQueries({ queryKey: ["flashcards:decks"], refetchType: "active" })
       qc.setQueryData<QuizRemediationConversionListResponse | undefined>(
         ["quizzes:attempt:remediation-conversions", variables.attemptId],
         (current) => {
@@ -576,7 +577,8 @@ export function useConvertAttemptRemediationQuestionsMutation() {
             }
           })
 
-          const supersededCount = nextItems.filter((item) => item.status === "superseded").length
+          const supersededCount = current.superseded_count
+            + response.results.filter((result) => result.status === "superseded_and_created").length
           return {
             attempt_id: current.attempt_id,
             items: nextItems,

--- a/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
@@ -138,7 +138,6 @@ interface ResultsTabProps {
 
 type RemediationConversionState = {
   active: QuizRemediationConversionSummary | null
-  supersededCount: number
 }
 
 export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
@@ -244,13 +243,9 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   const remediationConversions = remediationConversionsQuery.data?.items ?? []
   const remediationConversionStateByQuestionId = React.useMemo(() => {
     return remediationConversions.reduce<Map<number, RemediationConversionState>>((acc, item) => {
-      const existing = acc.get(item.question_id) ?? { active: null, supersededCount: 0 }
       if (item.status === "active") {
-        existing.active = item
-      } else {
-        existing.supersededCount += 1
+        acc.set(item.question_id, { active: item })
       }
-      acc.set(item.question_id, existing)
       return acc
     }, new Map())
   }, [remediationConversions])
@@ -666,7 +661,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
           orphaned,
           convertedDeckName: activeConversion?.target_deck_name_snapshot ?? null,
           linkedFlashcardCount: activeConversion?.flashcard_count ?? 0,
-          hasSupersededHistory: (conversionState?.supersededCount ?? 0) > 0
+          hasSupersededHistory: (activeConversion?.superseded_count ?? 0) > 0
         }
       })
   }, [formatAnswerValue, remediationConversionStateByQuestionId, selectedAttemptDetails, t])
@@ -849,6 +844,11 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
         attemptId: selectedAttemptDetails.id,
         request
       })
+
+      if (response.target_deck?.id && (deckTarget === "__new__" || deckTarget == null)) {
+        setDeckTarget(response.target_deck.id)
+        setNewDeckName(response.target_deck.name)
+      }
 
       const createdResults = response.results.filter(
         (result) => result.status === "created" || result.status === "superseded_and_created"

--- a/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
@@ -30,15 +30,18 @@ import { useNavigate } from "react-router-dom"
 import {
   useAllAttemptsQuery,
   useAttemptQuery,
+  useAttemptRemediationConversionsQuery,
+  useConvertAttemptRemediationQuestionsMutation,
   useGenerateRemediationQuizMutation,
   useQuizzesQuery
 } from "../hooks"
-import {
-  useCreateDeckMutation,
-  useCreateFlashcardsBulkMutation,
-  useDecksQuery
-} from "@/components/Flashcards/hooks/useFlashcardQueries"
-import type { AnswerValue, QuestionPublic, QuizAnswer } from "@/services/quizzes"
+import { useDecksQuery } from "@/components/Flashcards/hooks/useFlashcardQueries"
+import type {
+  AnswerValue,
+  QuestionPublic,
+  QuizAnswer,
+  QuizRemediationConversionSummary
+} from "@/services/quizzes"
 import { buildFlashcardsStudyRouteFromQuiz } from "@/services/tldw/quiz-flashcards-handoff"
 import type { TakeTabNavigationIntent } from "../navigation"
 import { RESULTS_FILTER_PREFS_KEY } from "../stateKeys"
@@ -51,8 +54,6 @@ import { formatMatchingAnswer } from "../utils/matchingAnswer"
 const { Text } = Typography
 
 const DEFAULT_PASSING_SCORE = 70
-const MISSED_FLASHCARD_CONVERSION_KEY = "quiz-results-missed-flashcards-v1"
-const ATTEMPT_FLASHCARD_DECK_MAP_KEY = "quiz-results-flashcard-deck-map-v1"
 type PassFilterKey = "all" | "pass" | "fail"
 type DateRangeFilterKey = "all" | "7d" | "30d" | "90d"
 type DeckTargetValue = number | "__new__" | null
@@ -80,61 +81,6 @@ const normalizeMultiSelectAnswer = (value: unknown): number[] => {
     return [Math.floor(value)]
   }
   return []
-}
-
-type ConvertedMissedFlashcards = Record<string, true>
-type AttemptFlashcardDeckMap = Record<string, number>
-
-const toMissedFlashcardKey = (attemptId: number, questionId: number) =>
-  `${attemptId}:${questionId}`
-
-const readConvertedMissedFlashcards = (): ConvertedMissedFlashcards => {
-  if (typeof window === "undefined") return {}
-  try {
-    const raw = window.sessionStorage.getItem(MISSED_FLASHCARD_CONVERSION_KEY)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw)
-    if (!parsed || typeof parsed !== "object") return {}
-    return Object.fromEntries(
-      Object.entries(parsed).filter(([, value]) => value === true)
-    ) as ConvertedMissedFlashcards
-  } catch {
-    return {}
-  }
-}
-
-const writeConvertedMissedFlashcards = (value: ConvertedMissedFlashcards) => {
-  if (typeof window === "undefined") return
-  try {
-    window.sessionStorage.setItem(MISSED_FLASHCARD_CONVERSION_KEY, JSON.stringify(value))
-  } catch {
-    // Ignore session-storage write failures.
-  }
-}
-
-const readAttemptFlashcardDeckMap = (): AttemptFlashcardDeckMap => {
-  if (typeof window === "undefined") return {}
-  try {
-    const raw = window.sessionStorage.getItem(ATTEMPT_FLASHCARD_DECK_MAP_KEY)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw)
-    if (!parsed || typeof parsed !== "object") return {}
-
-    return Object.fromEntries(
-      Object.entries(parsed).filter(([, value]) => typeof value === "number" && value > 0)
-    ) as AttemptFlashcardDeckMap
-  } catch {
-    return {}
-  }
-}
-
-const writeAttemptFlashcardDeckMap = (value: AttemptFlashcardDeckMap) => {
-  if (typeof window === "undefined") return
-  try {
-    window.sessionStorage.setItem(ATTEMPT_FLASHCARD_DECK_MAP_KEY, JSON.stringify(value))
-  } catch {
-    // Ignore session-storage write failures.
-  }
 }
 
 type ResultsFilterPrefs = {
@@ -188,6 +134,11 @@ interface ResultsTabProps {
   onRetakeQuiz?: (intent: TakeTabNavigationIntent) => void
 }
 
+type RemediationConversionState = {
+  active: QuizRemediationConversionSummary | null
+  supersededCount: number
+}
+
 export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   const { t } = useTranslation(["option", "common"])
   const navigate = useNavigate()
@@ -209,20 +160,18 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   const [selectedMissedQuestions, setSelectedMissedQuestions] = React.useState<Record<number, boolean>>({})
   const [deckTarget, setDeckTarget] = React.useState<DeckTargetValue>(null)
   const [newDeckName, setNewDeckName] = React.useState("")
-  const [convertedMissedFlashcards, setConvertedMissedFlashcards] = React.useState<ConvertedMissedFlashcards>(
-    () => readConvertedMissedFlashcards()
-  )
-  const [attemptFlashcardDeckMap, setAttemptFlashcardDeckMap] = React.useState<AttemptFlashcardDeckMap>(
-    () => readAttemptFlashcardDeckMap()
-  )
+  const [replaceExistingQuestionIds, setReplaceExistingQuestionIds] = React.useState<number[]>([])
 
   const { data: decksData, isLoading: decksLoading } = useDecksQuery({
     enabled: selectedAttemptId != null
   })
-  const createDeckMutation = useCreateDeckMutation()
-  const createFlashcardsBulkMutation = useCreateFlashcardsBulkMutation()
+  const remediationConversionsQuery = useAttemptRemediationConversionsQuery(
+    selectedAttemptId,
+    { enabled: selectedAttemptId != null }
+  )
+  const convertRemediationQuestionsMutation = useConvertAttemptRemediationQuestionsMutation()
   const generateRemediationQuizMutation = useGenerateRemediationQuizMutation()
-  const flashcardMutationPending = createDeckMutation.isPending || createFlashcardsBulkMutation.isPending
+  const flashcardMutationPending = convertRemediationQuestionsMutation.isPending
 
   const attemptsQueryParams = React.useMemo(() => ({
     limit: 200,
@@ -248,24 +197,14 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   React.useEffect(() => {
     if (selectedAttemptId == null) {
       setFlashcardModalOpen(false)
+      setReplaceExistingQuestionIds([])
     }
   }, [selectedAttemptId])
 
   React.useEffect(() => {
     setSelectedMissedQuestions({})
+    setReplaceExistingQuestionIds([])
   }, [selectedAttemptId])
-
-  const handleNavigateToFlashcardsStudy = React.useCallback(
-    (params: { quizId: number; attemptId: number }) => {
-      const route = buildFlashcardsStudyRouteFromQuiz({
-        quizId: params.quizId,
-        attemptId: params.attemptId,
-        deckId: attemptFlashcardDeckMap[String(params.attemptId)]
-      })
-      navigate(route)
-    },
-    [attemptFlashcardDeckMap, navigate]
-  )
 
   const { data: attemptsData, isLoading: attemptsLoading } = useAllAttemptsQuery({
     quiz_id: attemptsQueryParams.quiz_id
@@ -295,6 +234,52 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   )
 
   const decks = decksData ?? []
+  const remediationConversions = remediationConversionsQuery.data?.items ?? []
+  const remediationConversionStateByQuestionId = React.useMemo(() => {
+    return remediationConversions.reduce<Map<number, RemediationConversionState>>((acc, item) => {
+      const existing = acc.get(item.question_id) ?? { active: null, supersededCount: 0 }
+      if (item.status === "active") {
+        existing.active = item
+      } else {
+        existing.supersededCount += 1
+      }
+      acc.set(item.question_id, existing)
+      return acc
+    }, new Map())
+  }, [remediationConversions])
+  const linkedStudyDeckId = React.useMemo(() => {
+    const activeConversions = remediationConversions.filter(
+      (item) => item.status === "active" && !item.orphaned
+    )
+    if (activeConversions.length === 0) return undefined
+
+    const liveDeckIds = new Set(decks.map((deck) => deck.id))
+    const firstDeckId = activeConversions[0]?.target_deck_id
+
+    if (
+      typeof firstDeckId !== "number" ||
+      !liveDeckIds.has(firstDeckId) ||
+      !activeConversions.every(
+        (item) => item.target_deck_id === firstDeckId && liveDeckIds.has(firstDeckId)
+      )
+    ) {
+      return undefined
+    }
+
+    return firstDeckId
+  }, [decks, remediationConversions])
+
+  const handleNavigateToFlashcardsStudy = React.useCallback(
+    (params: { quizId: number; attemptId: number }) => {
+      const route = buildFlashcardsStudyRouteFromQuiz({
+        quizId: params.quizId,
+        attemptId: params.attemptId,
+        deckId: linkedStudyDeckId
+      })
+      navigate(route)
+    },
+    [linkedStudyDeckId, navigate]
+  )
 
   const attempts = attemptsData?.items ?? []
   const quizzes = quizzesData?.items ?? []
@@ -656,28 +641,40 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
       .filter((answer) => answer.is_correct === false)
       .map((answer) => {
         const question = questionMap.get(answer.question_id)
-        const conversionKey = toMissedFlashcardKey(selectedAttemptDetails.id, answer.question_id)
+        const conversionState = remediationConversionStateByQuestionId.get(answer.question_id)
+        const activeConversion = conversionState?.active ?? null
+        const orphaned = Boolean(activeConversion?.orphaned)
         return {
           questionId: answer.question_id,
-          conversionKey,
           questionText:
             question?.question_text ||
             t("option:quiz.questionFallbackLabel", {
               defaultValue: "Question #{{id}}",
               id: answer.question_id
-            }),
+          }),
           correctAnswerText: formatAnswerValue(answer.correct_answer, question),
           userAnswerText: formatAnswerValue(answer.user_answer, question),
           explanation: answer.explanation ?? null,
-          alreadyConverted: Boolean(convertedMissedFlashcards[conversionKey])
+          alreadyConverted: Boolean(activeConversion && !orphaned),
+          orphaned,
+          convertedDeckName: activeConversion?.target_deck_name_snapshot ?? null,
+          linkedFlashcardCount: activeConversion?.flashcard_count ?? 0,
+          hasSupersededHistory: (conversionState?.supersededCount ?? 0) > 0
         }
       })
-  }, [convertedMissedFlashcards, formatAnswerValue, selectedAttemptDetails, t])
+  }, [formatAnswerValue, remediationConversionStateByQuestionId, selectedAttemptDetails, t])
 
   const hasMissedQuestions = missedQuestionEntries.length > 0
   const selectedMissedQuestionCount = React.useMemo(() => {
     return missedQuestionEntries.filter((entry) => selectedMissedQuestions[entry.questionId]).length
   }, [missedQuestionEntries, selectedMissedQuestions])
+
+  const updateSelectedMissedQuestions = React.useCallback((
+    updater: Record<number, boolean> | ((previous: Record<number, boolean>) => Record<number, boolean>)
+  ) => {
+    setReplaceExistingQuestionIds([])
+    setSelectedMissedQuestions(updater)
+  }, [])
 
   React.useEffect(() => {
     if (!flashcardModalOpen) return
@@ -703,18 +700,28 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
     const nextSelection = hasExistingSelection
       ? { ...selectedMissedQuestions }
       : missedQuestionEntries.reduce<Record<number, boolean>>((acc, entry) => {
-        acc[entry.questionId] = !entry.alreadyConverted
+        acc[entry.questionId] = !entry.alreadyConverted || entry.orphaned
         return acc
       }, {})
 
-    setSelectedMissedQuestions(nextSelection)
+    updateSelectedMissedQuestions(nextSelection)
     setDeckTarget(decks[0]?.id ?? "__new__")
+    setReplaceExistingQuestionIds([])
 
     const quizName =
       quizMap.get(selectedAttemptDetails.quiz_id)?.name ?? `Quiz #${selectedAttemptDetails.quiz_id}`
     setNewDeckName(`${quizName} - Missed Questions`)
     setFlashcardModalOpen(true)
-  }, [decks, messageApi, missedQuestionEntries, quizMap, selectedAttemptDetails, selectedMissedQuestions, t])
+  }, [
+    decks,
+    messageApi,
+    missedQuestionEntries,
+    quizMap,
+    selectedAttemptDetails,
+    selectedMissedQuestions,
+    t,
+    updateSelectedMissedQuestions
+  ])
 
   const handleCreateRemediationQuiz = React.useCallback(async (questionIds: number[]) => {
     if (!selectedAttemptDetails) return
@@ -774,8 +781,14 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
       return
     }
 
-    const pendingEntries = selectedEntries.filter((entry) => !entry.alreadyConverted)
-    if (pendingEntries.length === 0) {
+    const replaceActive = replaceExistingQuestionIds.length > 0
+    const questionIds = replaceActive
+      ? selectedEntries
+          .map((entry) => entry.questionId)
+          .filter((questionId) => replaceExistingQuestionIds.includes(questionId))
+      : selectedEntries.map((entry) => entry.questionId)
+
+    if (questionIds.length === 0) {
       messageApi.info(
         t("option:quiz.missedQuestionsAlreadyConverted", {
           defaultValue: "Selected questions were already converted for this attempt."
@@ -784,78 +797,83 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
       return
     }
 
-    let targetDeckId: number | null = null
+    const request =
+      deckTarget === "__new__" || deckTarget == null
+        ? (() => {
+            const trimmedDeckName = newDeckName.trim()
+            if (!trimmedDeckName) {
+              messageApi.warning(
+                t("option:quiz.deckNameRequired", {
+                  defaultValue: "Enter a deck name."
+                })
+              )
+              return null
+            }
+            return {
+              question_ids: questionIds,
+              create_deck_name: trimmedDeckName,
+              replace_active: replaceActive
+            } as const
+          })()
+        : ({
+            question_ids: questionIds,
+            target_deck_id: deckTarget,
+            replace_active: replaceActive
+          } as const)
 
-    if (deckTarget === "__new__" || deckTarget == null) {
-      const trimmedDeckName = newDeckName.trim()
-      if (!trimmedDeckName) {
-        messageApi.warning(
-          t("option:quiz.deckNameRequired", {
-            defaultValue: "Enter a deck name."
+    if (request == null) {
+      return
+    }
+
+    try {
+      const response = await convertRemediationQuestionsMutation.mutateAsync({
+        attemptId: selectedAttemptDetails.id,
+        request
+      })
+
+      const createdResults = response.results.filter(
+        (result) => result.status === "created" || result.status === "superseded_and_created"
+      )
+      const existingResults = response.results.filter((result) => result.status === "already_exists")
+      const failedResults = response.results.filter((result) => result.status === "failed")
+
+      if (createdResults.length > 0) {
+        messageApi.success(
+          t("option:quiz.flashcardsCreatedFromMissed", {
+            defaultValue: "Created {{count}} flashcards from missed questions.",
+            count: response.created_flashcard_uuids.length || createdResults.length
+          })
+        )
+      }
+
+      if (existingResults.length > 0) {
+        const conflictingQuestionIds = existingResults.map((result) => result.question_id)
+        setReplaceExistingQuestionIds(conflictingQuestionIds)
+        setSelectedMissedQuestions(
+          conflictingQuestionIds.reduce<Record<number, boolean>>((acc, questionId) => {
+            acc[questionId] = true
+            return acc
+          }, {})
+        )
+        messageApi.info(
+          t("option:quiz.remediationConvertAgainPrompt", {
+            defaultValue: "Some selected questions already have active remediation flashcards. Use Convert Again Anyway to supersede them."
           })
         )
         return
       }
-      const createdDeck = await createDeckMutation.mutateAsync({
-        name: trimmedDeckName
-      })
-      targetDeckId = createdDeck.id
-    } else {
-      targetDeckId = deckTarget
-    }
 
-    const dedupedEntries = Array.from(
-      pendingEntries.reduce<Map<string, (typeof pendingEntries)[number]>>((acc, entry) => {
-        const dedupeKey = `${entry.questionText.trim().toLowerCase()}::${entry.correctAnswerText
-          .trim()
-          .toLowerCase()}`
-        if (!acc.has(dedupeKey)) {
-          acc.set(dedupeKey, entry)
-        }
-        return acc
-      }, new Map()).values()
-    )
-
-    const quizName =
-      quizMap.get(selectedAttemptDetails.quiz_id)?.name ?? `Quiz #${selectedAttemptDetails.quiz_id}`
-
-    try {
-      await createFlashcardsBulkMutation.mutateAsync(
-        dedupedEntries.map((entry) => ({
-          deck_id: targetDeckId,
-          front: entry.questionText,
-          back: `Correct answer: ${entry.correctAnswerText}${
-            entry.explanation ? `\n\nExplanation: ${entry.explanation}` : ""
-          }`,
-          notes: `Created from quiz "${quizName}" (attempt #${selectedAttemptDetails.id}). Your answer: ${entry.userAnswerText}`,
-          tags: ["quiz-missed", "quiz-review"],
-          source_ref_type: "manual",
-          source_ref_id: `quiz-attempt:${selectedAttemptDetails.id}:question:${entry.questionId}`
-        }))
-      )
-
-      const updatedConversions = { ...convertedMissedFlashcards }
-      pendingEntries.forEach((entry) => {
-        updatedConversions[entry.conversionKey] = true
-      })
-      setConvertedMissedFlashcards(updatedConversions)
-      writeConvertedMissedFlashcards(updatedConversions)
-      const updatedAttemptDeckMap: AttemptFlashcardDeckMap = {
-        ...attemptFlashcardDeckMap
+      if (failedResults.length > 0) {
+        messageApi.error(
+          t("option:quiz.flashcardsCreateFromMissedError", {
+            defaultValue: "Failed to create flashcards from missed questions."
+          })
+        )
+        return
       }
-      if (targetDeckId != null && targetDeckId > 0) {
-        updatedAttemptDeckMap[String(selectedAttemptDetails.id)] = targetDeckId
-      }
-      setAttemptFlashcardDeckMap(updatedAttemptDeckMap)
-      writeAttemptFlashcardDeckMap(updatedAttemptDeckMap)
+
+      setReplaceExistingQuestionIds([])
       setFlashcardModalOpen(false)
-
-      messageApi.success(
-        t("option:quiz.flashcardsCreatedFromMissed", {
-          defaultValue: "Created {{count}} flashcards from missed questions.",
-          count: dedupedEntries.length
-        })
-      )
     } catch (error) {
       messageApi.error(
         t("option:quiz.flashcardsCreateFromMissedError", {
@@ -867,18 +885,15 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
       }
     }
   }, [
-    convertedMissedFlashcards,
-    createDeckMutation,
-    createFlashcardsBulkMutation,
+    convertRemediationQuestionsMutation,
     deckTarget,
     messageApi,
     missedQuestionEntries,
     newDeckName,
-    attemptFlashcardDeckMap,
-    quizMap,
+    replaceExistingQuestionIds,
     selectedAttemptDetails,
     selectedMissedQuestions,
-    t
+    t,
   ])
 
   const renderFlashcardConversionModal = () => (
@@ -887,11 +902,16 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
         defaultValue: "Create Flashcards from Missed Questions"
       })}
       open={flashcardModalOpen}
-      onCancel={() => setFlashcardModalOpen(false)}
+      onCancel={() => {
+        setReplaceExistingQuestionIds([])
+        setFlashcardModalOpen(false)
+      }}
       onOk={() => {
         void handleCreateFlashcardsFromMissedQuestions()
       }}
-      okText={t("option:quiz.createFlashcards", { defaultValue: "Create Flashcards" })}
+      okText={replaceExistingQuestionIds.length > 0
+        ? t("option:quiz.convertAgainAnyway", { defaultValue: "Convert Again Anyway" })
+        : t("option:quiz.createFlashcards", { defaultValue: "Create Flashcards" })}
       okButtonProps={{
         loading: flashcardMutationPending
       }}
@@ -905,6 +925,13 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
         />
       ) : (
         <div className="space-y-4">
+          {replaceExistingQuestionIds.length > 0 && (
+            <div className="rounded border border-warning/40 bg-warning/10 p-3 text-sm text-text">
+              {t("option:quiz.remediationConvertAgainPrompt", {
+                defaultValue: "Some selected questions already have active remediation flashcards. Convert Again Anyway will supersede those prior conversions."
+              })}
+            </div>
+          )}
           <div className="space-y-2">
             <div className="text-sm font-medium text-text">
               {t("option:quiz.flashcardDestination", {
@@ -955,7 +982,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
                   acc[entry.questionId] = checked
                   return acc
                 }, {})
-                setSelectedMissedQuestions(next)
+                updateSelectedMissedQuestions(next)
               }}
             >
               {t("option:quiz.selectAllMissedQuestions", {
@@ -971,7 +998,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
                     <Checkbox
                       checked={Boolean(selectedMissedQuestions[entry.questionId])}
                       onChange={(event) => {
-                        setSelectedMissedQuestions((previous) => ({
+                        updateSelectedMissedQuestions((previous) => ({
                           ...previous,
                           [entry.questionId]: event.target.checked
                         }))
@@ -987,10 +1014,28 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
                       {t("option:quiz.yourAnswer", { defaultValue: "Your answer" })}:{" "}
                       {entry.userAnswerText}
                     </div>
-                    {entry.alreadyConverted && (
+                    {entry.orphaned ? (
+                      <div className="pl-6 text-xs text-warning">
+                        {t("option:quiz.linkedCardsDeleted", {
+                          defaultValue: "Linked cards were deleted. Convert again to recreate them."
+                        })}
+                      </div>
+                    ) : entry.alreadyConverted ? (
                       <div className="pl-6 text-xs text-text-subtle">
-                        {t("option:quiz.alreadyConverted", {
-                          defaultValue: "Already converted in this session."
+                        {entry.convertedDeckName
+                          ? t("option:quiz.alreadyConvertedDeckLabel", {
+                              defaultValue: "Converted in deck {{deckName}}.",
+                              deckName: entry.convertedDeckName
+                            })
+                          : t("option:quiz.alreadyConverted", {
+                              defaultValue: "Remediation flashcards already exist for this miss."
+                            })}
+                      </div>
+                    ) : null}
+                    {entry.hasSupersededHistory && (
+                      <div className="pl-6 text-xs text-text-subtle">
+                        {t("option:quiz.supersededRemediationHistory", {
+                          defaultValue: "Superseded remediation history exists for this question."
                         })}
                       </div>
                     )}
@@ -1090,7 +1135,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
               quizId={selectedAttemptDetails.quiz_id}
               missedQuestionEntries={missedQuestionEntries}
               selectedMissedQuestions={selectedMissedQuestions}
-              onSelectedMissedQuestionsChange={setSelectedMissedQuestions}
+              onSelectedMissedQuestionsChange={updateSelectedMissedQuestions}
               onCreateRemediationQuiz={handleCreateRemediationQuiz}
               onCreateRemediationFlashcards={openFlashcardModal}
               onStudyLinkedCards={() => {

--- a/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
@@ -6,7 +6,6 @@ import {
   Select,
   Descriptions,
   Empty,
-  Input,
   List,
   Modal,
   Progress,
@@ -36,6 +35,9 @@ import {
   useQuizzesQuery
 } from "../hooks"
 import { useDecksQuery } from "@/components/Flashcards/hooks/useFlashcardQueries"
+import { NewDeckConfigurationFields } from "@/components/Flashcards/components/NewDeckConfigurationFields"
+import { useDeckSchedulerDraft } from "@/components/Flashcards/hooks/useDeckSchedulerDraft"
+import { formatSchedulerSummary } from "@/components/Flashcards/utils/scheduler-settings"
 import type {
   AnswerValue,
   QuestionPublic,
@@ -161,6 +163,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   const [deckTarget, setDeckTarget] = React.useState<DeckTargetValue>(null)
   const [newDeckName, setNewDeckName] = React.useState("")
   const [replaceExistingQuestionIds, setReplaceExistingQuestionIds] = React.useState<number[]>([])
+  const newDeckSchedulerDraft = useDeckSchedulerDraft()
 
   const { data: decksData, isLoading: decksLoading } = useDecksQuery({
     enabled: selectedAttemptId != null
@@ -234,6 +237,10 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
   )
 
   const decks = decksData ?? []
+  const selectedDeck = React.useMemo(
+    () => (typeof deckTarget === "number" ? decks.find((deck) => deck.id === deckTarget) ?? null : null),
+    [deckTarget, decks]
+  )
   const remediationConversions = remediationConversionsQuery.data?.items ?? []
   const remediationConversionStateByQuestionId = React.useMemo(() => {
     return remediationConversions.reduce<Map<number, RemediationConversionState>>((acc, item) => {
@@ -707,6 +714,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
     updateSelectedMissedQuestions(nextSelection)
     setDeckTarget(decks[0]?.id ?? "__new__")
     setReplaceExistingQuestionIds([])
+    newDeckSchedulerDraft.resetToDefaults()
 
     const quizName =
       quizMap.get(selectedAttemptDetails.quiz_id)?.name ?? `Quiz #${selectedAttemptDetails.quiz_id}`
@@ -716,6 +724,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
     decks,
     messageApi,
     missedQuestionEntries,
+    newDeckSchedulerDraft,
     quizMap,
     selectedAttemptDetails,
     selectedMissedQuestions,
@@ -809,9 +818,19 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
               )
               return null
             }
+            const schedulerSettings = newDeckSchedulerDraft.getValidatedSettings()
+            if (!schedulerSettings) {
+              messageApi.warning(
+                t("option:flashcards.schedulerSettingsInvalid", {
+                  defaultValue: "Fix the scheduler settings before creating the deck."
+                })
+              )
+              return null
+            }
             return {
               question_ids: questionIds,
               create_deck_name: trimmedDeckName,
+              create_deck_scheduler_settings: schedulerSettings,
               replace_active: replaceActive
             } as const
           })()
@@ -889,6 +908,7 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
     deckTarget,
     messageApi,
     missedQuestionEntries,
+    newDeckSchedulerDraft,
     newDeckName,
     replaceExistingQuestionIds,
     selectedAttemptDetails,
@@ -956,14 +976,28 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
               ]}
             />
             {deckTarget === "__new__" && (
-              <Input
-                value={newDeckName}
-                onChange={(event) => setNewDeckName(event.target.value)}
-                placeholder={t("option:quiz.newDeckNamePlaceholder", {
-                  defaultValue: "e.g. Biology Basics - Missed Questions"
+              <NewDeckConfigurationFields
+                deckName={newDeckName}
+                onDeckNameChange={setNewDeckName}
+                schedulerDraft={newDeckSchedulerDraft}
+                nameTestId="quiz-remediation-new-deck-name"
+                hint={t("option:quiz.newDeckSchedulerHint", {
+                  defaultValue: "These scheduler settings will be applied to the new remediation deck."
                 })}
               />
             )}
+            {deckTarget !== "__new__" && selectedDeck?.scheduler_settings ? (
+              <Text
+                type="secondary"
+                className="block text-xs"
+                data-testid="quiz-remediation-selected-deck-summary"
+              >
+                {t("option:flashcards.selectedDeckSchedulerSummary", {
+                  defaultValue: "Scheduler: {{summary}}",
+                  summary: formatSchedulerSummary(selectedDeck.scheduler_settings)
+                })}
+              </Text>
+            ) : null}
           </div>
 
           <div className="space-y-2">

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
@@ -5,22 +5,17 @@ import { ResultsTab } from "../ResultsTab"
 import {
   useAllAttemptsQuery,
   useAttemptQuery,
+  useAttemptRemediationConversionsQuery,
+  useConvertAttemptRemediationQuestionsMutation,
   useGenerateRemediationQuizMutation,
   useQuizAttemptQuestionAssistantQuery,
   useQuizAttemptQuestionAssistantRespondMutation,
   useQuizzesQuery
 } from "../../hooks"
-import {
-  useCreateDeckMutation,
-  useCreateFlashcardsBulkMutation,
-  useCreateFlashcardMutation,
-  useDecksQuery
-} from "@/components/Flashcards/hooks/useFlashcardQueries"
+import { useDecksQuery } from "@/components/Flashcards/hooks/useFlashcardQueries"
 
 const flashcardMocks = vi.hoisted(() => ({
-  createDeck: vi.fn(),
-  createFlashcardsBulk: vi.fn(),
-  createFlashcard: vi.fn(),
+  convertRemediationQuestions: vi.fn(),
   navigate: vi.fn()
 }))
 
@@ -60,16 +55,15 @@ vi.mock("../../hooks", () => ({
   useAllAttemptsQuery: vi.fn(),
   useQuizzesQuery: vi.fn(),
   useAttemptQuery: vi.fn(),
+  useAttemptRemediationConversionsQuery: vi.fn(),
+  useConvertAttemptRemediationQuestionsMutation: vi.fn(),
   useGenerateRemediationQuizMutation: vi.fn(),
   useQuizAttemptQuestionAssistantQuery: vi.fn(),
   useQuizAttemptQuestionAssistantRespondMutation: vi.fn()
 }))
 
 vi.mock("@/components/Flashcards/hooks/useFlashcardQueries", () => ({
-  useDecksQuery: vi.fn(),
-  useCreateDeckMutation: vi.fn(),
-  useCreateFlashcardsBulkMutation: vi.fn(),
-  useCreateFlashcardMutation: vi.fn()
+  useDecksQuery: vi.fn()
 }))
 
 if (!(globalThis as any).ResizeObserver) {
@@ -111,20 +105,14 @@ describe("ResultsTab drill-down details", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.sessionStorage.clear()
-    flashcardMocks.createDeck.mockReset()
-    flashcardMocks.createFlashcardsBulk.mockReset()
-    flashcardMocks.createFlashcard.mockReset()
+    flashcardMocks.convertRemediationQuestions.mockReset()
     flashcardMocks.navigate.mockReset()
-    flashcardMocks.createDeck.mockResolvedValue({
-      id: 99,
-      name: "New deck"
-    })
-    flashcardMocks.createFlashcardsBulk.mockResolvedValue([
-      { uuid: "new-card-1" },
-      { uuid: "new-card-2" }
-    ])
-    flashcardMocks.createFlashcard.mockResolvedValue({
-      uuid: "new-card"
+    flashcardMocks.convertRemediationQuestions.mockResolvedValue({
+      attempt_id: 101,
+      quiz_id: 7,
+      target_deck: { id: 3, name: "Biology Recovery Deck" },
+      results: [],
+      created_flashcard_uuids: []
     })
 
     vi.mocked(useAllAttemptsQuery).mockReturnValue({
@@ -170,6 +158,19 @@ describe("ResultsTab drill-down details", () => {
       mutateAsync: vi.fn(),
       isPending: false
     } as any)
+    vi.mocked(useAttemptRemediationConversionsQuery).mockReturnValue({
+      data: {
+        attempt_id: 101,
+        items: [],
+        count: 0,
+        superseded_count: 0
+      },
+      isLoading: false
+    } as any)
+    vi.mocked(useConvertAttemptRemediationQuestionsMutation).mockReturnValue({
+      mutateAsync: flashcardMocks.convertRemediationQuestions,
+      isPending: false
+    } as any)
     vi.mocked(useQuizAttemptQuestionAssistantQuery).mockReturnValue({
       data: null,
       isLoading: false,
@@ -183,18 +184,6 @@ describe("ResultsTab drill-down details", () => {
     vi.mocked(useDecksQuery).mockReturnValue({
       data: [{ id: 3, name: "Biology Recovery Deck" }],
       isLoading: false
-    } as any)
-    vi.mocked(useCreateDeckMutation).mockReturnValue({
-      mutateAsync: flashcardMocks.createDeck,
-      isPending: false
-    } as any)
-    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
-      mutateAsync: flashcardMocks.createFlashcardsBulk,
-      isPending: false
-    } as any)
-    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
-      mutateAsync: flashcardMocks.createFlashcard,
-      isPending: false
     } as any)
   })
 
@@ -330,7 +319,7 @@ describe("ResultsTab drill-down details", () => {
     expect(screen.getByText("bar")).toBeInTheDocument()
   }, 15000)
 
-  it("creates flashcards from missed questions and marks converted entries in-session", async () => {
+  it("creates flashcards from missed questions through server-backed conversion state", async () => {
     vi.mocked(useAttemptQuery).mockReturnValue({
       data: {
         id: 101,
@@ -385,30 +374,19 @@ describe("ResultsTab drill-down details", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create Flashcards" }))
 
     await waitFor(() => {
-      expect(flashcardMocks.createFlashcardsBulk).toHaveBeenCalledTimes(1)
+      expect(flashcardMocks.convertRemediationQuestions).toHaveBeenCalledTimes(1)
     })
-    expect(flashcardMocks.createDeck).not.toHaveBeenCalled()
-    expect(flashcardMocks.createFlashcard).not.toHaveBeenCalled()
-    expect(flashcardMocks.createFlashcardsBulk).toHaveBeenCalledWith([
-      expect.objectContaining({
-        deck_id: 3,
-        front: "Cells are not alive.",
-        tags: ["quiz-missed", "quiz-review"]
-      })
-    ])
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Create Flashcards from Missed Questions" })
-    )
-    expect(await screen.findByText("Already converted in this session.")).toBeInTheDocument()
+    expect(flashcardMocks.convertRemediationQuestions).toHaveBeenCalledWith({
+      attemptId: 101,
+      request: {
+        question_ids: [2],
+        target_deck_id: 3,
+        replace_active: false
+      }
+    })
   }, 15000)
 
   it("navigates to flashcards study route with attempt context from details modal", async () => {
-    window.sessionStorage.setItem(
-      "quiz-results-flashcard-deck-map-v1",
-      JSON.stringify({ "101": 3 })
-    )
-
     vi.mocked(useAttemptQuery).mockReturnValue({
       data: {
         id: 101,
@@ -438,7 +416,7 @@ describe("ResultsTab drill-down details", () => {
 
     expect(flashcardMocks.navigate).toHaveBeenCalledWith(
       expect.stringContaining(
-        "/flashcards?tab=review&study_source=quiz&quiz_id=7&attempt_id=101&deck_id=3"
+        "/flashcards?tab=review&study_source=quiz&quiz_id=7&attempt_id=101"
       )
     )
   })

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.details.test.tsx
@@ -12,12 +12,14 @@ import {
 } from "../../hooks"
 import {
   useCreateDeckMutation,
+  useCreateFlashcardsBulkMutation,
   useCreateFlashcardMutation,
   useDecksQuery
 } from "@/components/Flashcards/hooks/useFlashcardQueries"
 
 const flashcardMocks = vi.hoisted(() => ({
   createDeck: vi.fn(),
+  createFlashcardsBulk: vi.fn(),
   createFlashcard: vi.fn(),
   navigate: vi.fn()
 }))
@@ -66,6 +68,7 @@ vi.mock("../../hooks", () => ({
 vi.mock("@/components/Flashcards/hooks/useFlashcardQueries", () => ({
   useDecksQuery: vi.fn(),
   useCreateDeckMutation: vi.fn(),
+  useCreateFlashcardsBulkMutation: vi.fn(),
   useCreateFlashcardMutation: vi.fn()
 }))
 
@@ -109,12 +112,17 @@ describe("ResultsTab drill-down details", () => {
     vi.clearAllMocks()
     window.sessionStorage.clear()
     flashcardMocks.createDeck.mockReset()
+    flashcardMocks.createFlashcardsBulk.mockReset()
     flashcardMocks.createFlashcard.mockReset()
     flashcardMocks.navigate.mockReset()
     flashcardMocks.createDeck.mockResolvedValue({
       id: 99,
       name: "New deck"
     })
+    flashcardMocks.createFlashcardsBulk.mockResolvedValue([
+      { uuid: "new-card-1" },
+      { uuid: "new-card-2" }
+    ])
     flashcardMocks.createFlashcard.mockResolvedValue({
       uuid: "new-card"
     })
@@ -178,6 +186,10 @@ describe("ResultsTab drill-down details", () => {
     } as any)
     vi.mocked(useCreateDeckMutation).mockReturnValue({
       mutateAsync: flashcardMocks.createDeck,
+      isPending: false
+    } as any)
+    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
+      mutateAsync: flashcardMocks.createFlashcardsBulk,
       isPending: false
     } as any)
     vi.mocked(useCreateFlashcardMutation).mockReturnValue({
@@ -373,16 +385,17 @@ describe("ResultsTab drill-down details", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create Flashcards" }))
 
     await waitFor(() => {
-      expect(flashcardMocks.createFlashcard).toHaveBeenCalledTimes(1)
+      expect(flashcardMocks.createFlashcardsBulk).toHaveBeenCalledTimes(1)
     })
     expect(flashcardMocks.createDeck).not.toHaveBeenCalled()
-    expect(flashcardMocks.createFlashcard).toHaveBeenCalledWith(
+    expect(flashcardMocks.createFlashcard).not.toHaveBeenCalled()
+    expect(flashcardMocks.createFlashcardsBulk).toHaveBeenCalledWith([
       expect.objectContaining({
         deck_id: 3,
         front: "Cells are not alive.",
         tags: ["quiz-missed", "quiz-review"]
       })
-    )
+    ])
 
     fireEvent.click(
       screen.getByRole("button", { name: "Create Flashcards from Missed Questions" })

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
@@ -410,7 +410,21 @@ describe("ResultsTab remediation panel", () => {
     } as any)
 
     vi.mocked(useDecksQuery).mockReturnValue({
-      data: [{ id: 3, name: "Renal Recovery Deck" }],
+      data: [{
+        id: 3,
+        name: "Renal Recovery Deck",
+        scheduler_settings: {
+          new_steps_minutes: [1, 10],
+          relearn_steps_minutes: [10],
+          graduating_interval_days: 1,
+          easy_interval_days: 4,
+          easy_bonus: 1.3,
+          interval_modifier: 1,
+          max_interval_days: 36500,
+          leech_threshold: 8,
+          enable_fuzz: false
+        }
+      }],
       isLoading: false
     } as any)
   })
@@ -502,6 +516,9 @@ describe("ResultsTab remediation panel", () => {
     await waitFor(() => {
       expect(screen.getByText("Destination deck")).toBeInTheDocument()
     })
+    expect(screen.getByTestId("quiz-remediation-selected-deck-summary")).toHaveTextContent(
+      "Scheduler: 1m,10m -> 1d / easy 4d / leech 8 / fuzz off"
+    )
 
     fireEvent.click(screen.getByRole("button", { name: /^create flashcards$/i }))
 
@@ -511,6 +528,50 @@ describe("ResultsTab remediation panel", () => {
         request: {
           question_ids: [13],
           target_deck_id: 3,
+          replace_active: false
+        }
+      })
+    })
+  })
+
+  it("submits scheduler settings when remediation creates a new deck", async () => {
+    await openDetails()
+
+    fireEvent.click(screen.getByRole("button", { name: /create remediation flashcards/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Destination deck")).toBeInTheDocument()
+    })
+
+    const dialog = screen
+      .getAllByRole("dialog")
+      .find((element) => within(element).queryByText("Destination deck"))
+    expect(dialog).not.toBeNull()
+    fireEvent.mouseDown(within(dialog as HTMLElement).getByRole("combobox"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+    fireEvent.change(screen.getByTestId("quiz-remediation-new-deck-name"), {
+      target: { value: "Missed Questions Deck" }
+    })
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-preset-fast_acquisition"))
+    fireEvent.click(screen.getByRole("button", { name: /^create flashcards$/i }))
+
+    await waitFor(() => {
+      expect(mocks.convertRemediationQuestions).toHaveBeenCalledWith({
+        attemptId: 101,
+        request: {
+          question_ids: [13],
+          create_deck_name: "Missed Questions Deck",
+          create_deck_scheduler_settings: {
+            new_steps_minutes: [1, 5, 15],
+            relearn_steps_minutes: [10],
+            graduating_interval_days: 1,
+            easy_interval_days: 3,
+            easy_bonus: 1.15,
+            interval_modifier: 0.9,
+            max_interval_days: 3650,
+            leech_threshold: 10,
+            enable_fuzz: false
+          },
           replace_active: false
         }
       })

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
@@ -103,11 +103,15 @@ if (!(globalThis as any).ResizeObserver) {
 
 describe("ResultsTab remediation panel", () => {
   const onRetakeQuiz = vi.fn()
+  let assistantQueryState: any
+  const assistantRefetchMock = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
     window.sessionStorage.clear()
     onRetakeQuiz.mockReset()
+    assistantQueryState = null
+    assistantRefetchMock.mockReset()
 
     mocks.createDeck.mockResolvedValue({ id: 99, name: "Recovery Deck" })
     mocks.createFlashcard.mockResolvedValue({ uuid: "new-card" })
@@ -243,44 +247,91 @@ describe("ResultsTab remediation panel", () => {
       isPending: false
     } as any)
 
+    assistantRefetchMock.mockImplementation(async () => {
+      const nextMessageId = 201 + (assistantQueryState.data?.messages?.length ?? 1)
+      assistantQueryState = {
+        ...assistantQueryState,
+        data: {
+          ...assistantQueryState.data,
+          thread: {
+            ...assistantQueryState.data.thread,
+            version: 2,
+            message_count: 2
+          },
+          messages: [
+            ...(assistantQueryState.data?.messages ?? []),
+            {
+              id: nextMessageId,
+              thread_id: 19,
+              role: "assistant",
+              action_type: "follow_up",
+              input_modality: "text",
+              content: "Latest remediation context",
+              structured_payload: {},
+              context_snapshot: {},
+              provider: "openai",
+              model: "gpt-5",
+              created_at: "2026-03-13T09:14:00Z",
+              client_id: "test"
+            }
+          ]
+        }
+      }
+      return assistantQueryState
+    })
     vi.mocked(useQuizAttemptQuestionAssistantQuery).mockImplementation(
-      (_attemptId: number | null | undefined, questionId: number | null | undefined) =>
-        ({
-          data: questionId === 12
-            ? {
-                thread: {
-                  id: 19,
-                  context_type: "quiz_attempt_question",
-                  quiz_attempt_id: 101,
-                  question_id: 12,
-                  message_count: 1,
-                  deleted: false,
-                  client_id: "test",
-                  version: 1
-                },
-                messages: [
-                  {
-                    id: 201,
-                    thread_id: 19,
-                    role: "assistant",
-                    action_type: "explain",
-                    input_modality: "text",
-                    content: "Review the misconception in your own words.",
-                    structured_payload: {},
-                    context_snapshot: {},
-                    provider: "openai",
-                    model: "gpt-5",
-                    created_at: "2026-03-13T09:13:00Z",
-                    client_id: "test"
-                  }
-                ],
-                context_snapshot: {},
-                available_actions: ["explain", "follow_up", "freeform"]
-              }
-            : null,
-          isLoading: false,
-          isError: false
-        }) as any
+      (_attemptId: number | null | undefined, questionId: number | null | undefined) => {
+        if (questionId !== 12) {
+          return {
+            data: null,
+            isLoading: false,
+            isError: false,
+            refetch: assistantRefetchMock
+          } as any
+        }
+
+        if (!assistantQueryState) {
+          assistantQueryState = {
+            data: {
+              thread: {
+                id: 19,
+                context_type: "quiz_attempt_question",
+                quiz_attempt_id: 101,
+                question_id: 12,
+                message_count: 1,
+                deleted: false,
+                client_id: "test",
+                version: 1
+              },
+              messages: [
+                {
+                  id: 201,
+                  thread_id: 19,
+                  role: "assistant",
+                  action_type: "explain",
+                  input_modality: "text",
+                  content: "Review the misconception in your own words.",
+                  structured_payload: {},
+                  context_snapshot: {},
+                  provider: "openai",
+                  model: "gpt-5",
+                  created_at: "2026-03-13T09:13:00Z",
+                  client_id: "test"
+                }
+              ],
+              context_snapshot: {},
+              available_actions: ["explain", "follow_up", "freeform"]
+            },
+            isLoading: false,
+            isError: false
+          }
+        }
+
+        return {
+          ...assistantQueryState,
+          refetch: assistantRefetchMock
+        } as any
+      }
     )
 
     vi.mocked(useQuizAttemptQuestionAssistantRespondMutation).mockReturnValue({
@@ -397,4 +448,40 @@ describe("ResultsTab remediation panel", () => {
     })
     expect(mocks.createFlashcard).not.toHaveBeenCalled()
   })
+
+  it("recovers remediation assistant conflicts in place", async () => {
+    mocks.assistantRespond
+      .mockRejectedValueOnce(Object.assign(new Error("Version mismatch"), { response: { status: 409 } }))
+      .mockRejectedValueOnce(Object.assign(new Error("Version mismatch"), { response: { status: 409 } }))
+      .mockResolvedValueOnce({
+        assistant_message: {
+          id: 401,
+          content: "Retried remediation response"
+        }
+      })
+    await openDetails()
+
+    fireEvent.click(screen.getByRole("button", { name: /explain mistake for question 12/i }))
+
+    await waitFor(() => {
+      expect(assistantRefetchMock).toHaveBeenCalled()
+      expect(screen.getByText("Latest remediation context")).toBeInTheDocument()
+      expect(screen.getByText("Conversation changed elsewhere.")).toBeInTheDocument()
+      expect(screen.getByText("Quiz #7, question 12")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole("button", { name: /explain mistake for question 12/i }))
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Retry my message" })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry my message" }))
+
+    await waitFor(() => {
+      expect(mocks.assistantRespond).toHaveBeenNthCalledWith(3, {
+        attemptId: 101,
+        questionId: 12,
+        request: { action: "explain" }
+      })
+    })
+  }, 12000)
 })

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
@@ -124,6 +124,7 @@ describe("ResultsTab remediation panel", () => {
             question_id: 13,
             status: "active",
             orphaned: false,
+            superseded_count: 0,
             target_deck_id: 3,
             target_deck_name_snapshot: "Renal Recovery Deck",
             flashcard_count: 1,
@@ -278,6 +279,7 @@ describe("ResultsTab remediation panel", () => {
             question_id: 12,
             status: "active",
             orphaned: false,
+            superseded_count: 1,
             target_deck_id: 3,
             target_deck_name_snapshot: "Renal Recovery Deck",
             flashcard_count: 1,
@@ -287,27 +289,9 @@ describe("ResultsTab remediation panel", () => {
             last_modified: "2026-03-13T09:15:00Z",
             client_id: "test",
             version: 1
-          },
-          {
-            id: 811,
-            attempt_id: 101,
-            quiz_id: 7,
-            question_id: 12,
-            status: "superseded",
-            orphaned: false,
-            superseded_by_id: 901,
-            target_deck_id: 2,
-            target_deck_name_snapshot: "Old Renal Deck",
-            flashcard_count: 1,
-            flashcard_uuids_json: ["fc-old-12"],
-            source_ref_id: "quiz-attempt:101:question:12",
-            created_at: "2026-03-12T09:15:00Z",
-            last_modified: "2026-03-12T09:15:00Z",
-            client_id: "test",
-            version: 1
           }
         ],
-        count: 2,
+        count: 1,
         superseded_count: 1
       },
       isLoading: false
@@ -576,7 +560,7 @@ describe("ResultsTab remediation panel", () => {
         }
       })
     })
-  })
+  }, 12000)
 
   it("resubmits already-converted questions with replace_active when confirmed", async () => {
     mocks.convertRemediationQuestions
@@ -595,6 +579,7 @@ describe("ResultsTab remediation panel", () => {
               question_id: 12,
               status: "active",
               orphaned: false,
+              superseded_count: 0,
               target_deck_id: 3,
               target_deck_name_snapshot: "Renal Recovery Deck",
               flashcard_count: 1,
@@ -626,6 +611,7 @@ describe("ResultsTab remediation panel", () => {
               question_id: 12,
               status: "active",
               orphaned: false,
+              superseded_count: 1,
               target_deck_id: 3,
               target_deck_name_snapshot: "Renal Recovery Deck",
               flashcard_count: 1,
@@ -673,6 +659,108 @@ describe("ResultsTab remediation panel", () => {
     })
   }, 12000)
 
+  it("reuses the server-created deck when a new-deck conversion needs replace_active retry", async () => {
+    mocks.convertRemediationQuestions
+      .mockResolvedValueOnce({
+        attempt_id: 101,
+        quiz_id: 7,
+        target_deck: { id: 44, name: "Retry Deck" },
+        results: [
+          {
+            question_id: 12,
+            status: "already_exists",
+            conversion: {
+              id: 901,
+              attempt_id: 101,
+              quiz_id: 7,
+              question_id: 12,
+              status: "active",
+              orphaned: false,
+              superseded_count: 0,
+              target_deck_id: 44,
+              target_deck_name_snapshot: "Retry Deck",
+              flashcard_count: 1,
+              flashcard_uuids_json: ["fc-12"],
+              source_ref_id: "quiz-attempt:101:question:12",
+              created_at: "2026-03-13T09:15:00Z",
+              last_modified: "2026-03-13T09:15:00Z",
+              client_id: "test",
+              version: 1
+            },
+            flashcard_uuids: ["fc-12"],
+            error: null
+          }
+        ],
+        created_flashcard_uuids: []
+      })
+      .mockResolvedValueOnce({
+        attempt_id: 101,
+        quiz_id: 7,
+        target_deck: { id: 44, name: "Retry Deck" },
+        results: [
+          {
+            question_id: 12,
+            status: "superseded_and_created",
+            conversion: {
+              id: 903,
+              attempt_id: 101,
+              quiz_id: 7,
+              question_id: 12,
+              status: "active",
+              orphaned: false,
+              superseded_count: 1,
+              target_deck_id: 44,
+              target_deck_name_snapshot: "Retry Deck",
+              flashcard_count: 1,
+              flashcard_uuids_json: ["fc-12-new"],
+              source_ref_id: "quiz-attempt:101:question:12",
+              created_at: "2026-03-13T09:18:00Z",
+              last_modified: "2026-03-13T09:18:00Z",
+              client_id: "test",
+              version: 1
+            },
+            flashcard_uuids: ["fc-12-new"],
+            error: null
+          }
+        ],
+        created_flashcard_uuids: ["fc-12-new"]
+      })
+
+    await openDetails()
+
+    fireEvent.click(screen.getByRole("button", { name: /create remediation flashcards/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Destination deck")).toBeInTheDocument()
+    })
+
+    const modal = screen.getAllByRole("dialog")[1]
+    fireEvent.mouseDown(within(modal).getByRole("combobox"))
+    fireEvent.click(await screen.findByText("Create new deck"))
+    fireEvent.change(screen.getByTestId("quiz-remediation-new-deck-name"), {
+      target: { value: "Retry Deck" }
+    })
+    fireEvent.click(within(modal).getByRole("checkbox", { name: /which structure filters blood/i }))
+    fireEvent.click(screen.getByRole("button", { name: /^create flashcards$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /convert again anyway/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /convert again anyway/i }))
+
+    await waitFor(() => {
+      expect(mocks.convertRemediationQuestions).toHaveBeenNthCalledWith(2, {
+        attemptId: 101,
+        request: {
+          question_ids: [12],
+          target_deck_id: 44,
+          replace_active: true
+        }
+      })
+    })
+  }, 12000)
+
   it("drops the deck filter when active remediation conversions span multiple decks", async () => {
     vi.mocked(useAttemptRemediationConversionsQuery).mockReturnValue({
       data: {
@@ -685,6 +773,7 @@ describe("ResultsTab remediation panel", () => {
             question_id: 12,
             status: "active",
             orphaned: false,
+            superseded_count: 0,
             target_deck_id: 3,
             target_deck_name_snapshot: "Renal Recovery Deck",
             flashcard_count: 1,
@@ -702,6 +791,7 @@ describe("ResultsTab remediation panel", () => {
             question_id: 13,
             status: "active",
             orphaned: false,
+            superseded_count: 0,
             target_deck_id: 4,
             target_deck_name_snapshot: "Renal Backup Deck",
             flashcard_count: 1,
@@ -769,5 +859,5 @@ describe("ResultsTab remediation panel", () => {
         request: { action: "explain" }
       })
     })
-  }, 12000)
+  }, 20000)
 })

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
@@ -1,26 +1,23 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ResultsTab } from "../ResultsTab"
 import {
   useAllAttemptsQuery,
   useAttemptQuery,
+  useAttemptRemediationConversionsQuery,
+  useConvertAttemptRemediationQuestionsMutation,
   useGenerateRemediationQuizMutation,
   useQuizAttemptQuestionAssistantQuery,
   useQuizAttemptQuestionAssistantRespondMutation,
   useQuizzesQuery
 } from "../../hooks"
 import {
-  useCreateDeckMutation,
-  useCreateFlashcardsBulkMutation,
-  useCreateFlashcardMutation,
   useDecksQuery
 } from "@/components/Flashcards/hooks/useFlashcardQueries"
 
 const mocks = vi.hoisted(() => ({
-  createDeck: vi.fn(),
-  createFlashcard: vi.fn(),
-  createFlashcardsBulk: vi.fn(),
+  convertRemediationQuestions: vi.fn(),
   navigate: vi.fn(),
   remediationQuiz: vi.fn(),
   assistantRespond: vi.fn()
@@ -62,16 +59,15 @@ vi.mock("../../hooks", () => ({
   useAllAttemptsQuery: vi.fn(),
   useQuizzesQuery: vi.fn(),
   useAttemptQuery: vi.fn(),
+  useAttemptRemediationConversionsQuery: vi.fn(),
+  useConvertAttemptRemediationQuestionsMutation: vi.fn(),
   useGenerateRemediationQuizMutation: vi.fn(),
   useQuizAttemptQuestionAssistantQuery: vi.fn(),
   useQuizAttemptQuestionAssistantRespondMutation: vi.fn()
 }))
 
 vi.mock("@/components/Flashcards/hooks/useFlashcardQueries", () => ({
-  useDecksQuery: vi.fn(),
-  useCreateDeckMutation: vi.fn(),
-  useCreateFlashcardMutation: vi.fn(),
-  useCreateFlashcardsBulkMutation: vi.fn()
+  useDecksQuery: vi.fn()
 }))
 
 vi.mock("@/hooks/useTTS", () => ({
@@ -113,12 +109,37 @@ describe("ResultsTab remediation panel", () => {
     assistantQueryState = null
     assistantRefetchMock.mockReset()
 
-    mocks.createDeck.mockResolvedValue({ id: 99, name: "Recovery Deck" })
-    mocks.createFlashcard.mockResolvedValue({ uuid: "new-card" })
-    mocks.createFlashcardsBulk.mockResolvedValue([
-      { uuid: "new-card-1" },
-      { uuid: "new-card-2" }
-    ])
+    mocks.convertRemediationQuestions.mockResolvedValue({
+      attempt_id: 101,
+      quiz_id: 7,
+      target_deck: { id: 3, name: "Renal Recovery Deck" },
+      results: [
+        {
+          question_id: 13,
+          status: "created",
+          conversion: {
+            id: 902,
+            attempt_id: 101,
+            quiz_id: 7,
+            question_id: 13,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 3,
+            target_deck_name_snapshot: "Renal Recovery Deck",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-13"],
+            source_ref_id: "quiz-attempt:101:question:13",
+            created_at: "2026-03-13T09:16:00Z",
+            last_modified: "2026-03-13T09:16:00Z",
+            client_id: "test",
+            version: 1
+          },
+          flashcard_uuids: ["fc-13"],
+          error: null
+        }
+      ],
+      created_flashcard_uuids: ["fc-13"]
+    })
     mocks.remediationQuiz.mockResolvedValue({
       quiz: {
         id: 55,
@@ -246,6 +267,55 @@ describe("ResultsTab remediation panel", () => {
       mutateAsync: mocks.remediationQuiz,
       isPending: false
     } as any)
+    vi.mocked(useAttemptRemediationConversionsQuery).mockReturnValue({
+      data: {
+        attempt_id: 101,
+        items: [
+          {
+            id: 901,
+            attempt_id: 101,
+            quiz_id: 7,
+            question_id: 12,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 3,
+            target_deck_name_snapshot: "Renal Recovery Deck",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-12"],
+            source_ref_id: "quiz-attempt:101:question:12",
+            created_at: "2026-03-13T09:15:00Z",
+            last_modified: "2026-03-13T09:15:00Z",
+            client_id: "test",
+            version: 1
+          },
+          {
+            id: 811,
+            attempt_id: 101,
+            quiz_id: 7,
+            question_id: 12,
+            status: "superseded",
+            orphaned: false,
+            superseded_by_id: 901,
+            target_deck_id: 2,
+            target_deck_name_snapshot: "Old Renal Deck",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-old-12"],
+            source_ref_id: "quiz-attempt:101:question:12",
+            created_at: "2026-03-12T09:15:00Z",
+            last_modified: "2026-03-12T09:15:00Z",
+            client_id: "test",
+            version: 1
+          }
+        ],
+        count: 2,
+        superseded_count: 1
+      },
+      isLoading: false
+    } as any)
+    vi.mocked(useConvertAttemptRemediationQuestionsMutation).mockReturnValue({
+      mutateAsync: mocks.convertRemediationQuestions,
+      isPending: false
+    } as any)
 
     assistantRefetchMock.mockImplementation(async () => {
       const nextMessageId = 201 + (assistantQueryState.data?.messages?.length ?? 1)
@@ -343,18 +413,6 @@ describe("ResultsTab remediation panel", () => {
       data: [{ id: 3, name: "Renal Recovery Deck" }],
       isLoading: false
     } as any)
-    vi.mocked(useCreateDeckMutation).mockReturnValue({
-      mutateAsync: mocks.createDeck,
-      isPending: false
-    } as any)
-    vi.mocked(useCreateFlashcardMutation).mockReturnValue({
-      mutateAsync: mocks.createFlashcard,
-      isPending: false
-    } as any)
-    vi.mocked(useCreateFlashcardsBulkMutation).mockReturnValue({
-      mutateAsync: mocks.createFlashcardsBulk,
-      isPending: false
-    } as any)
   })
 
   const openDetails = async () => {
@@ -405,8 +463,22 @@ describe("ResultsTab remediation panel", () => {
     })
   })
 
+  it("does not read remediation conversion state from session storage", async () => {
+    const getItemSpy = vi.spyOn(window.sessionStorage, "getItem")
+
+    await openDetails()
+
+    expect(getItemSpy).not.toHaveBeenCalledWith("quiz-results-missed-flashcards-v1")
+    expect(getItemSpy).not.toHaveBeenCalledWith("quiz-results-flashcard-deck-map-v1")
+  })
+
   it("opens remediation flashcards and preserves study handoff actions", async () => {
     await openDetails()
+
+    expect(screen.getByText("Converted in deck Renal Recovery Deck.")).toBeInTheDocument()
+    expect(
+      screen.getByText("Superseded remediation history exists for this question.")
+    ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: /create remediation flashcards/i }))
 
@@ -419,9 +491,10 @@ describe("ResultsTab remediation panel", () => {
     expect(mocks.navigate).toHaveBeenCalledWith(
       expect.stringContaining("/flashcards?tab=review&study_source=quiz&quiz_id=7&attempt_id=101")
     )
+    expect(mocks.navigate).toHaveBeenCalledWith(expect.stringContaining("deck_id=3"))
   })
 
-  it("creates missed-question flashcards with one bulk mutation", async () => {
+  it("creates missed-question flashcards through the quiz remediation conversion endpoint", async () => {
     await openDetails()
 
     fireEvent.click(screen.getByRole("button", { name: /create remediation flashcards/i }))
@@ -433,20 +506,172 @@ describe("ResultsTab remediation panel", () => {
     fireEvent.click(screen.getByRole("button", { name: /^create flashcards$/i }))
 
     await waitFor(() => {
-      expect(mocks.createFlashcardsBulk).toHaveBeenCalledWith([
-        expect.objectContaining({
-          deck_id: 3,
-          front: "Which structure filters blood?",
-          source_ref_id: "quiz-attempt:101:question:12"
-        }),
-        expect.objectContaining({
-          deck_id: 3,
-          front: "Which nephron segment reabsorbs sodium without water?",
-          source_ref_id: "quiz-attempt:101:question:13"
-        })
-      ])
+      expect(mocks.convertRemediationQuestions).toHaveBeenCalledWith({
+        attemptId: 101,
+        request: {
+          question_ids: [13],
+          target_deck_id: 3,
+          replace_active: false
+        }
+      })
     })
-    expect(mocks.createFlashcard).not.toHaveBeenCalled()
+  })
+
+  it("resubmits already-converted questions with replace_active when confirmed", async () => {
+    mocks.convertRemediationQuestions
+      .mockResolvedValueOnce({
+        attempt_id: 101,
+        quiz_id: 7,
+        target_deck: { id: 3, name: "Renal Recovery Deck" },
+        results: [
+          {
+            question_id: 12,
+            status: "already_exists",
+            conversion: {
+              id: 901,
+              attempt_id: 101,
+              quiz_id: 7,
+              question_id: 12,
+              status: "active",
+              orphaned: false,
+              target_deck_id: 3,
+              target_deck_name_snapshot: "Renal Recovery Deck",
+              flashcard_count: 1,
+              flashcard_uuids_json: ["fc-12"],
+              source_ref_id: "quiz-attempt:101:question:12",
+              created_at: "2026-03-13T09:15:00Z",
+              last_modified: "2026-03-13T09:15:00Z",
+              client_id: "test",
+              version: 1
+            },
+            flashcard_uuids: ["fc-12"],
+            error: null
+          }
+        ],
+        created_flashcard_uuids: []
+      })
+      .mockResolvedValueOnce({
+        attempt_id: 101,
+        quiz_id: 7,
+        target_deck: { id: 3, name: "Renal Recovery Deck" },
+        results: [
+          {
+            question_id: 12,
+            status: "superseded_and_created",
+            conversion: {
+              id: 903,
+              attempt_id: 101,
+              quiz_id: 7,
+              question_id: 12,
+              status: "active",
+              orphaned: false,
+              target_deck_id: 3,
+              target_deck_name_snapshot: "Renal Recovery Deck",
+              flashcard_count: 1,
+              flashcard_uuids_json: ["fc-12-new"],
+              source_ref_id: "quiz-attempt:101:question:12",
+              created_at: "2026-03-13T09:18:00Z",
+              last_modified: "2026-03-13T09:18:00Z",
+              client_id: "test",
+              version: 1
+            },
+            flashcard_uuids: ["fc-12-new"],
+            error: null
+          }
+        ],
+        created_flashcard_uuids: ["fc-12-new"]
+      })
+
+    await openDetails()
+
+    fireEvent.click(screen.getByRole("button", { name: /create remediation flashcards/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText("Destination deck")).toBeInTheDocument()
+    })
+
+    const modal = screen.getAllByRole("dialog")[1]
+    fireEvent.click(within(modal).getByRole("checkbox", { name: /which structure filters blood/i }))
+    fireEvent.click(screen.getByRole("button", { name: /^create flashcards$/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /convert again anyway/i })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: /convert again anyway/i }))
+
+    await waitFor(() => {
+      expect(mocks.convertRemediationQuestions).toHaveBeenNthCalledWith(2, {
+        attemptId: 101,
+        request: {
+          question_ids: [12],
+          target_deck_id: 3,
+          replace_active: true
+        }
+      })
+    })
+  }, 12000)
+
+  it("drops the deck filter when active remediation conversions span multiple decks", async () => {
+    vi.mocked(useAttemptRemediationConversionsQuery).mockReturnValue({
+      data: {
+        attempt_id: 101,
+        items: [
+          {
+            id: 901,
+            attempt_id: 101,
+            quiz_id: 7,
+            question_id: 12,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 3,
+            target_deck_name_snapshot: "Renal Recovery Deck",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-12"],
+            source_ref_id: "quiz-attempt:101:question:12",
+            created_at: "2026-03-13T09:15:00Z",
+            last_modified: "2026-03-13T09:15:00Z",
+            client_id: "test",
+            version: 1
+          },
+          {
+            id: 902,
+            attempt_id: 101,
+            quiz_id: 7,
+            question_id: 13,
+            status: "active",
+            orphaned: false,
+            target_deck_id: 4,
+            target_deck_name_snapshot: "Renal Backup Deck",
+            flashcard_count: 1,
+            flashcard_uuids_json: ["fc-13"],
+            source_ref_id: "quiz-attempt:101:question:13",
+            created_at: "2026-03-13T09:16:00Z",
+            last_modified: "2026-03-13T09:16:00Z",
+            client_id: "test",
+            version: 1
+          }
+        ],
+        count: 2,
+        superseded_count: 0
+      },
+      isLoading: false
+    } as any)
+    vi.mocked(useDecksQuery).mockReturnValue({
+      data: [
+        { id: 3, name: "Renal Recovery Deck" },
+        { id: 4, name: "Renal Backup Deck" }
+      ],
+      isLoading: false
+    } as any)
+
+    await openDetails()
+
+    fireEvent.click(screen.getByRole("button", { name: /study linked cards/i }))
+
+    expect(mocks.navigate).toHaveBeenCalledWith(
+      "/flashcards?tab=review&study_source=quiz&quiz_id=7&attempt_id=101"
+    )
   })
 
   it("recovers remediation assistant conflicts in place", async () => {

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -155,6 +155,12 @@ export type DeckUpdate = {
   expected_version?: number | null
 }
 
+export type DeckCreateInput = {
+  name: string
+  description?: string | null
+  scheduler_settings?: DeckSchedulerSettings | null
+}
+
 export type FlashcardCreate = {
   deck_id?: number | null
   front: string
@@ -356,7 +362,7 @@ export async function listDecks(options?: { signal?: AbortSignal }): Promise<Dec
 }
 
 export async function createDeck(
-  input: { name: string; description?: string | null; scheduler_settings?: Partial<DeckSchedulerSettings> | null },
+  input: DeckCreateInput,
   options?: { signal?: AbortSignal }
 ): Promise<Deck> {
   return await decksClient.create<Deck>(input, {

--- a/apps/packages/ui/src/services/quizzes.ts
+++ b/apps/packages/ui/src/services/quizzes.ts
@@ -218,6 +218,60 @@ export type QuizRemediationGenerateRequest = {
   workspace_tag?: string | null
 }
 
+export type QuizRemediationConversionSummary = {
+  id: number
+  attempt_id: number
+  quiz_id: number
+  question_id: number
+  status: "active" | "superseded"
+  orphaned: boolean
+  superseded_by_id?: number | null
+  target_deck_id?: number | null
+  target_deck_name_snapshot?: string | null
+  flashcard_count: number
+  flashcard_uuids_json: string[]
+  source_ref_id?: string | null
+  created_at?: string | null
+  last_modified?: string | null
+  client_id: string
+  version: number
+}
+
+export type QuizRemediationConversionListResponse = {
+  attempt_id: number
+  items: QuizRemediationConversionSummary[]
+  count: number
+  superseded_count: number
+}
+
+export type QuizRemediationTargetDeck = {
+  id: number
+  name: string
+}
+
+export type QuizRemediationConvertRequest = {
+  question_ids: number[]
+  target_deck_id?: number | null
+  create_deck_name?: string | null
+  replace_active?: boolean
+}
+
+export type QuizRemediationConvertResult = {
+  question_id: number
+  status: "created" | "already_exists" | "superseded_and_created" | "failed"
+  conversion?: QuizRemediationConversionSummary | null
+  flashcard_uuids: string[]
+  error?: string | null
+}
+
+export type QuizRemediationConvertResponse = {
+  attempt_id: number
+  quiz_id: number
+  target_deck?: QuizRemediationTargetDeck | null
+  results: QuizRemediationConvertResult[]
+  created_flashcard_uuids: string[]
+}
+
 // List response types
 export type QuizListResponse = {
   items: Quiz[]
@@ -405,6 +459,31 @@ export async function getAttempt(
   return await quizAttemptsClient.get<QuizAttempt>(attemptId, {
     include_questions: params?.include_questions ? true : undefined,
     include_answers: params?.include_answers ? true : undefined
+  })
+}
+
+export async function listAttemptRemediationConversions(
+  attemptId: number,
+  options?: { signal?: AbortSignal }
+): Promise<QuizRemediationConversionListResponse> {
+  return await bgRequest<QuizRemediationConversionListResponse, AllowedPath, "GET">({
+    path: `/api/v1/quizzes/attempts/${attemptId}/remediation-conversions` as AllowedPath,
+    method: "GET",
+    abortSignal: options?.signal
+  })
+}
+
+export async function convertAttemptRemediationQuestions(
+  attemptId: number,
+  input: QuizRemediationConvertRequest,
+  options?: { signal?: AbortSignal }
+): Promise<QuizRemediationConvertResponse> {
+  return await bgRequest<QuizRemediationConvertResponse, AllowedPath, "POST">({
+    path: `/api/v1/quizzes/attempts/${attemptId}/remediation-conversions/convert` as AllowedPath,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: input,
+    abortSignal: options?.signal
   })
 }
 

--- a/apps/packages/ui/src/services/quizzes.ts
+++ b/apps/packages/ui/src/services/quizzes.ts
@@ -226,6 +226,7 @@ export type QuizRemediationConversionSummary = {
   question_id: number
   status: "active" | "superseded"
   orphaned: boolean
+  superseded_count: number
   superseded_by_id?: number | null
   target_deck_id?: number | null
   target_deck_name_snapshot?: string | null

--- a/apps/packages/ui/src/services/quizzes.ts
+++ b/apps/packages/ui/src/services/quizzes.ts
@@ -1,6 +1,7 @@
 import { bgRequest } from "@/services/background-proxy"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
 import { createResourceClient } from "@/services/resource-client"
+import type { DeckSchedulerSettings } from "@/services/flashcards"
 import type {
   StudyAssistantContextResponse,
   StudyAssistantRespondRequest,
@@ -253,6 +254,7 @@ export type QuizRemediationConvertRequest = {
   question_ids: number[]
   target_deck_id?: number | null
   create_deck_name?: string | null
+  create_deck_scheduler_settings?: DeckSchedulerSettings | null
   replace_active?: boolean
 }
 

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -406,7 +406,7 @@ def get_attempt(
 def get_attempt_remediation_conversions(
     attempt_id: int,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
-):
+) -> QuizRemediationConversionListResponse:
     """Return server-backed remediation conversion state for a completed attempt."""
     attempt = db.get_attempt(attempt_id, include_questions=False, include_answers=False)
     if not attempt:
@@ -428,7 +428,7 @@ def convert_attempt_remediation_conversions(
     attempt_id: int,
     payload: QuizRemediationConvertRequest,
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
-):
+) -> QuizRemediationConvertResponse:
     """Create remediation flashcards plus conversion records for missed attempt questions."""
     try:
         return db.convert_quiz_remediation_questions(

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -75,10 +75,22 @@ def _mark_orphaned_remediation_items(
     items: list[dict[str, Any]],
     db: CharactersRAGDB,
 ) -> list[dict[str, Any]]:
+    """Mark remediation items orphaned when all linked flashcards have been deleted."""
+    all_uuids = {
+        str(card_uuid)
+        for item in items
+        for card_uuid in (item.get("flashcard_uuids_json") or [])
+        if str(card_uuid).strip()
+    }
+    existing_uuids = {
+        str(card.get("uuid"))
+        for card in db.get_flashcards_by_uuids(sorted(all_uuids))
+        if str(card.get("uuid") or "").strip()
+    }
     marked_items: list[dict[str, Any]] = []
     for item in items:
         flashcard_uuids = list(item.get("flashcard_uuids_json") or [])
-        orphaned = bool(flashcard_uuids) and not any(db.get_flashcard(card_uuid) for card_uuid in flashcard_uuids)
+        orphaned = bool(flashcard_uuids) and not any(card_uuid in existing_uuids for card_uuid in flashcard_uuids)
         marked_item = dict(item)
         marked_item["orphaned"] = orphaned
         marked_items.append(marked_item)
@@ -434,7 +446,7 @@ def convert_attempt_remediation_conversions(
     except InputError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except ConflictError as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except CharactersRAGDBError as exc:
         logger.error(f"Failed to convert remediation questions for attempt {attempt_id}: {exc}")
         raise HTTPException(status_code=500, detail="Failed to convert remediation questions") from exc

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -21,6 +21,9 @@ from tldw_Server_API.app.api.v1.schemas.quizzes import (
     QuizImportRequest,
     QuizImportResponse,
     QuizListResponse,
+    QuizRemediationConversionListResponse,
+    QuizRemediationConvertRequest,
+    QuizRemediationConvertResponse,
     QuizResponse,
     QuizUpdate,
 )
@@ -33,6 +36,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
     CharactersRAGDBError,
     ConflictError,
+    InputError,
 )
 from tldw_Server_API.app.core.Flashcards.study_assistant import (
     build_quiz_attempt_question_context,
@@ -65,6 +69,20 @@ def _default_study_assistant_message(action: str, context: dict[str, Any]) -> st
         "fact_check": f"Fact-check my explanation of this question: {question_text}",
         "freeform": f"Help me review this question: {question_text}",
     }.get(action, f"Help me review this question: {question_text}")
+
+
+def _mark_orphaned_remediation_items(
+    items: list[dict[str, Any]],
+    db: CharactersRAGDB,
+) -> list[dict[str, Any]]:
+    marked_items: list[dict[str, Any]] = []
+    for item in items:
+        flashcard_uuids = list(item.get("flashcard_uuids_json") or [])
+        orphaned = bool(flashcard_uuids) and not any(db.get_flashcard(card_uuid) for card_uuid in flashcard_uuids)
+        marked_item = dict(item)
+        marked_item["orphaned"] = orphaned
+        marked_items.append(marked_item)
+    return marked_items
 
 
 @router.get("", response_model=QuizListResponse)
@@ -367,6 +385,54 @@ def get_attempt(
     if not attempt:
         raise HTTPException(status_code=404, detail="Attempt not found")
     return attempt
+
+
+@router.get(
+    "/attempts/{attempt_id:int}/remediation-conversions",
+    response_model=QuizRemediationConversionListResponse,
+)
+def get_attempt_remediation_conversions(
+    attempt_id: int,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+):
+    """Return server-backed remediation conversion state for a completed attempt."""
+    attempt = db.get_attempt(attempt_id, include_questions=False, include_answers=False)
+    if not attempt:
+        raise HTTPException(status_code=404, detail="Attempt not found")
+    try:
+        payload = db.list_attempt_remediation_conversions(attempt_id)
+        payload["items"] = _mark_orphaned_remediation_items(list(payload.get("items") or []), db)
+        return payload
+    except CharactersRAGDBError as exc:
+        logger.error(f"Failed to list remediation conversions for attempt {attempt_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to list remediation conversions") from exc
+
+
+@router.post(
+    "/attempts/{attempt_id:int}/remediation-conversions/convert",
+    response_model=QuizRemediationConvertResponse,
+)
+def convert_attempt_remediation_conversions(
+    attempt_id: int,
+    payload: QuizRemediationConvertRequest,
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+):
+    """Create remediation flashcards plus conversion records for missed attempt questions."""
+    try:
+        return db.convert_quiz_remediation_questions(
+            attempt_id=attempt_id,
+            question_ids=payload.question_ids,
+            target_deck_id=payload.target_deck_id,
+            create_deck_name=payload.create_deck_name,
+            replace_active=payload.replace_active,
+        )
+    except InputError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ConflictError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except CharactersRAGDBError as exc:
+        logger.error(f"Failed to convert remediation questions for attempt {attempt_id}: {exc}")
+        raise HTTPException(status_code=500, detail="Failed to convert remediation questions") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -424,6 +424,11 @@ def convert_attempt_remediation_conversions(
             question_ids=payload.question_ids,
             target_deck_id=payload.target_deck_id,
             create_deck_name=payload.create_deck_name,
+            create_deck_scheduler_settings=(
+                payload.create_deck_scheduler_settings.model_dump()
+                if payload.create_deck_scheduler_settings
+                else None
+            ),
             replace_active=payload.replace_active,
         )
     except InputError as exc:

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -197,6 +197,7 @@ class QuizRemediationConversionSummary(BaseModel):
     question_id: int
     status: Literal["active", "superseded"]
     orphaned: bool = False
+    superseded_count: int = Field(0, ge=0)
     superseded_by_id: Optional[int] = None
     target_deck_id: Optional[int] = None
     target_deck_name_snapshot: Optional[str] = None

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -3,6 +3,8 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from .flashcards import DeckSchedulerSettings
+
 
 class QuestionType(str, Enum):
     MULTIPLE_CHOICE = "multiple_choice"
@@ -223,6 +225,7 @@ class QuizRemediationConvertRequest(BaseModel):
     question_ids: list[int] = Field(..., min_length=1)
     target_deck_id: Optional[int] = Field(None, ge=1)
     create_deck_name: Optional[str] = None
+    create_deck_scheduler_settings: Optional[DeckSchedulerSettings] = None
     replace_active: bool = False
 
     @model_validator(mode="after")
@@ -231,6 +234,8 @@ class QuizRemediationConvertRequest(BaseModel):
         has_create_deck = bool((self.create_deck_name or "").strip())
         if has_target_deck == has_create_deck:
             raise ValueError("Provide exactly one of target_deck_id or create_deck_name")
+        if self.create_deck_scheduler_settings is not None and not has_create_deck:
+            raise ValueError("create_deck_scheduler_settings requires create_deck_name")
         return self
 
 

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -186,6 +186,68 @@ class AttemptResponse(BaseModel):
 class AttemptListResponse(BaseModel):
     items: list[AttemptResponse]
     count: int
+
+
+class QuizRemediationConversionSummary(BaseModel):
+    id: int
+    attempt_id: int
+    quiz_id: int
+    question_id: int
+    status: Literal["active", "superseded"]
+    orphaned: bool = False
+    superseded_by_id: Optional[int] = None
+    target_deck_id: Optional[int] = None
+    target_deck_name_snapshot: Optional[str] = None
+    flashcard_count: int = Field(0, ge=0)
+    flashcard_uuids_json: list[str] = Field(default_factory=list)
+    source_ref_id: Optional[str] = None
+    created_at: Optional[str] = None
+    last_modified: Optional[str] = None
+    client_id: str
+    version: int
+
+
+class QuizRemediationConversionListResponse(BaseModel):
+    attempt_id: int
+    items: list[QuizRemediationConversionSummary] = Field(default_factory=list)
+    count: int = Field(..., ge=0)
+    superseded_count: int = Field(..., ge=0)
+
+
+class QuizRemediationTargetDeck(BaseModel):
+    id: int
+    name: str
+
+
+class QuizRemediationConvertRequest(BaseModel):
+    question_ids: list[int] = Field(..., min_length=1)
+    target_deck_id: Optional[int] = Field(None, ge=1)
+    create_deck_name: Optional[str] = None
+    replace_active: bool = False
+
+    @model_validator(mode="after")
+    def validate_deck_target(self) -> "QuizRemediationConvertRequest":
+        has_target_deck = self.target_deck_id is not None
+        has_create_deck = bool((self.create_deck_name or "").strip())
+        if has_target_deck == has_create_deck:
+            raise ValueError("Provide exactly one of target_deck_id or create_deck_name")
+        return self
+
+
+class QuizRemediationConvertResult(BaseModel):
+    question_id: int
+    status: Literal["created", "already_exists", "superseded_and_created", "failed"]
+    conversion: Optional[QuizRemediationConversionSummary] = None
+    flashcard_uuids: list[str] = Field(default_factory=list)
+    error: Optional[str] = None
+
+
+class QuizRemediationConvertResponse(BaseModel):
+    attempt_id: int
+    quiz_id: int
+    target_deck: Optional[QuizRemediationTargetDeck] = None
+    results: list[QuizRemediationConvertResult] = Field(default_factory=list)
+    created_flashcard_uuids: list[str] = Field(default_factory=list)
 
 
 class QuizGenerateRequest(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -19755,6 +19755,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             item["flashcard_uuids_json"] = flashcard_uuids
         else:
             item["flashcard_uuids_json"] = []
+        item["superseded_count"] = int(item.get("superseded_count") or 0)
         return item
 
     def _public_quiz_question(self, question: dict[str, Any]) -> dict[str, Any]:
@@ -20612,13 +20613,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
         try:
             with self.transaction() as conn:
-                placeholders = ", ".join("?" for _ in ordered_question_ids)
                 active_rows = conn.execute(
-                    "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
-                    "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
-                    "source_ref_id, created_at, last_modified, client_id, version "
-                    f"FROM quiz_remediation_conversions WHERE attempt_id = ? AND status = ? AND question_id IN ({placeholders})",  # nosec B608
-                    (int(attempt_id), "active", *ordered_question_ids),
+                    "SELECT qrc.id, qrc.attempt_id, qrc.quiz_id, qrc.question_id, qrc.status, "
+                    "qrc.superseded_by_id, qrc.target_deck_id, qrc.target_deck_name_snapshot, "
+                    "qrc.flashcard_count, qrc.flashcard_uuids_json, qrc.source_ref_id, qrc.created_at, "
+                    "qrc.last_modified, qrc.client_id, qrc.version, "
+                    "(SELECT COUNT(*) FROM quiz_remediation_conversions history "
+                    " WHERE history.attempt_id = qrc.attempt_id AND history.question_id = qrc.question_id "
+                    "   AND history.status = ?) AS superseded_count "
+                    "FROM quiz_remediation_conversions qrc WHERE qrc.attempt_id = ? AND qrc.status = ?",
+                    ("superseded", int(attempt_id), "active"),
                 ).fetchall()
                 existing_by_question = {
                     int(item["question_id"]): item
@@ -20626,7 +20630,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         self._deserialize_quiz_remediation_conversion_row(row)
                         for row in active_rows
                     )
-                    if item is not None
+                    if item is not None and int(item["question_id"]) in ordered_question_ids
                 }
 
                 pending_entries: list[dict[str, Any]] = []
@@ -20736,6 +20740,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     conversion = self._deserialize_quiz_remediation_conversion_row(conversion_row)
                     if not conversion:
                         raise CharactersRAGDBError("Failed to load remediation conversion after insert")  # noqa: TRY003
+                    prior_superseded_count = int(previous_active.get("superseded_count") or 0) if previous_active else 0
+                    conversion["superseded_count"] = prior_superseded_count + (
+                        1 if previous_active and replace_active else 0
+                    )
 
                     results_by_question[question_id] = {
                         "question_id": question_id,
@@ -20752,11 +20760,25 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     "results": ordered_results,
                     "created_flashcard_uuids": created_flashcard_uuids,
                 }
+        except sqlite3.IntegrityError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    f"Active remediation conversion already exists for attempt {attempt_id}.",
+                    entity="quiz_remediation_conversions",
+                    entity_id=str(attempt_id),
+                ) from exc  # noqa: TRY003
+            raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    f"Active remediation conversion already exists for attempt {attempt_id}.",
+                    entity="quiz_remediation_conversions",
+                    entity_id=str(attempt_id),
+                ) from exc  # noqa: TRY003
+            raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
         except CharactersRAGDBError:  # noqa: TRY203
             raise
         except sqlite3.Error as exc:
-            raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
-        except BackendDatabaseError as exc:
             raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
 
     def create_quiz_remediation_conversion(
@@ -20881,12 +20903,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         """List active remediation conversions for an attempt with superseded history count."""
         try:
             active_cursor = self.execute_query(
-                "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
-                "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
-                "source_ref_id, created_at, last_modified, client_id, version "
-                "FROM quiz_remediation_conversions WHERE attempt_id = ? AND status = ? "
-                "ORDER BY question_id ASC, created_at DESC, id DESC",
-                (int(attempt_id), "active"),
+                "SELECT qrc.id, qrc.attempt_id, qrc.quiz_id, qrc.question_id, qrc.status, "
+                "qrc.superseded_by_id, qrc.target_deck_id, qrc.target_deck_name_snapshot, "
+                "qrc.flashcard_count, qrc.flashcard_uuids_json, qrc.source_ref_id, qrc.created_at, "
+                "qrc.last_modified, qrc.client_id, qrc.version, "
+                "(SELECT COUNT(*) FROM quiz_remediation_conversions history "
+                " WHERE history.attempt_id = qrc.attempt_id AND history.question_id = qrc.question_id "
+                "   AND history.status = ?) AS superseded_count "
+                "FROM quiz_remediation_conversions qrc WHERE qrc.attempt_id = ? AND qrc.status = ? "
+                "ORDER BY qrc.question_id ASC, qrc.created_at DESC, qrc.id DESC",
+                ("superseded", int(attempt_id), "active"),
             )
             items = [
                 item

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -20587,6 +20587,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         question_ids: list[int],
         target_deck_id: int | None = None,
         create_deck_name: str | None = None,
+        create_deck_scheduler_settings: Mapping[str, Any] | str | None = None,
         replace_active: bool = False,
     ) -> dict[str, Any]:
         """Convert missed attempt questions into flashcards plus remediation conversion rows."""
@@ -20643,7 +20644,11 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     pending_entries.append(entry)
 
                 if pending_entries and normalized_create_deck_name is not None and target_deck is None:
-                    created_deck_id = self.add_deck(normalized_create_deck_name, description=None)
+                    created_deck_id = self.add_deck(
+                        normalized_create_deck_name,
+                        description=None,
+                        scheduler_settings=create_deck_scheduler_settings,
+                    )
                     deck = self.get_deck(int(created_deck_id))
                     target_deck = {
                         "id": int(created_deck_id),

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -452,7 +452,7 @@ class CharactersRAGDB:
         is_memory_db (bool): True if the database is in-memory.
         db_path_str (str): String representation of the database path for SQLite connection.
     """
-    _CURRENT_SCHEMA_VERSION = 37  # Schema v37 adds workspace sub-resources, settings, and flashcard scheduler state
+    _CURRENT_SCHEMA_VERSION = 38  # Schema v38 adds quiz remediation conversion state
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES: tuple[str, ...] = ("in-progress", "resolved", "backlog", "non-viable")
     _ALLOWED_CONVERSATION_CHARACTER_SCOPES: tuple[str, ...] = ("all", "character", "non_character")
@@ -3165,6 +3165,24 @@ UPDATE db_schema_version
  WHERE schema_name = 'rag_char_chat_schema'
    AND version < 37;
 """
+    _MIGRATION_SQL_V37_TO_V38 = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 38 - Quiz remediation conversion state (2026-03-13)
+───────────────────────────────────────────────────────────────*/
+UPDATE db_schema_version
+   SET version = 38
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 38;
+"""
+    _MIGRATION_SQL_V37_TO_V38_POSTGRES = """
+/*───────────────────────────────────────────────────────────────
+  Migration to Version 38 - Quiz remediation conversion state (2026-03-13)
+───────────────────────────────────────────────────────────────*/
+UPDATE db_schema_version
+   SET version = 38
+ WHERE schema_name = 'rag_char_chat_schema'
+   AND version < 38;
+"""
     _MIGRATION_SQL_V10_TO_V11_POSTGRES = """
 ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 """
@@ -4923,6 +4941,27 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V36->V37: {e}", exc_info=True)
             raise SchemaError(f"Unexpected error migrating to V37 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
 
+    def _migrate_from_v37_to_v38(self, conn: sqlite3.Connection) -> None:
+        """Migrate schema from V37 to V38 (quiz remediation conversion state)."""
+        logger.info(f"Migrating '{self._SCHEMA_NAME}' schema from V37 to V38 for DB: {self.db_path_str}...")
+        try:
+            self._ensure_quiz_remediation_conversion_schema_sqlite(conn)
+            conn.executescript(self._MIGRATION_SQL_V37_TO_V38)
+            final_version = self._get_db_version(conn)
+            if final_version != 38:
+                raise SchemaError(  # noqa: TRY003, TRY301
+                    f"[{self._SCHEMA_NAME}] Migration V37->V38 failed version check. Expected 38, got: {final_version}"
+                )
+            logger.info(f"[{self._SCHEMA_NAME}] Migration to V38 completed.")
+        except sqlite3.Error as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Migration V37->V38 failed: {e}", exc_info=True)
+            raise SchemaError(f"Migration V37->V38 failed for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+        except SchemaError:
+            raise
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as e:
+            logger.error(f"[{self._SCHEMA_NAME}] Unexpected error during migration V37->V38: {e}", exc_info=True)
+            raise SchemaError(f"Unexpected error migrating to V38 for '{self._SCHEMA_NAME}': {e}") from e  # noqa: TRY003
+
     def _ensure_recent_persona_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Backfill recent persona schema columns after version-number collisions."""
         profile_cols = {row[1] for row in conn.execute("PRAGMA table_info('persona_profiles')").fetchall()}
@@ -5293,6 +5332,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     self._ensure_flashcard_asset_schema_sqlite(conn)
                     self._ensure_flashcard_scheduler_schema_sqlite(conn)
                     self._ensure_study_assistant_schema_sqlite(conn)
+                    self._ensure_quiz_remediation_conversion_schema_sqlite(conn)
                     self._ensure_flashcard_fts_triggers_sqlite(conn)
                     self._ensure_character_cards_fts_triggers_sqlite(conn)
                     self._ensure_notes_fts_triggers_sqlite(conn)
@@ -5407,6 +5447,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         current_db_version = self._get_db_version(conn)
                     if target_version >= 37 and current_db_version == 36:
                         self._migrate_from_v36_to_v37(conn)
+                        current_db_version = self._get_db_version(conn)
+                    if target_version >= 38 and current_db_version == 37:
+                        self._migrate_from_v37_to_v38(conn)
                         current_db_version = self._get_db_version(conn)
                 # Ensure helpful indexes that may have been introduced post-creation
                 try:
@@ -5736,6 +5779,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                 self._migrate_from_v35_to_v36(conn)
                             elif fallback_version == 36:
                                 self._migrate_from_v36_to_v37(conn)
+                            elif fallback_version == 37:
+                                self._migrate_from_v37_to_v38(conn)
                             else:
                                 raise SchemaError(  # noqa: TRY003, TRY301
                                     f"Migration path undefined for '{self._SCHEMA_NAME}' from version {current_initial_version} to {target_version}. "
@@ -5823,6 +5868,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 if target_version >= 37 and current_db_version == 36:
                     self._migrate_from_v36_to_v37(conn)
                     current_db_version = self._get_db_version(conn)
+                if target_version >= 38 and current_db_version == 37:
+                    self._migrate_from_v37_to_v38(conn)
+                    current_db_version = self._get_db_version(conn)
 
                 self._ensure_recent_persona_schema_sqlite(conn)
 
@@ -5836,6 +5884,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 self._ensure_flashcard_asset_schema_sqlite(conn)
                 self._ensure_flashcard_scheduler_schema_sqlite(conn)
                 self._ensure_study_assistant_schema_sqlite(conn)
+                self._ensure_quiz_remediation_conversion_schema_sqlite(conn)
                 self._ensure_flashcard_fts_triggers_sqlite(conn)
                 self._ensure_character_cards_fts_triggers_sqlite(conn)
                 self._ensure_notes_fts_triggers_sqlite(conn)
@@ -6665,6 +6714,94 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
             raise SchemaError(f"Failed ensuring PostgreSQL study assistant schema: {exc}") from exc  # noqa: TRY003
 
+    def _ensure_quiz_remediation_conversion_schema_sqlite(self, conn: sqlite3.Connection) -> None:
+        """Ensure quiz remediation conversion storage exists for SQLite."""
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quiz_remediation_conversions(
+                  id                        INTEGER PRIMARY KEY AUTOINCREMENT,
+                  attempt_id                INTEGER NOT NULL REFERENCES quiz_attempts(id) ON DELETE CASCADE,
+                  quiz_id                   INTEGER NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+                  question_id               INTEGER NOT NULL REFERENCES quiz_questions(id) ON DELETE CASCADE,
+                  status                    TEXT NOT NULL CHECK(status IN ('active', 'superseded')),
+                  superseded_by_id          INTEGER REFERENCES quiz_remediation_conversions(id) ON DELETE SET NULL,
+                  target_deck_id            INTEGER REFERENCES decks(id) ON DELETE SET NULL,
+                  target_deck_name_snapshot TEXT,
+                  flashcard_count           INTEGER NOT NULL DEFAULT 0,
+                  flashcard_uuids_json      TEXT,
+                  source_ref_id             TEXT,
+                  created_at                DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  last_modified             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  client_id                 TEXT NOT NULL DEFAULT 'unknown',
+                  version                   INTEGER NOT NULL DEFAULT 1
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_attempt_id "
+                "ON quiz_remediation_conversions(attempt_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_attempt_question "
+                "ON quiz_remediation_conversions(attempt_id, question_id)"
+            )
+            conn.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_active_unique
+                    ON quiz_remediation_conversions(attempt_id, question_id)
+                 WHERE status = 'active'
+                """
+            )
+        except sqlite3.Error as exc:
+            raise SchemaError(f"Failed ensuring SQLite remediation conversion schema: {exc}") from exc  # noqa: TRY003
+
+    def _ensure_quiz_remediation_conversion_schema_postgres(self, conn) -> None:
+        """Ensure quiz remediation conversion storage exists for PostgreSQL."""
+        try:
+            self.backend.execute(
+                """
+                CREATE TABLE IF NOT EXISTS quiz_remediation_conversions(
+                  id BIGSERIAL PRIMARY KEY,
+                  attempt_id INTEGER NOT NULL REFERENCES quiz_attempts(id) ON DELETE CASCADE,
+                  quiz_id INTEGER NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+                  question_id INTEGER NOT NULL REFERENCES quiz_questions(id) ON DELETE CASCADE,
+                  status TEXT NOT NULL CHECK(status IN ('active', 'superseded')),
+                  superseded_by_id BIGINT REFERENCES quiz_remediation_conversions(id) ON DELETE SET NULL,
+                  target_deck_id INTEGER REFERENCES decks(id) ON DELETE SET NULL,
+                  target_deck_name_snapshot TEXT,
+                  flashcard_count INTEGER NOT NULL DEFAULT 0,
+                  flashcard_uuids_json TEXT,
+                  source_ref_id TEXT,
+                  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  last_modified TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  client_id TEXT NOT NULL DEFAULT 'unknown',
+                  version INTEGER NOT NULL DEFAULT 1
+                )
+                """,
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_attempt_id "
+                "ON quiz_remediation_conversions(attempt_id)",
+                connection=conn,
+            )
+            self.backend.execute(
+                "CREATE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_attempt_question "
+                "ON quiz_remediation_conversions(attempt_id, question_id)",
+                connection=conn,
+            )
+            self.backend.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_quiz_remediation_conversions_active_unique
+                    ON quiz_remediation_conversions(attempt_id, question_id)
+                 WHERE status = 'active'
+                """,
+                connection=conn,
+            )
+        except _CHACHA_NONCRITICAL_EXCEPTIONS as exc:
+            raise SchemaError(f"Failed ensuring PostgreSQL remediation conversion schema: {exc}") from exc  # noqa: TRY003
+
     def _self_heal_character_cards_fts_sqlite(self, conn: sqlite3.Connection) -> None:
         """Rebuild character_cards_fts when active card rows are not indexed.
 
@@ -6842,6 +6979,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             if current_version < 37:
                 self._apply_postgres_migration_script(self._MIGRATION_SQL_V36_TO_V37_POSTGRES, conn, expected_version=37)
                 current_version = 37
+            if current_version < 38:
+                self._ensure_quiz_remediation_conversion_schema_postgres(conn)
+                self._apply_postgres_migration_script(self._MIGRATION_SQL_V37_TO_V38_POSTGRES, conn, expected_version=38)
+                current_version = 38
 
             if current_version > target_version:
                 raise SchemaError(  # noqa: TRY003
@@ -6851,6 +6992,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             self._ensure_flashcard_asset_schema_postgres(conn)
             self._ensure_flashcard_scheduler_schema_postgres(conn)
             self._ensure_study_assistant_schema_postgres(conn)
+            self._ensure_quiz_remediation_conversion_schema_postgres(conn)
             self._ensure_postgres_flashcards_tsvector(conn)
             self._ensure_recent_persona_schema_postgres(conn)
             self._ensure_workspace_subresource_schema_postgres(conn)
@@ -19604,6 +19746,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             item["source_bundle_json"] = None
         return item
 
+    def _deserialize_quiz_remediation_conversion_row(self, row: Any) -> dict[str, Any] | None:
+        item = self._deserialize_row_fields(row, ["flashcard_uuids_json"])
+        if not item:
+            return None
+        flashcard_uuids = item.get("flashcard_uuids_json")
+        if isinstance(flashcard_uuids, list):
+            item["flashcard_uuids_json"] = flashcard_uuids
+        else:
+            item["flashcard_uuids_json"] = []
+        return item
+
     def _public_quiz_question(self, question: dict[str, Any]) -> dict[str, Any]:
         payload = dict(question)
         payload.pop("correct_answer", None)
@@ -20275,6 +20428,481 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             count_row = count_cursor.fetchone()
             total = int(count_row["count"]) if count_row else 0
             return {"items": items, "count": total}  # noqa: TRY300
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+
+    def _format_quiz_answer_value_for_remediation(
+        self,
+        value: Any,
+        question: dict[str, Any] | None,
+    ) -> str:
+        """Format a graded quiz answer into stable remediation text."""
+        if value is None:
+            return "No answer"
+
+        question_type = str((question or {}).get("question_type") or "").strip().lower()
+        options = (question or {}).get("options") or []
+
+        if question_type == "fill_blank":
+            if isinstance(value, str):
+                parsed_rules = self._parse_fill_blank_json_rules(value)
+                if parsed_rules:
+                    accepted = [entry for entry, _fuzzy, _threshold in parsed_rules if entry]
+                    if accepted:
+                        return " / ".join(accepted)
+            if isinstance(value, list):
+                return " / ".join(str(item) for item in value if str(item).strip())
+            return str(value)
+
+        if question_type == "multi_select":
+            indices = self._normalize_multi_select_indices(value)
+            if not indices:
+                return str(value)
+            labels = [options[index] if 0 <= index < len(options) else str(index) for index in indices]
+            return " / ".join(str(label) for label in labels)
+
+        if question_type == "multiple_choice":
+            try:
+                index = int(value)
+            except (TypeError, ValueError):
+                return str(value)
+            if 0 <= index < len(options):
+                return str(options[index])
+            return str(value)
+
+        if question_type == "matching":
+            pairs = self._normalize_matching_map(value)
+            if not pairs:
+                return str(value)
+            return " / ".join(f"{left} -> {right}" for left, right in pairs.items())
+
+        if question_type == "true_false":
+            normalized = str(value).strip().lower()
+            if normalized == "true":
+                return "True"
+            if normalized == "false":
+                return "False"
+
+        if isinstance(value, list):
+            return " / ".join(str(item) for item in value)
+
+        return str(value)
+
+    def _build_quiz_remediation_entries(
+        self,
+        *,
+        attempt_id: int,
+        question_ids: list[int],
+    ) -> tuple[dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+        """Load and validate missed question entries for remediation conversion."""
+        attempt = self.get_attempt(attempt_id, include_questions=True, include_answers=True)
+        if not attempt:
+            raise ConflictError("Attempt not found", entity="quiz_attempts", identifier=attempt_id)  # noqa: TRY003
+        if not attempt.get("completed_at"):
+            raise InputError("Quiz attempt must be completed before remediation flashcards can be created.")  # noqa: TRY003
+
+        normalized_question_ids: list[int] = []
+        seen_question_ids: set[int] = set()
+        for question_id in question_ids:
+            try:
+                normalized_question_id = int(question_id)
+            except (TypeError, ValueError) as exc:
+                raise InputError("question_ids must contain integers.") from exc  # noqa: TRY003
+            if normalized_question_id in seen_question_ids:
+                continue
+            normalized_question_ids.append(normalized_question_id)
+            seen_question_ids.add(normalized_question_id)
+
+        if not normalized_question_ids:
+            raise InputError("Select at least one missed question to convert.")  # noqa: TRY003
+
+        questions = attempt.get("questions") or []
+        answers = attempt.get("answers") or []
+        questions_by_id = {int(question["id"]): question for question in questions if question.get("id") is not None}
+        answers_by_id = {
+            int(answer["question_id"]): answer
+            for answer in answers
+            if answer.get("question_id") is not None
+        }
+
+        invalid_ids = [question_id for question_id in normalized_question_ids if question_id not in questions_by_id]
+        if invalid_ids:
+            raise InputError(f"Question IDs not found in quiz attempt: {invalid_ids}")  # noqa: TRY003
+
+        quiz = self.get_quiz(int(attempt["quiz_id"]))
+        if not quiz:
+            raise ConflictError("Quiz not found", entity="quizzes", identifier=attempt["quiz_id"])  # noqa: TRY003
+        quiz_name = str(quiz.get("name") or f"Quiz #{attempt['quiz_id']}")
+
+        entries: list[dict[str, Any]] = []
+        for question_id in normalized_question_ids:
+            question = questions_by_id[question_id]
+            answer = answers_by_id.get(question_id)
+            if not answer or answer.get("is_correct") is not False:
+                raise InputError(f"Question {question_id} was not missed in this completed attempt.")  # noqa: TRY003
+
+            question_text = str(
+                question.get("question_text") or f"Question #{question_id}"
+            ).strip() or f"Question #{question_id}"
+            correct_answer_text = self._format_quiz_answer_value_for_remediation(
+                answer.get("correct_answer"),
+                question,
+            )
+            user_answer_text = self._format_quiz_answer_value_for_remediation(
+                answer.get("user_answer"),
+                question,
+            )
+            explanation = answer.get("explanation")
+            explanation_suffix = f"\n\nExplanation: {explanation}" if explanation else ""
+            dedupe_key = f"{question_text.strip().lower()}::{correct_answer_text.strip().lower()}"
+            entries.append(
+                {
+                    "question_id": question_id,
+                    "question_text": question_text,
+                    "correct_answer_text": correct_answer_text,
+                    "user_answer_text": user_answer_text,
+                    "explanation": explanation,
+                    "dedupe_key": dedupe_key,
+                    "source_ref_id": f"quiz-attempt:{attempt_id}:question:{question_id}",
+                    "flashcard_payload": {
+                        "front": question_text,
+                        "back": f"Correct answer: {correct_answer_text}{explanation_suffix}",
+                        "notes": (
+                            f'Created from quiz "{quiz_name}" (attempt #{attempt_id}). '
+                            f"Your answer: {user_answer_text}"
+                        ),
+                        "tags_json": self._ensure_json_string(["quiz-missed", "quiz-review"]) or "[]",
+                        "source_ref_type": "manual",
+                        "source_ref_id": f"quiz-attempt:{attempt_id}:question:{question_id}",
+                    },
+                }
+            )
+
+        return attempt, quiz, entries
+
+    def convert_quiz_remediation_questions(
+        self,
+        *,
+        attempt_id: int,
+        question_ids: list[int],
+        target_deck_id: int | None = None,
+        create_deck_name: str | None = None,
+        replace_active: bool = False,
+    ) -> dict[str, Any]:
+        """Convert missed attempt questions into flashcards plus remediation conversion rows."""
+        normalized_create_deck_name = (create_deck_name or "").strip() or None
+        if target_deck_id is not None and normalized_create_deck_name is not None:
+            raise InputError("Specify either target_deck_id or create_deck_name, not both.")  # noqa: TRY003
+        if target_deck_id is None and normalized_create_deck_name is None:
+            raise InputError("Provide target_deck_id or create_deck_name for remediation conversion.")  # noqa: TRY003
+
+        attempt, quiz, entries = self._build_quiz_remediation_entries(
+            attempt_id=int(attempt_id),
+            question_ids=question_ids,
+        )
+        ordered_question_ids = [int(entry["question_id"]) for entry in entries]
+        target_deck: dict[str, Any] | None = None
+
+        if target_deck_id is not None:
+            deck = self.get_deck(int(target_deck_id))
+            if not deck or bool(deck.get("deleted")):
+                raise InputError(f"Deck {target_deck_id} does not exist or is deleted.")  # noqa: TRY003
+            target_deck = {"id": int(deck["id"]), "name": str(deck.get("name") or f"Deck #{deck['id']}")}
+
+        try:
+            with self.transaction() as conn:
+                placeholders = ", ".join("?" for _ in ordered_question_ids)
+                active_rows = conn.execute(
+                    "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
+                    "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
+                    "source_ref_id, created_at, last_modified, client_id, version "
+                    f"FROM quiz_remediation_conversions WHERE attempt_id = ? AND status = ? AND question_id IN ({placeholders})",  # nosec B608
+                    (int(attempt_id), "active", *ordered_question_ids),
+                ).fetchall()
+                existing_by_question = {
+                    int(item["question_id"]): item
+                    for item in (
+                        self._deserialize_quiz_remediation_conversion_row(row)
+                        for row in active_rows
+                    )
+                    if item is not None
+                }
+
+                pending_entries: list[dict[str, Any]] = []
+                results_by_question: dict[int, dict[str, Any]] = {}
+                for entry in entries:
+                    existing = existing_by_question.get(int(entry["question_id"]))
+                    if existing and not replace_active:
+                        results_by_question[int(entry["question_id"])] = {
+                            "question_id": int(entry["question_id"]),
+                            "status": "already_exists",
+                            "conversion": existing,
+                            "flashcard_uuids": list(existing.get("flashcard_uuids_json") or []),
+                        }
+                        continue
+                    pending_entries.append(entry)
+
+                if pending_entries and normalized_create_deck_name is not None and target_deck is None:
+                    created_deck_id = self.add_deck(normalized_create_deck_name, description=None)
+                    deck = self.get_deck(int(created_deck_id))
+                    target_deck = {
+                        "id": int(created_deck_id),
+                        "name": str((deck or {}).get("name") or normalized_create_deck_name),
+                    }
+
+                deduped_entries: dict[str, dict[str, Any]] = {}
+                for entry in pending_entries:
+                    deduped_entries.setdefault(str(entry["dedupe_key"]), entry)
+
+                dedupe_uuid_map: dict[str, list[str]] = {}
+                created_flashcard_uuids: list[str] = []
+                if pending_entries:
+                    if target_deck is None:
+                        raise InputError("Target deck resolution failed for remediation conversion.")  # noqa: TRY003
+                    flashcard_payloads = []
+                    for dedupe_entry in deduped_entries.values():
+                        payload = dict(dedupe_entry["flashcard_payload"])
+                        payload["deck_id"] = int(target_deck["id"])
+                        flashcard_payloads.append(payload)
+                    created_flashcard_uuids = self.add_flashcards_bulk(flashcard_payloads)
+                    for dedupe_entry, flashcard_uuid in zip(deduped_entries.values(), created_flashcard_uuids, strict=False):
+                        dedupe_uuid_map[str(dedupe_entry["dedupe_key"])] = [flashcard_uuid]
+
+                for entry in pending_entries:
+                    question_id = int(entry["question_id"])
+                    previous_active = existing_by_question.get(question_id)
+                    now = self._get_current_utc_timestamp_iso()
+                    if previous_active and replace_active:
+                        conn.execute(
+                            "UPDATE quiz_remediation_conversions "
+                            "SET status = ?, superseded_by_id = NULL, last_modified = ?, client_id = ?, version = version + 1 "
+                            "WHERE id = ?",
+                            ("superseded", now, self.client_id, int(previous_active["id"])),
+                        )
+
+                    flashcard_uuids = list(dedupe_uuid_map.get(str(entry["dedupe_key"])) or [])
+                    insert_sql = (
+                        "INSERT INTO quiz_remediation_conversions("
+                        "attempt_id, quiz_id, question_id, status, superseded_by_id, target_deck_id, "
+                        "target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, source_ref_id, "
+                        "created_at, last_modified, client_id, version"
+                        ") VALUES(?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    )
+                    insert_params = (
+                        int(attempt_id),
+                        int(quiz["id"]),
+                        question_id,
+                        "active",
+                        int(target_deck["id"]) if target_deck is not None else None,
+                        str((target_deck or {}).get("name") or ""),
+                        len(flashcard_uuids),
+                        self._ensure_json_string(flashcard_uuids) or "[]",
+                        str(entry["source_ref_id"]),
+                        now,
+                        now,
+                        self.client_id,
+                        1,
+                    )
+                    if self.backend_type == BackendType.POSTGRESQL:
+                        cursor = conn.execute(insert_sql + " RETURNING id", insert_params)
+                        row = cursor.fetchone()
+                        conversion_id = int(row["id"]) if row else None
+                    else:
+                        cursor = conn.execute(insert_sql, insert_params)
+                        conversion_id = int(cursor.lastrowid)
+                    if conversion_id is None:
+                        raise CharactersRAGDBError("Failed to determine remediation conversion ID after insert")  # noqa: TRY003
+
+                    if previous_active and replace_active:
+                        conn.execute(
+                            "UPDATE quiz_remediation_conversions "
+                            "SET superseded_by_id = ?, last_modified = ?, client_id = ?, version = version + 1 "
+                            "WHERE id = ?",
+                            (conversion_id, now, self.client_id, int(previous_active["id"])),
+                        )
+
+                    conversion_row = conn.execute(
+                        "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
+                        "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
+                        "source_ref_id, created_at, last_modified, client_id, version "
+                        "FROM quiz_remediation_conversions WHERE id = ?",
+                        (conversion_id,),
+                    ).fetchone()
+                    conversion = self._deserialize_quiz_remediation_conversion_row(conversion_row)
+                    if not conversion:
+                        raise CharactersRAGDBError("Failed to load remediation conversion after insert")  # noqa: TRY003
+
+                    results_by_question[question_id] = {
+                        "question_id": question_id,
+                        "status": "superseded_and_created" if previous_active and replace_active else "created",
+                        "conversion": conversion,
+                        "flashcard_uuids": flashcard_uuids,
+                    }
+
+                ordered_results = [results_by_question[question_id] for question_id in ordered_question_ids]
+                return {
+                    "attempt_id": int(attempt_id),
+                    "quiz_id": int(quiz["id"]),
+                    "target_deck": target_deck,
+                    "results": ordered_results,
+                    "created_flashcard_uuids": created_flashcard_uuids,
+                }
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed to convert remediation questions: {exc}") from exc  # noqa: TRY003
+
+    def create_quiz_remediation_conversion(
+        self,
+        *,
+        attempt_id: int,
+        quiz_id: int,
+        question_id: int,
+        target_deck_id: int | None,
+        target_deck_name_snapshot: str | None,
+        flashcard_uuids: list[str] | None,
+        source_ref_id: str | None,
+    ) -> dict[str, Any]:
+        """Create an active remediation conversion row for a quiz attempt question."""
+        now = self._get_current_utc_timestamp_iso()
+        normalized_flashcard_uuids = [str(uuid) for uuid in (flashcard_uuids or []) if str(uuid).strip()]
+        flashcard_uuids_json = self._ensure_json_string(normalized_flashcard_uuids) or "[]"
+        normalized_deck_name = (target_deck_name_snapshot or "").strip() or None
+        normalized_source_ref = (source_ref_id or "").strip() or None
+        params = (
+            int(attempt_id),
+            int(quiz_id),
+            int(question_id),
+            "active",
+            target_deck_id,
+            normalized_deck_name,
+            len(normalized_flashcard_uuids),
+            flashcard_uuids_json,
+            normalized_source_ref,
+            now,
+            now,
+            self.client_id,
+            1,
+        )
+        insert_sql = (
+            "INSERT INTO quiz_remediation_conversions("
+            "attempt_id, quiz_id, question_id, status, superseded_by_id, target_deck_id, "
+            "target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, source_ref_id, "
+            "created_at, last_modified, client_id, version"
+            ") VALUES(?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        )
+        try:
+            with self.transaction() as conn:
+                if self.backend_type == BackendType.POSTGRESQL:
+                    cursor = conn.execute(insert_sql + " RETURNING id", params)
+                    row = cursor.fetchone()
+                    conversion_id = int(row["id"]) if row else None
+                else:
+                    cursor = conn.execute(insert_sql, params)
+                    conversion_id = int(cursor.lastrowid)
+                if conversion_id is None:
+                    raise CharactersRAGDBError("Failed to determine remediation conversion ID after insert")  # noqa: TRY003
+            created = self.execute_query(
+                "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
+                "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
+                "source_ref_id, created_at, last_modified, client_id, version "
+                "FROM quiz_remediation_conversions WHERE id = ?",
+                (conversion_id,),
+            ).fetchone()
+            payload = self._deserialize_quiz_remediation_conversion_row(created)
+            if not payload:
+                raise CharactersRAGDBError("Failed to load remediation conversion after insert")  # noqa: TRY003
+            return payload
+        except sqlite3.IntegrityError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    "Active remediation conversion already exists for this attempt question.",
+                    entity="quiz_remediation_conversions",
+                    entity_id=f"{attempt_id}:{question_id}",
+                ) from exc
+            raise CharactersRAGDBError(f"Failed to create remediation conversion: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            if self._is_unique_violation(exc):
+                raise ConflictError(
+                    "Active remediation conversion already exists for this attempt question.",
+                    entity="quiz_remediation_conversions",
+                    entity_id=f"{attempt_id}:{question_id}",
+                ) from exc
+            raise CharactersRAGDBError(f"Failed to create remediation conversion: {exc}") from exc  # noqa: TRY003
+        except CharactersRAGDBError:  # noqa: TRY203
+            raise
+
+    def supersede_quiz_remediation_conversion(
+        self,
+        *,
+        attempt_id: int,
+        question_id: int,
+        superseded_by_id: int | None,
+    ) -> dict[str, Any] | None:
+        """Mark the active remediation conversion for an attempt question as superseded."""
+        now = self._get_current_utc_timestamp_iso()
+        try:
+            with self.transaction() as conn:
+                existing = conn.execute(
+                    "SELECT id FROM quiz_remediation_conversions "
+                    "WHERE attempt_id = ? AND question_id = ? AND status = ?",
+                    (int(attempt_id), int(question_id), "active"),
+                ).fetchone()
+                if not existing:
+                    return None
+                conversion_id = int(existing["id"])
+                conn.execute(
+                    "UPDATE quiz_remediation_conversions "
+                    "SET status = ?, superseded_by_id = ?, last_modified = ?, client_id = ?, version = version + 1 "
+                    "WHERE id = ?",
+                    ("superseded", superseded_by_id, now, self.client_id, conversion_id),
+                )
+            row = self.execute_query(
+                "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
+                "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
+                "source_ref_id, created_at, last_modified, client_id, version "
+                "FROM quiz_remediation_conversions WHERE id = ?",
+                (conversion_id,),
+            ).fetchone()
+            return self._deserialize_quiz_remediation_conversion_row(row)
+        except sqlite3.Error as exc:
+            raise CharactersRAGDBError(f"Failed to supersede remediation conversion: {exc}") from exc  # noqa: TRY003
+        except BackendDatabaseError as exc:
+            raise CharactersRAGDBError(f"Failed to supersede remediation conversion: {exc}") from exc  # noqa: TRY003
+
+    def list_attempt_remediation_conversions(self, attempt_id: int) -> dict[str, Any]:
+        """List active remediation conversions for an attempt with superseded history count."""
+        try:
+            active_cursor = self.execute_query(
+                "SELECT id, attempt_id, quiz_id, question_id, status, superseded_by_id, "
+                "target_deck_id, target_deck_name_snapshot, flashcard_count, flashcard_uuids_json, "
+                "source_ref_id, created_at, last_modified, client_id, version "
+                "FROM quiz_remediation_conversions WHERE attempt_id = ? AND status = ? "
+                "ORDER BY question_id ASC, created_at DESC, id DESC",
+                (int(attempt_id), "active"),
+            )
+            items = [
+                item
+                for item in (
+                    self._deserialize_quiz_remediation_conversion_row(row)
+                    for row in active_cursor.fetchall()
+                )
+                if item is not None
+            ]
+            count_row = self.execute_query(
+                "SELECT COUNT(*) AS count FROM quiz_remediation_conversions "
+                "WHERE attempt_id = ? AND status = ?",
+                (int(attempt_id), "superseded"),
+            ).fetchone()
+            superseded_count = int(count_row["count"]) if count_row else 0
+            return {
+                "attempt_id": int(attempt_id),
+                "items": items,
+                "count": len(items),
+                "superseded_count": superseded_count,
+            }
         except CharactersRAGDBError:  # noqa: TRY203
             raise
 

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -13,6 +13,14 @@ os.environ.setdefault("READING_DIGEST_SCHEDULER_ENABLED", "0")
 os.environ.setdefault("TEST_MODE", "1")
 
 from tldw_Server_API.app.main import app as fastapi_app
+from tldw_Server_API.app.api.v1.endpoints.quizzes import (
+    convert_attempt_remediation_conversions,
+    get_attempt_remediation_conversions,
+)
+from tldw_Server_API.app.api.v1.schemas.quizzes import (
+    QuizRemediationConversionListResponse,
+    QuizRemediationConvertResponse,
+)
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.services import quiz_generator
@@ -108,6 +116,11 @@ def _create_attempt_with_missed_questions(quizzes_db: CharactersRAGDB) -> tuple[
         ],
     )
     return int(attempt["id"]), question_ids
+
+
+def test_remediation_endpoints_declare_return_annotations():
+    assert get_attempt_remediation_conversions.__annotations__["return"] is QuizRemediationConversionListResponse
+    assert convert_attempt_remediation_conversions.__annotations__["return"] is QuizRemediationConvertResponse
 
 
 def test_quiz_source_bundle_roundtrip_via_db_create_and_get(quizzes_db: CharactersRAGDB):

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 
@@ -331,6 +332,43 @@ def test_convert_remediation_questions_creates_new_deck(
     assert payload["target_deck"]["name"] == "Quiz Remediation Deck"
     assert {result["status"] for result in payload["results"]} == {"created"}
     assert len(payload["created_flashcard_uuids"]) == 2
+
+
+def test_convert_remediation_questions_creates_new_deck_with_scheduler_settings(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+
+    response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": question_ids,
+            "create_deck_name": "Quiz Remediation Deck",
+            "create_deck_scheduler_settings": {
+                "new_steps_minutes": [1, 5, 15],
+                "relearn_steps_minutes": [10],
+                "graduating_interval_days": 1,
+                "easy_interval_days": 3,
+                "easy_bonus": 1.15,
+                "interval_modifier": 0.9,
+                "max_interval_days": 3650,
+                "leech_threshold": 10,
+                "enable_fuzz": False,
+            },
+            "replace_active": False,
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    created_deck = quizzes_db.get_deck(payload["target_deck"]["id"])
+    assert created_deck is not None
+    scheduler_settings = json.loads(created_deck["scheduler_settings_json"])
+    assert scheduler_settings["new_steps_minutes"] == [1, 5, 15]
+    assert scheduler_settings["easy_interval_days"] == 3
+    assert scheduler_settings["enable_fuzz"] is False
 
 
 def test_convert_remediation_questions_returns_mixed_results_without_replace_active(

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -282,6 +282,152 @@ def test_get_quiz_attempt_question_assistant_returns_thread_messages_and_context
     assert "follow_up" in payload["available_actions"]
 
 
+def test_get_attempt_remediation_conversions_returns_active_rows(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+    conversion_payload = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[question_ids[0]],
+        create_deck_name="Renal Remediation",
+        replace_active=False,
+    )
+
+    response = client_with_quizzes_db.get(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions",
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["attempt_id"] == attempt_id
+    assert payload["count"] == 1
+    assert payload["superseded_count"] == 0
+    assert payload["items"][0]["question_id"] == question_ids[0]
+    assert payload["items"][0]["target_deck_id"] == conversion_payload["target_deck"]["id"]
+    assert payload["items"][0]["orphaned"] is False
+
+
+def test_convert_remediation_questions_creates_new_deck(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+
+    response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": question_ids,
+            "create_deck_name": "Quiz Remediation Deck",
+            "replace_active": False,
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["attempt_id"] == attempt_id
+    assert payload["target_deck"]["name"] == "Quiz Remediation Deck"
+    assert {result["status"] for result in payload["results"]} == {"created"}
+    assert len(payload["created_flashcard_uuids"]) == 2
+
+
+def test_convert_remediation_questions_returns_mixed_results_without_replace_active(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+    quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[question_ids[0]],
+        target_deck_id=deck_id,
+        replace_active=False,
+    )
+
+    response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": question_ids,
+            "target_deck_id": deck_id,
+            "replace_active": False,
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    statuses = {result["question_id"]: result["status"] for result in payload["results"]}
+    assert statuses[question_ids[0]] == "already_exists"
+    assert statuses[question_ids[1]] == "created"
+    assert len(payload["created_flashcard_uuids"]) == 1
+
+
+def test_convert_remediation_questions_replace_active_returns_superseded_and_created(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+    quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[question_ids[0]],
+        target_deck_id=deck_id,
+        replace_active=False,
+    )
+
+    response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": [question_ids[0]],
+            "target_deck_id": deck_id,
+            "replace_active": True,
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["results"][0]["status"] == "superseded_and_created"
+
+    read_response = client_with_quizzes_db.get(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions",
+        headers=AUTH_HEADERS,
+    )
+    assert read_response.status_code == 200
+    read_payload = read_response.json()
+    assert read_payload["count"] == 1
+    assert read_payload["superseded_count"] == 1
+
+
+def test_get_attempt_remediation_conversions_marks_orphaned_linked_flashcards(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+    conversion_payload = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[question_ids[0]],
+        create_deck_name="Renal Remediation",
+        replace_active=False,
+    )
+    flashcard_uuid = conversion_payload["created_flashcard_uuids"][0]
+    flashcard = quizzes_db.get_flashcard(flashcard_uuid)
+    assert flashcard is not None
+    quizzes_db.soft_delete_flashcard(flashcard_uuid, expected_version=int(flashcard["version"]))
+
+    response = client_with_quizzes_db.get(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions",
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["question_id"] == question_ids[0]
+    assert payload["items"][0]["orphaned"] is True
+
+
 def test_quiz_attempt_question_assistant_respond_persists_user_and_assistant_messages(
     client_with_quizzes_db: TestClient,
     quizzes_db: CharactersRAGDB,

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -14,7 +14,7 @@ os.environ.setdefault("TEST_MODE", "1")
 
 from tldw_Server_API.app.main import app as fastapi_app
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
-from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
 from tldw_Server_API.app.services import quiz_generator
 from tldw_Server_API.tests.test_config import TestConfig
 
@@ -308,6 +308,7 @@ def test_get_attempt_remediation_conversions_returns_active_rows(
     assert payload["items"][0]["question_id"] == question_ids[0]
     assert payload["items"][0]["target_deck_id"] == conversion_payload["target_deck"]["id"]
     assert payload["items"][0]["orphaned"] is False
+    assert payload["items"][0]["superseded_count"] == 0
 
 
 def test_convert_remediation_questions_creates_new_deck(
@@ -437,11 +438,40 @@ def test_convert_remediation_questions_replace_active_returns_superseded_and_cre
     read_payload = read_response.json()
     assert read_payload["count"] == 1
     assert read_payload["superseded_count"] == 1
+    assert read_payload["items"][0]["superseded_count"] == 1
+
+
+def test_convert_remediation_questions_returns_409_for_conflict(
+    client_with_quizzes_db: TestClient,
+    quizzes_db: CharactersRAGDB,
+    monkeypatch,
+):
+    attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    def raise_conflict(**_kwargs):
+        raise ConflictError("Active remediation conversion already exists.")
+
+    monkeypatch.setattr(quizzes_db, "convert_quiz_remediation_questions", raise_conflict)
+
+    response = client_with_quizzes_db.post(
+        f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions/convert",
+        json={
+            "question_ids": [question_ids[0]],
+            "target_deck_id": deck_id,
+            "replace_active": False,
+        },
+        headers=AUTH_HEADERS,
+    )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"].lower()
 
 
 def test_get_attempt_remediation_conversions_marks_orphaned_linked_flashcards(
     client_with_quizzes_db: TestClient,
     quizzes_db: CharactersRAGDB,
+    monkeypatch,
 ):
     attempt_id, question_ids = _create_attempt_with_missed_questions(quizzes_db)
     conversion_payload = quizzes_db.convert_quiz_remediation_questions(
@@ -455,6 +485,19 @@ def test_get_attempt_remediation_conversions_marks_orphaned_linked_flashcards(
     assert flashcard is not None
     quizzes_db.soft_delete_flashcard(flashcard_uuid, expected_version=int(flashcard["version"]))
 
+    batch_lookup_calls: list[list[str]] = []
+    original_batch_lookup = quizzes_db.get_flashcards_by_uuids
+
+    def track_batch_lookup(uuids: list[str]):
+        batch_lookup_calls.append(list(uuids))
+        return original_batch_lookup(uuids)
+
+    def fail_single_lookup(_uuid: str):
+        raise AssertionError("Expected remediation orphan detection to use batch flashcard lookup.")
+
+    monkeypatch.setattr(quizzes_db, "get_flashcards_by_uuids", track_batch_lookup)
+    monkeypatch.setattr(quizzes_db, "get_flashcard", fail_single_lookup)
+
     response = client_with_quizzes_db.get(
         f"/api/v1/quizzes/attempts/{attempt_id}/remediation-conversions",
         headers=AUTH_HEADERS,
@@ -464,6 +507,7 @@ def test_get_attempt_remediation_conversions_marks_orphaned_linked_flashcards(
     payload = response.json()
     assert payload["items"][0]["question_id"] == question_ids[0]
     assert payload["items"][0]["orphaned"] is True
+    assert batch_lookup_calls == [[flashcard_uuid]]
 
 
 def test_quiz_attempt_question_assistant_respond_persists_user_and_assistant_messages(

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
@@ -195,6 +195,7 @@ def test_convert_quiz_remediation_questions_replace_active_supersedes_old_row(
 
     assert initial["results"][0]["status"] == "created"
     assert follow_up["results"][0]["status"] == "superseded_and_created"
+    assert follow_up["results"][0]["conversion"]["superseded_count"] == 1
     conversions = quizzes_db.list_attempt_remediation_conversions(attempt_id)
     assert conversions["count"] == 1
     assert conversions["superseded_count"] == 1

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
@@ -1,9 +1,11 @@
+import sqlite3
 import uuid
 
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
     CharactersRAGDB,
+    ConflictError,
     InputError,
 )
 
@@ -199,3 +201,75 @@ def test_convert_quiz_remediation_questions_replace_active_supersedes_old_row(
     conversions = quizzes_db.list_attempt_remediation_conversions(attempt_id)
     assert conversions["count"] == 1
     assert conversions["superseded_count"] == 1
+
+
+def test_convert_quiz_remediation_questions_translates_unique_violation_to_conflict(
+    quizzes_db: CharactersRAGDB,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _FakeCursor:
+        def __init__(self, rows=None):
+            self._rows = rows or []
+            self.lastrowid = None
+
+        def fetchall(self):
+            return list(self._rows)
+
+        def fetchone(self):
+            return self._rows[0] if self._rows else None
+
+    class _FakeConnection:
+        def execute(self, sql, params=()):
+            if (
+                "FROM quiz_remediation_conversions qrc" in sql
+                and "WHERE qrc.attempt_id = ?" in sql
+                and "AND qrc.status = ?" in sql
+            ):
+                return _FakeCursor([])
+            if sql.startswith("INSERT INTO quiz_remediation_conversions"):
+                raise sqlite3.IntegrityError(
+                    "UNIQUE constraint failed: quiz_remediation_conversions.attempt_id, quiz_remediation_conversions.question_id"
+                )
+            raise AssertionError(f"Unexpected SQL in test double: {sql} :: {params}")
+
+    class _FakeTransaction:
+        def __enter__(self):
+            return _FakeConnection()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        quizzes_db,
+        "_build_quiz_remediation_entries",
+        lambda *, attempt_id, question_ids: (
+            {"id": attempt_id, "quiz_id": 9},
+            {"id": 9, "name": "Race Quiz"},
+            [
+                {
+                    "question_id": question_ids[0],
+                    "dedupe_key": "dedupe-key",
+                    "source_ref_id": f"quiz-attempt:{attempt_id}:question:{question_ids[0]}",
+                    "flashcard_payload": {
+                        "front": "Question",
+                        "back": "Answer",
+                        "notes": "Notes",
+                        "tags_json": "[]",
+                        "source_ref_type": "manual",
+                        "source_ref_id": f"quiz-attempt:{attempt_id}:question:{question_ids[0]}",
+                    },
+                }
+            ],
+        ),
+    )
+    monkeypatch.setattr(quizzes_db, "get_deck", lambda deck_id: {"id": deck_id, "name": "Target Deck", "deleted": False})
+    monkeypatch.setattr(quizzes_db, "add_flashcards_bulk", lambda payloads: ["fc-race-1"])
+    monkeypatch.setattr(quizzes_db, "transaction", lambda: _FakeTransaction())
+
+    with pytest.raises(ConflictError):
+        quizzes_db.convert_quiz_remediation_questions(
+            attempt_id=101,
+            question_ids=[12],
+            target_deck_id=7,
+            replace_active=False,
+        )

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
@@ -1,0 +1,200 @@
+import uuid
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import (
+    CharactersRAGDB,
+    InputError,
+)
+
+
+@pytest.fixture(scope="function")
+def quizzes_db(tmp_path):
+    db_path = tmp_path / "remediation-conversion-service.db"
+    db = CharactersRAGDB(str(db_path), client_id=f"test-{uuid.uuid4().hex[:6]}")
+    yield db
+    db.close_connection()
+
+
+def _create_attempt_with_one_miss_and_one_correct(quizzes_db: CharactersRAGDB) -> tuple[int, int, int, int]:
+    quiz_id = quizzes_db.create_quiz(name="Remediation Service Quiz")
+    missed_question_id = quizzes_db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which structure filters blood?",
+        correct_answer=1,
+        options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+        explanation="The glomerulus performs the initial filtration step.",
+        points=2,
+        order_index=0,
+    )
+    correct_question_id = quizzes_db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which structure concentrates urine?",
+        correct_answer=0,
+        options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+        explanation="The loop of Henle creates the osmotic gradient.",
+        points=1,
+        order_index=1,
+    )
+    attempt = quizzes_db.start_attempt(quiz_id)
+    quizzes_db.submit_attempt(
+        int(attempt["id"]),
+        answers=[
+            {"question_id": missed_question_id, "user_answer": 2, "time_spent_ms": 1200},
+            {"question_id": correct_question_id, "user_answer": 0, "time_spent_ms": 900},
+        ],
+    )
+    return int(attempt["id"]), quiz_id, missed_question_id, correct_question_id
+
+
+def _create_incomplete_attempt(quizzes_db: CharactersRAGDB) -> tuple[int, int]:
+    quiz_id = quizzes_db.create_quiz(name="Incomplete Quiz")
+    question_id = quizzes_db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which structure filters blood?",
+        correct_answer=1,
+        options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+        order_index=0,
+    )
+    attempt = quizzes_db.start_attempt(quiz_id)
+    return int(attempt["id"]), question_id
+
+
+def _create_duplicate_missed_attempt(quizzes_db: CharactersRAGDB) -> tuple[int, int, list[int]]:
+    quiz_id = quizzes_db.create_quiz(name="Duplicate Misses Quiz")
+    question_ids = [
+        quizzes_db.create_question(
+            quiz_id=quiz_id,
+            question_type="multiple_choice",
+            question_text="Which structure filters blood?",
+            correct_answer=1,
+            options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+            explanation="The glomerulus performs the initial filtration step.",
+            order_index=0,
+        ),
+        quizzes_db.create_question(
+            quiz_id=quiz_id,
+            question_type="multiple_choice",
+            question_text="Which structure filters blood?",
+            correct_answer=1,
+            options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+            explanation="The glomerulus performs the initial filtration step.",
+            order_index=1,
+        ),
+    ]
+    attempt = quizzes_db.start_attempt(quiz_id)
+    quizzes_db.submit_attempt(
+        int(attempt["id"]),
+        answers=[
+            {"question_id": question_ids[0], "user_answer": 0, "time_spent_ms": 800},
+            {"question_id": question_ids[1], "user_answer": 2, "time_spent_ms": 850},
+        ],
+    )
+    return int(attempt["id"]), quiz_id, question_ids
+
+
+def test_convert_quiz_remediation_questions_rejects_incomplete_attempt(quizzes_db: CharactersRAGDB):
+    attempt_id, question_id = _create_incomplete_attempt(quizzes_db)
+
+    with pytest.raises(InputError):
+        quizzes_db.convert_quiz_remediation_questions(
+            attempt_id=attempt_id,
+            question_ids=[question_id],
+            create_deck_name="Remediation Deck",
+            replace_active=False,
+        )
+
+
+def test_convert_quiz_remediation_questions_rejects_question_ids_not_in_attempt(quizzes_db: CharactersRAGDB):
+    attempt_id, _quiz_id, missed_question_id, _correct_question_id = _create_attempt_with_one_miss_and_one_correct(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    with pytest.raises(InputError):
+        quizzes_db.convert_quiz_remediation_questions(
+            attempt_id=attempt_id,
+            question_ids=[missed_question_id, 999999],
+            target_deck_id=deck_id,
+            replace_active=False,
+        )
+
+
+def test_convert_quiz_remediation_questions_rejects_correct_answers(quizzes_db: CharactersRAGDB):
+    attempt_id, _quiz_id, _missed_question_id, correct_question_id = _create_attempt_with_one_miss_and_one_correct(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    with pytest.raises(InputError):
+        quizzes_db.convert_quiz_remediation_questions(
+            attempt_id=attempt_id,
+            question_ids=[correct_question_id],
+            target_deck_id=deck_id,
+            replace_active=False,
+        )
+
+
+def test_convert_quiz_remediation_questions_creates_new_deck_when_requested(quizzes_db: CharactersRAGDB):
+    attempt_id, quiz_id, missed_question_id, _correct_question_id = _create_attempt_with_one_miss_and_one_correct(quizzes_db)
+
+    payload = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[missed_question_id],
+        create_deck_name="Quiz Remediation Deck",
+        replace_active=False,
+    )
+
+    assert payload["attempt_id"] == attempt_id
+    assert payload["quiz_id"] == quiz_id
+    assert payload["target_deck"]["name"] == "Quiz Remediation Deck"
+    assert payload["results"][0]["status"] == "created"
+    assert payload["results"][0]["conversion"]["status"] == "active"
+    assert payload["created_flashcard_uuids"]
+    assert quizzes_db.count_flashcards(deck_id=payload["target_deck"]["id"]) == 1
+
+
+def test_convert_quiz_remediation_questions_preserves_dedupe_across_duplicate_misses(
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, _quiz_id, question_ids = _create_duplicate_missed_attempt(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    payload = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=question_ids,
+        target_deck_id=deck_id,
+        replace_active=False,
+    )
+
+    assert len(payload["results"]) == 2
+    assert payload["results"][0]["status"] == "created"
+    assert payload["results"][1]["status"] == "created"
+    assert payload["results"][0]["flashcard_uuids"] == payload["results"][1]["flashcard_uuids"]
+    assert len(payload["created_flashcard_uuids"]) == 1
+    assert quizzes_db.count_flashcards(deck_id=deck_id) == 1
+
+
+def test_convert_quiz_remediation_questions_replace_active_supersedes_old_row(
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, _quiz_id, missed_question_id, _correct_question_id = _create_attempt_with_one_miss_and_one_correct(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    initial = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[missed_question_id],
+        target_deck_id=deck_id,
+        replace_active=False,
+    )
+    follow_up = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[missed_question_id],
+        target_deck_id=deck_id,
+        replace_active=True,
+    )
+
+    assert initial["results"][0]["status"] == "created"
+    assert follow_up["results"][0]["status"] == "superseded_and_created"
+    conversions = quizzes_db.list_attempt_remediation_conversions(attempt_id)
+    assert conversions["count"] == 1
+    assert conversions["superseded_count"] == 1

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py
@@ -158,4 +158,5 @@ def test_list_attempt_remediation_conversions_returns_active_rows_and_superseded
     assert payload["superseded_count"] == 1
     assert payload["items"][0]["id"] == latest["id"]
     assert payload["items"][0]["status"] == "active"
+    assert payload["items"][0]["superseded_count"] == 1
     assert payload["items"][0]["flashcard_uuids_json"] == ["card-b"]

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversions_db.py
@@ -1,0 +1,161 @@
+import uuid
+
+import pytest
+
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB, ConflictError
+
+
+@pytest.fixture(scope="function")
+def quizzes_db(tmp_path):
+    db_path = tmp_path / "remediation-conversions.db"
+    db = CharactersRAGDB(str(db_path), client_id=f"test-{uuid.uuid4().hex[:6]}")
+    yield db
+    db.close_connection()
+
+
+def _create_completed_attempt_with_one_miss(quizzes_db: CharactersRAGDB) -> tuple[int, int, int]:
+    quiz_id = quizzes_db.create_quiz(name="Remediation Conversion Quiz")
+    missed_question_id = quizzes_db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which structure filters blood?",
+        correct_answer=1,
+        options=["Loop of Henle", "Glomerulus", "Collecting duct"],
+        explanation="The glomerulus performs the initial blood filtration step.",
+        points=2,
+        order_index=0,
+    )
+    correct_question_id = quizzes_db.create_question(
+        quiz_id=quiz_id,
+        question_type="multiple_choice",
+        question_text="Which segment concentrates urine?",
+        correct_answer=0,
+        options=["Loop of Henle", "Glomerulus", "Proximal tubule"],
+        explanation="The loop of Henle establishes the osmotic gradient.",
+        points=1,
+        order_index=1,
+    )
+    attempt = quizzes_db.start_attempt(quiz_id)
+    quizzes_db.submit_attempt(
+        int(attempt["id"]),
+        answers=[
+            {"question_id": missed_question_id, "user_answer": 2, "time_spent_ms": 1200},
+            {"question_id": correct_question_id, "user_answer": 0, "time_spent_ms": 800},
+        ],
+    )
+    return int(attempt["id"]), quiz_id, missed_question_id
+
+
+def test_create_active_remediation_conversion(quizzes_db: CharactersRAGDB):
+    attempt_id, quiz_id, question_id = _create_completed_attempt_with_one_miss(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    row = quizzes_db.create_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        quiz_id=quiz_id,
+        question_id=question_id,
+        target_deck_id=deck_id,
+        target_deck_name_snapshot="Renal Deck",
+        flashcard_uuids=["card-a", "card-b"],
+        source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+    )
+
+    assert row["attempt_id"] == attempt_id
+    assert row["quiz_id"] == quiz_id
+    assert row["question_id"] == question_id
+    assert row["status"] == "active"
+    assert row["target_deck_id"] == deck_id
+    assert row["target_deck_name_snapshot"] == "Renal Deck"
+    assert row["flashcard_count"] == 2
+    assert row["flashcard_uuids_json"] == ["card-a", "card-b"]
+
+
+def test_create_active_remediation_conversion_rejects_second_active_row(quizzes_db: CharactersRAGDB):
+    attempt_id, quiz_id, question_id = _create_completed_attempt_with_one_miss(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+
+    quizzes_db.create_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        quiz_id=quiz_id,
+        question_id=question_id,
+        target_deck_id=deck_id,
+        target_deck_name_snapshot="Renal Deck",
+        flashcard_uuids=["card-a"],
+        source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+    )
+
+    with pytest.raises(ConflictError):
+        quizzes_db.create_quiz_remediation_conversion(
+            attempt_id=attempt_id,
+            quiz_id=quiz_id,
+            question_id=question_id,
+            target_deck_id=deck_id,
+            target_deck_name_snapshot="Renal Deck",
+            flashcard_uuids=["card-b"],
+            source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+        )
+
+
+def test_supersede_quiz_remediation_conversion_marks_previous_row(quizzes_db: CharactersRAGDB):
+    attempt_id, quiz_id, question_id = _create_completed_attempt_with_one_miss(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+    original = quizzes_db.create_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        quiz_id=quiz_id,
+        question_id=question_id,
+        target_deck_id=deck_id,
+        target_deck_name_snapshot="Renal Deck",
+        flashcard_uuids=["card-a"],
+        source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+    )
+
+    superseded = quizzes_db.supersede_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        question_id=question_id,
+        superseded_by_id=None,
+    )
+
+    assert superseded is not None
+    assert superseded["id"] == original["id"]
+    assert superseded["status"] == "superseded"
+    assert superseded["superseded_by_id"] is None
+
+
+def test_list_attempt_remediation_conversions_returns_active_rows_and_superseded_count(
+    quizzes_db: CharactersRAGDB,
+):
+    attempt_id, quiz_id, question_id = _create_completed_attempt_with_one_miss(quizzes_db)
+    deck_id = quizzes_db.add_deck("Renal Deck")
+    original = quizzes_db.create_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        quiz_id=quiz_id,
+        question_id=question_id,
+        target_deck_id=deck_id,
+        target_deck_name_snapshot="Renal Deck",
+        flashcard_uuids=["card-a"],
+        source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+    )
+    quizzes_db.supersede_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        question_id=question_id,
+        superseded_by_id=None,
+    )
+    latest = quizzes_db.create_quiz_remediation_conversion(
+        attempt_id=attempt_id,
+        quiz_id=quiz_id,
+        question_id=question_id,
+        target_deck_id=deck_id,
+        target_deck_name_snapshot="Renal Deck v2",
+        flashcard_uuids=["card-b"],
+        source_ref_id=f"quiz-attempt:{attempt_id}:question:{question_id}",
+    )
+
+    payload = quizzes_db.list_attempt_remediation_conversions(attempt_id)
+
+    assert payload["attempt_id"] == attempt_id
+    assert payload["items"]
+    assert payload["count"] == 1
+    assert payload["superseded_count"] == 1
+    assert payload["items"][0]["id"] == latest["id"]
+    assert payload["items"][0]["status"] == "active"
+    assert payload["items"][0]["flashcard_uuids_json"] == ["card-b"]


### PR DESCRIPTION
## Summary
- recover flashcard and quiz study-assistant threads cleanly after version conflicts
- persist quiz remediation conversion state on the server with superseded history and multi-deck study handoff behavior
- add scheduler settings to new-deck creation flows across flashcards creation/import/image-occlusion and quiz remediation

## Test Plan
- `cd apps/packages/ui && bunx vitest run src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py -k "remediation" -v`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/endpoints/quizzes.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/api/v1/schemas/quizzes.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_scheduler_creation_flows.json`
- `git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/assistant-conflict-recovery-ux diff --check`