### PR TITLE
feat: add MCP Hub capability adapter registry

### DIFF
--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -15,9 +15,8 @@
 - Task 1: Complete
 - Task 2: Complete
 - Task 3: Complete
-- Task 4: In Progress
-- Task 5: Not Started
-- Task 6: Not Started
+- Task 4: Complete
+- Task 5: In Progress
 - Task 6: Not Started
 
 ### Task 1: Add capability-mapping storage and repo coverage

--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -17,7 +17,7 @@
 - Task 3: Complete
 - Task 4: Complete
 - Task 5: Complete
-- Task 6: In Progress
+- Task 6: Complete
 
 ### Task 1: Add capability-mapping storage and repo coverage
 

--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -14,8 +14,8 @@
 
 - Task 1: Complete
 - Task 2: Complete
-- Task 3: In Progress
-- Task 4: Not Started
+- Task 3: Complete
+- Task 4: In Progress
 - Task 5: Not Started
 - Task 6: Not Started
 - Task 6: Not Started

--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -13,10 +13,11 @@
 ## Status
 
 - Task 1: Complete
-- Task 2: In Progress
-- Task 3: Not Started
+- Task 2: Complete
+- Task 3: In Progress
 - Task 4: Not Started
 - Task 5: Not Started
+- Task 6: Not Started
 - Task 6: Not Started
 
 ### Task 1: Add capability-mapping storage and repo coverage

--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -16,8 +16,8 @@
 - Task 2: Complete
 - Task 3: Complete
 - Task 4: Complete
-- Task 5: In Progress
-- Task 6: Not Started
+- Task 5: Complete
+- Task 6: In Progress
 
 ### Task 1: Add capability-mapping storage and repo coverage
 

--- a/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-capability-adapter-registry-implementation-plan.md
@@ -12,8 +12,8 @@
 
 ## Status
 
-- Task 1: Not Started
-- Task 2: Not Started
+- Task 1: Complete
+- Task 2: In Progress
 - Task 3: Not Started
 - Task 4: Not Started
 - Task 5: Not Started

--- a/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx
@@ -122,29 +122,52 @@ export const CapabilityMappingsTab = () => {
     setSuccessMessage(null)
   }
 
