### PR TITLE
feat(flashcards): add optional per-deck fsrs

### DIFF
--- a/Docs/Plans/2026-03-13-optional-per-deck-fsrs-design.md
+++ b/Docs/Plans/2026-03-13-optional-per-deck-fsrs-design.md
@@ -1,0 +1,382 @@
+# Optional Per-Deck FSRS Design
+
+Date: 2026-03-13
+Status: Approved
+
+## Summary
+
+This slice adds FSRS as an optional per-deck scheduler alongside the existing `sm2_plus` path.
+
+The goal is to let new decks and manually switched decks use FSRS without breaking the current shared study loop, queue model, or deck-management flows.
+
+V1 keeps:
+
+- the current four review ratings
+- the current `review/next` contract
+- the current shared queue states
+- the dedicated `Scheduler` tab as the main scheduler control surface
+
+V1 does not:
+
+- replace `sm2_plus`
+- auto-migrate existing decks
+- reconstruct exact FSRS state from historic SM-2 review logs
+- mix scheduler types inside a single deck
+
+## Current Baseline
+
+The repo already has a substantial scheduler foundation:
+
+- deck-scoped scheduler settings
+- shared queue states for `new`, `learning`, `review`, `relearning`, and `suspended`
+- backend-selected `GET /api/v1/flashcards/review/next`
+- backend-computed `next_intervals`
+- a dedicated `Scheduler` tab plus creation-flow scheduler controls
+
+Relevant code anchors:
+
+- `tldw_Server_API/app/core/Flashcards/scheduler_sm2.py`
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+- `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+- `apps/packages/ui/src/services/flashcards.ts`
+- `apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx`
+- `apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts`
+- `apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx`
+
+## Product Decision
+
+Use FSRS as an optional per-deck scheduler beside the current `sm2_plus` scheduler.
+
+The active scheduler is chosen at the deck level through:
+
+- deck creation flows
+- the dedicated `Scheduler` tab
+
+Existing decks remain on `sm2_plus` unless the user manually switches them.
+
+This is the most pragmatic path because:
+
+- it preserves current behavior for existing users
+- it avoids a risky global scheduler migration
+- it reuses the already-shipped queue model and review endpoints
+- it makes stronger Anki-style scheduling available without forcing a rewrite of the broader flashcards module
+
+## Explicit Decisions
+
+- Add `scheduler_type` per deck with values `sm2_plus | fsrs`.
+- Keep one `scheduler_settings_json` field on the deck row, but store a typed envelope:
+  - `sm2_plus`
+  - `fsrs`
+- Add `scheduler_state_json` on flashcards for scheduler-specific per-card state.
+- Add `scheduler_type` to `flashcard_reviews`.
+- Keep learning and relearning queue behavior shared across both schedulers in v1.
+- Keep `interval_days` as the canonical compatibility interval used by analytics and maturity counts, even when FSRS is active.
+- Bootstrap switched cards into FSRS from the current card snapshot, not by reconstructing historic FSRS memory from old review logs.
+- Keep both scheduler configs stored in the deck settings envelope so switching is reversible.
+
+## Deck Data Model
+
+### Storage
+
+Add:
+
+- `scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'`
+
+Keep:
+
+- `scheduler_settings_json TEXT NOT NULL`
+
+New JSON envelope shape:
+
+```json
+{
+  "sm2_plus": {
+    "new_steps_minutes": [1, 10],
+    "relearn_steps_minutes": [10],
+    "graduating_interval_days": 1,
+    "easy_interval_days": 4,
+    "easy_bonus": 1.3,
+    "interval_modifier": 1.0,
+    "max_interval_days": 36500,
+    "leech_threshold": 8,
+    "enable_fuzz": false
+  },
+  "fsrs": {
+    "target_retention": 0.9,
+    "maximum_interval_days": 36500,
+    "enable_fuzz": false
+  }
+}
+```
+
+Why keep one settings blob:
+
+- lower schema churn than splitting into multiple deck JSON columns
+- smaller sync-log and API migration surface
+- easier compatibility with the existing deck schema/tests
+
+### API Shape
+
+Expose:
+
+- `scheduler_type`
+- `scheduler_settings`
+
+`scheduler_settings` is the envelope object, not just the active scheduler config.
+
+This lets the UI:
+
+- edit the active scheduler cleanly
+- preserve inactive settings for future switching
+- avoid losing per-scheduler edits
+
+## Flashcard Data Model
+
+Add:
+
+- `scheduler_state_json TEXT NOT NULL DEFAULT '{}'`
+
+This stores scheduler-specific state per card.
+
+V1 behavior:
+
+- `sm2_plus` cards may keep `{}` in this field
+- `fsrs` cards store derived FSRS memory state here
+
+Keep the shared top-level scheduling fields:
+
+- `queue_state`
+- `step_index`
+- `suspended_reason`
+- `due_at`
+- `interval_days`
+- `repetitions`
+- `lapses`
+- `last_reviewed_at`
+
+Those remain the stable compatibility layer for:
+
+- filters
+- analytics
+- review ordering
+- document/manage views
+
+## Review History Model
+
+Add `scheduler_type` to `flashcard_reviews`.
+
+Keep:
+
+- `rating`
+- `answer_time_ms`
+- `scheduled_interval_days`
+- queue transitions
+- due timestamp transitions
+
+This gives the repo enough data to explain:
+
+- which scheduler was active for a given review
+- what interval the scheduler chose
+- how queue state changed
+
+V1 does not need to persist full FSRS state snapshots in review history. The per-card `scheduler_state_json` is sufficient for active scheduling, while review history remains useful for analytics/debugging.
+
+## Shared Queue Semantics
+
+Queue behavior remains shared between `sm2_plus` and FSRS:
+
+- `new`
+- `learning`
+- `review`
+- `relearning`
+- `suspended`
+
+The backend-selected `review/next` ordering remains:
+
+1. due learning/relearning
+2. due review
+3. new
+
+Minute-based learning and relearning steps also remain shared.
+
+In v1, FSRS applies to the review-stage scheduling logic for review cards, not to a separate learning model.
+
+## FSRS Bootstrap For Manually Switched Decks
+
+The biggest risk in this slice is deck switching.
+
+V1 bootstrap rule:
+
+- switching an existing deck from `sm2_plus` to `fsrs` does not trigger a bulk migration
+- when a card in that deck is reviewed under FSRS for the first time and has empty `scheduler_state_json`, derive a conservative FSRS state from the current card snapshot:
+  - `interval_days`
+  - `repetitions`
+  - `lapses`
+  - `last_reviewed_at`
+  - `due_at`
+- persist the derived state immediately after the first FSRS review calculation
+
+Why conservative bootstrap:
+
+- it is deterministic
+- it avoids rewriting all cards up front
+- it acknowledges that historic logs were not collected as FSRS state
+- it allows the deck to stabilize naturally as cards continue to be reviewed
+
+Switching back to `sm2_plus`:
+
+- retain `scheduler_state_json`
+- stop using it while `sm2_plus` is active
+- keep the stored FSRS config for later switching
+
+## Review API Contract
+
+Keep:
+
+- `GET /api/v1/flashcards/review/next`
+- `POST /api/v1/flashcards/review`
+
+Extend review responses with:
+
+- `scheduler_type`
+- server-computed `next_intervals`
+
+The client does not compute FSRS math.
+
+The backend chooses the active scheduler from the deck, dispatches to the correct scheduler implementation, and returns the shared response shape.
+
+## Scheduler Engine Structure
+
+Add a new pure scheduler module:
+
+- `tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py`
+
+Keep `scheduler_sm2.py`.
+
+Add a small dispatcher layer that:
+
+- reads deck `scheduler_type`
+- normalizes the active scheduler config from the envelope
+- calls either the SM-2+ or FSRS transition function
+
+This avoids burying a second scheduler inside `ChaChaNotes_DB.py`.
+
+## Analytics And Compatibility Rules
+
+Analytics currently depend on `interval_days` for maturity counts.
+
+V1 decision:
+
+- `interval_days` remains the derived compatibility interval written after every review, regardless of scheduler
+- deck progress and `mature_count` continue using `interval_days`
+
+This keeps analytics stable while FSRS is introduced.
+
+It also avoids creating scheduler-specific analytics semantics before the review-history UI slice exists.
+
+## Sync Log Requirements
+
+The current sync payloads only cover the single-scheduler model.
+
+This slice must update sync triggers/payloads so they include:
+
+Deck payloads:
+
+- `scheduler_type`
+- envelope `scheduler_settings_json`
+
+Flashcard payloads:
+
+- `scheduler_state_json`
+- shared compatibility fields already used by the scheduler UI and review flows
+
+Without this, FSRS state can silently disappear for sync consumers.
+
+## UI Surface
+
+### Scheduler Tab
+
+The `Scheduler` tab remains the main edit surface for existing decks.
+
+Add:
+
+- scheduler-type selector
+- type-specific settings panel
+- switching warning for existing decks
+
+The warning should state:
+
+- switched decks do not receive a bulk FSRS migration
+- cards initialize conservative FSRS state when first reviewed under FSRS
+- switching back to `sm2_plus` is allowed
+
+### Deck Creation Flows
+
+The shared deck-creation scheduler editor should be extended to support:
+
+- `sm2_plus` mode
+- `fsrs` mode
+
+New decks still default to `sm2_plus`, but users can choose FSRS before creation.
+
+### Review UI
+
+The review screen should remain stable.
+
+V1 additions:
+
+- optional scheduler badge such as `SM-2+` or `FSRS`
+- continue using server `next_intervals`
+
+Do not add separate rating buttons or scheduler-specific study flows.
+
+## Validation
+
+Validation must be both local and server-side.
+
+SM-2+ validation remains as-is.
+
+FSRS v1 should keep a small settings surface:
+
+- `target_retention`
+- `maximum_interval_days`
+- `enable_fuzz`
+
+This avoids exposing a giant tuning surface before there is evidence the product needs it.
+
+## Testing
+
+Backend:
+
+- deck create/update with `scheduler_type=fsrs`
+- default deck still uses `sm2_plus`
+- lazy FSRS bootstrap on first review after manual switch
+- review responses include `scheduler_type`
+- `scheduler_state_json` persists and updates
+- sync-log payloads include new scheduler fields
+- analytics remain stable through derived `interval_days`
+- mixed deck scheduler types do not break `review/next`
+
+Frontend:
+
+- scheduler tab switches between SM-2+ and FSRS panels
+- deck creation flows can create FSRS decks
+- existing deck summaries show scheduler type cleanly
+- review UI continues to render server `next_intervals`
+- switching existing decks shows the bootstrap warning
+
+## Non-Scope
+
+This slice does not include:
+
+- forced migration of existing decks
+- per-card review history UI
+- stronger Anki APKG fidelity work
+- separate FSRS learning-step behavior
+- scheduler-type mixing within a single deck
+- importing/exporting scheduler choice to APKG metadata
+
+## Next Planning Target
+
+`Optional per-deck FSRS implementation`

