### PR TITLE
feat: add OPA governance packs to MCP Hub

### DIFF
--- a/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
@@ -15,7 +15,7 @@
 - Task 1: Complete
 - Task 2: Complete
 - Task 3: Complete
-- Task 4: Not Started
+- Task 4: Complete
 - Task 5: Not Started
 - Task 6: Not Started
 

--- a/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
@@ -16,8 +16,8 @@
 - Task 2: Complete
 - Task 3: Complete
 - Task 4: Complete
-- Task 5: Not Started
-- Task 6: Not Started
+- Task 5: Complete
+- Task 6: Complete
 
 ### Task 1: Add governance-pack schema, fixtures, and failing validation tests
 

--- a/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-opa-governance-packs-implementation-plan.md
@@ -12,9 +12,9 @@
 
 ## Status
 
-- Task 1: Not Started
-- Task 2: Not Started
-- Task 3: Not Started
+- Task 1: Complete
+- Task 2: Complete
+- Task 3: Complete
 - Task 4: Not Started
 - Task 5: Not Started
 - Task 6: Not Started

--- a/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from "react"
+import { Alert, Button, Card, Descriptions, Empty, Input, List, Space, Tag, Typography } from "antd"
+
+import {
+  dryRunGovernancePack,
+  getGovernancePackDetail,
+  importGovernancePack,
+  listGovernancePacks,
+  type McpHubGovernancePackDetail,
+  type McpHubGovernancePackDocument,
+  type McpHubGovernancePackDryRunReport,
+  type McpHubGovernancePackSummary
+} from "@/services/tldw/mcp-hub"
+
+const DEFAULT_PACK_JSON = JSON.stringify(
+  {
+    manifest: {},
+    profiles: [],
+    approvals: [],
+    personas: [],
+    assignments: []
+  },
+  null,
+  2
+)
+
+const getVerdictColor = (verdict?: McpHubGovernancePackDryRunReport["verdict"]) => {
+  if (verdict === "importable") return "green"
+  if (verdict === "blocked") return "red"
+  return "default"
+}
+
+const describeItems = (values: string[], emptyLabel: string) => {
+  if (!values.length) {
+    return <Typography.Text type="secondary">{emptyLabel}</Typography.Text>
+  }
+  return (
+    <Space wrap>
+      {values.map((value) => (
+        <Tag key={value}>{value}</Tag>
+      ))}
+    </Space>
+  )
+}
+
+export const GovernancePacksTab = () => {
+  const [packs, setPacks] = useState<McpHubGovernancePackSummary[]>([])
+  const [selectedPackId, setSelectedPackId] = useState<number | null>(null)
+  const [selectedPack, setSelectedPack] = useState<McpHubGovernancePackDetail | null>(null)
+  const [report, setReport] = useState<McpHubGovernancePackDryRunReport | null>(null)
+  const [packJson, setPackJson] = useState(DEFAULT_PACK_JSON)
+  const [loadingInventory, setLoadingInventory] = useState(false)
+  const [loadingDetail, setLoadingDetail] = useState(false)
+  const [previewing, setPreviewing] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const parsedPack = useMemo<McpHubGovernancePackDocument | null>(() => {
+    try {
+      const parsed = JSON.parse(packJson) as McpHubGovernancePackDocument
+      return {
+        manifest: parsed?.manifest ?? {},
+        profiles: Array.isArray(parsed?.profiles) ? parsed.profiles : [],
+        approvals: Array.isArray(parsed?.approvals) ? parsed.approvals : [],
+        personas: Array.isArray(parsed?.personas) ? parsed.personas : [],
+        assignments: Array.isArray(parsed?.assignments) ? parsed.assignments : []
+      }
+    } catch {
+      return null
+    }
+  }, [packJson])
+
+  const loadInventory = async () => {
+    setLoadingInventory(true)
+    setErrorMessage(null)
+    try {
+      const rows = await listGovernancePacks()
+      setPacks(Array.isArray(rows) ? rows : [])
+      setSelectedPackId((current) => {
+        if (rows.some((row) => row.id === current)) {
+          return current
+        }
+        return rows[0]?.id ?? null
+      })
+    } catch {
+      setPacks([])
+      setSelectedPackId(null)
+      setSelectedPack(null)
+      setErrorMessage("Failed to load governance packs.")
+    } finally {
+      setLoadingInventory(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadInventory()
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const loadDetail = async () => {
+      if (!selectedPackId) {
+        setSelectedPack(null)
+        return
+      }
+      setLoadingDetail(true)
+      try {
+        const detail = await getGovernancePackDetail(selectedPackId)
+        if (!cancelled) {
+          setSelectedPack(detail)
+        }
+      } catch {
+        if (!cancelled) {
+          setSelectedPack(null)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingDetail(false)
+        }
+      }
+    }
+    void loadDetail()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedPackId])
+
+  const handlePreview = async () => {
+    setSuccessMessage(null)
+    if (!parsedPack) {
+      setErrorMessage("Governance pack JSON must be valid JSON.")
+      setReport(null)
+      return
+    }
+    setPreviewing(true)
+    setErrorMessage(null)
+    try {
+      const response = await dryRunGovernancePack({
+        owner_scope_type: "user",
+        pack: parsedPack
+      })
+      setReport(response.report)
+    } catch {
+      setReport(null)
+      setErrorMessage("Failed to preview governance pack compatibility.")
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const handleImport = async () => {
+    setSuccessMessage(null)
+    if (!parsedPack) {
+      setErrorMessage("Governance pack JSON must be valid JSON.")
+      return
+    }
+    setImporting(true)
+    setErrorMessage(null)
+    try {
+      const response = await importGovernancePack({
+        owner_scope_type: "user",
+        pack: parsedPack
+      })
+      setReport(response.report)
+      setSelectedPackId(response.governance_pack_id)
+      setSuccessMessage(`Imported ${response.report.manifest.title}.`)
+      await loadInventory()
+    } catch {
+      setErrorMessage("Failed to import governance pack.")
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const canImport = !importing && report?.verdict === "importable" && Boolean(parsedPack)
+
+  return (
+    <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+      <Typography.Text type="secondary">
+        Governance packs provide portable MCP Hub policy templates that can be previewed before import.
+      </Typography.Text>
+      {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
+      {successMessage ? <Alert type="success" title={successMessage} showIcon /> : null}
+
+      <Space align="start" size="middle" style={{ width: "100%", justifyContent: "space-between" }}>
+        <Card title="Installed Packs" style={{ flex: 1, minWidth: 320 }}>
+          <List
+            bordered
+            loading={loadingInventory}
+            dataSource={packs}
+            locale={{ emptyText: <Empty description="No governance packs imported yet" /> }}
+            renderItem={(pack) => (
+              <List.Item
+                style={{
+                  cursor: "pointer",
+                  borderColor: pack.id === selectedPackId ? "var(--ant-color-primary, #1677ff)" : undefined
+                }}
+                onClick={() => setSelectedPackId(pack.id)}
+              >
+                <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+                  <Space wrap>
+                    <Typography.Text strong>{pack.title}</Typography.Text>
+                    <Tag>{pack.owner_scope_type}</Tag>
+                    <Tag color="blue">{`${pack.pack_id}@${pack.pack_version}`}</Tag>
+                  </Space>
+                  {pack.description ? (
+                    <Typography.Text type="secondary">{pack.description}</Typography.Text>
+                  ) : null}
+                </Space>
+              </List.Item>
+            )}
+          />
+        </Card>
+
+        <Card
+          title="Pack Details"
+          loading={loadingDetail}
+          style={{ flex: 1, minWidth: 320 }}
+        >
+          {selectedPack ? (
+            <Descriptions column={1} size="small">
+              <Descriptions.Item label="Pack">
+                {`${selectedPack.pack_id}@${selectedPack.pack_version}`}
+              </Descriptions.Item>
+              <Descriptions.Item label="Digest">
+                <Typography.Text code>{selectedPack.bundle_digest}</Typography.Text>
+              </Descriptions.Item>
+              <Descriptions.Item label="Imported Objects">
+                {describeItems(
+                  selectedPack.imported_objects.map(
+                    (item) => `${item.object_type}:${item.source_object_id}`
+                  ),
+                  "No imported objects recorded."
+                )}
+              </Descriptions.Item>
+            </Descriptions>
+          ) : (
+            <Empty description="Select a governance pack to inspect its imported objects." />
+          )}
+        </Card>
+      </Space>
+
+      <Card title="Preview Import">
+        <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+          <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+            <label htmlFor="mcp-governance-pack-json">Governance Pack JSON</label>
+            <Input.TextArea
+              id="mcp-governance-pack-json"
+              aria-label="Governance Pack JSON"
+              value={packJson}
+              rows={12}
+              onChange={(event) => setPackJson(event.target.value)}
+              spellCheck={false}
+            />
+          </Space>
+          <Space>
+            <Button type="primary" onClick={() => void handlePreview()} loading={previewing}>
+              Preview Pack
+            </Button>
+            <Button onClick={() => void handleImport()} disabled={!canImport} loading={importing}>
+              Import Pack
+            </Button>
+          </Space>
+          {report ? (
+            <Descriptions bordered column={1} size="small">
+              <Descriptions.Item label="Pack">{report.manifest.title}</Descriptions.Item>
+              <Descriptions.Item label="Verdict">
+                <Tag color={getVerdictColor(report.verdict)}>
+                  {report.verdict === "importable" ? "Importable" : "Blocked"}
+                </Tag>
+              </Descriptions.Item>
+              <Descriptions.Item label="Resolved capabilities">
+                {describeItems(report.resolved_capabilities, "None")}
+              </Descriptions.Item>
+              <Descriptions.Item label="Unresolved capabilities">
+                {describeItems(report.unresolved_capabilities, "None")}
+              </Descriptions.Item>
+              <Descriptions.Item label="Warnings">
+                {describeItems(report.warnings, "None")}
+              </Descriptions.Item>
+              <Descriptions.Item label="Blocked objects">
+                {describeItems(report.blocked_objects, "None")}
+              </Descriptions.Item>
+            </Descriptions>
+          ) : null}
+        </Space>
+      </Card>
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
@@ -23,6 +23,7 @@ const DEFAULT_PACK_JSON = JSON.stringify(
   null,
   2
 )
+const DETAIL_LOAD_ERROR = "Failed to load pack details."
 
 const getVerdictColor = (verdict?: McpHubGovernancePackDryRunReport["verdict"]) => {
   if (verdict === "importable") return "green"
@@ -76,12 +77,13 @@ export const GovernancePacksTab = () => {
     setErrorMessage(null)
     try {
       const rows = await listGovernancePacks()
-      setPacks(Array.isArray(rows) ? rows : [])
+      const safeRows = Array.isArray(rows) ? rows : []
+      setPacks(safeRows)
       setSelectedPackId((current) => {
-        if (rows.some((row) => row.id === current)) {
+        if (safeRows.some((row) => row.id === current)) {
           return current
         }
-        return rows[0]?.id ?? null
+        return safeRows[0]?.id ?? null
       })
     } catch {
       setPacks([])
@@ -102,6 +104,7 @@ export const GovernancePacksTab = () => {
     const loadDetail = async () => {
       if (!selectedPackId) {
         setSelectedPack(null)
+        setErrorMessage((current) => (current === DETAIL_LOAD_ERROR ? null : current))
         return
       }
       setLoadingDetail(true)
@@ -109,10 +112,12 @@ export const GovernancePacksTab = () => {
         const detail = await getGovernancePackDetail(selectedPackId)
         if (!cancelled) {
           setSelectedPack(detail)
+          setErrorMessage((current) => (current === DETAIL_LOAD_ERROR ? null : current))
         }
       } catch {
         if (!cancelled) {
           setSelectedPack(null)
+          setErrorMessage(DETAIL_LOAD_ERROR)
         }
       } finally {
         if (!cancelled) {

--- a/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
@@ -3,6 +3,7 @@ import { Tabs, Typography } from "antd"
 
 import { ApprovalPoliciesTab } from "./ApprovalPoliciesTab"
 import { GovernanceAuditTab } from "./GovernanceAuditTab"
+import { GovernancePacksTab } from "./GovernancePacksTab"
 import { PathScopesTab } from "./PathScopesTab"
 import { PermissionProfilesTab } from "./PermissionProfilesTab"
 import { PolicyAssignmentsTab } from "./PolicyAssignmentsTab"
@@ -103,6 +104,11 @@ export const McpHubPage = () => {
             key: "audit",
             label: "Audit",
             children: <GovernanceAuditTab onOpen={handleOpen} />
+          },
+          {
+            key: "governance-packs",
+            label: "Governance Packs",
+            children: <GovernancePacksTab />
           },
           {
             key: "approvals",

--- a/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
@@ -74,9 +74,10 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
     }
   }, [personaId])
 
+  const provenance = Array.isArray(policy?.provenance) ? policy.provenance : []
   const governancePackLabels = Array.from(
     new Set(
-      policy?.provenance
+      provenance
         .filter((entry) => entry.field === "governance_pack")
         .map((entry) => {
           const value = entry.value as { pack_id?: unknown; pack_version?: unknown } | null
@@ -87,7 +88,7 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
           }
           return `Pack ${packId}@${packVersion}`
         })
-        .filter((label): label is string => Boolean(label)) ?? []
+        .filter((label): label is string => Boolean(label))
     )
   )
 
@@ -150,10 +151,10 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
             {getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes) ? (
               <Tag color="blue">{`paths ${getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes)}`}</Tag>
             ) : null}
-            {policy.provenance.some((entry) => entry.source_kind === "assignment_override") ? (
+            {provenance.some((entry) => entry.source_kind === "assignment_override") ? (
               <Tag color="cyan">Override active</Tag>
             ) : null}
-            {policy.provenance.some((entry) => entry.source_kind === "assignment_path_scope_object") ? (
+            {provenance.some((entry) => entry.source_kind === "assignment_path_scope_object") ? (
               <Tag color="purple">Named path scope</Tag>
             ) : null}
             {governancePackLabels.map((label) => (

--- a/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
@@ -74,6 +74,23 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
     }
   }, [personaId])
 
+  const governancePackLabels = Array.from(
+    new Set(
+      policy?.provenance
+        .filter((entry) => entry.field === "governance_pack")
+        .map((entry) => {
+          const value = entry.value as { pack_id?: unknown; pack_version?: unknown } | null
+          const packId = typeof value?.pack_id === "string" ? value.pack_id : null
+          const packVersion = typeof value?.pack_version === "string" ? value.pack_version : null
+          if (!packId || !packVersion) {
+            return null
+          }
+          return `Pack ${packId}@${packVersion}`
+        })
+        .filter((label): label is string => Boolean(label)) ?? []
+    )
+  )
+
   return (
     <Card
       title="Tool Policy Summary"
@@ -139,6 +156,11 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
             {policy.provenance.some((entry) => entry.source_kind === "assignment_path_scope_object") ? (
               <Tag color="purple">Named path scope</Tag>
             ) : null}
+            {governancePackLabels.map((label) => (
+              <Tag key={label} color="geekblue">
+                {label}
+              </Tag>
+            ))}
             {policy.selected_workspace_source_mode === "named" && policy.selected_workspace_set_object_name ? (
               <Tag color="geekblue">{`workspace set ${policy.selected_workspace_set_object_name}`}</Tag>
             ) : null}

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/ExternalServersTab.test.tsx
@@ -259,6 +259,64 @@ describe("ExternalServersTab", () => {
     expect(await screen.findByText(/auth template updated/i)).toBeTruthy()
   })
 
+  it("preserves custom header targets for websocket auth templates", async () => {
+    const user = userEvent.setup()
+    mocks.listExternalServers.mockResolvedValueOnce([
+      {
+        id: "docs-websocket",
+        name: "Docs Websocket",
+        enabled: true,
+        owner_scope_type: "global",
+        transport: "websocket",
+        config: {},
+        secret_configured: false,
+        server_source: "managed",
+        binding_count: 1,
+        runtime_executable: true,
+        auth_template_present: false,
+        auth_template_valid: false,
+        auth_template_blocked_reason: "no_auth_template",
+        credential_slots: [
+          {
+            server_id: "docs-websocket",
+            slot_name: "token_readonly",
+            display_name: "Read-only token",
+            secret_kind: "bearer_token",
+            privilege_class: "read",
+            is_required: true,
+            secret_configured: false
+          }
+        ]
+      }
+    ])
+    mocks.getExternalServerAuthTemplate.mockResolvedValueOnce({
+      mode: "template",
+      mappings: []
+    })
+
+    render(<ExternalServersTab />)
+
+    expect((await screen.findAllByText("Docs Websocket")).length).toBeGreaterThan(0)
+    await user.click(screen.getByRole("button", { name: /add mapping/i }))
+    await user.type(screen.getByLabelText(/target name 1/i), "X-DOCS-TOKEN")
+    await user.type(screen.getByLabelText(/prefix 1/i), "Token ")
+    await user.click(screen.getByRole("button", { name: /save auth template/i }))
+
+    expect(mocks.updateExternalServerAuthTemplate).toHaveBeenCalledWith("docs-websocket", {
+      mode: "template",
+      mappings: [
+        {
+          slot_name: "token_readonly",
+          target_type: "header",
+          target_name: "X-DOCS-TOKEN",
+          prefix: "Token ",
+          suffix: "",
+          required: true
+        }
+      ]
+    })
+  })
+
   it("creates, edits, and deletes managed servers and credential slots", async () => {
     const user = userEvent.setup()
     render(<ExternalServersTab />)

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  listGovernancePacks: vi.fn(),
+  getGovernancePackDetail: vi.fn(),
+  dryRunGovernancePack: vi.fn(),
+  importGovernancePack: vi.fn()
+}))
+
+vi.mock("@/services/tldw/mcp-hub", () => ({
+  listGovernancePacks: (...args: unknown[]) => mocks.listGovernancePacks(...args),
+  getGovernancePackDetail: (...args: unknown[]) => mocks.getGovernancePackDetail(...args),
+  dryRunGovernancePack: (...args: unknown[]) => mocks.dryRunGovernancePack(...args),
+  importGovernancePack: (...args: unknown[]) => mocks.importGovernancePack(...args)
+}))
+
+import { GovernancePacksTab } from "../GovernancePacksTab"
+
+describe("GovernancePacksTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listGovernancePacks.mockResolvedValue([
+      {
+        id: 81,
+        pack_id: "researcher-pack",
+        pack_version: "1.0.0",
+        title: "Researcher Pack",
+        description: "Portable research governance pack",
+        owner_scope_type: "user",
+        owner_scope_id: 7,
+        bundle_digest: "a".repeat(64),
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack"
+        }
+      }
+    ])
+    mocks.getGovernancePackDetail.mockResolvedValue({
+      id: 81,
+      pack_id: "researcher-pack",
+      pack_version: "1.0.0",
+      title: "Researcher Pack",
+      description: "Portable research governance pack",
+      owner_scope_type: "user",
+      owner_scope_id: 7,
+      bundle_digest: "a".repeat(64),
+      manifest: {
+        pack_id: "researcher-pack",
+        pack_version: "1.0.0",
+        title: "Researcher Pack"
+      },
+      normalized_ir: {
+        data: {
+          profiles: [{ profile_id: "researcher.profile" }]
+        }
+      },
+      imported_objects: [
+        {
+          object_type: "permission_profile",
+          object_id: "5",
+          source_object_id: "researcher.profile"
+        }
+      ]
+    })
+    mocks.dryRunGovernancePack.mockResolvedValue({
+      report: {
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack",
+          description: "Portable research governance pack"
+        },
+        digest: "a".repeat(64),
+        resolved_capabilities: ["filesystem.read", "tool.invoke.research"],
+        unresolved_capabilities: [],
+        warnings: [],
+        blocked_objects: [],
+        verdict: "importable"
+      }
+    })
+    mocks.importGovernancePack.mockResolvedValue({
+      governance_pack_id: 81,
+      imported_object_counts: {
+        approval_policies: 1,
+        permission_profiles: 1,
+        policy_assignments: 1
+      },
+      blocked_objects: [],
+      report: {
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack",
+          description: "Portable research governance pack"
+        },
+        digest: "a".repeat(64),
+        resolved_capabilities: ["filesystem.read", "tool.invoke.research"],
+        unresolved_capabilities: [],
+        warnings: [],
+        blocked_objects: [],
+        verdict: "importable"
+      }
+    })
+  })
+
+  it("renders dry-run compatibility findings before import", async () => {
+    const user = userEvent.setup()
+    render(<GovernancePacksTab />)
+
+    expect(await screen.findByText("Researcher Pack")).toBeTruthy()
+
+    fireEvent.change(screen.getByLabelText(/governance pack json/i), {
+      target: {
+        value: JSON.stringify({
+          manifest: {
+            pack_id: "researcher-pack",
+            pack_version: "1.0.0",
+            pack_schema_version: 1,
+            capability_taxonomy_version: 1,
+            adapter_contract_version: 1,
+            title: "Researcher Pack"
+          },
+          profiles: [
+            {
+              profile_id: "researcher.profile",
+              name: "Researcher",
+              capabilities: { allow: ["filesystem.read", "tool.invoke.research"] },
+              approval_intent: "ask",
+              environment_requirements: ["workspace_bounded_read"]
+            }
+          ],
+          approvals: [
+            { approval_template_id: "researcher.ask", name: "Ask Before Use", mode: "ask" }
+          ],
+          personas: [],
+          assignments: []
+        })
+      }
+    })
+    await user.click(screen.getByRole("button", { name: /preview pack/i }))
+
+    expect(await screen.findByText("Resolved capabilities")).toBeTruthy()
+    expect(screen.getByText("tool.invoke.research")).toBeTruthy()
+    expect(screen.getByText("Importable")).toBeTruthy()
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
@@ -147,4 +147,23 @@ describe("GovernancePacksTab", () => {
     expect(screen.getByText("tool.invoke.research")).toBeTruthy()
     expect(screen.getByText("Importable")).toBeTruthy()
   })
+
+  it("surfaces detail load failures without clearing the inventory", async () => {
+    mocks.getGovernancePackDetail.mockRejectedValueOnce(new Error("boom"))
+
+    render(<GovernancePacksTab />)
+
+    expect(await screen.findByText("Researcher Pack")).toBeTruthy()
+    expect(await screen.findByText("Failed to load pack details.")).toBeTruthy()
+    expect(screen.getByText("Installed Packs")).toBeTruthy()
+  })
+
+  it("handles non-array inventory responses without crashing", async () => {
+    mocks.listGovernancePacks.mockResolvedValueOnce({ rows: [] })
+
+    render(<GovernancePacksTab />)
+
+    expect(await screen.findByText("No governance packs imported yet")).toBeTruthy()
+    expect(screen.getByText("Installed Packs")).toBeTruthy()
+  })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
@@ -43,6 +43,9 @@ vi.mock("../GovernanceAuditTab", () => ({
     </button>
   )
 }))
+vi.mock("../GovernancePacksTab", () => ({
+  GovernancePacksTab: () => <div>governance packs tab</div>
+}))
 
 import { McpHubPage } from "../McpHubPage"
 
@@ -53,6 +56,7 @@ describe("McpHubPage", () => {
     expect(screen.getByText("Profiles")).toBeTruthy()
     expect(screen.getByText("Assignments")).toBeTruthy()
     expect(screen.getByText("Audit")).toBeTruthy()
+    expect(screen.getByText("Governance Packs")).toBeTruthy()
   })
 
   it("opens the requested MCP Hub tab from the audit view", async () => {

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
@@ -41,6 +41,18 @@ describe("PersonaPolicySummary", () => {
           profile_id: 5,
           override_id: 31,
           effect: "merged"
+        },
+        {
+          field: "governance_pack",
+          value: {
+            pack_id: "researcher-pack",
+            pack_version: "1.0.0"
+          },
+          source_kind: "profile",
+          assignment_id: 11,
+          profile_id: 5,
+          override_id: null,
+          effect: "replaced"
         }
       ]
     })
@@ -121,6 +133,7 @@ describe("PersonaPolicySummary", () => {
     expect(screen.getByText("Write token")).toBeTruthy()
     expect(screen.getAllByText(/disabled by assignment/i).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/missing secret/i).length).toBeGreaterThan(0)
+    expect(screen.getByText("Pack researcher-pack@1.0.0")).toBeTruthy()
     expect(screen.getByRole("link", { name: /open mcp hub/i })).toBeTruthy()
   })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
@@ -136,4 +136,23 @@ describe("PersonaPolicySummary", () => {
     expect(screen.getByText("Pack researcher-pack@1.0.0")).toBeTruthy()
     expect(screen.getByRole("link", { name: /open mcp hub/i })).toBeTruthy()
   })
+
+  it("handles missing provenance arrays without crashing", async () => {
+    mocks.getEffectivePolicy.mockResolvedValueOnce({
+      enabled: true,
+      allowed_tools: ["Bash(git *)"],
+      denied_tools: [],
+      capabilities: ["process.execute"],
+      approval_policy_id: 17,
+      approval_mode: "ask_outside_profile",
+      policy_document: {},
+      sources: [],
+      provenance: null
+    })
+
+    render(<PersonaPolicySummary personaId="researcher" />)
+
+    expect(await screen.findByText("process.execute")).toBeTruthy()
+    expect(screen.queryByText("Pack researcher-pack@1.0.0")).toBeNull()
+  })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/index.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/index.tsx
@@ -1,6 +1,7 @@
 export { McpHubPage } from "./McpHubPage"
 export { AcpProfilesTab } from "./AcpProfilesTab"
 export { ApprovalPoliciesTab } from "./ApprovalPoliciesTab"
+export { GovernancePacksTab } from "./GovernancePacksTab"
 export { ToolCatalogsTab } from "./ToolCatalogsTab"
 export { ExternalServersTab } from "./ExternalServersTab"
 export { PermissionProfilesTab } from "./PermissionProfilesTab"

--- a/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
@@ -8,7 +8,11 @@ vi.mock("@/services/background-proxy", () => ({
   bgRequestClient: (...args: unknown[]) => mocks.bgRequestClient(...args)
 }))
 
-import { setExternalServerSecret } from "../mcp-hub"
+import {
+  dryRunGovernancePack,
+  listGovernancePacks,
+  setExternalServerSecret
+} from "../mcp-hub"
 
 describe("mcp hub service client", () => {
   beforeEach(() => {
@@ -31,6 +35,70 @@ describe("mcp hub service client", () => {
         path: "/api/v1/mcp/hub/external-servers/docs/secret",
         method: "POST",
         body: { secret: "my-secret" }
+      })
+    )
+  })
+
+  it("requests governance pack dry-run reports through the MCP Hub preview endpoint", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      report: {
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack"
+        },
+        digest: "a".repeat(64),
+        resolved_capabilities: ["tool.invoke.research"],
+        unresolved_capabilities: [],
+        warnings: [],
+        blocked_objects: [],
+        verdict: "importable"
+      }
+    })
+
+    const payload = {
+      owner_scope_type: "user" as const,
+      pack: {
+        manifest: { pack_id: "researcher-pack" },
+        profiles: [],
+        approvals: [],
+        personas: [],
+        assignments: []
+      }
+    }
+    const out = await dryRunGovernancePack(payload)
+
+    expect(out.report.verdict).toBe("importable")
+    expect(mocks.bgRequestClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/mcp/hub/governance-packs/dry-run",
+        method: "POST",
+        body: payload
+      })
+    )
+  })
+
+  it("lists governance packs with scope filters", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce([
+      {
+        id: 81,
+        pack_id: "researcher-pack",
+        pack_version: "1.0.0",
+        title: "Researcher Pack",
+        owner_scope_type: "user",
+        owner_scope_id: 7,
+        bundle_digest: "a".repeat(64),
+        manifest: {}
+      }
+    ])
+
+    const out = await listGovernancePacks({ owner_scope_type: "user", owner_scope_id: 7 })
+
+    expect(out).toHaveLength(1)
+    expect(mocks.bgRequestClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "/api/v1/mcp/hub/governance-packs?owner_scope_type=user&owner_scope_id=7",
+        method: "GET"
       })
     )
   })

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -43,6 +43,7 @@ export type McpHubGovernanceAuditTabKey =
   | "workspace-sets"
   | "shared-workspaces"
   | "audit"
+  | "governance-packs"
   | "approvals"
   | "tool-catalogs"
   | "credentials"
@@ -111,6 +112,7 @@ export type McpHubPermissionProfile = {
   path_scope_object_id?: number | null
   policy_document: McpHubPermissionPolicyDocument
   is_active: boolean
+  is_immutable?: boolean
   created_by?: number | null
   updated_by?: number | null
   created_at?: string | null
@@ -263,6 +265,7 @@ export type McpHubPolicyAssignment = {
   inline_policy_document: McpHubPermissionPolicyDocument
   approval_policy_id?: number | null
   is_active: boolean
+  is_immutable?: boolean
   has_override?: boolean
   override_id?: number | null
   override_active?: boolean
@@ -317,6 +320,7 @@ export type McpHubApprovalPolicy = {
   mode: McpHubApprovalMode
   rules: Record<string, unknown>
   is_active: boolean
+  is_immutable?: boolean
   created_by?: number | null
   updated_by?: number | null
   created_at?: string | null
@@ -638,6 +642,69 @@ export type McpHubGovernanceAuditFindingList = {
     error: number
     warning: number
   }
+}
+
+export type McpHubGovernancePackDocument = {
+  manifest: Record<string, unknown>
+  profiles: Record<string, unknown>[]
+  approvals: Record<string, unknown>[]
+  personas: Record<string, unknown>[]
+  assignments: Record<string, unknown>[]
+}
+
+export type McpHubGovernancePackManifest = {
+  pack_id: string
+  pack_version: string
+  title: string
+  description?: string | null
+}
+
+export type McpHubGovernancePackDryRunReport = {
+  manifest: McpHubGovernancePackManifest
+  digest: string
+  resolved_capabilities: string[]
+  unresolved_capabilities: string[]
+  warnings: string[]
+  blocked_objects: string[]
+  verdict: "importable" | "blocked"
+}
+
+export type McpHubGovernancePackDryRunResponse = {
+  report: McpHubGovernancePackDryRunReport
+}
+
+export type McpHubGovernancePackObjectProvenance = {
+  object_type: string
+  object_id: string
+  source_object_id: string
+}
+
+export type McpHubGovernancePackSummary = {
+  id: number
+  pack_id: string
+  pack_version: string
+  title: string
+  description?: string | null
+  owner_scope_type: McpHubScopeType
+  owner_scope_id?: number | null
+  bundle_digest: string
+  manifest: Record<string, unknown>
+  created_by?: number | null
+  updated_by?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type McpHubGovernancePackDetail = McpHubGovernancePackSummary & {
+  normalized_ir: Record<string, unknown>
+  imported_objects: McpHubGovernancePackObjectProvenance[]
+}
+
+export type McpHubGovernancePackImportResponse = {
+  governance_pack_id: number
+  imported_object_counts: Record<string, number>
+  blocked_objects: string[]
+  report: McpHubGovernancePackDryRunReport
 }
 
 const withQuery = (
@@ -1335,5 +1402,51 @@ export const listGovernanceAuditFindings = async (params: {
       scope_type: params.scope_type
     }),
     method: "GET"
+  })
+}
+
+export const listGovernancePacks = async (params: {
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+} = {}): Promise<McpHubGovernancePackSummary[]> => {
+  return await bgRequestClient<McpHubGovernancePackSummary[]>({
+    path: withQuery("/api/v1/mcp/hub/governance-packs", {
+      owner_scope_type: params.owner_scope_type,
+      owner_scope_id: params.owner_scope_id
+    }),
+    method: "GET"
+  })
+}
+
+export const getGovernancePackDetail = async (
+  governancePackId: number
+): Promise<McpHubGovernancePackDetail> => {
+  return await bgRequestClient<McpHubGovernancePackDetail>({
+    path: `/api/v1/mcp/hub/governance-packs/${governancePackId}`,
+    method: "GET"
+  })
+}
+
+export const dryRunGovernancePack = async (payload: {
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  pack: McpHubGovernancePackDocument
+}): Promise<McpHubGovernancePackDryRunResponse> => {
+  return await bgRequestClient<McpHubGovernancePackDryRunResponse>({
+    path: "/api/v1/mcp/hub/governance-packs/dry-run",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const importGovernancePack = async (payload: {
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  pack: McpHubGovernancePackDocument
+}): Promise<McpHubGovernancePackImportResponse> => {
+  return await bgRequestClient<McpHubGovernancePackImportResponse>({
+    path: "/api/v1/mcp/hub/governance-packs/import",
+    method: "POST",
+    body: payload
   })
 }

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -34,6 +34,12 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     ExternalServerCreateRequest,
     ExternalServerResponse,
     ExternalServerUpdateRequest,
+    GovernancePackDetailResponse,
+    GovernancePackDryRunRequest,
+    GovernancePackDryRunResponse,
+    GovernancePackImportRequest,
+    GovernancePackImportResponse,
+    GovernancePackSummaryResponse,
     GovernanceAuditFindingListResponse,
     MCPHubDeleteResponse,
     PathScopeObjectCreateRequest,
@@ -69,6 +75,9 @@ from tldw_Server_API.app.core.config import config
 from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
 from tldw_Server_API.app.services.mcp_hub_external_legacy_inventory import (
     McpHubExternalLegacyInventoryService,
+)
+from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+    McpHubGovernancePackService,
 )
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
 from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError, McpHubService
@@ -118,6 +127,14 @@ async def get_mcp_hub_service() -> McpHubService:
         )
     )
     return McpHubService(repo, legacy_inventory_service=inventory_service)
+
+
+async def get_mcp_hub_governance_pack_service() -> McpHubGovernancePackService:
+    """Resolve governance-pack service with MCP Hub storage bootstrap checks."""
+    pool = await get_db_pool()
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return McpHubGovernancePackService(repo=repo)
 
 
 async def get_mcp_hub_policy_resolver_dep() -> McpHubPolicyResolver:
@@ -170,6 +187,15 @@ def _require_mutation_permission(principal: AuthPrincipal) -> None:
     if _is_mutation_allowed(principal):
         return
     raise HTTPException(status_code=403, detail=f"{SYSTEM_CONFIGURE} permission required")
+
+
+def _ensure_mutable_governance_object(row: dict[str, Any] | None, object_label: str) -> None:
+    """Reject direct mutation of imported governance-pack managed base objects."""
+    if row and bool(row.get("is_immutable")):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{object_label} is immutable because it is managed by an imported governance pack",
+        )
 
 
 def _require_grant_authority(principal: AuthPrincipal, policy_document: dict[str, Any]) -> None:
@@ -608,6 +634,20 @@ def _resolve_visible_scope_filters(
         return [("team", int(owner_scope_id))]
 
     raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+
+
+def _assert_principal_can_access_scope(
+    principal: AuthPrincipal,
+    *,
+    owner_scope_type: str,
+    owner_scope_id: int | None,
+) -> None:
+    """Assert that the principal can access a concrete owner scope."""
+    _resolve_visible_scope_filters(
+        principal=principal,
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
 
 
 def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -1113,6 +1153,89 @@ async def get_tool_registry_summary(
     )
 
 
+@router.post("/governance-packs/dry-run", response_model=GovernancePackDryRunResponse)
+async def dry_run_governance_pack(
+    payload: GovernancePackDryRunRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> GovernancePackDryRunResponse:
+    """Validate a governance-pack document and report dry-run compatibility details."""
+    _require_mutation_permission(principal)
+    try:
+        report = await svc.dry_run_pack_document(
+            document=payload.pack.model_dump(),
+            owner_scope_type=payload.owner_scope_type,
+            owner_scope_id=payload.owner_scope_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    report_payload = report.model_dump() if hasattr(report, "model_dump") else dict(report)
+    return GovernancePackDryRunResponse.model_validate({"report": report_payload})
+
+
+@router.post("/governance-packs/import", response_model=GovernancePackImportResponse, status_code=201)
+async def import_governance_pack(
+    payload: GovernancePackImportRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> GovernancePackImportResponse:
+    """Persist an importable governance-pack document into immutable MCP Hub base objects."""
+    _require_mutation_permission(principal)
+    try:
+        result = await svc.import_pack_document(
+            document=payload.pack.model_dump(),
+            owner_scope_type=payload.owner_scope_type,
+            owner_scope_id=payload.owner_scope_id,
+            actor_id=principal.user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return GovernancePackImportResponse.model_validate(result)
+
+
+@router.get("/governance-packs", response_model=list[GovernancePackSummaryResponse])
+async def list_governance_packs(
+    owner_scope_type: str | None = None,
+    owner_scope_id: int | None = None,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> list[GovernancePackSummaryResponse]:
+    """List governance packs visible to the current principal with scope-constrained filtering."""
+    filters = _resolve_visible_scope_filters(
+        principal=principal,
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
+    rows: list[dict[str, Any]] = []
+    for scope_type, scope_id in filters:
+        rows.extend(
+            await svc.list_governance_packs(
+                owner_scope_type=scope_type,
+                owner_scope_id=scope_id,
+            )
+        )
+    rows = _dedupe_rows(rows)
+    return [GovernancePackSummaryResponse.model_validate(row) for row in rows]
+
+
+@router.get("/governance-packs/{governance_pack_id}", response_model=GovernancePackDetailResponse)
+async def get_governance_pack_detail(
+    governance_pack_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> GovernancePackDetailResponse:
+    """Return the persisted governance pack manifest plus imported-object provenance links."""
+    row = await svc.get_governance_pack_detail(governance_pack_id)
+    if not row:
+        raise HTTPException(status_code=404, detail=f"mcp_governance_pack '{governance_pack_id}' was not found")
+    _assert_principal_can_access_scope(
+        principal,
+        owner_scope_type=str(row.get("owner_scope_type") or "global"),
+        owner_scope_id=row.get("owner_scope_id"),
+    )
+    return GovernancePackDetailResponse.model_validate(row)
+
+
 @router.post("/permission-profiles", response_model=PermissionProfileResponse, status_code=201)
 async def create_permission_profile(
     payload: PermissionProfileCreateRequest,
@@ -1192,6 +1315,10 @@ async def update_permission_profile(
         )
         _require_grant_authority(principal, update_fields.get("policy_document") or {})
     try:
+        existing = await svc.get_permission_profile(profile_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_permission_profile", identifier=str(profile_id))
+        _ensure_mutable_governance_object(existing, "Permission profile")
         if (
             "path_scope_object_id" in update_fields
             or "workspace_source_mode" in update_fields
@@ -1199,9 +1326,6 @@ async def update_permission_profile(
             or "owner_scope_type" in update_fields
             or "owner_scope_id" in update_fields
         ):
-            existing = await svc.get_permission_profile(profile_id)
-            if not existing:
-                raise ResourceNotFoundError("mcp_permission_profile", identifier=str(profile_id))
             await svc.validate_path_scope_object_reference(
                 path_scope_object_id=update_fields.get(
                     "path_scope_object_id",
@@ -1233,6 +1357,10 @@ async def delete_permission_profile(
     """Delete a permission profile by id."""
     _require_mutation_permission(principal)
     try:
+        existing = await svc.get_permission_profile(profile_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_permission_profile", identifier=str(profile_id))
+        _ensure_mutable_governance_object(existing, "Permission profile")
         deleted = await svc.delete_permission_profile(profile_id, actor_id=principal.user_id)
         if not deleted:
             raise ResourceNotFoundError("mcp_permission_profile", identifier=str(profile_id))
@@ -1773,14 +1901,15 @@ async def update_policy_assignment(
         )
         _require_grant_authority(principal, update_fields.get("inline_policy_document") or {})
     try:
+        existing = await svc.get_policy_assignment(assignment_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
+        _ensure_mutable_governance_object(existing, "Policy assignment")
         if (
             "path_scope_object_id" in update_fields
             or "owner_scope_type" in update_fields
             or "owner_scope_id" in update_fields
         ):
-            existing = await svc.get_policy_assignment(assignment_id)
-            if not existing:
-                raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
             await svc.validate_path_scope_object_reference(
                 path_scope_object_id=update_fields.get(
                     "path_scope_object_id",
@@ -1825,6 +1954,10 @@ async def delete_policy_assignment(
     """Delete a policy assignment by id."""
     _require_mutation_permission(principal)
     try:
+        existing = await svc.get_policy_assignment(assignment_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
+        _ensure_mutable_governance_object(existing, "Policy assignment")
         deleted = await svc.delete_policy_assignment(assignment_id, actor_id=principal.user_id)
         if not deleted:
             raise ResourceNotFoundError("mcp_policy_assignment", identifier=str(assignment_id))
@@ -2061,6 +2194,10 @@ async def update_approval_policy(
     if "rules" in update_fields:
         update_fields["rules"] = _normalized_approval_rules(update_fields.get("rules"))
     try:
+        existing = await svc.get_approval_policy(approval_policy_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_approval_policy", identifier=str(approval_policy_id))
+        _ensure_mutable_governance_object(existing, "Approval policy")
         row = await svc.update_approval_policy(
             approval_policy_id,
             actor_id=principal.user_id,
@@ -2082,6 +2219,10 @@ async def delete_approval_policy(
     """Delete an approval policy by id."""
     _require_mutation_permission(principal)
     try:
+        existing = await svc.get_approval_policy(approval_policy_id)
+        if not existing:
+            raise ResourceNotFoundError("mcp_approval_policy", identifier=str(approval_policy_id))
+        _ensure_mutable_governance_object(existing, "Approval policy")
         deleted = await svc.delete_approval_policy(approval_policy_id, actor_id=principal.user_id)
         if not deleted:
             raise ResourceNotFoundError("mcp_approval_policy", identifier=str(approval_policy_id))

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -77,6 +77,7 @@ from tldw_Server_API.app.services.mcp_hub_external_legacy_inventory import (
     McpHubExternalLegacyInventoryService,
 )
 from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+    GovernancePackAlreadyExistsError,
     McpHubGovernancePackService,
 )
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
@@ -650,6 +651,83 @@ def _assert_principal_can_access_scope(
     )
 
 
+def _resolve_governance_pack_mutation_scope(
+    *,
+    principal: AuthPrincipal,
+    owner_scope_type: str,
+    owner_scope_id: int | None,
+) -> tuple[str, int | None]:
+    """Resolve governance-pack mutation scope, defaulting user scope to the active principal."""
+    scope_type = str(owner_scope_type or "").strip().lower()
+    if scope_type not in _VALID_SCOPE_TYPES:
+        raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+
+    if scope_type == "global":
+        if owner_scope_id is not None:
+            raise HTTPException(status_code=422, detail="global scope cannot include owner_scope_id")
+        return ("global", None)
+
+    if scope_type == "user":
+        if owner_scope_id is not None:
+            return ("user", int(owner_scope_id))
+        if principal.user_id is None:
+            raise HTTPException(status_code=422, detail="user scope requires owner_scope_id")
+        return ("user", int(principal.user_id))
+
+    if owner_scope_id is None:
+        raise HTTPException(status_code=422, detail=f"{scope_type} scope requires owner_scope_id")
+    return (scope_type, int(owner_scope_id))
+
+
+def _portable_grant_capability(capability: Any) -> str | None:
+    """Map a portable governance-pack capability to the runtime grant-authority root capability."""
+    normalized = str(capability or "").strip().lower()
+    if not normalized:
+        return None
+    if normalized in _CAPABILITY_GRANT_PERMISSIONS:
+        return normalized
+    if normalized.startswith("tool.invoke."):
+        return "tool.invoke"
+    if normalized.startswith("network.external."):
+        return "network.external"
+    if normalized.startswith("process.execute."):
+        return "process.execute"
+    if normalized.startswith("mcp.server.connect"):
+        return "mcp.server.connect"
+    if normalized.startswith("filesystem."):
+        return normalized if normalized in _CAPABILITY_GRANT_PERMISSIONS else None
+    return None
+
+
+def _governance_pack_grant_document(pack_document: dict[str, Any]) -> dict[str, Any]:
+    """Build a synthetic policy document for grant-authority evaluation of portable capabilities."""
+    capabilities: list[str] = []
+    raw_profiles = pack_document.get("profiles")
+    if not isinstance(raw_profiles, list):
+        return {"capabilities": capabilities}
+    for raw_profile in raw_profiles:
+        if not isinstance(raw_profile, dict):
+            continue
+        raw_capabilities = raw_profile.get("capabilities")
+        if not isinstance(raw_capabilities, dict):
+            continue
+        for capability in _as_str_list(raw_capabilities.get("allow")):
+            mapped = _portable_grant_capability(capability)
+            if mapped:
+                capabilities.append(mapped)
+    return {"capabilities": _unique(capabilities)}
+
+
+def _governance_pack_manifest_summary(pack_document: dict[str, Any]) -> tuple[str, str]:
+    """Return safe manifest identifiers for audit logging without logging the full pack payload."""
+    manifest = pack_document.get("manifest")
+    if not isinstance(manifest, dict):
+        return ("<unknown>", "<unknown>")
+    pack_id = str(manifest.get("pack_id") or "").strip() or "<unknown>"
+    pack_version = str(manifest.get("pack_version") or "").strip() or "<unknown>"
+    return (pack_id, pack_version)
+
+
 def _dedupe_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Deduplicate row dictionaries by `id` while preserving final-write wins semantics."""
     deduped: dict[str, dict[str, Any]] = {}
@@ -1161,13 +1239,28 @@ async def dry_run_governance_pack(
 ) -> GovernancePackDryRunResponse:
     """Validate a governance-pack document and report dry-run compatibility details."""
     _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_governance_pack_mutation_scope(
+        principal=principal,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    pack_document = payload.pack.model_dump()
+    pack_id, pack_version = _governance_pack_manifest_summary(pack_document)
     try:
         report = await svc.dry_run_pack_document(
-            document=payload.pack.model_dump(),
-            owner_scope_type=payload.owner_scope_type,
-            owner_scope_id=payload.owner_scope_id,
+            document=pack_document,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
         )
     except ValueError as exc:
+        logger.warning(
+            "Governance pack dry-run rejected for pack {}@{} in scope {}:{}: {}",
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     report_payload = report.model_dump() if hasattr(report, "model_dump") else dict(report)
     return GovernancePackDryRunResponse.model_validate({"report": report_payload})
@@ -1181,14 +1274,40 @@ async def import_governance_pack(
 ) -> GovernancePackImportResponse:
     """Persist an importable governance-pack document into immutable MCP Hub base objects."""
     _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_governance_pack_mutation_scope(
+        principal=principal,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    pack_document = payload.pack.model_dump()
+    _require_grant_authority(principal, _governance_pack_grant_document(pack_document))
+    pack_id, pack_version = _governance_pack_manifest_summary(pack_document)
     try:
         result = await svc.import_pack_document(
-            document=payload.pack.model_dump(),
-            owner_scope_type=payload.owner_scope_type,
-            owner_scope_id=payload.owner_scope_id,
+            document=pack_document,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
             actor_id=principal.user_id,
         )
+    except GovernancePackAlreadyExistsError as exc:
+        logger.warning(
+            "Governance pack import conflict for pack {}@{} in scope {}:{}: {}",
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ValueError as exc:
+        logger.warning(
+            "Governance pack import rejected for pack {}@{} in scope {}:{}: {}",
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return GovernancePackImportResponse.model_validate(result)
 

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -99,6 +99,7 @@ class PermissionProfileResponse(BaseModel):
     path_scope_object_id: int | None = None
     policy_document: dict[str, Any] = Field(default_factory=dict)
     is_active: bool
+    is_immutable: bool = False
     created_by: int | None = None
     updated_by: int | None = None
     created_at: datetime | str | None = None
@@ -178,6 +179,7 @@ class PolicyAssignmentResponse(BaseModel):
     inline_policy_document: dict[str, Any] = Field(default_factory=dict)
     approval_policy_id: int | None = None
     is_active: bool
+    is_immutable: bool = False
     has_override: bool = False
     override_id: int | None = None
     override_active: bool = False
@@ -360,6 +362,7 @@ class ApprovalPolicyResponse(BaseModel):
     mode: ApprovalMode
     rules: dict[str, Any] = Field(default_factory=dict)
     is_active: bool
+    is_immutable: bool = False
     created_by: int | None = None
     updated_by: int | None = None
     created_at: datetime | str | None = None
@@ -637,3 +640,78 @@ class EffectiveExternalAccessResponse(BaseModel):
 
 class MCPHubDeleteResponse(BaseModel):
     ok: bool
+
+
+class GovernancePackDocumentRequest(BaseModel):
+    manifest: dict[str, Any] = Field(default_factory=dict)
+    profiles: list[dict[str, Any]] = Field(default_factory=list)
+    approvals: list[dict[str, Any]] = Field(default_factory=list)
+    personas: list[dict[str, Any]] = Field(default_factory=list)
+    assignments: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class GovernancePackDryRunRequest(BaseModel):
+    owner_scope_type: ScopeType = Field(default="user")
+    owner_scope_id: int | None = None
+    pack: GovernancePackDocumentRequest
+
+
+class GovernancePackImportRequest(BaseModel):
+    owner_scope_type: ScopeType = Field(default="user")
+    owner_scope_id: int | None = None
+    pack: GovernancePackDocumentRequest
+
+
+class GovernancePackReportManifestResponse(BaseModel):
+    pack_id: str
+    pack_version: str
+    title: str
+    description: str | None = None
+
+
+class GovernancePackDryRunReportResponse(BaseModel):
+    manifest: GovernancePackReportManifestResponse
+    digest: str
+    resolved_capabilities: list[str] = Field(default_factory=list)
+    unresolved_capabilities: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    blocked_objects: list[str] = Field(default_factory=list)
+    verdict: Literal["importable", "blocked"]
+
+
+class GovernancePackDryRunResponse(BaseModel):
+    report: GovernancePackDryRunReportResponse
+
+
+class GovernancePackObjectProvenanceResponse(BaseModel):
+    object_type: str
+    object_id: str
+    source_object_id: str
+
+
+class GovernancePackSummaryResponse(BaseModel):
+    id: int
+    pack_id: str
+    pack_version: str
+    title: str
+    description: str | None = None
+    owner_scope_type: ScopeType
+    owner_scope_id: int | None = None
+    bundle_digest: str
+    manifest: dict[str, Any] = Field(default_factory=dict)
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class GovernancePackDetailResponse(GovernancePackSummaryResponse):
+    normalized_ir: dict[str, Any] = Field(default_factory=dict)
+    imported_objects: list[GovernancePackObjectProvenanceResponse] = Field(default_factory=list)
+
+
+class GovernancePackImportResponse(BaseModel):
+    governance_pack_id: int
+    imported_object_counts: dict[str, int] = Field(default_factory=dict)
+    blocked_objects: list[str] = Field(default_factory=list)
+    report: GovernancePackDryRunReportResponse

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -1993,6 +1993,95 @@ def migration_063_add_mcp_shared_workspaces(conn: sqlite3.Connection) -> None:
     logger.info("Migration 063: Added MCP shared workspace registry schema")
 
 
+def migration_069_add_mcp_governance_pack_schema(conn: sqlite3.Connection) -> None:
+    """Add governance-pack provenance tables and immutability flags for MCP Hub."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_packs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pack_id TEXT NOT NULL,
+            pack_version TEXT NOT NULL,
+            pack_schema_version INTEGER NOT NULL,
+            capability_taxonomy_version INTEGER NOT NULL,
+            adapter_contract_version INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER,
+            bundle_digest TEXT NOT NULL,
+            manifest_json TEXT NOT NULL DEFAULT '{}',
+            normalized_ir_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER,
+            updated_by INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_packs_scope "
+        "ON mcp_governance_packs(owner_scope_type, owner_scope_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_scope_version "
+        "ON mcp_governance_packs(pack_id, pack_version, owner_scope_type, owner_scope_id)"
+    )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_pack_objects (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            governance_pack_id INTEGER NOT NULL,
+            object_type TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            source_object_id TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (governance_pack_id) REFERENCES mcp_governance_packs(id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_pack_objects_pack "
+        "ON mcp_governance_pack_objects(governance_pack_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_pack_objects_pack_source "
+        "ON mcp_governance_pack_objects(governance_pack_id, object_type, source_object_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_pack_objects_object "
+        "ON mcp_governance_pack_objects(object_type, object_id)"
+    )
+
+    profile_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(mcp_permission_profiles)").fetchall()
+    }
+    if "is_immutable" not in profile_columns:
+        conn.execute(
+            "ALTER TABLE mcp_permission_profiles ADD COLUMN is_immutable INTEGER NOT NULL DEFAULT 0"
+        )
+
+    assignment_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(mcp_policy_assignments)").fetchall()
+    }
+    if "is_immutable" not in assignment_columns:
+        conn.execute(
+            "ALTER TABLE mcp_policy_assignments ADD COLUMN is_immutable INTEGER NOT NULL DEFAULT 0"
+        )
+
+    approval_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(mcp_approval_policies)").fetchall()
+    }
+    if "is_immutable" not in approval_columns:
+        conn.execute(
+            "ALTER TABLE mcp_approval_policies ADD COLUMN is_immutable INTEGER NOT NULL DEFAULT 0"
+        )
+
+    conn.commit()
+    logger.info("Migration 069: Added MCP governance pack schema")
+
+
 def rollback_053_drop_byok_oauth_state(conn: sqlite3.Connection) -> None:
     """Rollback migration 053 by dropping the byok_oauth_state table."""
     conn.execute("DROP TABLE IF EXISTS byok_oauth_state")
@@ -3820,6 +3909,11 @@ def get_authnz_migrations() -> list[Migration]:
             "Create BYOK validation runs table",
             migration_068_create_byok_validation_runs_table,
             rollback_068_drop_byok_validation_runs_table,
+        ),
+        Migration(
+            69,
+            "Add MCP governance pack schema",
+            migration_069_add_mcp_governance_pack_schema,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -230,6 +230,11 @@ _CREATE_MCP_HUB_TABLES = [
         (),
     ),
     (
+        "ALTER TABLE mcp_permission_profiles "
+        "ADD COLUMN IF NOT EXISTS is_immutable BOOLEAN NOT NULL DEFAULT FALSE",
+        (),
+    ),
+    (
         "CREATE INDEX IF NOT EXISTS idx_mcp_permission_profiles_path_scope_object "
         "ON mcp_permission_profiles(path_scope_object_id)",
         (),
@@ -390,6 +395,11 @@ _CREATE_MCP_HUB_TABLES = [
         (),
     ),
     (
+        "ALTER TABLE mcp_policy_assignments "
+        "ADD COLUMN IF NOT EXISTS is_immutable BOOLEAN NOT NULL DEFAULT FALSE",
+        (),
+    ),
+    (
         "CREATE INDEX IF NOT EXISTS idx_mcp_policy_assignments_workspace_set_object "
         "ON mcp_policy_assignments(workspace_set_object_id)",
         (),
@@ -443,6 +453,73 @@ _CREATE_MCP_HUB_TABLES = [
     (
         "CREATE INDEX IF NOT EXISTS idx_mcp_approval_policies_scope "
         "ON mcp_approval_policies(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        "ALTER TABLE mcp_approval_policies "
+        "ADD COLUMN IF NOT EXISTS is_immutable BOOLEAN NOT NULL DEFAULT FALSE",
+        (),
+    ),
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_packs (
+            id SERIAL PRIMARY KEY,
+            pack_id TEXT NOT NULL,
+            pack_version TEXT NOT NULL,
+            pack_schema_version INTEGER NOT NULL,
+            capability_taxonomy_version INTEGER NOT NULL,
+            adapter_contract_version INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT NULL,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER NULL,
+            bundle_digest TEXT NOT NULL,
+            manifest_json TEXT NOT NULL DEFAULT '{}',
+            normalized_ir_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_packs_scope "
+        "ON mcp_governance_packs(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_scope_version "
+        "ON mcp_governance_packs(pack_id, pack_version, owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_pack_objects (
+            id SERIAL PRIMARY KEY,
+            governance_pack_id INTEGER NOT NULL REFERENCES mcp_governance_packs(id) ON DELETE CASCADE,
+            object_type TEXT NOT NULL,
+            object_id TEXT NOT NULL,
+            source_object_id TEXT NOT NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_pack_objects_pack "
+        "ON mcp_governance_pack_objects(governance_pack_id)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_pack_objects_pack_source "
+        "ON mcp_governance_pack_objects(governance_pack_id, object_type, source_object_id)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_pack_objects_object "
+        "ON mcp_governance_pack_objects(object_type, object_id)",
         (),
     ),
     (

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -458,6 +458,42 @@ class McpHubRepo:
         )
         return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
 
+    async def get_governance_pack_by_identity(
+        self,
+        *,
+        pack_id: str,
+        pack_version: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict[str, Any] | None:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
+                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
+                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_governance_packs
+            WHERE pack_id = ?
+              AND pack_version = ?
+              AND owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (
+                str(pack_id or "").strip(),
+                str(pack_version or "").strip(),
+                scope_type,
+                owner_scope_id,
+                owner_scope_id,
+            ),
+        )
+        return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
+
     async def list_governance_packs(
         self,
         *,
@@ -492,6 +528,14 @@ class McpHubRepo:
             self._normalize_governance_pack_row(self._row_to_dict(row)) or {}
             for row in rows
         ]
+
+    async def delete_governance_pack(self, governance_pack_id: int) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_governance_packs WHERE id = ?",
+            (int(governance_pack_id),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)
 
     async def create_governance_pack_object(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -140,6 +140,8 @@ class McpHubRepo:
                 "mcp_external_server_credential_slots",
                 "mcp_external_server_secrets",
                 "mcp_external_server_slot_secrets",
+                "mcp_governance_pack_objects",
+                "mcp_governance_packs",
                 "mcp_path_scope_objects",
                 "mcp_permission_profiles",
                 "mcp_policy_assignments",
@@ -233,6 +235,7 @@ class McpHubRepo:
             return None
         out = dict(row)
         out["is_active"] = _to_bool(out.get("is_active"))
+        out["is_immutable"] = _to_bool(out.get("is_immutable"))
         out["policy_document"] = _load_json_dict(out.pop("policy_document_json", None))
         return out
 
@@ -251,6 +254,7 @@ class McpHubRepo:
             return None
         out = dict(row)
         out["is_active"] = _to_bool(out.get("is_active"))
+        out["is_immutable"] = _to_bool(out.get("is_immutable"))
         out["workspace_source_mode"] = str(out.get("workspace_source_mode") or "").strip().lower() or None
         out["inline_policy_document"] = _load_json_dict(out.pop("inline_policy_document_json", None))
         out["has_override"] = _to_bool(out.get("has_override"))
@@ -310,7 +314,27 @@ class McpHubRepo:
             return None
         out = dict(row)
         out["is_active"] = _to_bool(out.get("is_active"))
+        out["is_immutable"] = _to_bool(out.get("is_immutable"))
         out["rules"] = _load_json_dict(out.pop("rules_json", None))
+        return out
+
+    @staticmethod
+    def _normalize_governance_pack_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["manifest"] = _load_json_dict(out.pop("manifest_json", None))
+        out["normalized_ir"] = _load_json_dict(out.pop("normalized_ir_json", None))
+        return out
+
+    @staticmethod
+    def _normalize_governance_pack_object_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["object_type"] = str(out.get("object_type") or "").strip().lower()
+        out["object_id"] = str(out.get("object_id") or "").strip()
+        out["source_object_id"] = str(out.get("source_object_id") or "").strip()
         return out
 
     @staticmethod
@@ -344,6 +368,147 @@ class McpHubRepo:
         if isinstance(rowcount, int):
             return rowcount > 0
         return False
+
+    async def create_governance_pack(
+        self,
+        *,
+        pack_id: str,
+        pack_version: str,
+        pack_schema_version: int,
+        capability_taxonomy_version: int,
+        adapter_contract_version: int,
+        title: str,
+        description: str | None,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        bundle_digest: str,
+        manifest: dict[str, Any],
+        normalized_ir: dict[str, Any],
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_governance_packs (
+                pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
+                adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
+                bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(pack_id or "").strip(),
+                str(pack_version or "").strip(),
+                int(pack_schema_version),
+                int(capability_taxonomy_version),
+                int(adapter_contract_version),
+                str(title or "").strip(),
+                description,
+                scope_type,
+                owner_scope_id,
+                str(bundle_digest or "").strip(),
+                json.dumps(manifest or {}),
+                json.dumps(normalized_ir or {}),
+                actor_id,
+                actor_id,
+                ts,
+                ts,
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM mcp_governance_packs
+            WHERE pack_id = ?
+              AND pack_version = ?
+              AND owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (
+                str(pack_id or "").strip(),
+                str(pack_version or "").strip(),
+                scope_type,
+                owner_scope_id,
+                owner_scope_id,
+            ),
+        )
+        if not row:
+            return {}
+        created = await self.get_governance_pack(int(row["id"]))
+        return created or {}
+
+    async def get_governance_pack(self, governance_pack_id: int) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
+                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
+                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_governance_packs
+            WHERE id = ?
+            """,
+            (int(governance_pack_id),),
+        )
+        return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
+
+    async def create_governance_pack_object(
+        self,
+        *,
+        governance_pack_id: int,
+        object_type: str,
+        object_id: int | str,
+        source_object_id: str,
+    ) -> dict[str, Any]:
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        normalized_object_type = str(object_type or "").strip().lower()
+        normalized_object_id = str(object_id).strip()
+        normalized_source_object_id = str(source_object_id or "").strip()
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_governance_pack_objects (
+                governance_pack_id, object_type, object_id, source_object_id, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                int(governance_pack_id),
+                normalized_object_type,
+                normalized_object_id,
+                normalized_source_object_id,
+                ts,
+            ),
+        )
+        return (
+            await self.get_governance_pack_object(
+                object_type=normalized_object_type,
+                object_id=normalized_object_id,
+            )
+            or {}
+        )
+
+    async def get_governance_pack_object(
+        self,
+        *,
+        object_type: str,
+        object_id: int | str,
+    ) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, governance_pack_id, object_type, object_id, source_object_id, created_at
+            FROM mcp_governance_pack_objects
+            WHERE object_type = ?
+              AND object_id = ?
+            """,
+            (str(object_type or "").strip().lower(), str(object_id).strip()),
+        )
+        return self._normalize_governance_pack_object_row(self._row_to_dict(row) if row else None)
 
     async def create_acp_profile(
         self,
@@ -524,18 +689,22 @@ class McpHubRepo:
         actor_id: int | None,
         description: str | None = None,
         is_active: bool = True,
+        is_immutable: bool = False,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         profile_mode = _normalize_profile_mode(mode)
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
+        immutable_value: bool | int = (
+            is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
+        )
         await self.db_pool.execute(
             """
             INSERT INTO mcp_permission_profiles (
-                name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id, policy_document_json, is_active,
-                created_by, updated_by, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id,
+                policy_document_json, is_active, is_immutable, created_by, updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name.strip(),
@@ -546,6 +715,7 @@ class McpHubRepo:
                 path_scope_object_id,
                 json.dumps(policy_document or {}),
                 active_value,
+                immutable_value,
                 actor_id,
                 actor_id,
                 ts,
@@ -575,7 +745,8 @@ class McpHubRepo:
     async def get_permission_profile(self, profile_id: int) -> dict[str, Any] | None:
         row = await self.db_pool.fetchone(
             """
-            SELECT id, name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id, policy_document_json, is_active,
+            SELECT id, name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id,
+                   policy_document_json, is_active, is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_permission_profiles
             WHERE id = ?
@@ -598,7 +769,8 @@ class McpHubRepo:
         normalized_scope_id = int(owner_scope_id) if owner_scope_id is not None else None
         rows = await self.db_pool.fetchall(
             """
-            SELECT id, name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id, policy_document_json, is_active,
+            SELECT id, name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id,
+                   policy_document_json, is_active, is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_permission_profiles
             WHERE (? IS NULL OR owner_scope_type = ?)
@@ -1282,6 +1454,7 @@ class McpHubRepo:
         approval_policy_id: int | None,
         actor_id: int | None,
         is_active: bool = True,
+        is_immutable: bool = False,
     ) -> dict[str, Any]:
         normalized_target_type = _normalize_target_type(target_type)
         normalized_target_id = str(target_id).strip() if target_id is not None else None
@@ -1289,14 +1462,17 @@ class McpHubRepo:
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
+        immutable_value: bool | int = (
+            is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
+        )
         await self.db_pool.execute(
             """
             INSERT INTO mcp_policy_assignments (
                 target_type, target_id, owner_scope_type, owner_scope_id, profile_id,
                 path_scope_object_id, workspace_source_mode, workspace_set_object_id,
-                inline_policy_document_json, approval_policy_id, is_active,
+                inline_policy_document_json, approval_policy_id, is_active, is_immutable,
                 created_by, updated_by, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 normalized_target_type,
@@ -1310,6 +1486,7 @@ class McpHubRepo:
                 json.dumps(inline_policy_document or {}),
                 approval_policy_id,
                 active_value,
+                immutable_value,
                 actor_id,
                 actor_id,
                 ts,
@@ -1352,7 +1529,7 @@ class McpHubRepo:
             """
             SELECT a.id, a.target_type, a.target_id, a.owner_scope_type, a.owner_scope_id, a.profile_id,
                    a.path_scope_object_id, a.workspace_source_mode, a.workspace_set_object_id,
-                   a.inline_policy_document_json, a.approval_policy_id, a.is_active,
+                   a.inline_policy_document_json, a.approval_policy_id, a.is_active, a.is_immutable,
                    a.created_by, a.updated_by, a.created_at, a.updated_at,
                    o.id AS override_id,
                    CASE WHEN o.id IS NULL THEN 0 ELSE 1 END AS has_override,
@@ -1390,7 +1567,7 @@ class McpHubRepo:
             """
             SELECT a.id, a.target_type, a.target_id, a.owner_scope_type, a.owner_scope_id, a.profile_id,
                    a.path_scope_object_id, a.workspace_source_mode, a.workspace_set_object_id,
-                   a.inline_policy_document_json, a.approval_policy_id, a.is_active,
+                   a.inline_policy_document_json, a.approval_policy_id, a.is_active, a.is_immutable,
                    a.created_by, a.updated_by, a.created_at, a.updated_at,
                    o.id AS override_id,
                    CASE WHEN o.id IS NULL THEN 0 ELSE 1 END AS has_override,
@@ -1670,18 +1847,22 @@ class McpHubRepo:
         actor_id: int | None,
         description: str | None = None,
         is_active: bool = True,
+        is_immutable: bool = False,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         approval_mode = _normalize_approval_mode(mode)
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = is_active if getattr(self.db_pool, "pool", None) is not None else int(is_active)
+        immutable_value: bool | int = (
+            is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
+        )
         await self.db_pool.execute(
             """
             INSERT INTO mcp_approval_policies (
                 name, description, owner_scope_type, owner_scope_id, mode, rules_json, is_active,
-                created_by, updated_by, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                is_immutable, created_by, updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name.strip(),
@@ -1691,6 +1872,7 @@ class McpHubRepo:
                 approval_mode,
                 json.dumps(rules or {}),
                 active_value,
+                immutable_value,
                 actor_id,
                 actor_id,
                 ts,
@@ -1721,6 +1903,7 @@ class McpHubRepo:
         row = await self.db_pool.fetchone(
             """
             SELECT id, name, description, owner_scope_type, owner_scope_id, mode, rules_json, is_active,
+                   is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_approval_policies
             WHERE id = ?
@@ -1744,6 +1927,7 @@ class McpHubRepo:
         rows = await self.db_pool.fetchall(
             """
             SELECT id, name, description, owner_scope_type, owner_scope_id, mode, rules_json, is_active,
+                   is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_approval_policies
             WHERE (? IS NULL OR owner_scope_type = ?)

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -458,6 +458,41 @@ class McpHubRepo:
         )
         return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
 
+    async def list_governance_packs(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        normalized_scope_type = (
+            _normalize_scope_type(owner_scope_type)
+            if owner_scope_type is not None
+            else None
+        )
+        normalized_scope_id = int(owner_scope_id) if owner_scope_id is not None else None
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
+                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
+                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_governance_packs
+            WHERE (? IS NULL OR owner_scope_type = ?)
+              AND (? IS NULL OR owner_scope_id = ?)
+            ORDER BY pack_id, pack_version, id
+            """,
+            (
+                normalized_scope_type,
+                normalized_scope_type,
+                normalized_scope_id,
+                normalized_scope_id,
+            ),
+        )
+        return [
+            self._normalize_governance_pack_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
+
     async def create_governance_pack_object(
         self,
         *,
@@ -509,6 +544,21 @@ class McpHubRepo:
             (str(object_type or "").strip().lower(), str(object_id).strip()),
         )
         return self._normalize_governance_pack_object_row(self._row_to_dict(row) if row else None)
+
+    async def list_governance_pack_objects(self, governance_pack_id: int) -> list[dict[str, Any]]:
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, governance_pack_id, object_type, object_id, source_object_id, created_at
+            FROM mcp_governance_pack_objects
+            WHERE governance_pack_id = ?
+            ORDER BY object_type, source_object_id, id
+            """,
+            (int(governance_pack_id),),
+        )
+        return [
+            self._normalize_governance_pack_object_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
 
     async def create_acp_profile(
         self,

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/__init__.py
@@ -1,0 +1,23 @@
+from .fixtures import load_governance_pack_fixture
+from .models import (
+    ApprovalTemplate,
+    AssignmentTemplate,
+    CapabilityProfile,
+    GovernancePack,
+    GovernancePackManifest,
+    GovernancePackValidationResult,
+    PersonaTemplate,
+)
+from .validation import validate_governance_pack
+
+__all__ = [
+    "ApprovalTemplate",
+    "AssignmentTemplate",
+    "CapabilityProfile",
+    "GovernancePack",
+    "GovernancePackManifest",
+    "GovernancePackValidationResult",
+    "PersonaTemplate",
+    "load_governance_pack_fixture",
+    "validate_governance_pack",
+]

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/__init__.py
@@ -8,16 +8,22 @@ from .models import (
     GovernancePackValidationResult,
     PersonaTemplate,
 )
+from .normalize import NormalizedGovernancePackIR, normalize_governance_pack
+from .opa_bundle import GeneratedGovernancePackBundle, build_opa_bundle
 from .validation import validate_governance_pack
 
 __all__ = [
     "ApprovalTemplate",
     "AssignmentTemplate",
     "CapabilityProfile",
+    "GeneratedGovernancePackBundle",
     "GovernancePack",
     "GovernancePackManifest",
     "GovernancePackValidationResult",
+    "NormalizedGovernancePackIR",
     "PersonaTemplate",
+    "build_opa_bundle",
     "load_governance_pack_fixture",
+    "normalize_governance_pack",
     "validate_governance_pack",
 ]

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/fixtures.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/fixtures.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .models import (
+    ApprovalTemplate,
+    AssignmentTemplate,
+    CapabilityProfile,
+    GovernancePack,
+    GovernancePackManifest,
+    PersonaTemplate,
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _fixture_root() -> Path:
+    return _repo_root() / "tldw_Server_API" / "tests" / "MCP_unified" / "fixtures" / "governance_packs"
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return loaded
+
+
+def _load_yaml_directory(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    documents: list[dict[str, Any]] = []
+    for file_path in sorted(
+        candidate
+        for candidate in path.iterdir()
+        if candidate.is_file() and candidate.suffix.lower() in {".yaml", ".yml"}
+    ):
+        documents.append(_load_yaml_file(file_path))
+    return documents
+
+
+def load_governance_pack_fixture(name_or_path: str | Path) -> GovernancePack:
+    candidate_path = Path(name_or_path)
+    pack_path = candidate_path if candidate_path.exists() else _fixture_root() / str(name_or_path)
+
+    manifest = GovernancePackManifest(**_load_yaml_file(pack_path / "manifest.yaml"))
+    raw_profiles = _load_yaml_directory(pack_path / "profiles")
+    raw_approvals = _load_yaml_directory(pack_path / "approvals")
+    raw_personas = _load_yaml_directory(pack_path / "personas")
+    raw_assignments = _load_yaml_directory(pack_path / "assignments")
+
+    return GovernancePack(
+        source_path=pack_path,
+        manifest=manifest,
+        profiles=[CapabilityProfile(**item) for item in raw_profiles],
+        approvals=[ApprovalTemplate(**item) for item in raw_approvals],
+        personas=[PersonaTemplate(**item) for item in raw_personas],
+        assignments=[AssignmentTemplate(**item) for item in raw_assignments],
+        raw_profiles=raw_profiles,
+        raw_approvals=raw_approvals,
+        raw_personas=raw_personas,
+        raw_assignments=raw_assignments,
+    )

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/fixtures.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/fixtures.py
@@ -44,6 +44,7 @@ def _load_yaml_directory(path: Path) -> list[dict[str, Any]]:
 
 
 def load_governance_pack_fixture(name_or_path: str | Path) -> GovernancePack:
+    """Load a governance-pack fixture directory by fixture name or explicit path."""
     candidate_path = Path(name_or_path)
     pack_path = candidate_path if candidate_path.exists() else _fixture_root() / str(name_or_path)
 

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/models.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class GovernancePackManifest(BaseModel):
+    pack_id: str
+    pack_version: str
+    pack_schema_version: int
+    capability_taxonomy_version: int
+    adapter_contract_version: int
+    title: str
+    description: str | None = None
+    authors: list[str] = Field(default_factory=list)
+    compatible_runtime_targets: list[str] = Field(default_factory=list)
+
+
+class CapabilitySet(BaseModel):
+    allow: list[str] = Field(default_factory=list)
+    deny: list[str] = Field(default_factory=list)
+
+
+class CapabilityProfile(BaseModel):
+    profile_id: str
+    name: str
+    description: str | None = None
+    capabilities: CapabilitySet = Field(default_factory=CapabilitySet)
+    approval_intent: str
+    environment_requirements: list[str] = Field(default_factory=list)
+
+
+class ApprovalTemplate(BaseModel):
+    approval_template_id: str
+    name: str
+    mode: str
+
+
+class PersonaTemplate(BaseModel):
+    persona_template_id: str
+    name: str
+    description: str | None = None
+    capability_profile_id: str
+    approval_template_id: str
+    persona_traits: list[str] = Field(default_factory=list)
+
+
+class AssignmentTemplate(BaseModel):
+    assignment_template_id: str
+    target_type: str
+    capability_profile_id: str
+    persona_template_id: str | None = None
+    approval_template_id: str | None = None
+
+
+@dataclass
+class GovernancePack:
+    source_path: Path
+    manifest: GovernancePackManifest
+    profiles: list[CapabilityProfile] = field(default_factory=list)
+    approvals: list[ApprovalTemplate] = field(default_factory=list)
+    personas: list[PersonaTemplate] = field(default_factory=list)
+    assignments: list[AssignmentTemplate] = field(default_factory=list)
+    raw_profiles: list[dict[str, Any]] = field(default_factory=list)
+    raw_approvals: list[dict[str, Any]] = field(default_factory=list)
+    raw_personas: list[dict[str, Any]] = field(default_factory=list)
+    raw_assignments: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class GovernancePackValidationResult:
+    manifest: GovernancePackManifest | None
+    errors: list[str] = field(default_factory=list)

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/normalize.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/normalize.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .models import GovernancePack
+
+
+def _dump_model(model: Any) -> dict[str, Any]:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(exclude_none=True)
+    return model.dict(exclude_none=True)
+
+
+@dataclass
+class NormalizedGovernancePackIR:
+    manifest: dict[str, Any]
+    data: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest": self.manifest,
+            "data": self.data,
+        }
+
+
+def normalize_governance_pack(pack: GovernancePack) -> NormalizedGovernancePackIR:
+    profiles = sorted(
+        (_dump_model(profile) for profile in pack.profiles),
+        key=lambda item: str(item.get("profile_id") or ""),
+    )
+    approvals = sorted(
+        (_dump_model(approval) for approval in pack.approvals),
+        key=lambda item: str(item.get("approval_template_id") or ""),
+    )
+    personas = sorted(
+        (_dump_model(persona) for persona in pack.personas),
+        key=lambda item: str(item.get("persona_template_id") or ""),
+    )
+    assignments = sorted(
+        (_dump_model(assignment) for assignment in pack.assignments),
+        key=lambda item: str(item.get("assignment_template_id") or ""),
+    )
+
+    return NormalizedGovernancePackIR(
+        manifest=_dump_model(pack.manifest),
+        data={
+            "profiles": profiles,
+            "approvals": approvals,
+            "personas": personas,
+            "assignments": assignments,
+        },
+    )

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/opa_bundle.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/opa_bundle.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .models import GovernancePack
+from .normalize import NormalizedGovernancePackIR, normalize_governance_pack
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+@dataclass
+class GeneratedGovernancePackBundle:
+    ir: NormalizedGovernancePackIR
+    bundle_json: dict[str, Any]
+    digest: str
+
+
+def build_opa_bundle(pack: GovernancePack) -> GeneratedGovernancePackBundle:
+    ir = normalize_governance_pack(pack)
+    bundle_json = ir.to_dict()
+    digest = hashlib.sha256(_canonical_json(bundle_json).encode("utf-8")).hexdigest()
+    return GeneratedGovernancePackBundle(
+        ir=ir,
+        bundle_json=bundle_json,
+        digest=digest,
+    )

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/validation.py
@@ -20,6 +20,7 @@ def _collect_duplicates(documents: list[dict[str, object]], key: str) -> list[st
 
 
 def validate_governance_pack(pack: GovernancePack) -> GovernancePackValidationResult:
+    """Validate a schema-first governance pack and return collected structural errors."""
     errors: list[str] = []
     manifest = pack.manifest
 

--- a/tldw_Server_API/app/core/MCP_unified/governance_packs/validation.py
+++ b/tldw_Server_API/app/core/MCP_unified/governance_packs/validation.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from .models import GovernancePack, GovernancePackValidationResult
+
+SUPPORTED_CAPABILITY_TAXONOMY_VERSIONS = {1}
+RUNTIME_ONLY_PERSONA_FIELDS = {
+    "memory_snapshot",
+    "session_history",
+    "live_state",
+    "workspace_history",
+}
+
+
+def _collect_duplicates(documents: list[dict[str, object]], key: str) -> list[str]:
+    values = [str(item.get(key) or "").strip() for item in documents if str(item.get(key) or "").strip()]
+    counts = Counter(values)
+    return sorted(value for value, count in counts.items() if count > 1)
+
+
+def validate_governance_pack(pack: GovernancePack) -> GovernancePackValidationResult:
+    errors: list[str] = []
+    manifest = pack.manifest
+
+    if manifest.capability_taxonomy_version not in SUPPORTED_CAPABILITY_TAXONOMY_VERSIONS:
+        errors.append(f"Unsupported capability_taxonomy_version: {manifest.capability_taxonomy_version}")
+
+    for duplicate in _collect_duplicates(pack.raw_profiles, "profile_id"):
+        errors.append(f"Duplicate profile_id: {duplicate}")
+    for duplicate in _collect_duplicates(pack.raw_approvals, "approval_template_id"):
+        errors.append(f"Duplicate approval_template_id: {duplicate}")
+    for duplicate in _collect_duplicates(pack.raw_personas, "persona_template_id"):
+        errors.append(f"Duplicate persona_template_id: {duplicate}")
+    for duplicate in _collect_duplicates(pack.raw_assignments, "assignment_template_id"):
+        errors.append(f"Duplicate assignment_template_id: {duplicate}")
+
+    profile_ids = {profile.profile_id for profile in pack.profiles}
+    approval_ids = {approval.approval_template_id for approval in pack.approvals}
+    persona_ids = {persona.persona_template_id for persona in pack.personas}
+
+    for raw_persona, persona in zip(pack.raw_personas, pack.personas, strict=False):
+        if persona.capability_profile_id not in profile_ids:
+            errors.append(f"Unknown capability profile reference: {persona.capability_profile_id}")
+        if persona.approval_template_id not in approval_ids:
+            errors.append(f"Unknown approval template reference: {persona.approval_template_id}")
+
+        for field_name in sorted(RUNTIME_ONLY_PERSONA_FIELDS.intersection(raw_persona.keys())):
+            errors.append(
+                f"Persona template {persona.persona_template_id} contains runtime-only field: {field_name}"
+            )
+
+    for assignment in pack.assignments:
+        if assignment.capability_profile_id not in profile_ids:
+            errors.append(f"Unknown capability profile reference: {assignment.capability_profile_id}")
+        if assignment.persona_template_id and assignment.persona_template_id not in persona_ids:
+            errors.append(f"Unknown persona template reference: {assignment.persona_template_id}")
+        if assignment.approval_template_id and assignment.approval_template_id not in approval_ids:
+            errors.append(f"Unknown approval template reference: {assignment.approval_template_id}")
+
+    return GovernancePackValidationResult(
+        manifest=manifest,
+        errors=errors,
+    )

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
@@ -67,11 +68,87 @@ class GovernancePackDryRunReport(BaseModel):
     verdict: str
 
 
+class GovernancePackAlreadyExistsError(ValueError):
+    """Raised when a governance pack identity already exists in the target scope."""
+
+    def __init__(
+        self,
+        pack_id: str,
+        pack_version: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> None:
+        scope_label = (
+            f"{owner_scope_type}:{owner_scope_id}"
+            if owner_scope_id is not None
+            else str(owner_scope_type or "global")
+        )
+        super().__init__(
+            f"Governance pack '{pack_id}@{pack_version}' already exists for scope {scope_label}"
+        )
+        self.pack_id = pack_id
+        self.pack_version = pack_version
+        self.owner_scope_type = owner_scope_type
+        self.owner_scope_id = owner_scope_id
+
+
+def _is_duplicate_governance_pack_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return (
+        "uq_mcp_governance_packs_scope_version" in message
+        or "unique constraint failed: mcp_governance_packs" in message
+        or "duplicate key value violates unique constraint" in message
+    )
+
+
 class McpHubGovernancePackService:
     """Materialize schema-first governance packs into immutable MCP Hub base objects."""
 
     def __init__(self, repo: McpHubRepo):
         self.repo = repo
+
+    async def _rollback_import(
+        self,
+        *,
+        governance_pack_id: int | None,
+        imported_object_ids: dict[str, list[int]],
+    ) -> None:
+        for assignment_id in reversed(imported_object_ids.get("policy_assignments", [])):
+            try:
+                await self.repo.delete_policy_assignment(assignment_id)
+            except Exception as exc:
+                logger.warning(
+                    "Governance pack rollback could not delete policy_assignment {}: {}",
+                    assignment_id,
+                    exc,
+                )
+        for profile_id in reversed(imported_object_ids.get("permission_profiles", [])):
+            try:
+                await self.repo.delete_permission_profile(profile_id)
+            except Exception as exc:
+                logger.warning(
+                    "Governance pack rollback could not delete permission_profile {}: {}",
+                    profile_id,
+                    exc,
+                )
+        for approval_policy_id in reversed(imported_object_ids.get("approval_policies", [])):
+            try:
+                await self.repo.delete_approval_policy(approval_policy_id)
+            except Exception as exc:
+                logger.warning(
+                    "Governance pack rollback could not delete approval_policy {}: {}",
+                    approval_policy_id,
+                    exc,
+                )
+        if governance_pack_id is not None:
+            try:
+                await self.repo.delete_governance_pack(governance_pack_id)
+            except Exception as exc:
+                logger.warning(
+                    "Governance pack rollback could not delete governance_pack {}: {}",
+                    governance_pack_id,
+                    exc,
+                )
 
     @staticmethod
     def build_pack_from_document(document: dict[str, Any]) -> GovernancePack:
@@ -241,23 +318,19 @@ class McpHubGovernancePackService:
         normalized_ir = normalize_governance_pack(pack)
         bundle = build_opa_bundle(pack)
         manifest = pack.manifest
-        pack_row = await self.repo.create_governance_pack(
+        existing = await self.repo.get_governance_pack_by_identity(
             pack_id=manifest.pack_id,
             pack_version=manifest.pack_version,
-            pack_schema_version=manifest.pack_schema_version,
-            capability_taxonomy_version=manifest.capability_taxonomy_version,
-            adapter_contract_version=manifest.adapter_contract_version,
-            title=manifest.title,
-            description=manifest.description,
             owner_scope_type=owner_scope_type,
             owner_scope_id=owner_scope_id,
-            bundle_digest=bundle.digest,
-            manifest=_dump_model(manifest),
-            normalized_ir=normalized_ir.to_dict(),
-            actor_id=actor_id,
         )
-        if not pack_row:
-            raise RuntimeError("Failed to persist governance pack manifest")
+        if existing is not None:
+            raise GovernancePackAlreadyExistsError(
+                manifest.pack_id,
+                manifest.pack_version,
+                owner_scope_type,
+                owner_scope_id,
+            )
 
         blocked_objects: list[str] = []
         imported_object_ids: dict[str, list[int]] = {
@@ -265,6 +338,7 @@ class McpHubGovernancePackService:
             "permission_profiles": [],
             "policy_assignments": [],
         }
+        governance_pack_id: int | None = None
         approval_policy_ids_by_template: dict[str, int] = {}
         profile_ids_by_template: dict[str, int] = {}
         persona_ids_by_template: dict[str, str] = {
@@ -276,134 +350,170 @@ class McpHubGovernancePackService:
             for persona in pack.personas
         }
 
-        for approval in pack.approvals:
-            runtime_mode = _RUNTIME_APPROVAL_MODE_MAP.get(str(approval.mode or "").strip().lower())
-            if runtime_mode is None:
-                blocked_objects.append(f"approval_template:{approval.approval_template_id}")
-                continue
-            created = await self.repo.create_approval_policy(
-                name=_imported_name(
-                    approval.name,
+        try:
+            try:
+                pack_row = await self.repo.create_governance_pack(
                     pack_id=manifest.pack_id,
+                    pack_version=manifest.pack_version,
+                    pack_schema_version=manifest.pack_schema_version,
+                    capability_taxonomy_version=manifest.capability_taxonomy_version,
+                    adapter_contract_version=manifest.adapter_contract_version,
+                    title=manifest.title,
+                    description=manifest.description,
+                    owner_scope_type=owner_scope_type,
+                    owner_scope_id=owner_scope_id,
+                    bundle_digest=bundle.digest,
+                    manifest=_dump_model(manifest),
+                    normalized_ir=normalized_ir.to_dict(),
+                    actor_id=actor_id,
+                )
+            except Exception as exc:
+                if _is_duplicate_governance_pack_error(exc):
+                    raise GovernancePackAlreadyExistsError(
+                        manifest.pack_id,
+                        manifest.pack_version,
+                        owner_scope_type,
+                        owner_scope_id,
+                    ) from exc
+                raise
+            if not pack_row:
+                raise RuntimeError("Failed to persist governance pack manifest")
+            governance_pack_id = int(pack_row["id"])
+
+            for approval in pack.approvals:
+                runtime_mode = _RUNTIME_APPROVAL_MODE_MAP.get(str(approval.mode or "").strip().lower())
+                if runtime_mode is None:
+                    blocked_objects.append(f"approval_template:{approval.approval_template_id}")
+                    continue
+                created = await self.repo.create_approval_policy(
+                    name=_imported_name(
+                        approval.name,
+                        pack_id=manifest.pack_id,
+                        source_object_id=approval.approval_template_id,
+                    ),
+                    owner_scope_type=owner_scope_type,
+                    owner_scope_id=owner_scope_id,
+                    mode=runtime_mode,
+                    rules={
+                        "portable_mode": approval.mode,
+                        "approval_template_id": approval.approval_template_id,
+                        "governance_pack": {
+                            "pack_id": manifest.pack_id,
+                            "pack_version": manifest.pack_version,
+                            "source_object_id": approval.approval_template_id,
+                        },
+                    },
+                    actor_id=actor_id,
+                    description=approval.name,
+                    is_active=True,
+                    is_immutable=True,
+                )
+                approval_id = int(created["id"])
+                approval_policy_ids_by_template[approval.approval_template_id] = approval_id
+                imported_object_ids["approval_policies"].append(approval_id)
+                await self.repo.create_governance_pack_object(
+                    governance_pack_id=governance_pack_id,
+                    object_type="approval_policy",
+                    object_id=approval_id,
                     source_object_id=approval.approval_template_id,
-                ),
-                owner_scope_type=owner_scope_type,
-                owner_scope_id=owner_scope_id,
-                mode=runtime_mode,
-                rules={
-                    "portable_mode": approval.mode,
-                    "approval_template_id": approval.approval_template_id,
-                    "governance_pack": {
-                        "pack_id": manifest.pack_id,
-                        "pack_version": manifest.pack_version,
-                        "source_object_id": approval.approval_template_id,
-                    },
-                },
-                actor_id=actor_id,
-                description=approval.name,
-                is_active=True,
-                is_immutable=True,
-            )
-            approval_id = int(created["id"])
-            approval_policy_ids_by_template[approval.approval_template_id] = approval_id
-            imported_object_ids["approval_policies"].append(approval_id)
-            await self.repo.create_governance_pack_object(
-                governance_pack_id=int(pack_row["id"]),
-                object_type="approval_policy",
-                object_id=approval_id,
-                source_object_id=approval.approval_template_id,
-            )
+                )
 
-        for profile in pack.profiles:
-            created = await self.repo.create_permission_profile(
-                name=_imported_name(
-                    profile.name,
-                    pack_id=manifest.pack_id,
+            for profile in pack.profiles:
+                created = await self.repo.create_permission_profile(
+                    name=_imported_name(
+                        profile.name,
+                        pack_id=manifest.pack_id,
+                        source_object_id=profile.profile_id,
+                    ),
+                    owner_scope_type=owner_scope_type,
+                    owner_scope_id=owner_scope_id,
+                    mode="preset",
+                    policy_document={
+                        "capabilities": list(profile.capabilities.allow),
+                        "denied_capabilities": list(profile.capabilities.deny),
+                        "environment_requirements": list(profile.environment_requirements),
+                        "approval_intent": profile.approval_intent,
+                        "governance_pack": {
+                            "pack_id": manifest.pack_id,
+                            "pack_version": manifest.pack_version,
+                            "source_object_id": profile.profile_id,
+                        },
+                    },
+                    actor_id=actor_id,
+                    description=profile.description,
+                    is_active=True,
+                    is_immutable=True,
+                )
+                profile_id = int(created["id"])
+                profile_ids_by_template[profile.profile_id] = profile_id
+                imported_object_ids["permission_profiles"].append(profile_id)
+                await self.repo.create_governance_pack_object(
+                    governance_pack_id=governance_pack_id,
+                    object_type="permission_profile",
+                    object_id=profile_id,
                     source_object_id=profile.profile_id,
-                ),
-                owner_scope_type=owner_scope_type,
-                owner_scope_id=owner_scope_id,
-                mode="preset",
-                policy_document={
-                    "capabilities": list(profile.capabilities.allow),
-                    "denied_capabilities": list(profile.capabilities.deny),
-                    "environment_requirements": list(profile.environment_requirements),
-                    "approval_intent": profile.approval_intent,
-                    "governance_pack": {
-                        "pack_id": manifest.pack_id,
-                        "pack_version": manifest.pack_version,
-                        "source_object_id": profile.profile_id,
+                )
+
+            for assignment in pack.assignments:
+                profile_id = profile_ids_by_template.get(assignment.capability_profile_id)
+                if profile_id is None:
+                    blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
+                    continue
+
+                approval_template_id = assignment.approval_template_id
+                if approval_template_id is None and assignment.persona_template_id is not None:
+                    approval_template_id = persona_approval_ids.get(assignment.persona_template_id)
+                approval_policy_id = (
+                    approval_policy_ids_by_template.get(approval_template_id)
+                    if approval_template_id is not None
+                    else None
+                )
+                if approval_template_id is not None and approval_policy_id is None:
+                    blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
+                    continue
+
+                target_id = None
+                if assignment.target_type == "persona" and assignment.persona_template_id is not None:
+                    target_id = persona_ids_by_template.get(assignment.persona_template_id)
+
+                created = await self.repo.create_policy_assignment(
+                    target_type=assignment.target_type,
+                    target_id=target_id,
+                    owner_scope_type=owner_scope_type,
+                    owner_scope_id=owner_scope_id,
+                    profile_id=profile_id,
+                    inline_policy_document={
+                        "persona_template_id": assignment.persona_template_id,
+                        "approval_template_id": approval_template_id,
+                        "capability_profile_id": assignment.capability_profile_id,
+                        "governance_pack": {
+                            "pack_id": manifest.pack_id,
+                            "pack_version": manifest.pack_version,
+                            "source_object_id": assignment.assignment_template_id,
+                        },
                     },
-                },
-                actor_id=actor_id,
-                description=profile.description,
-                is_active=True,
-                is_immutable=True,
+                    approval_policy_id=approval_policy_id,
+                    actor_id=actor_id,
+                    is_active=True,
+                    is_immutable=True,
+                )
+                assignment_id = int(created["id"])
+                imported_object_ids["policy_assignments"].append(assignment_id)
+                await self.repo.create_governance_pack_object(
+                    governance_pack_id=governance_pack_id,
+                    object_type="policy_assignment",
+                    object_id=assignment_id,
+                    source_object_id=assignment.assignment_template_id,
+                )
+        except Exception:
+            await self._rollback_import(
+                governance_pack_id=governance_pack_id,
+                imported_object_ids=imported_object_ids,
             )
-            profile_id = int(created["id"])
-            profile_ids_by_template[profile.profile_id] = profile_id
-            imported_object_ids["permission_profiles"].append(profile_id)
-            await self.repo.create_governance_pack_object(
-                governance_pack_id=int(pack_row["id"]),
-                object_type="permission_profile",
-                object_id=profile_id,
-                source_object_id=profile.profile_id,
-            )
-
-        for assignment in pack.assignments:
-            profile_id = profile_ids_by_template.get(assignment.capability_profile_id)
-            if profile_id is None:
-                blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
-                continue
-
-            approval_template_id = assignment.approval_template_id
-            if approval_template_id is None and assignment.persona_template_id is not None:
-                approval_template_id = persona_approval_ids.get(assignment.persona_template_id)
-            approval_policy_id = (
-                approval_policy_ids_by_template.get(approval_template_id)
-                if approval_template_id is not None
-                else None
-            )
-            if approval_template_id is not None and approval_policy_id is None:
-                blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
-                continue
-
-            target_id = None
-            if assignment.target_type == "persona" and assignment.persona_template_id is not None:
-                target_id = persona_ids_by_template.get(assignment.persona_template_id)
-
-            created = await self.repo.create_policy_assignment(
-                target_type=assignment.target_type,
-                target_id=target_id,
-                owner_scope_type=owner_scope_type,
-                owner_scope_id=owner_scope_id,
-                profile_id=profile_id,
-                inline_policy_document={
-                    "persona_template_id": assignment.persona_template_id,
-                    "approval_template_id": approval_template_id,
-                    "capability_profile_id": assignment.capability_profile_id,
-                    "governance_pack": {
-                        "pack_id": manifest.pack_id,
-                        "pack_version": manifest.pack_version,
-                        "source_object_id": assignment.assignment_template_id,
-                    },
-                },
-                approval_policy_id=approval_policy_id,
-                actor_id=actor_id,
-                is_active=True,
-                is_immutable=True,
-            )
-            assignment_id = int(created["id"])
-            imported_object_ids["policy_assignments"].append(assignment_id)
-            await self.repo.create_governance_pack_object(
-                governance_pack_id=int(pack_row["id"]),
-                object_type="policy_assignment",
-                object_id=assignment_id,
-                source_object_id=assignment.assignment_template_id,
-            )
+            raise
 
         return GovernancePackImportResult(
-            governance_pack_id=int(pack_row["id"]),
+            governance_pack_id=governance_pack_id,
             imported_object_ids=imported_object_ids,
             imported_object_counts={
                 key: len(value) for key, value in imported_object_ids.items()

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+    ApprovalTemplate,
+    AssignmentTemplate,
+    CapabilityProfile,
     GovernancePack,
+    GovernancePackManifest,
+    PersonaTemplate,
     build_opa_bundle,
     normalize_governance_pack,
     validate_governance_pack,
@@ -15,6 +21,22 @@ from tldw_Server_API.app.core.MCP_unified.governance_packs import (
 _RUNTIME_APPROVAL_MODE_MAP = {
     "allow": "allow_silently",
     "ask": "ask_every_time",
+}
+_SUPPORTED_PORTABLE_CAPABILITIES = {
+    "filesystem.read",
+    "filesystem.write",
+    "mcp.server.connect",
+    "network.external.fetch",
+    "network.external.search",
+    "process.execute.safe",
+    "tool.invoke.code_edit",
+    "tool.invoke.research",
+}
+_SUPPORTED_ENVIRONMENT_REQUIREMENTS = {
+    "local_mapping_required",
+    "no_external_secrets",
+    "workspace_bounded_read",
+    "workspace_bounded_write",
 }
 
 
@@ -35,11 +57,174 @@ class GovernancePackImportResult(BaseModel):
     blocked_objects: list[str] = Field(default_factory=list)
 
 
+class GovernancePackDryRunReport(BaseModel):
+    manifest: dict[str, Any] = Field(default_factory=dict)
+    digest: str
+    resolved_capabilities: list[str] = Field(default_factory=list)
+    unresolved_capabilities: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    blocked_objects: list[str] = Field(default_factory=list)
+    verdict: str
+
+
 class McpHubGovernancePackService:
     """Materialize schema-first governance packs into immutable MCP Hub base objects."""
 
     def __init__(self, repo: McpHubRepo):
         self.repo = repo
+
+    @staticmethod
+    def build_pack_from_document(document: dict[str, Any]) -> GovernancePack:
+        payload = dict(document or {})
+        return GovernancePack(
+            source_path=Path("<api>"),
+            manifest=GovernancePackManifest.model_validate(payload.get("manifest") or {}),
+            profiles=[
+                CapabilityProfile.model_validate(item)
+                for item in payload.get("profiles") or []
+            ],
+            approvals=[
+                ApprovalTemplate.model_validate(item)
+                for item in payload.get("approvals") or []
+            ],
+            personas=[
+                PersonaTemplate.model_validate(item)
+                for item in payload.get("personas") or []
+            ],
+            assignments=[
+                AssignmentTemplate.model_validate(item)
+                for item in payload.get("assignments") or []
+            ],
+            raw_profiles=[dict(item) for item in payload.get("profiles") or []],
+            raw_approvals=[dict(item) for item in payload.get("approvals") or []],
+            raw_personas=[dict(item) for item in payload.get("personas") or []],
+            raw_assignments=[dict(item) for item in payload.get("assignments") or []],
+        )
+
+    async def dry_run_pack(
+        self,
+        *,
+        pack: GovernancePack,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> GovernancePackDryRunReport:
+        del owner_scope_type, owner_scope_id
+
+        validation = validate_governance_pack(pack)
+        if validation.errors:
+            raise ValueError("; ".join(validation.errors))
+
+        bundle = build_opa_bundle(pack)
+        resolved_capabilities: list[str] = []
+        unresolved_capabilities: list[str] = []
+        warnings: list[str] = []
+        blocked_objects: list[str] = []
+
+        for profile in pack.profiles:
+            for capability in list(profile.capabilities.allow) + list(profile.capabilities.deny):
+                capability_value = str(capability or "").strip()
+                if not capability_value:
+                    continue
+                if capability_value in _SUPPORTED_PORTABLE_CAPABILITIES:
+                    if capability_value not in resolved_capabilities:
+                        resolved_capabilities.append(capability_value)
+                elif capability_value not in unresolved_capabilities:
+                    unresolved_capabilities.append(capability_value)
+            for requirement in profile.environment_requirements:
+                requirement_value = str(requirement or "").strip()
+                if requirement_value and requirement_value not in _SUPPORTED_ENVIRONMENT_REQUIREMENTS:
+                    warnings.append(
+                        f"profile:{profile.profile_id} uses unsupported environment requirement '{requirement_value}'"
+                    )
+
+        for approval in pack.approvals:
+            if str(approval.mode or "").strip().lower() not in _RUNTIME_APPROVAL_MODE_MAP:
+                blocked_objects.append(f"approval_template:{approval.approval_template_id}")
+                warnings.append(
+                    f"approval template '{approval.approval_template_id}' cannot map to a local runtime approval mode"
+                )
+
+        verdict = "importable"
+        if unresolved_capabilities or blocked_objects:
+            verdict = "blocked"
+
+        return GovernancePackDryRunReport(
+            manifest={
+                "pack_id": pack.manifest.pack_id,
+                "pack_version": pack.manifest.pack_version,
+                "title": pack.manifest.title,
+                "description": pack.manifest.description,
+            },
+            digest=bundle.digest,
+            resolved_capabilities=resolved_capabilities,
+            unresolved_capabilities=unresolved_capabilities,
+            warnings=warnings,
+            blocked_objects=blocked_objects,
+            verdict=verdict,
+        )
+
+    async def dry_run_pack_document(
+        self,
+        *,
+        document: dict[str, Any],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> GovernancePackDryRunReport:
+        pack = self.build_pack_from_document(document)
+        return await self.dry_run_pack(
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def import_pack_document(
+        self,
+        *,
+        document: dict[str, Any],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+    ) -> dict[str, Any]:
+        pack = self.build_pack_from_document(document)
+        report = await self.dry_run_pack(
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+        if report.verdict != "importable":
+            raise ValueError("Governance pack dry-run did not pass")
+        imported = await self.import_pack(
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            actor_id=actor_id,
+        )
+        return {
+            "governance_pack_id": imported.governance_pack_id,
+            "imported_object_counts": dict(imported.imported_object_counts),
+            "blocked_objects": list(imported.blocked_objects),
+            "report": report.model_dump(),
+        }
+
+    async def list_governance_packs(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return await self.repo.list_governance_packs(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def get_governance_pack_detail(self, governance_pack_id: int) -> dict[str, Any] | None:
+        pack_row = await self.repo.get_governance_pack(governance_pack_id)
+        if pack_row is None:
+            return None
+        return {
+            **pack_row,
+            "imported_objects": await self.repo.list_governance_pack_objects(governance_pack_id),
+        }
 
     async def import_pack(
         self,

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+    GovernancePack,
+    build_opa_bundle,
+    normalize_governance_pack,
+    validate_governance_pack,
+)
+
+_RUNTIME_APPROVAL_MODE_MAP = {
+    "allow": "allow_silently",
+    "ask": "ask_every_time",
+}
+
+
+def _dump_model(model: Any) -> dict[str, Any]:
+    if hasattr(model, "model_dump"):
+        return model.model_dump(exclude_none=True)
+    return model.dict(exclude_none=True)
+
+
+def _imported_name(display_name: str, *, pack_id: str, source_object_id: str) -> str:
+    return f"{display_name} [{pack_id}:{source_object_id}]"
+
+
+class GovernancePackImportResult(BaseModel):
+    governance_pack_id: int
+    imported_object_ids: dict[str, list[int]] = Field(default_factory=dict)
+    imported_object_counts: dict[str, int] = Field(default_factory=dict)
+    blocked_objects: list[str] = Field(default_factory=list)
+
+
+class McpHubGovernancePackService:
+    """Materialize schema-first governance packs into immutable MCP Hub base objects."""
+
+    def __init__(self, repo: McpHubRepo):
+        self.repo = repo
+
+    async def import_pack(
+        self,
+        *,
+        pack: GovernancePack,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+    ) -> GovernancePackImportResult:
+        validation = validate_governance_pack(pack)
+        if validation.errors:
+            raise ValueError("; ".join(validation.errors))
+
+        normalized_ir = normalize_governance_pack(pack)
+        bundle = build_opa_bundle(pack)
+        manifest = pack.manifest
+        pack_row = await self.repo.create_governance_pack(
+            pack_id=manifest.pack_id,
+            pack_version=manifest.pack_version,
+            pack_schema_version=manifest.pack_schema_version,
+            capability_taxonomy_version=manifest.capability_taxonomy_version,
+            adapter_contract_version=manifest.adapter_contract_version,
+            title=manifest.title,
+            description=manifest.description,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            bundle_digest=bundle.digest,
+            manifest=_dump_model(manifest),
+            normalized_ir=normalized_ir.to_dict(),
+            actor_id=actor_id,
+        )
+        if not pack_row:
+            raise RuntimeError("Failed to persist governance pack manifest")
+
+        blocked_objects: list[str] = []
+        imported_object_ids: dict[str, list[int]] = {
+            "approval_policies": [],
+            "permission_profiles": [],
+            "policy_assignments": [],
+        }
+        approval_policy_ids_by_template: dict[str, int] = {}
+        profile_ids_by_template: dict[str, int] = {}
+        persona_ids_by_template: dict[str, str] = {
+            persona.persona_template_id: persona.persona_template_id
+            for persona in pack.personas
+        }
+        persona_approval_ids: dict[str, str] = {
+            persona.persona_template_id: persona.approval_template_id
+            for persona in pack.personas
+        }
+
+        for approval in pack.approvals:
+            runtime_mode = _RUNTIME_APPROVAL_MODE_MAP.get(str(approval.mode or "").strip().lower())
+            if runtime_mode is None:
+                blocked_objects.append(f"approval_template:{approval.approval_template_id}")
+                continue
+            created = await self.repo.create_approval_policy(
+                name=_imported_name(
+                    approval.name,
+                    pack_id=manifest.pack_id,
+                    source_object_id=approval.approval_template_id,
+                ),
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                mode=runtime_mode,
+                rules={
+                    "portable_mode": approval.mode,
+                    "approval_template_id": approval.approval_template_id,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": approval.approval_template_id,
+                    },
+                },
+                actor_id=actor_id,
+                description=approval.name,
+                is_active=True,
+                is_immutable=True,
+            )
+            approval_id = int(created["id"])
+            approval_policy_ids_by_template[approval.approval_template_id] = approval_id
+            imported_object_ids["approval_policies"].append(approval_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=int(pack_row["id"]),
+                object_type="approval_policy",
+                object_id=approval_id,
+                source_object_id=approval.approval_template_id,
+            )
+
+        for profile in pack.profiles:
+            created = await self.repo.create_permission_profile(
+                name=_imported_name(
+                    profile.name,
+                    pack_id=manifest.pack_id,
+                    source_object_id=profile.profile_id,
+                ),
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                mode="preset",
+                policy_document={
+                    "capabilities": list(profile.capabilities.allow),
+                    "denied_capabilities": list(profile.capabilities.deny),
+                    "environment_requirements": list(profile.environment_requirements),
+                    "approval_intent": profile.approval_intent,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": profile.profile_id,
+                    },
+                },
+                actor_id=actor_id,
+                description=profile.description,
+                is_active=True,
+                is_immutable=True,
+            )
+            profile_id = int(created["id"])
+            profile_ids_by_template[profile.profile_id] = profile_id
+            imported_object_ids["permission_profiles"].append(profile_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=int(pack_row["id"]),
+                object_type="permission_profile",
+                object_id=profile_id,
+                source_object_id=profile.profile_id,
+            )
+
+        for assignment in pack.assignments:
+            profile_id = profile_ids_by_template.get(assignment.capability_profile_id)
+            if profile_id is None:
+                blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
+                continue
+
+            approval_template_id = assignment.approval_template_id
+            if approval_template_id is None and assignment.persona_template_id is not None:
+                approval_template_id = persona_approval_ids.get(assignment.persona_template_id)
+            approval_policy_id = (
+                approval_policy_ids_by_template.get(approval_template_id)
+                if approval_template_id is not None
+                else None
+            )
+            if approval_template_id is not None and approval_policy_id is None:
+                blocked_objects.append(f"assignment_template:{assignment.assignment_template_id}")
+                continue
+
+            target_id = None
+            if assignment.target_type == "persona" and assignment.persona_template_id is not None:
+                target_id = persona_ids_by_template.get(assignment.persona_template_id)
+
+            created = await self.repo.create_policy_assignment(
+                target_type=assignment.target_type,
+                target_id=target_id,
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                profile_id=profile_id,
+                inline_policy_document={
+                    "persona_template_id": assignment.persona_template_id,
+                    "approval_template_id": approval_template_id,
+                    "capability_profile_id": assignment.capability_profile_id,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": assignment.assignment_template_id,
+                    },
+                },
+                approval_policy_id=approval_policy_id,
+                actor_id=actor_id,
+                is_active=True,
+                is_immutable=True,
+            )
+            assignment_id = int(created["id"])
+            imported_object_ids["policy_assignments"].append(assignment_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=int(pack_row["id"]),
+                object_type="policy_assignment",
+                object_id=assignment_id,
+                source_object_id=assignment.assignment_template_id,
+            )
+
+        return GovernancePackImportResult(
+            governance_pack_id=int(pack_row["id"]),
+            imported_object_ids=imported_object_ids,
+            imported_object_counts={
+                key: len(value) for key, value in imported_object_ids.items()
+            },
+            blocked_objects=blocked_objects,
+        )

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
@@ -25,6 +25,8 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
             'mcp_external_server_credential_slots',
             'mcp_external_server_secrets',
             'mcp_external_server_slot_secrets',
+            'mcp_governance_pack_objects',
+            'mcp_governance_packs',
             'mcp_permission_profiles',
             'mcp_policy_assignments',
             'mcp_policy_audit_history',
@@ -45,6 +47,8 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
     assert "mcp_external_server_credential_slots" in names
     assert "mcp_external_server_secrets" in names
     assert "mcp_external_server_slot_secrets" in names
+    assert "mcp_governance_pack_objects" in names
+    assert "mcp_governance_packs" in names
     assert "mcp_permission_profiles" in names
     assert "mcp_policy_assignments" in names
     assert "mcp_policy_audit_history" in names
@@ -78,18 +82,84 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
     override_column_names = {str(row["column_name"]) for row in override_column_rows}
     assert "is_active" in override_column_names
 
+    governance_pack_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_governance_packs'
+          AND column_name IN (
+            'pack_id',
+            'pack_version',
+            'bundle_digest',
+            'manifest_json',
+            'normalized_ir_json',
+            'owner_scope_type',
+            'owner_scope_id'
+          )
+        """
+    )
+    governance_pack_column_names = {str(row["column_name"]) for row in governance_pack_column_rows}
+    assert "pack_id" in governance_pack_column_names
+    assert "pack_version" in governance_pack_column_names
+    assert "bundle_digest" in governance_pack_column_names
+    assert "manifest_json" in governance_pack_column_names
+    assert "normalized_ir_json" in governance_pack_column_names
+    assert "owner_scope_type" in governance_pack_column_names
+    assert "owner_scope_id" in governance_pack_column_names
+
+    governance_object_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_governance_pack_objects'
+          AND column_name IN ('governance_pack_id', 'object_type', 'object_id', 'source_object_id')
+        """
+    )
+    governance_object_column_names = {str(row["column_name"]) for row in governance_object_column_rows}
+    assert "governance_pack_id" in governance_object_column_names
+    assert "object_type" in governance_object_column_names
+    assert "object_id" in governance_object_column_names
+    assert "source_object_id" in governance_object_column_names
+
     assignment_column_rows = await test_db_pool.fetch(
         """
         SELECT column_name
         FROM information_schema.columns
         WHERE table_schema = 'public'
           AND table_name = 'mcp_policy_assignments'
-          AND column_name IN ('workspace_source_mode', 'workspace_set_object_id')
+          AND column_name IN ('workspace_source_mode', 'workspace_set_object_id', 'is_immutable')
         """
     )
     assignment_column_names = {str(row["column_name"]) for row in assignment_column_rows}
+    assert "is_immutable" in assignment_column_names
     assert "workspace_source_mode" in assignment_column_names
     assert "workspace_set_object_id" in assignment_column_names
+
+    profile_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_permission_profiles'
+          AND column_name IN ('is_immutable')
+        """
+    )
+    profile_column_names = {str(row["column_name"]) for row in profile_column_rows}
+    assert "is_immutable" in profile_column_names
+
+    approval_policy_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_approval_policies'
+          AND column_name IN ('is_immutable')
+        """
+    )
+    approval_policy_column_names = {str(row["column_name"]) for row in approval_policy_column_rows}
+    assert "is_immutable" in approval_policy_column_names
 
     workspace_set_column_rows = await test_db_pool.fetch(
         """

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_governance_pack_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_governance_pack_migrations.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mcp_hub_governance_pack_tables_exist_after_authnz_migrations_sqlite(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(pool.db_path))
+
+    rows = await pool.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    names = {str(row["name"]) for row in rows}
+
+    assert "mcp_governance_packs" in names
+    assert "mcp_governance_pack_objects" in names
+
+    governance_pack_columns = await pool.fetchall("PRAGMA table_info(mcp_governance_packs)")
+    governance_pack_column_names = {str(row["name"]) for row in governance_pack_columns}
+    assert "pack_id" in governance_pack_column_names
+    assert "pack_version" in governance_pack_column_names
+    assert "bundle_digest" in governance_pack_column_names
+    assert "manifest_json" in governance_pack_column_names
+    assert "normalized_ir_json" in governance_pack_column_names
+    assert "owner_scope_type" in governance_pack_column_names
+    assert "owner_scope_id" in governance_pack_column_names
+
+    governance_object_columns = await pool.fetchall("PRAGMA table_info(mcp_governance_pack_objects)")
+    governance_object_column_names = {str(row["name"]) for row in governance_object_columns}
+    assert "governance_pack_id" in governance_object_column_names
+    assert "object_type" in governance_object_column_names
+    assert "object_id" in governance_object_column_names
+    assert "source_object_id" in governance_object_column_names
+
+    profile_columns = await pool.fetchall("PRAGMA table_info(mcp_permission_profiles)")
+    profile_column_names = {str(row["name"]) for row in profile_columns}
+    assert "is_immutable" in profile_column_names
+
+    assignment_columns = await pool.fetchall("PRAGMA table_info(mcp_policy_assignments)")
+    assignment_column_names = {str(row["name"]) for row in assignment_columns}
+    assert "is_immutable" in assignment_column_names
+
+    approval_columns = await pool.fetchall("PRAGMA table_info(mcp_approval_policies)")
+    approval_column_names = {str(row["name"]) for row in approval_columns}
+    assert "is_immutable" in approval_column_names

--- a/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/approvals/ask.yaml
+++ b/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/approvals/ask.yaml
@@ -1,0 +1,3 @@
+approval_template_id: researcher.ask
+name: Ask Before Use
+mode: ask

--- a/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/assignments/default.yaml
+++ b/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/assignments/default.yaml
@@ -1,0 +1,5 @@
+assignment_template_id: researcher.default
+target_type: default
+capability_profile_id: researcher.profile
+persona_template_id: researcher.persona
+approval_template_id: researcher.ask

--- a/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/manifest.yaml
+++ b/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/manifest.yaml
@@ -1,0 +1,12 @@
+pack_id: researcher-pack
+pack_version: 1.0.0
+pack_schema_version: 1
+capability_taxonomy_version: 1
+adapter_contract_version: 1
+title: Researcher Pack
+description: Minimal governance pack fixture for validation tests.
+authors:
+  - codex
+compatible_runtime_targets:
+  - tldw
+  - acp

--- a/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/personas/researcher.yaml
+++ b/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/personas/researcher.yaml
@@ -1,0 +1,7 @@
+persona_template_id: researcher.persona
+name: Research Companion
+description: Research-oriented persona template.
+capability_profile_id: researcher.profile
+approval_template_id: researcher.ask
+persona_traits:
+  - researcher

--- a/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/profiles/researcher.yaml
+++ b/tldw_Server_API/tests/MCP_unified/fixtures/governance_packs/minimal_researcher_pack/profiles/researcher.yaml
@@ -1,0 +1,10 @@
+profile_id: researcher.profile
+name: Researcher
+description: Read-oriented research capability profile.
+capabilities:
+  allow:
+    - filesystem.read
+    - tool.invoke.research
+approval_intent: ask
+environment_requirements:
+  - workspace_bounded_read

--- a/tldw_Server_API/tests/MCP_unified/snapshots/governance_pack_minimal_bundle.json
+++ b/tldw_Server_API/tests/MCP_unified/snapshots/governance_pack_minimal_bundle.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "approvals": [
+      {
+        "approval_template_id": "researcher.ask",
+        "mode": "ask",
+        "name": "Ask Before Use"
+      }
+    ],
+    "assignments": [
+      {
+        "approval_template_id": "researcher.ask",
+        "assignment_template_id": "researcher.default",
+        "capability_profile_id": "researcher.profile",
+        "persona_template_id": "researcher.persona",
+        "target_type": "default"
+      }
+    ],
+    "personas": [
+      {
+        "approval_template_id": "researcher.ask",
+        "capability_profile_id": "researcher.profile",
+        "description": "Research-oriented persona template.",
+        "name": "Research Companion",
+        "persona_template_id": "researcher.persona",
+        "persona_traits": [
+          "researcher"
+        ]
+      }
+    ],
+    "profiles": [
+      {
+        "approval_intent": "ask",
+        "capabilities": {
+          "allow": [
+            "filesystem.read",
+            "tool.invoke.research"
+          ],
+          "deny": []
+        },
+        "description": "Read-oriented research capability profile.",
+        "environment_requirements": [
+          "workspace_bounded_read"
+        ],
+        "name": "Researcher",
+        "profile_id": "researcher.profile"
+      }
+    ]
+  },
+  "manifest": {
+    "adapter_contract_version": 1,
+    "authors": [
+      "codex"
+    ],
+    "capability_taxonomy_version": 1,
+    "compatible_runtime_targets": [
+      "tldw",
+      "acp"
+    ],
+    "description": "Minimal governance pack fixture for validation tests.",
+    "pack_id": "researcher-pack",
+    "pack_schema_version": 1,
+    "pack_version": "1.0.0",
+    "title": "Researcher Pack"
+  }
+}

--- a/tldw_Server_API/tests/MCP_unified/test_governance_pack_opa_bundle.py
+++ b/tldw_Server_API/tests/MCP_unified/test_governance_pack_opa_bundle.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.governance_packs.fixtures import (
+    load_governance_pack_fixture,
+)
+from tldw_Server_API.app.core.MCP_unified.governance_packs.normalize import (
+    normalize_governance_pack,
+)
+from tldw_Server_API.app.core.MCP_unified.governance_packs.opa_bundle import (
+    build_opa_bundle,
+)
+
+
+def _copy_pack_to_tmp(tmp_path: Path) -> Path:
+    source = Path(__file__).resolve().parent / "fixtures" / "governance_packs" / "minimal_researcher_pack"
+    target = tmp_path / "minimal_researcher_pack"
+    shutil.copytree(source, target)
+    return target
+
+
+def _load_snapshot(name: str) -> dict[str, object]:
+    snapshot_path = Path(__file__).resolve().parent / "snapshots" / name
+    return json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.unit
+def test_normalized_ir_and_bundle_are_deterministic() -> None:
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+
+    first_ir = normalize_governance_pack(pack)
+    second_ir = normalize_governance_pack(pack)
+    first_bundle = build_opa_bundle(pack)
+    second_bundle = build_opa_bundle(pack)
+
+    assert first_ir.to_dict() == second_ir.to_dict()
+    assert first_bundle.digest == second_bundle.digest
+    assert first_bundle.bundle_json == second_bundle.bundle_json
+
+
+@pytest.mark.unit
+def test_generated_bundle_matches_snapshot() -> None:
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+
+    bundle = build_opa_bundle(pack)
+
+    assert bundle.bundle_json == _load_snapshot("governance_pack_minimal_bundle.json")
+
+
+@pytest.mark.unit
+def test_bundle_digest_changes_when_pack_changes(tmp_path: Path) -> None:
+    original_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    pack_dir = _copy_pack_to_tmp(tmp_path)
+    profile_path = pack_dir / "profiles" / "researcher.yaml"
+    profile_path.write_text(
+        "\n".join(
+            [
+                "profile_id: researcher.profile",
+                "name: Researcher",
+                "description: Read-oriented research capability profile.",
+                "capabilities:",
+                "  allow:",
+                "    - filesystem.read",
+                "    - tool.invoke.research",
+                "    - network.external.search",
+                "approval_intent: ask",
+                "environment_requirements:",
+                "  - workspace_bounded_read",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    updated_pack = load_governance_pack_fixture(pack_dir)
+
+    original_bundle = build_opa_bundle(original_pack)
+    updated_bundle = build_opa_bundle(updated_pack)
+
+    assert original_bundle.digest != updated_bundle.digest
+
+
+@pytest.mark.unit
+def test_generated_bundle_excludes_runtime_only_persona_fields() -> None:
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+
+    bundle = build_opa_bundle(pack)
+    serialized = json.dumps(bundle.bundle_json, sort_keys=True)
+
+    assert "memory_snapshot" not in serialized
+    assert "session_history" not in serialized

--- a/tldw_Server_API/tests/MCP_unified/test_governance_pack_validation.py
+++ b/tldw_Server_API/tests/MCP_unified/test_governance_pack_validation.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.governance_packs.fixtures import (
+    load_governance_pack_fixture,
+)
+from tldw_Server_API.app.core.MCP_unified.governance_packs.validation import (
+    validate_governance_pack,
+)
+
+
+def _copy_pack_to_tmp(tmp_path: Path) -> Path:
+    source = Path(__file__).resolve().parent / "fixtures" / "governance_packs" / "minimal_researcher_pack"
+    target = tmp_path / "minimal_researcher_pack"
+    shutil.copytree(source, target)
+    return target
+
+
+@pytest.mark.unit
+def test_validate_minimal_pack() -> None:
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+
+    result = validate_governance_pack(pack)
+
+    assert result.errors == []
+    assert result.manifest is not None
+    assert result.manifest.pack_id == "researcher-pack"
+
+
+@pytest.mark.unit
+def test_validate_pack_reports_missing_profile_reference(tmp_path: Path) -> None:
+    pack_dir = _copy_pack_to_tmp(tmp_path)
+    persona_path = pack_dir / "personas" / "researcher.yaml"
+    persona_path.write_text(
+        "\n".join(
+            [
+                "persona_template_id: researcher.persona",
+                "name: Research Companion",
+                "description: Research-oriented persona template.",
+                "capability_profile_id: missing.profile",
+                "approval_template_id: researcher.ask",
+                "persona_traits:",
+                "  - researcher",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pack = load_governance_pack_fixture(pack_dir)
+
+    result = validate_governance_pack(pack)
+
+    assert "Unknown capability profile reference: missing.profile" in result.errors
+
+
+@pytest.mark.unit
+def test_validate_pack_reports_duplicate_stable_ids(tmp_path: Path) -> None:
+    pack_dir = _copy_pack_to_tmp(tmp_path)
+    duplicate_profile_path = pack_dir / "profiles" / "duplicate.yaml"
+    duplicate_profile_path.write_text(
+        "\n".join(
+            [
+                "profile_id: researcher.profile",
+                "name: Duplicate",
+                "description: Intentional duplicate id.",
+                "capabilities:",
+                "  allow:",
+                "    - tool.invoke.notes",
+                "approval_intent: ask",
+                "environment_requirements: []",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pack = load_governance_pack_fixture(pack_dir)
+
+    result = validate_governance_pack(pack)
+
+    assert "Duplicate profile_id: researcher.profile" in result.errors
+
+
+@pytest.mark.unit
+def test_validate_pack_reports_unsupported_taxonomy_version(tmp_path: Path) -> None:
+    pack_dir = _copy_pack_to_tmp(tmp_path)
+    manifest_path = pack_dir / "manifest.yaml"
+    manifest_path.write_text(
+        "\n".join(
+            [
+                "pack_id: researcher-pack",
+                "pack_version: 1.0.0",
+                "pack_schema_version: 1",
+                "capability_taxonomy_version: 99",
+                "adapter_contract_version: 1",
+                "title: Researcher Pack",
+                "description: Minimal governance pack fixture for validation tests.",
+                "authors:",
+                "  - codex",
+                "compatible_runtime_targets:",
+                "  - tldw",
+                "  - acp",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pack = load_governance_pack_fixture(pack_dir)
+
+    result = validate_governance_pack(pack)
+
+    assert "Unsupported capability_taxonomy_version: 99" in result.errors
+
+
+@pytest.mark.unit
+def test_validate_pack_rejects_runtime_only_persona_fields(tmp_path: Path) -> None:
+    pack_dir = _copy_pack_to_tmp(tmp_path)
+    persona_path = pack_dir / "personas" / "researcher.yaml"
+    persona_path.write_text(
+        "\n".join(
+            [
+                "persona_template_id: researcher.persona",
+                "name: Research Companion",
+                "description: Research-oriented persona template.",
+                "capability_profile_id: researcher.profile",
+                "approval_template_id: researcher.ask",
+                "persona_traits:",
+                "  - researcher",
+                "memory_snapshot:",
+                "  note: forbidden",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    pack = load_governance_pack_fixture(pack_dir)
+
+    result = validate_governance_pack(pack)
+
+    assert "Persona template researcher.persona contains runtime-only field: memory_snapshot" in result.errors

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_external_auth_bridge.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_external_auth_bridge.py
@@ -9,6 +9,10 @@ def _b64_key(byte_char: bytes) -> str:
     return base64.b64encode(byte_char * 32).decode("ascii")
 
 
+def _slot_secret(label: str) -> str:
+    return f"{label}-credential-value"
+
+
 @pytest.mark.asyncio
 async def test_managed_external_auth_bridge_hydrates_bearer_token(monkeypatch) -> None:
     monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
@@ -18,6 +22,7 @@ async def test_managed_external_auth_bridge_hydrates_bearer_token(monkeypatch) -
     )
 
     bridge = ManagedExternalAuthBridge()
+    secret_value = _slot_secret("primary")
     auth = await bridge.hydrate_runtime_auth(
         server_config={
             "transport": "websocket",
@@ -26,10 +31,10 @@ async def test_managed_external_auth_bridge_hydrates_bearer_token(monkeypatch) -
                 "auth": {"mode": "bearer_token"},
             },
         },
-        secret_payload={"secret": "super-secret-token"},
+        secret_payload={"secret": secret_value},
     )
 
-    assert auth["headers"]["Authorization"] == "Bearer super-secret-token"
+    assert auth["headers"]["Authorization"] == f"Bearer {secret_value}"
 
 
 @pytest.mark.asyncio
@@ -39,6 +44,7 @@ async def test_managed_external_auth_bridge_rejects_unsupported_auth_mode() -> N
     )
 
     bridge = ManagedExternalAuthBridge()
+    secret_value = _slot_secret("unsupported-mode")
 
     with pytest.raises(ValueError):
         await bridge.hydrate_runtime_auth(
@@ -48,7 +54,7 @@ async def test_managed_external_auth_bridge_rejects_unsupported_auth_mode() -> N
                     "auth": {"mode": "sigv4_env"},
                 },
             },
-            secret_payload={"secret": "super-secret-token"},
+            secret_payload={"secret": secret_value},
         )
 
 
@@ -62,6 +68,7 @@ async def test_managed_external_auth_bridge_hydrates_named_required_slot() -> No
         )
 
         bridge = ManagedExternalAuthBridge()
+        secret_value = _slot_secret("readonly")
         auth = await bridge.hydrate_runtime_auth(
             server_config={
                 "transport": "websocket",
@@ -82,12 +89,12 @@ async def test_managed_external_auth_bridge_hydrates_named_required_slot() -> No
             },
             secret_payload={
                 "slots": {
-                    "token_readonly": "super-secret-token",
+                    "token_readonly": secret_value,
                 }
             },
         )
 
-        assert auth["headers"]["Authorization"] == "Bearer super-secret-token"
+        assert auth["headers"]["Authorization"] == f"Bearer {secret_value}"
     finally:
         monkeypatch.undo()
 
@@ -99,6 +106,7 @@ async def test_managed_external_auth_bridge_hydrates_template_header_mapping() -
     )
 
     bridge = ManagedExternalAuthBridge()
+    secret_value = _slot_secret("template-header")
     auth = await bridge.hydrate_runtime_auth(
         server_config={
             "transport": "websocket",
@@ -119,10 +127,44 @@ async def test_managed_external_auth_bridge_hydrates_template_header_mapping() -
                 },
             },
         },
-        secret_payload={"slots": {"token_readonly": "super-secret-token"}},
+        secret_payload={"slots": {"token_readonly": secret_value}},
     )
 
-    assert auth["headers"]["Authorization"] == "Bearer super-secret-token"
+    assert auth["headers"]["Authorization"] == f"Bearer {secret_value}"
+
+
+@pytest.mark.asyncio
+async def test_managed_external_auth_bridge_preserves_custom_template_header_name() -> None:
+    from tldw_Server_API.app.services.mcp_hub_external_auth_service import (
+        ManagedExternalAuthBridge,
+    )
+
+    bridge = ManagedExternalAuthBridge()
+    secret_value = _slot_secret("custom-header")
+    auth = await bridge.hydrate_runtime_auth(
+        server_config={
+            "transport": "websocket",
+            "config": {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "X-DOCS-TOKEN",
+                            "prefix": "Token ",
+                            "suffix": "",
+                            "required": True,
+                        }
+                    ],
+                },
+            },
+        },
+        secret_payload={"slots": {"token_readonly": secret_value}},
+    )
+
+    assert auth["headers"] == {"X-DOCS-TOKEN": f"Token {secret_value}"}
 
 
 @pytest.mark.asyncio
@@ -132,6 +174,7 @@ async def test_managed_external_auth_bridge_hydrates_template_env_mapping() -> N
     )
 
     bridge = ManagedExternalAuthBridge()
+    secret_value = _slot_secret("template-env")
     auth = await bridge.hydrate_runtime_auth(
         server_config={
             "transport": "stdio",
@@ -152,10 +195,10 @@ async def test_managed_external_auth_bridge_hydrates_template_env_mapping() -> N
                 },
             },
         },
-        secret_payload={"slots": {"token_readonly": "super-secret-token"}},
+        secret_payload={"slots": {"token_readonly": secret_value}},
     )
 
-    assert auth["env"]["DOCS_TOKEN"] == "super-secret-token"
+    assert auth["env"]["DOCS_TOKEN"] == secret_value
 
 
 @pytest.mark.asyncio
@@ -165,6 +208,8 @@ async def test_managed_external_auth_bridge_rejects_duplicate_template_targets()
     )
 
     bridge = ManagedExternalAuthBridge()
+    readonly_secret = _slot_secret("readonly")
+    write_secret = _slot_secret("write")
 
     with pytest.raises(ValueError, match="duplicate"):
         await bridge.hydrate_runtime_auth(
@@ -197,8 +242,8 @@ async def test_managed_external_auth_bridge_rejects_duplicate_template_targets()
             },
             secret_payload={
                 "slots": {
-                    "token_readonly": "readonly-token",
-                    "token_write": "write-token",
+                    "token_readonly": readonly_secret,
+                    "token_write": write_secret,
                 }
             },
         )
@@ -211,6 +256,8 @@ async def test_managed_external_auth_bridge_prefers_template_shape_over_legacy_s
     )
 
     bridge = ManagedExternalAuthBridge()
+    legacy_secret = _slot_secret("legacy")
+    readonly_secret = _slot_secret("readonly")
     auth = await bridge.hydrate_runtime_auth(
         server_config={
             "transport": "websocket",
@@ -241,13 +288,13 @@ async def test_managed_external_auth_bridge_prefers_template_shape_over_legacy_s
         },
         secret_payload={
             "slots": {
-                "legacy_token": "legacy-token",
-                "token_readonly": "super-secret-token",
+                "legacy_token": legacy_secret,
+                "token_readonly": readonly_secret,
             }
         },
     )
 
-    assert auth["headers"]["Authorization"] == "Bearer super-secret-token"
+    assert auth["headers"]["Authorization"] == f"Bearer {readonly_secret}"
     assert "X-API-KEY" not in auth["headers"]
 
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+
+def _make_principal(
+    *,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=7,
+        api_key_id=None,
+        subject="7",
+        token_type="access",
+        jti=None,
+        roles=roles or [],
+        permissions=permissions or [],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+class _FakePolicyService:
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self.permission_profiles = [
+            {
+                "id": 5,
+                "name": "Imported Researcher",
+                "description": None,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "mode": "preset",
+                "path_scope_object_id": None,
+                "policy_document": {"capabilities": ["filesystem.read"]},
+                "is_active": True,
+                "is_immutable": False,
+                "created_by": 7,
+                "updated_by": 7,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ]
+
+    async def get_permission_profile(self, profile_id: int):
+        for profile in self.permission_profiles:
+            if int(profile["id"]) == int(profile_id):
+                return dict(profile)
+        return None
+
+    async def update_permission_profile(self, profile_id: int, **kwargs):
+        profile = await self.get_permission_profile(profile_id)
+        if profile is None:
+            return None
+        profile.update(kwargs)
+        self.permission_profiles = [profile]
+        return profile
+
+
+class _FakeGovernancePackService:
+    def __init__(self) -> None:
+        self.dry_run_calls: list[dict] = []
+        self.import_calls: list[dict] = []
+        self.report = {
+            "manifest": {
+                "pack_id": "researcher-pack",
+                "pack_version": "1.0.0",
+                "title": "Researcher Pack",
+                "description": "Portable research governance pack",
+            },
+            "digest": "a" * 64,
+            "resolved_capabilities": ["filesystem.read", "tool.invoke.research"],
+            "unresolved_capabilities": [],
+            "warnings": [],
+            "blocked_objects": [],
+            "verdict": "importable",
+        }
+        self.inventory = [
+            {
+                "id": 81,
+                "pack_id": "researcher-pack",
+                "pack_version": "1.0.0",
+                "title": "Researcher Pack",
+                "description": "Portable research governance pack",
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "bundle_digest": "a" * 64,
+                "manifest": {
+                    "pack_id": "researcher-pack",
+                    "pack_version": "1.0.0",
+                    "title": "Researcher Pack",
+                },
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ]
+        self.detail = {
+            **self.inventory[0],
+            "normalized_ir": {
+                "manifest": self.inventory[0]["manifest"],
+                "data": {
+                    "profiles": [{"profile_id": "researcher.profile"}],
+                    "approvals": [{"approval_template_id": "researcher.ask"}],
+                    "personas": [{"persona_template_id": "researcher.persona"}],
+                    "assignments": [{"assignment_template_id": "researcher.default"}],
+                },
+            },
+            "imported_objects": [
+                {
+                    "object_type": "permission_profile",
+                    "object_id": "5",
+                    "source_object_id": "researcher.profile",
+                },
+                {
+                    "object_type": "policy_assignment",
+                    "object_id": "11",
+                    "source_object_id": "researcher.default",
+                },
+            ],
+        }
+
+    async def dry_run_pack_document(self, **kwargs):
+        self.dry_run_calls.append(dict(kwargs))
+        return dict(self.report)
+
+    async def import_pack_document(self, **kwargs):
+        self.import_calls.append(dict(kwargs))
+        return {
+            "governance_pack_id": 81,
+            "imported_object_counts": {
+                "approval_policies": 1,
+                "permission_profiles": 1,
+                "policy_assignments": 1,
+            },
+            "blocked_objects": [],
+            "report": dict(self.report),
+        }
+
+    async def list_governance_packs(self, **_kwargs):
+        return list(self.inventory)
+
+    async def get_governance_pack_detail(self, governance_pack_id: int):
+        if int(governance_pack_id) == 81:
+            return dict(self.detail)
+        return None
+
+
+def _build_app(
+    principal: AuthPrincipal,
+    *,
+    policy_service: _FakePolicyService | None = None,
+    governance_service: _FakeGovernancePackService | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(mcp_hub_management.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_service] = (
+        lambda: policy_service or _FakePolicyService()
+    )
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_governance_pack_service] = (
+        lambda: governance_service or _FakeGovernancePackService()
+    )
+    return app
+
+
+def _minimal_pack_document() -> dict:
+    return {
+        "manifest": {
+            "pack_id": "researcher-pack",
+            "pack_version": "1.0.0",
+            "pack_schema_version": 1,
+            "capability_taxonomy_version": 1,
+            "adapter_contract_version": 1,
+            "title": "Researcher Pack",
+            "description": "Portable research governance pack",
+            "authors": ["codex"],
+            "compatible_runtime_targets": ["tldw"],
+        },
+        "profiles": [
+            {
+                "profile_id": "researcher.profile",
+                "name": "Researcher",
+                "capabilities": {"allow": ["filesystem.read", "tool.invoke.research"]},
+                "approval_intent": "ask",
+                "environment_requirements": ["workspace_bounded_read"],
+            }
+        ],
+        "approvals": [
+            {
+                "approval_template_id": "researcher.ask",
+                "name": "Ask Before Use",
+                "mode": "ask",
+            }
+        ],
+        "personas": [
+            {
+                "persona_template_id": "researcher.persona",
+                "name": "Research Companion",
+                "capability_profile_id": "researcher.profile",
+                "approval_template_id": "researcher.ask",
+            }
+        ],
+        "assignments": [
+            {
+                "assignment_template_id": "researcher.default",
+                "target_type": "default",
+                "capability_profile_id": "researcher.profile",
+                "approval_template_id": "researcher.ask",
+            }
+        ],
+    }
+
+
+def test_governance_pack_dry_run_returns_compatibility_report() -> None:
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"])
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/dry-run",
+            json={
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["report"]["resolved_capabilities"] == [
+        "filesystem.read",
+        "tool.invoke.research",
+    ]
+    assert payload["report"]["unresolved_capabilities"] == []
+    assert payload["report"]["verdict"] == "importable"
+
+
+def test_governance_pack_import_returns_import_result() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/import",
+            json={
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 201
+    payload = resp.json()
+    assert payload["governance_pack_id"] == 81
+    assert payload["imported_object_counts"]["permission_profiles"] == 1
+    assert governance_service.import_calls
+
+
+def test_update_permission_profile_rejects_immutable_pack_managed_base_object() -> None:
+    policy_service = _FakePolicyService()
+    policy_service.permission_profiles[0]["is_immutable"] = True
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read"]),
+        policy_service=policy_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.put(
+            "/api/v1/mcp/hub/permission-profiles/5",
+            json={"description": "locally edited"},
+        )
+
+    assert resp.status_code == 400
+    assert "immutable" in resp.json()["detail"].lower()
+
+
+def test_governance_pack_list_and_detail_include_provenance() -> None:
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"])
+    )
+
+    with TestClient(app) as client:
+        list_resp = client.get("/api/v1/mcp/hub/governance-packs")
+        detail_resp = client.get("/api/v1/mcp/hub/governance-packs/81")
+
+    assert list_resp.status_code == 200
+    assert list_resp.json()[0]["pack_id"] == "researcher-pack"
+
+    assert detail_resp.status_code == 200
+    detail_payload = detail_resp.json()
+    assert detail_payload["imported_objects"][0]["source_object_id"] == "researcher.profile"
+    assert detail_payload["imported_objects"][1]["object_type"] == "policy_assignment"

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
@@ -11,6 +11,9 @@ from tldw_Server_API.app.api.v1.API_Deps import auth_deps
 from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management
 from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+    GovernancePackAlreadyExistsError,
+)
 
 
 def _make_principal(
@@ -132,12 +135,38 @@ class _FakeGovernancePackService:
             ],
         }
 
-    async def dry_run_pack_document(self, **kwargs):
-        self.dry_run_calls.append(dict(kwargs))
+    async def dry_run_pack_document(
+        self,
+        *,
+        document: dict[str, object],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict[str, object]:
+        self.dry_run_calls.append(
+            {
+                "document": dict(document),
+                "owner_scope_type": owner_scope_type,
+                "owner_scope_id": owner_scope_id,
+            }
+        )
         return dict(self.report)
 
-    async def import_pack_document(self, **kwargs):
-        self.import_calls.append(dict(kwargs))
+    async def import_pack_document(
+        self,
+        *,
+        document: dict[str, object],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+    ) -> dict[str, object]:
+        self.import_calls.append(
+            {
+                "document": dict(document),
+                "owner_scope_type": owner_scope_type,
+                "owner_scope_id": owner_scope_id,
+                "actor_id": actor_id,
+            }
+        )
         return {
             "governance_pack_id": 81,
             "imported_object_counts": {
@@ -149,10 +178,16 @@ class _FakeGovernancePackService:
             "report": dict(self.report),
         }
 
-    async def list_governance_packs(self, **_kwargs):
+    async def list_governance_packs(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, object]]:
+        del owner_scope_type, owner_scope_id
         return list(self.inventory)
 
-    async def get_governance_pack_detail(self, governance_pack_id: int):
+    async def get_governance_pack_detail(self, governance_pack_id: int) -> dict[str, object] | None:
         if int(governance_pack_id) == 81:
             return dict(self.detail)
         return None
@@ -275,6 +310,100 @@ def test_governance_pack_import_returns_import_result() -> None:
     assert payload["governance_pack_id"] == 81
     assert payload["imported_object_counts"]["permission_profiles"] == 1
     assert governance_service.import_calls
+
+
+def test_governance_pack_dry_run_defaults_user_scope_id_from_principal() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/dry-run",
+            json={
+                "owner_scope_type": "user",
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 200
+    assert governance_service.dry_run_calls[0]["owner_scope_id"] == 7
+
+
+def test_governance_pack_import_requires_grant_authority_for_portable_tool_capability() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read"]),
+        governance_service=governance_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/import",
+            json={
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 403
+    assert "grant.tool.invoke" in resp.json()["detail"]
+    assert governance_service.import_calls == []
+
+
+def test_governance_pack_import_defaults_user_scope_id_from_principal() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/import",
+            json={
+                "owner_scope_type": "user",
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 201
+    assert governance_service.import_calls[0]["owner_scope_id"] == 7
+
+
+def test_governance_pack_import_returns_conflict_for_duplicate_pack() -> None:
+    class _DuplicateGovernancePackService(_FakeGovernancePackService):
+        async def import_pack_document(
+            self,
+            *,
+            document: dict[str, object],
+            owner_scope_type: str,
+            owner_scope_id: int | None,
+            actor_id: int | None,
+        ) -> dict[str, object]:
+            del document, owner_scope_type, owner_scope_id, actor_id
+            raise GovernancePackAlreadyExistsError("researcher-pack", "1.0.0", "user", 7)
+
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=_DuplicateGovernancePackService(),
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/import",
+            json={
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "pack": _minimal_pack_document(),
+            },
+        )
+
+    assert resp.status_code == 409
+    assert "already exists" in resp.json()["detail"].lower()
 
 
 def test_update_permission_profile_rejects_immutable_pack_managed_base_object() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_import_governance_pack_materializes_immutable_base_objects_with_provenance(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+    service = McpHubGovernancePackService(repo=repo)
+
+    result = await service.import_pack(
+        pack=pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    assert result.blocked_objects == []
+    assert result.imported_object_counts["approval_policies"] == 1
+    assert result.imported_object_counts["permission_profiles"] == 1
+    assert result.imported_object_counts["policy_assignments"] == 1
+
+    governance_pack = await repo.get_governance_pack(result.governance_pack_id)
+    assert governance_pack is not None
+    assert governance_pack["pack_id"] == "researcher-pack"
+    assert governance_pack["pack_version"] == "1.0.0"
+    assert len(str(governance_pack["bundle_digest"])) == 64
+
+    approval_policy = await repo.get_approval_policy(result.imported_object_ids["approval_policies"][0])
+    assert approval_policy is not None
+    assert approval_policy["is_immutable"] is True
+    assert approval_policy["mode"] == "ask_every_time"
+
+    permission_profile = await repo.get_permission_profile(
+        result.imported_object_ids["permission_profiles"][0]
+    )
+    assert permission_profile is not None
+    assert permission_profile["is_immutable"] is True
+    assert permission_profile["mode"] == "preset"
+    assert permission_profile["policy_document"]["capabilities"] == [
+        "filesystem.read",
+        "tool.invoke.research",
+    ]
+    assert permission_profile["policy_document"]["environment_requirements"] == [
+        "workspace_bounded_read",
+    ]
+
+    profile_link = await repo.get_governance_pack_object(
+        object_type="permission_profile",
+        object_id=permission_profile["id"],
+    )
+    assert profile_link is not None
+    assert profile_link["source_object_id"] == "researcher.profile"
+
+    assignment = await repo.get_policy_assignment(result.imported_object_ids["policy_assignments"][0])
+    assert assignment is not None
+    assert assignment["is_immutable"] is True
+    assert assignment["target_type"] == "default"
+    assert int(assignment["profile_id"]) == int(permission_profile["id"])
+    assert int(assignment["approval_policy_id"]) == int(approval_policy["id"])
+
+    override = await repo.upsert_policy_override(
+        int(assignment["id"]),
+        override_policy_document={"allowed_tools": ["Read"]},
+        broadens_access=False,
+        grant_authority_snapshot={"source": "local-overlay"},
+        actor_id=8,
+        is_active=True,
+    )
+    assert override is not None
+    assert override["override_policy_document"]["allowed_tools"] == ["Read"]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -98,3 +98,111 @@ async def test_import_governance_pack_materializes_immutable_base_objects_with_p
     )
     assert override is not None
     assert override["override_policy_document"]["allowed_tools"] == ["Read"]
+
+
+@pytest.mark.asyncio
+async def test_import_governance_pack_rejects_duplicate_scope_identity(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        GovernancePackAlreadyExistsError,
+        McpHubGovernancePackService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+    service = McpHubGovernancePackService(repo=repo)
+
+    await service.import_pack(
+        pack=pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    with pytest.raises(GovernancePackAlreadyExistsError):
+        await service.import_pack(
+            pack=pack,
+            owner_scope_type="user",
+            owner_scope_id=7,
+            actor_id=7,
+        )
+
+    inventory = await repo.list_governance_packs(owner_scope_type="user", owner_scope_id=7)
+    assert len(inventory) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_governance_pack_rolls_back_partial_objects_on_failure(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    original_create_policy_assignment = repo.create_policy_assignment
+
+    async def _boom_create_policy_assignment(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("assignment insert failed")
+
+    repo.create_policy_assignment = _boom_create_policy_assignment  # type: ignore[method-assign]
+
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+    service = McpHubGovernancePackService(repo=repo)
+
+    with pytest.raises(RuntimeError, match="assignment insert failed"):
+        await service.import_pack(
+            pack=pack,
+            owner_scope_type="user",
+            owner_scope_id=7,
+            actor_id=7,
+        )
+
+    repo.create_policy_assignment = original_create_policy_assignment  # type: ignore[method-assign]
+
+    assert await repo.list_governance_packs(owner_scope_type="user", owner_scope_id=7) == []
+    assert await repo.list_permission_profiles(owner_scope_type="user", owner_scope_id=7) == []
+    assert await repo.list_approval_policies(owner_scope_type="user", owner_scope_id=7) == []
+    assert await repo.list_policy_assignments(owner_scope_type="user", owner_scope_id=7) == []


### PR DESCRIPTION
## Summary
- add schema-first governance pack validation, normalization, and deterministic OPA artifact generation
- import immutable governance packs into MCP Hub with provenance storage and dry-run/import/list/detail APIs
- add MCP Hub governance-pack UI for preview/import plus persona provenance badges

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_governance_pack_validation.py tldw_Server_API/tests/MCP_unified/test_governance_pack_opa_bundle.py tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_governance_pack_migrations.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py -q
- cd apps/packages/ui && bunx vitest run src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx src/services/tldw/__tests__/mcp-hub.test.ts
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/MCP_unified/governance_packs tldw_Server_API/app/services/mcp_hub_governance_pack_service.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py -f json -o /tmp/bandit_governance_packs.json