-  const buildPayload = (): McpHubCapabilityAdapterMappingInput | null => {
+  const buildPayload = (): {
+    payload: McpHubCapabilityAdapterMappingInput | null
+    validationError: string | null
+  } => {
     if (!mappingId.trim() || !capabilityName.trim() || !parsedResolvedPolicy) {
-      return null
+      return {
+        payload: null,
+        validationError: "Mapping ID, capability name, and valid policy JSON are required."
+      }
     }
+
+    const trimmedOwnerScopeId = ownerScopeId.trim()
+    let numericOwnerScopeId: number | null = null
+
+    if (trimmedOwnerScopeId) {
+      if (!/^\d+$/.test(trimmedOwnerScopeId)) {
+        return {
+          payload: null,
+          validationError: "Owner Scope ID must be a valid integer."
+        }
+      }
+      numericOwnerScopeId = Number.parseInt(trimmedOwnerScopeId, 10)
+    }
+
     return {
-      mapping_id: mappingId.trim(),
-      title: title.trim() || null,
-      description: description.trim() || null,
-      owner_scope_type: ownerScopeType,
-      owner_scope_id: ownerScopeId.trim() ? Number(ownerScopeId) : null,
-      capability_name: capabilityName.trim(),
-      adapter_contract_version: 1,
-      resolved_policy_document: parsedResolvedPolicy,
-      supported_environment_requirements: parseLineList(supportedRequirementsText),
-      is_active: isActive
+      payload: {
+        mapping_id: mappingId.trim(),
+        title: title.trim() || null,
+        description: description.trim() || null,
+        owner_scope_type: ownerScopeType,
+        owner_scope_id: numericOwnerScopeId,
+        capability_name: capabilityName.trim(),
+        adapter_contract_version: 1,
+        resolved_policy_document: parsedResolvedPolicy,
+        supported_environment_requirements: parseLineList(supportedRequirementsText),
+        is_active: isActive
+      },
+      validationError: null
     }
   }
 
   const handlePreview = async () => {
     setSuccessMessage(null)
-    const payload = buildPayload()
+    const { payload, validationError } = buildPayload()
     if (!payload) {
-      setErrorMessage("Mapping ID, capability name, and valid policy JSON are required.")
+      setErrorMessage(validationError)
       setPreview(null)
       return
     }
@@ -162,9 +185,9 @@ export const CapabilityMappingsTab = () => {
 
   const handleSave = async () => {
     setSuccessMessage(null)
-    const payload = buildPayload()
+    const { payload, validationError } = buildPayload()
     if (!payload) {
-      setErrorMessage("Mapping ID, capability name, and valid policy JSON are required.")
+      setErrorMessage(validationError)
       return
     }
     setSaving(true)
@@ -280,6 +303,7 @@ export const CapabilityMappingsTab = () => {
                   id="mcp-capability-mapping-scope-id"
                   aria-label="Owner Scope ID"
                   value={ownerScopeId}
+                  inputMode="numeric"
                   onChange={(event) => setOwnerScopeId(event.target.value)}
                   placeholder="Optional"
                 />

--- a/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/CapabilityMappingsTab.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useMemo, useState } from "react"
+import { Alert, Button, Card, Descriptions, Empty, Input, List, Space, Switch, Tag, Typography } from "antd"
+
+import {
+  createCapabilityAdapterMapping,
+  listCapabilityAdapterMappings,
+  previewCapabilityAdapterMapping,
+  updateCapabilityAdapterMapping,
+  type McpHubCapabilityAdapterMapping,
+  type McpHubCapabilityAdapterMappingInput,
+  type McpHubCapabilityAdapterMappingPreview,
+  type McpHubCapabilityAdapterScopeType,
+  type McpHubPermissionPolicyDocument
+} from "@/services/tldw/mcp-hub"
+
+const DEFAULT_POLICY_JSON = JSON.stringify(
+  {
+    allowed_tools: []
+  },
+  null,
+  2
+)
+
+const parseLineList = (value: string) =>
+  value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+
+export const CapabilityMappingsTab = () => {
+  const [mappings, setMappings] = useState<McpHubCapabilityAdapterMapping[]>([])
+  const [selectedMappingId, setSelectedMappingId] = useState<number | null>(null)
+  const [mappingId, setMappingId] = useState("")
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [ownerScopeType, setOwnerScopeType] = useState<McpHubCapabilityAdapterScopeType>("global")
+  const [ownerScopeId, setOwnerScopeId] = useState("")
+  const [capabilityName, setCapabilityName] = useState("")
+  const [resolvedPolicyJson, setResolvedPolicyJson] = useState(DEFAULT_POLICY_JSON)
+  const [supportedRequirementsText, setSupportedRequirementsText] = useState("")
+  const [isActive, setIsActive] = useState(true)
+  const [preview, setPreview] = useState<McpHubCapabilityAdapterMappingPreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [previewing, setPreviewing] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  const parsedResolvedPolicy = useMemo<McpHubPermissionPolicyDocument | null>(() => {
+    try {
+      const parsed = JSON.parse(resolvedPolicyJson) as McpHubPermissionPolicyDocument
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return null
+      }
+      return parsed
+    } catch {
+      return null
+    }
+  }, [resolvedPolicyJson])
+
+  const loadMappings = async () => {
+    setLoading(true)
+    setErrorMessage(null)
+    try {
+      const rows = await listCapabilityAdapterMappings()
+      const safeRows = Array.isArray(rows) ? rows : []
+      setMappings(safeRows)
+      setSelectedMappingId((current) => {
+        if (safeRows.some((row) => row.id === current)) {
+          return current
+        }
+        return safeRows[0]?.id ?? null
+      })
+    } catch {
+      setMappings([])
+      setSelectedMappingId(null)
+      setErrorMessage("Failed to load capability mappings.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadMappings()
+  }, [])
+
+  useEffect(() => {
+    const selected = mappings.find((row) => row.id === selectedMappingId)
+    if (!selected) {
+      return
+    }
+    setMappingId(selected.mapping_id)
+    setTitle(selected.title)
+    setDescription(String(selected.description || ""))
+    setOwnerScopeType(selected.owner_scope_type)
+    setOwnerScopeId(
+      selected.owner_scope_id === null || selected.owner_scope_id === undefined
+        ? ""
+        : String(selected.owner_scope_id)
+    )
+    setCapabilityName(selected.capability_name)
+    setResolvedPolicyJson(JSON.stringify(selected.resolved_policy_document || {}, null, 2))
+    setSupportedRequirementsText((selected.supported_environment_requirements || []).join("\n"))
+    setIsActive(selected.is_active)
+    setPreview(null)
+    setSuccessMessage(null)
+  }, [mappings, selectedMappingId])
+
+  const resetForm = () => {
+    setSelectedMappingId(null)
+    setMappingId("")
+    setTitle("")
+    setDescription("")
+    setOwnerScopeType("global")
+    setOwnerScopeId("")
+    setCapabilityName("")
+    setResolvedPolicyJson(DEFAULT_POLICY_JSON)
+    setSupportedRequirementsText("")
+    setIsActive(true)
+    setPreview(null)
+    setErrorMessage(null)
+    setSuccessMessage(null)
+  }
+
+  const buildPayload = (): McpHubCapabilityAdapterMappingInput | null => {
+    if (!mappingId.trim() || !capabilityName.trim() || !parsedResolvedPolicy) {
+      return null
+    }
+    return {
+      mapping_id: mappingId.trim(),
+      title: title.trim() || null,
+      description: description.trim() || null,
+      owner_scope_type: ownerScopeType,
+      owner_scope_id: ownerScopeId.trim() ? Number(ownerScopeId) : null,
+      capability_name: capabilityName.trim(),
+      adapter_contract_version: 1,
+      resolved_policy_document: parsedResolvedPolicy,
+      supported_environment_requirements: parseLineList(supportedRequirementsText),
+      is_active: isActive
+    }
+  }
+
+  const handlePreview = async () => {
+    setSuccessMessage(null)
+    const payload = buildPayload()
+    if (!payload) {
+      setErrorMessage("Mapping ID, capability name, and valid policy JSON are required.")
+      setPreview(null)
+      return
+    }
+    setPreviewing(true)
+    setErrorMessage(null)
+    try {
+      setPreview(await previewCapabilityAdapterMapping(payload))
+    } catch {
+      setPreview(null)
+      setErrorMessage("Failed to preview capability mapping.")
+    } finally {
+      setPreviewing(false)
+    }
+  }
+
+  const handleSave = async () => {
+    setSuccessMessage(null)
+    const payload = buildPayload()
+    if (!payload) {
+      setErrorMessage("Mapping ID, capability name, and valid policy JSON are required.")
+      return
+    }
+    setSaving(true)
+    setErrorMessage(null)
+    try {
+      if (selectedMappingId) {
+        await updateCapabilityAdapterMapping(selectedMappingId, payload)
+        setSuccessMessage(`Updated ${payload.mapping_id}.`)
+      } else {
+        const created = await createCapabilityAdapterMapping(payload)
+        setSelectedMappingId(created.id)
+        setSuccessMessage(`Saved ${payload.mapping_id}.`)
+      }
+      await loadMappings()
+    } catch {
+      setErrorMessage(selectedMappingId ? "Failed to update capability mapping." : "Failed to save capability mapping.")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+      <Typography.Text type="secondary">
+        Capability mappings turn portable capability names into concrete local MCP Hub policy effects.
+      </Typography.Text>
+      {errorMessage ? <Alert type="error" title={errorMessage} showIcon /> : null}
+      {successMessage ? <Alert type="success" title={successMessage} showIcon /> : null}
+
+      <Space align="start" size="middle" style={{ width: "100%", justifyContent: "space-between" }}>
+        <Card title="Mappings" style={{ flex: 1, minWidth: 320 }}>
+          <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+            <Button onClick={resetForm}>New Mapping</Button>
+            <List
+              bordered
+              loading={loading}
+              dataSource={mappings}
+              locale={{ emptyText: <Empty description="No capability mappings configured yet" /> }}
+              renderItem={(mapping) => (
+                <List.Item
+                  style={{
+                    cursor: "pointer",
+                    borderColor:
+                      mapping.id === selectedMappingId ? "var(--ant-color-primary, #1677ff)" : undefined
+                  }}
+                  onClick={() => setSelectedMappingId(mapping.id)}
+                >
+                  <Space orientation="vertical" size={4} style={{ width: "100%" }}>
+                    <Space wrap>
+                      <Typography.Text strong>{mapping.title || mapping.mapping_id}</Typography.Text>
+                      <Tag>{mapping.owner_scope_type}</Tag>
+                      <Tag color="blue">{mapping.capability_name}</Tag>
+                    </Space>
+                    <Typography.Text type="secondary">{mapping.mapping_id}</Typography.Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </Space>
+        </Card>
+
+        <Card title={selectedMappingId ? "Edit Mapping" : "Create Mapping"} style={{ flex: 1, minWidth: 360 }}>
+          <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-id">Mapping ID</label>
+              <Input
+                id="mcp-capability-mapping-id"
+                aria-label="Mapping ID"
+                value={mappingId}
+                onChange={(event) => setMappingId(event.target.value)}
+                placeholder="research.global"
+              />
+            </Space>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-title">Title</label>
+              <Input
+                id="mcp-capability-mapping-title"
+                aria-label="Title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Research Mapping"
+              />
+            </Space>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-description">Description</label>
+              <Input
+                id="mcp-capability-mapping-description"
+                aria-label="Description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="Maps portable research access to local search tools"
+              />
+            </Space>
+            <Space wrap>
+              <Space orientation="vertical">
+                <label htmlFor="mcp-capability-mapping-scope">Owner Scope</label>
+                <select
+                  id="mcp-capability-mapping-scope"
+                  aria-label="Owner Scope"
+                  value={ownerScopeType}
+                  onChange={(event) =>
+                    setOwnerScopeType(event.target.value as McpHubCapabilityAdapterScopeType)
+                  }
+                >
+                  <option value="global">Global</option>
+                  <option value="org">Organization</option>
+                  <option value="team">Team</option>
+                </select>
+              </Space>
+              <Space orientation="vertical">
+                <label htmlFor="mcp-capability-mapping-scope-id">Owner Scope ID</label>
+                <Input
+                  id="mcp-capability-mapping-scope-id"
+                  aria-label="Owner Scope ID"
+                  value={ownerScopeId}
+                  onChange={(event) => setOwnerScopeId(event.target.value)}
+                  placeholder="Optional"
+                />
+              </Space>
+            </Space>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-capability">Capability Name</label>
+              <Input
+                id="mcp-capability-mapping-capability"
+                aria-label="Capability Name"
+                value={capabilityName}
+                onChange={(event) => setCapabilityName(event.target.value)}
+                placeholder="tool.invoke.research"
+              />
+            </Space>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-requirements">Supported Environment Requirements</label>
+              <Input.TextArea
+                id="mcp-capability-mapping-requirements"
+                aria-label="Supported Environment Requirements"
+                value={supportedRequirementsText}
+                rows={3}
+                onChange={(event) => setSupportedRequirementsText(event.target.value)}
+                placeholder="workspace_bounded_read"
+              />
+            </Space>
+            <Space orientation="vertical" style={{ width: "100%" }}>
+              <label htmlFor="mcp-capability-mapping-policy">Resolved Policy JSON</label>
+              <Input.TextArea
+                id="mcp-capability-mapping-policy"
+                aria-label="Resolved Policy JSON"
+                value={resolvedPolicyJson}
+                rows={10}
+                onChange={(event) => setResolvedPolicyJson(event.target.value)}
+                spellCheck={false}
+              />
+            </Space>
+            <Space align="center">
+              <Typography.Text>Active</Typography.Text>
+              <Switch checked={isActive} onChange={setIsActive} aria-label="Active" />
+            </Space>
+            <Space>
+              <Button type="primary" onClick={() => void handlePreview()} loading={previewing}>
+                Preview Mapping
+              </Button>
+              <Button onClick={() => void handleSave()} loading={saving}>
+                Save Mapping
+              </Button>
+            </Space>
+          </Space>
+        </Card>
+      </Space>
+
+      {preview ? (
+        <Card title="Preview Result">
+          <Descriptions bordered column={1} size="small">
+            <Descriptions.Item label="Scope">
+              {preview.affected_scope_summary.display_scope}
+            </Descriptions.Item>
+            <Descriptions.Item label="Capability">
+              {preview.normalized_mapping.capability_name}
+            </Descriptions.Item>
+            <Descriptions.Item label="Warnings">
+              {preview.warnings.length ? (
+                <Space wrap>
+                  {preview.warnings.map((warning) => (
+                    <Tag key={warning} color="orange">
+                      {warning}
+                    </Tag>
+                  ))}
+                </Space>
+              ) : (
+                <Typography.Text type="secondary">None</Typography.Text>
+              )}
+            </Descriptions.Item>
+            <Descriptions.Item label="Resolved Effects">
+              <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>
+                {JSON.stringify(preview.normalized_mapping.resolved_policy_document, null, 2)}
+              </pre>
+            </Descriptions.Item>
+          </Descriptions>
+        </Card>
+      ) : null}
+    </Space>
+  )
+}

--- a/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/McpHubPage.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react"
 import { Tabs, Typography } from "antd"
 
 import { ApprovalPoliciesTab } from "./ApprovalPoliciesTab"
+import { CapabilityMappingsTab } from "./CapabilityMappingsTab"
 import { GovernanceAuditTab } from "./GovernanceAuditTab"
 import { GovernancePacksTab } from "./GovernancePacksTab"
 import { PathScopesTab } from "./PathScopesTab"
@@ -79,6 +80,11 @@ export const McpHubPage = () => {
             key: "path-scopes",
             label: "Path Scopes",
             children: <PathScopesTab />
+          },
+          {
+            key: "capability-mappings",
+            label: "Capability Mappings",
+            children: <CapabilityMappingsTab />
           },
           {
             key: "workspace-sets",

--- a/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
@@ -75,6 +75,19 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
   }, [personaId])
 
   const provenance = Array.isArray(policy?.provenance) ? policy.provenance : []
+  const resolvedPolicyDocument =
+    (policy?.resolved_policy_document as Record<string, unknown> | null | undefined) ??
+    policy?.policy_document ??
+    {}
+  const capabilityMappingSummary = Array.isArray(policy?.capability_mapping_summary)
+    ? policy.capability_mapping_summary
+    : []
+  const unresolvedCapabilities = Array.isArray(policy?.unresolved_capabilities)
+    ? policy.unresolved_capabilities
+    : []
+  const capabilityWarnings = Array.isArray(policy?.capability_warnings)
+    ? policy.capability_warnings
+    : []
   const governancePackLabels = Array.from(
     new Set(
       provenance
@@ -110,12 +123,12 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
         <Space orientation="vertical" size="small" style={{ width: "100%" }}>
           {getPathScopeLabel(policy.policy_document?.path_scope_mode) ? (
             <Typography.Text type="secondary">
-              {`Local file scope: ${getPathScopeLabel(policy.policy_document?.path_scope_mode)}`}
+              {`Local file scope: ${getPathScopeLabel(resolvedPolicyDocument?.path_scope_mode)}`}
             </Typography.Text>
           ) : null}
-          {getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes) ? (
+          {getPathAllowlistSummary(resolvedPolicyDocument?.path_allowlist_prefixes) ? (
             <Typography.Text type="secondary">
-              {`Allowed paths: ${getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes)}`}
+              {`Allowed paths: ${getPathAllowlistSummary(resolvedPolicyDocument?.path_allowlist_prefixes)}`}
             </Typography.Text>
           ) : null}
           {policy.selected_assignment_workspace_ids?.length ? (
@@ -137,19 +150,46 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
               }`}
             </Typography.Text>
           ) : null}
+          {capabilityMappingSummary.length ? (
+            <Space orientation="vertical" size={4}>
+              {capabilityMappingSummary.map((summary) => (
+                <Typography.Text key={`${summary.capability_name}:${summary.mapping_id ?? "unmapped"}`}>
+                  {`Mapped ${summary.capability_name} via ${summary.mapping_id ?? "local mapping"}`}
+                </Typography.Text>
+              ))}
+            </Space>
+          ) : null}
+          {unresolvedCapabilities.length ? (
+            <Space orientation="vertical" size={4}>
+              {unresolvedCapabilities.map((capability) => (
+                <Typography.Text key={capability} type="warning">
+                  {`Unresolved capability: ${capability}`}
+                </Typography.Text>
+              ))}
+            </Space>
+          ) : null}
+          {capabilityWarnings.length ? (
+            <Space orientation="vertical" size={4}>
+              {capabilityWarnings.map((warning) => (
+                <Typography.Text key={warning} type="warning">
+                  {warning}
+                </Typography.Text>
+              ))}
+            </Space>
+          ) : null}
           <Space wrap>
             {policy.capabilities.map((capability) => (
               <Tag key={capability}>{capability}</Tag>
             ))}
             {policy.approval_mode ? <Tag color="gold">{policy.approval_mode}</Tag> : null}
-            {getPathScopeLabel(policy.policy_document?.path_scope_mode) ? (
-              <Tag color="cyan">{getPathScopeLabel(policy.policy_document?.path_scope_mode)}</Tag>
+            {getPathScopeLabel(resolvedPolicyDocument?.path_scope_mode) ? (
+              <Tag color="cyan">{getPathScopeLabel(resolvedPolicyDocument?.path_scope_mode)}</Tag>
             ) : null}
-            {policy.policy_document?.path_scope_enforcement ? (
+            {resolvedPolicyDocument?.path_scope_enforcement ? (
               <Tag color="orange">Path approval fallback</Tag>
             ) : null}
-            {getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes) ? (
-              <Tag color="blue">{`paths ${getPathAllowlistSummary(policy.policy_document?.path_allowlist_prefixes)}`}</Tag>
+            {getPathAllowlistSummary(resolvedPolicyDocument?.path_allowlist_prefixes) ? (
+              <Tag color="blue">{`paths ${getPathAllowlistSummary(resolvedPolicyDocument?.path_allowlist_prefixes)}`}</Tag>
             ) : null}
             {provenance.some((entry) => entry.source_kind === "assignment_override") ? (
               <Tag color="cyan">Override active</Tag>
@@ -172,6 +212,11 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
                   : "user-local"}
               </Tag>
             ) : null}
+            {unresolvedCapabilities.map((capability) => (
+              <Tag key={`unresolved:${capability}`} color="red">
+                {`unresolved ${capability}`}
+              </Tag>
+            ))}
           </Space>
           <Space wrap>
             {policy.allowed_tools.map((tool) => (

--- a/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/PersonaPolicySummary.tsx
@@ -154,7 +154,9 @@ export const PersonaPolicySummary = ({ personaId }: PersonaPolicySummaryProps) =
             <Space orientation="vertical" size={4}>
               {capabilityMappingSummary.map((summary) => (
                 <Typography.Text key={`${summary.capability_name}:${summary.mapping_id ?? "unmapped"}`}>
-                  {`Mapped ${summary.capability_name} via ${summary.mapping_id ?? "local mapping"}`}
+                  {`${
+                    summary.resolution_intent === "deny" ? "Denied" : "Mapped"
+                  } ${summary.capability_name} via ${summary.mapping_id ?? "local mapping"}`}
                 </Typography.Text>
               ))}
             </Space>

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/CapabilityMappingsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/CapabilityMappingsTab.test.tsx
@@ -155,4 +155,25 @@ describe("CapabilityMappingsTab", () => {
     )
     expect(await screen.findByText("Docs Mapping")).toBeTruthy()
   })
+
+  it("rejects invalid owner scope ids before previewing", async () => {
+    const user = userEvent.setup()
+    render(<CapabilityMappingsTab />)
+
+    expect(await screen.findByText("Research Mapping")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: /new mapping/i }))
+    await user.type(screen.getByLabelText("Mapping ID"), "docs.org")
+    await user.type(screen.getByLabelText("Capability Name"), "tool.invoke.docs")
+    await user.selectOptions(screen.getByLabelText("Owner Scope"), "org")
+    await user.type(screen.getByLabelText("Owner Scope ID"), "abc")
+    fireEvent.change(screen.getByLabelText("Resolved Policy JSON"), {
+      target: { value: JSON.stringify({ allowed_tools: ["docs.search"] }) }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview mapping/i }))
+
+    expect(await screen.findByText("Owner Scope ID must be a valid integer.")).toBeTruthy()
+    expect(mocks.previewCapabilityAdapterMapping).not.toHaveBeenCalled()
+  })
 })

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/CapabilityMappingsTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/CapabilityMappingsTab.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const mocks = vi.hoisted(() => ({
+  listCapabilityAdapterMappings: vi.fn(),
+  previewCapabilityAdapterMapping: vi.fn(),
+  createCapabilityAdapterMapping: vi.fn(),
+  updateCapabilityAdapterMapping: vi.fn()
+}))
+
+vi.mock("@/services/tldw/mcp-hub", () => ({
+  listCapabilityAdapterMappings: (...args: unknown[]) => mocks.listCapabilityAdapterMappings(...args),
+  previewCapabilityAdapterMapping: (...args: unknown[]) => mocks.previewCapabilityAdapterMapping(...args),
+  createCapabilityAdapterMapping: (...args: unknown[]) => mocks.createCapabilityAdapterMapping(...args),
+  updateCapabilityAdapterMapping: (...args: unknown[]) => mocks.updateCapabilityAdapterMapping(...args)
+}))
+
+import { CapabilityMappingsTab } from "../CapabilityMappingsTab"
+
+describe("CapabilityMappingsTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listCapabilityAdapterMappings
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          mapping_id: "research.global",
+          title: "Research Mapping",
+          description: "Maps research capability to search tools",
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          capability_name: "tool.invoke.research",
+          adapter_contract_version: 1,
+          resolved_policy_document: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          is_active: true
+        }
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          mapping_id: "research.global",
+          title: "Research Mapping",
+          description: "Maps research capability to search tools",
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          capability_name: "tool.invoke.research",
+          adapter_contract_version: 1,
+          resolved_policy_document: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          is_active: true
+        },
+        {
+          id: 2,
+          mapping_id: "docs.global",
+          title: "Docs Mapping",
+          description: null,
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          capability_name: "tool.invoke.docs",
+          adapter_contract_version: 1,
+          resolved_policy_document: { allowed_tools: ["docs.search"] },
+          supported_environment_requirements: [],
+          is_active: true
+        }
+      ])
+    mocks.previewCapabilityAdapterMapping.mockResolvedValue({
+      normalized_mapping: {
+        mapping_id: "docs.global",
+        title: "Docs Mapping",
+        description: null,
+        owner_scope_type: "global",
+        owner_scope_id: null,
+        capability_name: "tool.invoke.docs",
+        adapter_contract_version: 1,
+        resolved_policy_document: { allowed_tools: ["docs.search"] },
+        supported_environment_requirements: [],
+        is_active: true
+      },
+      warnings: ["preview warning"],
+      affected_scope_summary: {
+        owner_scope_type: "global",
+        owner_scope_id: null,
+        display_scope: "Global"
+      }
+    })
+    mocks.createCapabilityAdapterMapping.mockResolvedValue({
+      id: 2,
+      mapping_id: "docs.global",
+      title: "Docs Mapping",
+      description: null,
+      owner_scope_type: "global",
+      owner_scope_id: null,
+      capability_name: "tool.invoke.docs",
+      adapter_contract_version: 1,
+      resolved_policy_document: { allowed_tools: ["docs.search"] },
+      supported_environment_requirements: [],
+      is_active: true
+    })
+    mocks.updateCapabilityAdapterMapping.mockResolvedValue({
+      id: 1,
+      mapping_id: "research.global",
+      title: "Research Mapping",
+      description: "Maps research capability to search tools",
+      owner_scope_type: "global",
+      owner_scope_id: null,
+      capability_name: "tool.invoke.research",
+      adapter_contract_version: 1,
+      resolved_policy_document: { allowed_tools: ["web.search"] },
+      supported_environment_requirements: ["workspace_bounded_read"],
+      is_active: true
+    })
+  })
+
+  it("lists mappings and lets users preview and save a new mapping", async () => {
+    const user = userEvent.setup()
+    render(<CapabilityMappingsTab />)
+
+    expect(await screen.findByText("Research Mapping")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: /new mapping/i }))
+    await user.type(screen.getByLabelText("Mapping ID"), "docs.global")
+    await user.type(screen.getByLabelText("Title"), "Docs Mapping")
+    await user.type(screen.getByLabelText("Capability Name"), "tool.invoke.docs")
+    fireEvent.change(screen.getByLabelText("Resolved Policy JSON"), {
+      target: { value: JSON.stringify({ allowed_tools: ["docs.search"] }) }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview mapping/i }))
+
+    await waitFor(() =>
+      expect(mocks.previewCapabilityAdapterMapping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mapping_id: "docs.global",
+          capability_name: "tool.invoke.docs",
+          resolved_policy_document: { allowed_tools: ["docs.search"] }
+        })
+      )
+    )
+    expect(screen.getByText("preview warning")).toBeTruthy()
+    expect(within(screen.getByText("Preview Result").closest(".ant-card")!).getByText("Global")).toBeTruthy()
+
+    await user.click(screen.getByRole("button", { name: /save mapping/i }))
+
+    await waitFor(() =>
+      expect(mocks.createCapabilityAdapterMapping).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mapping_id: "docs.global",
+          title: "Docs Mapping",
+          capability_name: "tool.invoke.docs"
+        })
+      )
+    )
+    expect(await screen.findByText("Docs Mapping")).toBeTruthy()
+  })
+})

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/McpHubPage.test.tsx
@@ -46,6 +46,9 @@ vi.mock("../GovernanceAuditTab", () => ({
 vi.mock("../GovernancePacksTab", () => ({
   GovernancePacksTab: () => <div>governance packs tab</div>
 }))
+vi.mock("../CapabilityMappingsTab", () => ({
+  CapabilityMappingsTab: () => <div>capability mappings tab</div>
+}))
 
 import { McpHubPage } from "../McpHubPage"
 
@@ -56,6 +59,7 @@ describe("McpHubPage", () => {
     expect(screen.getByText("Profiles")).toBeTruthy()
     expect(screen.getByText("Assignments")).toBeTruthy()
     expect(screen.getByText("Audit")).toBeTruthy()
+    expect(screen.getByText("Capability Mappings")).toBeTruthy()
     expect(screen.getByText("Governance Packs")).toBeTruthy()
   })
 

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
@@ -24,6 +24,32 @@ describe("PersonaPolicySummary", () => {
       allowed_tools: ["Bash(git *)"],
       denied_tools: ["Bash(rm *)"],
       capabilities: ["process.execute"],
+      authored_policy_document: {
+        capabilities: ["tool.invoke.research", "network.external.search"]
+      },
+      resolved_policy_document: {
+        capabilities: ["tool.invoke.research", "network.external.search"],
+        allowed_tools: ["Bash(git *)"],
+        path_scope_mode: "workspace_root",
+        path_scope_enforcement: "approval_required_when_unenforceable",
+        path_allowlist_prefixes: ["src", "docs/api"]
+      },
+      resolved_capabilities: ["tool.invoke.research"],
+      unresolved_capabilities: ["network.external.search"],
+      capability_mapping_summary: [
+        {
+          capability_name: "tool.invoke.research",
+          mapping_id: "research.global",
+          mapping_scope_type: "global",
+          mapping_scope_id: null,
+          resolved_effects: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          unsupported_environment_requirements: []
+        }
+      ],
+      capability_warnings: [
+        "profile:researcher: No active capability adapter mapping found for 'network.external.search'"
+      ],
       approval_policy_id: 17,
       approval_mode: "ask_outside_profile",
       policy_document: {
@@ -134,6 +160,11 @@ describe("PersonaPolicySummary", () => {
     expect(screen.getAllByText(/disabled by assignment/i).length).toBeGreaterThan(0)
     expect(screen.getAllByText(/missing secret/i).length).toBeGreaterThan(0)
     expect(screen.getByText("Pack researcher-pack@1.0.0")).toBeTruthy()
+    expect(screen.getByText("Mapped tool.invoke.research via research.global")).toBeTruthy()
+    expect(screen.getByText("Unresolved capability: network.external.search")).toBeTruthy()
+    expect(
+      screen.getByText("profile:researcher: No active capability adapter mapping found for 'network.external.search'")
+    ).toBeTruthy()
     expect(screen.getByRole("link", { name: /open mcp hub/i })).toBeTruthy()
   })
 
@@ -143,6 +174,12 @@ describe("PersonaPolicySummary", () => {
       allowed_tools: ["Bash(git *)"],
       denied_tools: [],
       capabilities: ["process.execute"],
+      authored_policy_document: {},
+      resolved_policy_document: {},
+      resolved_capabilities: [],
+      unresolved_capabilities: [],
+      capability_mapping_summary: [],
+      capability_warnings: [],
       approval_policy_id: 17,
       approval_mode: "ask_outside_profile",
       policy_document: {},

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/PersonaPolicySummary.test.tsx
@@ -39,11 +39,22 @@ describe("PersonaPolicySummary", () => {
       capability_mapping_summary: [
         {
           capability_name: "tool.invoke.research",
+          resolution_intent: "allow",
           mapping_id: "research.global",
           mapping_scope_type: "global",
           mapping_scope_id: null,
           resolved_effects: { allowed_tools: ["web.search"] },
           supported_environment_requirements: ["workspace_bounded_read"],
+          unsupported_environment_requirements: []
+        },
+        {
+          capability_name: "tool.invoke.docs",
+          resolution_intent: "deny",
+          mapping_id: "docs.global",
+          mapping_scope_type: "global",
+          mapping_scope_id: null,
+          resolved_effects: { allowed_tools: ["docs.search"] },
+          supported_environment_requirements: [],
           unsupported_environment_requirements: []
         }
       ],
@@ -161,6 +172,7 @@ describe("PersonaPolicySummary", () => {
     expect(screen.getAllByText(/missing secret/i).length).toBeGreaterThan(0)
     expect(screen.getByText("Pack researcher-pack@1.0.0")).toBeTruthy()
     expect(screen.getByText("Mapped tool.invoke.research via research.global")).toBeTruthy()
+    expect(screen.getByText("Denied tool.invoke.docs via docs.global")).toBeTruthy()
     expect(screen.getByText("Unresolved capability: network.external.search")).toBeTruthy()
     expect(
       screen.getByText("profile:researcher: No active capability adapter mapping found for 'network.external.search'")

--- a/apps/packages/ui/src/components/Option/MCPHub/index.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/index.tsx
@@ -1,6 +1,7 @@
 export { McpHubPage } from "./McpHubPage"
 export { AcpProfilesTab } from "./AcpProfilesTab"
 export { ApprovalPoliciesTab } from "./ApprovalPoliciesTab"
+export { CapabilityMappingsTab } from "./CapabilityMappingsTab"
 export { GovernancePacksTab } from "./GovernancePacksTab"
 export { ToolCatalogsTab } from "./ToolCatalogsTab"
 export { ExternalServersTab } from "./ExternalServersTab"

--- a/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/mcp-hub.test.ts
@@ -10,7 +10,10 @@ vi.mock("@/services/background-proxy", () => ({
 
 import {
   dryRunGovernancePack,
+  getEffectivePolicy,
   listGovernancePacks,
+  listCapabilityAdapterMappings,
+  previewCapabilityAdapterMapping,
   setExternalServerSecret
 } from "../mcp-hub"
 
@@ -50,6 +53,19 @@ describe("mcp hub service client", () => {
         digest: "a".repeat(64),
         resolved_capabilities: ["tool.invoke.research"],
         unresolved_capabilities: [],
+        capability_mapping_summary: [
+          {
+            capability_name: "tool.invoke.research",
+            mapping_id: "research.global",
+            mapping_scope_type: "global",
+            mapping_scope_id: null,
+            resolved_effects: { allowed_tools: ["web.search"] },
+            supported_environment_requirements: ["workspace_bounded_read"],
+            unsupported_environment_requirements: []
+          }
+        ],
+        supported_environment_requirements: ["workspace_bounded_read"],
+        unsupported_environment_requirements: [],
         warnings: [],
         blocked_objects: [],
         verdict: "importable"
@@ -69,6 +85,7 @@ describe("mcp hub service client", () => {
     const out = await dryRunGovernancePack(payload)
 
     expect(out.report.verdict).toBe("importable")
+    expect(out.report.capability_mapping_summary[0]?.mapping_id).toBe("research.global")
     expect(mocks.bgRequestClient).toHaveBeenCalledWith(
       expect.objectContaining({
         path: "/api/v1/mcp/hub/governance-packs/dry-run",
@@ -99,6 +116,115 @@ describe("mcp hub service client", () => {
       expect.objectContaining({
         path: "/api/v1/mcp/hub/governance-packs?owner_scope_type=user&owner_scope_id=7",
         method: "GET"
+      })
+    )
+  })
+
+  it("maps effective policy responses with authored and resolved documents", async () => {
+    mocks.bgRequestClient.mockResolvedValueOnce({
+      enabled: true,
+      allowed_tools: ["web.search"],
+      denied_tools: [],
+      capabilities: ["tool.invoke.research", "network.external.search"],
+      authored_policy_document: { capabilities: ["tool.invoke.research", "network.external.search"] },
+      resolved_policy_document: {
+        capabilities: ["tool.invoke.research", "network.external.search"],
+        allowed_tools: ["web.search"]
+      },
+      resolved_capabilities: ["tool.invoke.research"],
+      unresolved_capabilities: ["network.external.search"],
+      capability_mapping_summary: [
+        {
+          capability_name: "tool.invoke.research",
+          mapping_id: "research.global",
+          mapping_scope_type: "global",
+          mapping_scope_id: null,
+          resolved_effects: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          unsupported_environment_requirements: []
+        }
+      ],
+      capability_warnings: [
+        "profile:researcher: No active capability adapter mapping found for 'network.external.search'"
+      ],
+      policy_document: { allowed_tools: ["web.search"] },
+      sources: [],
+      provenance: []
+    })
+
+    const out = await getEffectivePolicy({ persona_id: "researcher" })
+
+    expect(out.authored_policy_document.capabilities).toEqual([
+      "tool.invoke.research",
+      "network.external.search"
+    ])
+    expect(out.capability_mapping_summary[0]?.mapping_id).toBe("research.global")
+    expect(out.unresolved_capabilities).toEqual(["network.external.search"])
+  })
+
+  it("requests capability mapping previews and listing through MCP Hub endpoints", async () => {
+    mocks.bgRequestClient
+      .mockResolvedValueOnce([
+        {
+          id: 9,
+          mapping_id: "research.global",
+          title: "Research Mapping",
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          capability_name: "tool.invoke.research",
+          adapter_contract_version: 1,
+          resolved_policy_document: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          is_active: true
+        }
+      ])
+      .mockResolvedValueOnce({
+        normalized_mapping: {
+          mapping_id: "research.global",
+          title: "Research Mapping",
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          capability_name: "tool.invoke.research",
+          adapter_contract_version: 1,
+          resolved_policy_document: { allowed_tools: ["web.search"] },
+          supported_environment_requirements: ["workspace_bounded_read"],
+          is_active: true
+        },
+        warnings: [],
+        affected_scope_summary: {
+          owner_scope_type: "global",
+          owner_scope_id: null,
+          display_scope: "Global"
+        }
+      })
+
+    const listOut = await listCapabilityAdapterMappings({ owner_scope_type: "global" })
+    const previewOut = await previewCapabilityAdapterMapping({
+      mapping_id: "research.global",
+      title: "Research Mapping",
+      owner_scope_type: "global",
+      owner_scope_id: null,
+      capability_name: "tool.invoke.research",
+      adapter_contract_version: 1,
+      resolved_policy_document: { allowed_tools: ["web.search"] },
+      supported_environment_requirements: ["workspace_bounded_read"],
+      is_active: true
+    })
+
+    expect(listOut).toHaveLength(1)
+    expect(previewOut.affected_scope_summary.display_scope).toBe("Global")
+    expect(mocks.bgRequestClient).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        path: "/api/v1/mcp/hub/capability-mappings?owner_scope_type=global",
+        method: "GET"
+      })
+    )
+    expect(mocks.bgRequestClient).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        path: "/api/v1/mcp/hub/capability-mappings/preview",
+        method: "POST"
       })
     )
   })

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -2,6 +2,7 @@ import { bgRequestClient } from "@/services/background-proxy"
 import type { ClientPathOrUrlWithQuery } from "@/services/tldw/openapi-guard"
 
 export type McpHubScopeType = "global" | "org" | "team" | "user"
+export type McpHubCapabilityAdapterScopeType = "global" | "org" | "team"
 export type McpHubProfileMode = "preset" | "custom"
 export type McpHubAssignmentTargetType = "default" | "group" | "persona"
 export type McpHubApprovalMode =
@@ -40,6 +41,7 @@ export type McpHubGovernanceAuditTabKey =
   | "profiles"
   | "assignments"
   | "path-scopes"
+  | "capability-mappings"
   | "workspace-sets"
   | "shared-workspaces"
   | "audit"
@@ -407,10 +409,27 @@ export type McpHubEffectivePolicyProvenance = {
     | "assignment_path_scope_object"
     | "assignment_inline"
     | "assignment_override"
-  assignment_id: number
+    | "capability_mapping"
+    | "runtime_constraint"
+  assignment_id?: number | null
   profile_id?: number | null
   override_id?: number | null
-  effect: "merged" | "replaced"
+  capability_name?: string | null
+  mapping_id?: string | null
+  mapping_scope_type?: McpHubCapabilityAdapterScopeType | null
+  mapping_scope_id?: number | null
+  resolved_effects?: Record<string, unknown>
+  effect: "merged" | "replaced" | "narrowed" | "blocked"
+}
+
+export type McpHubEffectivePolicyCapabilityMapping = {
+  capability_name: string
+  mapping_id?: string | null
+  mapping_scope_type?: McpHubCapabilityAdapterScopeType | null
+  mapping_scope_id?: number | null
+  resolved_effects: Record<string, unknown>
+  supported_environment_requirements: string[]
+  unsupported_environment_requirements: string[]
 }
 
 export type McpHubEffectivePolicy = {
@@ -421,6 +440,14 @@ export type McpHubEffectivePolicy = {
   approval_policy_id?: number | null
   approval_mode?: McpHubApprovalMode | null
   policy_document: Record<string, unknown>
+  authored_policy_document: Record<string, unknown>
+  resolved_policy_document: Record<string, unknown>
+  resolved_capabilities: string[]
+  unresolved_capabilities: string[]
+  capability_mapping_summary: McpHubEffectivePolicyCapabilityMapping[]
+  capability_warnings: string[]
+  supported_environment_requirements: string[]
+  unsupported_environment_requirements: string[]
   selected_assignment_id?: number | null
   selected_workspace_source_mode?: McpHubWorkspaceSourceMode | null
   selected_workspace_set_object_id?: number | null
@@ -664,9 +691,81 @@ export type McpHubGovernancePackDryRunReport = {
   digest: string
   resolved_capabilities: string[]
   unresolved_capabilities: string[]
+  capability_mapping_summary: McpHubEffectivePolicyCapabilityMapping[]
+  supported_environment_requirements: string[]
+  unsupported_environment_requirements: string[]
   warnings: string[]
   blocked_objects: string[]
   verdict: "importable" | "blocked"
+}
+
+export type McpHubCapabilityAdapterMapping = {
+  id: number
+  mapping_id: string
+  title: string
+  description?: string | null
+  owner_scope_type: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+  capability_name: string
+  adapter_contract_version: number
+  resolved_policy_document: McpHubPermissionPolicyDocument
+  supported_environment_requirements: string[]
+  is_active: boolean
+  created_by?: number | null
+  updated_by?: number | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export type McpHubCapabilityAdapterMappingInput = {
+  mapping_id: string
+  title?: string | null
+  description?: string | null
+  owner_scope_type?: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+  capability_name: string
+  adapter_contract_version?: number
+  resolved_policy_document?: McpHubPermissionPolicyDocument
+  supported_environment_requirements?: string[]
+  is_active?: boolean
+}
+
+export type McpHubCapabilityAdapterMappingUpdateInput = {
+  mapping_id?: string
+  title?: string | null
+  description?: string | null
+  owner_scope_type?: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+  capability_name?: string
+  adapter_contract_version?: number
+  resolved_policy_document?: McpHubPermissionPolicyDocument
+  supported_environment_requirements?: string[]
+  is_active?: boolean
+}
+
+export type McpHubCapabilityAdapterMappingNormalized = {
+  mapping_id: string
+  title: string
+  description?: string | null
+  owner_scope_type: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+  capability_name: string
+  adapter_contract_version: number
+  resolved_policy_document: McpHubPermissionPolicyDocument
+  supported_environment_requirements: string[]
+  is_active: boolean
+}
+
+export type McpHubCapabilityAdapterMappingScopeSummary = {
+  owner_scope_type: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+  display_scope: string
+}
+
+export type McpHubCapabilityAdapterMappingPreview = {
+  normalized_mapping: McpHubCapabilityAdapterMappingNormalized
+  warnings: string[]
+  affected_scope_summary: McpHubCapabilityAdapterMappingScopeSummary
 }
 
 export type McpHubGovernancePackDryRunResponse = {
@@ -984,6 +1083,50 @@ export const getAssignmentExternalAccess = async (
   return await bgRequestClient<McpHubEffectiveExternalAccess>({
     path: `/api/v1/mcp/hub/policy-assignments/${assignmentId}/external-access`,
     method: "GET"
+  })
+}
+
+export const listCapabilityAdapterMappings = async (params: {
+  owner_scope_type?: McpHubCapabilityAdapterScopeType
+  owner_scope_id?: number | null
+} = {}): Promise<McpHubCapabilityAdapterMapping[]> => {
+  return await bgRequestClient<McpHubCapabilityAdapterMapping[]>({
+    path: withQuery("/api/v1/mcp/hub/capability-mappings", {
+      owner_scope_type: params.owner_scope_type,
+      owner_scope_id: params.owner_scope_id
+    }),
+    method: "GET"
+  })
+}
+
+export const previewCapabilityAdapterMapping = async (
+  payload: McpHubCapabilityAdapterMappingInput
+): Promise<McpHubCapabilityAdapterMappingPreview> => {
+  return await bgRequestClient<McpHubCapabilityAdapterMappingPreview>({
+    path: "/api/v1/mcp/hub/capability-mappings/preview",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const createCapabilityAdapterMapping = async (
+  payload: McpHubCapabilityAdapterMappingInput
+): Promise<McpHubCapabilityAdapterMapping> => {
+  return await bgRequestClient<McpHubCapabilityAdapterMapping>({
+    path: "/api/v1/mcp/hub/capability-mappings",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const updateCapabilityAdapterMapping = async (
+  capabilityAdapterMappingId: number,
+  payload: McpHubCapabilityAdapterMappingUpdateInput
+): Promise<McpHubCapabilityAdapterMapping> => {
+  return await bgRequestClient<McpHubCapabilityAdapterMapping>({
+    path: `/api/v1/mcp/hub/capability-mappings/${capabilityAdapterMappingId}`,
+    method: "PUT",
+    body: payload
   })
 }
 

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -419,11 +419,13 @@ export type McpHubEffectivePolicyProvenance = {
   mapping_scope_type?: McpHubCapabilityAdapterScopeType | null
   mapping_scope_id?: number | null
   resolved_effects?: Record<string, unknown>
+  resolution_intent?: "allow" | "deny" | null
   effect: "merged" | "replaced" | "narrowed" | "blocked"
 }
 
 export type McpHubEffectivePolicyCapabilityMapping = {
   capability_name: string
+  resolution_intent?: "allow" | "deny" | null
   mapping_id?: string | null
   mapping_scope_type?: McpHubCapabilityAdapterScopeType | null
   mapping_scope_id?: number | null

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -20,6 +20,10 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     ApprovalPolicyResponse,
     ApprovalPolicyUpdateRequest,
     AssignmentCredentialBindingUpsertRequest,
+    CapabilityAdapterMappingCreateRequest,
+    CapabilityAdapterMappingPreviewResponse,
+    CapabilityAdapterMappingResponse,
+    CapabilityAdapterMappingUpdateRequest,
     CredentialBindingResponse,
     EffectivePolicyResponse,
     EffectiveExternalAccessResponse,
@@ -75,6 +79,9 @@ from tldw_Server_API.app.core.config import config
 from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
 from tldw_Server_API.app.services.mcp_hub_external_legacy_inventory import (
     McpHubExternalLegacyInventoryService,
+)
+from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+    McpHubCapabilityAdapterService,
 )
 from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
     GovernancePackAlreadyExistsError,
@@ -136,6 +143,17 @@ async def get_mcp_hub_governance_pack_service() -> McpHubGovernancePackService:
     repo = McpHubRepo(pool)
     await repo.ensure_tables()
     return McpHubGovernancePackService(repo=repo)
+
+
+async def get_mcp_hub_capability_adapter_service() -> McpHubCapabilityAdapterService:
+    """Resolve capability-adapter service with storage bootstrap checks."""
+    pool = await get_db_pool()
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return McpHubCapabilityAdapterService(
+        repo=repo,
+        tool_registry=McpHubToolRegistryService(),
+    )
 
 
 async def get_mcp_hub_policy_resolver_dep() -> McpHubPolicyResolver:
@@ -677,6 +695,45 @@ def _resolve_governance_pack_mutation_scope(
     if owner_scope_id is None:
         raise HTTPException(status_code=422, detail=f"{scope_type} scope requires owner_scope_id")
     return (scope_type, int(owner_scope_id))
+
+
+def _resolve_capability_adapter_mutation_scope(
+    *,
+    owner_scope_type: str,
+    owner_scope_id: int | None,
+) -> tuple[str, int | None]:
+    """Resolve capability-adapter mapping scope, rejecting unsupported user scope."""
+    scope_type = str(owner_scope_type or "").strip().lower()
+    if scope_type not in {"global", "org", "team"}:
+        raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+    if scope_type == "global":
+        if owner_scope_id is not None:
+            raise HTTPException(status_code=422, detail="global scope cannot include owner_scope_id")
+        return ("global", None)
+    if owner_scope_id is None:
+        raise HTTPException(status_code=422, detail=f"{scope_type} scope requires owner_scope_id")
+    return (scope_type, int(owner_scope_id))
+
+
+def _resolve_visible_capability_adapter_scope_filters(
+    *,
+    principal: AuthPrincipal,
+    owner_scope_type: str | None,
+    owner_scope_id: int | None,
+) -> list[tuple[str | None, int | None]]:
+    """Resolve visible filters for capability mappings, excluding unsupported user scope."""
+    if owner_scope_type is not None and str(owner_scope_type or "").strip().lower() == "user":
+        raise HTTPException(status_code=422, detail="Invalid owner_scope_type")
+    filters = _resolve_visible_scope_filters(
+        principal=principal,
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
+    return [
+        (scope_type, scope_id)
+        for scope_type, scope_id in filters
+        if scope_type is None or scope_type in {"global", "org", "team"}
+    ]
 
 
 def _portable_grant_capability(capability: Any) -> str | None:
@@ -1229,6 +1286,154 @@ async def get_tool_registry_summary(
         entries=[ToolRegistryEntryResponse.model_validate(row) for row in summary.get("entries", [])],
         modules=[ToolRegistryModuleResponse.model_validate(row) for row in summary.get("modules", [])],
     )
+
+
+@router.post("/capability-mappings/preview", response_model=CapabilityAdapterMappingPreviewResponse)
+async def preview_capability_mapping(
+    payload: CapabilityAdapterMappingCreateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubCapabilityAdapterService = Depends(get_mcp_hub_capability_adapter_service),
+) -> CapabilityAdapterMappingPreviewResponse:
+    """Validate and preview a capability adapter mapping without persisting it."""
+    _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_capability_adapter_mutation_scope(
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    try:
+        preview = await svc.preview_mapping(
+            mapping_id=payload.mapping_id,
+            title=payload.title,
+            description=payload.description,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
+            capability_name=payload.capability_name,
+            adapter_contract_version=payload.adapter_contract_version,
+            resolved_policy_document=payload.resolved_policy_document,
+            supported_environment_requirements=payload.supported_environment_requirements,
+            is_active=payload.is_active,
+        )
+    except BadRequestError as exc:
+        raise HTTPException(status_code=400, detail=_bad_request_detail(exc)) from exc
+    return CapabilityAdapterMappingPreviewResponse.model_validate(preview)
+
+
+@router.get("/capability-mappings", response_model=list[CapabilityAdapterMappingResponse])
+async def list_capability_mappings(
+    owner_scope_type: str | None = None,
+    owner_scope_id: int | None = None,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubCapabilityAdapterService = Depends(get_mcp_hub_capability_adapter_service),
+) -> list[CapabilityAdapterMappingResponse]:
+    """List capability adapter mappings visible to the current principal."""
+    filters = _resolve_visible_capability_adapter_scope_filters(
+        principal=principal,
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+    )
+    rows: list[dict[str, Any]] = []
+    for scope_type, scope_id in filters:
+        rows.extend(
+            await svc.list_capability_adapter_mappings(
+                owner_scope_type=scope_type,
+                owner_scope_id=scope_id,
+            )
+        )
+    rows = _dedupe_rows(rows)
+    return [CapabilityAdapterMappingResponse.model_validate(row) for row in rows]
+
+
+@router.post("/capability-mappings", response_model=CapabilityAdapterMappingResponse, status_code=201)
+async def create_capability_mapping(
+    payload: CapabilityAdapterMappingCreateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubCapabilityAdapterService = Depends(get_mcp_hub_capability_adapter_service),
+) -> CapabilityAdapterMappingResponse:
+    """Create a capability adapter mapping after validation and grant-authority checks."""
+    _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_capability_adapter_mutation_scope(
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    try:
+        preview = await svc.preview_mapping(
+            mapping_id=payload.mapping_id,
+            title=payload.title,
+            description=payload.description,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
+            capability_name=payload.capability_name,
+            adapter_contract_version=payload.adapter_contract_version,
+            resolved_policy_document=payload.resolved_policy_document,
+            supported_environment_requirements=payload.supported_environment_requirements,
+            is_active=payload.is_active,
+        )
+        _require_grant_authority(
+            principal,
+            dict(preview["normalized_mapping"].get("resolved_policy_document") or {}),
+        )
+        created = await svc.create_mapping(
+            mapping_id=payload.mapping_id,
+            title=payload.title,
+            description=payload.description,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
+            capability_name=payload.capability_name,
+            adapter_contract_version=payload.adapter_contract_version,
+            resolved_policy_document=payload.resolved_policy_document,
+            supported_environment_requirements=payload.supported_environment_requirements,
+            actor_id=principal.user_id,
+            is_active=payload.is_active,
+        )
+    except BadRequestError as exc:
+        raise HTTPException(status_code=400, detail=_bad_request_detail(exc)) from exc
+    return CapabilityAdapterMappingResponse.model_validate(created)
+
+
+@router.put("/capability-mappings/{capability_adapter_mapping_id}", response_model=CapabilityAdapterMappingResponse)
+async def update_capability_mapping(
+    capability_adapter_mapping_id: int,
+    payload: CapabilityAdapterMappingUpdateRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubCapabilityAdapterService = Depends(get_mcp_hub_capability_adapter_service),
+) -> CapabilityAdapterMappingResponse:
+    """Update a capability adapter mapping after validation and grant-authority checks."""
+    _require_mutation_permission(principal)
+    update_fields = payload.model_dump(exclude_unset=True)
+    try:
+        preview = await svc.preview_update(
+            capability_adapter_mapping_id,
+            **update_fields,
+        )
+        _require_grant_authority(
+            principal,
+            dict(preview["normalized_mapping"].get("resolved_policy_document") or {}),
+        )
+        updated = await svc.update_mapping(
+            capability_adapter_mapping_id,
+            **update_fields,
+            actor_id=principal.user_id,
+        )
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except BadRequestError as exc:
+        raise HTTPException(status_code=400, detail=_bad_request_detail(exc)) from exc
+    return CapabilityAdapterMappingResponse.model_validate(updated)
+
+
+@router.delete("/capability-mappings/{capability_adapter_mapping_id}", response_model=MCPHubDeleteResponse)
+async def delete_capability_mapping(
+    capability_adapter_mapping_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubCapabilityAdapterService = Depends(get_mcp_hub_capability_adapter_service),
+) -> MCPHubDeleteResponse:
+    """Delete a capability adapter mapping."""
+    _require_mutation_permission(principal)
+    try:
+        await svc.delete_capability_adapter_mapping(capability_adapter_mapping_id)
+    except ResourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return MCPHubDeleteResponse(ok=True)
 
 
 @router.post("/governance-packs/dry-run", response_model=GovernancePackDryRunResponse)

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 ScopeType = Literal["global", "org", "team", "user"]
+CapabilityAdapterScopeType = Literal["global", "org", "team"]
 ProfileMode = Literal["preset", "custom"]
 AssignmentTargetType = Literal["default", "group", "persona"]
 PolicyProvenanceSourceKind = Literal[
@@ -392,6 +393,75 @@ class ApprovalDecisionResponse(BaseModel):
     consumed_at: datetime | str | None = None
     created_by: int | None = None
     created_at: datetime | str | None = None
+
+
+class CapabilityAdapterMappingCreateRequest(BaseModel):
+    mapping_id: str = Field(..., min_length=1, max_length=200)
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=512)
+    owner_scope_type: CapabilityAdapterScopeType = Field(default="global")
+    owner_scope_id: int | None = None
+    capability_name: str = Field(..., min_length=1, max_length=200)
+    adapter_contract_version: int = Field(default=1, ge=1)
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    is_active: bool = True
+
+
+class CapabilityAdapterMappingUpdateRequest(BaseModel):
+    mapping_id: str | None = Field(default=None, min_length=1, max_length=200)
+    title: str | None = Field(default=None, max_length=200)
+    description: str | None = Field(default=None, max_length=512)
+    owner_scope_type: CapabilityAdapterScopeType | None = None
+    owner_scope_id: int | None = None
+    capability_name: str | None = Field(default=None, min_length=1, max_length=200)
+    adapter_contract_version: int | None = Field(default=None, ge=1)
+    resolved_policy_document: dict[str, Any] | None = None
+    supported_environment_requirements: list[str] | None = None
+    is_active: bool | None = None
+
+
+class CapabilityAdapterMappingResponse(BaseModel):
+    id: int
+    mapping_id: str
+    title: str
+    description: str | None = None
+    owner_scope_type: CapabilityAdapterScopeType
+    owner_scope_id: int | None = None
+    capability_name: str
+    adapter_contract_version: int
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    is_active: bool
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | str | None = None
+    updated_at: datetime | str | None = None
+
+
+class CapabilityAdapterMappingNormalizedResponse(BaseModel):
+    mapping_id: str
+    title: str
+    description: str | None = None
+    owner_scope_type: CapabilityAdapterScopeType
+    owner_scope_id: int | None = None
+    capability_name: str
+    adapter_contract_version: int
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    is_active: bool
+
+
+class CapabilityAdapterMappingScopeSummaryResponse(BaseModel):
+    owner_scope_type: CapabilityAdapterScopeType
+    owner_scope_id: int | None = None
+    display_scope: str
+
+
+class CapabilityAdapterMappingPreviewResponse(BaseModel):
+    normalized_mapping: CapabilityAdapterMappingNormalizedResponse
+    warnings: list[str] = Field(default_factory=list)
+    affected_scope_summary: CapabilityAdapterMappingScopeSummaryResponse
 
 
 class EffectivePolicySourceResponse(BaseModel):

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -15,8 +15,10 @@ PolicyProvenanceSourceKind = Literal[
     "assignment_path_scope_object",
     "assignment_inline",
     "assignment_override",
+    "capability_mapping",
+    "runtime_constraint",
 ]
-PolicyProvenanceEffect = Literal["merged", "replaced"]
+PolicyProvenanceEffect = Literal["merged", "replaced", "narrowed", "blocked"]
 ApprovalMode = Literal[
     "allow_silently",
     "ask_every_time",
@@ -478,10 +480,25 @@ class EffectivePolicyProvenanceResponse(BaseModel):
     field: str
     value: Any
     source_kind: PolicyProvenanceSourceKind
-    assignment_id: int
+    assignment_id: int | None = None
     profile_id: int | None = None
     override_id: int | None = None
+    capability_name: str | None = None
+    mapping_id: str | None = None
+    mapping_scope_type: CapabilityAdapterScopeType | None = None
+    mapping_scope_id: int | None = None
+    resolved_effects: dict[str, Any] = Field(default_factory=dict)
     effect: PolicyProvenanceEffect
+
+
+class EffectivePolicyCapabilityMappingResponse(BaseModel):
+    capability_name: str
+    mapping_id: str | None = None
+    mapping_scope_type: CapabilityAdapterScopeType | None = None
+    mapping_scope_id: int | None = None
+    resolved_effects: dict[str, Any] = Field(default_factory=dict)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    unsupported_environment_requirements: list[str] = Field(default_factory=list)
 
 
 class EffectivePolicyResponse(BaseModel):
@@ -492,6 +509,14 @@ class EffectivePolicyResponse(BaseModel):
     approval_policy_id: int | None = None
     approval_mode: ApprovalMode | None = None
     policy_document: dict[str, Any] = Field(default_factory=dict)
+    authored_policy_document: dict[str, Any] = Field(default_factory=dict)
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    resolved_capabilities: list[str] = Field(default_factory=list)
+    unresolved_capabilities: list[str] = Field(default_factory=list)
+    capability_mapping_summary: list[EffectivePolicyCapabilityMappingResponse] = Field(default_factory=list)
+    capability_warnings: list[str] = Field(default_factory=list)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    unsupported_environment_requirements: list[str] = Field(default_factory=list)
     selected_assignment_id: int | None = None
     selected_workspace_source_mode: WorkspaceSourceMode | None = None
     selected_workspace_set_object_id: int | None = None

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -488,11 +488,13 @@ class EffectivePolicyProvenanceResponse(BaseModel):
     mapping_scope_type: CapabilityAdapterScopeType | None = None
     mapping_scope_id: int | None = None
     resolved_effects: dict[str, Any] = Field(default_factory=dict)
+    resolution_intent: Literal["allow", "deny"] | None = None
     effect: PolicyProvenanceEffect
 
 
 class EffectivePolicyCapabilityMappingResponse(BaseModel):
     capability_name: str
+    resolution_intent: Literal["allow", "deny"] | None = None
     mapping_id: str | None = None
     mapping_scope_type: CapabilityAdapterScopeType | None = None
     mapping_scope_id: int | None = None

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -769,6 +769,9 @@ class GovernancePackDryRunReportResponse(BaseModel):
     digest: str
     resolved_capabilities: list[str] = Field(default_factory=list)
     unresolved_capabilities: list[str] = Field(default_factory=list)
+    capability_mapping_summary: list[EffectivePolicyCapabilityMappingResponse] = Field(default_factory=list)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    unsupported_environment_requirements: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     blocked_objects: list[str] = Field(default_factory=list)
     verdict: Literal["importable", "blocked"]

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -2082,6 +2082,49 @@ def migration_069_add_mcp_governance_pack_schema(conn: sqlite3.Connection) -> No
     logger.info("Migration 069: Added MCP governance pack schema")
 
 
+def migration_070_add_mcp_capability_adapter_mappings(conn: sqlite3.Connection) -> None:
+    """Add scope-aware MCP capability adapter mapping storage."""
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_capability_adapter_mappings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mapping_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            owner_scope_type TEXT NOT NULL DEFAULT 'global',
+            owner_scope_id INTEGER,
+            capability_name TEXT NOT NULL,
+            adapter_contract_version INTEGER NOT NULL,
+            resolved_policy_document_json TEXT NOT NULL DEFAULT '{}',
+            supported_environment_requirements_json TEXT NOT NULL DEFAULT '[]',
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_by INTEGER,
+            updated_by INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_capability_adapter_mappings_scope "
+        "ON mcp_capability_adapter_mappings(owner_scope_type, owner_scope_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_capability_adapter_mappings_mapping_id "
+        "ON mcp_capability_adapter_mappings(mapping_id)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_capability_adapter_mappings_active_scope_capability "
+        "ON mcp_capability_adapter_mappings("
+        "owner_scope_type, IFNULL(owner_scope_id, -1), capability_name"
+        ") WHERE is_active = 1"
+    )
+
+    conn.commit()
+    logger.info("Migration 070: Added MCP capability adapter mapping schema")
+
+
 def rollback_053_drop_byok_oauth_state(conn: sqlite3.Connection) -> None:
     """Rollback migration 053 by dropping the byok_oauth_state table."""
     conn.execute("DROP TABLE IF EXISTS byok_oauth_state")
@@ -3914,6 +3957,11 @@ def get_authnz_migrations() -> list[Migration]:
             69,
             "Add MCP governance pack schema",
             migration_069_add_mcp_governance_pack_schema,
+        ),
+        Migration(
+            70,
+            "Add MCP capability adapter mapping schema",
+            migration_070_add_mcp_capability_adapter_mappings,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -462,6 +462,45 @@ _CREATE_MCP_HUB_TABLES = [
     ),
     (
         """
+        CREATE TABLE IF NOT EXISTS mcp_capability_adapter_mappings (
+            id SERIAL PRIMARY KEY,
+            mapping_id TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT NULL,
+            owner_scope_type TEXT NOT NULL DEFAULT 'global',
+            owner_scope_id INTEGER NULL,
+            capability_name TEXT NOT NULL,
+            adapter_contract_version INTEGER NOT NULL,
+            resolved_policy_document_json TEXT NOT NULL DEFAULT '{}',
+            supported_environment_requirements_json TEXT NOT NULL DEFAULT '[]',
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_capability_adapter_mappings_scope "
+        "ON mcp_capability_adapter_mappings(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_capability_adapter_mappings_mapping_id "
+        "ON mcp_capability_adapter_mappings(mapping_id)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_capability_adapter_mappings_active_scope_capability "
+        "ON mcp_capability_adapter_mappings("
+        "owner_scope_type, COALESCE(owner_scope_id, -1), capability_name"
+        ") WHERE is_active",
+        (),
+    ),
+    (
+        """
         CREATE TABLE IF NOT EXISTS mcp_governance_packs (
             id SERIAL PRIMARY KEY,
             pack_id TEXT NOT NULL,

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -10,6 +10,7 @@ from loguru import logger
 from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
 
 _VALID_SCOPE_TYPES = {"global", "org", "team", "user"}
+_VALID_CAPABILITY_ADAPTER_SCOPE_TYPES = {"global", "org", "team"}
 _VALID_TARGET_TYPES = {"default", "group", "persona"}
 _VALID_PROFILE_MODES = {"preset", "custom"}
 _VALID_APPROVAL_MODES = {
@@ -34,6 +35,13 @@ def _normalize_scope_type(scope_type: str | None) -> str:
     if value in _VALID_SCOPE_TYPES:
         return value
     raise ValueError(f"Invalid owner_scope_type: {scope_type}")
+
+
+def _normalize_capability_adapter_scope_type(scope_type: str | None) -> str:
+    value = _normalize_scope_type(scope_type)
+    if value not in _VALID_CAPABILITY_ADAPTER_SCOPE_TYPES:
+        raise ValueError(f"Invalid capability adapter owner_scope_type: {scope_type}")
+    return value
 
 
 def _to_bool(value: Any) -> bool:
@@ -112,6 +120,36 @@ def _load_json_dict(raw: Any) -> dict[str, Any]:
     return {}
 
 
+def _load_json_list(raw: Any) -> list[Any]:
+    if isinstance(raw, list):
+        return list(raw)
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
+        return list(parsed) if isinstance(parsed, list) else []
+    return []
+
+
+def _normalize_string_list(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if not isinstance(values, (list, tuple, set)):
+        raise ValueError("supported_environment_requirements must be a list")
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        normalized.append(text)
+        seen.add(text)
+    return normalized
+
+
 @dataclass
 class McpHubRepo:
     """Data access for MCP Hub ACP profiles and external server configuration."""
@@ -135,6 +173,7 @@ class McpHubRepo:
                 "mcp_acp_profiles",
                 "mcp_approval_decisions",
                 "mcp_approval_policies",
+                "mcp_capability_adapter_mappings",
                 "mcp_credential_bindings",
                 "mcp_external_servers",
                 "mcp_external_server_credential_slots",
@@ -316,6 +355,26 @@ class McpHubRepo:
         out["is_active"] = _to_bool(out.get("is_active"))
         out["is_immutable"] = _to_bool(out.get("is_immutable"))
         out["rules"] = _load_json_dict(out.pop("rules_json", None))
+        return out
+
+    @staticmethod
+    def _normalize_capability_adapter_mapping_row(
+        row: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["is_active"] = _to_bool(out.get("is_active"))
+        out["owner_scope_type"] = _normalize_capability_adapter_scope_type(out.get("owner_scope_type"))
+        out["mapping_id"] = str(out.get("mapping_id") or "").strip()
+        out["title"] = str(out.get("title") or out["mapping_id"]).strip()
+        out["capability_name"] = str(out.get("capability_name") or "").strip()
+        out["resolved_policy_document"] = _load_json_dict(
+            out.pop("resolved_policy_document_json", None)
+        )
+        out["supported_environment_requirements"] = _normalize_string_list(
+            _load_json_list(out.pop("supported_environment_requirements_json", None))
+        )
         return out
 
     @staticmethod
@@ -603,6 +662,323 @@ class McpHubRepo:
             self._normalize_governance_pack_object_row(self._row_to_dict(row)) or {}
             for row in rows
         ]
+
+    async def create_capability_adapter_mapping(
+        self,
+        *,
+        mapping_id: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+        adapter_contract_version: int,
+        resolved_policy_document: dict[str, Any],
+        supported_environment_requirements: list[str],
+        actor_id: int | None,
+        title: str | None = None,
+        description: str | None = None,
+        is_active: bool = True,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_capability_adapter_scope_type(owner_scope_type)
+        normalized_scope_id = None if scope_type == "global" else (
+            int(owner_scope_id) if owner_scope_id is not None else None
+        )
+        if scope_type != "global" and normalized_scope_id is None:
+            raise ValueError("owner_scope_id is required for org and team capability mappings")
+        normalized_mapping_id = str(mapping_id or "").strip()
+        if not normalized_mapping_id:
+            raise ValueError("mapping_id is required")
+        normalized_title = str(title or normalized_mapping_id).strip()
+        normalized_capability_name = str(capability_name or "").strip()
+        if not normalized_capability_name:
+            raise ValueError("capability_name is required")
+        normalized_requirements = _normalize_string_list(supported_environment_requirements)
+        normalized_is_active = _to_bool(is_active)
+        if normalized_is_active:
+            existing = await self.find_active_capability_mapping(
+                owner_scope_type=scope_type,
+                owner_scope_id=normalized_scope_id,
+                capability_name=normalized_capability_name,
+            )
+            if existing is not None:
+                raise ValueError("active capability adapter mapping already exists for scope/capability")
+
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        active_value: bool | int = (
+            normalized_is_active if getattr(self.db_pool, "pool", None) is not None else int(normalized_is_active)
+        )
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_capability_adapter_mappings (
+                mapping_id, title, description, owner_scope_type, owner_scope_id,
+                capability_name, adapter_contract_version, resolved_policy_document_json,
+                supported_environment_requirements_json, is_active, created_by, updated_by,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                normalized_mapping_id,
+                normalized_title,
+                description,
+                scope_type,
+                normalized_scope_id,
+                normalized_capability_name,
+                int(adapter_contract_version),
+                json.dumps(dict(resolved_policy_document or {})),
+                json.dumps(normalized_requirements),
+                active_value,
+                actor_id,
+                actor_id,
+                ts,
+                ts,
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM mcp_capability_adapter_mappings
+            WHERE mapping_id = ?
+            """,
+            (normalized_mapping_id,),
+        )
+        if not row:
+            return {}
+        created = await self.get_capability_adapter_mapping(int(row["id"]))
+        return created or {}
+
+    async def get_capability_adapter_mapping(
+        self,
+        capability_adapter_mapping_id: int,
+    ) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, mapping_id, title, description, owner_scope_type, owner_scope_id,
+                   capability_name, adapter_contract_version, resolved_policy_document_json,
+                   supported_environment_requirements_json, is_active, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_capability_adapter_mappings
+            WHERE id = ?
+            """,
+            (int(capability_adapter_mapping_id),),
+        )
+        return self._normalize_capability_adapter_mapping_row(self._row_to_dict(row) if row else None)
+
+    async def list_capability_adapter_mappings(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        capability_name: str | None = None,
+    ) -> list[dict[str, Any]]:
+        normalized_scope_type = (
+            _normalize_capability_adapter_scope_type(owner_scope_type)
+            if owner_scope_type is not None
+            else None
+        )
+        normalized_scope_id = int(owner_scope_id) if owner_scope_id is not None else None
+        normalized_capability_name = (
+            str(capability_name or "").strip() if capability_name is not None else None
+        )
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, mapping_id, title, description, owner_scope_type, owner_scope_id,
+                   capability_name, adapter_contract_version, resolved_policy_document_json,
+                   supported_environment_requirements_json, is_active, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_capability_adapter_mappings
+            WHERE (? IS NULL OR owner_scope_type = ?)
+              AND (? IS NULL OR owner_scope_id = ?)
+              AND (? IS NULL OR capability_name = ?)
+            ORDER BY capability_name, mapping_id, id
+            """,
+            (
+                normalized_scope_type,
+                normalized_scope_type,
+                normalized_scope_id,
+                normalized_scope_id,
+                normalized_capability_name,
+                normalized_capability_name,
+            ),
+        )
+        return [
+            self._normalize_capability_adapter_mapping_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
+
+    async def update_capability_adapter_mapping(
+        self,
+        capability_adapter_mapping_id: int,
+        *,
+        mapping_id: str | object = _UNSET,
+        title: str | None | object = _UNSET,
+        description: str | None | object = _UNSET,
+        owner_scope_type: str | object = _UNSET,
+        owner_scope_id: int | None | object = _UNSET,
+        capability_name: str | object = _UNSET,
+        adapter_contract_version: int | object = _UNSET,
+        resolved_policy_document: dict[str, Any] | None | object = _UNSET,
+        supported_environment_requirements: list[str] | None | object = _UNSET,
+        is_active: bool | object = _UNSET,
+        actor_id: int | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_capability_adapter_mapping(capability_adapter_mapping_id)
+        if not existing:
+            return None
+
+        next_scope = (
+            _normalize_capability_adapter_scope_type(owner_scope_type)
+            if owner_scope_type is not _UNSET
+            else str(existing["owner_scope_type"])
+        )
+        if owner_scope_id is _UNSET:
+            next_scope_id = existing.get("owner_scope_id")
+        elif next_scope == "global":
+            next_scope_id = None
+        elif owner_scope_id is None:
+            raise ValueError("owner_scope_id is required for org and team capability mappings")
+        else:
+            next_scope_id = int(owner_scope_id)
+        next_mapping_id = (
+            str(existing["mapping_id"])
+            if mapping_id is _UNSET
+            else str(mapping_id or "").strip()
+        )
+        if not next_mapping_id:
+            raise ValueError("mapping_id is required")
+        next_title = (
+            str(existing.get("title") or existing["mapping_id"]).strip()
+            if title is _UNSET
+            else str(title or next_mapping_id).strip()
+        )
+        next_description = existing.get("description") if description is _UNSET else description
+        next_capability_name = (
+            str(existing["capability_name"])
+            if capability_name is _UNSET
+            else str(capability_name or "").strip()
+        )
+        if not next_capability_name:
+            raise ValueError("capability_name is required")
+        next_adapter_contract_version = (
+            int(existing["adapter_contract_version"])
+            if adapter_contract_version is _UNSET
+            else int(adapter_contract_version)
+        )
+        next_resolved_policy_document = (
+            dict(existing.get("resolved_policy_document") or {})
+            if resolved_policy_document is _UNSET
+            else dict(resolved_policy_document or {})
+        )
+        next_supported_environment_requirements = (
+            list(existing.get("supported_environment_requirements") or [])
+            if supported_environment_requirements is _UNSET
+            else _normalize_string_list(supported_environment_requirements)
+        )
+        next_is_active = (
+            _to_bool(existing.get("is_active"))
+            if is_active is _UNSET
+            else _to_bool(is_active)
+        )
+        if next_scope == "global":
+            next_scope_id = None
+        elif next_scope_id is None:
+            raise ValueError("owner_scope_id is required for org and team capability mappings")
+        if next_is_active:
+            current_active = await self.find_active_capability_mapping(
+                owner_scope_type=next_scope,
+                owner_scope_id=next_scope_id,
+                capability_name=next_capability_name,
+            )
+            if current_active is not None and int(current_active["id"]) != int(capability_adapter_mapping_id):
+                raise ValueError("active capability adapter mapping already exists for scope/capability")
+
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        active_value: bool | int = next_is_active if getattr(self.db_pool, "pool", None) is not None else int(next_is_active)
+        await self.db_pool.execute(
+            """
+            UPDATE mcp_capability_adapter_mappings
+            SET mapping_id = ?,
+                title = ?,
+                description = ?,
+                owner_scope_type = ?,
+                owner_scope_id = ?,
+                capability_name = ?,
+                adapter_contract_version = ?,
+                resolved_policy_document_json = ?,
+                supported_environment_requirements_json = ?,
+                is_active = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                next_mapping_id,
+                next_title,
+                next_description,
+                next_scope,
+                next_scope_id,
+                next_capability_name,
+                next_adapter_contract_version,
+                json.dumps(next_resolved_policy_document),
+                json.dumps(next_supported_environment_requirements),
+                active_value,
+                actor_id,
+                ts,
+                int(capability_adapter_mapping_id),
+            ),
+        )
+        return await self.get_capability_adapter_mapping(capability_adapter_mapping_id)
+
+    async def delete_capability_adapter_mapping(self, capability_adapter_mapping_id: int) -> bool:
+        cursor = await self.db_pool.execute(
+            "DELETE FROM mcp_capability_adapter_mappings WHERE id = ?",
+            (int(capability_adapter_mapping_id),),
+        )
+        rowcount = getattr(cursor, "rowcount", 0)
+        return bool(rowcount and rowcount > 0)
+
+    async def find_active_capability_mapping(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+    ) -> dict[str, Any] | None:
+        scope_type = _normalize_capability_adapter_scope_type(owner_scope_type)
+        normalized_scope_id = None if scope_type == "global" else (
+            int(owner_scope_id) if owner_scope_id is not None else None
+        )
+        if scope_type != "global" and normalized_scope_id is None:
+            raise ValueError("owner_scope_id is required for org and team capability mappings")
+        normalized_capability_name = str(capability_name or "").strip()
+        if not normalized_capability_name:
+            raise ValueError("capability_name is required")
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, mapping_id, title, description, owner_scope_type, owner_scope_id,
+                   capability_name, adapter_contract_version, resolved_policy_document_json,
+                   supported_environment_requirements_json, is_active, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_capability_adapter_mappings
+            WHERE owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+              AND capability_name = ?
+              AND is_active = ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (
+                scope_type,
+                normalized_scope_id,
+                normalized_scope_id,
+                normalized_capability_name,
+                True if getattr(self.db_pool, "pool", None) is not None else 1,
+            ),
+        )
+        return self._normalize_capability_adapter_mapping_row(self._row_to_dict(row) if row else None)
 
     async def create_acp_profile(
         self,

--- a/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
@@ -102,7 +102,13 @@ class McpHubCapabilityAdapterService:
             raise BadRequestError("capability_name is required")
         normalized_title = str(title or normalized_mapping_id).strip()
         normalized_policy_document = self._normalize_policy_document(resolved_policy_document)
-        await self._validate_policy_document_against_registry(normalized_policy_document)
+        module_to_tool_names = await self._validate_policy_document_against_registry(
+            normalized_policy_document
+        )
+        normalized_policy_document = self._expand_module_policy_effects(
+            normalized_policy_document,
+            module_to_tool_names=module_to_tool_names,
+        )
         normalized_requirements, warnings = self._normalize_environment_requirements(
             supported_environment_requirements
         )
@@ -350,7 +356,7 @@ class McpHubCapabilityAdapterService:
     async def _validate_policy_document_against_registry(
         self,
         policy_document: dict[str, Any],
-    ) -> None:
+    ) -> dict[str, list[str]]:
         entries = await self.tool_registry.list_entries()
         known_tool_names = {
             str(entry.get("tool_name") or "").strip()
@@ -362,6 +368,13 @@ class McpHubCapabilityAdapterService:
             for entry in entries
             if str(entry.get("module") or "").strip()
         }
+        module_to_tool_names: dict[str, list[str]] = {}
+        for entry in entries:
+            module_id = str(entry.get("module") or "").strip()
+            tool_name = str(entry.get("tool_name") or "").strip()
+            if not module_id or not tool_name:
+                continue
+            module_to_tool_names.setdefault(module_id, []).append(tool_name)
         for module_row in await self.tool_registry.list_modules():
             module_id = str(module_row.get("module") or "").strip()
             if module_id:
@@ -381,3 +394,25 @@ class McpHubCapabilityAdapterService:
             for tool_ref in _as_str_list(policy_document.get(key)):
                 if _looks_like_exact_tool_reference(tool_ref) and tool_ref not in known_tool_names:
                     raise BadRequestError(f"unknown tool '{tool_ref}'")
+        return {
+            module_id: _unique(tool_names)
+            for module_id, tool_names in module_to_tool_names.items()
+        }
+
+    @staticmethod
+    def _expand_module_policy_effects(
+        policy_document: dict[str, Any],
+        *,
+        module_to_tool_names: dict[str, list[str]],
+    ) -> dict[str, Any]:
+        expanded = deepcopy(policy_document)
+        module_ids = _unique(
+            _as_str_list(expanded.get("tool_modules")) + _as_str_list(expanded.get("module_ids"))
+        )
+        if not module_ids:
+            return expanded
+        expanded_tool_names = _as_str_list(expanded.get("tool_names"))
+        for module_id in module_ids:
+            expanded_tool_names.extend(module_to_tool_names.get(module_id, []))
+        expanded["tool_names"] = _unique(expanded_tool_names)
+        return expanded

--- a/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
@@ -73,6 +73,21 @@ def _coalesce_update_value(value: Any, existing_value: Any) -> Any:
     return existing_value if value is _UNSET else value
 
 
+def _resolve_update_scope(
+    *,
+    owner_scope_type: str | None | object,
+    owner_scope_id: int | None | object,
+    existing_scope_type: str,
+    existing_scope_id: int | None,
+) -> tuple[str | None | object, int | None | object]:
+    """Mirror repo update semantics for scope-type/id transitions."""
+    next_scope_type = _coalesce_update_value(owner_scope_type, existing_scope_type)
+    next_scope_id = _coalesce_update_value(owner_scope_id, existing_scope_id)
+    if str(next_scope_type or "").strip().lower() == "global":
+        return next_scope_type, None
+    return next_scope_type, next_scope_id
+
+
 class McpHubCapabilityAdapterService:
     """Validate, preview, and persist scope-aware capability adapter mappings."""
 
@@ -176,13 +191,11 @@ class McpHubCapabilityAdapterService:
             description,
             existing.get("description"),
         )
-        next_owner_scope_type = _coalesce_update_value(
-            owner_scope_type,
-            str(existing["owner_scope_type"]),
-        )
-        next_owner_scope_id = _coalesce_update_value(
-            owner_scope_id,
-            existing.get("owner_scope_id"),
+        next_owner_scope_type, next_owner_scope_id = _resolve_update_scope(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            existing_scope_type=str(existing["owner_scope_type"]),
+            existing_scope_id=existing.get("owner_scope_id"),
         )
         next_capability_name = _coalesce_update_value(
             capability_name,
@@ -196,6 +209,8 @@ class McpHubCapabilityAdapterService:
             resolved_policy_document,
             dict(existing.get("resolved_policy_document") or {}),
         )
+        if next_resolved_policy_document is None:
+            next_resolved_policy_document = {}
         next_supported_environment_requirements = _coalesce_update_value(
             supported_environment_requirements,
             list(existing.get("supported_environment_requirements") or []),
@@ -278,17 +293,17 @@ class McpHubCapabilityAdapterService:
         self,
         capability_adapter_mapping_id: int,
         *,
-        mapping_id: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
-        owner_scope_type: str | None = None,
-        owner_scope_id: int | None = None,
-        capability_name: str | None = None,
-        adapter_contract_version: int | None = None,
-        resolved_policy_document: dict[str, Any] | None = None,
-        supported_environment_requirements: list[str] | None = None,
+        mapping_id: str | None | object = _UNSET,
+        title: str | None | object = _UNSET,
+        description: str | None | object = _UNSET,
+        owner_scope_type: str | None | object = _UNSET,
+        owner_scope_id: int | None | object = _UNSET,
+        capability_name: str | None | object = _UNSET,
+        adapter_contract_version: int | None | object = _UNSET,
+        resolved_policy_document: dict[str, Any] | None | object = _UNSET,
+        supported_environment_requirements: list[str] | None | object = _UNSET,
         actor_id: int | None,
-        is_active: bool | None = None,
+        is_active: bool | None | object = _UNSET,
     ) -> dict[str, Any]:
         preview = await self.preview_update(
             capability_adapter_mapping_id,

--- a/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
@@ -1,3 +1,5 @@
+"""Validate and persist scope-aware capability adapter mappings."""
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -10,6 +12,7 @@ from tldw_Server_API.app.services.mcp_hub_tool_registry import McpHubToolRegistr
 
 _SUPPORTED_SCOPE_TYPES = frozenset({"global", "org", "team"})
 _SUPPORTED_ADAPTER_CONTRACT_VERSION = 1
+_UNSET = object()
 _SUPPORTED_ENVIRONMENT_REQUIREMENTS = frozenset(
     {
         "local_mapping_required",
@@ -58,10 +61,16 @@ def _unique(items: list[str]) -> list[str]:
 
 
 def _looks_like_exact_tool_reference(value: str) -> bool:
+    """Return True when the value is a concrete tool reference, not a wildcard."""
     candidate = str(value or "").strip()
     if not candidate:
         return False
     return bool(_EXACT_TOOL_REF_RE.fullmatch(candidate))
+
+
+def _coalesce_update_value(value: Any, existing_value: Any) -> Any:
+    """Preserve the stored value for omitted fields while allowing explicit nulls."""
+    return existing_value if value is _UNSET else value
 
 
 class McpHubCapabilityAdapterService:
@@ -140,16 +149,16 @@ class McpHubCapabilityAdapterService:
         self,
         capability_adapter_mapping_id: int,
         *,
-        mapping_id: str | None = None,
-        title: str | None = None,
-        description: str | None = None,
-        owner_scope_type: str | None = None,
-        owner_scope_id: int | None = None,
-        capability_name: str | None = None,
-        adapter_contract_version: int | None = None,
-        resolved_policy_document: dict[str, Any] | None = None,
-        supported_environment_requirements: list[str] | None = None,
-        is_active: bool | None = None,
+        mapping_id: str | None | object = _UNSET,
+        title: str | None | object = _UNSET,
+        description: str | None | object = _UNSET,
+        owner_scope_type: str | None | object = _UNSET,
+        owner_scope_id: int | None | object = _UNSET,
+        capability_name: str | None | object = _UNSET,
+        adapter_contract_version: int | None | object = _UNSET,
+        resolved_policy_document: dict[str, Any] | None | object = _UNSET,
+        supported_environment_requirements: list[str] | None | object = _UNSET,
+        is_active: bool | None | object = _UNSET,
     ) -> dict[str, Any]:
         existing = await self.repo.get_capability_adapter_mapping(capability_adapter_mapping_id)
         if existing is None:
@@ -157,29 +166,56 @@ class McpHubCapabilityAdapterService:
                 "mcp_capability_adapter_mapping",
                 identifier=str(capability_adapter_mapping_id),
             )
+
+        next_mapping_id = _coalesce_update_value(mapping_id, str(existing["mapping_id"]))
+        next_title = _coalesce_update_value(
+            title,
+            str(existing.get("title") or existing["mapping_id"]),
+        )
+        next_description = _coalesce_update_value(
+            description,
+            existing.get("description"),
+        )
+        next_owner_scope_type = _coalesce_update_value(
+            owner_scope_type,
+            str(existing["owner_scope_type"]),
+        )
+        next_owner_scope_id = _coalesce_update_value(
+            owner_scope_id,
+            existing.get("owner_scope_id"),
+        )
+        next_capability_name = _coalesce_update_value(
+            capability_name,
+            str(existing["capability_name"]),
+        )
+        next_adapter_contract_version = _coalesce_update_value(
+            adapter_contract_version,
+            int(existing["adapter_contract_version"]),
+        )
+        next_resolved_policy_document = _coalesce_update_value(
+            resolved_policy_document,
+            dict(existing.get("resolved_policy_document") or {}),
+        )
+        next_supported_environment_requirements = _coalesce_update_value(
+            supported_environment_requirements,
+            list(existing.get("supported_environment_requirements") or []),
+        )
+        next_is_active = _coalesce_update_value(
+            is_active,
+            bool(existing.get("is_active")),
+        )
+
         return await self.preview_mapping(
-            mapping_id=mapping_id if mapping_id is not None else str(existing["mapping_id"]),
-            owner_scope_type=owner_scope_type if owner_scope_type is not None else str(existing["owner_scope_type"]),
-            owner_scope_id=owner_scope_id if owner_scope_type is not None or owner_scope_id is not None else existing.get("owner_scope_id"),
-            capability_name=capability_name if capability_name is not None else str(existing["capability_name"]),
-            adapter_contract_version=(
-                adapter_contract_version
-                if adapter_contract_version is not None
-                else int(existing["adapter_contract_version"])
-            ),
-            resolved_policy_document=(
-                resolved_policy_document
-                if resolved_policy_document is not None
-                else dict(existing.get("resolved_policy_document") or {})
-            ),
-            supported_environment_requirements=(
-                supported_environment_requirements
-                if supported_environment_requirements is not None
-                else list(existing.get("supported_environment_requirements") or [])
-            ),
-            title=title if title is not None else str(existing.get("title") or existing["mapping_id"]),
-            description=description if description is not None else existing.get("description"),
-            is_active=bool(existing.get("is_active")) if is_active is None else bool(is_active),
+            mapping_id=next_mapping_id,
+            title=next_title,
+            description=next_description,
+            owner_scope_type=next_owner_scope_type,
+            owner_scope_id=next_owner_scope_id,
+            capability_name=next_capability_name,
+            adapter_contract_version=next_adapter_contract_version,
+            resolved_policy_document=next_resolved_policy_document,
+            supported_environment_requirements=next_supported_environment_requirements,
+            is_active=bool(next_is_active),
         )
 
     async def create_mapping(

--- a/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_adapter_service.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.exceptions import BadRequestError, ResourceNotFoundError
+from tldw_Server_API.app.services.mcp_hub_tool_registry import McpHubToolRegistryService
+
+_SUPPORTED_SCOPE_TYPES = frozenset({"global", "org", "team"})
+_SUPPORTED_ADAPTER_CONTRACT_VERSION = 1
+_SUPPORTED_ENVIRONMENT_REQUIREMENTS = frozenset(
+    {
+        "local_mapping_required",
+        "no_external_secrets",
+        "workspace_bounded_read",
+        "workspace_bounded_write",
+    }
+)
+_LIST_POLICY_KEYS = frozenset(
+    {
+        "allowed_tools",
+        "denied_tools",
+        "tool_names",
+        "tool_patterns",
+        "capabilities",
+        "tool_modules",
+        "module_ids",
+    }
+)
+_EXACT_TOOL_REF_RE = re.compile(r"^[A-Za-z0-9_.:-]+$")
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _looks_like_exact_tool_reference(value: str) -> bool:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return False
+    return bool(_EXACT_TOOL_REF_RE.fullmatch(candidate))
+
+
+class McpHubCapabilityAdapterService:
+    """Validate, preview, and persist scope-aware capability adapter mappings."""
+
+    def __init__(
+        self,
+        *,
+        repo: McpHubRepo,
+        tool_registry: McpHubToolRegistryService,
+    ) -> None:
+        self.repo = repo
+        self.tool_registry = tool_registry
+
+    async def preview_mapping(
+        self,
+        *,
+        mapping_id: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+        adapter_contract_version: int,
+        resolved_policy_document: dict[str, Any],
+        supported_environment_requirements: list[str],
+        title: str | None = None,
+        description: str | None = None,
+        is_active: bool = True,
+    ) -> dict[str, Any]:
+        normalized_scope_type, normalized_scope_id, display_scope = self._normalize_scope(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+        normalized_mapping_id = str(mapping_id or "").strip()
+        if not normalized_mapping_id:
+            raise BadRequestError("mapping_id is required")
+        normalized_capability_name = str(capability_name or "").strip()
+        if not normalized_capability_name:
+            raise BadRequestError("capability_name is required")
+        normalized_title = str(title or normalized_mapping_id).strip()
+        normalized_policy_document = self._normalize_policy_document(resolved_policy_document)
+        await self._validate_policy_document_against_registry(normalized_policy_document)
+        normalized_requirements, warnings = self._normalize_environment_requirements(
+            supported_environment_requirements
+        )
+        normalized_mapping = {
+            "mapping_id": normalized_mapping_id,
+            "title": normalized_title,
+            "description": description,
+            "owner_scope_type": normalized_scope_type,
+            "owner_scope_id": normalized_scope_id,
+            "capability_name": normalized_capability_name,
+            "adapter_contract_version": self._normalize_adapter_contract_version(
+                adapter_contract_version
+            ),
+            "resolved_policy_document": normalized_policy_document,
+            "supported_environment_requirements": normalized_requirements,
+            "is_active": bool(is_active),
+        }
+        return {
+            "normalized_mapping": normalized_mapping,
+            "warnings": warnings,
+            "affected_scope_summary": {
+                "owner_scope_type": normalized_scope_type,
+                "owner_scope_id": normalized_scope_id,
+                "display_scope": display_scope,
+            },
+        }
+
+    async def preview_update(
+        self,
+        capability_adapter_mapping_id: int,
+        *,
+        mapping_id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        capability_name: str | None = None,
+        adapter_contract_version: int | None = None,
+        resolved_policy_document: dict[str, Any] | None = None,
+        supported_environment_requirements: list[str] | None = None,
+        is_active: bool | None = None,
+    ) -> dict[str, Any]:
+        existing = await self.repo.get_capability_adapter_mapping(capability_adapter_mapping_id)
+        if existing is None:
+            raise ResourceNotFoundError(
+                "mcp_capability_adapter_mapping",
+                identifier=str(capability_adapter_mapping_id),
+            )
+        return await self.preview_mapping(
+            mapping_id=mapping_id if mapping_id is not None else str(existing["mapping_id"]),
+            owner_scope_type=owner_scope_type if owner_scope_type is not None else str(existing["owner_scope_type"]),
+            owner_scope_id=owner_scope_id if owner_scope_type is not None or owner_scope_id is not None else existing.get("owner_scope_id"),
+            capability_name=capability_name if capability_name is not None else str(existing["capability_name"]),
+            adapter_contract_version=(
+                adapter_contract_version
+                if adapter_contract_version is not None
+                else int(existing["adapter_contract_version"])
+            ),
+            resolved_policy_document=(
+                resolved_policy_document
+                if resolved_policy_document is not None
+                else dict(existing.get("resolved_policy_document") or {})
+            ),
+            supported_environment_requirements=(
+                supported_environment_requirements
+                if supported_environment_requirements is not None
+                else list(existing.get("supported_environment_requirements") or [])
+            ),
+            title=title if title is not None else str(existing.get("title") or existing["mapping_id"]),
+            description=description if description is not None else existing.get("description"),
+            is_active=bool(existing.get("is_active")) if is_active is None else bool(is_active),
+        )
+
+    async def create_mapping(
+        self,
+        *,
+        mapping_id: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+        adapter_contract_version: int,
+        resolved_policy_document: dict[str, Any],
+        supported_environment_requirements: list[str],
+        actor_id: int | None,
+        title: str | None = None,
+        description: str | None = None,
+        is_active: bool = True,
+    ) -> dict[str, Any]:
+        preview = await self.preview_mapping(
+            mapping_id=mapping_id,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            capability_name=capability_name,
+            adapter_contract_version=adapter_contract_version,
+            resolved_policy_document=resolved_policy_document,
+            supported_environment_requirements=supported_environment_requirements,
+            title=title,
+            description=description,
+            is_active=is_active,
+        )
+        normalized = dict(preview["normalized_mapping"])
+        try:
+            return await self.repo.create_capability_adapter_mapping(
+                mapping_id=normalized["mapping_id"],
+                owner_scope_type=normalized["owner_scope_type"],
+                owner_scope_id=normalized["owner_scope_id"],
+                capability_name=normalized["capability_name"],
+                adapter_contract_version=normalized["adapter_contract_version"],
+                resolved_policy_document=normalized["resolved_policy_document"],
+                supported_environment_requirements=normalized["supported_environment_requirements"],
+                actor_id=actor_id,
+                title=normalized["title"],
+                description=normalized.get("description"),
+                is_active=normalized["is_active"],
+            )
+        except ValueError as exc:
+            raise BadRequestError(str(exc)) from exc
+
+    async def list_capability_adapter_mappings(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return await self.repo.list_capability_adapter_mappings(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def update_mapping(
+        self,
+        capability_adapter_mapping_id: int,
+        *,
+        mapping_id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        capability_name: str | None = None,
+        adapter_contract_version: int | None = None,
+        resolved_policy_document: dict[str, Any] | None = None,
+        supported_environment_requirements: list[str] | None = None,
+        actor_id: int | None,
+        is_active: bool | None = None,
+    ) -> dict[str, Any]:
+        preview = await self.preview_update(
+            capability_adapter_mapping_id,
+            mapping_id=mapping_id,
+            title=title,
+            description=description,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            capability_name=capability_name,
+            adapter_contract_version=adapter_contract_version,
+            resolved_policy_document=resolved_policy_document,
+            supported_environment_requirements=supported_environment_requirements,
+            is_active=is_active,
+        )
+        normalized = dict(preview["normalized_mapping"])
+        try:
+            updated = await self.repo.update_capability_adapter_mapping(
+                capability_adapter_mapping_id,
+                mapping_id=normalized["mapping_id"],
+                title=normalized["title"],
+                description=normalized.get("description"),
+                owner_scope_type=normalized["owner_scope_type"],
+                owner_scope_id=normalized["owner_scope_id"],
+                capability_name=normalized["capability_name"],
+                adapter_contract_version=normalized["adapter_contract_version"],
+                resolved_policy_document=normalized["resolved_policy_document"],
+                supported_environment_requirements=normalized["supported_environment_requirements"],
+                is_active=normalized["is_active"],
+                actor_id=actor_id,
+            )
+        except ValueError as exc:
+            raise BadRequestError(str(exc)) from exc
+        if updated is None:
+            raise ResourceNotFoundError(
+                "mcp_capability_adapter_mapping",
+                identifier=str(capability_adapter_mapping_id),
+            )
+        return updated
+
+    async def delete_capability_adapter_mapping(self, capability_adapter_mapping_id: int) -> bool:
+        deleted = await self.repo.delete_capability_adapter_mapping(capability_adapter_mapping_id)
+        if not deleted:
+            raise ResourceNotFoundError(
+                "mcp_capability_adapter_mapping",
+                identifier=str(capability_adapter_mapping_id),
+            )
+        return True
+
+    @staticmethod
+    def _normalize_scope(
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> tuple[str, int | None, str]:
+        normalized_scope_type = str(owner_scope_type or "").strip().lower()
+        if normalized_scope_type not in _SUPPORTED_SCOPE_TYPES:
+            raise BadRequestError("owner_scope_type must be one of: global, org, team")
+        if normalized_scope_type == "global":
+            if owner_scope_id is not None:
+                raise BadRequestError("global scope cannot include owner_scope_id")
+            return "global", None, "global"
+        if owner_scope_id is None:
+            raise BadRequestError(f"{normalized_scope_type} scope requires owner_scope_id")
+        normalized_scope_id = int(owner_scope_id)
+        return normalized_scope_type, normalized_scope_id, f"{normalized_scope_type}:{normalized_scope_id}"
+
+    @staticmethod
+    def _normalize_adapter_contract_version(value: int) -> int:
+        normalized = int(value)
+        if normalized != _SUPPORTED_ADAPTER_CONTRACT_VERSION:
+            raise BadRequestError(
+                f"adapter_contract_version must be {_SUPPORTED_ADAPTER_CONTRACT_VERSION}"
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_policy_document(policy_document: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(policy_document, dict):
+            raise BadRequestError("resolved_policy_document must be an object")
+        normalized = deepcopy(dict(policy_document))
+        for key in _LIST_POLICY_KEYS:
+            if key not in normalized:
+                continue
+            normalized[key] = _unique(_as_str_list(normalized.get(key)))
+        return normalized
+
+    @staticmethod
+    def _normalize_environment_requirements(values: list[str]) -> tuple[list[str], list[str]]:
+        normalized = _unique(_as_str_list(values))
+        supported: list[str] = []
+        warnings: list[str] = []
+        for requirement in normalized:
+            if requirement in _SUPPORTED_ENVIRONMENT_REQUIREMENTS:
+                supported.append(requirement)
+            else:
+                warnings.append(
+                    f"unsupported environment requirement '{requirement}' will be ignored"
+                )
+        return supported, warnings
+
+    async def _validate_policy_document_against_registry(
+        self,
+        policy_document: dict[str, Any],
+    ) -> None:
+        entries = await self.tool_registry.list_entries()
+        known_tool_names = {
+            str(entry.get("tool_name") or "").strip()
+            for entry in entries
+            if str(entry.get("tool_name") or "").strip()
+        }
+        known_module_ids = {
+            str(entry.get("module") or "").strip()
+            for entry in entries
+            if str(entry.get("module") or "").strip()
+        }
+        for module_row in await self.tool_registry.list_modules():
+            module_id = str(module_row.get("module") or "").strip()
+            if module_id:
+                known_module_ids.add(module_id)
+
+        for key in ("tool_names",):
+            for tool_name in _as_str_list(policy_document.get(key)):
+                if tool_name not in known_tool_names:
+                    raise BadRequestError(f"unknown tool '{tool_name}'")
+
+        for key in ("tool_modules", "module_ids"):
+            for module_id in _as_str_list(policy_document.get(key)):
+                if module_id not in known_module_ids:
+                    raise BadRequestError(f"unknown module '{module_id}'")
+
+        for key in ("allowed_tools", "denied_tools"):
+            for tool_ref in _as_str_list(policy_document.get(key)):
+                if _looks_like_exact_tool_reference(tool_ref) and tool_ref not in known_tool_names:
+                    raise BadRequestError(f"unknown tool '{tool_ref}'")

--- a/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
@@ -7,7 +7,15 @@ from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 
-_UNION_LIST_KEYS = {"allowed_tools", "denied_tools", "tool_names", "tool_patterns", "capabilities"}
+_UNION_LIST_KEYS = {
+    "allowed_tools",
+    "denied_tools",
+    "tool_names",
+    "tool_patterns",
+    "capabilities",
+    "tool_modules",
+    "module_ids",
+}
 _SUPPORTED_ENVIRONMENT_REQUIREMENTS = frozenset(
     {
         "local_mapping_required",
@@ -104,6 +112,7 @@ class McpHubCapabilityResolutionService:
         *,
         capability_names: list[str],
         metadata: dict[str, Any] | None,
+        resolution_intent: str = "allow",
     ) -> CapabilityResolutionResult:
         metadata_map = dict(metadata or {})
         resolved_capabilities: list[str] = []
@@ -121,7 +130,14 @@ class McpHubCapabilityResolutionService:
             )
             if mapping is None:
                 unresolved_capabilities.append(capability_name)
-                warnings.append(f"No active capability adapter mapping found for '{capability_name}'")
+                if str(resolution_intent or "").strip().lower() == "deny":
+                    warnings.append(
+                        f"No active capability adapter mapping found for denied capability '{capability_name}'"
+                    )
+                else:
+                    warnings.append(
+                        f"No active capability adapter mapping found for '{capability_name}'"
+                    )
                 continue
 
             resolved_capabilities.append(capability_name)
@@ -141,6 +157,7 @@ class McpHubCapabilityResolutionService:
             mapping_summaries.append(
                 {
                     "capability_name": capability_name,
+                    "resolution_intent": str(resolution_intent or "allow").strip().lower() or "allow",
                     "mapping_id": mapping.get("mapping_id"),
                     "mapping_scope_type": mapping.get("owner_scope_type"),
                     "mapping_scope_id": mapping.get("owner_scope_id"),

--- a/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+
+_UNION_LIST_KEYS = {"allowed_tools", "denied_tools", "tool_names", "tool_patterns", "capabilities"}
+_SUPPORTED_ENVIRONMENT_REQUIREMENTS = frozenset(
+    {
+        "local_mapping_required",
+        "no_external_secrets",
+        "workspace_bounded_read",
+        "workspace_bounded_write",
+    }
+)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    out: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _unique(items: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _collect_scope_ids(metadata: dict[str, Any], singular_key: str, plural_key: str) -> list[int]:
+    out: list[int] = []
+    seen: set[int] = set()
+
+    def _maybe_add(raw: Any) -> None:
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return
+        if value in seen:
+            return
+        seen.add(value)
+        out.append(value)
+
+    if singular_key in metadata:
+        _maybe_add(metadata.get(singular_key))
+    plural = metadata.get(plural_key)
+    if isinstance(plural, (list, tuple, set)):
+        for raw in plural:
+            _maybe_add(raw)
+    return out
+
+
+def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if key in _UNION_LIST_KEYS:
+            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
+            continue
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _merge_policy_documents(_as_dict(merged.get(key)), value)
+            continue
+        merged[key] = deepcopy(value)
+    return merged
+
+
+class CapabilityResolutionResult(BaseModel):
+    resolved_capabilities: list[str] = Field(default_factory=list)
+    unresolved_capabilities: list[str] = Field(default_factory=list)
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    mapping_summaries: list[dict[str, Any]] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    unsupported_environment_requirements: list[str] = Field(default_factory=list)
+
+
+class McpHubCapabilityResolutionService:
+    """Resolve portable capability names into concrete policy effects via scope-aware mappings."""
+
+    def __init__(self, *, repo: McpHubRepo) -> None:
+        self.repo = repo
+
+    async def resolve_capabilities(
+        self,
+        *,
+        capability_names: list[str],
+        metadata: dict[str, Any] | None,
+    ) -> CapabilityResolutionResult:
+        metadata_map = dict(metadata or {})
+        resolved_capabilities: list[str] = []
+        unresolved_capabilities: list[str] = []
+        resolved_policy_document: dict[str, Any] = {}
+        mapping_summaries: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        supported_environment_requirements: list[str] = []
+        unsupported_environment_requirements: list[str] = []
+
+        for capability_name in _unique(_as_str_list(capability_names)):
+            mapping = await self._find_best_mapping(
+                capability_name=capability_name,
+                metadata=metadata_map,
+            )
+            if mapping is None:
+                unresolved_capabilities.append(capability_name)
+                warnings.append(f"No active capability adapter mapping found for '{capability_name}'")
+                continue
+
+            resolved_capabilities.append(capability_name)
+            resolved_policy_document = _merge_policy_documents(
+                resolved_policy_document,
+                _as_dict(mapping.get("resolved_policy_document")),
+            )
+            supported, unsupported = self._split_environment_requirements(
+                mapping.get("supported_environment_requirements")
+            )
+            supported_environment_requirements = _unique(
+                supported_environment_requirements + supported
+            )
+            unsupported_environment_requirements = _unique(
+                unsupported_environment_requirements + unsupported
+            )
+            mapping_summaries.append(
+                {
+                    "capability_name": capability_name,
+                    "mapping_id": mapping.get("mapping_id"),
+                    "mapping_scope_type": mapping.get("owner_scope_type"),
+                    "mapping_scope_id": mapping.get("owner_scope_id"),
+                    "resolved_effects": deepcopy(
+                        _as_dict(mapping.get("resolved_policy_document"))
+                    ),
+                    "supported_environment_requirements": supported,
+                    "unsupported_environment_requirements": unsupported,
+                }
+            )
+
+        return CapabilityResolutionResult(
+            resolved_capabilities=resolved_capabilities,
+            unresolved_capabilities=unresolved_capabilities,
+            resolved_policy_document=resolved_policy_document,
+            mapping_summaries=mapping_summaries,
+            warnings=warnings,
+            supported_environment_requirements=supported_environment_requirements,
+            unsupported_environment_requirements=unsupported_environment_requirements,
+        )
+
+    async def _find_best_mapping(
+        self,
+        *,
+        capability_name: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        for team_id in _collect_scope_ids(metadata, "team_id", "team_ids"):
+            mapping = await self.repo.find_active_capability_mapping(
+                owner_scope_type="team",
+                owner_scope_id=team_id,
+                capability_name=capability_name,
+            )
+            if mapping is not None:
+                return mapping
+
+        for org_id in _collect_scope_ids(metadata, "org_id", "org_ids"):
+            mapping = await self.repo.find_active_capability_mapping(
+                owner_scope_type="org",
+                owner_scope_id=org_id,
+                capability_name=capability_name,
+            )
+            if mapping is not None:
+                return mapping
+
+        return await self.repo.find_active_capability_mapping(
+            owner_scope_type="global",
+            owner_scope_id=None,
+            capability_name=capability_name,
+        )
+
+    @staticmethod
+    def _split_environment_requirements(values: Any) -> tuple[list[str], list[str]]:
+        supported: list[str] = []
+        unsupported: list[str] = []
+        for requirement in _unique(_as_str_list(values)):
+            if requirement in _SUPPORTED_ENVIRONMENT_REQUIREMENTS:
+                supported.append(requirement)
+            else:
+                unsupported.append(requirement)
+        return supported, unsupported

--- a/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_capability_resolution_service.py
@@ -1,3 +1,5 @@
+"""Resolve portable MCP Hub capabilities into concrete policy documents."""
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -27,10 +29,12 @@ _SUPPORTED_ENVIRONMENT_REQUIREMENTS = frozenset(
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
+    """Return a shallow dict copy when the input is dictionary-like."""
     return dict(value) if isinstance(value, dict) else {}
 
 
 def _as_str_list(value: Any) -> list[str]:
+    """Normalize scalars and collections into a cleaned list of strings."""
     if isinstance(value, str):
         cleaned = value.strip()
         return [cleaned] if cleaned else []
@@ -45,6 +49,7 @@ def _as_str_list(value: Any) -> list[str]:
 
 
 def _unique(items: list[str]) -> list[str]:
+    """Preserve first-seen order while removing duplicates."""
     out: list[str] = []
     seen: set[str] = set()
     for item in items:
@@ -56,6 +61,7 @@ def _unique(items: list[str]) -> list[str]:
 
 
 def _collect_scope_ids(metadata: dict[str, Any], singular_key: str, plural_key: str) -> list[int]:
+    """Extract deduplicated integer scope identifiers from metadata."""
     out: list[int] = []
     seen: set[int] = set()
 
@@ -79,6 +85,7 @@ def _collect_scope_ids(metadata: dict[str, Any], singular_key: str, plural_key: 
 
 
 def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Union list fields and deep-merge nested dictionaries into a new document."""
     merged = deepcopy(base)
     for key, value in overlay.items():
         if key in _UNION_LIST_KEYS:
@@ -92,6 +99,8 @@ def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> di
 
 
 class CapabilityResolutionResult(BaseModel):
+    """Normalized output for a capability resolution request."""
+
     resolved_capabilities: list[str] = Field(default_factory=list)
     unresolved_capabilities: list[str] = Field(default_factory=list)
     resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
@@ -114,6 +123,7 @@ class McpHubCapabilityResolutionService:
         metadata: dict[str, Any] | None,
         resolution_intent: str = "allow",
     ) -> CapabilityResolutionResult:
+        """Resolve capabilities using the highest-precedence active mapping in scope."""
         metadata_map = dict(metadata or {})
         resolved_capabilities: list[str] = []
         unresolved_capabilities: list[str] = []
@@ -185,6 +195,7 @@ class McpHubCapabilityResolutionService:
         capability_name: str,
         metadata: dict[str, Any],
     ) -> dict[str, Any] | None:
+        """Return the first active mapping found in team, org, then global scope order."""
         for team_id in _collect_scope_ids(metadata, "team_id", "team_ids"):
             mapping = await self.repo.find_active_capability_mapping(
                 owner_scope_type="team",
@@ -211,6 +222,7 @@ class McpHubCapabilityResolutionService:
 
     @staticmethod
     def _split_environment_requirements(values: Any) -> tuple[list[str], list[str]]:
+        """Partition environment requirements into supported and unsupported lists."""
         supported: list[str] = []
         unsupported: list[str] = []
         for requirement in _unique(_as_str_list(values)):

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -231,33 +231,44 @@ class McpHubGovernancePackService:
         )
 
         for profile in pack.profiles:
-            profile_capabilities = self._unique(
-                list(profile.capabilities.allow) + list(profile.capabilities.deny)
-            )
-            resolution = await self.capability_resolution_service.resolve_capabilities(
-                capability_names=profile_capabilities,
+            allow_resolution = await self.capability_resolution_service.resolve_capabilities(
+                capability_names=self._unique(list(profile.capabilities.allow)),
                 metadata=resolution_metadata,
+                resolution_intent="allow",
+            )
+            deny_resolution = await self.capability_resolution_service.resolve_capabilities(
+                capability_names=self._unique(list(profile.capabilities.deny)),
+                metadata=resolution_metadata,
+                resolution_intent="deny",
             )
             resolved_capabilities = self._unique(
-                resolved_capabilities + resolution.resolved_capabilities
+                resolved_capabilities
+                + allow_resolution.resolved_capabilities
+                + deny_resolution.resolved_capabilities
             )
             unresolved_capabilities = self._unique(
-                unresolved_capabilities + resolution.unresolved_capabilities
+                unresolved_capabilities
+                + allow_resolution.unresolved_capabilities
+                + deny_resolution.unresolved_capabilities
             )
             supported_environment_requirements = self._unique(
-                supported_environment_requirements + resolution.supported_environment_requirements
+                supported_environment_requirements
+                + allow_resolution.supported_environment_requirements
+                + deny_resolution.supported_environment_requirements
             )
             unsupported_environment_requirements = self._unique(
-                unsupported_environment_requirements + resolution.unsupported_environment_requirements
+                unsupported_environment_requirements
+                + allow_resolution.unsupported_environment_requirements
+                + deny_resolution.unsupported_environment_requirements
             )
-            for summary in resolution.mapping_summaries:
+            for summary in [*allow_resolution.mapping_summaries, *deny_resolution.mapping_summaries]:
                 mapping_key = str(summary.get("mapping_id") or summary.get("capability_name") or "").strip()
                 if mapping_key and mapping_key in seen_mapping_ids:
                     continue
                 if mapping_key:
                     seen_mapping_ids.add(mapping_key)
                 capability_mapping_summary.append(dict(summary))
-            for warning in resolution.warnings:
+            for warning in [*allow_resolution.warnings, *deny_resolution.warnings]:
                 warnings.append(f"profile:{profile.profile_id}: {warning}")
             for requirement in profile.environment_requirements:
                 requirement_value = str(requirement or "").strip()
@@ -268,7 +279,11 @@ class McpHubGovernancePackService:
                         f"profile:{profile.profile_id} uses unsupported environment requirement '{requirement_value}'"
                     )
                     continue
-                if requirement_value not in resolution.supported_environment_requirements:
+                profile_supported_environment_requirements = self._unique(
+                    allow_resolution.supported_environment_requirements
+                    + deny_resolution.supported_environment_requirements
+                )
+                if requirement_value not in profile_supported_environment_requirements:
                     warnings.append(
                         f"profile:{profile.profile_id} requires environment requirement "
                         f"'{requirement_value}' but current capability mappings do not guarantee it"

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -18,20 +18,13 @@ from tldw_Server_API.app.core.MCP_unified.governance_packs import (
     normalize_governance_pack,
     validate_governance_pack,
 )
+from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+    McpHubCapabilityResolutionService,
+)
 
 _RUNTIME_APPROVAL_MODE_MAP = {
     "allow": "allow_silently",
     "ask": "ask_every_time",
-}
-_SUPPORTED_PORTABLE_CAPABILITIES = {
-    "filesystem.read",
-    "filesystem.write",
-    "mcp.server.connect",
-    "network.external.fetch",
-    "network.external.search",
-    "process.execute.safe",
-    "tool.invoke.code_edit",
-    "tool.invoke.research",
 }
 _SUPPORTED_ENVIRONMENT_REQUIREMENTS = {
     "local_mapping_required",
@@ -63,6 +56,9 @@ class GovernancePackDryRunReport(BaseModel):
     digest: str
     resolved_capabilities: list[str] = Field(default_factory=list)
     unresolved_capabilities: list[str] = Field(default_factory=list)
+    capability_mapping_summary: list[dict[str, Any]] = Field(default_factory=list)
+    supported_environment_requirements: list[str] = Field(default_factory=list)
+    unsupported_environment_requirements: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
     blocked_objects: list[str] = Field(default_factory=list)
     verdict: str
@@ -104,8 +100,39 @@ def _is_duplicate_governance_pack_error(exc: Exception) -> bool:
 class McpHubGovernancePackService:
     """Materialize schema-first governance packs into immutable MCP Hub base objects."""
 
-    def __init__(self, repo: McpHubRepo):
+    def __init__(
+        self,
+        repo: McpHubRepo,
+        capability_resolution_service: McpHubCapabilityResolutionService | None = None,
+    ):
         self.repo = repo
+        self.capability_resolution_service = capability_resolution_service or McpHubCapabilityResolutionService(
+            repo=repo
+        )
+
+    @staticmethod
+    def _unique(items: list[str]) -> list[str]:
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in items:
+            cleaned = str(item or "").strip()
+            if not cleaned or cleaned in seen:
+                continue
+            seen.add(cleaned)
+            out.append(cleaned)
+        return out
+
+    @staticmethod
+    def _resolution_metadata(
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict[str, Any]:
+        if owner_scope_type == "team" and owner_scope_id is not None:
+            return {"team_id": owner_scope_id}
+        if owner_scope_type == "org" and owner_scope_id is not None:
+            return {"org_id": owner_scope_id}
+        return {}
 
     async def _rollback_import(
         self,
@@ -185,8 +212,6 @@ class McpHubGovernancePackService:
         owner_scope_type: str,
         owner_scope_id: int | None,
     ) -> GovernancePackDryRunReport:
-        del owner_scope_type, owner_scope_id
-
         validation = validate_governance_pack(pack)
         if validation.errors:
             raise ValueError("; ".join(validation.errors))
@@ -194,24 +219,59 @@ class McpHubGovernancePackService:
         bundle = build_opa_bundle(pack)
         resolved_capabilities: list[str] = []
         unresolved_capabilities: list[str] = []
+        capability_mapping_summary: list[dict[str, Any]] = []
+        supported_environment_requirements: list[str] = []
+        unsupported_environment_requirements: list[str] = []
         warnings: list[str] = []
         blocked_objects: list[str] = []
+        seen_mapping_ids: set[str] = set()
+        resolution_metadata = self._resolution_metadata(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
 
         for profile in pack.profiles:
-            for capability in list(profile.capabilities.allow) + list(profile.capabilities.deny):
-                capability_value = str(capability or "").strip()
-                if not capability_value:
+            profile_capabilities = self._unique(
+                list(profile.capabilities.allow) + list(profile.capabilities.deny)
+            )
+            resolution = await self.capability_resolution_service.resolve_capabilities(
+                capability_names=profile_capabilities,
+                metadata=resolution_metadata,
+            )
+            resolved_capabilities = self._unique(
+                resolved_capabilities + resolution.resolved_capabilities
+            )
+            unresolved_capabilities = self._unique(
+                unresolved_capabilities + resolution.unresolved_capabilities
+            )
+            supported_environment_requirements = self._unique(
+                supported_environment_requirements + resolution.supported_environment_requirements
+            )
+            unsupported_environment_requirements = self._unique(
+                unsupported_environment_requirements + resolution.unsupported_environment_requirements
+            )
+            for summary in resolution.mapping_summaries:
+                mapping_key = str(summary.get("mapping_id") or summary.get("capability_name") or "").strip()
+                if mapping_key and mapping_key in seen_mapping_ids:
                     continue
-                if capability_value in _SUPPORTED_PORTABLE_CAPABILITIES:
-                    if capability_value not in resolved_capabilities:
-                        resolved_capabilities.append(capability_value)
-                elif capability_value not in unresolved_capabilities:
-                    unresolved_capabilities.append(capability_value)
+                if mapping_key:
+                    seen_mapping_ids.add(mapping_key)
+                capability_mapping_summary.append(dict(summary))
+            for warning in resolution.warnings:
+                warnings.append(f"profile:{profile.profile_id}: {warning}")
             for requirement in profile.environment_requirements:
                 requirement_value = str(requirement or "").strip()
-                if requirement_value and requirement_value not in _SUPPORTED_ENVIRONMENT_REQUIREMENTS:
+                if not requirement_value:
+                    continue
+                if requirement_value not in _SUPPORTED_ENVIRONMENT_REQUIREMENTS:
                     warnings.append(
                         f"profile:{profile.profile_id} uses unsupported environment requirement '{requirement_value}'"
+                    )
+                    continue
+                if requirement_value not in resolution.supported_environment_requirements:
+                    warnings.append(
+                        f"profile:{profile.profile_id} requires environment requirement "
+                        f"'{requirement_value}' but current capability mappings do not guarantee it"
                     )
 
         for approval in pack.approvals:
@@ -235,7 +295,10 @@ class McpHubGovernancePackService:
             digest=bundle.digest,
             resolved_capabilities=resolved_capabilities,
             unresolved_capabilities=unresolved_capabilities,
-            warnings=warnings,
+            capability_mapping_summary=capability_mapping_summary,
+            supported_environment_requirements=supported_environment_requirements,
+            unsupported_environment_requirements=unsupported_environment_requirements,
+            warnings=self._unique(warnings),
             blocked_objects=blocked_objects,
             verdict=verdict,
         )

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -241,7 +241,7 @@ class McpHubPolicyResolver:
         self,
         repo: McpHubRepo,
         capability_resolution_service: McpHubCapabilityResolutionService | None = None,
-    ):
+    ) -> None:
         self.repo = repo
         self.capability_resolution_service = capability_resolution_service or McpHubCapabilityResolutionService(
             repo=repo

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -14,7 +14,15 @@ from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
 
 _TARGET_ORDER = {"default": 0, "group": 1, "persona": 2}
 _SCOPE_ORDER = {"global": 0, "org": 1, "team": 2, "user": 3}
-_UNION_LIST_KEYS = {"allowed_tools", "denied_tools", "tool_names", "tool_patterns", "capabilities"}
+_UNION_LIST_KEYS = {
+    "allowed_tools",
+    "denied_tools",
+    "tool_names",
+    "tool_patterns",
+    "capabilities",
+    "tool_modules",
+    "module_ids",
+}
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -163,9 +171,12 @@ def _provenance_entries(
 
 def _capability_mapping_provenance_entries(
     resolution: CapabilityResolutionResult,
+    *,
+    resolution_intent: str,
 ) -> list[dict[str, Any]]:
     entries: list[dict[str, Any]] = []
     for summary in resolution.mapping_summaries:
+        is_deny = str(resolution_intent or "").strip().lower() == "deny"
         entries.append(
             {
                 "field": "capabilities",
@@ -179,10 +190,12 @@ def _capability_mapping_provenance_entries(
                 "mapping_scope_type": summary.get("mapping_scope_type"),
                 "mapping_scope_id": summary.get("mapping_scope_id"),
                 "resolved_effects": deepcopy(_as_dict(summary.get("resolved_effects"))),
-                "effect": "merged",
+                "resolution_intent": "deny" if is_deny else "allow",
+                "effect": "narrowed" if is_deny else "merged",
             }
         )
     for capability_name in resolution.unresolved_capabilities:
+        is_deny = str(resolution_intent or "").strip().lower() == "deny"
         entries.append(
             {
                 "field": "capabilities",
@@ -196,10 +209,29 @@ def _capability_mapping_provenance_entries(
                 "mapping_scope_type": None,
                 "mapping_scope_id": None,
                 "resolved_effects": {},
+                "resolution_intent": "deny" if is_deny else "allow",
                 "effect": "blocked",
             }
         )
     return entries
+
+
+def _apply_denied_capability_resolution(
+    base: dict[str, Any],
+    deny_overlay: dict[str, Any],
+) -> dict[str, Any]:
+    merged = deepcopy(base)
+    denied_patterns = _unique(
+        _as_str_list(deny_overlay.get("denied_tools"))
+        + _as_str_list(deny_overlay.get("allowed_tools"))
+        + _as_str_list(deny_overlay.get("tool_patterns"))
+        + _as_str_list(deny_overlay.get("tool_names"))
+    )
+    if denied_patterns:
+        merged["denied_tools"] = _unique(
+            _as_str_list(merged.get("denied_tools")) + denied_patterns
+        )
+    return merged
 
 
 class McpHubPolicyResolver:
@@ -426,15 +458,60 @@ class McpHubPolicyResolver:
             )
 
         authored_policy_document = deepcopy(merged_policy_document)
-        capability_resolution = await self.capability_resolution_service.resolve_capabilities(
+        allow_capability_resolution = await self.capability_resolution_service.resolve_capabilities(
             capability_names=_as_str_list(authored_policy_document.get("capabilities")),
             metadata=metadata_map,
+            resolution_intent="allow",
+        )
+        deny_capability_resolution = await self.capability_resolution_service.resolve_capabilities(
+            capability_names=_as_str_list(authored_policy_document.get("denied_capabilities")),
+            metadata=metadata_map,
+            resolution_intent="deny",
         )
         resolved_policy_document = _merge_resolved_policy_documents(
             authored_policy_document,
-            capability_resolution.resolved_policy_document,
+            allow_capability_resolution.resolved_policy_document,
         )
-        provenance.extend(_capability_mapping_provenance_entries(capability_resolution))
+        resolved_policy_document = _apply_denied_capability_resolution(
+            resolved_policy_document,
+            deny_capability_resolution.resolved_policy_document,
+        )
+        provenance.extend(
+            _capability_mapping_provenance_entries(
+                allow_capability_resolution,
+                resolution_intent="allow",
+            )
+        )
+        provenance.extend(
+            _capability_mapping_provenance_entries(
+                deny_capability_resolution,
+                resolution_intent="deny",
+            )
+        )
+        capability_mapping_summary = [
+            *allow_capability_resolution.mapping_summaries,
+            *deny_capability_resolution.mapping_summaries,
+        ]
+        capability_warnings = [
+            *allow_capability_resolution.warnings,
+            *deny_capability_resolution.warnings,
+        ]
+        resolved_capabilities = _unique(
+            allow_capability_resolution.resolved_capabilities
+            + deny_capability_resolution.resolved_capabilities
+        )
+        unresolved_capabilities = _unique(
+            allow_capability_resolution.unresolved_capabilities
+            + deny_capability_resolution.unresolved_capabilities
+        )
+        supported_environment_requirements = _unique(
+            allow_capability_resolution.supported_environment_requirements
+            + deny_capability_resolution.supported_environment_requirements
+        )
+        unsupported_environment_requirements = _unique(
+            allow_capability_resolution.unsupported_environment_requirements
+            + deny_capability_resolution.unsupported_environment_requirements
+        )
 
         return {
             "enabled": True,
@@ -446,12 +523,12 @@ class McpHubPolicyResolver:
             "policy_document": resolved_policy_document,
             "authored_policy_document": authored_policy_document,
             "resolved_policy_document": resolved_policy_document,
-            "resolved_capabilities": capability_resolution.resolved_capabilities,
-            "unresolved_capabilities": capability_resolution.unresolved_capabilities,
-            "capability_mapping_summary": capability_resolution.mapping_summaries,
-            "capability_warnings": capability_resolution.warnings,
-            "supported_environment_requirements": capability_resolution.supported_environment_requirements,
-            "unsupported_environment_requirements": capability_resolution.unsupported_environment_requirements,
+            "resolved_capabilities": resolved_capabilities,
+            "unresolved_capabilities": unresolved_capabilities,
+            "capability_mapping_summary": capability_mapping_summary,
+            "capability_warnings": capability_warnings,
+            "supported_environment_requirements": supported_environment_requirements,
+            "unsupported_environment_requirements": unsupported_environment_requirements,
             "selected_assignment_id": selected_assignment_id,
             "selected_workspace_source_mode": selected_workspace_source_mode,
             "selected_workspace_set_object_id": selected_workspace_set_object_id,

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -7,6 +7,10 @@ from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+    CapabilityResolutionResult,
+    McpHubCapabilityResolutionService,
+)
 
 _TARGET_ORDER = {"default": 0, "group": 1, "persona": 2}
 _SCOPE_ORDER = {"global": 0, "org": 1, "team": 2, "user": 3}
@@ -99,6 +103,30 @@ def _merge_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> di
     return merged
 
 
+def _has_explicit_scalar_value(value: Any) -> bool:
+    """Return whether a scalar value should override mapping-provided hints."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
+def _merge_resolved_policy_documents(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge mapping effects into authored policy while preserving explicit authored scalars."""
+    merged = deepcopy(base)
+    for key, value in overlay.items():
+        if key in _UNION_LIST_KEYS:
+            merged[key] = _unique(_as_str_list(merged.get(key)) + _as_str_list(value))
+            continue
+        if isinstance(merged.get(key), dict) and isinstance(value, dict):
+            merged[key] = _merge_resolved_policy_documents(_as_dict(merged.get(key)), value)
+            continue
+        if key not in merged or not _has_explicit_scalar_value(merged.get(key)):
+            merged[key] = deepcopy(value)
+    return merged
+
+
 def _allowed_tool_patterns(policy_document: dict[str, Any]) -> list[str]:
     """Return the effective allowed-tool pattern list from a policy document."""
     patterns = (
@@ -133,11 +161,59 @@ def _provenance_entries(
     return entries
 
 
+def _capability_mapping_provenance_entries(
+    resolution: CapabilityResolutionResult,
+) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for summary in resolution.mapping_summaries:
+        entries.append(
+            {
+                "field": "capabilities",
+                "value": summary.get("capability_name"),
+                "source_kind": "capability_mapping",
+                "assignment_id": None,
+                "profile_id": None,
+                "override_id": None,
+                "capability_name": summary.get("capability_name"),
+                "mapping_id": summary.get("mapping_id"),
+                "mapping_scope_type": summary.get("mapping_scope_type"),
+                "mapping_scope_id": summary.get("mapping_scope_id"),
+                "resolved_effects": deepcopy(_as_dict(summary.get("resolved_effects"))),
+                "effect": "merged",
+            }
+        )
+    for capability_name in resolution.unresolved_capabilities:
+        entries.append(
+            {
+                "field": "capabilities",
+                "value": capability_name,
+                "source_kind": "capability_mapping",
+                "assignment_id": None,
+                "profile_id": None,
+                "override_id": None,
+                "capability_name": capability_name,
+                "mapping_id": None,
+                "mapping_scope_type": None,
+                "mapping_scope_id": None,
+                "resolved_effects": {},
+                "effect": "blocked",
+            }
+        )
+    return entries
+
+
 class McpHubPolicyResolver:
     """Resolve effective MCP Hub policy for a runtime request context."""
 
-    def __init__(self, repo: McpHubRepo):
+    def __init__(
+        self,
+        repo: McpHubRepo,
+        capability_resolution_service: McpHubCapabilityResolutionService | None = None,
+    ):
         self.repo = repo
+        self.capability_resolution_service = capability_resolution_service or McpHubCapabilityResolutionService(
+            repo=repo
+        )
 
     async def resolve_for_context(
         self,
@@ -349,14 +425,33 @@ class McpHubPolicyResolver:
                 }
             )
 
+        authored_policy_document = deepcopy(merged_policy_document)
+        capability_resolution = await self.capability_resolution_service.resolve_capabilities(
+            capability_names=_as_str_list(authored_policy_document.get("capabilities")),
+            metadata=metadata_map,
+        )
+        resolved_policy_document = _merge_resolved_policy_documents(
+            authored_policy_document,
+            capability_resolution.resolved_policy_document,
+        )
+        provenance.extend(_capability_mapping_provenance_entries(capability_resolution))
+
         return {
             "enabled": True,
-            "allowed_tools": _allowed_tool_patterns(merged_policy_document),
-            "denied_tools": _unique(_as_str_list(merged_policy_document.get("denied_tools"))),
-            "capabilities": _unique(_as_str_list(merged_policy_document.get("capabilities"))),
+            "allowed_tools": _allowed_tool_patterns(resolved_policy_document),
+            "denied_tools": _unique(_as_str_list(resolved_policy_document.get("denied_tools"))),
+            "capabilities": _unique(_as_str_list(resolved_policy_document.get("capabilities"))),
             "approval_policy_id": resolved_approval_policy_id,
-            "approval_mode": str(merged_policy_document.get("approval_mode") or "").strip() or None,
-            "policy_document": merged_policy_document,
+            "approval_mode": str(resolved_policy_document.get("approval_mode") or "").strip() or None,
+            "policy_document": resolved_policy_document,
+            "authored_policy_document": authored_policy_document,
+            "resolved_policy_document": resolved_policy_document,
+            "resolved_capabilities": capability_resolution.resolved_capabilities,
+            "unresolved_capabilities": capability_resolution.unresolved_capabilities,
+            "capability_mapping_summary": capability_resolution.mapping_summaries,
+            "capability_warnings": capability_resolution.warnings,
+            "supported_environment_requirements": capability_resolution.supported_environment_requirements,
+            "unsupported_environment_requirements": capability_resolution.unsupported_environment_requirements,
             "selected_assignment_id": selected_assignment_id,
             "selected_workspace_source_mode": selected_workspace_source_mode,
             "selected_workspace_set_object_id": selected_workspace_set_object_id,
@@ -417,6 +512,14 @@ class McpHubPolicyResolver:
             "approval_policy_id": None,
             "approval_mode": None,
             "policy_document": {},
+            "authored_policy_document": {},
+            "resolved_policy_document": {},
+            "resolved_capabilities": [],
+            "unresolved_capabilities": [],
+            "capability_mapping_summary": [],
+            "capability_warnings": [],
+            "supported_environment_requirements": [],
+            "unsupported_environment_requirements": [],
             "selected_assignment_id": None,
             "selected_workspace_source_mode": None,
             "selected_workspace_set_object_id": None,

--- a/tldw_Server_API/app/services/mcp_hub_workspace_root_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_workspace_root_resolver.py
@@ -111,6 +111,12 @@ class McpHubWorkspaceRootResolver:
                 result["workspace_root"] = _normalize_workspace_root(str(workspace_root))
                 result["source"] = "sandbox_session"
                 return result
+        elif session_key:
+            workspace_root = self._sandbox_service.get_session_workspace_path(session_key)
+            if workspace_root:
+                result["workspace_root"] = _normalize_workspace_root(str(workspace_root))
+                result["source"] = "sandbox_session"
+                return result
 
         if not user_key or not workspace_key:
             result["reason"] = "workspace_root_unavailable"

--- a/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
+++ b/tldw_Server_API/tests/AuthNZ_Postgres/test_mcp_hub_pg_ensure.py
@@ -20,6 +20,7 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
             'mcp_acp_profiles',
             'mcp_approval_decisions',
             'mcp_approval_policies',
+            'mcp_capability_adapter_mappings',
             'mcp_credential_bindings',
             'mcp_external_servers',
             'mcp_external_server_credential_slots',
@@ -42,6 +43,7 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
     assert "mcp_acp_profiles" in names
     assert "mcp_approval_decisions" in names
     assert "mcp_approval_policies" in names
+    assert "mcp_capability_adapter_mappings" in names
     assert "mcp_credential_bindings" in names
     assert "mcp_external_servers" in names
     assert "mcp_external_server_credential_slots" in names
@@ -107,6 +109,36 @@ async def test_ensure_mcp_hub_tables_pg_creates_required_tables(test_db_pool) ->
     assert "normalized_ir_json" in governance_pack_column_names
     assert "owner_scope_type" in governance_pack_column_names
     assert "owner_scope_id" in governance_pack_column_names
+
+    capability_mapping_column_rows = await test_db_pool.fetch(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'mcp_capability_adapter_mappings'
+          AND column_name IN (
+            'mapping_id',
+            'owner_scope_type',
+            'owner_scope_id',
+            'capability_name',
+            'adapter_contract_version',
+            'resolved_policy_document_json',
+            'supported_environment_requirements_json',
+            'is_active'
+          )
+        """
+    )
+    capability_mapping_column_names = {
+        str(row["column_name"]) for row in capability_mapping_column_rows
+    }
+    assert "mapping_id" in capability_mapping_column_names
+    assert "owner_scope_type" in capability_mapping_column_names
+    assert "owner_scope_id" in capability_mapping_column_names
+    assert "capability_name" in capability_mapping_column_names
+    assert "adapter_contract_version" in capability_mapping_column_names
+    assert "resolved_policy_document_json" in capability_mapping_column_names
+    assert "supported_environment_requirements_json" in capability_mapping_column_names
+    assert "is_active" in capability_mapping_column_names
 
     governance_object_column_rows = await test_db_pool.fetch(
         """

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_capability_adapter_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_capability_adapter_migrations.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_mcp_hub_capability_adapter_tables_exist_after_authnz_migrations_sqlite(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(pool.db_path))
+
+    rows = await pool.fetchall("SELECT name FROM sqlite_master WHERE type='table'")
+    names = {str(row["name"]) for row in rows}
+
+    assert "mcp_capability_adapter_mappings" in names
+
+    mapping_columns = await pool.fetchall("PRAGMA table_info(mcp_capability_adapter_mappings)")
+    mapping_column_names = {str(row["name"]) for row in mapping_columns}
+    assert "mapping_id" in mapping_column_names
+    assert "owner_scope_type" in mapping_column_names
+    assert "owner_scope_id" in mapping_column_names
+    assert "capability_name" in mapping_column_names
+    assert "adapter_contract_version" in mapping_column_names
+    assert "resolved_policy_document_json" in mapping_column_names
+    assert "supported_environment_requirements_json" in mapping_column_names
+    assert "is_active" in mapping_column_names
+
+    index_rows = await pool.fetchall("PRAGMA index_list(mcp_capability_adapter_mappings)")
+    index_names = {str(row["name"]) for row in index_rows}
+    assert "idx_mcp_capability_adapter_mappings_scope" in index_names
+    assert "uq_mcp_capability_adapter_mappings_mapping_id" in index_names
+    assert "uq_mcp_capability_adapter_mappings_active_scope_capability" in index_names

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_capability_adapter_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_capability_adapter_repo.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+@pytest.mark.asyncio
+async def test_repo_can_crud_capability_adapter_mapping(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    created = await repo.create_capability_adapter_mapping(
+        mapping_id="research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=["local_mapping_required"],
+        actor_id=1,
+        title="Global research mapping",
+        description="Maps portable research capability to MCP search tools",
+        is_active=True,
+    )
+
+    assert created["mapping_id"] == "research.global"
+    assert created["capability_name"] == "tool.invoke.research"
+    assert created["resolved_policy_document"]["allowed_tools"] == ["web.search"]
+    assert created["supported_environment_requirements"] == ["local_mapping_required"]
+    assert created["is_active"] is True
+
+    fetched = await repo.get_capability_adapter_mapping(int(created["id"]))
+    assert fetched is not None
+    assert fetched["mapping_id"] == "research.global"
+
+    listed = await repo.list_capability_adapter_mappings(owner_scope_type="global", owner_scope_id=None)
+    assert len(listed) == 1
+    assert listed[0]["mapping_id"] == "research.global"
+
+    updated = await repo.update_capability_adapter_mapping(
+        int(created["id"]),
+        title="Updated global research mapping",
+        resolved_policy_document={"allowed_tools": ["web.search", "docs.search"]},
+        supported_environment_requirements=["local_mapping_required", "workspace_bounded_read"],
+        actor_id=2,
+    )
+    assert updated is not None
+    assert updated["title"] == "Updated global research mapping"
+    assert updated["resolved_policy_document"]["allowed_tools"] == ["web.search", "docs.search"]
+    assert updated["supported_environment_requirements"] == [
+        "local_mapping_required",
+        "workspace_bounded_read",
+    ]
+
+    deleted = await repo.delete_capability_adapter_mapping(int(created["id"]))
+    assert deleted is True
+    missing = await repo.get_capability_adapter_mapping(int(created["id"]))
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_repo_rejects_duplicate_active_capability_adapter_mapping_per_scope(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    created = await repo.create_capability_adapter_mapping(
+        mapping_id="research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=["local_mapping_required"],
+        actor_id=1,
+        is_active=True,
+    )
+    assert created["is_active"] is True
+
+    with pytest.raises(Exception):
+        await repo.create_capability_adapter_mapping(
+            mapping_id="research.global.duplicate",
+            owner_scope_type="global",
+            owner_scope_id=None,
+            capability_name="tool.invoke.research",
+            adapter_contract_version=1,
+            resolved_policy_document={"allowed_tools": ["docs.search"]},
+            supported_environment_requirements=[],
+            actor_id=1,
+            is_active=True,
+        )
+
+    deactivated = await repo.update_capability_adapter_mapping(
+        int(created["id"]),
+        is_active=False,
+        actor_id=2,
+    )
+    assert deactivated is not None
+    assert deactivated["is_active"] is False
+
+    replacement = await repo.create_capability_adapter_mapping(
+        mapping_id="research.global.replacement",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["docs.search"]},
+        supported_environment_requirements=[],
+        actor_id=2,
+        is_active=True,
+    )
+    assert replacement["mapping_id"] == "research.global.replacement"

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_api.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+from starlette.requests import Request
+
+from tldw_Server_API.app.api.v1.API_Deps import auth_deps
+from tldw_Server_API.app.api.v1.endpoints import mcp_hub_management
+from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.exceptions import BadRequestError
+
+
+def _make_principal(
+    *,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=7,
+        api_key_id=None,
+        subject="7",
+        token_type="access",
+        jti=None,
+        roles=roles or [],
+        permissions=permissions or [],
+        is_admin=False,
+        org_ids=[],
+        team_ids=[],
+    )
+
+
+class _FakeCapabilityAdapterService:
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self.preview_calls: list[dict] = []
+        self.create_calls: list[dict] = []
+        self.update_calls: list[dict] = []
+        self.delete_calls: list[int] = []
+        self.preview_error: Exception | None = None
+        self.inventory = [
+            {
+                "id": 11,
+                "mapping_id": "research.global",
+                "title": "Research",
+                "description": "Global research mapping",
+                "owner_scope_type": "global",
+                "owner_scope_id": None,
+                "capability_name": "tool.invoke.research",
+                "adapter_contract_version": 1,
+                "resolved_policy_document": {"allowed_tools": ["web.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+                "is_active": True,
+                "created_by": 7,
+                "updated_by": 7,
+                "created_at": now,
+                "updated_at": now,
+            }
+        ]
+
+    async def preview_mapping(self, **kwargs):
+        self.preview_calls.append(dict(kwargs))
+        if self.preview_error is not None:
+            raise self.preview_error
+        scope_type = kwargs["owner_scope_type"]
+        scope_id = kwargs.get("owner_scope_id")
+        display_scope = scope_type if scope_id is None else f"{scope_type}:{scope_id}"
+        return {
+            "normalized_mapping": {
+                "mapping_id": kwargs["mapping_id"],
+                "title": kwargs.get("title") or kwargs["mapping_id"],
+                "description": kwargs.get("description"),
+                "owner_scope_type": scope_type,
+                "owner_scope_id": scope_id,
+                "capability_name": kwargs["capability_name"],
+                "adapter_contract_version": kwargs["adapter_contract_version"],
+                "resolved_policy_document": dict(kwargs["resolved_policy_document"]),
+                "supported_environment_requirements": list(kwargs["supported_environment_requirements"]),
+                "is_active": kwargs.get("is_active", True),
+            },
+            "warnings": ["preview warning"] if kwargs["supported_environment_requirements"] else [],
+            "affected_scope_summary": {
+                "owner_scope_type": scope_type,
+                "owner_scope_id": scope_id,
+                "display_scope": display_scope,
+            },
+        }
+
+    async def preview_update(self, capability_adapter_mapping_id: int, **kwargs):
+        if int(capability_adapter_mapping_id) != 11:
+            raise BadRequestError("missing mapping")
+        current = dict(self.inventory[0])
+        current.update({key: value for key, value in kwargs.items() if value is not None})
+        return await self.preview_mapping(**current)
+
+    async def create_mapping(self, **kwargs):
+        self.create_calls.append(dict(kwargs))
+        row = dict(self.inventory[0])
+        row.update(
+            {
+                "mapping_id": kwargs["mapping_id"],
+                "title": kwargs.get("title") or kwargs["mapping_id"],
+                "description": kwargs.get("description"),
+                "owner_scope_type": kwargs["owner_scope_type"],
+                "owner_scope_id": kwargs.get("owner_scope_id"),
+                "capability_name": kwargs["capability_name"],
+                "adapter_contract_version": kwargs["adapter_contract_version"],
+                "resolved_policy_document": dict(kwargs["resolved_policy_document"]),
+                "supported_environment_requirements": list(kwargs["supported_environment_requirements"]),
+                "is_active": kwargs.get("is_active", True),
+                "updated_by": kwargs.get("actor_id"),
+            }
+        )
+        self.inventory = [row]
+        return row
+
+    async def list_capability_adapter_mappings(self, **_kwargs):
+        return list(self.inventory)
+
+    async def update_mapping(self, capability_adapter_mapping_id: int, **kwargs):
+        self.update_calls.append({"id": capability_adapter_mapping_id, **dict(kwargs)})
+        if int(capability_adapter_mapping_id) != 11:
+            return None
+        row = dict(self.inventory[0])
+        row.update(
+            {
+                "title": kwargs.get("title") or row["title"],
+                "description": kwargs.get("description", row["description"]),
+                "resolved_policy_document": dict(kwargs.get("resolved_policy_document") or row["resolved_policy_document"]),
+                "supported_environment_requirements": list(
+                    kwargs.get("supported_environment_requirements") or row["supported_environment_requirements"]
+                ),
+                "updated_by": kwargs.get("actor_id"),
+            }
+        )
+        self.inventory = [row]
+        return row
+
+    async def delete_capability_adapter_mapping(self, capability_adapter_mapping_id: int):
+        self.delete_calls.append(int(capability_adapter_mapping_id))
+        return int(capability_adapter_mapping_id) == 11
+
+
+def _build_app(
+    principal: AuthPrincipal,
+    *,
+    capability_adapter_service: _FakeCapabilityAdapterService | None = None,
+) -> FastAPI:
+    app = FastAPI()
+    app.include_router(mcp_hub_management.router, prefix="/api/v1")
+
+    async def _fake_get_auth_principal(_request: Request) -> AuthPrincipal:  # type: ignore[override]
+        return principal
+
+    app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
+    app.dependency_overrides[mcp_hub_management.get_mcp_hub_capability_adapter_service] = (
+        lambda: capability_adapter_service or _FakeCapabilityAdapterService()
+    )
+    return app
+
+
+def _mapping_payload() -> dict:
+    return {
+        "mapping_id": "research.global",
+        "title": "Research",
+        "description": "Global research mapping",
+        "owner_scope_type": "global",
+        "owner_scope_id": None,
+        "capability_name": "tool.invoke.research",
+        "adapter_contract_version": 1,
+        "resolved_policy_document": {"allowed_tools": ["web.search"]},
+        "supported_environment_requirements": ["workspace_bounded_read"],
+        "is_active": True,
+    }
+
+
+def test_capability_mapping_preview_returns_normalized_report() -> None:
+    service = _FakeCapabilityAdapterService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.tool.invoke"]),
+        capability_adapter_service=service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/capability-mappings/preview",
+            json=_mapping_payload(),
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["normalized_mapping"]["resolved_policy_document"] == {
+        "allowed_tools": ["web.search"]
+    }
+    assert payload["affected_scope_summary"]["display_scope"] == "global"
+    assert service.preview_calls
+
+
+def test_capability_mapping_create_requires_grant_authority() -> None:
+    service = _FakeCapabilityAdapterService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE]),
+        capability_adapter_service=service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/capability-mappings",
+            json=_mapping_payload(),
+        )
+
+    assert resp.status_code == 403
+    assert "grant.tool.invoke" in resp.json()["detail"]
+    assert service.create_calls == []
+
+
+def test_capability_mapping_crud_round_trip() -> None:
+    service = _FakeCapabilityAdapterService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.tool.invoke"]),
+        capability_adapter_service=service,
+    )
+
+    with TestClient(app) as client:
+        list_resp = client.get("/api/v1/mcp/hub/capability-mappings")
+        create_resp = client.post(
+            "/api/v1/mcp/hub/capability-mappings",
+            json=_mapping_payload(),
+        )
+        update_resp = client.put(
+            "/api/v1/mcp/hub/capability-mappings/11",
+            json={
+                "title": "Research Updated",
+                "resolved_policy_document": {"allowed_tools": ["docs.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+            },
+        )
+        delete_resp = client.delete("/api/v1/mcp/hub/capability-mappings/11")
+
+    assert list_resp.status_code == 200
+    assert list_resp.json()[0]["mapping_id"] == "research.global"
+    assert create_resp.status_code == 201
+    assert create_resp.json()["mapping_id"] == "research.global"
+    assert update_resp.status_code == 200
+    assert update_resp.json()["title"] == "Research Updated"
+    assert delete_resp.status_code == 200
+    assert delete_resp.json() == {"ok": True}
+
+
+def test_capability_mapping_create_returns_bad_request_for_invalid_contract_version() -> None:
+    service = _FakeCapabilityAdapterService()
+    service.preview_error = BadRequestError("adapter_contract_version must be 1")
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.tool.invoke"]),
+        capability_adapter_service=service,
+    )
+
+    payload = _mapping_payload()
+    payload["adapter_contract_version"] = 2
+
+    with TestClient(app) as client:
+        resp = client.post("/api/v1/mcp/hub/capability-mappings", json=payload)
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "adapter_contract_version must be 1"
+    assert service.create_calls == []

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.exceptions import BadRequestError
+
+
+class _FakeRepo:
+    def __init__(self) -> None:
+        self.created_payloads: list[dict] = []
+
+    async def create_capability_adapter_mapping(self, **kwargs):
+        self.created_payloads.append(dict(kwargs))
+        return {
+            "id": 11,
+            "mapping_id": kwargs["mapping_id"],
+            "title": kwargs["title"],
+            "description": kwargs.get("description"),
+            "owner_scope_type": kwargs["owner_scope_type"],
+            "owner_scope_id": kwargs.get("owner_scope_id"),
+            "capability_name": kwargs["capability_name"],
+            "adapter_contract_version": kwargs["adapter_contract_version"],
+            "resolved_policy_document": kwargs["resolved_policy_document"],
+            "supported_environment_requirements": kwargs["supported_environment_requirements"],
+            "is_active": kwargs.get("is_active", True),
+            "created_by": kwargs.get("actor_id"),
+            "updated_by": kwargs.get("actor_id"),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+
+class _FakeToolRegistry:
+    async def list_entries(self):
+        return [
+            {
+                "tool_name": "web.search",
+                "display_name": "Web Search",
+                "module": "search",
+            },
+            {
+                "tool_name": "docs.search",
+                "display_name": "Docs Search",
+                "module": "docs",
+            },
+        ]
+
+    async def list_modules(self):
+        return [
+            {
+                "module": "search",
+                "display_name": "Search",
+                "tool_count": 1,
+                "risk_summary": {"low": 1, "medium": 0, "high": 0, "unclassified": 0},
+                "metadata_warnings": [],
+            },
+            {
+                "module": "docs",
+                "display_name": "Docs",
+                "tool_count": 1,
+                "risk_summary": {"low": 1, "medium": 0, "high": 0, "unclassified": 0},
+                "metadata_warnings": [],
+            },
+        ]
+
+
+@pytest.mark.asyncio
+async def test_preview_mapping_rejects_unknown_tools() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    svc = McpHubCapabilityAdapterService(repo=_FakeRepo(), tool_registry=_FakeToolRegistry())
+
+    with pytest.raises(BadRequestError, match="unknown tool"):
+        await svc.preview_mapping(
+            mapping_id="research.global",
+            owner_scope_type="global",
+            owner_scope_id=None,
+            capability_name="tool.invoke.research",
+            adapter_contract_version=1,
+            resolved_policy_document={"allowed_tools": ["missing.tool"]},
+            supported_environment_requirements=[],
+            title="Research",
+            description=None,
+            is_active=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_preview_mapping_warns_for_unsupported_environment_requirements() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    svc = McpHubCapabilityAdapterService(repo=_FakeRepo(), tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_mapping(
+        mapping_id="research.team",
+        owner_scope_type="team",
+        owner_scope_id=21,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=["workspace_bounded_read", "future.flag"],
+        title="Team Research",
+        description="Shared research capability mapping",
+        is_active=True,
+    )
+
+    assert preview["normalized_mapping"]["supported_environment_requirements"] == [
+        "workspace_bounded_read"
+    ]
+    assert preview["warnings"] == [
+        "unsupported environment requirement 'future.flag' will be ignored"
+    ]
+    assert preview["affected_scope_summary"] == {
+        "owner_scope_type": "team",
+        "owner_scope_id": 21,
+        "display_scope": "team:21",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_mapping_uses_normalized_preview_payload() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    created = await svc.create_mapping(
+        mapping_id="research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search", "web.search"]},
+        supported_environment_requirements=["workspace_bounded_read", "workspace_bounded_read"],
+        actor_id=7,
+        title="Research",
+        description="Maps research capability",
+        is_active=True,
+    )
+
+    assert repo.created_payloads[0]["resolved_policy_document"] == {
+        "allowed_tools": ["web.search"]
+    }
+    assert repo.created_payloads[0]["supported_environment_requirements"] == [
+        "workspace_bounded_read"
+    ]
+    assert created["id"] == 11

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
@@ -10,6 +10,7 @@ from tldw_Server_API.app.core.exceptions import BadRequestError
 class _FakeRepo:
     def __init__(self) -> None:
         self.created_payloads: list[dict] = []
+        self.updated_payloads: list[dict] = []
         self.inventory = {
             11: {
                 "id": 11,
@@ -49,6 +50,33 @@ class _FakeRepo:
     async def get_capability_adapter_mapping(self, capability_adapter_mapping_id: int):
         row = self.inventory.get(int(capability_adapter_mapping_id))
         return dict(row) if row is not None else None
+
+    async def update_capability_adapter_mapping(
+        self,
+        capability_adapter_mapping_id: int,
+        **kwargs,
+    ):
+        row = self.inventory.get(int(capability_adapter_mapping_id))
+        if row is None:
+            return None
+        self.updated_payloads.append({"id": capability_adapter_mapping_id, **dict(kwargs)})
+        updated = dict(row)
+        updated.update(
+            {
+                "mapping_id": kwargs["mapping_id"],
+                "title": kwargs["title"],
+                "description": kwargs.get("description"),
+                "owner_scope_type": kwargs["owner_scope_type"],
+                "owner_scope_id": kwargs.get("owner_scope_id"),
+                "capability_name": kwargs["capability_name"],
+                "adapter_contract_version": kwargs["adapter_contract_version"],
+                "resolved_policy_document": kwargs["resolved_policy_document"],
+                "supported_environment_requirements": kwargs["supported_environment_requirements"],
+                "is_active": kwargs.get("is_active", True),
+            }
+        )
+        self.inventory[int(capability_adapter_mapping_id)] = updated
+        return dict(updated)
 
 
 class _FakeToolRegistry:
@@ -236,3 +264,60 @@ async def test_preview_update_allows_clearing_nullable_description() -> None:
     )
 
     assert preview["normalized_mapping"]["description"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_mapping_preserves_existing_fields_for_omitted_values() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    updated = await svc.update_mapping(
+        11,
+        title="Renamed Mapping",
+        actor_id=7,
+    )
+
+    assert updated["title"] == "Renamed Mapping"
+    assert updated["description"] == "Maps research capability to search tools"
+    assert updated["owner_scope_type"] == "team"
+    assert updated["owner_scope_id"] == 21
+
+
+@pytest.mark.asyncio
+async def test_preview_update_allows_switching_to_global_scope_without_scope_id() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_update(
+        11,
+        owner_scope_type="global",
+    )
+
+    assert preview["normalized_mapping"]["owner_scope_type"] == "global"
+    assert preview["normalized_mapping"]["owner_scope_id"] is None
+    assert preview["affected_scope_summary"]["display_scope"] == "global"
+
+
+@pytest.mark.asyncio
+async def test_preview_update_allows_clearing_policy_document_with_null() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_update(
+        11,
+        resolved_policy_document=None,
+    )
+
+    assert preview["normalized_mapping"]["resolved_policy_document"] == {}

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
@@ -10,6 +10,21 @@ from tldw_Server_API.app.core.exceptions import BadRequestError
 class _FakeRepo:
     def __init__(self) -> None:
         self.created_payloads: list[dict] = []
+        self.inventory = {
+            11: {
+                "id": 11,
+                "mapping_id": "research.team",
+                "title": "Research Team Mapping",
+                "description": "Maps research capability to search tools",
+                "owner_scope_type": "team",
+                "owner_scope_id": 21,
+                "capability_name": "tool.invoke.research",
+                "adapter_contract_version": 1,
+                "resolved_policy_document": {"allowed_tools": ["web.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+                "is_active": True,
+            }
+        }
 
     async def create_capability_adapter_mapping(self, **kwargs):
         self.created_payloads.append(dict(kwargs))
@@ -30,6 +45,10 @@ class _FakeRepo:
             "created_at": datetime.now(timezone.utc).isoformat(),
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
+
+    async def get_capability_adapter_mapping(self, capability_adapter_mapping_id: int):
+        row = self.inventory.get(int(capability_adapter_mapping_id))
+        return dict(row) if row is not None else None
 
 
 class _FakeToolRegistry:
@@ -180,3 +199,40 @@ async def test_preview_mapping_expands_module_ids_to_tool_names() -> None:
         "module_ids": ["docs"],
         "tool_names": ["docs.search"],
     }
+
+
+@pytest.mark.asyncio
+async def test_preview_update_preserves_existing_scope_id_when_omitted() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_update(
+        11,
+        owner_scope_type="team",
+        title="Updated Team Mapping",
+    )
+
+    assert preview["normalized_mapping"]["owner_scope_type"] == "team"
+    assert preview["normalized_mapping"]["owner_scope_id"] == 21
+    assert preview["affected_scope_summary"]["display_scope"] == "team:21"
+
+
+@pytest.mark.asyncio
+async def test_preview_update_allows_clearing_nullable_description() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    repo = _FakeRepo()
+    svc = McpHubCapabilityAdapterService(repo=repo, tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_update(
+        11,
+        description=None,
+    )
+
+    assert preview["normalized_mapping"]["description"] is None

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_adapter_service.py
@@ -153,3 +153,30 @@ async def test_create_mapping_uses_normalized_preview_payload() -> None:
         "workspace_bounded_read"
     ]
     assert created["id"] == 11
+
+
+@pytest.mark.asyncio
+async def test_preview_mapping_expands_module_ids_to_tool_names() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
+        McpHubCapabilityAdapterService,
+    )
+
+    svc = McpHubCapabilityAdapterService(repo=_FakeRepo(), tool_registry=_FakeToolRegistry())
+
+    preview = await svc.preview_mapping(
+        mapping_id="docs.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.docs",
+        adapter_contract_version=1,
+        resolved_policy_document={"module_ids": ["docs"]},
+        supported_environment_requirements=[],
+        title="Docs",
+        description=None,
+        is_active=True,
+    )
+
+    assert preview["normalized_mapping"]["resolved_policy_document"] == {
+        "module_ids": ["docs"],
+        "tool_names": ["docs.search"],
+    }

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_resolution.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_resolution.py
@@ -49,6 +49,32 @@ class _FakeRepo:
                 "supported_environment_requirements": ["workspace_bounded_read", "future.flag"],
                 "is_active": True,
             },
+            ("org", 4, "tool.invoke.docs"): {
+                "id": 5,
+                "mapping_id": "docs.org.4",
+                "owner_scope_type": "org",
+                "owner_scope_id": 4,
+                "capability_name": "tool.invoke.docs",
+                "resolved_policy_document": {
+                    "module_ids": ["docs"],
+                    "tool_names": ["docs.search"],
+                },
+                "supported_environment_requirements": [],
+                "is_active": True,
+            },
+            ("org", 4, "tool.invoke.search"): {
+                "id": 6,
+                "mapping_id": "search.org.4",
+                "owner_scope_type": "org",
+                "owner_scope_id": 4,
+                "capability_name": "tool.invoke.search",
+                "resolved_policy_document": {
+                    "module_ids": ["search"],
+                    "tool_names": ["web.search"],
+                },
+                "supported_environment_requirements": [],
+                "is_active": True,
+            },
         }
 
     async def find_active_capability_mapping(
@@ -126,3 +152,20 @@ async def test_resolution_reports_unresolved_capabilities_dedupes_effects_and_tr
     assert result.supported_environment_requirements == ["workspace_bounded_read"]
     assert result.unsupported_environment_requirements == ["future.flag"]
     assert "tool.invoke.missing" in result.warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_resolution_unions_module_ids_across_multiple_capability_mappings() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+        McpHubCapabilityResolutionService,
+    )
+
+    service = McpHubCapabilityResolutionService(repo=_FakeRepo())
+
+    result = await service.resolve_capabilities(
+        capability_names=["tool.invoke.docs", "tool.invoke.search"],
+        metadata={"org_id": 4},
+    )
+
+    assert result.resolved_policy_document["module_ids"] == ["docs", "search"]
+    assert result.resolved_policy_document["tool_names"] == ["docs.search", "web.search"]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_resolution.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_capability_resolution.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeRepo:
+    def __init__(self) -> None:
+        self.rows = {
+            ("global", None, "tool.invoke.research"): {
+                "id": 1,
+                "mapping_id": "research.global",
+                "owner_scope_type": "global",
+                "owner_scope_id": None,
+                "capability_name": "tool.invoke.research",
+                "resolved_policy_document": {"allowed_tools": ["global.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+                "is_active": True,
+            },
+            ("org", 4, "tool.invoke.research"): {
+                "id": 2,
+                "mapping_id": "research.org.4",
+                "owner_scope_type": "org",
+                "owner_scope_id": 4,
+                "capability_name": "tool.invoke.research",
+                "resolved_policy_document": {"allowed_tools": ["org.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+                "is_active": True,
+            },
+            ("team", 9, "tool.invoke.research"): {
+                "id": 3,
+                "mapping_id": "research.team.9",
+                "owner_scope_type": "team",
+                "owner_scope_id": 9,
+                "capability_name": "tool.invoke.research",
+                "resolved_policy_document": {"allowed_tools": ["team.search"]},
+                "supported_environment_requirements": ["workspace_bounded_read"],
+                "is_active": True,
+            },
+            ("org", 4, "tool.invoke.notes"): {
+                "id": 4,
+                "mapping_id": "notes.org.4",
+                "owner_scope_type": "org",
+                "owner_scope_id": 4,
+                "capability_name": "tool.invoke.notes",
+                "resolved_policy_document": {
+                    "allowed_tools": ["notes.search", "notes.search"],
+                    "tool_patterns": ["notes.*"],
+                },
+                "supported_environment_requirements": ["workspace_bounded_read", "future.flag"],
+                "is_active": True,
+            },
+        }
+
+    async def find_active_capability_mapping(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+    ):
+        return self.rows.get((owner_scope_type, owner_scope_id, capability_name))
+
+
+@pytest.mark.asyncio
+async def test_resolution_prefers_team_mapping_over_org_and_global() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+        McpHubCapabilityResolutionService,
+    )
+
+    service = McpHubCapabilityResolutionService(repo=_FakeRepo())
+
+    result = await service.resolve_capabilities(
+        capability_names=["tool.invoke.research"],
+        metadata={"team_id": 9, "org_id": 4},
+    )
+
+    assert result.resolved_capabilities == ["tool.invoke.research"]
+    assert result.unresolved_capabilities == []
+    assert result.resolved_policy_document["allowed_tools"] == ["team.search"]
+    assert result.mapping_summaries[0]["mapping_scope_type"] == "team"
+    assert result.mapping_summaries[0]["mapping_scope_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_user_scoped_runtime_context_still_resolves_through_org_then_global() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+        McpHubCapabilityResolutionService,
+    )
+
+    service = McpHubCapabilityResolutionService(repo=_FakeRepo())
+
+    result = await service.resolve_capabilities(
+        capability_names=["tool.invoke.research"],
+        metadata={"user_id": 7, "org_id": 4},
+    )
+
+    assert result.resolved_capabilities == ["tool.invoke.research"]
+    assert result.resolved_policy_document["allowed_tools"] == ["org.search"]
+    assert result.mapping_summaries[0]["mapping_scope_type"] == "org"
+    assert result.mapping_summaries[0]["mapping_scope_id"] == 4
+
+
+@pytest.mark.asyncio
+async def test_resolution_reports_unresolved_capabilities_dedupes_effects_and_tracks_requirement_support() -> None:
+    from tldw_Server_API.app.services.mcp_hub_capability_resolution_service import (
+        McpHubCapabilityResolutionService,
+    )
+
+    service = McpHubCapabilityResolutionService(repo=_FakeRepo())
+
+    result = await service.resolve_capabilities(
+        capability_names=[
+            "tool.invoke.notes",
+            "tool.invoke.missing",
+            "tool.invoke.notes",
+        ],
+        metadata={"org_id": 4},
+    )
+
+    assert result.resolved_capabilities == ["tool.invoke.notes"]
+    assert result.unresolved_capabilities == ["tool.invoke.missing"]
+    assert result.resolved_policy_document == {
+        "allowed_tools": ["notes.search"],
+        "tool_patterns": ["notes.*"],
+    }
+    assert result.supported_environment_requirements == ["workspace_bounded_read"]
+    assert result.unsupported_environment_requirements == ["future.flag"]
+    assert "tool.invoke.missing" in result.warnings[0]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
@@ -87,6 +87,19 @@ class _FakeGovernancePackService:
             "digest": "a" * 64,
             "resolved_capabilities": ["filesystem.read", "tool.invoke.research"],
             "unresolved_capabilities": [],
+            "capability_mapping_summary": [
+                {
+                    "capability_name": "tool.invoke.research",
+                    "mapping_id": "research.global",
+                    "mapping_scope_type": "global",
+                    "mapping_scope_id": None,
+                    "resolved_effects": {"allowed_tools": ["web.search"]},
+                    "supported_environment_requirements": ["workspace_bounded_read"],
+                    "unsupported_environment_requirements": [],
+                }
+            ],
+            "supported_environment_requirements": ["workspace_bounded_read"],
+            "unsupported_environment_requirements": [],
             "warnings": [],
             "blocked_objects": [],
             "verdict": "importable",
@@ -285,6 +298,7 @@ def test_governance_pack_dry_run_returns_compatibility_report() -> None:
         "tool.invoke.research",
     ]
     assert payload["report"]["unresolved_capabilities"] == []
+    assert payload["report"]["capability_mapping_summary"][0]["mapping_id"] == "research.global"
     assert payload["report"]["verdict"] == "importable"
 
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -264,6 +264,79 @@ async def test_import_governance_pack_rejects_duplicate_scope_identity(
             actor_id=7,
         )
 
+
+@pytest.mark.asyncio
+async def test_imported_governance_pack_denied_capabilities_narrow_runtime_policy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    service = McpHubGovernancePackService(repo=repo)
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+    pack.profiles[0].capabilities.deny = ["tool.invoke.docs"]
+
+    await repo.create_capability_adapter_mapping(
+        mapping_id="filesystem.read.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="filesystem.read",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["files.read"]},
+        supported_environment_requirements=["workspace_bounded_read"],
+        is_active=True,
+        actor_id=7,
+    )
+    await repo.create_capability_adapter_mapping(
+        mapping_id="tool.invoke.research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=7,
+    )
+    await repo.create_capability_adapter_mapping(
+        mapping_id="tool.invoke.docs.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.docs",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["docs.search"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=7,
+    )
+
+    await service.import_pack(
+        pack=pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    resolver = McpHubPolicyResolver(repo=repo)
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+    assert sorted(policy["allowed_tools"]) == ["files.read", "web.search"]
+    assert policy["denied_tools"] == ["docs.search"]
+    assert any(
+        summary["capability_name"] == "tool.invoke.docs" and summary["resolution_intent"] == "deny"
+        for summary in policy["capability_mapping_summary"]
+    )
+
     inventory = await repo.list_governance_packs(owner_scope_type="user", owner_scope_id=7)
     assert len(inventory) == 1
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -5,21 +5,11 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.asyncio
-async def test_import_governance_pack_materializes_immutable_base_objects_with_provenance(
-    tmp_path,
-    monkeypatch,
-) -> None:
+async def _make_repo(tmp_path, monkeypatch):
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
     from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
     from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
-    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
-        load_governance_pack_fixture,
-    )
-    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
-        McpHubGovernancePackService,
-    )
 
     db_path = tmp_path / "users.db"
     monkeypatch.setenv("AUTH_MODE", "multi_user")
@@ -33,6 +23,147 @@ async def test_import_governance_pack_materializes_immutable_base_objects_with_p
 
     repo = McpHubRepo(pool)
     await repo.ensure_tables()
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_dry_run_governance_pack_uses_live_capability_mappings(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    service = McpHubGovernancePackService(repo=repo)
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+
+    report = await service.dry_run_pack(
+        pack=pack,
+        owner_scope_type="team",
+        owner_scope_id=21,
+    )
+
+    assert report.verdict == "blocked"
+    assert report.resolved_capabilities == []
+    assert sorted(report.unresolved_capabilities) == [
+        "filesystem.read",
+        "tool.invoke.research",
+    ]
+    assert report.capability_mapping_summary == []
+
+    await repo.create_capability_adapter_mapping(
+        mapping_id="filesystem.read.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="filesystem.read",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["files.read"]},
+        supported_environment_requirements=["workspace_bounded_read"],
+        is_active=True,
+        actor_id=7,
+    )
+    await repo.create_capability_adapter_mapping(
+        mapping_id="tool.invoke.research.team-21",
+        owner_scope_type="team",
+        owner_scope_id=21,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=7,
+    )
+
+    report = await service.dry_run_pack(
+        pack=pack,
+        owner_scope_type="team",
+        owner_scope_id=21,
+    )
+
+    assert report.verdict == "importable"
+    assert sorted(report.resolved_capabilities) == [
+        "filesystem.read",
+        "tool.invoke.research",
+    ]
+    assert report.unresolved_capabilities == []
+    assert sorted(summary["mapping_id"] for summary in report.capability_mapping_summary) == [
+        "filesystem.read.global",
+        "tool.invoke.research.team-21",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_governance_pack_warns_when_profile_requirement_not_guaranteed(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    service = McpHubGovernancePackService(repo=repo)
+    pack = load_governance_pack_fixture("minimal_researcher_pack")
+    pack.profiles[0].environment_requirements = ["workspace_bounded_write"]
+
+    await repo.create_capability_adapter_mapping(
+        mapping_id="filesystem.read.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="filesystem.read",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["files.read"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=7,
+    )
+    await repo.create_capability_adapter_mapping(
+        mapping_id="tool.invoke.research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=7,
+    )
+
+    report = await service.dry_run_pack(
+        pack=pack,
+        owner_scope_type="global",
+        owner_scope_id=None,
+    )
+
+    assert report.verdict == "importable"
+    assert report.unresolved_capabilities == []
+    assert (
+        "profile:researcher.profile requires environment requirement 'workspace_bounded_write' "
+        "but current capability mappings do not guarantee it"
+    ) in report.warnings
+
+
+@pytest.mark.asyncio
+async def test_import_governance_pack_materializes_immutable_base_objects_with_provenance(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
 
     pack = load_governance_pack_fixture("minimal_researcher_pack")
     service = McpHubGovernancePackService(repo=repo)
@@ -105,10 +236,6 @@ async def test_import_governance_pack_rejects_duplicate_scope_identity(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
-    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
-    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
-    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
     from tldw_Server_API.app.core.MCP_unified.governance_packs import (
         load_governance_pack_fixture,
     )
@@ -117,18 +244,7 @@ async def test_import_governance_pack_rejects_duplicate_scope_identity(
         McpHubGovernancePackService,
     )
 
-    db_path = tmp_path / "users.db"
-    monkeypatch.setenv("AUTH_MODE", "multi_user")
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-
-    reset_settings()
-    await reset_db_pool()
-
-    pool = await get_db_pool()
-    ensure_authnz_tables(Path(str(db_path)))
-
-    repo = McpHubRepo(pool)
-    await repo.ensure_tables()
+    repo = await _make_repo(tmp_path, monkeypatch)
 
     pack = load_governance_pack_fixture("minimal_researcher_pack")
     service = McpHubGovernancePackService(repo=repo)
@@ -157,10 +273,6 @@ async def test_import_governance_pack_rolls_back_partial_objects_on_failure(
     tmp_path,
     monkeypatch,
 ) -> None:
-    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
-    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
-    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
-    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
     from tldw_Server_API.app.core.MCP_unified.governance_packs import (
         load_governance_pack_fixture,
     )
@@ -168,18 +280,7 @@ async def test_import_governance_pack_rolls_back_partial_objects_on_failure(
         McpHubGovernancePackService,
     )
 
-    db_path = tmp_path / "users.db"
-    monkeypatch.setenv("AUTH_MODE", "multi_user")
-    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
-
-    reset_settings()
-    await reset_db_pool()
-
-    pool = await get_db_pool()
-    ensure_authnz_tables(Path(str(db_path)))
-
-    repo = McpHubRepo(pool)
-    await repo.ensure_tables()
+    repo = await _make_repo(tmp_path, monkeypatch)
 
     original_create_policy_assignment = repo.create_policy_assignment
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_overrides.py
@@ -175,6 +175,18 @@ class _ResolverRepo:
     async def get_policy_override_by_assignment(self, assignment_id: int) -> dict | None:
         return self.overrides.get(assignment_id)
 
+    async def list_policy_assignment_workspaces(self, assignment_id: int) -> list[dict]:  # noqa: ARG002
+        return []
+
+    async def find_active_capability_mapping(
+        self,
+        *,
+        owner_scope_type: str,  # noqa: ARG002
+        owner_scope_id: int | None,  # noqa: ARG002
+        capability_name: str,  # noqa: ARG002
+    ) -> dict | None:
+        return None
+
 
 @pytest.mark.asyncio
 async def test_policy_resolver_applies_assignment_override_and_emits_provenance() -> None:
@@ -191,6 +203,7 @@ async def test_policy_resolver_applies_assignment_override_and_emits_provenance(
     assert policy["allowed_tools"] == ["notes.search", "Bash(git *)", "remote.fetch"]
     assert policy["capabilities"] == ["filesystem.read"]
     assert policy["approval_mode"] == "ask_outside_profile"
+    assert policy["authored_policy_document"] == policy["resolved_policy_document"]
     assert policy["sources"] == [
         {
             "assignment_id": 12,
@@ -199,6 +212,7 @@ async def test_policy_resolver_applies_assignment_override_and_emits_provenance(
             "owner_scope_type": "user",
             "owner_scope_id": 7,
             "profile_id": 1,
+            "path_scope_object_id": None,
         }
     ]
     assert policy["provenance"] == [
@@ -256,6 +270,20 @@ async def test_policy_resolver_applies_assignment_override_and_emits_provenance(
             "override_id": 101,
             "effect": "replaced",
         },
+        {
+            "field": "capabilities",
+            "value": "filesystem.read",
+            "source_kind": "capability_mapping",
+            "assignment_id": None,
+            "profile_id": None,
+            "override_id": None,
+            "capability_name": "filesystem.read",
+            "mapping_id": None,
+            "mapping_scope_type": None,
+            "mapping_scope_id": None,
+            "resolved_effects": {},
+            "effect": "blocked",
+        },
     ]
 
 
@@ -273,6 +301,7 @@ async def test_policy_resolver_ignores_inactive_assignment_override() -> None:
     assert policy["enabled"] is True
     assert policy["allowed_tools"] == ["notes.search", "Bash(git *)"]
     assert policy["approval_mode"] == "ask_every_time"
+    assert policy["unresolved_capabilities"] == ["filesystem.read"]
     assert not any(
         entry["source_kind"] == "assignment_override" for entry in policy["provenance"]
     )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -346,6 +346,7 @@ async def test_policy_resolver_returns_authored_and_resolved_documents_when_mapp
     assert policy["capability_mapping_summary"] == [
         {
             "capability_name": "tool.invoke.research",
+            "resolution_intent": "allow",
             "mapping_id": "research.global",
             "mapping_scope_type": "global",
             "mapping_scope_id": None,
@@ -395,5 +396,56 @@ async def test_policy_resolver_keeps_unresolved_capabilities_visible_without_gra
         entry["source_kind"] == "capability_mapping"
         and entry["capability_name"] == "tool.invoke.unmapped"
         and entry["effect"] == "blocked"
+        for entry in policy["provenance"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_turns_denied_capabilities_into_denied_tool_patterns() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = _FakeRepo()
+    repo.assignments = [repo.assignments[0]]
+    repo.profiles[1]["policy_document"] = {
+        "capabilities": ["filesystem.read"],
+        "denied_capabilities": ["tool.invoke.docs"],
+    }
+    repo.capability_mappings = {
+        ("global", None, "filesystem.read"): {
+            "mapping_id": "filesystem.read.global",
+            "owner_scope_type": "global",
+            "owner_scope_id": None,
+            "capability_name": "filesystem.read",
+            "resolved_policy_document": {"allowed_tools": ["files.read"]},
+            "supported_environment_requirements": [],
+            "is_active": True,
+        },
+        ("global", None, "tool.invoke.docs"): {
+            "mapping_id": "docs.global",
+            "owner_scope_type": "global",
+            "owner_scope_id": None,
+            "capability_name": "tool.invoke.docs",
+            "resolved_policy_document": {"allowed_tools": ["docs.search"]},
+            "supported_environment_requirements": [],
+            "is_active": True,
+        },
+    }
+    resolver = McpHubPolicyResolver(repo=repo)
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+    assert policy["allowed_tools"] == ["files.read"]
+    assert policy["denied_tools"] == ["docs.search"]
+    assert sorted(summary["resolution_intent"] for summary in policy["capability_mapping_summary"]) == [
+        "allow",
+        "deny",
+    ]
+    assert any(
+        entry["source_kind"] == "capability_mapping"
+        and entry["capability_name"] == "tool.invoke.docs"
+        and entry["effect"] == "narrowed"
         for entry in policy["provenance"]
     )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -90,6 +90,7 @@ class _FakeRepo:
         ]
         self.overrides: dict[int, dict] = {}
         self.assignment_workspaces: dict[int, list[str]] = {}
+        self.capability_mappings: dict[tuple[str, int | None, str], dict] = {}
 
     async def list_policy_assignments(
         self,
@@ -125,6 +126,15 @@ class _FakeRepo:
             for workspace_id in self.assignment_workspaces.get(assignment_id, [])
         ]
 
+    async def find_active_capability_mapping(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        capability_name: str,
+    ) -> dict | None:
+        return self.capability_mappings.get((owner_scope_type, owner_scope_id, capability_name))
+
 
 @pytest.mark.asyncio
 async def test_policy_resolver_merges_default_group_and_persona_targets() -> None:
@@ -150,6 +160,8 @@ async def test_policy_resolver_merges_default_group_and_persona_targets() -> Non
     assert policy["denied_tools"] == ["external.tools.refresh"]
     assert policy["capabilities"] == ["filesystem.read", "network.external"]
     assert policy["approval_mode"] == "ask_every_time"
+    assert policy["authored_policy_document"] == policy["policy_document"]
+    assert policy["resolved_policy_document"] == policy["policy_document"]
     assert policy["policy_document"]["path_scope_mode"] == "cwd_descendants"
     assert policy["policy_document"]["path_scope_enforcement"] == "approval_required_when_unenforceable"
     assert [source["assignment_id"] for source in policy["sources"]] == [10, 11, 12]
@@ -268,5 +280,120 @@ async def test_policy_resolver_applies_path_scope_object_layers_before_inline_an
     assert any(
         entry["field"] == "path_scope_mode"
         and entry["source_kind"] == "assignment_path_scope_object"
+        for entry in policy["provenance"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_returns_authored_and_resolved_documents_when_mapping_applies() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = _FakeRepo()
+    repo.profiles[1]["policy_document"] = {
+        "allowed_tools": ["notes.search"],
+        "capabilities": ["tool.invoke.research"],
+        "path_scope_enforcement": "approval_required_when_unenforceable",
+    }
+    repo.capability_mappings[("global", None, "tool.invoke.research")] = {
+        "mapping_id": "research.global",
+        "owner_scope_type": "global",
+        "owner_scope_id": None,
+        "capability_name": "tool.invoke.research",
+        "resolved_policy_document": {
+            "allowed_tools": ["web.search"],
+            "approval_mode": "allow_silently",
+            "path_scope_mode": "workspace_root",
+        },
+        "supported_environment_requirements": ["workspace_bounded_read"],
+        "is_active": True,
+    }
+    resolver = McpHubPolicyResolver(repo=repo)
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={
+            "mcp_policy_context_enabled": True,
+            "group_id": "ops",
+            "persona_id": "researcher",
+        },
+    )
+
+    assert policy["authored_policy_document"]["allowed_tools"] == [
+        "notes.search",
+        "external.servers.list",
+        "Bash(git *)",
+    ]
+    assert policy["authored_policy_document"]["capabilities"] == [
+        "tool.invoke.research",
+        "network.external",
+    ]
+    assert policy["resolved_policy_document"]["allowed_tools"] == [
+        "notes.search",
+        "external.servers.list",
+        "Bash(git *)",
+        "web.search",
+    ]
+    assert policy["resolved_policy_document"]["approval_mode"] == "ask_every_time"
+    assert policy["resolved_policy_document"]["path_scope_mode"] == "cwd_descendants"
+    assert policy["allowed_tools"] == [
+        "notes.search",
+        "external.servers.list",
+        "Bash(git *)",
+        "web.search",
+    ]
+    assert policy["resolved_capabilities"] == ["tool.invoke.research"]
+    assert policy["unresolved_capabilities"] == ["network.external"]
+    assert policy["capability_mapping_summary"] == [
+        {
+            "capability_name": "tool.invoke.research",
+            "mapping_id": "research.global",
+            "mapping_scope_type": "global",
+            "mapping_scope_id": None,
+            "resolved_effects": {
+                "allowed_tools": ["web.search"],
+                "approval_mode": "allow_silently",
+                "path_scope_mode": "workspace_root",
+            },
+            "supported_environment_requirements": ["workspace_bounded_read"],
+            "unsupported_environment_requirements": [],
+        }
+    ]
+    assert any(
+        entry["source_kind"] == "capability_mapping"
+        and entry["capability_name"] == "tool.invoke.research"
+        and entry["mapping_id"] == "research.global"
+        and entry["effect"] == "merged"
+        for entry in policy["provenance"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_keeps_unresolved_capabilities_visible_without_grants() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = _FakeRepo()
+    repo.assignments = [repo.assignments[0]]
+    repo.profiles[1]["policy_document"] = {
+        "capabilities": ["tool.invoke.unmapped"],
+    }
+    resolver = McpHubPolicyResolver(repo=repo)
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={"mcp_policy_context_enabled": True},
+    )
+
+    assert policy["allowed_tools"] == []
+    assert policy["authored_policy_document"] == {"capabilities": ["tool.invoke.unmapped"]}
+    assert policy["resolved_policy_document"] == {"capabilities": ["tool.invoke.unmapped"]}
+    assert policy["resolved_capabilities"] == []
+    assert policy["unresolved_capabilities"] == ["tool.invoke.unmapped"]
+    assert policy["capability_warnings"] == [
+        "No active capability adapter mapping found for 'tool.invoke.unmapped'"
+    ]
+    assert any(
+        entry["source_kind"] == "capability_mapping"
+        and entry["capability_name"] == "tool.invoke.unmapped"
+        and entry["effect"] == "blocked"
         for entry in policy["provenance"]
     )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_shared_workspace_registry.py
@@ -128,3 +128,4 @@ async def test_policy_resolver_marks_shared_workspace_set_as_shared_registry_sou
     assert policy["selected_workspace_set_object_name"] == "Team Workspaces"
     assert policy["selected_workspace_trust_source"] == "shared_registry"
     assert policy["selected_assignment_workspace_ids"] == ["shared-docs"]
+    assert policy["authored_policy_document"] == policy["resolved_policy_document"]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_root_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_root_resolver.py
@@ -76,6 +76,30 @@ async def test_workspace_root_resolver_prefers_session_root() -> None:
 
 
 @pytest.mark.asyncio
+async def test_workspace_root_resolver_uses_session_root_without_user_context() -> None:
+    from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
+        McpHubWorkspaceRootResolver,
+    )
+
+    resolver = McpHubWorkspaceRootResolver(
+        sandbox_service=_FakeSandboxService(
+            session_roots={"sess-1": "/tmp/mcp-hub-workspace/session-root"},
+            session_owners={"sess-1": "7"},
+        )
+    )
+
+    result = await resolver.resolve_for_context(
+        session_id="sess-1",
+        user_id=None,
+        workspace_id=None,
+    )
+
+    assert result["workspace_root"] == str(Path("/tmp/mcp-hub-workspace/session-root").resolve())
+    assert result["source"] == "sandbox_session"
+    assert result["reason"] is None
+
+
+@pytest.mark.asyncio
 async def test_workspace_root_resolver_ignores_session_root_owned_by_other_user() -> None:
     from tldw_Server_API.app.services.mcp_hub_workspace_root_resolver import (
         McpHubWorkspaceRootResolver,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_workspace_set_objects.py
@@ -105,3 +105,4 @@ async def test_policy_resolver_uses_named_workspace_set_members_over_preserved_i
     assert policy["selected_workspace_set_object_id"] == 501
     assert policy["selected_workspace_set_object_name"] == "Research Workspaces"
     assert policy["selected_assignment_workspace_ids"] == ["workspace-alpha", "workspace-beta"]
+    assert policy["authored_policy_document"] == policy["resolved_policy_document"]


### PR DESCRIPTION
## Summary
- add MCP Hub capability adapter mapping storage, APIs, and scope-aware resolution
- resolve portable capabilities through the effective-policy path and governance-pack dry-run/import
- add MCP Hub UI for capability mappings and resolved-policy visibility

## Verification
- backend MCP Hub slice: 30 passed
- focused UI slice: 10 passed
- broader MCP Hub UI regression slice: 62 passed
- Bandit on touched backend services/endpoints: 0 issues
- git diff --check: clean

## Local Review Findings To Address
1. `tool_modules` and `module_ids` are validated by the mapping service but are not union-merged by the capability resolution/effective-policy merge path, so module-based mapping effects can be lost when multiple mappings contribute policy.
2. governance-pack `capabilities.deny` is not implemented end-to-end: dry-run treats deny capabilities as resolvable requirements, but imported `denied_capabilities` are not consumed by the policy resolver/runtime path.