--- a/Docs/Plans/2026-03-13-optional-per-deck-fsrs-implementation-plan.md
+++ b/Docs/Plans/2026-03-13-optional-per-deck-fsrs-implementation-plan.md
@@ -1,0 +1,592 @@
+# Optional Per-Deck FSRS Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add FSRS as an optional per-deck scheduler alongside the existing SM-2+ path without breaking current review, analytics, deck creation, or sync behavior.
+
+**Architecture:** Keep the shared queue model and review endpoints, add deck-level `scheduler_type`, store scheduler config in a single JSON envelope, add per-card `scheduler_state_json`, and dispatch review calculations to either `scheduler_sm2.py` or a new `scheduler_fsrs.py`. The backend remains the sole owner of interval math and review previews; the UI only edits deck config and renders returned state.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL migrations inside `ChaChaNotes_DB.py`, React, TypeScript, Vitest, pytest.
+
+---
+
+### Task 1: Add failing backend schema tests for FSRS storage
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py`
+- Modify: `tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py` (only if deck schema helpers are shared)
+
+**Step 1: Write the failing test**
+
+Add tests that assert:
+
+```python
+assert "scheduler_type" in deck_columns
+assert "scheduler_state_json" in flashcard_columns
+assert "scheduler_type" in review_columns
+
+deck = chacha_db.get_deck(deck_id)
+settings = json.loads(deck["scheduler_settings_json"])
+assert "sm2_plus" in settings
+assert "fsrs" in settings
+assert deck["scheduler_type"] == "sm2_plus"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py -v
+```
+
+Expected: FAIL because the new columns and envelope shape do not exist yet.
+
+**Step 3: Write minimal schema changes**
+
+Modify:
+
+- `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+
+Add column-ensure logic for:
+
+```python
+ALTER TABLE decks ADD COLUMN scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'
+ALTER TABLE flashcards ADD COLUMN scheduler_state_json TEXT NOT NULL DEFAULT '{}'
+ALTER TABLE flashcard_reviews ADD COLUMN scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'
+```
+
+Update default deck settings JSON creation to:
+
+```python
+{
+    "sm2_plus": get_default_scheduler_settings(),
+    "fsrs": get_default_fsrs_settings(),
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+git commit -m "feat: add fsrs scheduler schema fields"
+```
+
+### Task 2: Add a pure FSRS scheduler module with deterministic bootstrap tests
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py`
+- Create: `tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py`
+- Modify: `tldw_Server_API/app/core/Flashcards/__init__.py` if exports are used
+
+**Step 1: Write the failing test**
+
+Add unit tests for:
+
+- default FSRS settings normalization
+- bootstrap from an existing card snapshot
+- review transition returns shared compatibility fields
+- `next_intervals` preview generation
+
+Example:
+
+```python
+def test_bootstrap_fsrs_state_from_existing_card_snapshot():
+    card = {
+        "interval_days": 12,
+        "repetitions": 7,
+        "lapses": 1,
+        "last_reviewed_at": "2026-03-01T00:00:00Z",
+        "due_at": "2026-03-13T00:00:00Z",
+        "queue_state": "review",
+    }
+    state = bootstrap_fsrs_state(card, now=parse_iso_datetime("2026-03-13T00:00:00Z"))
+    assert isinstance(state, dict)
+    assert state["stability"] > 0
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py -v
+```
+
+Expected: FAIL because the module does not exist.
+
+**Step 3: Write minimal implementation**
+
+Create `scheduler_fsrs.py` with:
+
+- `DEFAULT_FSRS_SETTINGS`
+- `normalize_fsrs_settings`
+- `bootstrap_fsrs_state`
+- `simulate_fsrs_review_transition`
+- `build_fsrs_next_interval_previews`
+
+Keep the v1 settings intentionally small:
+
+```python
+DEFAULT_FSRS_SETTINGS = {
+    "target_retention": 0.9,
+    "maximum_interval_days": 36500,
+    "enable_fuzz": False,
+}
+```
+
+Return shared fields:
+
+```python
+{
+    "queue_state": "review",
+    "due_at": ...,
+    "interval_days": ...,
+    "repetitions": ...,
+    "lapses": ...,
+    "scheduler_state_json": "...",
+    "last_reviewed_at": ...,
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py
+git commit -m "feat: add fsrs scheduler engine"
+```
+
+### Task 3: Dispatch review logic by scheduler type and persist FSRS state
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:19524-19598`
+- Modify: `tldw_Server_API/app/core/Flashcards/scheduler_sm2.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/flashcards.py:1411-1424`
+- Test: `tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py`
+
+**Step 1: Write the failing integration tests**
+
+Add tests for:
+
+- `POST /api/v1/flashcards/review` returns `scheduler_type`
+- FSRS deck review persists `scheduler_state_json`
+- switched existing deck lazily bootstraps missing FSRS state on first review
+
+Example:
+
+```python
+assert payload["scheduler_type"] == "fsrs"
+assert card_after["scheduler_state_json"] != "{}"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "fsrs or scheduler_type" -v
+```
+
+Expected: FAIL because review still assumes one SM-2+ scheduler.
+
+**Step 3: Write minimal implementation**
+
+In `ChaChaNotes_DB.py`:
+
+- select `d.scheduler_type` and `d.scheduler_settings_json`
+- deserialize the settings envelope
+- dispatch:
+
+```python
+if scheduler_type == "fsrs":
+    upd = simulate_fsrs_review_transition(...)
+else:
+    upd = simulate_review_transition(...)
+```
+
+- update `flashcards.scheduler_state_json`
+- insert `flashcard_reviews.scheduler_type`
+- include `scheduler_type` in returned payload
+
+In `flashcards.py`:
+
+- include `scheduler_type` in `review/next` and review response shapes
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py -k "fsrs or scheduler_type" -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/core/Flashcards/scheduler_sm2.py tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+git commit -m "feat: dispatch flashcard review by scheduler type"
+```
+
+### Task 4: Extend deck schemas, create/update endpoints, and sync-log payloads
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/flashcards.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/flashcards.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:6422-6468`
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py:6482-6560`
+- Test: `tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py`
+- Test: `tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that assert:
+
+- deck create/update accepts `scheduler_type`
+- `scheduler_settings_json` stays envelope-shaped
+- sync-log deck payload includes `scheduler_type`
+- sync-log flashcard payload includes `scheduler_state_json`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py -k "scheduler or sync_log" -v
+```
+
+Expected: FAIL because the schema/API only support one scheduler model.
+
+**Step 3: Write minimal implementation**
+
+In `schemas/flashcards.py`, add:
+
+```python
+class FsrsSettings(BaseModel):
+    target_retention: float = 0.9
+    maximum_interval_days: int = 36500
+    enable_fuzz: bool = False
+
+class DeckSchedulerSettingsEnvelope(BaseModel):
+    sm2_plus: DeckSchedulerSettings = Field(default_factory=DeckSchedulerSettings)
+    fsrs: FsrsSettings = Field(default_factory=FsrsSettings)
+```
+
+Extend `DeckCreate`, `DeckUpdate`, and `Deck` with:
+
+- `scheduler_type`
+- envelope `scheduler_settings`
+
+Update DB sync triggers so JSON payloads include the new fields.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py -k "scheduler or sync_log" -v
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/flashcards.py tldw_Server_API/app/api/v1/endpoints/flashcards.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py
+git commit -m "feat: extend flashcard deck schemas for fsrs"
+```
+
+### Task 5: Add scheduler-type-aware frontend models and shared editor support
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/flashcards.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts`
+- Modify: `apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx`
+- Test: `apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Add tests that assert:
+
+- scheduler-type selector switches between SM-2+ and FSRS
+- FSRS settings validate locally
+- inactive scheduler settings remain preserved
+
+Example:
+
+```tsx
+expect(screen.getByLabelText(/scheduler type/i)).toHaveValue("fsrs")
+expect(screen.getByLabelText(/target retention/i)).toBeInTheDocument()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+```
+
+Expected: FAIL because the editor is single-scheduler and SM-2+-only.
+
+**Step 3: Write minimal implementation**
+
+In `services/flashcards.ts`, replace the single settings type with:
+
+```ts
+export type DeckSchedulerType = "sm2_plus" | "fsrs"
+
+export type FsrsSchedulerSettings = {
+  target_retention: number
+  maximum_interval_days: number
+  enable_fuzz: boolean
+}
+
+export type DeckSchedulerSettingsEnvelope = {
+  sm2_plus: DeckSchedulerSettings
+  fsrs: FsrsSchedulerSettings
+}
+```
+
+Update the shared draft/editor layer so it:
+
+- tracks `schedulerType`
+- validates SM-2+ and FSRS separately
+- preserves both config objects in one draft
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/services/flashcards.ts apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+git commit -m "feat: add fsrs-aware scheduler editor"
+```
+
+### Task 6: Expose FSRS in Scheduler tab and deck creation flows
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx`
+- Modify: `apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx`
+- Test: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx`
+- Test: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx`
+- Test: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx`
+- Test: `apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx`
+
+**Step 1: Write the failing UI tests**
+
+Add tests that assert:
+
+- new decks can be created with `scheduler_type="fsrs"`
+- existing decks show scheduler type summary
+- switching an existing deck to FSRS shows the bootstrap warning
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: FAIL because create flows and scheduler tab do not support FSRS.
+
+**Step 3: Write minimal implementation**
+
+Wire the shared editor into:
+
+- `SchedulerTab`
+- flashcard create drawer
+- import/generate/image-occlusion deck creation blocks
+- remediation create-new-deck path
+
+Add warning text in `SchedulerTab`:
+
+```tsx
+<Alert
+  type="warning"
+  message="Switching to FSRS initializes existing cards conservatively as they are reviewed."
+/>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+git commit -m "feat: expose fsrs across deck creation flows"
+```
+
+### Task 7: Keep review UI stable and add scheduler visibility
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx`
+- Modify: `apps/packages/ui/src/components/Flashcards/utils/queue-state-badges.tsx` if a scheduler badge helper is needed
+- Test: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx`
+- Test: `apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx` (create if missing)
+
+**Step 1: Write the failing test**
+
+Add a test that asserts:
+
+- returned `scheduler_type` renders a small badge
+- review buttons still render server `next_intervals`
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx
+```
+
+Expected: FAIL because review responses and UI do not expose scheduler type yet.
+
+**Step 3: Write minimal implementation**
+
+Add a small display-only badge:
+
+```tsx
+<Tag>{reviewCard.next_intervals ? activeSchedulerTypeLabel : null}</Tag>
+```
+
+Do not change the rating flow or button layout.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx apps/packages/ui/src/components/Flashcards/utils/queue-state-badges.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx
+git commit -m "feat: show scheduler type in flashcard review"
+```
+
+### Task 8: Run full targeted verification, docs update, and security check
+
+**Files:**
+- Modify: `Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md`
+- Modify: any touched implementation files above
+
+**Step 1: Update docs**
+
+Add:
+
+- what FSRS is in this app
+- that it is optional per deck
+- that existing decks stay on SM-2+ unless switched
+- that switched decks bootstrap conservatively
+
+**Step 2: Run backend verification**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py \
+  tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py \
+  tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py \
+  tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py -v
+```
+
+Expected: all pass.
+
+**Step 3: Run frontend verification**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run \
+  src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx \
+  src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.assistant.test.tsx \
+  src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx \
+  src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+```
+
+Expected: all pass.
+
+**Step 4: Run Bandit on touched Python scope**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py \
+  tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py \
+  tldw_Server_API/app/api/v1/endpoints/flashcards.py \
+  tldw_Server_API/app/api/v1/schemas/flashcards.py \
+  -f json -o /tmp/bandit_optional_fsrs.json
+```
+
+Expected: no new findings in touched code.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+git commit -m "docs: add optional fsrs guidance"
+```

--- a/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
+++ b/Docs/User_Guides/WebUI_Extension/Flashcards_Study_Guide.md
@@ -68,11 +68,14 @@ Open `Scheduler` from the top-level Flashcards tabs to edit deck-level review po
 What it includes:
 
 - A searchable deck list with compact scheduler summaries.
+- A scheduler-type selector for `SM-2+` or `FSRS` on each deck.
 - A per-deck editor for step timing, interval growth, leech handling, and fuzz.
 - Built-in presets:
   - `Default`: backend defaults for balanced daily review.
   - `Fast acquisition`: shorter early steps and shorter easy intervals.
   - `Conservative review`: slower acquisition and stronger long-term spacing.
+  - `High retention`: FSRS preset tuned for shorter review intervals.
+  - `Long horizon`: FSRS preset tuned for larger mature decks.
 - `Copy settings` to clone another deck's scheduler into the current draft.
 - `Reset to defaults` to restore the standard scheduler bundle.
 - Active-deck counts for `Due review`, `New`, `Learning`, and total due cards.
@@ -80,9 +83,11 @@ What it includes:
 Important behavior:
 
 - New decks start with the default scheduler settings.
+- New decks default to `SM-2+`, but you can switch them to `FSRS` before saving.
 - Scheduler edits are deck-scoped; they do not affect other decks unless you copy them.
 - Unsaved scheduler drafts are guarded when you switch decks or leave the `Scheduler` tab.
 - If another client updates the same deck first, the tab shows `Reload latest` and `Reapply my draft` actions.
+- Switching an existing deck to `FSRS` keeps review history intact and bootstraps FSRS state conservatively as cards are reviewed.
 
 ## Scheduler Settings During Deck Creation
 
@@ -99,6 +104,7 @@ How it works:
 
 - Existing deck selectors now include `Create new deck`.
 - Choosing that option opens a deck-name field plus the same scheduler preset/editor used by the scheduler UI.
+- The inline editor also lets you choose the scheduler type for the new deck.
 - Existing decks remain read-only in those flows and show a compact scheduler summary instead.
 - New decks created there start with exactly the scheduler settings you selected.
 
@@ -114,7 +120,7 @@ Later edits:
 
 ## Queue States
 
-Queue-state badges now appear on the active card in `Study`, on expanded cards in `Manage`, and on document-mode rows.
+Queue-state badges now appear on the active card in `Study`, on expanded cards in `Manage`, and on document-mode rows. The active card in `Study` also shows a small scheduler badge (`SM-2+` or `FSRS`) so you can see which policy is driving the interval previews.
 
 Meanings:
 

--- a/apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/DeckSchedulerSettingsEditor.tsx
@@ -1,37 +1,26 @@
 import React from "react"
-import { Button, Checkbox, Input, Typography } from "antd"
+import { Button, Checkbox, Input, Select, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 
-import type {
-  SchedulerPresetId,
-  SchedulerSettingsDraft,
-  SchedulerValidationErrors
-} from "../utils/scheduler-settings"
-import { SCHEDULER_PRESETS } from "../utils/scheduler-settings"
+import type { DeckSchedulerDraftState } from "../hooks/useDeckSchedulerDraft"
+import type { SchedulerPresetId } from "../utils/scheduler-settings"
+import { getSchedulerPresets } from "../utils/scheduler-settings"
 
 const { Text } = Typography
 
 type DeckSchedulerSettingsEditorProps = {
-  draft: SchedulerSettingsDraft
-  errors: SchedulerValidationErrors
-  summary: string | null
-  onFieldChange: <K extends keyof SchedulerSettingsDraft>(
-    field: K,
-    value: SchedulerSettingsDraft[K]
-  ) => void
-  onApplyPreset: (presetId: SchedulerPresetId) => void
-  onResetDefaults: () => void
+  schedulerDraft: DeckSchedulerDraftState
   advancedDefaultOpen?: boolean
 }
 
-type SchedulerFieldConfig = {
-  key: Exclude<keyof SchedulerSettingsDraft, "enable_fuzz">
+type Sm2FieldConfig = {
+  key: Exclude<keyof DeckSchedulerDraftState["draft"]["sm2_plus"], "enable_fuzz">
   label: string
   placeholder?: string
   testId: string
 }
 
-const ADVANCED_FIELDS: SchedulerFieldConfig[] = [
+const SM2_ADVANCED_FIELDS: Sm2FieldConfig[] = [
   {
     key: "new_steps_minutes",
     label: "New steps (minutes)",
@@ -76,106 +65,191 @@ const ADVANCED_FIELDS: SchedulerFieldConfig[] = [
   }
 ]
 
+type FsrsFieldConfig = {
+  key: Exclude<keyof DeckSchedulerDraftState["draft"]["fsrs"], "enable_fuzz">
+  label: string
+  placeholder?: string
+  testId: string
+}
+
+const FSRS_FIELDS: FsrsFieldConfig[] = [
+  {
+    key: "target_retention",
+    label: "Target retention",
+    placeholder: "0.90",
+    testId: "deck-scheduler-editor-field-target-retention"
+  },
+  {
+    key: "maximum_interval_days",
+    label: "Maximum interval (days)",
+    placeholder: "36500",
+    testId: "deck-scheduler-editor-field-maximum-interval"
+  }
+]
+
 export const DeckSchedulerSettingsEditor: React.FC<DeckSchedulerSettingsEditorProps> = ({
-  draft,
-  errors,
-  summary,
-  onFieldChange,
-  onApplyPreset,
-  onResetDefaults,
+  schedulerDraft,
   advancedDefaultOpen = false
 }) => {
   const { t } = useTranslation(["option", "common"])
   const [advancedOpen, setAdvancedOpen] = React.useState(advancedDefaultOpen)
+  const schedulerType = schedulerDraft.draft.scheduler_type
+  const presets = React.useMemo(() => getSchedulerPresets(schedulerType), [schedulerType])
 
-  const renderFieldError = (field: keyof SchedulerValidationErrors) => {
-    const error = errors[field]
-    if (!error) return null
-    return (
-      <Text type="danger" className="text-xs">
-        {error}
+  const renderFieldError = React.useCallback(
+    (field: string) => {
+      const error =
+        schedulerType === "fsrs"
+          ? schedulerDraft.errors.fsrs[field as keyof typeof schedulerDraft.errors.fsrs]
+          : schedulerDraft.errors.sm2_plus[field as keyof typeof schedulerDraft.errors.sm2_plus]
+      if (!error) return null
+      return (
+        <Text type="danger" className="text-xs">
+          {error}
+        </Text>
+      )
+    },
+    [schedulerDraft.errors.fsrs, schedulerDraft.errors.sm2_plus, schedulerType]
+  )
+
+  const renderPresetButtons = () => (
+    <div className="space-y-2">
+      <Text strong>
+        {t("option:flashcards.schedulerPresets", { defaultValue: "Presets" })}
       </Text>
-    )
-  }
+      <div className="flex flex-wrap gap-2">
+        {presets.map((preset) => (
+          <Button
+            key={preset.id}
+            size="small"
+            onClick={() => schedulerDraft.applyPreset(preset.id as SchedulerPresetId)}
+            data-testid={`deck-scheduler-editor-preset-${preset.id}`}
+          >
+            {preset.label}
+          </Button>
+        ))}
+        <Button
+          size="small"
+          onClick={schedulerDraft.resetToDefaults}
+          data-testid="deck-scheduler-editor-reset"
+        >
+          {t("option:flashcards.schedulerResetAction", {
+            defaultValue: "Reset to defaults"
+          })}
+        </Button>
+      </div>
+    </div>
+  )
 
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
+      <label className="flex flex-col gap-1">
         <Text strong>
-          {t("option:flashcards.schedulerPresets", { defaultValue: "Presets" })}
+          {t("option:flashcards.schedulerTypeLabel", {
+            defaultValue: "Scheduler type"
+          })}
         </Text>
-        <div className="flex flex-wrap gap-2">
-          {SCHEDULER_PRESETS.map((preset) => (
-            <Button
-              key={preset.id}
-              size="small"
-              onClick={() => onApplyPreset(preset.id)}
-              data-testid={`deck-scheduler-editor-preset-${preset.id}`}
-            >
-              {preset.label}
-            </Button>
-          ))}
-          <Button
-            size="small"
-            onClick={onResetDefaults}
-            data-testid="deck-scheduler-editor-reset"
-          >
-            {t("option:flashcards.schedulerResetAction", {
-              defaultValue: "Reset to defaults"
-            })}
-          </Button>
-        </div>
-      </div>
+        <Select
+          value={schedulerType}
+          onChange={(value) => schedulerDraft.updateSchedulerType(value)}
+          options={[
+            { value: "sm2_plus", label: "SM-2+" },
+            { value: "fsrs", label: "FSRS" }
+          ]}
+          data-testid="deck-scheduler-editor-field-scheduler-type"
+        />
+      </label>
+
+      {renderPresetButtons()}
 
       <div className="rounded border border-border bg-muted/20 p-3">
         <Text
-          type={summary ? "secondary" : "danger"}
+          type={schedulerDraft.summary ? "secondary" : "danger"}
           data-testid="deck-scheduler-editor-summary"
         >
-          {summary ??
+          {schedulerDraft.summary ??
             t("option:flashcards.schedulerDraftInvalid", {
               defaultValue: "Draft has validation errors."
             })}
         </Text>
       </div>
 
-      <div>
-        <Button
-          type="text"
-          size="small"
-          onClick={() => setAdvancedOpen((current) => !current)}
-          data-testid="deck-scheduler-editor-toggle-advanced"
-        >
-          {advancedOpen
-            ? t("option:flashcards.hideAdvancedScheduler", {
-                defaultValue: "Hide advanced settings"
-              })
-            : t("option:flashcards.showAdvancedScheduler", {
-                defaultValue: "Customize scheduler"
-              })}
-        </Button>
-      </div>
+      {schedulerType === "sm2_plus" ? (
+        <>
+          <div>
+            <Button
+              type="text"
+              size="small"
+              onClick={() => setAdvancedOpen((current) => !current)}
+              data-testid="deck-scheduler-editor-toggle-advanced"
+            >
+              {advancedOpen
+                ? t("option:flashcards.hideAdvancedScheduler", {
+                    defaultValue: "Hide advanced settings"
+                  })
+                : t("option:flashcards.showAdvancedScheduler", {
+                    defaultValue: "Customize scheduler"
+                  })}
+            </Button>
+          </div>
 
-      {advancedOpen && (
+          {advancedOpen && (
+            <div className="grid gap-4 md:grid-cols-2">
+              {SM2_ADVANCED_FIELDS.map((field) => (
+                <label key={field.key} className="flex flex-col gap-1">
+                  <Text strong>{field.label}</Text>
+                  <Input
+                    value={schedulerDraft.draft.sm2_plus[field.key]}
+                    onChange={(event) =>
+                      schedulerDraft.updateSm2Field(field.key, event.target.value)
+                    }
+                    placeholder={field.placeholder}
+                    data-testid={field.testId}
+                  />
+                  {renderFieldError(field.key)}
+                </label>
+              ))}
+
+              <div className="md:col-span-2">
+                <Checkbox
+                  checked={schedulerDraft.draft.sm2_plus.enable_fuzz}
+                  onChange={(event) =>
+                    schedulerDraft.updateSm2Field("enable_fuzz", event.target.checked)
+                  }
+                  data-testid="deck-scheduler-editor-field-enable-fuzz"
+                >
+                  {t("option:flashcards.schedulerEnableFuzz", {
+                    defaultValue: "Enable review fuzz"
+                  })}
+                </Checkbox>
+              </div>
+            </div>
+          )}
+        </>
+      ) : (
         <div className="grid gap-4 md:grid-cols-2">
-          {ADVANCED_FIELDS.map((field) => (
+          {FSRS_FIELDS.map((field) => (
             <label key={field.key} className="flex flex-col gap-1">
               <Text strong>{field.label}</Text>
               <Input
-                value={draft[field.key]}
-                onChange={(event) => onFieldChange(field.key, event.target.value)}
+                value={schedulerDraft.draft.fsrs[field.key]}
+                onChange={(event) =>
+                  schedulerDraft.updateFsrsField(field.key, event.target.value)
+                }
                 placeholder={field.placeholder}
                 data-testid={field.testId}
               />
-              {renderFieldError(field.key as keyof SchedulerValidationErrors)}
+              {renderFieldError(field.key)}
             </label>
           ))}
 
           <div className="md:col-span-2">
             <Checkbox
-              checked={draft.enable_fuzz}
-              onChange={(event) => onFieldChange("enable_fuzz", event.target.checked)}
-              data-testid="deck-scheduler-editor-field-enable-fuzz"
+              checked={schedulerDraft.draft.fsrs.enable_fuzz}
+              onChange={(event) =>
+                schedulerDraft.updateFsrsField("enable_fuzz", event.target.checked)
+              }
+              data-testid="deck-scheduler-editor-field-fsrs-enable-fuzz"
             >
               {t("option:flashcards.schedulerEnableFuzz", {
                 defaultValue: "Enable review fuzz"

--- a/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/FlashcardCreateDrawer.tsx
@@ -215,7 +215,8 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
       if (!schedulerSettings) return
       const deck = await createDeckMutation.mutateAsync({
         name: inlineDeckName.trim(),
-        scheduler_settings: schedulerSettings
+        scheduler_type: schedulerSettings.scheduler_type,
+        scheduler_settings: schedulerSettings.scheduler_settings
       })
       message.success(t("common:created", { defaultValue: "Created" }))
       setShowInlineCreate(false)
@@ -416,12 +417,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
                 />
               </div>
               <DeckSchedulerSettingsEditor
-                draft={inlineSchedulerDraft.draft}
-                errors={inlineSchedulerDraft.errors}
-                summary={inlineSchedulerDraft.summary}
-                onFieldChange={inlineSchedulerDraft.updateField}
-                onApplyPreset={inlineSchedulerDraft.applyPreset}
-                onResetDefaults={inlineSchedulerDraft.resetToDefaults}
+                schedulerDraft={inlineSchedulerDraft}
               />
               <div className="flex items-center gap-2">
                 <Button
@@ -455,7 +451,7 @@ export const FlashcardCreateDrawer: React.FC<FlashcardCreateDrawerProps> = ({
 
           {!showInlineCreate && selectedDeck && (
             <Text type="secondary" className="block text-xs -mt-2 mb-3">
-              {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+              {formatSchedulerSummary(selectedDeck.scheduler_type, selectedDeck.scheduler_settings)}
             </Text>
           )}
 

--- a/apps/packages/ui/src/components/Flashcards/components/NewDeckConfigurationFields.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/NewDeckConfigurationFields.tsx
@@ -43,12 +43,7 @@ export const NewDeckConfigurationFields: React.FC<NewDeckConfigurationFieldsProp
       </label>
 
       <DeckSchedulerSettingsEditor
-        draft={schedulerDraft.draft}
-        errors={schedulerDraft.errors}
-        summary={schedulerDraft.summary}
-        onFieldChange={schedulerDraft.updateField}
-        onApplyPreset={schedulerDraft.applyPreset}
-        onResetDefaults={schedulerDraft.resetToDefaults}
+        schedulerDraft={schedulerDraft}
       />
 
       {hint ? (

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx
@@ -42,14 +42,7 @@ const Harness = () => {
 
   return (
     <div>
-      <DeckSchedulerSettingsEditor
-        draft={schedulerDraft.draft}
-        errors={schedulerDraft.errors}
-        summary={schedulerDraft.summary}
-        onFieldChange={schedulerDraft.updateField}
-        onApplyPreset={schedulerDraft.applyPreset}
-        onResetDefaults={schedulerDraft.resetToDefaults}
-      />
+      <DeckSchedulerSettingsEditor schedulerDraft={schedulerDraft} />
       <button
         type="button"
         onClick={() => {
@@ -88,6 +81,9 @@ describe("DeckSchedulerSettingsEditor", () => {
     })
     fireEvent.click(screen.getByRole("button", { name: /validate draft/i }))
 
+    expect(screen.getByTestId("deck-scheduler-editor-validated-json")).toHaveTextContent(
+      '"scheduler_type":"sm2_plus"'
+    )
     expect(screen.getByTestId("deck-scheduler-editor-validated-json")).toHaveTextContent(
       '"leech_threshold":12'
     )

--- a/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx
@@ -3,9 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { FlashcardCreateDrawer } from "../FlashcardCreateDrawer"
 import { useCreateDeckMutation, useCreateFlashcardMutation, useDecksQuery } from "../../hooks"
-import type { DeckSchedulerSettings } from "@/services/flashcards"
+import type { DeckSchedulerSettings, DeckSchedulerSettingsEnvelope } from "@/services/flashcards"
 
 const uploadFlashcardAsset = vi.hoisted(() => vi.fn())
+
+const defaultFsrsSettings = {
+  target_retention: 0.9,
+  maximum_interval_days: 36500,
+  enable_fuzz: false
+}
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -163,6 +169,10 @@ describe("FlashcardCreateDrawer image insertion", () => {
       leech_threshold: 10,
       enable_fuzz: false
     }
+    const createdDeckEnvelope: DeckSchedulerSettingsEnvelope = {
+      sm2_plus: createdDeckSettings,
+      fsrs: defaultFsrsSettings
+    }
     createDeckMutateAsync.mockResolvedValue({
       id: 7,
       name: "New deck",
@@ -170,8 +180,9 @@ describe("FlashcardCreateDrawer image insertion", () => {
       deleted: false,
       client_id: "test",
       version: 1,
-      scheduler_settings_json: JSON.stringify(createdDeckSettings),
-      scheduler_settings: createdDeckSettings
+      scheduler_type: "sm2_plus",
+      scheduler_settings_json: JSON.stringify(createdDeckEnvelope),
+      scheduler_settings: createdDeckEnvelope
     })
 
     render(<FlashcardCreateDrawer open onClose={vi.fn()} onSuccess={vi.fn()} />)
@@ -188,7 +199,8 @@ describe("FlashcardCreateDrawer image insertion", () => {
     await waitFor(() =>
       expect(createDeckMutateAsync).toHaveBeenCalledWith({
         name: "New deck",
-        scheduler_settings: createdDeckSettings
+        scheduler_type: "sm2_plus",
+        scheduler_settings: createdDeckEnvelope
       })
     )
 

--- a/apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useDeckSchedulerDraft.ts
@@ -1,16 +1,23 @@
 import React from "react"
 
-import type { DeckSchedulerSettings } from "@/services/flashcards"
+import type {
+  DeckSchedulerSettingsEnvelope,
+  DeckSchedulerType,
+  FsrsSchedulerSettings
+} from "@/services/flashcards"
 import type {
   SchedulerPresetId,
   SchedulerSettingsDraft,
   SchedulerValidationErrors
 } from "../utils/scheduler-settings"
 import {
+  DEFAULT_FSRS_SCHEDULER_SETTINGS,
   DEFAULT_SCHEDULER_SETTINGS,
   applySchedulerPreset,
-  copySchedulerSettings,
+  copySchedulerSettingsEnvelope,
   createSchedulerDraft,
+  createFsrsSchedulerDraft,
+  createSm2SchedulerDraft,
   formatSchedulerSummary,
   validateSchedulerDraft
 } from "../utils/scheduler-settings"
@@ -19,73 +26,179 @@ export type DeckSchedulerDraftState = {
   draft: SchedulerSettingsDraft
   errors: SchedulerValidationErrors
   summary: string | null
-  updateField: <K extends keyof SchedulerSettingsDraft>(
+  replaceDraftState: (draft: SchedulerSettingsDraft) => void
+  updateSchedulerType: (schedulerType: DeckSchedulerType) => void
+  updateSm2Field: <K extends keyof SchedulerSettingsDraft["sm2_plus"]>(
     field: K,
-    value: SchedulerSettingsDraft[K]
+    value: SchedulerSettingsDraft["sm2_plus"][K]
+  ) => void
+  updateFsrsField: <K extends keyof SchedulerSettingsDraft["fsrs"]>(
+    field: K,
+    value: SchedulerSettingsDraft["fsrs"][K]
   ) => void
   applyPreset: (presetId: SchedulerPresetId) => void
   resetToDefaults: () => void
-  replaceDraft: (settings: DeckSchedulerSettings) => void
-  getValidatedSettings: () => DeckSchedulerSettings | null
+  replaceDraft: (config: {
+    schedulerType: DeckSchedulerType
+    settings: DeckSchedulerSettingsEnvelope
+  }) => void
+  getValidatedSettings: () => {
+    scheduler_type: DeckSchedulerType
+    scheduler_settings: DeckSchedulerSettingsEnvelope
+  } | null
   clearErrors: () => void
 }
 
 export const useDeckSchedulerDraft = (
-  initialSettings: DeckSchedulerSettings = DEFAULT_SCHEDULER_SETTINGS
+  initialConfig: {
+    schedulerType?: DeckSchedulerType
+    settings?: DeckSchedulerSettingsEnvelope
+  } = {}
 ): DeckSchedulerDraftState => {
   const [draft, setDraft] = React.useState<SchedulerSettingsDraft>(() =>
-    createSchedulerDraft(copySchedulerSettings(initialSettings))
+    createSchedulerDraft({
+      schedulerType: initialConfig.schedulerType ?? "sm2_plus",
+      settings: initialConfig.settings
+    })
   )
-  const [errors, setErrors] = React.useState<SchedulerValidationErrors>({})
+  const [errors, setErrors] = React.useState<SchedulerValidationErrors>({
+    sm2_plus: {},
+    fsrs: {}
+  })
 
-  const replaceDraft = React.useCallback((settings: DeckSchedulerSettings) => {
-    setDraft(createSchedulerDraft(copySchedulerSettings(settings)))
-    setErrors({})
+  const replaceDraft = React.useCallback(
+    (config: { schedulerType: DeckSchedulerType; settings: DeckSchedulerSettingsEnvelope }) => {
+      setDraft(
+        createSchedulerDraft({
+          schedulerType: config.schedulerType,
+          settings: copySchedulerSettingsEnvelope(config.settings)
+        })
+      )
+      setErrors({ sm2_plus: {}, fsrs: {} })
+    },
+    []
+  )
+
+  const replaceDraftState = React.useCallback((nextDraft: SchedulerSettingsDraft) => {
+    setDraft(nextDraft)
+    setErrors({ sm2_plus: {}, fsrs: {} })
   }, [])
 
-  const updateField = React.useCallback(
-    <K extends keyof SchedulerSettingsDraft>(field: K, value: SchedulerSettingsDraft[K]) => {
-      setDraft((current) => ({ ...current, [field]: value }))
+  const clearErrors = React.useCallback(() => {
+    setErrors({ sm2_plus: {}, fsrs: {} })
+  }, [])
+
+  const updateSchedulerType = React.useCallback((schedulerType: DeckSchedulerType) => {
+    setDraft((current) => ({ ...current, scheduler_type: schedulerType }))
+  }, [])
+
+  const updateSm2Field = React.useCallback(
+    <K extends keyof SchedulerSettingsDraft["sm2_plus"]>(
+      field: K,
+      value: SchedulerSettingsDraft["sm2_plus"][K]
+    ) => {
+      setDraft((current) => ({
+        ...current,
+        sm2_plus: {
+          ...current.sm2_plus,
+          [field]: value
+        }
+      }))
       setErrors((current) => {
-        if (!current[field as keyof SchedulerValidationErrors]) return current
-        const next = { ...current }
-        delete next[field as keyof SchedulerValidationErrors]
-        return next
+        if (!current.sm2_plus[field as keyof typeof current.sm2_plus]) return current
+        return {
+          ...current,
+          sm2_plus: {
+            ...current.sm2_plus,
+            [field]: undefined
+          }
+        }
+      })
+    },
+    []
+  )
+
+  const updateFsrsField = React.useCallback(
+    <K extends keyof SchedulerSettingsDraft["fsrs"]>(
+      field: K,
+      value: SchedulerSettingsDraft["fsrs"][K]
+    ) => {
+      setDraft((current) => ({
+        ...current,
+        fsrs: {
+          ...current.fsrs,
+          [field]: value
+        }
+      }))
+      setErrors((current) => {
+        if (!current.fsrs[field as keyof typeof current.fsrs]) return current
+        return {
+          ...current,
+          fsrs: {
+            ...current.fsrs,
+            [field]: undefined
+          }
+        }
       })
     },
     []
   )
 
   const applyPreset = React.useCallback((presetId: SchedulerPresetId) => {
-    setDraft(createSchedulerDraft(applySchedulerPreset(presetId)))
-    setErrors({})
+    setDraft((current) => {
+      const presetEnvelope = applySchedulerPreset(current.scheduler_type, presetId)
+      if (current.scheduler_type === "fsrs") {
+        return {
+          ...current,
+          fsrs: createFsrsSchedulerDraft(presetEnvelope.fsrs)
+        }
+      }
+      return {
+        ...current,
+        sm2_plus: createSm2SchedulerDraft(presetEnvelope.sm2_plus)
+      }
+    })
+    setErrors({ sm2_plus: {}, fsrs: {} })
   }, [])
 
   const resetToDefaults = React.useCallback(() => {
-    setDraft(createSchedulerDraft(DEFAULT_SCHEDULER_SETTINGS))
-    setErrors({})
+    setDraft((current) =>
+      current.scheduler_type === "fsrs"
+        ? {
+            ...current,
+            fsrs: createFsrsSchedulerDraft(DEFAULT_FSRS_SCHEDULER_SETTINGS)
+          }
+        : {
+            ...current,
+            sm2_plus: createSm2SchedulerDraft(DEFAULT_SCHEDULER_SETTINGS)
+          }
+    )
+    setErrors({ sm2_plus: {}, fsrs: {} })
   }, [])
 
   const getValidatedSettings = React.useCallback(() => {
     const parsed = validateSchedulerDraft(draft)
     setErrors(parsed.errors)
-    return parsed.settings
+    if (!parsed.settings) return null
+    return {
+      scheduler_type: parsed.schedulerType,
+      scheduler_settings: parsed.settings
+    }
   }, [draft])
-
-  const clearErrors = React.useCallback(() => {
-    setErrors({})
-  }, [])
 
   const summary = React.useMemo(() => {
     const parsed = validateSchedulerDraft(draft)
-    return parsed.settings ? formatSchedulerSummary(parsed.settings) : null
+    return parsed.settings ? formatSchedulerSummary(parsed.schedulerType, parsed.settings) : null
   }, [draft])
 
   return {
     draft,
     errors,
     summary,
-    updateField,
+    replaceDraftState,
+    updateSchedulerType,
+    updateSm2Field,
+    updateFsrsField,
     applyPreset,
     resetToDefaults,
     replaceDraft,

--- a/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
+++ b/apps/packages/ui/src/components/Flashcards/hooks/useFlashcardQueries.ts
@@ -457,11 +457,13 @@ export function useCreateDeckMutation() {
     mutationFn: (params: {
       name: string
       description?: string
+      scheduler_type?: Deck["scheduler_type"]
       scheduler_settings?: Deck["scheduler_settings"]
     }) =>
       createDeck({
         name: params.name.trim(),
         description: params.description?.trim() || undefined,
+        scheduler_type: params.scheduler_type,
         scheduler_settings: params.scheduler_settings
       }),
     onSuccess: () => {

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImageOcclusionTransferPanel.tsx
@@ -201,7 +201,8 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
       }
       const createdDeck = await createDeckMutation.mutateAsync({
         name,
-        scheduler_settings: schedulerSettings
+        scheduler_type: schedulerSettings.scheduler_type,
+        scheduler_settings: schedulerSettings.scheduler_settings
       })
       setTargetDeckId(createdDeck.id)
       return createdDeck.id
@@ -472,7 +473,7 @@ export const ImageOcclusionTransferPanel: React.FC<ImageOcclusionTransferPanelPr
             className="block text-xs -mt-2 mb-2"
             data-testid="flashcards-occlusion-selected-deck-summary"
           >
-            {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+            {formatSchedulerSummary(selectedDeck.scheduler_type, selectedDeck.scheduler_settings)}
           </Text>
         ) : null}
         <Form.Item

--- a/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ImportExportTab.tsx
@@ -504,7 +504,8 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
       }
       const createdDeck = await createDeckMutation.mutateAsync({
         name,
-        scheduler_settings: schedulerSettings
+        scheduler_type: schedulerSettings.scheduler_type,
+        scheduler_settings: schedulerSettings.scheduler_settings
       })
       setStructuredTargetDeckId(createdDeck.id)
       return createdDeck.id
@@ -1313,7 +1314,10 @@ const ImportPanel: React.FC<TransferActionReporterProps> = ({ onTransferAction }
                   className="block text-xs"
                   data-testid="flashcards-structured-selected-deck-summary"
                 >
-                  {formatSchedulerSummary(structuredSelectedDeck.scheduler_settings)}
+                  {formatSchedulerSummary(
+                    structuredSelectedDeck.scheduler_type,
+                    structuredSelectedDeck.scheduler_settings
+                  )}
                 </Text>
               ) : null}
               <Button
@@ -2145,7 +2149,8 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
       }
       const createdDeck = await createDeckMutation.mutateAsync({
         name,
-        scheduler_settings: schedulerSettings
+        scheduler_type: schedulerSettings.scheduler_type,
+        scheduler_settings: schedulerSettings.scheduler_settings
       })
       setTargetDeckId(createdDeck.id)
       return createdDeck.id
@@ -2369,7 +2374,7 @@ const GeneratePanel: React.FC<GeneratePanelProps & TransferActionReporterProps> 
             className="block text-xs -mt-2 mb-2"
             data-testid="flashcards-generate-selected-deck-summary"
           >
-            {formatSchedulerSummary(selectedDeck.scheduler_settings)}
+            {formatSchedulerSummary(selectedDeck.scheduler_type, selectedDeck.scheduler_settings)}
           </Text>
         ) : null}
         <Form.Item

--- a/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/ReviewTab.tsx
@@ -260,6 +260,11 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
     return decksQuery.data.find((d) => d.id === reviewDeckId)?.name
   }, [reviewDeckId, decksQuery.data])
 
+  const activeSchedulerLabel = React.useMemo(() => {
+    if (!activeCard?.scheduler_type) return null
+    return activeCard.scheduler_type === "fsrs" ? "FSRS" : "SM-2+"
+  }, [activeCard?.scheduler_type])
+
   // Calculate intervals for current card
   const intervals = React.useMemo(() => {
     if (!activeCard) return null
@@ -894,6 +899,11 @@ export const ReviewTab: React.FC<ReviewTabProps> = ({
                   card={activeCard}
                   testId="flashcards-review-queue-state"
                 />
+                {activeSchedulerLabel && (
+                  <Tag data-testid="flashcards-review-scheduler-type">
+                    {activeSchedulerLabel}
+                  </Tag>
+                )}
                 {activeCard.tags?.map((tag) => (
                   <Tag key={tag}>{tag}</Tag>
                 ))}

--- a/apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/SchedulerTab.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Alert, Button, Card, Checkbox, Empty, Input, List, Space, Typography } from "antd"
+import { Alert, Button, Card, Empty, Input, List, Space, Typography } from "antd"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -7,20 +7,11 @@ import {
   useDueCountsQuery,
   useUpdateDeckMutation
 } from "../hooks/useFlashcardQueries"
+import { DeckSchedulerSettingsEditor } from "../components/DeckSchedulerSettingsEditor"
+import { useDeckSchedulerDraft } from "../hooks/useDeckSchedulerDraft"
 import type { Deck } from "@/services/flashcards"
-import type {
-  SchedulerSettingsDraft,
-  SchedulerValidationErrors
-} from "../utils/scheduler-settings"
-import {
-  SCHEDULER_PRESETS,
-  DEFAULT_SCHEDULER_SETTINGS,
-  applySchedulerPreset,
-  copySchedulerSettings,
-  createSchedulerDraft,
-  formatSchedulerSummary,
-  validateSchedulerDraft
-} from "../utils/scheduler-settings"
+import type { SchedulerSettingsDraft } from "../utils/scheduler-settings"
+import { createSchedulerDraft, formatSchedulerSummary } from "../utils/scheduler-settings"
 
 const { Text, Title } = Typography
 
@@ -47,18 +38,10 @@ const isVersionConflict = (error: unknown): boolean =>
   (error as { response?: { status?: number } }).response?.status === 409
 
 const cloneDraft = (draft: SchedulerSettingsDraft): SchedulerSettingsDraft => ({
-  ...draft
+  scheduler_type: draft.scheduler_type,
+  sm2_plus: { ...draft.sm2_plus },
+  fsrs: { ...draft.fsrs }
 })
-
-const discardFieldError = (
-  errors: SchedulerValidationErrors,
-  field: keyof SchedulerValidationErrors
-): SchedulerValidationErrors => {
-  if (!errors[field]) return errors
-  const next = { ...errors }
-  delete next[field]
-  return next
-}
 
 export const SchedulerTab: React.FC<SchedulerTabProps> = ({
   isActive = false,
@@ -68,15 +51,15 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
   const { t } = useTranslation(["option", "common"])
   const decksQuery = useDecksQuery()
   const updateDeckMutation = useUpdateDeckMutation()
+  const schedulerDraft = useDeckSchedulerDraft()
 
   const [searchText, setSearchText] = React.useState("")
   const [selectedDeckId, setSelectedDeckId] = React.useState<number | null>(null)
-  const [draft, setDraft] = React.useState<SchedulerSettingsDraft | null>(null)
   const [copyDeckId, setCopyDeckId] = React.useState("")
-  const [validationErrors, setValidationErrors] = React.useState<SchedulerValidationErrors>({})
   const [editorStatus, setEditorStatus] = React.useState<EditorStatus>("idle")
   const [baseDeckId, setBaseDeckId] = React.useState<number | null>(null)
   const [baseVersion, setBaseVersion] = React.useState<number | null>(null)
+  const [baseDraft, setBaseDraft] = React.useState<SchedulerSettingsDraft | null>(null)
   const [conflictDraft, setConflictDraft] = React.useState<SchedulerSettingsDraft | null>(null)
   const [saveError, setSaveError] = React.useState<string | null>(null)
 
@@ -108,16 +91,20 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
 
   const syncDraftFromDeck = React.useCallback(
     (deck: Deck, status: EditorStatus = "idle") => {
+      const nextDraft = createSchedulerDraft({
+        schedulerType: deck.scheduler_type,
+        settings: deck.scheduler_settings
+      })
+      schedulerDraft.replaceDraftState(nextDraft)
       setBaseDeckId(deck.id)
       setBaseVersion(deck.version)
-      setDraft(createSchedulerDraft(copySchedulerSettings(deck.scheduler_settings)))
+      setBaseDraft(cloneDraft(nextDraft))
       setCopyDeckId("")
-      setValidationErrors({})
       setConflictDraft(null)
       setSaveError(null)
       setEditorStatus(status)
     },
-    []
+    [schedulerDraft]
   )
 
   const refreshDeckFromServer = React.useCallback(
@@ -126,20 +113,30 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
       const refreshedDecks = response.data ?? decksQuery.data ?? []
       const latestDeck = refreshedDecks.find((deck) => deck.id === deckId) ?? null
       if (latestDeck) {
-        syncDraftFromDeck(latestDeck, status)
+        const latestDraft = createSchedulerDraft({
+          schedulerType: latestDeck.scheduler_type,
+          settings: latestDeck.scheduler_settings
+        })
+        schedulerDraft.replaceDraftState(latestDraft)
+        setBaseDeckId(latestDeck.id)
+        setBaseVersion(latestDeck.version)
+        setBaseDraft(cloneDraft(latestDraft))
+        setCopyDeckId("")
+        setConflictDraft(null)
+        setSaveError(null)
+        setEditorStatus(status)
       }
       return latestDeck
     },
-    [decksQuery, syncDraftFromDeck]
+    [decksQuery, schedulerDraft]
   )
 
   React.useEffect(() => {
     if (!activeDeck) {
       setBaseDeckId(null)
       setBaseVersion(null)
-      setDraft(null)
+      setBaseDraft(null)
       setCopyDeckId("")
-      setValidationErrors({})
       setConflictDraft(null)
       setSaveError(null)
       setEditorStatus("idle")
@@ -160,54 +157,55 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
     }
   }, [activeDeck, baseDeckId, baseVersion, editorStatus, syncDraftFromDeck])
 
-  const markDirty = React.useCallback(() => {
-    setEditorStatus("dirty")
-    setConflictDraft(null)
-    setSaveError(null)
-  }, [])
+  const draftChanged = React.useMemo(() => {
+    if (!baseDraft) return false
+    return JSON.stringify(schedulerDraft.draft) !== JSON.stringify(baseDraft)
+  }, [baseDraft, schedulerDraft.draft])
 
-  const updateDraftField = React.useCallback(
-    <K extends keyof SchedulerSettingsDraft>(field: K, value: SchedulerSettingsDraft[K]) => {
-      setDraft((current) => (current ? { ...current, [field]: value } : current))
-      setValidationErrors((current) => discardFieldError(current, field as keyof SchedulerValidationErrors))
-      markDirty()
-    },
-    [markDirty]
-  )
+  React.useEffect(() => {
+    if (editorStatus === "saving" || editorStatus === "conflict") return
+    if (draftChanged) {
+      setEditorStatus("dirty")
+    } else if (editorStatus === "dirty") {
+      setEditorStatus("idle")
+    }
+  }, [draftChanged, editorStatus])
 
   const otherDecks = React.useMemo(
     () => allDecks.filter((deck) => deck.id !== activeDeck?.id),
     [activeDeck?.id, allDecks]
   )
 
-  const draftPreview = React.useMemo(() => {
-    if (!draft) return null
-    const parsed = validateSchedulerDraft(draft)
-    return parsed.settings ? formatSchedulerSummary(parsed.settings) : null
-  }, [draft])
+  const draftPreview = schedulerDraft.summary
 
   const applyPreset = React.useCallback(
-    (presetId: (typeof SCHEDULER_PRESETS)[number]["id"]) => {
-      setDraft(createSchedulerDraft(applySchedulerPreset(presetId)))
-      setValidationErrors({})
-      markDirty()
+    (presetId: Parameters<typeof schedulerDraft.applyPreset>[0]) => {
+      schedulerDraft.applyPreset(presetId)
+      setConflictDraft(null)
+      setSaveError(null)
+      setEditorStatus("dirty")
     },
-    [markDirty]
+    [schedulerDraft]
   )
 
   const copyFromSelectedDeck = React.useCallback(() => {
     const sourceDeck = otherDecks.find((deck) => String(deck.id) === copyDeckId)
     if (!sourceDeck) return
-    setDraft(createSchedulerDraft(copySchedulerSettings(sourceDeck.scheduler_settings)))
-    setValidationErrors({})
-    markDirty()
-  }, [copyDeckId, markDirty, otherDecks])
+    schedulerDraft.replaceDraft({
+      schedulerType: sourceDeck.scheduler_type,
+      settings: sourceDeck.scheduler_settings
+    })
+    setConflictDraft(null)
+    setSaveError(null)
+    setEditorStatus("dirty")
+  }, [copyDeckId, otherDecks, schedulerDraft])
 
   const resetToDefaults = React.useCallback(() => {
-    setDraft(createSchedulerDraft(DEFAULT_SCHEDULER_SETTINGS))
-    setValidationErrors({})
-    markDirty()
-  }, [markDirty])
+    schedulerDraft.resetToDefaults()
+    setConflictDraft(null)
+    setSaveError(null)
+    setEditorStatus("dirty")
+  }, [schedulerDraft])
 
   const reloadLatest = React.useCallback(async () => {
     if (!activeDeck) return
@@ -226,18 +224,16 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
 
   const reapplyConflict = React.useCallback(() => {
     if (!conflictDraft) return
-    setDraft(cloneDraft(conflictDraft))
-    setValidationErrors({})
+    schedulerDraft.replaceDraftState(cloneDraft(conflictDraft))
     setEditorStatus("dirty")
     setSaveError(null)
-  }, [conflictDraft])
+  }, [conflictDraft, schedulerDraft])
 
   const handleSave = React.useCallback(async () => {
-    if (!activeDeck || !draft) return
+    if (!activeDeck) return
 
-    const parsed = validateSchedulerDraft(draft)
-    setValidationErrors(parsed.errors)
-    if (!parsed.settings) return
+    const parsed = schedulerDraft.getValidatedSettings()
+    if (!parsed) return
 
     setEditorStatus("saving")
     setSaveError(null)
@@ -246,14 +242,15 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
       const updatedDeck = await updateDeckMutation.mutateAsync({
         deckId: activeDeck.id,
         update: {
-          scheduler_settings: parsed.settings,
+          scheduler_type: parsed.scheduler_type,
+          scheduler_settings: parsed.scheduler_settings,
           expected_version: baseVersion ?? activeDeck.version
         }
       })
       syncDraftFromDeck(updatedDeck, "saved")
     } catch (error: unknown) {
       if (isVersionConflict(error)) {
-        const pendingDraft = cloneDraft(draft)
+        const pendingDraft = cloneDraft(schedulerDraft.draft)
 
         try {
           const latestDeck = await refreshDeckFromServer(activeDeck.id)
@@ -276,19 +273,9 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
         })
       )
     }
-  }, [activeDeck, baseVersion, draft, refreshDeckFromServer, syncDraftFromDeck, t, updateDeckMutation])
+  }, [activeDeck, baseVersion, refreshDeckFromServer, schedulerDraft, t, updateDeckMutation])
 
-  const renderFieldError = (field: keyof SchedulerValidationErrors) => {
-    const error = validationErrors[field]
-    if (!error) return null
-    return (
-      <Text type="danger" className="text-xs">
-        {error}
-      </Text>
-    )
-  }
-
-  const isDirty = editorStatus === "dirty" || editorStatus === "conflict"
+  const isDirty = draftChanged || editorStatus === "conflict"
 
   React.useEffect(() => {
     onDirtyChange?.(isDirty)
@@ -300,9 +287,8 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
     if (!activeDeck) {
       setBaseDeckId(null)
       setBaseVersion(null)
-      setDraft(null)
+      setBaseDraft(null)
       setCopyDeckId("")
-      setValidationErrors({})
       setConflictDraft(null)
       setSaveError(null)
       setEditorStatus("idle")
@@ -371,7 +357,7 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
                           <div className="text-xs text-text-muted">{deck.description}</div>
                         ) : null}
                         <div className="text-xs text-text-subtle">
-                          {formatSchedulerSummary(deck.scheduler_settings)}
+                          {formatSchedulerSummary(deck.scheduler_type, deck.scheduler_settings)}
                         </div>
                       </div>
                     </Button>
@@ -383,7 +369,7 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
         </Card>
 
         <Card size="small">
-          {activeDeck && draft ? (
+          {activeDeck ? (
             <Space orientation="vertical" size={16} className="w-full">
               <div>
                 <Title level={5} className="!mb-0">
@@ -432,6 +418,20 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
 
               {saveError && <Alert type="error" message={saveError} />}
 
+              {schedulerDraft.draft.scheduler_type === "fsrs" &&
+                activeDeck.scheduler_type !== "fsrs" && (
+                  <Alert
+                    type="info"
+                    message={t("option:flashcards.fsrsSwitchInfoTitle", {
+                      defaultValue: "Switching this deck to FSRS"
+                    })}
+                    description={t("option:flashcards.fsrsSwitchInfoBody", {
+                      defaultValue:
+                        "Existing cards keep their review history. FSRS state will be derived conservatively as cards are reviewed."
+                    })}
+                  />
+                )}
+
               <Card
                 size="small"
                 title={t("option:flashcards.schedulerSummaryCard", {
@@ -477,23 +477,6 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
                 title={t("option:flashcards.schedulerTools", { defaultValue: "Tools" })}
               >
                 <Space orientation="vertical" size={12} className="w-full">
-                  <div>
-                    <Text strong>
-                      {t("option:flashcards.schedulerPresets", { defaultValue: "Presets" })}
-                    </Text>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {SCHEDULER_PRESETS.map((preset) => (
-                        <Button
-                          key={preset.id}
-                          onClick={() => applyPreset(preset.id)}
-                          data-testid={`flashcards-scheduler-preset-${preset.id}`}
-                        >
-                          {preset.label}
-                        </Button>
-                      ))}
-                    </div>
-                  </div>
-
                   <div className="flex flex-wrap items-end gap-2">
                     <label className="flex min-w-[220px] flex-col gap-1 text-sm text-text-muted">
                       <span>
@@ -533,115 +516,7 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
                 </Space>
               </Card>
 
-              <div className="grid gap-4 md:grid-cols-2">
-                <label className="flex flex-col gap-1">
-                  <Text strong>
-                    {t("option:flashcards.schedulerFieldNewSteps", {
-                      defaultValue: "New steps (minutes)"
-                    })}
-                  </Text>
-                  <Input
-                    value={draft.new_steps_minutes}
-                    onChange={(event) => updateDraftField("new_steps_minutes", event.target.value)}
-                    data-testid="flashcards-scheduler-field-new-steps"
-                    aria-label="New steps"
-                    placeholder="1, 10"
-                  />
-                  {renderFieldError("new_steps_minutes")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>
-                    {t("option:flashcards.schedulerFieldRelearnSteps", {
-                      defaultValue: "Relearn steps (minutes)"
-                    })}
-                  </Text>
-                  <Input
-                    value={draft.relearn_steps_minutes}
-                    onChange={(event) => updateDraftField("relearn_steps_minutes", event.target.value)}
-                    data-testid="flashcards-scheduler-field-relearn-steps"
-                    aria-label="Relearn steps"
-                    placeholder="10"
-                  />
-                  {renderFieldError("relearn_steps_minutes")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Graduating interval (days)</Text>
-                  <Input
-                    value={draft.graduating_interval_days}
-                    onChange={(event) => updateDraftField("graduating_interval_days", event.target.value)}
-                    data-testid="flashcards-scheduler-field-graduating-interval"
-                    aria-label="Graduating interval"
-                  />
-                  {renderFieldError("graduating_interval_days")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Easy interval (days)</Text>
-                  <Input
-                    value={draft.easy_interval_days}
-                    onChange={(event) => updateDraftField("easy_interval_days", event.target.value)}
-                    data-testid="flashcards-scheduler-field-easy-interval"
-                    aria-label="Easy interval"
-                  />
-                  {renderFieldError("easy_interval_days")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Easy bonus</Text>
-                  <Input
-                    value={draft.easy_bonus}
-                    onChange={(event) => updateDraftField("easy_bonus", event.target.value)}
-                    data-testid="flashcards-scheduler-field-easy-bonus"
-                    aria-label="Easy bonus"
-                  />
-                  {renderFieldError("easy_bonus")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Interval modifier</Text>
-                  <Input
-                    value={draft.interval_modifier}
-                    onChange={(event) => updateDraftField("interval_modifier", event.target.value)}
-                    data-testid="flashcards-scheduler-field-interval-modifier"
-                    aria-label="Interval modifier"
-                  />
-                  {renderFieldError("interval_modifier")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Max interval (days)</Text>
-                  <Input
-                    value={draft.max_interval_days}
-                    onChange={(event) => updateDraftField("max_interval_days", event.target.value)}
-                    data-testid="flashcards-scheduler-field-max-interval"
-                    aria-label="Max interval"
-                  />
-                  {renderFieldError("max_interval_days")}
-                </label>
-
-                <label className="flex flex-col gap-1">
-                  <Text strong>Leech threshold</Text>
-                  <Input
-                    value={draft.leech_threshold}
-                    onChange={(event) => updateDraftField("leech_threshold", event.target.value)}
-                    data-testid="flashcards-scheduler-field-leech-threshold"
-                    aria-label="Leech threshold"
-                  />
-                  {renderFieldError("leech_threshold")}
-                </label>
-              </div>
-
-              <Checkbox
-                checked={draft.enable_fuzz}
-                onChange={(event) => updateDraftField("enable_fuzz", event.target.checked)}
-                data-testid="flashcards-scheduler-field-enable-fuzz"
-              >
-                {t("option:flashcards.schedulerEnableFuzz", {
-                  defaultValue: "Enable review fuzz"
-                })}
-              </Checkbox>
+              <DeckSchedulerSettingsEditor schedulerDraft={schedulerDraft} advancedDefaultOpen />
 
               <div className="flex flex-wrap items-center gap-3">
                 <Button
@@ -653,14 +528,14 @@ export const SchedulerTab: React.FC<SchedulerTabProps> = ({
                     defaultValue: "Save changes"
                   })}
                 </Button>
-                {editorStatus === "dirty" && (
+                {draftChanged && editorStatus !== "conflict" && (
                   <Text type="warning">
                     {t("option:flashcards.schedulerDirtyState", {
                       defaultValue: "Unsaved changes"
                     })}
                   </Text>
                 )}
-                {editorStatus === "saved" && (
+                {editorStatus === "saved" && !draftChanged && (
                   <Text type="success">
                     {t("option:flashcards.schedulerSavedState", {
                       defaultValue: "All changes saved"

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx
@@ -253,6 +253,14 @@ describe("ImageOcclusionTransferPanel", () => {
       leech_threshold: 10,
       enable_fuzz: false
     }
+    const fastAcquisitionEnvelope = {
+      sm2_plus: fastAcquisitionSettings,
+      fsrs: {
+        target_retention: 0.9,
+        maximum_interval_days: 36500,
+        enable_fuzz: false
+      }
+    }
     createDeckMutateAsync.mockResolvedValue({
       id: 9,
       name: "Occlusion deck",
@@ -260,8 +268,9 @@ describe("ImageOcclusionTransferPanel", () => {
       deleted: false,
       client_id: "test",
       version: 1,
-      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
-      scheduler_settings: fastAcquisitionSettings
+      scheduler_type: "sm2_plus",
+      scheduler_settings_json: JSON.stringify(fastAcquisitionEnvelope),
+      scheduler_settings: fastAcquisitionEnvelope
     })
 
     render(<ImageOcclusionTransferPanel />)
@@ -285,7 +294,8 @@ describe("ImageOcclusionTransferPanel", () => {
     await waitFor(() =>
       expect(createDeckMutateAsync).toHaveBeenCalledWith({
         name: "Occlusion deck",
-        scheduler_settings: fastAcquisitionSettings
+        scheduler_type: "sm2_plus",
+        scheduler_settings: fastAcquisitionEnvelope
       })
     )
   })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx
@@ -14,7 +14,7 @@ import {
   useImportLimitsQuery,
   usePreviewStructuredQaImportMutation
 } from "../../hooks"
-import type { DeckSchedulerSettings } from "@/services/flashcards"
+import type { DeckSchedulerSettings, DeckSchedulerSettingsEnvelope } from "@/services/flashcards"
 
 const messageSpies = {
   success: vi.fn(),
@@ -33,6 +33,11 @@ const generateMutateAsync = vi.hoisted(() => vi.fn())
 const previewStructuredMutateAsync = vi.hoisted(() => vi.fn())
 const invalidateQueriesMock = vi.hoisted(() => vi.fn())
 const useQueryMock = vi.hoisted(() => vi.fn())
+const defaultFsrsSettings = {
+  target_retention: 0.9,
+  maximum_interval_days: 36500,
+  enable_fuzz: false
+}
 
 vi.mock("@tanstack/react-query", async () => {
   const actual = await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query")
@@ -115,6 +120,11 @@ const fastAcquisitionSettings: DeckSchedulerSettings = {
   enable_fuzz: false
 }
 
+const fastAcquisitionEnvelope: DeckSchedulerSettingsEnvelope = {
+  sm2_plus: fastAcquisitionSettings,
+  fsrs: defaultFsrsSettings
+}
+
 describe("ImportExportTab deck creation flows", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -137,6 +147,7 @@ describe("ImportExportTab deck creation flows", () => {
           deleted: false,
           client_id: "test",
           version: 1,
+          scheduler_type: "sm2_plus",
           scheduler_settings_json: null,
           scheduler_settings: {
             new_steps_minutes: [1, 10],
@@ -198,8 +209,9 @@ describe("ImportExportTab deck creation flows", () => {
       deleted: false,
       client_id: "test",
       version: 1,
-      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
-      scheduler_settings: fastAcquisitionSettings
+      scheduler_type: "sm2_plus",
+      scheduler_settings_json: JSON.stringify(fastAcquisitionEnvelope),
+      scheduler_settings: fastAcquisitionEnvelope
     })
     previewStructuredMutateAsync.mockResolvedValue({
       drafts: [
@@ -250,7 +262,8 @@ describe("ImportExportTab deck creation flows", () => {
     await waitFor(() =>
       expect(createDeckMutateAsync).toHaveBeenCalledWith({
         name: "Structured deck",
-        scheduler_settings: fastAcquisitionSettings
+        scheduler_type: "sm2_plus",
+        scheduler_settings: fastAcquisitionEnvelope
       })
     )
   })
@@ -263,8 +276,9 @@ describe("ImportExportTab deck creation flows", () => {
       deleted: false,
       client_id: "test",
       version: 1,
-      scheduler_settings_json: JSON.stringify(fastAcquisitionSettings),
-      scheduler_settings: fastAcquisitionSettings
+      scheduler_type: "sm2_plus",
+      scheduler_settings_json: JSON.stringify(fastAcquisitionEnvelope),
+      scheduler_settings: fastAcquisitionEnvelope
     })
     generateMutateAsync.mockResolvedValue({
       flashcards: [
@@ -302,7 +316,8 @@ describe("ImportExportTab deck creation flows", () => {
     await waitFor(() =>
       expect(createDeckMutateAsync).toHaveBeenCalledWith({
         name: "Generated deck",
-        scheduler_settings: fastAcquisitionSettings
+        scheduler_type: "sm2_plus",
+        scheduler_settings: fastAcquisitionEnvelope
       })
     )
   })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx
@@ -102,7 +102,8 @@ if (!(globalThis as any).ResizeObserver) {
 
 const makeCard = (
   queueState: "new" | "learning" | "review" | "relearning" | "suspended",
-  suspendedReason: "manual" | "leech" | null = null
+  suspendedReason: "manual" | "leech" | null = null,
+  schedulerType: "sm2_plus" | "fsrs" = "sm2_plus"
 ) => ({
   uuid: `card-${queueState}`,
   deck_id: 1,
@@ -126,6 +127,7 @@ const makeCard = (
   version: 2,
   model_type: "basic" as const,
   reverse: false,
+  scheduler_type: schedulerType,
   next_intervals: {
     again: "1 min",
     hard: "10 min",
@@ -183,5 +185,25 @@ describe("ReviewTab queue state visibility", () => {
     )
 
     expect(screen.getByTestId("flashcards-review-queue-state")).toHaveTextContent(expectedLabel)
+    expect(screen.getByTestId("flashcards-review-scheduler-type")).toHaveTextContent("SM-2+")
+  })
+
+  it("renders an FSRS scheduler badge when the active card uses the FSRS deck scheduler", () => {
+    vi.mocked(useReviewQuery).mockReturnValue({
+      data: makeCard("review", null, "fsrs"),
+      refetch: vi.fn().mockResolvedValue(undefined)
+    } as any)
+
+    render(
+      <ReviewTab
+        onNavigateToCreate={() => {}}
+        onNavigateToImport={() => {}}
+        reviewDeckId={1}
+        onReviewDeckChange={() => {}}
+        isActive
+      />
+    )
+
+    expect(screen.getByTestId("flashcards-review-scheduler-type")).toHaveTextContent("FSRS")
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
+++ b/apps/packages/ui/src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx
@@ -48,15 +48,8 @@ vi.mock("../../hooks/useFlashcardQueries", () => ({
 const updateDeckMock = vi.fn()
 const refetchDecksMock = vi.fn()
 
-const biologyDeck = {
-  id: 1,
-  name: "Biology",
-  description: "Cells",
-  deleted: false,
-  client_id: "test",
-  version: 2,
-  scheduler_settings_json: null,
-  scheduler_settings: {
+const biologySettings = {
+  sm2_plus: {
     new_steps_minutes: [1, 10],
     relearn_steps_minutes: [10],
     graduating_interval_days: 1,
@@ -66,18 +59,16 @@ const biologyDeck = {
     max_interval_days: 36500,
     leech_threshold: 8,
     enable_fuzz: false
+  },
+  fsrs: {
+    target_retention: 0.9,
+    maximum_interval_days: 36500,
+    enable_fuzz: false
   }
 }
 
-const chemistryDeck = {
-  id: 2,
-  name: "Chemistry",
-  description: "Atoms",
-  deleted: false,
-  client_id: "test",
-  version: 5,
-  scheduler_settings_json: null,
-  scheduler_settings: {
+const chemistrySettings = {
+  sm2_plus: {
     new_steps_minutes: [2, 20],
     relearn_steps_minutes: [15],
     graduating_interval_days: 2,
@@ -87,7 +78,36 @@ const chemistryDeck = {
     max_interval_days: 180,
     leech_threshold: 6,
     enable_fuzz: true
+  },
+  fsrs: {
+    target_retention: 0.88,
+    maximum_interval_days: 1825,
+    enable_fuzz: true
   }
+}
+
+const biologyDeck = {
+  id: 1,
+  name: "Biology",
+  description: "Cells",
+  deleted: false,
+  client_id: "test",
+  version: 2,
+  scheduler_type: "sm2_plus",
+  scheduler_settings_json: null,
+  scheduler_settings: biologySettings
+}
+
+const chemistryDeck = {
+  id: 2,
+  name: "Chemistry",
+  description: "Atoms",
+  deleted: false,
+  client_id: "test",
+  version: 5,
+  scheduler_type: "sm2_plus",
+  scheduler_settings_json: null,
+  scheduler_settings: chemistrySettings
 }
 
 let decksData = [biologyDeck, chemistryDeck]
@@ -127,26 +147,26 @@ describe("SchedulerTab editor", () => {
   it("applies presets, copies another deck, and resets to defaults", async () => {
     render(<SchedulerTab isActive />)
 
-    expect(screen.getByTestId("flashcards-scheduler-field-new-steps")).toHaveValue("1, 10")
+    expect(screen.getByTestId("deck-scheduler-editor-field-new-steps")).toHaveValue("1, 10")
 
     fireEvent.click(screen.getByRole("button", { name: /fast acquisition/i }))
-    expect(screen.getByTestId("flashcards-scheduler-field-new-steps")).toHaveValue("1, 5, 15")
+    expect(screen.getByTestId("deck-scheduler-editor-field-new-steps")).toHaveValue("1, 5, 15")
 
     fireEvent.change(screen.getByTestId("flashcards-scheduler-copy-select"), {
       target: { value: "2" }
     })
     fireEvent.click(screen.getByRole("button", { name: /copy settings/i }))
-    expect(screen.getByTestId("flashcards-scheduler-field-new-steps")).toHaveValue("2, 20")
+    expect(screen.getByTestId("deck-scheduler-editor-field-new-steps")).toHaveValue("2, 20")
 
-    fireEvent.click(screen.getByRole("button", { name: /reset to defaults/i }))
-    expect(screen.getByTestId("flashcards-scheduler-field-new-steps")).toHaveValue("1, 10")
-    expect(screen.getByTestId("flashcards-scheduler-field-leech-threshold")).toHaveValue("8")
+    fireEvent.click(screen.getByTestId("deck-scheduler-editor-reset"))
+    expect(screen.getByTestId("deck-scheduler-editor-field-new-steps")).toHaveValue("1, 10")
+    expect(screen.getByTestId("deck-scheduler-editor-field-leech-threshold")).toHaveValue("8")
   })
 
   it("blocks save when client validation fails", async () => {
     render(<SchedulerTab isActive />)
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "0" }
     })
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
@@ -160,14 +180,17 @@ describe("SchedulerTab editor", () => {
       ...biologyDeck,
       version: 3,
       scheduler_settings: {
-        ...biologyDeck.scheduler_settings,
-        leech_threshold: 9
+        ...biologySettings,
+        sm2_plus: {
+          ...biologySettings.sm2_plus,
+          leech_threshold: 9
+        }
       }
     })
 
     render(<SchedulerTab isActive />)
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "9" }
     })
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
@@ -176,16 +199,20 @@ describe("SchedulerTab editor", () => {
       expect(updateDeckMock).toHaveBeenCalledWith({
         deckId: 1,
         update: {
+          scheduler_type: "sm2_plus",
           scheduler_settings: {
-            new_steps_minutes: [1, 10],
-            relearn_steps_minutes: [10],
-            graduating_interval_days: 1,
-            easy_interval_days: 4,
-            easy_bonus: 1.3,
-            interval_modifier: 1,
-            max_interval_days: 36500,
-            leech_threshold: 9,
-            enable_fuzz: false
+            sm2_plus: {
+              new_steps_minutes: [1, 10],
+              relearn_steps_minutes: [10],
+              graduating_interval_days: 1,
+              easy_interval_days: 4,
+              easy_bonus: 1.3,
+              interval_modifier: 1,
+              max_interval_days: 36500,
+              leech_threshold: 9,
+              enable_fuzz: false
+            },
+            fsrs: biologySettings.fsrs
           },
           expected_version: 2
         }
@@ -204,21 +231,24 @@ describe("SchedulerTab editor", () => {
 
     render(<SchedulerTab isActive />)
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "9" }
     })
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
 
     await screen.findByText(/deck settings changed elsewhere/i)
-    expect(screen.getByTestId("flashcards-scheduler-field-leech-threshold")).toHaveValue("8")
+    expect(screen.getByTestId("deck-scheduler-editor-field-leech-threshold")).toHaveValue("8")
 
     decksData = [
       {
         ...biologyDeck,
         version: 3,
         scheduler_settings: {
-          ...biologyDeck.scheduler_settings,
-          leech_threshold: 12
+          ...biologySettings,
+          sm2_plus: {
+            ...biologySettings.sm2_plus,
+            leech_threshold: 12
+          }
         }
       },
       chemistryDeck
@@ -227,23 +257,23 @@ describe("SchedulerTab editor", () => {
 
     await waitFor(() => {
       expect(refetchDecksMock).toHaveBeenCalled()
-      expect(screen.getByTestId("flashcards-scheduler-field-leech-threshold")).toHaveValue("12")
+      expect(screen.getByTestId("deck-scheduler-editor-field-leech-threshold")).toHaveValue("12")
     })
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "9" }
     })
     fireEvent.click(screen.getByRole("button", { name: /save changes/i }))
 
     await screen.findByText(/deck settings changed elsewhere/i)
     fireEvent.click(screen.getByRole("button", { name: /reapply my draft/i }))
-    expect(screen.getByTestId("flashcards-scheduler-field-leech-threshold")).toHaveValue("9")
+    expect(screen.getByTestId("deck-scheduler-editor-field-leech-threshold")).toHaveValue("9")
   })
 
   it("keeps the active draft when deck search hides the selected deck", () => {
     render(<SchedulerTab isActive />)
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "11" }
     })
     fireEvent.change(screen.getByPlaceholderText(/search decks/i), {
@@ -251,7 +281,7 @@ describe("SchedulerTab editor", () => {
     })
 
     expect(screen.getByText("Biology Scheduler")).toBeInTheDocument()
-    expect(screen.getByTestId("flashcards-scheduler-field-leech-threshold")).toHaveValue("11")
+    expect(screen.getByTestId("deck-scheduler-editor-field-leech-threshold")).toHaveValue("11")
   })
 
   it("loads active-deck counts only for the selected deck and guards dirty deck switches", async () => {
@@ -264,7 +294,7 @@ describe("SchedulerTab editor", () => {
     expect(screen.getByText(/due review/i)).toBeInTheDocument()
     expect(screen.getByText("3")).toBeInTheDocument()
 
-    fireEvent.change(screen.getByTestId("flashcards-scheduler-field-leech-threshold"), {
+    fireEvent.change(screen.getByTestId("deck-scheduler-editor-field-leech-threshold"), {
       target: { value: "11" }
     })
     fireEvent.click(screen.getByRole("button", { name: /chemistry/i }))

--- a/apps/packages/ui/src/components/Flashcards/utils/__tests__/scheduler-settings.test.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/__tests__/scheduler-settings.test.ts
@@ -1,48 +1,73 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  DEFAULT_FSRS_SCHEDULER_SETTINGS,
   DEFAULT_SCHEDULER_SETTINGS,
+  DEFAULT_SCHEDULER_SETTINGS_ENVELOPE,
   applySchedulerPreset,
   createSchedulerDraft,
   formatSchedulerSummary,
+  normalizeSchedulerSettingsEnvelope,
   validateSchedulerDraft
 } from "../scheduler-settings"
 
 describe("scheduler-settings utilities", () => {
   it("formats scheduler summaries from normalized settings", () => {
-    expect(formatSchedulerSummary(DEFAULT_SCHEDULER_SETTINGS)).toBe(
+    expect(formatSchedulerSummary("sm2_plus", DEFAULT_SCHEDULER_SETTINGS_ENVELOPE)).toBe(
+      "1m,10m -> 1d / easy 4d / leech 8 / fuzz off"
+    )
+    expect(formatSchedulerSummary("fsrs", DEFAULT_SCHEDULER_SETTINGS_ENVELOPE)).toBe(
+      "Retention 90% / max 36500d / fuzz off"
+    )
+    expect(formatSchedulerSummary("sm2_plus", DEFAULT_SCHEDULER_SETTINGS)).toBe(
       "1m,10m -> 1d / easy 4d / leech 8 / fuzz off"
     )
   })
 
   it("validates draft values using the scheduler rules", () => {
     const draft = createSchedulerDraft({
-      ...DEFAULT_SCHEDULER_SETTINGS,
-      easy_bonus: 0.8
+      schedulerType: "sm2_plus",
+      settings: {
+        ...DEFAULT_SCHEDULER_SETTINGS_ENVELOPE,
+        sm2_plus: {
+          ...DEFAULT_SCHEDULER_SETTINGS,
+          easy_bonus: 0.8
+        }
+      }
     })
 
-    draft.new_steps_minutes = "1, 0"
-    draft.leech_threshold = "0"
+    draft.sm2_plus.new_steps_minutes = "1, 0"
+    draft.sm2_plus.leech_threshold = "0"
 
     const result = validateSchedulerDraft(draft)
 
     expect(result.settings).toBeNull()
-    expect(result.errors.new_steps_minutes).toMatch(/positive integers/i)
-    expect(result.errors.easy_bonus).toMatch(/>= 1/i)
-    expect(result.errors.leech_threshold).toMatch(/>= 1/i)
+    expect(result.errors.sm2_plus.new_steps_minutes).toMatch(/positive integers/i)
+    expect(result.errors.sm2_plus.easy_bonus).toMatch(/>= 1/i)
+    expect(result.errors.sm2_plus.leech_threshold).toMatch(/>= 1/i)
   })
 
   it("applies the fast acquisition preset as a normalized settings bundle", () => {
-    expect(applySchedulerPreset("fast_acquisition")).toEqual({
-      new_steps_minutes: [1, 5, 15],
-      relearn_steps_minutes: [10],
-      graduating_interval_days: 1,
-      easy_interval_days: 3,
-      easy_bonus: 1.15,
-      interval_modifier: 0.9,
-      max_interval_days: 3650,
-      leech_threshold: 10,
-      enable_fuzz: false
+    expect(applySchedulerPreset("sm2_plus", "fast_acquisition")).toEqual({
+      sm2_plus: {
+        new_steps_minutes: [1, 5, 15],
+        relearn_steps_minutes: [10],
+        graduating_interval_days: 1,
+        easy_interval_days: 3,
+        easy_bonus: 1.15,
+        interval_modifier: 0.9,
+        max_interval_days: 3650,
+        leech_threshold: 10,
+        enable_fuzz: false
+      },
+      fsrs: DEFAULT_FSRS_SCHEDULER_SETTINGS
+    })
+  })
+
+  it("normalizes legacy flat scheduler settings into the envelope shape", () => {
+    expect(normalizeSchedulerSettingsEnvelope(DEFAULT_SCHEDULER_SETTINGS)).toEqual({
+      sm2_plus: DEFAULT_SCHEDULER_SETTINGS,
+      fsrs: DEFAULT_FSRS_SCHEDULER_SETTINGS
     })
   })
 })

--- a/apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts
+++ b/apps/packages/ui/src/components/Flashcards/utils/scheduler-settings.ts
@@ -1,8 +1,24 @@
-import type { DeckSchedulerSettings } from "@/services/flashcards"
+import type {
+  DeckSchedulerSettings,
+  DeckSchedulerSettingsEnvelope,
+  DeckSchedulerType,
+  FsrsSchedulerSettings
+} from "@/services/flashcards"
 
-export type SchedulerPresetId = "default" | "fast_acquisition" | "conservative_review"
+type SchedulerSettingsLike =
+  | DeckSchedulerSettingsEnvelope
+  | DeckSchedulerSettings
+  | null
+  | undefined
 
-export type SchedulerSettingsDraft = {
+export type SchedulerPresetId =
+  | "default"
+  | "fast_acquisition"
+  | "conservative_review"
+  | "high_retention"
+  | "long_horizon"
+
+export type Sm2SchedulerSettingsDraft = {
   new_steps_minutes: string
   relearn_steps_minutes: string
   graduating_interval_days: string
@@ -14,7 +30,22 @@ export type SchedulerSettingsDraft = {
   enable_fuzz: boolean
 }
 
-export type SchedulerValidationErrors = Partial<Record<keyof DeckSchedulerSettings, string>>
+export type FsrsSchedulerSettingsDraft = {
+  target_retention: string
+  maximum_interval_days: string
+  enable_fuzz: boolean
+}
+
+export type SchedulerSettingsDraft = {
+  scheduler_type: DeckSchedulerType
+  sm2_plus: Sm2SchedulerSettingsDraft
+  fsrs: FsrsSchedulerSettingsDraft
+}
+
+export type SchedulerValidationErrors = {
+  sm2_plus: Partial<Record<keyof DeckSchedulerSettings, string>>
+  fsrs: Partial<Record<keyof FsrsSchedulerSettings, string>>
+}
 
 export const DEFAULT_SCHEDULER_SETTINGS: DeckSchedulerSettings = {
   new_steps_minutes: [1, 10],
@@ -28,8 +59,47 @@ export const DEFAULT_SCHEDULER_SETTINGS: DeckSchedulerSettings = {
   enable_fuzz: false
 }
 
-export const SCHEDULER_PRESETS: Array<{
-  id: SchedulerPresetId
+export const DEFAULT_FSRS_SCHEDULER_SETTINGS: FsrsSchedulerSettings = {
+  target_retention: 0.9,
+  maximum_interval_days: 36500,
+  enable_fuzz: false
+}
+
+export const DEFAULT_SCHEDULER_SETTINGS_ENVELOPE: DeckSchedulerSettingsEnvelope = {
+  sm2_plus: DEFAULT_SCHEDULER_SETTINGS,
+  fsrs: DEFAULT_FSRS_SCHEDULER_SETTINGS
+}
+
+const isSchedulerEnvelope = (
+  settings: SchedulerSettingsLike
+): settings is DeckSchedulerSettingsEnvelope =>
+  typeof settings === "object" &&
+  settings !== null &&
+  "sm2_plus" in settings
+
+export const normalizeSchedulerSettingsEnvelope = (
+  settings: SchedulerSettingsLike
+): DeckSchedulerSettingsEnvelope => {
+  if (isSchedulerEnvelope(settings)) {
+    return {
+      sm2_plus: cloneSm2Settings(settings.sm2_plus),
+      fsrs: cloneFsrsSettings(settings.fsrs)
+    }
+  }
+  if (settings && typeof settings === "object") {
+    return {
+      sm2_plus: cloneSm2Settings(settings as DeckSchedulerSettings),
+      fsrs: cloneFsrsSettings(DEFAULT_FSRS_SCHEDULER_SETTINGS)
+    }
+  }
+  return {
+    sm2_plus: cloneSm2Settings(DEFAULT_SCHEDULER_SETTINGS),
+    fsrs: cloneFsrsSettings(DEFAULT_FSRS_SCHEDULER_SETTINGS)
+  }
+}
+
+const SM2_SCHEDULER_PRESETS: Array<{
+  id: Exclude<SchedulerPresetId, "high_retention" | "long_horizon">
   label: string
   description: string
   settings: DeckSchedulerSettings
@@ -74,16 +144,41 @@ export const SCHEDULER_PRESETS: Array<{
   }
 ]
 
-const formatStepSummary = (steps: number[]): string => {
-  if (!steps.length) return "none"
-  return steps.map((step) => `${step}m`).join(",")
-}
+const FSRS_SCHEDULER_PRESETS: Array<{
+  id: Exclude<SchedulerPresetId, "fast_acquisition" | "conservative_review">
+  label: string
+  description: string
+  settings: FsrsSchedulerSettings
+}> = [
+  {
+    id: "default",
+    label: "Default",
+    description: "Baseline FSRS settings",
+    settings: DEFAULT_FSRS_SCHEDULER_SETTINGS
+  },
+  {
+    id: "high_retention",
+    label: "High retention",
+    description: "Shorter review intervals with a higher recall target",
+    settings: {
+      target_retention: 0.95,
+      maximum_interval_days: 3650,
+      enable_fuzz: false
+    }
+  },
+  {
+    id: "long_horizon",
+    label: "Long horizon",
+    description: "Longer review growth for large mature decks",
+    settings: {
+      target_retention: 0.85,
+      maximum_interval_days: 36500,
+      enable_fuzz: true
+    }
+  }
+]
 
-export const formatSchedulerSummary = (settings: DeckSchedulerSettings): string => {
-  return `${formatStepSummary(settings.new_steps_minutes)} -> ${settings.graduating_interval_days}d / easy ${settings.easy_interval_days}d / leech ${settings.leech_threshold} / fuzz ${settings.enable_fuzz ? "on" : "off"}`
-}
-
-const cloneSettings = (settings: DeckSchedulerSettings): DeckSchedulerSettings => ({
+const cloneSm2Settings = (settings: DeckSchedulerSettings): DeckSchedulerSettings => ({
   new_steps_minutes: [...settings.new_steps_minutes],
   relearn_steps_minutes: [...settings.relearn_steps_minutes],
   graduating_interval_days: settings.graduating_interval_days,
@@ -95,7 +190,40 @@ const cloneSettings = (settings: DeckSchedulerSettings): DeckSchedulerSettings =
   enable_fuzz: settings.enable_fuzz
 })
 
-export const createSchedulerDraft = (settings: DeckSchedulerSettings): SchedulerSettingsDraft => ({
+const cloneFsrsSettings = (settings: FsrsSchedulerSettings): FsrsSchedulerSettings => ({
+  target_retention: settings.target_retention,
+  maximum_interval_days: settings.maximum_interval_days,
+  enable_fuzz: settings.enable_fuzz
+})
+
+export const copySchedulerSettings = (settings: DeckSchedulerSettings): DeckSchedulerSettings =>
+  cloneSm2Settings(settings)
+
+export const copySchedulerSettingsEnvelope = (
+  settings: SchedulerSettingsLike
+): DeckSchedulerSettingsEnvelope => normalizeSchedulerSettingsEnvelope(settings)
+
+const formatStepSummary = (steps: number[]): string => {
+  if (!steps.length) return "none"
+  return steps.map((step) => `${step}m`).join(",")
+}
+
+const formatTargetRetention = (value: number): string => `${Math.round(value * 100)}%`
+
+export const formatSchedulerSummary = (
+  schedulerType: DeckSchedulerType,
+  settings: SchedulerSettingsLike
+): string => {
+  const normalized = normalizeSchedulerSettingsEnvelope(settings)
+  if (schedulerType === "fsrs") {
+    return `Retention ${formatTargetRetention(normalized.fsrs.target_retention)} / max ${normalized.fsrs.maximum_interval_days}d / fuzz ${normalized.fsrs.enable_fuzz ? "on" : "off"}`
+  }
+
+  const sm2 = normalized.sm2_plus
+  return `${formatStepSummary(sm2.new_steps_minutes)} -> ${sm2.graduating_interval_days}d / easy ${sm2.easy_interval_days}d / leech ${sm2.leech_threshold} / fuzz ${sm2.enable_fuzz ? "on" : "off"}`
+}
+
+export const createSm2SchedulerDraft = (settings: DeckSchedulerSettings): Sm2SchedulerSettingsDraft => ({
   new_steps_minutes: settings.new_steps_minutes.join(", "),
   relearn_steps_minutes: settings.relearn_steps_minutes.join(", "),
   graduating_interval_days: String(settings.graduating_interval_days),
@@ -106,6 +234,55 @@ export const createSchedulerDraft = (settings: DeckSchedulerSettings): Scheduler
   leech_threshold: String(settings.leech_threshold),
   enable_fuzz: settings.enable_fuzz
 })
+
+export const createFsrsSchedulerDraft = (settings: FsrsSchedulerSettings): FsrsSchedulerSettingsDraft => ({
+  target_retention: String(settings.target_retention),
+  maximum_interval_days: String(settings.maximum_interval_days),
+  enable_fuzz: settings.enable_fuzz
+})
+
+export const createSchedulerDraft = ({
+  schedulerType = "sm2_plus",
+  settings = DEFAULT_SCHEDULER_SETTINGS_ENVELOPE
+}: {
+  schedulerType?: DeckSchedulerType
+  settings?: SchedulerSettingsLike
+} = {}): SchedulerSettingsDraft => {
+  const envelope = normalizeSchedulerSettingsEnvelope(settings)
+  return {
+    scheduler_type: schedulerType,
+    sm2_plus: createSm2SchedulerDraft(envelope.sm2_plus),
+    fsrs: createFsrsSchedulerDraft(envelope.fsrs)
+  }
+}
+
+export const getSchedulerPresets = (schedulerType: DeckSchedulerType) =>
+  schedulerType === "fsrs" ? FSRS_SCHEDULER_PRESETS : SM2_SCHEDULER_PRESETS
+
+export const applySchedulerPreset = (
+  schedulerType: DeckSchedulerType,
+  presetId: SchedulerPresetId
+): DeckSchedulerSettingsEnvelope => {
+  const base = copySchedulerSettingsEnvelope(DEFAULT_SCHEDULER_SETTINGS_ENVELOPE)
+  if (schedulerType === "fsrs") {
+    const preset = FSRS_SCHEDULER_PRESETS.find((candidate) => candidate.id === presetId)
+    base.fsrs = cloneFsrsSettings(preset?.settings ?? DEFAULT_FSRS_SCHEDULER_SETTINGS)
+    return base
+  }
+  const preset = SM2_SCHEDULER_PRESETS.find((candidate) => candidate.id === presetId)
+  base.sm2_plus = cloneSm2Settings(preset?.settings ?? DEFAULT_SCHEDULER_SETTINGS)
+  return base
+}
+
+export const resetSchedulerDefaults = (
+  draft: SchedulerSettingsDraft
+): SchedulerSettingsDraft => {
+  const next = createSchedulerDraft({
+    schedulerType: draft.scheduler_type,
+    settings: copySchedulerSettingsEnvelope(DEFAULT_SCHEDULER_SETTINGS_ENVELOPE)
+  })
+  return next
+}
 
 export const parseSchedulerStepInput = (value: string): number[] => {
   const tokens = value
@@ -161,10 +338,10 @@ const parseFloatField = (value: string, fieldName: string): { value: number | nu
   return { value: parsed }
 }
 
-export const validateSchedulerDraft = (
-  draft: SchedulerSettingsDraft
-): { settings: DeckSchedulerSettings | null; errors: SchedulerValidationErrors } => {
-  const errors: SchedulerValidationErrors = {}
+const validateSm2Draft = (
+  draft: Sm2SchedulerSettingsDraft
+): { settings: DeckSchedulerSettings | null; errors: SchedulerValidationErrors["sm2_plus"] } => {
+  const errors: SchedulerValidationErrors["sm2_plus"] = {}
 
   const newSteps = validateStepField(draft.new_steps_minutes, "New steps")
   if (newSteps.error) errors.new_steps_minutes = newSteps.error
@@ -237,10 +414,65 @@ export const validateSchedulerDraft = (
   }
 }
 
-export const applySchedulerPreset = (presetId: SchedulerPresetId): DeckSchedulerSettings => {
-  const preset = SCHEDULER_PRESETS.find((candidate) => candidate.id === presetId)
-  return cloneSettings(preset?.settings ?? DEFAULT_SCHEDULER_SETTINGS)
+const validateFsrsDraft = (
+  draft: FsrsSchedulerSettingsDraft
+): { settings: FsrsSchedulerSettings | null; errors: SchedulerValidationErrors["fsrs"] } => {
+  const errors: SchedulerValidationErrors["fsrs"] = {}
+  const targetRetention = parseFloatField(draft.target_retention, "Target retention")
+  if (targetRetention.error) errors.target_retention = targetRetention.error
+
+  const maxInterval = parseIntegerField(draft.maximum_interval_days, "Maximum interval")
+  if (maxInterval.error) errors.maximum_interval_days = maxInterval.error
+
+  if ((targetRetention.value ?? 0) <= 0 || (targetRetention.value ?? 0) >= 1) {
+    errors.target_retention = "Target retention must be between 0 and 1"
+  }
+  if ((maxInterval.value ?? 0) < 1) {
+    errors.maximum_interval_days = "Maximum interval must be >= 1"
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { settings: null, errors }
+  }
+
+  return {
+    settings: {
+      target_retention: targetRetention.value!,
+      maximum_interval_days: maxInterval.value!,
+      enable_fuzz: draft.enable_fuzz
+    },
+    errors
+  }
 }
 
-export const copySchedulerSettings = (settings: DeckSchedulerSettings): DeckSchedulerSettings =>
-  cloneSettings(settings)
+export const validateSchedulerDraft = (
+  draft: SchedulerSettingsDraft
+): {
+  schedulerType: DeckSchedulerType
+  settings: DeckSchedulerSettingsEnvelope | null
+  errors: SchedulerValidationErrors
+} => {
+  const sm2 = validateSm2Draft(draft.sm2_plus)
+  const fsrs = validateFsrsDraft(draft.fsrs)
+  const errors: SchedulerValidationErrors = {
+    sm2_plus: sm2.errors,
+    fsrs: fsrs.errors
+  }
+
+  if (!sm2.settings || !fsrs.settings) {
+    return {
+      schedulerType: draft.scheduler_type,
+      settings: null,
+      errors
+    }
+  }
+
+  return {
+    schedulerType: draft.scheduler_type,
+    settings: {
+      sm2_plus: sm2.settings,
+      fsrs: fsrs.settings
+    },
+    errors
+  }
+}

--- a/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/ResultsTab.tsx
@@ -825,7 +825,8 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
             return {
               question_ids: questionIds,
               create_deck_name: trimmedDeckName,
-              create_deck_scheduler_settings: schedulerSettings,
+              create_deck_scheduler_type: schedulerSettings.scheduler_type,
+              create_deck_scheduler_settings: schedulerSettings.scheduler_settings,
               replace_active: replaceActive
             } as const
           })()
@@ -994,7 +995,10 @@ export const ResultsTab: React.FC<ResultsTabProps> = ({ onRetakeQuiz }) => {
               >
                 {t("option:flashcards.selectedDeckSchedulerSummary", {
                   defaultValue: "Scheduler: {{summary}}",
-                  summary: formatSchedulerSummary(selectedDeck.scheduler_settings)
+                  summary: formatSchedulerSummary(
+                    selectedDeck.scheduler_type,
+                    selectedDeck.scheduler_settings
+                  )
                 })}
               </Text>
             ) : null}

--- a/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
+++ b/apps/packages/ui/src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
@@ -545,16 +545,24 @@ describe("ResultsTab remediation panel", () => {
         request: {
           question_ids: [13],
           create_deck_name: "Missed Questions Deck",
+          create_deck_scheduler_type: "sm2_plus",
           create_deck_scheduler_settings: {
-            new_steps_minutes: [1, 5, 15],
-            relearn_steps_minutes: [10],
-            graduating_interval_days: 1,
-            easy_interval_days: 3,
-            easy_bonus: 1.15,
-            interval_modifier: 0.9,
-            max_interval_days: 3650,
-            leech_threshold: 10,
-            enable_fuzz: false
+            sm2_plus: {
+              new_steps_minutes: [1, 5, 15],
+              relearn_steps_minutes: [10],
+              graduating_interval_days: 1,
+              easy_interval_days: 3,
+              easy_bonus: 1.15,
+              interval_modifier: 0.9,
+              max_interval_days: 3650,
+              leech_threshold: 10,
+              enable_fuzz: false
+            },
+            fsrs: {
+              target_retention: 0.9,
+              maximum_interval_days: 36500,
+              enable_fuzz: false
+            }
           },
           replace_active: false
         }

--- a/apps/packages/ui/src/services/flashcards.ts
+++ b/apps/packages/ui/src/services/flashcards.ts
@@ -25,6 +25,24 @@ export type DeckSchedulerSettings = {
   enable_fuzz: boolean
 }
 
+export type DeckSchedulerType = "sm2_plus" | "fsrs"
+
+export type FsrsSchedulerSettings = {
+  target_retention: number
+  maximum_interval_days: number
+  enable_fuzz: boolean
+}
+
+export type DeckSchedulerSettingsEnvelope = {
+  sm2_plus: DeckSchedulerSettings
+  fsrs: FsrsSchedulerSettings
+}
+
+export type DeckSchedulerSettingsEnvelopeUpdate = {
+  sm2_plus?: Partial<DeckSchedulerSettings>
+  fsrs?: Partial<FsrsSchedulerSettings>
+}
+
 export type FlashcardIntervalPreviews = {
   again: string
   hard: string
@@ -112,8 +130,9 @@ export type Deck = {
   version: number
   created_at?: string | null
   last_modified?: string | null
+  scheduler_type: DeckSchedulerType
   scheduler_settings_json?: string | null
-  scheduler_settings: DeckSchedulerSettings
+  scheduler_settings: DeckSchedulerSettingsEnvelope
 }
 
 export type Flashcard = {
@@ -141,6 +160,7 @@ export type Flashcard = {
   version: number
   model_type: "basic" | "basic_reverse" | "cloze"
   reverse: boolean
+  scheduler_type?: DeckSchedulerType | null
   source_ref_type?: "media" | "message" | "note" | "manual" | null
   source_ref_id?: string | null
   conversation_id?: string | null
@@ -151,14 +171,16 @@ export type Flashcard = {
 export type DeckUpdate = {
   name?: string | null
   description?: string | null
-  scheduler_settings?: Partial<DeckSchedulerSettings> | null
+  scheduler_type?: DeckSchedulerType | null
+  scheduler_settings?: DeckSchedulerSettingsEnvelopeUpdate | null
   expected_version?: number | null
 }
 
 export type DeckCreateInput = {
   name: string
   description?: string | null
-  scheduler_settings?: DeckSchedulerSettings | null
+  scheduler_type?: DeckSchedulerType | null
+  scheduler_settings?: DeckSchedulerSettingsEnvelope | null
 }
 
 export type FlashcardCreate = {
@@ -260,6 +282,7 @@ export type FlashcardReviewResponse = {
   last_reviewed_at?: string | null
   last_modified?: string | null
   version: number
+  scheduler_type: DeckSchedulerType
   queue_state: Flashcard["queue_state"]
   step_index?: number | null
   suspended_reason?: Flashcard["suspended_reason"]

--- a/apps/packages/ui/src/services/quizzes.ts
+++ b/apps/packages/ui/src/services/quizzes.ts
@@ -1,8 +1,9 @@
 import { bgRequest } from "@/services/background-proxy"
 import type { AllowedPath } from "@/services/tldw/openapi-guard"
 import { createResourceClient } from "@/services/resource-client"
-import type { DeckSchedulerSettings } from "@/services/flashcards"
 import type {
+  DeckSchedulerSettingsEnvelope,
+  DeckSchedulerType,
   StudyAssistantContextResponse,
   StudyAssistantRespondRequest,
   StudyAssistantRespondResponse
@@ -255,7 +256,8 @@ export type QuizRemediationConvertRequest = {
   question_ids: number[]
   target_deck_id?: number | null
   create_deck_name?: string | null
-  create_deck_scheduler_settings?: DeckSchedulerSettings | null
+  create_deck_scheduler_type?: DeckSchedulerType | null
+  create_deck_scheduler_settings?: DeckSchedulerSettingsEnvelope | null
   replace_active?: boolean
 }
 

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -56,8 +56,9 @@ from tldw_Server_API.app.core.Flashcards.asset_refs import (
 from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (
     SchedulerSettingsError,
     build_next_interval_previews,
-    get_default_scheduler_settings,
+    get_default_scheduler_settings_envelope,
 )
+from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import build_fsrs_next_interval_previews
 from tldw_Server_API.app.core.Flashcards.apkg_exporter import export_apkg_from_rows
 from tldw_Server_API.app.core.Flashcards.apkg_importer import (
     APKGImportError,
@@ -79,6 +80,38 @@ _FLASHCARDS_INT_PARSE_EXCEPTIONS: tuple[type[BaseException], ...] = (
     TypeError,
     ValueError,
 )
+
+
+def _coerce_scheduler_type(value: Any) -> str:
+    return "fsrs" if str(value or "").strip().lower() == "fsrs" else "sm2_plus"
+
+
+def _parse_scheduler_settings_envelope(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, str):
+        if not raw.strip():
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    if isinstance(raw, dict):
+        return raw
+    return {}
+
+
+def _attach_scheduler_preview(card: dict[str, Any], deck: dict[str, Any] | None) -> dict[str, Any]:
+    scheduler_type = _coerce_scheduler_type(deck.get("scheduler_type") if deck else None)
+    card["scheduler_type"] = scheduler_type
+    raw_settings = deck.get("scheduler_settings_json") if deck else None
+    queue_state = str(card.get("queue_state") or "").strip().lower()
+
+    if scheduler_type == "fsrs" and queue_state == "review":
+        envelope = _parse_scheduler_settings_envelope(raw_settings)
+        card["next_intervals"] = build_fsrs_next_interval_previews(card, envelope.get("fsrs"))
+    else:
+        card["next_intervals"] = build_next_interval_previews(card, raw_settings)
+    return card
 _FLASHCARDS_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     AttributeError,
     CharactersRAGDBError,
@@ -383,6 +416,7 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
             payload.name,
             payload.description,
             payload.scheduler_settings.model_dump() if payload.scheduler_settings else None,
+            scheduler_type=payload.scheduler_type,
         )
         # Return the exact deck row by id
         deck = db.get_deck(deck_id)
@@ -398,11 +432,12 @@ def create_deck(payload: DeckCreate, db: CharactersRAGDB = Depends(get_chacha_db
             "deleted": False,
             "client_id": "",
             "version": 1,
+            "scheduler_type": payload.scheduler_type,
             "scheduler_settings_json": None,
             "scheduler_settings": (
                 payload.scheduler_settings.model_dump()
                 if payload.scheduler_settings
-                else get_default_scheduler_settings()
+                else get_default_scheduler_settings_envelope()
             ),
         }
     except SchedulerSettingsError as e:
@@ -433,12 +468,14 @@ def update_deck(
     data = payload.model_dump(exclude_unset=True)
     expected_version = data.pop("expected_version", None)
     scheduler_settings = data.pop("scheduler_settings", None)
+    scheduler_type = data.pop("scheduler_type", None)
     try:
         ok = db.update_deck(
             deck_id,
             name=data.get("name"),
             description=data.get("description"),
             scheduler_settings=scheduler_settings,
+            scheduler_type=scheduler_type,
             expected_version=expected_version,
         )
         if not ok:
@@ -1418,10 +1455,7 @@ def get_next_review_card(
         if not card:
             return {"card": None, "selection_reason": "none"}
         deck = db.get_deck(int(card["deck_id"])) if card.get("deck_id") is not None else None
-        card["next_intervals"] = build_next_interval_previews(
-            card,
-            deck.get("scheduler_settings_json") if deck else None,
-        )
+        card = _attach_scheduler_preview(card, deck)
         return {"card": card, "selection_reason": selection_reason}
     except CharactersRAGDBError as e:
         logger.error(f"Failed to fetch next review card: {e}")

--- a/tldw_Server_API/app/api/v1/endpoints/flashcards.py
+++ b/tldw_Server_API/app/api/v1/endpoints/flashcards.py
@@ -58,7 +58,10 @@ from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (
     build_next_interval_previews,
     get_default_scheduler_settings_envelope,
 )
-from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import build_fsrs_next_interval_previews
+from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (
+    FsrsSettingsError,
+    build_fsrs_next_interval_previews,
+)
 from tldw_Server_API.app.core.Flashcards.apkg_exporter import export_apkg_from_rows
 from tldw_Server_API.app.core.Flashcards.apkg_importer import (
     APKGImportError,
@@ -1438,6 +1441,8 @@ def review_flashcard(payload: FlashcardReviewRequest, db: CharactersRAGDB = Depe
     try:
         updated = db.review_flashcard(payload.card_uuid, payload.rating, payload.answer_time_ms)
         return updated
+    except (SchedulerSettingsError, FsrsSettingsError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except ConflictError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except CharactersRAGDBError as e:
@@ -1457,6 +1462,8 @@ def get_next_review_card(
         deck = db.get_deck(int(card["deck_id"])) if card.get("deck_id") is not None else None
         card = _attach_scheduler_preview(card, deck)
         return {"card": card, "selection_reason": selection_reason}
+    except (SchedulerSettingsError, FsrsSettingsError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except CharactersRAGDBError as e:
         logger.error(f"Failed to fetch next review card: {e}")
         raise HTTPException(status_code=500, detail="Failed to fetch next review card") from e

--- a/tldw_Server_API/app/api/v1/endpoints/quizzes.py
+++ b/tldw_Server_API/app/api/v1/endpoints/quizzes.py
@@ -436,6 +436,7 @@ def convert_attempt_remediation_conversions(
             question_ids=payload.question_ids,
             target_deck_id=payload.target_deck_id,
             create_deck_name=payload.create_deck_name,
+            create_deck_scheduler_type=payload.create_deck_scheduler_type,
             create_deck_scheduler_settings=(
                 payload.create_deck_scheduler_settings.model_dump()
                 if payload.create_deck_scheduler_settings

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -5,6 +5,9 @@ from uuid import UUID
 from pydantic import BaseModel, Field, model_validator
 
 
+DeckSchedulerType = Literal["sm2_plus", "fsrs"]
+
+
 class DeckSchedulerSettings(BaseModel):
     new_steps_minutes: list[int] = Field(default_factory=lambda: [1, 10])
     relearn_steps_minutes: list[int] = Field(default_factory=lambda: [10])
@@ -17,17 +20,54 @@ class DeckSchedulerSettings(BaseModel):
     enable_fuzz: bool = False
 
 
+class FsrsSchedulerSettings(BaseModel):
+    target_retention: float = 0.9
+    maximum_interval_days: int = 36500
+    enable_fuzz: bool = False
+
+
+class DeckSchedulerSettingsEnvelope(BaseModel):
+    sm2_plus: DeckSchedulerSettings = Field(default_factory=DeckSchedulerSettings)
+    fsrs: FsrsSchedulerSettings = Field(default_factory=FsrsSchedulerSettings)
+
+
+def _coerce_scheduler_settings_envelope(raw: Any) -> Any:
+    if not isinstance(raw, dict):
+        return raw
+    if "sm2_plus" in raw or "fsrs" in raw:
+        return raw
+    return {"sm2_plus": raw}
+
+
 class DeckCreate(BaseModel):
     name: str = Field(..., description="Deck name (unique)")
     description: Optional[str] = Field(None, description="Deck description")
-    scheduler_settings: Optional[DeckSchedulerSettings] = None
+    scheduler_type: DeckSchedulerType = "sm2_plus"
+    scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
+
+    @model_validator(mode="before")
+    def _normalize_scheduler_settings(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if "scheduler_settings" in data:
+            data["scheduler_settings"] = _coerce_scheduler_settings_envelope(data.get("scheduler_settings"))
+        return data
 
 
 class DeckUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
-    scheduler_settings: Optional[DeckSchedulerSettings] = None
+    scheduler_type: Optional[DeckSchedulerType] = None
+    scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
     expected_version: Optional[int] = Field(None, ge=1)
+
+    @model_validator(mode="before")
+    def _normalize_scheduler_settings(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if "scheduler_settings" in data:
+            data["scheduler_settings"] = _coerce_scheduler_settings_envelope(data.get("scheduler_settings"))
+        return data
 
 
 class Deck(BaseModel):
@@ -39,8 +79,9 @@ class Deck(BaseModel):
     deleted: bool
     client_id: str
     version: int
+    scheduler_type: DeckSchedulerType = "sm2_plus"
     scheduler_settings_json: Optional[str] = None
-    scheduler_settings: DeckSchedulerSettings = Field(default_factory=DeckSchedulerSettings)
+    scheduler_settings: DeckSchedulerSettingsEnvelope = Field(default_factory=DeckSchedulerSettingsEnvelope)
 
     @model_validator(mode="before")
     def _populate_scheduler_settings(cls, data):
@@ -53,9 +94,9 @@ class Deck(BaseModel):
             try:
                 parsed = json.loads(raw)
                 if isinstance(parsed, dict):
-                    data["scheduler_settings"] = parsed
+                    data["scheduler_settings"] = _coerce_scheduler_settings_envelope(parsed)
             except Exception:
-                data["scheduler_settings"] = DeckSchedulerSettings().model_dump()
+                data["scheduler_settings"] = DeckSchedulerSettingsEnvelope().model_dump()
         return data
 
 
@@ -111,6 +152,7 @@ class Flashcard(BaseModel):
     version: int
     model_type: Literal['basic','basic_reverse','cloze']
     reverse: bool
+    scheduler_type: Optional[DeckSchedulerType] = None
     next_intervals: Optional[FlashcardReviewIntervalPreviews] = None
 
     @model_validator(mode="before")
@@ -156,6 +198,7 @@ class FlashcardReviewResponse(BaseModel):
     last_reviewed_at: Optional[str] = None
     last_modified: Optional[str] = None
     version: int
+    scheduler_type: DeckSchedulerType
     queue_state: Literal["new", "learning", "review", "relearning", "suspended"]
     step_index: Optional[int] = None
     suspended_reason: Optional[Literal["manual", "leech"]] = None

--- a/tldw_Server_API/app/api/v1/schemas/flashcards.py
+++ b/tldw_Server_API/app/api/v1/schemas/flashcards.py
@@ -21,8 +21,8 @@ class DeckSchedulerSettings(BaseModel):
 
 
 class FsrsSchedulerSettings(BaseModel):
-    target_retention: float = 0.9
-    maximum_interval_days: int = 36500
+    target_retention: float = Field(0.9, gt=0, lt=1)
+    maximum_interval_days: int = Field(36500, ge=1)
     enable_fuzz: bool = False
 
 
@@ -46,7 +46,7 @@ class DeckCreate(BaseModel):
     scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
 
     @model_validator(mode="before")
-    def _normalize_scheduler_settings(cls, data):
+    def _normalize_scheduler_settings(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
         if "scheduler_settings" in data:
@@ -62,7 +62,7 @@ class DeckUpdate(BaseModel):
     expected_version: Optional[int] = Field(None, ge=1)
 
     @model_validator(mode="before")
-    def _normalize_scheduler_settings(cls, data):
+    def _normalize_scheduler_settings(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
         if "scheduler_settings" in data:
@@ -84,7 +84,7 @@ class Deck(BaseModel):
     scheduler_settings: DeckSchedulerSettingsEnvelope = Field(default_factory=DeckSchedulerSettingsEnvelope)
 
     @model_validator(mode="before")
-    def _populate_scheduler_settings(cls, data):
+    def _populate_scheduler_settings(cls, data: Any) -> Any:
         if not isinstance(data, dict):
             return data
         if data.get("scheduler_settings") is not None:

--- a/tldw_Server_API/app/api/v1/schemas/quizzes.py
+++ b/tldw_Server_API/app/api/v1/schemas/quizzes.py
@@ -3,7 +3,11 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from .flashcards import DeckSchedulerSettings
+from .flashcards import (
+    DeckSchedulerSettingsEnvelope,
+    DeckSchedulerType,
+    _coerce_scheduler_settings_envelope,
+)
 
 
 class QuestionType(str, Enum):
@@ -226,8 +230,19 @@ class QuizRemediationConvertRequest(BaseModel):
     question_ids: list[int] = Field(..., min_length=1)
     target_deck_id: Optional[int] = Field(None, ge=1)
     create_deck_name: Optional[str] = None
-    create_deck_scheduler_settings: Optional[DeckSchedulerSettings] = None
+    create_deck_scheduler_type: Optional[DeckSchedulerType] = None
+    create_deck_scheduler_settings: Optional[DeckSchedulerSettingsEnvelope] = None
     replace_active: bool = False
+
+    @model_validator(mode="before")
+    def normalize_scheduler_settings(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if "create_deck_scheduler_settings" in data:
+            data["create_deck_scheduler_settings"] = _coerce_scheduler_settings_envelope(
+                data.get("create_deck_scheduler_settings")
+            )
+        return data
 
     @model_validator(mode="after")
     def validate_deck_target(self) -> "QuizRemediationConvertRequest":
@@ -235,8 +250,8 @@ class QuizRemediationConvertRequest(BaseModel):
         has_create_deck = bool((self.create_deck_name or "").strip())
         if has_target_deck == has_create_deck:
             raise ValueError("Provide exactly one of target_deck_id or create_deck_name")
-        if self.create_deck_scheduler_settings is not None and not has_create_deck:
-            raise ValueError("create_deck_scheduler_settings requires create_deck_name")
+        if (self.create_deck_scheduler_settings is not None or self.create_deck_scheduler_type is not None) and not has_create_deck:
+            raise ValueError("create_deck scheduler options require create_deck_name")
         return self
 
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -6572,6 +6572,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 conn.execute(
                     f"ALTER TABLE decks ADD COLUMN scheduler_settings_json TEXT NOT NULL DEFAULT '{default_settings_json}'"
                 )
+            if "scheduler_type" not in deck_cols:
+                conn.execute("ALTER TABLE decks ADD COLUMN scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'")
             conn.execute(
                 """
                 UPDATE decks
@@ -6579,6 +6581,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                  WHERE scheduler_settings_json IS NULL OR trim(scheduler_settings_json) = ''
                 """,
                 (default_settings_json,),
+            )
+            conn.execute(
+                """
+                UPDATE decks
+                   SET scheduler_type = 'sm2_plus'
+                 WHERE scheduler_type IS NULL OR trim(scheduler_type) = ''
+                """
             )
         except sqlite3.Error as exc:
             raise SchemaError(f"Failed ensuring decks.scheduler_settings_json: {exc}") from exc  # noqa: TRY003
@@ -6591,6 +6600,15 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 conn.execute("ALTER TABLE flashcards ADD COLUMN step_index INTEGER")
             if "suspended_reason" not in flashcard_cols:
                 conn.execute("ALTER TABLE flashcards ADD COLUMN suspended_reason TEXT")
+            if "scheduler_state_json" not in flashcard_cols:
+                conn.execute("ALTER TABLE flashcards ADD COLUMN scheduler_state_json TEXT NOT NULL DEFAULT '{}'")
+            conn.execute(
+                """
+                UPDATE flashcards
+                   SET scheduler_state_json = '{}'
+                 WHERE scheduler_state_json IS NULL OR trim(scheduler_state_json) = ''
+                """
+            )
 
             rows = conn.execute(
                 """
@@ -6630,6 +6648,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
         try:
             review_cols = {str(row[1]): row for row in conn.execute("PRAGMA table_info('flashcard_reviews')").fetchall()}
+            if "scheduler_type" not in review_cols:
+                conn.execute("ALTER TABLE flashcard_reviews ADD COLUMN scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'")
             if "previous_queue_state" not in review_cols:
                 conn.execute("ALTER TABLE flashcard_reviews ADD COLUMN previous_queue_state TEXT")
             if "next_queue_state" not in review_cols:
@@ -6780,8 +6800,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 connection=conn,
             )
             self.backend.execute(
+                "ALTER TABLE decks ADD COLUMN IF NOT EXISTS scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'",
+                connection=conn,
+            )
+            self.backend.execute(
                 "UPDATE decks SET scheduler_settings_json = %s WHERE scheduler_settings_json IS NULL OR btrim(scheduler_settings_json) = ''",
                 (default_settings_json,),
+                connection=conn,
+            )
+            self.backend.execute(
+                "UPDATE decks SET scheduler_type = 'sm2_plus' WHERE scheduler_type IS NULL OR btrim(scheduler_type) = ''",
                 connection=conn,
             )
             self.backend.execute(
@@ -6794,6 +6822,18 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             )
             self.backend.execute(
                 "ALTER TABLE flashcards ADD COLUMN IF NOT EXISTS suspended_reason TEXT",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcards ADD COLUMN IF NOT EXISTS scheduler_state_json TEXT NOT NULL DEFAULT '{}'",
+                connection=conn,
+            )
+            self.backend.execute(
+                "UPDATE flashcards SET scheduler_state_json = '{}' WHERE scheduler_state_json IS NULL OR btrim(scheduler_state_json) = ''",
+                connection=conn,
+            )
+            self.backend.execute(
+                "ALTER TABLE flashcard_reviews ADD COLUMN IF NOT EXISTS scheduler_type TEXT NOT NULL DEFAULT 'sm2_plus'",
                 connection=conn,
             )
             self.backend.execute(
@@ -18810,13 +18850,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         )
                     return deck_id
                 insert_sql = (
-                    "INSERT INTO decks(name, description, scheduler_settings_json, created_at, last_modified, client_id, version, deleted)"
-                    " VALUES(?, ?, ?, ?, ?, ?, ?, ?)"
+                    "INSERT INTO decks(name, description, scheduler_settings_json, scheduler_type, created_at, last_modified, client_id, version, deleted)"
+                    " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 )
                 params = (
                     name,
                     description,
                     scheduler_settings_json,
+                    "sm2_plus",
                     now,
                     now,
                     self.client_id,
@@ -18849,12 +18890,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def list_decks(self, limit: int = 100, offset: int = 0, include_deleted: bool = False) -> list[dict[str, Any]]:
         if include_deleted:
             query = (
-                "SELECT id, name, description, scheduler_settings_json, created_at, last_modified, "
+                "SELECT id, name, description, scheduler_settings_json, scheduler_type, created_at, last_modified, "
                 "deleted, client_id, version FROM decks ORDER BY name LIMIT ? OFFSET ?"
             )
         else:
             query = (
-                "SELECT id, name, description, scheduler_settings_json, created_at, last_modified, "
+                "SELECT id, name, description, scheduler_settings_json, scheduler_type, created_at, last_modified, "
                 "deleted, client_id, version FROM decks WHERE deleted = 0 ORDER BY name LIMIT ? OFFSET ?"
             )
         try:
@@ -18866,7 +18907,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def get_deck(self, deck_id: int) -> dict[str, Any] | None:
         """Fetch a single deck row by id."""
         query = (
-            "SELECT id, name, description, scheduler_settings_json, created_at, last_modified, deleted, client_id, version "
+            "SELECT id, name, description, scheduler_settings_json, scheduler_type, created_at, last_modified, deleted, client_id, version "
             "FROM decks WHERE id = ?"
         )
         try:

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -101,11 +101,79 @@ from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (  # noqa: E402
     simulate_review_transition,
     to_iso_z,
 )
+from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (  # noqa: E402
+    build_fsrs_next_interval_previews,
+    normalize_fsrs_settings,
+    simulate_fsrs_review_transition,
+)
 
 #
 ########################################################################################################################
 #
 # Functions:
+
+_SUPPORTED_FLASHCARD_SCHEDULERS = {"sm2_plus", "fsrs"}
+
+
+def _coerce_scheduler_type(value: Any) -> str:
+    normalized = str(value or "").strip().lower()
+    return normalized if normalized in _SUPPORTED_FLASHCARD_SCHEDULERS else "sm2_plus"
+
+
+def _normalize_scheduler_settings_envelope(raw: Mapping[str, Any] | str | None) -> dict[str, Any]:
+    if raw is None:
+        source: dict[str, Any] = {}
+    elif isinstance(raw, str):
+        if not raw.strip():
+            source = {}
+        else:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                raise SchedulerSettingsError("scheduler_settings must be a JSON object")
+            source = parsed
+    elif isinstance(raw, Mapping):
+        source = dict(raw)
+    else:
+        raise SchedulerSettingsError("scheduler_settings must be a mapping or JSON string")
+
+    if "sm2_plus" in source or "fsrs" in source:
+        sm2_source = source.get("sm2_plus")
+        fsrs_source = source.get("fsrs")
+    else:
+        sm2_source = source
+        fsrs_source = None
+
+    return {
+        "sm2_plus": normalize_scheduler_settings(sm2_source),
+        "fsrs": normalize_fsrs_settings(fsrs_source),
+    }
+
+
+def _simulate_scheduler_review_transition(
+    card: Mapping[str, Any],
+    *,
+    scheduler_type: str,
+    scheduler_settings_envelope: Mapping[str, Any],
+    rating: int,
+    now: datetime,
+) -> dict[str, Any]:
+    queue_state = coerce_queue_state(card)
+    if scheduler_type == "fsrs" and queue_state == "review":
+        return simulate_fsrs_review_transition(card, scheduler_settings_envelope["fsrs"], rating, now=now)
+    return simulate_review_transition(card, scheduler_settings_envelope["sm2_plus"], rating, now=now)
+
+
+def _build_scheduler_next_interval_previews(
+    card: Mapping[str, Any],
+    *,
+    scheduler_type: str,
+    scheduler_settings_envelope: Mapping[str, Any],
+    now: datetime,
+) -> dict[str, str]:
+    queue_state = coerce_queue_state(card)
+    if scheduler_type == "fsrs" and queue_state == "review":
+        return build_fsrs_next_interval_previews(card, scheduler_settings_envelope["fsrs"], now=now)
+    return build_next_interval_previews(card, scheduler_settings_envelope["sm2_plus"], now=now)
 
 # --- Order-by validation helpers (defense in depth) ---
 _ORDER_BY_COLUMN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)?$")
@@ -6424,6 +6492,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'create',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
@@ -6434,6 +6503,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 WHEN OLD.deleted = NEW.deleted AND (
                      OLD.name IS NOT NEW.name OR
                      OLD.description IS NOT NEW.description OR
+                     OLD.scheduler_type IS NOT NEW.scheduler_type OR
                      OLD.scheduler_settings_json IS NOT NEW.scheduler_settings_json OR
                      OLD.last_modified IS NOT NEW.last_modified OR
                      OLD.version IS NOT NEW.version)
@@ -6441,6 +6511,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
@@ -6463,6 +6534,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                   INSERT INTO sync_log(entity,entity_id,operation,timestamp,client_id,version,payload)
                   VALUES('decks',CAST(NEW.id AS TEXT),'update',NEW.last_modified,NEW.client_id,NEW.version,
                          json_object('id',NEW.id,'name',NEW.name,'description',NEW.description,
+                                     'scheduler_type',NEW.scheduler_type,
                                      'scheduler_settings_json',NEW.scheduler_settings_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
@@ -6485,6 +6557,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                      'lapses',NEW.lapses,'due_at',NEW.due_at,'last_reviewed_at',NEW.last_reviewed_at,
                                      'model_type',NEW.model_type,'reverse',NEW.reverse,
                                      'queue_state',NEW.queue_state,'step_index',NEW.step_index,'suspended_reason',NEW.suspended_reason,
+                                     'scheduler_state_json',NEW.scheduler_state_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
                 END;
@@ -6514,6 +6587,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                      OLD.queue_state IS NOT NEW.queue_state OR
                      OLD.step_index IS NOT NEW.step_index OR
                      OLD.suspended_reason IS NOT NEW.suspended_reason OR
+                     OLD.scheduler_state_json IS NOT NEW.scheduler_state_json OR
                      OLD.last_modified IS NOT NEW.last_modified OR
                      OLD.version IS NOT NEW.version)
                 BEGIN
@@ -6527,6 +6601,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                      'lapses',NEW.lapses,'due_at',NEW.due_at,'last_reviewed_at',NEW.last_reviewed_at,
                                      'model_type',NEW.model_type,'reverse',NEW.reverse,
                                      'queue_state',NEW.queue_state,'step_index',NEW.step_index,'suspended_reason',NEW.suspended_reason,
+                                     'scheduler_state_json',NEW.scheduler_state_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
                 END;
@@ -6555,6 +6630,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                                      'lapses',NEW.lapses,'due_at',NEW.due_at,'last_reviewed_at',NEW.last_reviewed_at,
                                      'model_type',NEW.model_type,'reverse',NEW.reverse,
                                      'queue_state',NEW.queue_state,'step_index',NEW.step_index,'suspended_reason',NEW.suspended_reason,
+                                     'scheduler_state_json',NEW.scheduler_state_json,
                                      'created_at',NEW.created_at,'last_modified',NEW.last_modified,
                                      'deleted',NEW.deleted,'client_id',NEW.client_id,'version',NEW.version));
                 END;
@@ -18809,9 +18885,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         name: str,
         description: str | None = None,
         scheduler_settings: Mapping[str, Any] | str | None = None,
+        *,
+        scheduler_type: str = "sm2_plus",
     ) -> int:
         """Create a deck and return its id."""
         now = self._get_current_utc_timestamp_iso()
+        scheduler_type = _coerce_scheduler_type(scheduler_type)
         scheduler_settings_json = scheduler_settings_to_json(scheduler_settings)
         try:
             with self.transaction() as conn:
@@ -18828,6 +18907,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         (
                             "UPDATE decks SET deleted = ?, last_modified = ?, version = ?, client_id = ?, "
                             "description = COALESCE(?, description), "
+                            "scheduler_type = COALESCE(?, scheduler_type), "
                             "scheduler_settings_json = COALESCE(?, scheduler_settings_json) "
                             "WHERE id = ? AND version = ?"
                         ),
@@ -18837,6 +18917,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                             next_version,
                             self.client_id,
                             description,
+                            scheduler_type,
                             scheduler_settings_json,
                             deck_id,
                             current_version,
@@ -18857,7 +18938,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     name,
                     description,
                     scheduler_settings_json,
-                    "sm2_plus",
+                    scheduler_type,
                     now,
                     now,
                     self.client_id,
@@ -18924,6 +19005,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         name: str | None = None,
         description: str | None = None,
         scheduler_settings: Mapping[str, Any] | str | None = None,
+        scheduler_type: str | None = None,
         expected_version: int | None = None,
     ) -> bool:
         """Update mutable deck fields with optimistic locking."""
@@ -18938,6 +19020,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if scheduler_settings is not None:
             set_parts.append("scheduler_settings_json = ?")
             params.append(scheduler_settings_to_json(scheduler_settings))
+        if scheduler_type is not None:
+            set_parts.append("scheduler_type = ?")
+            params.append(_coerce_scheduler_type(scheduler_type))
         if not set_parts:
             if expected_version is None:
                 return True
@@ -19563,6 +19648,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     """
                     SELECT f.id, f.uuid, f.deck_id, f.ef, f.interval_days, f.repetitions, f.lapses,
                            f.due_at, f.last_reviewed_at, f.queue_state, f.step_index, f.suspended_reason,
+                           f.scheduler_state_json,
+                           COALESCE(d.scheduler_type, 'sm2_plus') AS scheduler_type,
                            COALESCE(d.scheduler_settings_json, ?) AS scheduler_settings_json
                       FROM flashcards f
                       LEFT JOIN decks d ON d.id = f.deck_id
@@ -19575,15 +19662,22 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 card_id = int(card['id'])
                 previous_queue_state = coerce_queue_state(dict(card))
                 previous_due_at = self._normalize_nullable_text(card["due_at"])
-                scheduler_settings = normalize_scheduler_settings(card["scheduler_settings_json"])
-                upd = simulate_review_transition(dict(card), scheduler_settings, int(rating), now=now_dt)
+                scheduler_type = _coerce_scheduler_type(card["scheduler_type"])
+                scheduler_settings = _normalize_scheduler_settings_envelope(card["scheduler_settings_json"])
+                upd = _simulate_scheduler_review_transition(
+                    dict(card),
+                    scheduler_type=scheduler_type,
+                    scheduler_settings_envelope=scheduler_settings,
+                    rating=int(rating),
+                    now=now_dt,
+                )
 
                 conn.execute(
                     """
                     UPDATE flashcards
                        SET ef = ?, interval_days = ?, repetitions = ?, lapses = ?,
                            due_at = ?, last_reviewed_at = ?, queue_state = ?, step_index = ?,
-                           suspended_reason = ?, last_modified = ?, version = version + 1, client_id = ?
+                           suspended_reason = ?, scheduler_state_json = ?, last_modified = ?, version = version + 1, client_id = ?
                      WHERE id = ? AND deleted = 0
                     """,
                     (
@@ -19596,6 +19690,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         upd["queue_state"],
                         upd["step_index"],
                         upd["suspended_reason"],
+                        upd.get("scheduler_state_json", "{}"),
                         now,
                         self.client_id,
                         card_id,
@@ -19605,10 +19700,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     """
                     INSERT INTO flashcard_reviews(
                         card_id, reviewed_at, rating, answer_time_ms, scheduled_interval_days,
-                        new_ef, new_repetitions, was_lapse, client_id,
+                        new_ef, new_repetitions, was_lapse, client_id, scheduler_type,
                         previous_queue_state, next_queue_state, previous_due_at, next_due_at
                     )
-                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         card_id,
@@ -19620,6 +19715,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                         upd["repetitions"],
                         1 if upd["was_lapse"] else 0,
                         self.client_id,
+                        scheduler_type,
                         previous_queue_state,
                         upd["queue_state"],
                         previous_due_at,
@@ -19629,14 +19725,20 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 updated = conn.execute(
                     """
                     SELECT uuid, ef, interval_days, repetitions, lapses, due_at, last_reviewed_at,
-                           last_modified, version, queue_state, step_index, suspended_reason
+                           last_modified, version, queue_state, step_index, suspended_reason, scheduler_state_json
                       FROM flashcards
                      WHERE id = ?
                     """,
                     (card_id,)
                 ).fetchone()
                 updated_payload = dict(updated)
-                updated_payload["next_intervals"] = build_next_interval_previews(updated_payload, scheduler_settings, now=now_dt)
+                updated_payload["scheduler_type"] = scheduler_type
+                updated_payload["next_intervals"] = _build_scheduler_next_interval_previews(
+                    updated_payload,
+                    scheduler_type=scheduler_type,
+                    scheduler_settings_envelope=scheduler_settings,
+                    now=now_dt,
+                )
                 return updated_payload
         except sqlite3.Error as e:
             raise CharactersRAGDBError(f"Failed to review flashcard: {e}") from e  # noqa: TRY003
@@ -19807,7 +19909,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             SELECT f.uuid, f.deck_id, d.name AS deck_name, f.front, f.back, f.notes, f.extra, f.is_cloze, f.tags_json,
                    f.source_ref_type, f.source_ref_id, f.conversation_id, f.message_id,
                    f.ef, f.interval_days, f.repetitions, f.lapses, f.due_at, f.last_reviewed_at,
-                   f.queue_state, f.step_index, f.suspended_reason,
+                   f.queue_state, f.step_index, f.suspended_reason, f.scheduler_state_json, d.scheduler_type,
                    f.created_at, f.last_modified, f.deleted, f.client_id, f.version, f.model_type, f.reverse
               FROM flashcards f
               LEFT JOIN decks d ON d.id = f.deck_id
@@ -21212,6 +21314,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         question_ids: list[int],
         target_deck_id: int | None = None,
         create_deck_name: str | None = None,
+        create_deck_scheduler_type: str | None = None,
         create_deck_scheduler_settings: Mapping[str, Any] | str | None = None,
         replace_active: bool = False,
     ) -> dict[str, Any]:
@@ -21275,6 +21378,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     created_deck_id = self.add_deck(
                         normalized_create_deck_name,
                         description=None,
+                        scheduler_type=_coerce_scheduler_type(create_deck_scheduler_type),
                         scheduler_settings=create_deck_scheduler_settings,
                     )
                     deck = self.get_deck(int(created_deck_id))

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -92,6 +92,7 @@ from tldw_Server_API.app.core.Flashcards.asset_refs import (  # noqa: E402
 )
 from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (  # noqa: E402
     MATURE_INTERVAL_DAYS,
+    SchedulerSettingsError,
     build_next_interval_previews,
     coerce_queue_state,
     get_default_scheduler_settings,
@@ -102,6 +103,7 @@ from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (  # noqa: E402
     to_iso_z,
 )
 from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (  # noqa: E402
+    FsrsSettingsError,
     build_fsrs_next_interval_previews,
     normalize_fsrs_settings,
     simulate_fsrs_review_transition,
@@ -127,7 +129,10 @@ def _normalize_scheduler_settings_envelope(raw: Mapping[str, Any] | str | None) 
         if not raw.strip():
             source = {}
         else:
-            parsed = json.loads(raw)
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise SchedulerSettingsError("scheduler_settings must be valid JSON") from exc
             if not isinstance(parsed, dict):
                 raise SchedulerSettingsError("scheduler_settings must be a JSON object")
             source = parsed
@@ -143,10 +148,13 @@ def _normalize_scheduler_settings_envelope(raw: Mapping[str, Any] | str | None) 
         sm2_source = source
         fsrs_source = None
 
-    return {
-        "sm2_plus": normalize_scheduler_settings(sm2_source),
-        "fsrs": normalize_fsrs_settings(fsrs_source),
-    }
+    try:
+        return {
+            "sm2_plus": normalize_scheduler_settings(sm2_source),
+            "fsrs": normalize_fsrs_settings(fsrs_source),
+        }
+    except FsrsSettingsError as exc:
+        raise SchedulerSettingsError(str(exc)) from exc
 
 
 def _simulate_scheduler_review_transition(
@@ -20225,6 +20233,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                            queue_state = 'new',
                            step_index = NULL,
                            suspended_reason = NULL,
+                           scheduler_state_json = '{}',
                            due_at = ?,
                            last_reviewed_at = NULL,
                            last_modified = ?,

--- a/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
+++ b/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
@@ -1,3 +1,5 @@
+"""FSRS review-stage scheduling helpers for flashcards."""
+
 import math
 import copy
 import json

--- a/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
+++ b/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
@@ -4,6 +4,8 @@ import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
 
+from loguru import logger
+
 from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (
     format_interval_label,
     parse_iso_datetime,
@@ -32,7 +34,10 @@ def normalize_fsrs_settings(raw: Mapping[str, Any] | str | None) -> dict[str, An
         if not raw.strip():
             source = {}
         else:
-            parsed = json.loads(raw)
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise FsrsSettingsError("fsrs settings must be valid JSON") from exc
             if not isinstance(parsed, dict):
                 raise FsrsSettingsError("fsrs settings must be a JSON object")
             source = parsed
@@ -105,6 +110,10 @@ def _load_fsrs_state(card: Mapping[str, Any], now: datetime) -> dict[str, Any]:
         try:
             loaded = json.loads(raw)
         except json.JSONDecodeError:
+            logger.warning(
+                "Invalid FSRS scheduler_state_json for flashcard {}. Rebootstrapping state.",
+                card.get("uuid") or "<unknown>",
+            )
             loaded = {}
         parsed = dict(loaded) if isinstance(loaded, dict) else {}
     else:

--- a/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
+++ b/tldw_Server_API/app/core/Flashcards/scheduler_fsrs.py
@@ -1,0 +1,229 @@
+import math
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (
+    format_interval_label,
+    parse_iso_datetime,
+    to_iso_z,
+)
+
+DEFAULT_FSRS_SETTINGS: dict[str, Any] = {
+    "target_retention": 0.9,
+    "maximum_interval_days": 36500,
+    "enable_fuzz": False,
+}
+
+
+class FsrsSettingsError(ValueError):
+    """Raised when FSRS deck settings are invalid."""
+
+
+def get_default_fsrs_settings() -> dict[str, Any]:
+    return copy.deepcopy(DEFAULT_FSRS_SETTINGS)
+
+
+def normalize_fsrs_settings(raw: Mapping[str, Any] | str | None) -> dict[str, Any]:
+    if raw is None:
+        source: dict[str, Any] = {}
+    elif isinstance(raw, str):
+        if not raw.strip():
+            source = {}
+        else:
+            parsed = json.loads(raw)
+            if not isinstance(parsed, dict):
+                raise FsrsSettingsError("fsrs settings must be a JSON object")
+            source = parsed
+    elif isinstance(raw, Mapping):
+        source = dict(raw)
+    else:
+        raise FsrsSettingsError("fsrs settings must be a mapping or JSON string")
+
+    settings = get_default_fsrs_settings()
+    for key in settings:
+        if key in source and source[key] is not None:
+            settings[key] = source[key]
+
+    try:
+        settings["target_retention"] = float(settings["target_retention"])
+    except (TypeError, ValueError) as exc:
+        raise FsrsSettingsError("target_retention must be numeric") from exc
+
+    try:
+        settings["maximum_interval_days"] = int(settings["maximum_interval_days"])
+    except (TypeError, ValueError) as exc:
+        raise FsrsSettingsError("maximum_interval_days must be an integer") from exc
+
+    settings["enable_fuzz"] = bool(settings.get("enable_fuzz"))
+
+    if settings["target_retention"] <= 0 or settings["target_retention"] >= 1:
+        raise FsrsSettingsError("target_retention must be between 0 and 1")
+    if settings["maximum_interval_days"] < 1:
+        raise FsrsSettingsError("maximum_interval_days must be >= 1")
+
+    return settings
+
+
+def bootstrap_fsrs_state(
+    card: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    interval_days = max(1, int(card.get("interval_days") or 1))
+    repetitions = max(0, int(card.get("repetitions") or 0))
+    lapses = max(0, int(card.get("lapses") or 0))
+    due_at = parse_iso_datetime(str(card.get("due_at") or "")) if card.get("due_at") else None
+    last_reviewed_at = str(card.get("last_reviewed_at") or "") or None
+
+    if due_at is None:
+        retrievability = 0.9
+    elif current_time <= due_at:
+        retrievability = 0.95
+    else:
+        overdue_days = max(0.0, (current_time - due_at).total_seconds() / 86400.0)
+        retrievability = max(0.3, min(0.95, 1.0 - (overdue_days / max(interval_days, 1)) * 0.4))
+
+    stability = max(1.0, float(interval_days) * max(0.75, 1.0 - lapses * 0.05))
+    difficulty = min(10.0, max(1.0, 5.0 + lapses * 0.35 - min(repetitions, 10) * 0.1))
+
+    return {
+        "stability": round(stability, 4),
+        "difficulty": round(difficulty, 4),
+        "retrievability": round(retrievability, 4),
+        "last_reviewed_at": last_reviewed_at,
+    }
+
+
+def _load_fsrs_state(card: Mapping[str, Any], now: datetime) -> dict[str, Any]:
+    raw = card.get("scheduler_state_json")
+    if isinstance(raw, Mapping):
+        parsed = dict(raw)
+    elif isinstance(raw, str) and raw.strip():
+        try:
+            loaded = json.loads(raw)
+        except json.JSONDecodeError:
+            loaded = {}
+        parsed = dict(loaded) if isinstance(loaded, dict) else {}
+    else:
+        parsed = {}
+
+    if not parsed:
+        return bootstrap_fsrs_state(card, now=now)
+
+    merged = bootstrap_fsrs_state(card, now=now)
+    for key in ("stability", "difficulty", "retrievability", "last_reviewed_at"):
+        if key in parsed and parsed[key] is not None:
+            merged[key] = parsed[key]
+    return merged
+
+
+def _determine_interval_days(interval_days: int, repetitions: int) -> int:
+    return max(1, interval_days + min(4, max(2, 7 - repetitions)))
+
+
+def simulate_fsrs_review_transition(
+    card: Mapping[str, Any],
+    settings: Mapping[str, Any] | str | None,
+    rating: int,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current_time = now or datetime.now(timezone.utc)
+    normalized_settings = normalize_fsrs_settings(settings)
+    state = _load_fsrs_state(card, current_time)
+
+    interval_days = max(1, int(card.get("interval_days") or 1))
+    repetitions = max(0, int(card.get("repetitions") or 0))
+    lapses = max(0, int(card.get("lapses") or 0))
+    ef = float(card.get("ef") or 2.5)
+
+    result = {
+        "queue_state": "review",
+        "step_index": None,
+        "suspended_reason": None,
+        "ef": ef,
+        "interval_days": interval_days,
+        "repetitions": repetitions,
+        "lapses": lapses,
+        "due_at": None,
+        "last_reviewed_at": to_iso_z(current_time),
+        "was_lapse": False,
+        "next_due_dt": None,
+        "scheduler_state_json": "{}",
+    }
+
+    if rating == 0:
+        next_interval = 1
+        next_state = {
+            "stability": round(max(1.0, float(state["stability"]) * 0.5), 4),
+            "difficulty": round(min(10.0, float(state["difficulty"]) + 0.35), 4),
+            "retrievability": 0.3,
+            "last_reviewed_at": result["last_reviewed_at"],
+        }
+        result["lapses"] = lapses + 1
+        result["repetitions"] = max(0, repetitions - 1)
+        result["was_lapse"] = True
+    elif rating == 2:
+        next_interval = min(
+            int(normalized_settings["maximum_interval_days"]),
+            interval_days + 1,
+        )
+        next_state = {
+            "stability": round(max(float(state["stability"]), next_interval * 0.95), 4),
+            "difficulty": round(max(1.0, float(state["difficulty"]) - 0.05), 4),
+            "retrievability": round(max(0.75, float(normalized_settings["target_retention"]) - 0.05), 4),
+            "last_reviewed_at": result["last_reviewed_at"],
+        }
+        result["repetitions"] = repetitions + 1
+    elif rating == 5:
+        good_interval = _determine_interval_days(interval_days, repetitions)
+        next_interval = min(
+            int(normalized_settings["maximum_interval_days"]),
+            int(math.ceil(good_interval * 1.5)),
+        )
+        next_state = {
+            "stability": round(max(float(state["stability"]), next_interval * 1.05), 4),
+            "difficulty": round(max(1.0, float(state["difficulty"]) - 0.2), 4),
+            "retrievability": round(min(0.99, float(normalized_settings["target_retention"]) + 0.05), 4),
+            "last_reviewed_at": result["last_reviewed_at"],
+        }
+        result["repetitions"] = repetitions + 1
+    else:
+        next_interval = min(
+            int(normalized_settings["maximum_interval_days"]),
+            _determine_interval_days(interval_days, repetitions),
+        )
+        next_state = {
+            "stability": round(max(float(state["stability"]), next_interval * float(normalized_settings["target_retention"])), 4),
+            "difficulty": round(max(1.0, float(state["difficulty"]) - 0.1), 4),
+            "retrievability": round(float(normalized_settings["target_retention"]), 4),
+            "last_reviewed_at": result["last_reviewed_at"],
+        }
+        result["repetitions"] = repetitions + 1
+
+    next_due_at = current_time + timedelta(days=next_interval)
+    result["interval_days"] = next_interval
+    result["due_at"] = to_iso_z(next_due_at)
+    result["next_due_dt"] = next_due_at
+    result["scheduler_state_json"] = json.dumps(next_state, sort_keys=True)
+    return result
+
+
+def build_fsrs_next_interval_previews(
+    card: Mapping[str, Any],
+    settings: Mapping[str, Any] | str | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, str]:
+    current_time = now or datetime.now(timezone.utc)
+    previews: dict[str, str] = {}
+    for label, rating in (("again", 0), ("hard", 2), ("good", 3), ("easy", 5)):
+        simulated = simulate_fsrs_review_transition(card, settings, rating, now=current_time)
+        previews[label] = format_interval_label(
+            next_due_at=simulated.get("next_due_dt"),
+            now=current_time,
+        )
+    return previews

--- a/tldw_Server_API/app/core/Flashcards/scheduler_sm2.py
+++ b/tldw_Server_API/app/core/Flashcards/scheduler_sm2.py
@@ -21,6 +21,12 @@ DEFAULT_SCHEDULER_SETTINGS: dict[str, Any] = {
     "enable_fuzz": False,
 }
 
+DEFAULT_FSRS_SETTINGS: dict[str, Any] = {
+    "target_retention": 0.9,
+    "maximum_interval_days": 36500,
+    "enable_fuzz": False,
+}
+
 
 class SchedulerSettingsError(ValueError):
     """Raised when deck scheduler settings are invalid."""
@@ -28,6 +34,17 @@ class SchedulerSettingsError(ValueError):
 
 def get_default_scheduler_settings() -> dict[str, Any]:
     return copy.deepcopy(DEFAULT_SCHEDULER_SETTINGS)
+
+
+def get_default_fsrs_settings() -> dict[str, Any]:
+    return copy.deepcopy(DEFAULT_FSRS_SETTINGS)
+
+
+def get_default_scheduler_settings_envelope() -> dict[str, Any]:
+    return {
+        "sm2_plus": get_default_scheduler_settings(),
+        "fsrs": get_default_fsrs_settings(),
+    }
 
 
 def parse_iso_datetime(value: str | None) -> datetime | None:
@@ -69,6 +86,9 @@ def normalize_scheduler_settings(raw: Mapping[str, Any] | str | None) -> dict[st
         source = dict(raw)
     else:
         raise SchedulerSettingsError("scheduler_settings must be a mapping or JSON string")
+
+    if isinstance(source.get("sm2_plus"), Mapping):
+        source = dict(source["sm2_plus"])
 
     settings = get_default_scheduler_settings()
     for key in settings:
@@ -130,7 +150,36 @@ def normalize_scheduler_settings(raw: Mapping[str, Any] | str | None) -> dict[st
 
 
 def scheduler_settings_to_json(raw: Mapping[str, Any] | str | None) -> str:
-    return json.dumps(normalize_scheduler_settings(raw), sort_keys=True)
+    envelope = get_default_scheduler_settings_envelope()
+    if raw is None:
+        return json.dumps(envelope, sort_keys=True)
+
+    if isinstance(raw, str):
+        if not raw.strip():
+            return json.dumps(envelope, sort_keys=True)
+        parsed = json.loads(raw)
+        if not isinstance(parsed, dict):
+            raise SchedulerSettingsError("scheduler_settings must be a JSON object")
+        raw = parsed
+
+    if not isinstance(raw, Mapping):
+        raise SchedulerSettingsError("scheduler_settings must be a mapping or JSON string")
+
+    raw_dict = dict(raw)
+    if "sm2_plus" in raw_dict or "fsrs" in raw_dict:
+        if isinstance(raw_dict.get("sm2_plus"), Mapping):
+            envelope["sm2_plus"] = normalize_scheduler_settings(raw_dict["sm2_plus"])
+        if isinstance(raw_dict.get("fsrs"), Mapping):
+            fsrs_source = dict(raw_dict["fsrs"])
+            fsrs_defaults = get_default_fsrs_settings()
+            for key in fsrs_defaults:
+                if key in fsrs_source and fsrs_source[key] is not None:
+                    fsrs_defaults[key] = fsrs_source[key]
+            envelope["fsrs"] = fsrs_defaults
+        return json.dumps(envelope, sort_keys=True)
+
+    envelope["sm2_plus"] = normalize_scheduler_settings(raw_dict)
+    return json.dumps(envelope, sort_keys=True)
 
 
 def coerce_queue_state(card: Mapping[str, Any]) -> str:

--- a/tldw_Server_API/app/core/Flashcards/scheduler_sm2.py
+++ b/tldw_Server_API/app/core/Flashcards/scheduler_sm2.py
@@ -78,7 +78,10 @@ def normalize_scheduler_settings(raw: Mapping[str, Any] | str | None) -> dict[st
         if not raw.strip():
             source = {}
         else:
-            parsed = json.loads(raw)
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                raise SchedulerSettingsError("scheduler_settings must be valid JSON") from exc
             if not isinstance(parsed, dict):
                 raise SchedulerSettingsError("scheduler_settings must be a JSON object")
             source = parsed
@@ -157,7 +160,10 @@ def scheduler_settings_to_json(raw: Mapping[str, Any] | str | None) -> str:
     if isinstance(raw, str):
         if not raw.strip():
             return json.dumps(envelope, sort_keys=True)
-        parsed = json.loads(raw)
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise SchedulerSettingsError("scheduler_settings must be valid JSON") from exc
         if not isinstance(parsed, dict):
             raise SchedulerSettingsError("scheduler_settings must be a JSON object")
         raw = parsed
@@ -169,13 +175,16 @@ def scheduler_settings_to_json(raw: Mapping[str, Any] | str | None) -> str:
     if "sm2_plus" in raw_dict or "fsrs" in raw_dict:
         if isinstance(raw_dict.get("sm2_plus"), Mapping):
             envelope["sm2_plus"] = normalize_scheduler_settings(raw_dict["sm2_plus"])
-        if isinstance(raw_dict.get("fsrs"), Mapping):
-            fsrs_source = dict(raw_dict["fsrs"])
-            fsrs_defaults = get_default_fsrs_settings()
-            for key in fsrs_defaults:
-                if key in fsrs_source and fsrs_source[key] is not None:
-                    fsrs_defaults[key] = fsrs_source[key]
-            envelope["fsrs"] = fsrs_defaults
+        if "fsrs" in raw_dict:
+            from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (  # local import avoids module cycle
+                FsrsSettingsError,
+                normalize_fsrs_settings,
+            )
+
+            try:
+                envelope["fsrs"] = normalize_fsrs_settings(raw_dict.get("fsrs"))
+            except FsrsSettingsError as exc:
+                raise SchedulerSettingsError(str(exc)) from exc
         return json.dumps(envelope, sort_keys=True)
 
     envelope["sm2_plus"] = normalize_scheduler_settings(raw_dict)

--- a/tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py
+++ b/tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py
@@ -1134,6 +1134,58 @@ class TestKeywordsAndCollections:
 
 
 class TestSyncLog:
+    def test_sync_log_entry_on_create_deck_includes_scheduler_fields(self, db_instance: CharactersRAGDB):
+        initial_log_max_id = db_instance.get_latest_sync_log_change_id()
+        deck_id = db_instance.add_deck(
+            "Sync FSRS Deck",
+            scheduler_type="fsrs",
+            scheduler_settings={"fsrs": {"target_retention": 0.88, "maximum_interval_days": 7300}},
+        )
+
+        log_entries = db_instance.get_sync_log_entries(since_change_id=initial_log_max_id)
+        deck_log_entry = None
+        for entry in log_entries:
+            if entry["entity"] == "decks" and entry["entity_id"] == str(deck_id) and entry["operation"] == "create":
+                deck_log_entry = entry
+                break
+
+        assert deck_log_entry is not None
+        assert deck_log_entry["payload"]["scheduler_type"] == "fsrs"
+        settings = json.loads(deck_log_entry["payload"]["scheduler_settings_json"])
+        assert settings["sm2_plus"]["new_steps_minutes"] == [1, 10]
+        assert settings["fsrs"]["target_retention"] == pytest.approx(0.88)
+
+    def test_sync_log_entry_on_fsrs_review_includes_scheduler_state(self, db_instance: CharactersRAGDB):
+        deck_id = db_instance.add_deck("Review Sync Deck", scheduler_type="fsrs")
+        card_uuid = db_instance.add_flashcard(
+            {
+                "deck_id": deck_id,
+                "front": "Review sync",
+                "back": "Answer",
+                "queue_state": "review",
+                "interval_days": 12,
+                "repetitions": 7,
+                "lapses": 1,
+                "last_reviewed_at": "2026-03-01T00:00:00Z",
+                "due_at": "2026-03-13T00:00:00Z",
+            }
+        )
+
+        latest_change_id = db_instance.get_latest_sync_log_change_id()
+        db_instance.review_flashcard(card_uuid, rating=3, answer_time_ms=1500)
+
+        new_entries = db_instance.get_sync_log_entries(since_change_id=latest_change_id)
+        update_log_entry = None
+        for entry in new_entries:
+            if entry["entity"] == "flashcards" and entry["entity_id"] == card_uuid and entry["operation"] == "update":
+                update_log_entry = entry
+                break
+
+        assert update_log_entry is not None
+        assert update_log_entry["payload"]["scheduler_state_json"] != "{}"
+        state = json.loads(update_log_entry["payload"]["scheduler_state_json"])
+        assert state["stability"] > 0
+
     def test_sync_log_entry_on_add_character(self, db_instance: CharactersRAGDB):
         initial_log_max_id = db_instance.get_latest_sync_log_change_id()
         card_data = _create_sample_card_data("SyncLogChar")

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -21,6 +21,7 @@ from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGD
 from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
 from tldw_Server_API.app.core.Flashcards.asset_refs import extract_flashcard_asset_uuids
 from tldw_Server_API.app.core.Flashcards.apkg_exporter import export_apkg_from_rows
+from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import SchedulerSettingsError
 from tldw_Server_API.tests.test_config import TestConfig
 
 # Explicit auth headers for single-user mode (required by get_request_user)
@@ -778,6 +779,7 @@ def test_fsrs_review_bootstraps_scheduler_state_and_returns_scheduler_type(
 def test_fsrs_review_returns_400_for_invalid_deck_settings(
     client_with_flashcards_db: TestClient,
     flashcards_db: CharactersRAGDB,
+    monkeypatch,
 ):
     deck_id = flashcards_db.add_deck("Broken FSRS Deck", scheduler_type="fsrs")
     card_uuid = flashcards_db.add_flashcard(
@@ -793,11 +795,14 @@ def test_fsrs_review_returns_400_for_invalid_deck_settings(
             "due_at": "2026-03-13T00:00:00Z",
         }
     )
-    with flashcards_db.transaction() as conn:
-        conn.execute(
-            "UPDATE decks SET scheduler_settings_json = ?, version = version + 1 WHERE id = ?",
-            (json.dumps({"fsrs": {"target_retention": 1.2, "maximum_interval_days": 36500}}), deck_id),
-        )
+
+    def raise_invalid_settings(raw):
+        raise SchedulerSettingsError("target_retention must be between 0 and 1")
+
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB._normalize_scheduler_settings_envelope",
+        raise_invalid_settings,
+    )
 
     reviewed = client_with_flashcards_db.post(
         "/api/v1/flashcards/review",

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -775,6 +775,40 @@ def test_fsrs_review_bootstraps_scheduler_state_and_returns_scheduler_type(
     assert review_row["scheduler_type"] == "fsrs"
 
 
+def test_fsrs_review_returns_400_for_invalid_deck_settings(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    deck_id = flashcards_db.add_deck("Broken FSRS Deck", scheduler_type="fsrs")
+    card_uuid = flashcards_db.add_flashcard(
+        {
+            "deck_id": deck_id,
+            "front": "Broken review card",
+            "back": "Answer",
+            "queue_state": "review",
+            "interval_days": 12,
+            "repetitions": 7,
+            "lapses": 1,
+            "last_reviewed_at": "2026-03-01T00:00:00Z",
+            "due_at": "2026-03-13T00:00:00Z",
+        }
+    )
+    with flashcards_db.transaction() as conn:
+        conn.execute(
+            "UPDATE decks SET scheduler_settings_json = ?, version = version + 1 WHERE id = ?",
+            (json.dumps({"fsrs": {"target_retention": 1.2, "maximum_interval_days": 36500}}), deck_id),
+        )
+
+    reviewed = client_with_flashcards_db.post(
+        "/api/v1/flashcards/review",
+        json={"card_uuid": card_uuid, "rating": 3, "answer_time_ms": 1800},
+        headers=AUTH_HEADERS,
+    )
+
+    assert reviewed.status_code == 400
+    assert "target_retention" in reviewed.json()["detail"]
+
+
 def test_get_flashcard_assistant_returns_thread_messages_and_context(
     client_with_flashcards_db: TestClient,
     flashcards_db: CharactersRAGDB,
@@ -1107,10 +1141,13 @@ def test_analytics_summary_honors_deck_filter(client_with_flashcards_db: TestCli
     assert payload["decks"][0]["deck_name"] == "DeckA"
 
 
-def test_reset_scheduling_resets_card_to_new_defaults(client_with_flashcards_db: TestClient):
+def test_reset_scheduling_resets_card_to_new_defaults(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
     r = client_with_flashcards_db.post(
         "/api/v1/flashcards/decks",
-        json={"name": "ResetDeck"},
+        json={"name": "ResetDeck", "scheduler_type": "fsrs"},
         headers=AUTH_HEADERS,
     )
     assert r.status_code == 200
@@ -1124,15 +1161,22 @@ def test_reset_scheduling_resets_card_to_new_defaults(client_with_flashcards_db:
     assert created.status_code == 200
     card = created.json()
     card_uuid = card["uuid"]
-
-    reviewed = client_with_flashcards_db.post(
-        "/api/v1/flashcards/review",
-        json={"card_uuid": card_uuid, "rating": 3, "answer_time_ms": 2100},
-        headers=AUTH_HEADERS,
-    )
-    assert reviewed.status_code == 200
-    reviewed_payload = reviewed.json()
-    assert reviewed_payload["repetitions"] >= 1
+    with flashcards_db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE flashcards
+               SET queue_state = 'review',
+                   interval_days = 12,
+                   repetitions = 7,
+                   lapses = 1,
+                   due_at = '2026-03-13T00:00:00Z',
+                   last_reviewed_at = '2026-03-01T00:00:00Z',
+                   scheduler_state_json = ?
+             WHERE uuid = ?
+            """,
+            ('{"stability": 12.5, "difficulty": 4.2, "retrievability": 0.86}', card_uuid),
+        )
+    assert flashcards_db.get_flashcard(card_uuid)["scheduler_state_json"] != "{}"
 
     current = client_with_flashcards_db.get(f"/api/v1/flashcards/id/{card_uuid}", headers=AUTH_HEADERS)
     assert current.status_code == 200
@@ -1152,6 +1196,9 @@ def test_reset_scheduling_resets_card_to_new_defaults(client_with_flashcards_db:
     assert payload["lapses"] == 0
     assert payload["last_reviewed_at"] is None
     assert payload["due_at"] is not None
+    persisted = flashcards_db.get_flashcard(card_uuid)
+    assert persisted is not None
+    assert persisted["scheduler_state_json"] == "{}"
 
     conflict = client_with_flashcards_db.post(
         f"/api/v1/flashcards/{card_uuid}/reset-scheduling",

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py
@@ -610,17 +610,27 @@ def test_deck_endpoints_expose_and_patch_scheduler_settings(
     )
     assert created.status_code == 200
     deck = created.json()
-    assert deck["scheduler_settings"]["new_steps_minutes"] == [1, 10]
-    assert deck["scheduler_settings"]["enable_fuzz"] is False
+    assert deck["scheduler_type"] == "sm2_plus"
+    assert deck["scheduler_settings"]["sm2_plus"]["new_steps_minutes"] == [1, 10]
+    assert deck["scheduler_settings"]["sm2_plus"]["enable_fuzz"] is False
+    assert deck["scheduler_settings"]["fsrs"]["target_retention"] == pytest.approx(0.9)
 
     updated = client_with_flashcards_db.patch(
         f"/api/v1/flashcards/decks/{deck['id']}",
         json={
             "description": "updated",
+            "scheduler_type": "fsrs",
             "scheduler_settings": {
-                "new_steps_minutes": [2, 20],
-                "relearn_steps_minutes": [15],
-                "easy_bonus": 1.5,
+                "sm2_plus": {
+                    "new_steps_minutes": [2, 20],
+                    "relearn_steps_minutes": [15],
+                    "easy_bonus": 1.5,
+                },
+                "fsrs": {
+                    "target_retention": 0.88,
+                    "maximum_interval_days": 7300,
+                    "enable_fuzz": True,
+                },
             },
             "expected_version": deck["version"],
         },
@@ -629,10 +639,14 @@ def test_deck_endpoints_expose_and_patch_scheduler_settings(
     assert updated.status_code == 200
     payload = updated.json()
     assert payload["description"] == "updated"
-    assert payload["scheduler_settings"]["new_steps_minutes"] == [2, 20]
-    assert payload["scheduler_settings"]["relearn_steps_minutes"] == [15]
-    assert payload["scheduler_settings"]["easy_bonus"] == pytest.approx(1.5)
-    assert payload["scheduler_settings"]["graduating_interval_days"] == 1
+    assert payload["scheduler_type"] == "fsrs"
+    assert payload["scheduler_settings"]["sm2_plus"]["new_steps_minutes"] == [2, 20]
+    assert payload["scheduler_settings"]["sm2_plus"]["relearn_steps_minutes"] == [15]
+    assert payload["scheduler_settings"]["sm2_plus"]["easy_bonus"] == pytest.approx(1.5)
+    assert payload["scheduler_settings"]["sm2_plus"]["graduating_interval_days"] == 1
+    assert payload["scheduler_settings"]["fsrs"]["target_retention"] == pytest.approx(0.88)
+    assert payload["scheduler_settings"]["fsrs"]["maximum_interval_days"] == 7300
+    assert payload["scheduler_settings"]["fsrs"]["enable_fuzz"] is True
 
     conflict = client_with_flashcards_db.patch(
         f"/api/v1/flashcards/decks/{deck['id']}",
@@ -695,10 +709,70 @@ def test_review_next_prefers_due_learning_before_due_review_and_new_cards(
     assert payload["selection_reason"] == "learning_due"
     assert payload["card"]["uuid"] == learning_due_uuid
     assert payload["card"]["queue_state"] == "learning"
+    assert payload["card"]["scheduler_type"] == "sm2_plus"
     assert payload["card"]["next_intervals"]["again"] == "1 min"
     assert payload["card"]["next_intervals"]["easy"] == "4 days"
     assert payload["card"]["uuid"] != review_due_uuid
     assert payload["card"]["uuid"] != new_uuid
+
+
+def test_fsrs_review_bootstraps_scheduler_state_and_returns_scheduler_type(
+    client_with_flashcards_db: TestClient,
+    flashcards_db: CharactersRAGDB,
+):
+    created_deck = client_with_flashcards_db.post(
+        "/api/v1/flashcards/decks",
+        json={
+            "name": "FSRS Deck",
+            "scheduler_type": "fsrs",
+            "scheduler_settings": {
+                "fsrs": {
+                    "target_retention": 0.88,
+                    "maximum_interval_days": 7300,
+                    "enable_fuzz": False,
+                }
+            },
+        },
+        headers=AUTH_HEADERS,
+    )
+    assert created_deck.status_code == 200
+    deck_id = created_deck.json()["id"]
+
+    card_uuid = flashcards_db.add_flashcard(
+        {
+            "deck_id": deck_id,
+            "front": "Existing review card",
+            "back": "Answer",
+            "queue_state": "review",
+            "interval_days": 12,
+            "repetitions": 7,
+            "lapses": 1,
+            "last_reviewed_at": "2026-03-01T00:00:00Z",
+            "due_at": "2026-03-13T00:00:00Z",
+        }
+    )
+
+    reviewed = client_with_flashcards_db.post(
+        "/api/v1/flashcards/review",
+        json={"card_uuid": card_uuid, "rating": 3, "answer_time_ms": 1800},
+        headers=AUTH_HEADERS,
+    )
+    assert reviewed.status_code == 200
+    payload = reviewed.json()
+
+    assert payload["scheduler_type"] == "fsrs"
+    assert payload["next_intervals"]["good"]
+
+    persisted = flashcards_db.get_flashcard(card_uuid)
+    assert persisted is not None
+    assert persisted["scheduler_state_json"] != "{}"
+
+    review_row = flashcards_db.execute_query(
+        "SELECT scheduler_type FROM flashcard_reviews fr JOIN flashcards f ON f.id = fr.card_id WHERE f.uuid = ? ORDER BY fr.id DESC LIMIT 1",
+        (card_uuid,),
+    ).fetchone()
+    assert review_row is not None
+    assert review_row["scheduler_type"] == "fsrs"
 
 
 def test_get_flashcard_assistant_returns_thread_messages_and_context(

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
@@ -26,9 +26,12 @@ def test_scheduler_schema_columns_exist_on_fresh_db(chacha_db: CharactersRAGDB):
     }
 
     assert "scheduler_settings_json" in deck_columns
+    assert "scheduler_type" in deck_columns
     assert "queue_state" in flashcard_columns
     assert "step_index" in flashcard_columns
     assert "suspended_reason" in flashcard_columns
+    assert "scheduler_state_json" in flashcard_columns
+    assert "scheduler_type" in review_columns
     assert "previous_queue_state" in review_columns
     assert "next_queue_state" in review_columns
     assert "previous_due_at" in review_columns
@@ -44,12 +47,21 @@ def test_new_deck_persists_default_scheduler_settings(chacha_db: CharactersRAGDB
     assert isinstance(raw_settings, str)
 
     settings = json.loads(raw_settings)
-    assert settings["new_steps_minutes"] == [1, 10]
-    assert settings["relearn_steps_minutes"] == [10]
-    assert settings["graduating_interval_days"] == 1
-    assert settings["easy_interval_days"] == 4
-    assert settings["easy_bonus"] == pytest.approx(1.3)
-    assert settings["interval_modifier"] == pytest.approx(1.0)
-    assert settings["max_interval_days"] == 36500
-    assert settings["leech_threshold"] == 8
-    assert settings["enable_fuzz"] is False
+    assert deck["scheduler_type"] == "sm2_plus"
+    assert set(settings.keys()) == {"sm2_plus", "fsrs"}
+
+    sm2_settings = settings["sm2_plus"]
+    assert sm2_settings["new_steps_minutes"] == [1, 10]
+    assert sm2_settings["relearn_steps_minutes"] == [10]
+    assert sm2_settings["graduating_interval_days"] == 1
+    assert sm2_settings["easy_interval_days"] == 4
+    assert sm2_settings["easy_bonus"] == pytest.approx(1.3)
+    assert sm2_settings["interval_modifier"] == pytest.approx(1.0)
+    assert sm2_settings["max_interval_days"] == 36500
+    assert sm2_settings["leech_threshold"] == 8
+    assert sm2_settings["enable_fuzz"] is False
+
+    fsrs_settings = settings["fsrs"]
+    assert fsrs_settings["target_retention"] == pytest.approx(0.9)
+    assert fsrs_settings["maximum_interval_days"] == 36500
+    assert fsrs_settings["enable_fuzz"] is False

--- a/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
+++ b/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py
@@ -3,6 +3,10 @@ import json
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import (
+    SchedulerSettingsError,
+    scheduler_settings_to_json,
+)
 
 
 @pytest.fixture
@@ -65,3 +69,11 @@ def test_new_deck_persists_default_scheduler_settings(chacha_db: CharactersRAGDB
     assert fsrs_settings["target_retention"] == pytest.approx(0.9)
     assert fsrs_settings["maximum_interval_days"] == 36500
     assert fsrs_settings["enable_fuzz"] is False
+
+
+def test_scheduler_settings_to_json_validates_fsrs_envelope():
+    with pytest.raises(SchedulerSettingsError):
+        scheduler_settings_to_json({"fsrs": {"target_retention": 1.2}})
+
+    with pytest.raises(SchedulerSettingsError):
+        scheduler_settings_to_json({"fsrs": "{not-valid-json"})

--- a/tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py
+++ b/tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py
@@ -1,8 +1,11 @@
 import json
+from unittest.mock import patch
 
 import pytest
 
 from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (
+    FsrsSettingsError,
+    _load_fsrs_state,
     build_fsrs_next_interval_previews,
     bootstrap_fsrs_state,
     get_default_fsrs_settings,
@@ -29,6 +32,32 @@ def test_normalize_fsrs_settings_fills_defaults_and_validates_ranges():
 
     with pytest.raises(ValueError):
         normalize_fsrs_settings({"target_retention": 1.2})
+
+
+def test_normalize_fsrs_settings_wraps_invalid_json_as_domain_error():
+    with pytest.raises(FsrsSettingsError):
+        normalize_fsrs_settings("{not-valid-json")
+
+
+def test_load_fsrs_state_logs_and_bootstraps_when_json_is_corrupt():
+    now = parse_iso_datetime("2026-03-13T00:00:00Z")
+    card = {
+        "uuid": "fsrs-card-corrupt",
+        "interval_days": 12,
+        "repetitions": 7,
+        "lapses": 1,
+        "last_reviewed_at": "2026-03-01T00:00:00Z",
+        "due_at": "2026-03-13T00:00:00Z",
+        "queue_state": "review",
+        "scheduler_state_json": "{bad-json",
+    }
+
+    with patch("tldw_Server_API.app.core.Flashcards.scheduler_fsrs.logger.warning") as warning:
+        state = _load_fsrs_state(card, now)
+
+    warning.assert_called_once()
+    assert state["stability"] > 0
+    assert state["last_reviewed_at"] == "2026-03-01T00:00:00Z"
 
 
 def test_bootstrap_fsrs_state_from_existing_card_snapshot():

--- a/tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py
+++ b/tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py
@@ -1,0 +1,99 @@
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Flashcards.scheduler_fsrs import (
+    build_fsrs_next_interval_previews,
+    bootstrap_fsrs_state,
+    get_default_fsrs_settings,
+    normalize_fsrs_settings,
+    simulate_fsrs_review_transition,
+)
+from tldw_Server_API.app.core.Flashcards.scheduler_sm2 import parse_iso_datetime
+
+
+def test_default_fsrs_settings_are_stable():
+    settings = get_default_fsrs_settings()
+
+    assert settings["target_retention"] == pytest.approx(0.9)
+    assert settings["maximum_interval_days"] == 36500
+    assert settings["enable_fuzz"] is False
+
+
+def test_normalize_fsrs_settings_fills_defaults_and_validates_ranges():
+    settings = normalize_fsrs_settings({"target_retention": 0.85})
+
+    assert settings["target_retention"] == pytest.approx(0.85)
+    assert settings["maximum_interval_days"] == 36500
+    assert settings["enable_fuzz"] is False
+
+    with pytest.raises(ValueError):
+        normalize_fsrs_settings({"target_retention": 1.2})
+
+
+def test_bootstrap_fsrs_state_from_existing_card_snapshot():
+    now = parse_iso_datetime("2026-03-13T00:00:00Z")
+    card = {
+        "interval_days": 12,
+        "repetitions": 7,
+        "lapses": 1,
+        "last_reviewed_at": "2026-03-01T00:00:00Z",
+        "due_at": "2026-03-13T00:00:00Z",
+        "queue_state": "review",
+    }
+
+    state = bootstrap_fsrs_state(card, now=now)
+
+    assert state["stability"] > 0
+    assert 1.0 <= state["difficulty"] <= 10.0
+    assert 0.0 < state["retrievability"] <= 1.0
+    assert state["last_reviewed_at"] == "2026-03-01T00:00:00Z"
+
+
+def test_simulate_fsrs_review_transition_returns_shared_compatibility_fields():
+    now = parse_iso_datetime("2026-03-13T00:00:00Z")
+    card = {
+        "uuid": "fsrs-card-1",
+        "queue_state": "review",
+        "interval_days": 10,
+        "repetitions": 5,
+        "lapses": 0,
+        "ef": 2.5,
+        "last_reviewed_at": "2026-03-03T00:00:00Z",
+        "due_at": "2026-03-13T00:00:00Z",
+        "scheduler_state_json": "{}",
+    }
+
+    result = simulate_fsrs_review_transition(card, None, 3, now=now)
+
+    assert result["queue_state"] == "review"
+    assert result["interval_days"] >= 10
+    assert result["repetitions"] == 6
+    assert result["due_at"] == "2026-03-25T00:00:00.000Z"
+
+    state = json.loads(result["scheduler_state_json"])
+    assert state["stability"] >= 10.0
+    assert state["difficulty"] >= 1.0
+
+
+def test_build_fsrs_next_interval_previews_returns_all_ratings():
+    now = parse_iso_datetime("2026-03-13T00:00:00Z")
+    card = {
+        "uuid": "fsrs-card-2",
+        "queue_state": "review",
+        "interval_days": 7,
+        "repetitions": 3,
+        "lapses": 0,
+        "ef": 2.5,
+        "last_reviewed_at": "2026-03-06T00:00:00Z",
+        "due_at": "2026-03-13T00:00:00Z",
+        "scheduler_state_json": "{}",
+    }
+
+    previews = build_fsrs_next_interval_previews(card, None, now=now)
+
+    assert set(previews.keys()) == {"again", "hard", "good", "easy"}
+    assert previews["again"] == "1 day"
+    assert previews["hard"] == "8 days"
+    assert previews["good"] == "11 days"
+    assert previews["easy"] == "17 days"

--- a/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
+++ b/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py
@@ -359,16 +359,24 @@ def test_convert_remediation_questions_creates_new_deck_with_scheduler_settings(
         json={
             "question_ids": question_ids,
             "create_deck_name": "Quiz Remediation Deck",
+            "create_deck_scheduler_type": "fsrs",
             "create_deck_scheduler_settings": {
-                "new_steps_minutes": [1, 5, 15],
-                "relearn_steps_minutes": [10],
-                "graduating_interval_days": 1,
-                "easy_interval_days": 3,
-                "easy_bonus": 1.15,
-                "interval_modifier": 0.9,
-                "max_interval_days": 3650,
-                "leech_threshold": 10,
-                "enable_fuzz": False,
+                "sm2_plus": {
+                    "new_steps_minutes": [1, 5, 15],
+                    "relearn_steps_minutes": [10],
+                    "graduating_interval_days": 1,
+                    "easy_interval_days": 3,
+                    "easy_bonus": 1.15,
+                    "interval_modifier": 0.9,
+                    "max_interval_days": 3650,
+                    "leech_threshold": 10,
+                    "enable_fuzz": False,
+                },
+                "fsrs": {
+                    "target_retention": 0.95,
+                    "maximum_interval_days": 1825,
+                    "enable_fuzz": True,
+                },
             },
             "replace_active": False,
         },
@@ -379,10 +387,13 @@ def test_convert_remediation_questions_creates_new_deck_with_scheduler_settings(
     payload = response.json()
     created_deck = quizzes_db.get_deck(payload["target_deck"]["id"])
     assert created_deck is not None
+    assert created_deck["scheduler_type"] == "fsrs"
     scheduler_settings = json.loads(created_deck["scheduler_settings_json"])
-    assert scheduler_settings["new_steps_minutes"] == [1, 5, 15]
-    assert scheduler_settings["easy_interval_days"] == 3
-    assert scheduler_settings["enable_fuzz"] is False
+    assert scheduler_settings["sm2_plus"]["new_steps_minutes"] == [1, 5, 15]
+    assert scheduler_settings["sm2_plus"]["easy_interval_days"] == 3
+    assert scheduler_settings["fsrs"]["target_retention"] == pytest.approx(0.95)
+    assert scheduler_settings["fsrs"]["maximum_interval_days"] == 1825
+    assert scheduler_settings["fsrs"]["enable_fuzz"] is True
 
 
 def test_convert_remediation_questions_returns_mixed_results_without_replace_active(

--- a/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
+++ b/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py
@@ -1,3 +1,4 @@
+import json
 import sqlite3
 import uuid
 
@@ -153,6 +154,43 @@ def test_convert_quiz_remediation_questions_creates_new_deck_when_requested(quiz
     assert payload["results"][0]["conversion"]["status"] == "active"
     assert payload["created_flashcard_uuids"]
     assert quizzes_db.count_flashcards(deck_id=payload["target_deck"]["id"]) == 1
+
+
+def test_convert_quiz_remediation_questions_creates_fsrs_deck_when_requested(quizzes_db: CharactersRAGDB):
+    attempt_id, _quiz_id, missed_question_id, _correct_question_id = _create_attempt_with_one_miss_and_one_correct(quizzes_db)
+
+    payload = quizzes_db.convert_quiz_remediation_questions(
+        attempt_id=attempt_id,
+        question_ids=[missed_question_id],
+        create_deck_name="FSRS Remediation Deck",
+        create_deck_scheduler_type="fsrs",
+        create_deck_scheduler_settings={
+            "sm2_plus": {
+                "new_steps_minutes": [1, 5],
+                "relearn_steps_minutes": [10],
+                "graduating_interval_days": 1,
+                "easy_interval_days": 3,
+                "easy_bonus": 1.15,
+                "interval_modifier": 0.9,
+                "max_interval_days": 3650,
+                "leech_threshold": 10,
+                "enable_fuzz": False,
+            },
+            "fsrs": {
+                "target_retention": 0.95,
+                "maximum_interval_days": 1825,
+                "enable_fuzz": True,
+            },
+        },
+        replace_active=False,
+    )
+
+    created_deck = quizzes_db.get_deck(payload["target_deck"]["id"])
+    assert created_deck is not None
+    assert created_deck["scheduler_type"] == "fsrs"
+    scheduler_settings = json.loads(created_deck["scheduler_settings_json"])
+    assert scheduler_settings["fsrs"]["target_retention"] == pytest.approx(0.95)
+    assert scheduler_settings["fsrs"]["maximum_interval_days"] == 1825
 
 
 def test_convert_quiz_remediation_questions_preserves_dedupe_across_duplicate_misses(


### PR DESCRIPTION
## Summary
- add optional per-deck FSRS support alongside the existing SM-2+ scheduler
- persist deck scheduler type/settings envelope and per-card scheduler state through review, sync, and remediation flows
- expose FSRS in the Scheduler tab, deck creation flows, quiz remediation deck creation, and review UI

## Verification
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/Flashcards/test_flashcards_scheduler_schema.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/Flashcards/test_scheduler_fsrs.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/Flashcards/test_flashcards_endpoint_integration.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/ChaChaNotesDB/test_chachanotes_db.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/Quizzes/test_remediation_conversion_service.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/tests/Quizzes/test_quizzes_endpoint_integration.py -k "fsrs or scheduler_type or scheduler_settings or remediation or sync_log_entry_on_create_deck_includes_scheduler_fields or sync_log_entry_on_fsrs_review_includes_scheduler_state or review_next_prefers_due_learning_before_due_review_and_new_cards or deck_endpoints_expose_and_patch_scheduler_settings" -v
- cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/apps/packages/ui && bun run test -- src/components/Flashcards/utils/__tests__/scheduler-settings.test.ts src/components/Flashcards/components/__tests__/DeckSchedulerSettingsEditor.test.tsx src/components/Flashcards/hooks/__tests__/useCreateDeckMutation.test.tsx src/components/Flashcards/hooks/__tests__/useDeckSchedulerMutation.test.tsx src/components/Flashcards/tabs/__tests__/SchedulerTab.test.tsx src/components/Flashcards/tabs/__tests__/SchedulerTab.editor.test.tsx src/components/Flashcards/tabs/__tests__/ImportExportTab.deck-creation.test.tsx src/components/Flashcards/tabs/__tests__/ImageOcclusionTransferPanel.test.tsx src/components/Flashcards/components/__tests__/FlashcardCreateDrawer.image-insert.test.tsx src/components/Flashcards/tabs/__tests__/ReviewTab.queue-state.test.tsx src/components/Quiz/tabs/__tests__/ResultsTab.remediation.test.tsx
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/app/api/v1/endpoints/flashcards.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/app/api/v1/endpoints/quizzes.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/app/api/v1/schemas/flashcards.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/app/api/v1/schemas/quizzes.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/fsrs-per-deck-optional/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py -f json -o /tmp/bandit_fsrs_optional_per_deck.json