### PR TITLE
Persona setup detours, handoff tightening, and setup analytics

### DIFF
--- a/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-design.md
@@ -1,0 +1,472 @@
+# Persona Setup Handoff Tightening And Analytics Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+Finish the remaining post-setup handoff tightening in Persona Garden and add
+setup-specific analytics that can answer whether setup actually leads to first
+successful use.
+
+This slice should:
+
+- make the post-setup handoff recommend one clear next step
+- keep the handoff visible long enough to bridge into real use
+- record setup and handoff behavior without mixing it into live voice runtime
+  analytics
+
+## Why This Slice Exists
+
+The current setup flow is functionally complete, but the completion handoff is
+still thinner than the rest of the setup experience.
+
+Today:
+
+- the handoff card shows useful review data, but it clears on any handoff action
+- the card does not distinguish between navigation and real follow-through
+- the route has no explicit notion of a first meaningful post-setup action
+- setup success and recovery are not instrumented separately from live voice
+  analytics
+
+That means the UX is still abrupt after completion, and product decisions about
+which setup paths work best are still guesswork.
+
+## Scope
+
+### In scope
+
+- post-setup handoff recommendation logic
+- delayed handoff dismissal and compact post-consumption state
+- explicit `setup_run_id` correlation for setup flows
+- append-only setup analytics event persistence and a small summary read path
+- route-side setup analytics emission and handoff instrumentation
+- focused frontend/backend tests
+
+### Out of scope
+
+- new live voice runtime behavior
+- generic product telemetry
+- a full analytics dashboard
+- stable scroll/focus anchors across all Persona Garden tabs
+- broad setup wizard redesign
+
+## Review-Driven Constraints
+
+### 1. Setup runs need a durable identifier
+
+The current persona setup state stores:
+
+- `status`
+- `version`
+- `current_step`
+- `completed_steps`
+- `completed_at`
+- `last_test_type`
+
+That is not enough to group events into one setup attempt across:
+
+- resume after reload
+- reset
+- rerun
+- completion and handoff actions
+
+This design adds a durable `run_id` to setup state. That `run_id` is the
+correlation key for setup analytics and for post-completion handoff state.
+
+### 2. Handoff persistence needs explicit rules
+
+The current route clears `setupHandoff` on any handoff action. That is too
+eager, but replacing it with vague “keep the handoff around longer” behavior is
+not enough.
+
+This design makes the rule explicit:
+
+- same-tab handoff actions keep the handoff visible on the current tab
+- cross-tab handoff actions retarget the handoff to the destination tab
+- the handoff clears only on:
+  - explicit dismiss
+  - persona/setup context change
+  - first successful post-setup action, which collapses it into a compact
+    completion banner instead of dropping it immediately
+
+### 3. First post-setup action must mean success, not navigation
+
+CTA clicks and tab switches are not meaningful follow-through by themselves.
+
+This design treats only successful domain actions as
+`first_post_setup_action`, for example:
+
+- `command_saved`
+- `connection_saved`
+- `connection_test_succeeded`
+- `voice_defaults_saved`
+- `dry_run_match`
+- `live_response_received`
+
+Navigation events remain `handoff_action_clicked`, not success.
+
+### 4. Same-tab anchoring is not ready in V1
+
+Commands, Profiles, and Connections do not currently expose a stable
+handoff-anchor contract. This design does not promise scroll/focus targeting in
+V1.
+
+Instead:
+
+- same-tab actions keep the handoff visible
+- cross-tab actions retarget the handoff to the new tab
+- target anchoring can be a later polish slice once dedicated refs exist
+
+### 5. Setup analytics should not ride on profile PATCH writes
+
+Setup profile mutations are already versioned with `expected_version`. Analytics
+events are append-only. Combining those two concerns would create conflict
+churn, couple telemetry to mutable profile state, and make retries harder to
+reason about.
+
+This design uses:
+
+- profile PATCH for setup state and setup `run_id`
+- a separate append-only setup analytics event endpoint/table for instrumentation
+
+### 6. Dedupe rules must be explicit
+
+Some setup events are effect-driven and should be recorded at most once per run
+or step. Others are user-click-driven and may occur more than once.
+
+This design splits them into two groups:
+
+- deterministic once-only events with stable `event_key`
+- user-action events with unique `event_id`
+
+## Chosen Approach
+
+Use a route-owned, run-aware handoff model on the frontend and a separate,
+append-only persona setup analytics store on the backend.
+
+Concretely:
+
+1. Extend `PersonaSetupState` with a persistent `run_id`.
+2. Freeze `run_id`, review summary, completion type, and recommended next step
+   into `setupHandoff` at completion time.
+3. Let handoff actions either preserve the handoff on the same tab or retarget
+   it to a new tab.
+4. Collapse the full handoff into a compact success banner only after one
+   successful post-setup action.
+5. Emit setup analytics events through a dedicated route-level helper into a new
+   append-only backend table.
+6. Expose a small setup analytics summary endpoint for recent runs and aggregate
+   handoff/recovery metrics.
+
+This keeps UX state and analytics state coherent without turning setup
+instrumentation into another profile mutation layer.
+
+## Setup State Model
+
+### `PersonaSetupState`
+
+Extend setup state with:
+
+```ts
+type PersonaSetupState = {
+  status: "not_started" | "in_progress" | "completed"
+  version: number
+  run_id: string | null
+  current_step: PersonaSetupStep
+  completed_steps: PersonaSetupStep[]
+  completed_at: string | null
+  last_test_type: "dry_run" | "live_session" | null
+}
+```
+
+### `run_id` lifecycle
+
+- when setup starts from `not_started`, generate a new `run_id`
+- when setup is reset or rerun, generate a new `run_id`
+- when setup resumes, keep the existing `run_id`
+- when setup completes, keep that `run_id` in the completed setup state until
+  the next reset/rerun
+
+This gives the route and backend one durable identifier for:
+
+- step progress
+- detours
+- completion
+- handoff actions
+- first real post-setup success
+
+## Handoff Tightening
+
+### Handoff state
+
+Extend the current route-owned handoff state to include:
+
+```ts
+type SetupRecommendedActionTarget =
+  | "commands"
+  | "connections"
+  | "profiles"
+  | "live"
+  | "test-lab"
+
+type SetupPostSetupActionType =
+  | "command_saved"
+  | "connection_saved"
+  | "connection_test_succeeded"
+  | "voice_defaults_saved"
+  | "dry_run_match"
+  | "live_response_received"
+
+type SetupHandoffState = {
+  runId: string
+  targetTab: PersonaGardenTabKey
+  completionType: "dry_run" | "live_session"
+  reviewSummary: SetupReviewSummary
+  recommendedAction: {
+    target: SetupRecommendedActionTarget
+    label: string
+    reason: string
+  }
+  consumedAction: SetupPostSetupActionType | null
+  compact: boolean
+}
+```
+
+### Recommended next step
+
+Derive one preferred next step from the frozen review summary plus completion
+type:
+
+- no starter commands configured:
+  - target: `commands`
+  - label: `Add your first command`
+- no connection available:
+  - target: `connections`
+  - label: `Add a connection`
+- completed by `dry_run`:
+  - target: `live`
+  - label: `Try your first live turn`
+- completed by `live_session`:
+  - target: `commands`
+  - label: `Review starter commands`
+- fallback:
+  - target: `profiles`
+  - label: `Adjust assistant defaults`
+
+The handoff card should present this as the primary CTA and keep the starter
+pack review rows as secondary actions.
+
+### Persistence and dismissal rules
+
+- the full handoff card renders on `setupHandoff.targetTab`
+- clicking a same-tab action:
+  - keeps `setupHandoff` intact
+  - records `handoff_action_clicked`
+- clicking a cross-tab action:
+  - switches `activeTab`
+  - retargets `setupHandoff.targetTab`
+  - records `handoff_action_clicked`
+- clicking dismiss:
+  - clears `setupHandoff`
+  - records `handoff_dismissed`
+
+### Compact completion state
+
+After the first successful post-setup action:
+
+- do not remove the handoff immediately
+- set `compact = true`
+- replace the full review card with a smaller `Setup complete` banner for the
+  current setup run
+
+The compact banner exists to confirm follow-through without keeping the full
+review UI on screen indefinitely.
+
+It clears on:
+
+- explicit dismiss
+- persona/setup context change
+- reset/rerun
+
+## Setup Analytics
+
+### Separate analytics model
+
+Add a new append-only setup analytics model separate from persona live voice
+analytics.
+
+Recommended table: `persona_setup_events`
+
+Fields:
+
+- `event_id`
+- `user_id`
+- `persona_id`
+- `run_id`
+- `event_type`
+- `event_key`
+- `step`
+- `completion_type`
+- `detour_source`
+- `action_target`
+- `created_at`
+- `metadata_json`
+
+### Event types
+
+Recommended initial set:
+
+- `setup_started`
+- `step_viewed`
+- `step_completed`
+- `step_error`
+- `retry_clicked`
+- `detour_started`
+- `detour_returned`
+- `setup_completed`
+- `handoff_action_clicked`
+- `handoff_dismissed`
+- `first_post_setup_action`
+
+### Dedupe and idempotency
+
+Use both `event_id` and optional `event_key`.
+
+- `event_id`
+  - always unique
+  - required for every event
+- `event_key`
+  - present for once-only events
+  - unique within `(persona_id, run_id, event_key)`
+
+Once-only events should use deterministic keys such as:
+
+- `setup_started`
+- `step_viewed:test`
+- `step_completed:commands`
+- `setup_completed`
+- `handoff_dismissed`
+- `first_post_setup_action`
+
+Repeatable click-driven events such as `retry_clicked` and
+`handoff_action_clicked` should omit `event_key` and use a fresh `event_id`.
+
+### Backend summary API
+
+Add a small summary endpoint:
+
+- `GET /api/v1/persona/profiles/{persona_id}/setup-analytics`
+
+Recommended response shape:
+
+- aggregate summary:
+  - `total_runs`
+  - `completed_runs`
+  - `completion_rate`
+  - `dry_run_completion_count`
+  - `live_session_completion_count`
+  - `most_common_dropoff_step`
+  - `handoff_click_rate`
+  - `first_post_setup_action_rate`
+  - detour recovery counts by source
+- recent runs:
+  - `run_id`
+  - `started_at`
+  - `completed_at`
+  - `completion_type`
+  - `terminal_step`
+  - `handoff_clicked`
+  - `handoff_dismissed`
+  - `first_post_setup_action`
+
+### Frontend emission rules
+
+The route should emit setup analytics best-effort from the handlers and effects
+that already own setup state:
+
+- on start/reset/rerun -> `setup_started`
+- on step changes -> `step_viewed`
+- on successful step transitions -> `step_completed`
+- on step-local failures -> `step_error`
+- on retry buttons -> `retry_clicked`
+- on setup detours -> `detour_started`
+- on return from detours -> `detour_returned`
+- on completion -> `setup_completed`
+- on handoff CTA clicks -> `handoff_action_clicked`
+- on dismiss -> `handoff_dismissed`
+- on first successful post-setup action -> `first_post_setup_action`
+
+These writes should be best-effort and never block setup UX.
+
+## V1 Analytics Exposure
+
+This PR should not add a full end-user analytics dashboard.
+
+V1 analytics exposure is:
+
+- append-only event persistence
+- one setup analytics summary endpoint
+- backend and route tests proving the emitted data is correct
+
+Any future Profiles-side setup insights card can reuse that endpoint later.
+
+## Testing
+
+### Frontend
+
+- `PersonaSetupHandoffCard.test.tsx`
+  - recommended CTA derivation
+  - compact banner rendering after `consumedAction`
+- `sidepanel-persona.test.tsx`
+  - same-tab handoff action keeps the handoff visible
+  - cross-tab handoff action retargets the handoff
+  - first successful post-setup action collapses the handoff
+  - setup analytics events are emitted with the correct run/action metadata
+
+### Backend
+
+- `test_persona_profiles_api.py`
+  - setup `run_id` round-trips through profile create/update/get
+- new setup analytics API tests
+  - append-only event write
+  - once-only dedupe via `event_key`
+  - recent run summary aggregation
+
+### End-to-end
+
+- one Playwright update:
+  - complete setup
+  - land on handoff
+  - take the recommended next action
+  - verify compact completion state instead of abrupt disappearance
+
+## Risks
+
+### Overcounting events
+
+Mitigation:
+
+- deterministic `event_key` for once-only events
+- unique `event_id` for repeatable actions
+- keep effect-driven analytics emission in one route helper
+
+### Handoff staying around too long
+
+Mitigation:
+
+- compact the handoff after first successful action
+- keep explicit dismiss available
+
+### Scope creep from target anchoring
+
+Mitigation:
+
+- do not promise scroll/focus targeting in V1
+- keep same-tab behavior limited to persistence, not deep navigation
+
+## Recommended Slice Order
+
+1. add `run_id` and backend setup analytics primitives
+2. wire route-level setup analytics emission
+3. tighten handoff recommendation/retargeting/collapse behavior
+4. add Playwright coverage for the post-setup action flow

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md
@@ -1,0 +1,555 @@
+# Persona Setup Handoff Tightening And Analytics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Tighten the Persona Garden post-setup handoff so it survives into real first use, and add setup-specific analytics that measure setup completion, recovery, and first post-setup success.
+
+**Architecture:** Extend persona setup state with a durable `run_id`, add a separate append-only `persona_setup_events` model and summary endpoint on the backend, then teach `sidepanel-persona.tsx` to emit setup events and keep the handoff alive until a successful post-setup action collapses it into a compact banner. Keep analytics separate from live voice/runtime analytics and keep same-tab handoff behavior anchor-free in V1.
+
+**Tech Stack:** FastAPI, Pydantic, SQLite/PostgreSQL DB helpers, React, TypeScript, Vitest, React Testing Library, Playwright, Bun.
+
+---
+
+### Task 1: Add Setup `run_id` To Persona Setup State
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_profiles_api.py`
+
+**Step 1: Write the failing backend tests**
+
+Add coverage proving `run_id` is preserved through persona profile operations:
+
+```python
+def test_persona_profile_setup_run_id_round_trips(client, auth_headers):
+    create_resp = client.post(
+        "/api/v1/persona/profiles",
+        json={
+            "id": "garden-helper",
+            "name": "Garden Helper",
+            "setup": {
+                "status": "in_progress",
+                "run_id": "setup-run-1",
+                "current_step": "commands",
+                "completed_steps": ["persona", "voice"],
+            },
+        },
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+    assert create_resp.json()["setup"]["run_id"] == "setup-run-1"
+```
+
+Also add a PATCH/update assertion for reset/rerun shape.
+
+**Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q -k run_id
+```
+
+Expected: FAIL because `PersonaSetupState` does not yet include `run_id`.
+
+**Step 3: Add the minimal schema support**
+
+In `persona.py`, extend `PersonaSetupState`:
+
+```python
+class PersonaSetupState(BaseModel):
+    status: PersonaSetupStatus = "not_started"
+    version: int = Field(default=1, ge=1)
+    run_id: str | None = Field(default=None, min_length=1, max_length=200)
+    current_step: PersonaSetupStep = "persona"
+    completed_steps: list[PersonaSetupStep] = Field(default_factory=list)
+    completed_at: str | None = None
+    last_test_type: PersonaSetupTestType | None = None
+```
+
+Do not add extra setup fields in this task.
+
+**Step 4: Re-run the targeted test**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py -q -k run_id
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+git commit -m "feat: add persona setup run ids"
+```
+
+### Task 2: Add Backend Setup Analytics Event Persistence And Summary API
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/persona.py`
+- Create: `tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py`
+
+**Step 1: Write the failing backend API tests**
+
+Add tests that prove:
+
+- events can be appended to a setup run
+- deterministic `event_key` dedupes once-only events
+- the summary endpoint returns recent runs and aggregate counts
+
+Example:
+
+```python
+def test_persona_setup_events_dedupe_by_event_key(client, auth_headers):
+    persona_id = "garden-helper"
+    body = {
+        "event_id": "evt-1",
+        "event_key": "step_viewed:test",
+        "run_id": "setup-run-1",
+        "event_type": "step_viewed",
+        "step": "test",
+    }
+
+    first = client.post(
+        f"/api/v1/persona/profiles/{persona_id}/setup-events",
+        json=body,
+        headers=auth_headers,
+    )
+    second = client.post(
+        f"/api/v1/persona/profiles/{persona_id}/setup-events",
+        json={**body, "event_id": "evt-2"},
+        headers=auth_headers,
+    )
+
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.json()["deduped"] is True
+```
+
+Add a summary test that expects `completion_rate`, `most_common_dropoff_step`,
+and `recent_runs`.
+
+**Step 2: Run the new backend tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: FAIL because the DB table and endpoints do not exist yet.
+
+**Step 3: Add DB table and helpers**
+
+In `ChaChaNotes_DB.py`, add:
+
+- `_ensure_persona_setup_events_table()`
+- `record_persona_setup_event(...)`
+- `list_persona_setup_events(...)`
+- `get_persona_setup_analytics_summary(...)`
+
+Recommended schema:
+
+```sql
+CREATE TABLE IF NOT EXISTS persona_setup_events (
+    event_id TEXT PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    persona_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    event_key TEXT,
+    step TEXT,
+    completion_type TEXT,
+    detour_source TEXT,
+    action_target TEXT,
+    metadata_json TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+)
+```
+
+Also add a partial unique index for `(persona_id, run_id, event_key)` where
+`event_key IS NOT NULL`.
+
+**Step 4: Add API schemas and endpoints**
+
+In `tldw_Server_API/app/api/v1/schemas/persona.py`, add:
+
+- `PersonaSetupEventType`
+- `PersonaSetupEventCreate`
+- `PersonaSetupEventWriteResponse`
+- `PersonaSetupAnalyticsRunSummary`
+- `PersonaSetupAnalyticsSummary`
+- `PersonaSetupAnalyticsResponse`
+
+In `tldw_Server_API/app/api/v1/endpoints/persona.py`, add:
+
+- `POST /api/v1/persona/profiles/{persona_id}/setup-events`
+- `GET /api/v1/persona/profiles/{persona_id}/setup-analytics`
+
+Keep the event write endpoint append-only and idempotent on `event_key`.
+
+**Step 5: Re-run the new backend tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
+git commit -m "feat: add persona setup analytics events"
+```
+
+### Task 3: Add Route-Level Setup Analytics Emission
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Create: `apps/packages/ui/src/services/tldw/persona-setup-analytics.ts`
+- Create: `apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing frontend tests**
+
+Add helper tests for deterministic event-key construction:
+
+```ts
+it("builds stable event keys for once-only setup events", () => {
+  expect(buildSetupEventKey({
+    runId: "setup-run-1",
+    eventType: "step_viewed",
+    step: "test"
+  })).toBe("step_viewed:test")
+})
+```
+
+In the route suite, add a test that completes setup and asserts setup analytics
+POSTs are sent for:
+
+- `setup_completed`
+- `handoff_action_clicked`
+- `first_post_setup_action`
+
+**Step 2: Run the targeted frontend tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts src/routes/__tests__/sidepanel-persona.test.tsx -t "setup analytics|stable event keys"
+```
+
+Expected: FAIL because no setup analytics helper or route emission exists.
+
+**Step 3: Add the helper**
+
+Create `persona-setup-analytics.ts` with:
+
+- `buildSetupEventKey(...)`
+- `postPersonaSetupEvent(...)`
+- tiny event payload normalizers
+
+Keep it small and route-facing only.
+
+**Step 4: Wire route emission**
+
+In `sidepanel-persona.tsx`:
+
+- emit `setup_started` when a new `run_id` is created for a setup run
+- emit `step_viewed` on step changes with once-only `event_key`
+- emit `step_completed` on successful step transitions
+- emit `step_error` from step-local failure handlers
+- emit `retry_clicked` from step retry actions
+- emit `detour_started` / `detour_returned`
+- emit `setup_completed` on completion
+
+Use best-effort writes and do not block UX.
+
+**Step 5: Re-run the targeted frontend tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts src/routes/__tests__/sidepanel-persona.test.tsx -t "setup analytics|stable event keys"
+```
+
+Expected: PASS.
+
+**Step 6: Commit**
+
+```bash
+git add apps/packages/ui/src/services/tldw/persona-setup-analytics.ts apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: emit persona setup analytics events"
+```
+
+### Task 4: Tighten Handoff Recommendation And Retargeting
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing handoff tests**
+
+Add component coverage for recommended next-step rendering:
+
+```tsx
+it("prioritizes trying a live turn after dry-run completion", () => {
+  render(
+    <PersonaSetupHandoffCard
+      ...
+      completionType="dry_run"
+      reviewSummary={{
+        starterCommands: { mode: "added", count: 3 },
+        confirmationMode: "destructive_only",
+        connection: { mode: "created", name: "Slack" },
+      }}
+    />
+  )
+
+  expect(screen.getByText("Try your first live turn")).toBeInTheDocument()
+})
+```
+
+Add route coverage for:
+
+- same-tab handoff action keeps the card visible
+- cross-tab handoff action retargets the card to the destination tab
+
+**Step 2: Run the targeted tests to verify they fail**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff|recommended next step"
+```
+
+Expected: FAIL because the current card has no recommended action model and the
+route clears the handoff on any action.
+
+**Step 3: Implement the tighter handoff model**
+
+In `sidepanel-persona.tsx`:
+
+- extend `setupHandoff` with:
+  - `runId`
+  - `recommendedAction`
+  - `consumedAction`
+  - `compact`
+- replace `openSetupHandoffTab()` so it:
+  - keeps the handoff on same-tab actions
+  - retargets `targetTab` on cross-tab actions
+  - does not clear the handoff immediately
+
+In `PersonaSetupHandoffCard.tsx`:
+
+- add a `Recommended next step` section
+- keep starter-pack review rows below it
+- render a compact variant when `compact` is true
+
+**Step 4: Re-run the targeted tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff|recommended next step"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: tighten persona setup handoff actions"
+```
+
+### Task 5: Collapse Handoff On First Successful Post-Setup Action
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing route tests**
+
+Add route coverage like:
+
+```tsx
+it("collapses the setup handoff after the first successful post-setup action", async () => {
+  ...
+  fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+  ...
+  fireEvent.click(screen.getByTestId("persona-commands-save"))
+
+  await waitFor(() => {
+    expect(screen.getByText("Setup complete")).toBeInTheDocument()
+  })
+})
+```
+
+Add one test for each meaningful post-setup action family only if needed.
+Prefer one representative happy path plus unit-level callback coverage.
+
+**Step 2: Run the targeted route test to verify it fails**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "collapses the setup handoff"
+```
+
+Expected: FAIL because the route has no consumed-action model yet.
+
+**Step 3: Add success callbacks**
+
+Wire route callbacks for:
+
+- `CommandsPanel.onCommandSaved` -> `command_saved`
+- `ConnectionsPanel` save success -> `connection_saved`
+- `ConnectionsPanel` test success -> `connection_test_succeeded`
+- `AssistantDefaultsPanel` or `ProfilePanel` save success -> `voice_defaults_saved`
+- dry-run match path -> `dry_run_match`
+- live assistant response after handoff -> `live_response_received`
+
+On the first such success for the current `runId`:
+
+- emit `first_post_setup_action`
+- set `setupHandoff.compact = true`
+- set `setupHandoff.consumedAction`
+
+Do not emit or collapse twice.
+
+**Step 4: Re-run the targeted route test**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "collapses the setup handoff"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: collapse setup handoff after first success"
+```
+
+### Task 6: Add Setup Analytics Summary Endpoint Coverage And One E2E Flow
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py`
+- Modify: `apps/extension/tests/e2e/persona-assistant-setup.spec.ts`
+
+**Step 1: Add summary-focused backend assertions**
+
+Extend the backend analytics tests to assert:
+
+- `completion_rate`
+- `most_common_dropoff_step`
+- `handoff_click_rate`
+- `first_post_setup_action_rate`
+
+for a small seeded mix of setup runs.
+
+**Step 2: Add one Playwright scenario**
+
+Add a flow to `persona-assistant-setup.spec.ts` that:
+
+- finishes setup
+- sees the handoff card on the target tab
+- takes the recommended next action
+- verifies the compact `Setup complete` banner appears afterward
+
+**Step 3: Run the new targeted tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+cd apps/extension && bunx playwright test tests/e2e/persona-assistant-setup.spec.ts --reporter=line
+```
+
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py apps/extension/tests/e2e/persona-assistant-setup.spec.ts
+git commit -m "test: cover persona setup handoff analytics flow"
+```
+
+### Task 7: Run Regressions, Security Checks, And Close Out
+
+**Files:**
+- Update: `Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md`
+
+**Step 1: Mark this plan complete**
+
+Update task statuses in this plan file after implementation.
+
+**Step 2: Run focused backend tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: PASS.
+
+**Step 3: Run focused frontend tests**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 4: Run broader setup sweep**
+
+Run:
+
+```bash
+cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx src/components/PersonaGarden/__tests__/SetupSafetyConnectionsStep.test.tsx src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Run security and hygiene checks**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py apps/packages/ui/src/components/PersonaGarden apps/packages/ui/src/routes apps/packages/ui/src/services/tldw -f json -o /tmp/bandit_persona_setup_handoff_analytics.json
+git diff --check
+```
+
+Expected:
+
+- Bandit reports no new findings in touched code
+- `git diff --check` returns no output
+
+**Step 6: Commit plan closeout if needed**
+
+```bash
+git add Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md
+git commit -m "docs: mark setup handoff analytics plan complete"
+```
+
+Expected: clean regressions, clean security checks, and a clean worktree.

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-tightening-and-analytics-implementation-plan.md
@@ -1,5 +1,12 @@
 # Persona Setup Handoff Tightening And Analytics Implementation Plan
 
+Execution Status: Complete
+
+Closeout Notes:
+- Tasks 1 through 7 are implemented on `codex/persona-voice-assistant-builder`.
+- Backend and frontend regressions passed during closeout.
+- The updated Playwright setup spec was executed in this environment, but the run was skipped because extension launch was unavailable here.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Tighten the Persona Garden post-setup handoff so it survives into real first use, and add setup-specific analytics that measure setup completion, recovery, and first post-setup success.

--- a/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-design.md
@@ -1,0 +1,176 @@
+# Persona Setup Live Recovery Detour Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+When assistant setup reaches `Test and finish` and the live test fails because the live session is unavailable or the send attempt fails, let the user detour into the real `Live Session` tab, recover there, and then resume setup without losing the setup flow.
+
+## Problem
+
+The setup test step already distinguishes `live_unavailable` and `live_failure`, but the current UX only shows text guidance. That is weaker than the recovery flow users now get for `dry_run_no_match`, because the only real place to fix live issues is the actual `Live Session` surface that owns connection state, session banners, and runtime status.
+
+## Constraints
+
+- Setup must remain persona-scoped and `in_progress` until the user explicitly finishes.
+- The detour must reuse the existing `Live Session` tab and route-owned session logic.
+- Auto-return must only trigger for the specific setup live test response the route is already awaiting.
+- Manual return must not leave a stale awaited-live-response state behind.
+- This slice should stay frontend-only.
+
+## Recommended Approach
+
+Add a route-owned `setupLiveDetour` state that temporarily suppresses the setup overlay and opens the `Live Session` tab. While active, the route shows a small setup recovery banner in Live and auto-returns to the setup test step after the awaited setup live response succeeds. The user can also return manually before success.
+
+## Architecture
+
+### 1. Route-Owned Setup Live Detour
+
+Add route state in `sidepanel-persona.tsx`:
+
+```ts
+type SetupLiveDetourState = {
+  source: "live_unavailable" | "live_failure"
+  lastText: string
+}
+```
+
+This is independent from:
+
+- `setupCommandDetour`
+- `setupTestOutcome`
+- `setupWizardAwaitingLiveResponseRef`
+
+The route also keeps a small `setupLiveReturnNote: string | null` so the test step can explain why the user is back in setup after a detour.
+
+### 2. Setup Gating Escape Hatch
+
+The setup overlay remains the default while `personaSetupWizard.isSetupRequired` is true, except when either of these route-owned detours is active:
+
+- `setupCommandDetour`
+- `setupLiveDetour`
+
+When `setupLiveDetour` is active, the route renders the normal tab surface and switches to `Live Session` so the user sees the real session controls and status panels.
+
+### 3. Outcome-Specific Recovery Actions In The Test Step
+
+`SetupTestAndFinishStep` gets one optional callback:
+
+```ts
+onRecoverInLiveSession?: (context: {
+  source: "live_unavailable" | "live_failure"
+  text: string
+}) => void
+```
+
+The test step renders:
+
+- `Open Live Session to fix this` for `live_unavailable`
+- `Try again in Live Session` for `live_failure`
+
+For `live_failure`, the callback should receive the failed text attempt. For `live_unavailable`, it should receive the last known setup live text if available, otherwise an empty string.
+
+### 4. Auto-Return On Successful Setup Live Response
+
+The route already uses `setupWizardAwaitingLiveResponseRef` plus the next assistant response to recognize a successful setup live test. That same path should be extended:
+
+- if `setupLiveDetour` is active
+- and the route consumes the awaited setup live response successfully
+
+then:
+
+- clear `setupLiveDetour`
+- restore the setup overlay at `test`
+- keep `setupTestOutcome = { kind: "live_success", ... }`
+- set `setupLiveReturnNote = "Live session responded. Finish setup when you're ready."`
+
+This auto-return should consume the awaited setup response exactly once.
+
+### 5. Manual Return Before Success
+
+The live detour banner adds a single action:
+
+- `Return to setup`
+
+Clicking it should:
+
+- clear `setupLiveDetour`
+- clear `setupWizardAwaitingLiveResponseRef.current`
+- restore the setup overlay at `test`
+- keep the setup incomplete
+- set a neutral note:
+  - `Live session is still available if you want to retry.`
+
+Manual return must not allow a later unrelated assistant message to bounce the user back unexpectedly.
+
+## UX Behavior
+
+### Test Step
+
+For live failure states:
+
+- `live_unavailable`
+  - explanation stays visible
+  - action: `Open Live Session to fix this`
+- `live_failure`
+  - explanation stays visible
+  - action: `Try again in Live Session`
+
+### Live Session During Detour
+
+The Live tab shows a compact recovery banner above the normal controls:
+
+- `Finish this live test, then return to setup.`
+- action: `Return to setup`
+
+No duplicate connection or send controls are added there. The normal Live session UI remains the real recovery surface.
+
+### Return To Setup
+
+On auto-return after success:
+
+- `SetupTestAndFinishStep` shows:
+  - `Live session responded. Finish setup when you're ready.`
+- `setupTestOutcome` remains `live_success`
+- the user can immediately click `Finish with live session`
+
+On manual return before success:
+
+- the test step shows:
+  - `Live session is still available if you want to retry.`
+- no completion affordance is unlocked
+
+## Edge Cases
+
+- If the user disconnects while the live detour is active, keep the detour active until they either reconnect successfully or return to setup manually.
+- If the user resets or reruns setup while the live detour is active, clear:
+  - `setupLiveDetour`
+  - `setupLiveReturnNote`
+  - `setupWizardAwaitingLiveResponseRef`
+- Existing non-setup live usage must stay unchanged. The detour logic only runs when setup is required and the detour is active.
+- Auto-return must never trigger from unrelated later assistant messages once the detour has been cleared manually.
+
+## Testing Strategy
+
+### Component
+
+`SetupTestAndFinishStep.test.tsx`
+
+- `live_unavailable` renders `Open Live Session to fix this`
+- `live_failure` renders `Try again in Live Session`
+
+### Route
+
+`sidepanel-persona.test.tsx`
+
+- clicking live recovery hides the setup overlay and opens the `Live Session` tab
+- active detour shows `Return to setup`
+- a successful awaited setup live response auto-returns to setup with `live_success`
+- manual `Return to setup` works before success and does not unlock finish
+- reset/rerun clears the detour
+
+## Out Of Scope
+
+- Backend websocket changes
+- New live-session transport behavior
+- Auto-sending a setup live retry from the detour banner

--- a/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md
@@ -8,9 +8,13 @@
 
 **Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
 
+**Status:** Complete
+
 ---
 
 ### Task 1: Add Live Recovery Actions To The Setup Test Step
+
+**Status:** Complete
 
 **Files:**
 - Modify: `apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx`
@@ -108,6 +112,8 @@ bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTes
 Expected: PASS.
 
 ### Task 2: Add Route-Owned Live Detour State And Manual Return
+
+**Status:** Complete
 
 **Files:**
 - Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
@@ -211,6 +217,8 @@ Expected: PASS for the new manual live detour assertions.
 
 ### Task 3: Auto-Return After Successful Setup Live Response
 
+**Status:** Complete
+
 **Files:**
 - Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
 - Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
@@ -273,6 +281,8 @@ Expected: PASS.
 
 ### Task 4: Clear Live Detour On Setup Reset Or Rerun
 
+**Status:** Complete
+
 **Files:**
 - Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
 - Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
@@ -316,6 +326,8 @@ bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
 Expected: PASS.
 
 ### Task 5: Run Focused Regressions And Commit
+
+**Status:** Complete
 
 **Files:**
 - Update: `Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md`

--- a/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md
@@ -1,0 +1,370 @@
+# Persona Setup Live Recovery Detour Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let setup recover from `live_unavailable` and `live_failure` by detouring into the real `Live Session` tab, then resuming `Test and finish` automatically on success or manually on demand.
+
+**Architecture:** Add route-owned `setupLiveDetour` and `setupLiveReturnNote` state in `sidepanel-persona.tsx`, extend `SetupTestAndFinishStep.tsx` with outcome-specific live recovery actions, and reuse the existing awaited setup live-response path for auto-return. Keep the slice frontend-only and avoid changing websocket contracts.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
+
+---
+
+### Task 1: Add Live Recovery Actions To The Setup Test Step
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add coverage like:
+
+```tsx
+it("renders a live recovery action for live_unavailable", () => {
+  const onRecoverInLiveSession = vi.fn()
+
+  render(
+    <SetupTestAndFinishStep
+      ...
+      outcome={{ kind: "live_unavailable" }}
+      onRecoverInLiveSession={onRecoverInLiveSession}
+    />
+  )
+
+  fireEvent.click(screen.getByRole("button", { name: "Open Live Session to fix this" }))
+  expect(onRecoverInLiveSession).toHaveBeenCalledWith({
+    source: "live_unavailable",
+    text: ""
+  })
+})
+```
+
+And:
+
+```tsx
+it("renders a live recovery action for live_failure", () => {
+  const onRecoverInLiveSession = vi.fn()
+
+  render(
+    <SetupTestAndFinishStep
+      ...
+      outcome={{
+        kind: "live_failure",
+        text: "summarize my assistant setup",
+        message: "Socket send failed"
+      }}
+      onRecoverInLiveSession={onRecoverInLiveSession}
+    />
+  )
+
+  fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+  expect(onRecoverInLiveSession).toHaveBeenCalledWith({
+    source: "live_failure",
+    text: "summarize my assistant setup"
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+```
+
+Expected: FAIL because the step has no live recovery callback or buttons.
+
+**Step 3: Write minimal implementation**
+
+In `SetupTestAndFinishStep.tsx`:
+
+- add prop:
+
+```ts
+onRecoverInLiveSession?: (context: {
+  source: "live_unavailable" | "live_failure"
+  text: string
+}) => void
+```
+
+- when `live_unavailable` is present, render:
+  - button label: `Open Live Session to fix this`
+  - click calls the callback with `{ source: "live_unavailable", text: "" }`
+
+- when `live_failure` is present, render:
+  - button label: `Try again in Live Session`
+  - click calls the callback with the failed `text`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+```
+
+Expected: PASS.
+
+### Task 2: Add Route-Owned Live Detour State And Manual Return
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add route coverage like:
+
+```tsx
+it("detours setup into live for live_unavailable and returns manually", async () => {
+  ...
+  fireEvent.click(screen.getByRole("button", { name: "Open Live Session to fix this" }))
+
+  await waitFor(() => {
+    expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+  })
+
+  expect(screen.getByText("Finish this live test, then return to setup.")).toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole("button", { name: "Return to setup" }))
+
+  await waitFor(() => {
+    expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+  })
+  expect(
+    screen.getByText("Live session is still available if you want to retry.")
+  ).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: FAIL because there is no setup live detour state or live recovery banner.
+
+**Step 3: Write minimal implementation**
+
+In `sidepanel-persona.tsx`:
+
+- add route state:
+  - `setupLiveDetour`
+  - `setupLiveReturnNote`
+- add handler:
+
+```ts
+handleRecoverSetupInLiveSession({
+  source,
+  text
+})
+```
+
+This should:
+
+- set `setupLiveDetour`
+- clear any old `setupLiveReturnNote`
+- switch `activeTab` to `live`
+
+Also add:
+
+```ts
+handleReturnToSetupFromLiveDetour()
+```
+
+This should:
+
+- clear `setupLiveDetour`
+- clear `setupWizardAwaitingLiveResponseRef.current`
+- restore the setup overlay
+- set `setupLiveReturnNote` to `Live session is still available if you want to retry.`
+
+Update setup gating to render the wizard only when:
+
+```ts
+personaSetupWizard.isSetupRequired &&
+!setupCommandDetour &&
+!setupLiveDetour
+```
+
+Render a small live recovery banner while `setupLiveDetour` is active with:
+
+- text: `Finish this live test, then return to setup.`
+- button: `Return to setup`
+
+Pass `onRecoverInLiveSession` into `SetupTestAndFinishStep`.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS for the new manual live detour assertions.
+
+### Task 3: Auto-Return After Successful Setup Live Response
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add route coverage like:
+
+```tsx
+it("auto-returns setup from live detour after a successful setup live response", async () => {
+  ...
+  fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+
+  // trigger the awaited setup live response through the existing websocket path
+
+  await waitFor(() => {
+    expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+  })
+
+  expect(
+    screen.getByText("Live session responded. Finish setup when you're ready.")
+  ).toBeInTheDocument()
+  expect(screen.getByRole("button", { name: "Finish with live session" })).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: FAIL because live success does not currently clear a detour or restore setup automatically.
+
+**Step 3: Write minimal implementation**
+
+In the existing setup-live-response handling path in `sidepanel-persona.tsx`:
+
+- when the route consumes the awaited setup live response successfully:
+  - if `setupLiveDetour` is active:
+    - clear `setupLiveDetour`
+    - set `setupLiveReturnNote = "Live session responded. Finish setup when you're ready."`
+  - keep the current `setupTestOutcome = { kind: "live_success", ... }`
+
+Use `setupWizardLastLiveTextRef.current` when building the resumed note/outcome context.
+
+Make sure this path only fires once for the awaited setup live response.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+### Task 4: Clear Live Detour On Setup Reset Or Rerun
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing test**
+
+Add coverage like:
+
+```tsx
+it("clears the setup live detour when setup is reset", async () => {
+  ...
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: FAIL because reset/rerun does not yet clear setup live detour state.
+
+**Step 3: Write minimal implementation**
+
+In the existing setup reset/rerun paths:
+
+- clear `setupLiveDetour`
+- clear `setupLiveReturnNote`
+- clear `setupWizardAwaitingLiveResponseRef.current`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+### Task 5: Run Focused Regressions And Commit
+
+**Files:**
+- Update: `Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md`
+
+**Step 1: Run focused coverage**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run broader setup sweep**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupSafetyConnectionsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Check hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+**Step 4: Run Bandit on touched UI scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/PersonaGarden apps/packages/ui/src/routes -f json -o /tmp/bandit_persona_setup_live_recovery_detour.json
+```
+
+Expected: `0` findings in the touched UI scope.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-design.md Docs/Plans/2026-03-14-persona-setup-live-recovery-detour-implementation-plan.md apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: add setup live recovery detour"
+```
+
+Expected: clean focused regressions, clean `git diff --check`, and one feature commit.

--- a/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-design.md
@@ -1,0 +1,117 @@
+# Persona Setup Live Unavailable Autoconnect Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+When assistant setup reaches `Test and finish`, the live test is unavailable, and the user chooses `Open Live Session to fix this`, the route should detour into `Live Session` and immediately start the normal connection flow without requiring an extra click.
+
+## Problem
+
+The previous slice made `live_unavailable` detour-capable, but the user still has to click `Connect` again after landing in `Live Session`. That is unnecessary friction because the only thing blocking them is the missing live connection, and the route already has a single authoritative `connect()` path.
+
+## Constraints
+
+- Reuse the existing `connect()` callback and connection lifecycle exactly.
+- Do not add a second websocket/session creation path.
+- Only auto-connect for `live_unavailable`, not `live_failure`.
+- Do not auto-send any message or auto-complete setup on connect alone.
+- Preserve the current manual `Return to setup` detour behavior.
+
+## Recommended Approach
+
+Patch only the route recovery handler in `sidepanel-persona.tsx` so the `live_unavailable` detour activates the existing `connect()` flow immediately after switching to `Live Session`.
+
+## Architecture
+
+### 1. Route-Only Recovery Branch
+
+The current setup live-recovery path already calls:
+
+```ts
+handleRecoverSetupInLiveSession({
+  source,
+  text
+})
+```
+
+That handler should branch by source:
+
+- `live_failure`
+  - keep current behavior
+  - activate the live detour
+  - switch to `activeTab = "live"`
+- `live_unavailable`
+  - activate the live detour
+  - switch to `activeTab = "live"`
+  - immediately call `void connect()`
+
+### 2. Idempotent Guard
+
+Auto-connect should only happen when:
+
+```ts
+context.source === "live_unavailable" &&
+!connected &&
+!connecting
+```
+
+This prevents duplicate websocket/session creation if:
+
+- the route is already connected
+- a connect attempt is already in progress
+
+### 3. No New UI Surface
+
+No component changes are required in this slice.
+
+The existing setup live detour banner remains:
+
+- `Finish this live test, then return to setup.`
+- `Return to setup`
+
+The `SetupTestAndFinishStep` button copy also remains unchanged:
+
+- `Open Live Session to fix this`
+
+## UX Behavior
+
+### Before
+
+1. Setup shows `live_unavailable`
+2. User clicks `Open Live Session to fix this`
+3. Route detours into `Live Session`
+4. User must click `Connect`
+
+### After
+
+1. Setup shows `live_unavailable`
+2. User clicks `Open Live Session to fix this`
+3. Route detours into `Live Session`
+4. Route immediately starts `connect()`
+5. User can continue from the real Live surface once connected
+
+This does not auto-send any setup test message. The user still explicitly drives the live attempt from there.
+
+## Edge Cases
+
+- If `connect()` is already in progress, just detour into Live and let the existing connection state finish naturally.
+- If the route is already connected, detour into Live without calling `connect()` again.
+- If auto-connect fails, keep the detour active and let the user retry or return manually.
+- Reset/rerun setup behavior stays unchanged because the previous slice already clears the live detour state.
+
+## Testing Strategy
+
+### Route
+
+`sidepanel-persona.test.tsx`
+
+- `live_unavailable` detour auto-creates the websocket/session without an extra click
+- `live_failure` detour does not auto-connect again
+- if already connected, `live_unavailable` detour does not create a second websocket
+
+## Out Of Scope
+
+- Backend changes
+- New live-session copy
+- Auto-sending a setup live retry after auto-connect

--- a/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md
@@ -8,9 +8,13 @@
 
 **Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
 
+**Status:** Complete
+
 ---
 
 ### Task 1: Add Red Tests For Live-Unavailable Autoconnect
+
+**Status:** Complete
 
 **Files:**
 - Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
@@ -72,6 +76,8 @@ Expected: same FAIL.
 
 ### Task 2: Patch The Route Recovery Handler
 
+**Status:** Complete
+
 **Files:**
 - Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
 
@@ -118,6 +124,8 @@ git commit -m "feat: autoconnect setup live-unavailable detours"
 ```
 
 ### Task 3: Run Focused Regressions And Hygiene
+
+**Status:** Complete
 
 **Files:**
 - Update: `Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md`

--- a/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md
@@ -1,0 +1,176 @@
+# Persona Setup Live Unavailable Autoconnect Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically start the normal live-session connection flow when setup detours into `Live Session` from a `live_unavailable` outcome.
+
+**Architecture:** Patch only the route recovery handler in `sidepanel-persona.tsx` so `live_unavailable` reuses the existing `connect()` callback immediately after activating the live detour. Keep `live_failure` unchanged, add focused route tests first, and avoid any component or websocket contract changes.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
+
+---
+
+### Task 1: Add Red Tests For Live-Unavailable Autoconnect
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add focused route coverage like:
+
+```tsx
+it("auto-connects after a live_unavailable setup detour", async () => {
+  ...
+  fireEvent.click(screen.getByRole("button", { name: "Open Live Session to fix this" }))
+
+  await waitFor(() => {
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+})
+```
+
+Also add:
+
+```tsx
+it("does not auto-connect again for a live_failure detour", async () => {
+  ...
+})
+```
+
+And:
+
+```tsx
+it("does not create a duplicate websocket when already connected", async () => {
+  ...
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "auto-connects after a live_unavailable setup detour"
+```
+
+Expected: FAIL because the current detour only switches tabs and does not call `connect()`.
+
+**Step 3: Write minimal implementation**
+
+Do nothing yet. This step is just the failing test stage.
+
+**Step 4: Re-run to confirm the same failure**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "auto-connects after a live_unavailable setup detour"
+```
+
+Expected: same FAIL.
+
+### Task 2: Patch The Route Recovery Handler
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+
+**Step 1: Implement the minimal route change**
+
+In `handleRecoverSetupInLiveSession`:
+
+- keep the existing detour state update
+- after activating the detour, branch:
+
+```ts
+if (context.source === "live_unavailable" && !connected && !connecting) {
+  void connect()
+}
+```
+
+Do not change any component code or banner copy.
+
+**Step 2: Run the focused failing test**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "auto-connects after a live_unavailable setup detour"
+```
+
+Expected: PASS.
+
+**Step 3: Run the related detour route tests**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx -t "setup live"
+```
+
+Expected: PASS for the detour-focused cases.
+
+**Step 4: Commit**
+
+```bash
+git add apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: autoconnect setup live-unavailable detours"
+```
+
+### Task 3: Run Focused Regressions And Hygiene
+
+**Files:**
+- Update: `Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md`
+
+**Step 1: Mark the plan complete**
+
+Update this plan file so each task is marked complete.
+
+**Step 2: Run focused route coverage**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Run broader setup sweep**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupSafetyConnectionsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 4: Check hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+**Step 5: Run Bandit on touched UI scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r apps/packages/ui/src/components/PersonaGarden apps/packages/ui/src/routes -f json -o /tmp/bandit_persona_setup_live_unavailable_autoconnect.json
+```
+
+Expected: `0` findings in the touched UI scope.
+
+**Step 6: Commit plan closeout if needed**
+
+```bash
+git add Docs/Plans/2026-03-14-persona-setup-live-unavailable-autoconnect-implementation-plan.md
+git commit -m "docs: mark setup live-unavailable autoconnect plan complete"
+```
+
+Expected: clean regressions, clean hygiene checks, and no unstaged changes.

--- a/Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-design.md
@@ -1,0 +1,145 @@
+# Persona Setup No-Match Command Detour Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+When assistant setup reaches `Test and finish` and a dry-run returns `no direct command matched`, let the user create a saved command from that phrase without abandoning setup. After saving, return them to the setup test step with the phrase restored so they can confirm the same phrase now matches.
+
+## Problem
+
+The current setup test step can explain `dry_run_no_match`, but it cannot recover the user forward. The route already supports drafting commands from Test Lab, but setup gating hides the normal `Commands` tab whenever setup is required. The existing “rerun after save” flow also assumes a known command id and only supports editing an existing command, not creating a new one during setup.
+
+## Constraints
+
+- Setup must remain persona-scoped and `in_progress` until the user completes the test step.
+- The solution should reuse the existing command draft flow where practical.
+- This slice should stay frontend-only.
+- The user should return to the setup test step explicitly after save, with the unmatched phrase restored.
+
+## Recommended Approach
+
+Use a route-owned setup detour state that temporarily suspends the setup overlay, opens `Commands` with the unmatched phrase drafted, and resumes the wizard after a successful save.
+
+## Architecture
+
+### 1. Route-Owned Setup Command Detour
+
+Add route state in `sidepanel-persona.tsx`:
+
+```ts
+type SetupCommandDetour = {
+  phrase: string
+  returnStep: "test"
+}
+```
+
+This state is distinct from:
+
+- `draftCommandPhrase`
+- `rerunAfterSaveCommandId`
+- `lastTestLabPhrase`
+
+The route also keeps a persistent `setupNoMatchPhrase: string | null` so the dry-run phrase survives after `CommandsPanel` consumes the initial draft payload.
+
+### 2. Setup Gating Escape Hatch
+
+The setup overlay remains the default while `personaSetupWizard.isSetupRequired` is true, except when the route has an active setup command detour. In that case, the route renders the normal tab surface and switches to `Commands` initially so the drafted command is immediately visible.
+
+This is a controlled exception, not setup completion.
+
+### 3. Source-Aware Command Drafts
+
+The existing command draft path is extended with source metadata:
+
+```ts
+type CommandDraftSource = "test_lab" | "setup_no_match"
+```
+
+`CommandsPanel` uses this source to render the correct draft banner copy:
+
+- Test Lab: existing message
+- Setup no-match: `Drafted from assistant setup. Save this command, then return to finish setup.`
+
+### 4. Dedicated Save Callback
+
+`CommandsPanel` gains a dedicated callback for successful saves from a fresh draft flow:
+
+```ts
+onCommandSaved?: (savedCommandId: string, context: { fromDraft: boolean }) => void
+```
+
+The route uses this callback only for setup detours. It does not rely on `rerunAfterSaveCommandId`, because new command ids are unknown before save.
+
+On successful save during an active setup detour:
+
+- clear the setup detour active flag
+- restore the setup overlay
+- return to `current_step = "test"` without changing backend setup metadata
+- restore the saved unmatched phrase into the setup test step
+- set a small route-owned note like `Command saved. Run the same phrase again to confirm setup.`
+
+This callback only auto-returns when the saved command came from the setup-created draft flow. Editing an unrelated command while the detour is active should not bounce the user back unexpectedly.
+
+## UX Behavior
+
+### Setup Test Step
+
+For `dry_run_no_match`, `SetupTestAndFinishStep` shows:
+
+- existing no-match explanation
+- primary action: `Create command from this phrase`
+- secondary fallback guidance to try live session instead
+
+### Commands During Setup Detour
+
+The Commands tab shows:
+
+- the draft phrase prefilled through the existing draft path
+- a setup-specific banner explaining the user will return to setup after save
+
+### Resume To Setup
+
+After save:
+
+- route re-enters setup overlay
+- current step is `test`
+- dry-run textarea is prefilled with the original phrase
+- success note appears once:
+  - `Command saved. Run the same phrase again to confirm setup.`
+
+No auto-rerun in V1. Confirmation stays explicit.
+
+## Edge Cases
+
+- If the user changes tabs manually during the detour, keep the detour state until they save the setup-created draft or reset/rerun setup.
+- If the user edits or saves an unrelated command while the detour is active, do not auto-return to setup. Only the setup-created draft save should resume the wizard.
+- If the user resets or reruns setup while the detour is active, clear:
+  - `setupCommandDetour`
+  - `setupNoMatchPhrase`
+  - the one-shot setup success note
+- Existing Test Lab draft flows remain unchanged.
+
+## Testing Strategy
+
+### Component
+
+`SetupTestAndFinishStep.test.tsx`
+
+- `dry_run_no_match` renders `Create command from this phrase`
+
+### Route
+
+`sidepanel-persona.test.tsx`
+
+- clicking the no-match action exits the setup overlay into `Commands`
+- commands render the setup-specific draft banner
+- saving returns to setup overlay at `test`
+- the unmatched phrase is restored into the dry-run textarea
+- reset/rerun clears the pending detour state
+
+## Out of Scope
+
+- Auto-rerunning the dry-run after command save
+- Backend setup metadata changes
+- Reusing this detour for live-session failures

--- a/Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-implementation-plan.md
@@ -1,0 +1,270 @@
+# Persona Setup No-Match Command Detour Implementation Plan
+
+**Goal:** Let setup recover from `dry_run_no_match` by detouring into `Commands`, drafting a command from the unmatched phrase, and returning to the setup test step after save.
+
+**Architecture:** Add route-owned setup detour state in `sidepanel-persona.tsx`, extend command draft state with a setup-aware source, add a dedicated command-saved callback in `CommandsPanel.tsx`, and add a `Create command from this phrase` action in `SetupTestAndFinishStep.tsx`. Keep the slice frontend-only and do not change backend setup metadata.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
+
+**Status:** Complete
+
+---
+
+### Task 1: Add The Setup No-Match Action To The Test Step
+
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add coverage like:
+
+```tsx
+it("renders a create-command action for dry-run no-match outcomes", () => {
+  const onCreateCommandFromPhrase = vi.fn()
+
+  render(
+    <SetupTestAndFinishStep
+      ...
+      outcome={{ kind: "dry_run_no_match", heardText: "open the pod bay doors" }}
+      onCreateCommandFromPhrase={onCreateCommandFromPhrase}
+    />
+  )
+
+  fireEvent.click(screen.getByRole("button", { name: "Create command from this phrase" }))
+  expect(onCreateCommandFromPhrase).toHaveBeenCalledWith("open the pod bay doors")
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+```
+
+Expected: FAIL because the step has no such action or callback.
+
+**Step 3: Write minimal implementation**
+
+In `SetupTestAndFinishStep.tsx`:
+
+- add prop:
+
+```ts
+onCreateCommandFromPhrase?: (heardText: string) => void
+```
+
+- when `dry_run_no_match` is present, render:
+  - button label: `Create command from this phrase`
+  - click calls the new callback with `heardText`
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+```
+
+Expected: PASS.
+
+### Task 2: Add Route-Owned Setup Detour State And Resume Logic
+
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing tests**
+
+Add route coverage like:
+
+```tsx
+it("detours setup into commands for a dry-run no-match and returns to test after save", async () => {
+  ...
+  fireEvent.click(screen.getByRole("button", { name: "Create command from this phrase" }))
+  expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+  expect(screen.getByTestId("persona-commands-draft-banner")).toHaveTextContent(
+    "Drafted from assistant setup"
+  )
+
+  fireEvent.click(screen.getByRole("button", { name: "Save command" }))
+
+  await waitFor(() => {
+    expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+  })
+  expect(screen.getByPlaceholderText("Try a spoken phrase")).toHaveValue(
+    "open the pod bay doors"
+  )
+  expect(screen.getByText(/Command saved. Run the same phrase again/i)).toBeInTheDocument()
+})
+```
+
+Also add coverage that reset/rerun clears the pending detour.
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: FAIL because setup gating cannot be bypassed and there is no resume state.
+
+**Step 3: Write minimal implementation**
+
+In `sidepanel-persona.tsx`:
+
+- add route state:
+  - `setupCommandDetour`
+  - `setupNoMatchPhrase`
+  - `setupTestResumeNote`
+  - `draftCommandSource`
+- add handler:
+
+```ts
+handleCreateCommandFromSetupNoMatch(heardText: string)
+```
+
+This should:
+
+- set detour active
+- persist the phrase
+- feed the existing command draft path
+- switch `activeTab` to `commands`
+
+Adjust setup gating to render tabs when:
+
+```ts
+personaSetupWizard.isSetupRequired && !setupCommandDetour?.active
+```
+
+Pass the new action into `SetupTestAndFinishStep`.
+
+On successful command save during an active detour:
+
+- clear detour active state
+- clear draft source
+- return to setup overlay
+- restore test phrase
+- set resume note
+
+Use a dedicated `onCommandSaved` callback and only auto-return when the saved command came from the setup-created draft flow.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS for the new detour/resume assertions.
+
+### Task 3: Make Commands Drafts Source-Aware For Setup
+
+**Status:** Complete
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+
+**Step 1: Write the failing tests**
+
+Add component coverage like:
+
+```tsx
+it("renders setup-specific draft banner copy when the draft source is assistant setup", () => {
+  ...
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
+```
+
+Expected: FAIL because draft banners only know the Test Lab phrasing.
+
+**Step 3: Write minimal implementation**
+
+In `CommandsPanel.tsx`:
+
+- keep `draftCommandPhrase?: string | null`
+- add `draftCommandSource?: "test_lab" | "setup_no_match" | null`
+- preserve existing assist behavior
+- render source-specific banner text
+- add optional callback:
+
+```ts
+onCommandSaved?: (savedCommandId: string, context: { fromDraft: boolean }) => void
+```
+
+Call it after successful save.
+
+Update the route to pass phrase and source separately.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
+```
+
+Expected: PASS.
+
+### Task 4: Run Focused Regressions And Commit
+
+**Status:** Complete
+
+**Files:**
+- Update: `Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-implementation-plan.md`
+
+**Step 1: Run focused coverage**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run broader setup sweep**
+
+Run:
+
+```bash
+bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupSafetyConnectionsStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Check hygiene**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+**Step 4: Commit**
+
+```bash
+git add Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-design.md Docs/Plans/2026-03-14-persona-setup-no-match-command-detour-implementation-plan.md apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: add setup no-match command detour"
+```

--- a/apps/extension/tests/e2e/persona-assistant-setup.spec.ts
+++ b/apps/extension/tests/e2e/persona-assistant-setup.spec.ts
@@ -31,6 +31,7 @@ type PersonaProfileMock = {
 type PersonaMockState = {
   profile: PersonaProfileMock
   commandCount: number
+  connections: Array<{ id: string; name: string; base_url: string; auth_type: string }>
   failStarterCommandOnce: boolean
   failedStarterCommand: boolean
 }
@@ -210,10 +211,25 @@ const handleMockApiRequest = async (route: Route, state: PersonaMockState) => {
     return
   }
 
+  if (pathname === `/api/v1/persona/profiles/${PERSONA_ID}/connections` && method === "GET") {
+    await fulfillJson(route, 200, state.connections)
+    return
+  }
+
   if (pathname === `/api/v1/persona/profiles/${PERSONA_ID}/connections` && method === "POST") {
-    await fulfillJson(route, 201, {
-      id: "conn-setup-1"
-    })
+    const body = request.postDataJSON() as {
+      name?: string
+      base_url?: string
+      auth_type?: string
+    }
+    const nextConnection = {
+      id: `conn-setup-${state.connections.length + 1}`,
+      name: String(body?.name || "Setup Connection"),
+      base_url: String(body?.base_url || "https://api.example.com"),
+      auth_type: String(body?.auth_type || "none")
+    }
+    state.connections = [nextConnection, ...state.connections]
+    await fulfillJson(route, 201, nextConnection)
     return
   }
 
@@ -250,6 +266,7 @@ const installPersonaSetupMocks = async (
   const state: PersonaMockState = {
     profile: buildInitialProfile(),
     commandCount: 0,
+    connections: [],
     failStarterCommandOnce,
     failedStarterCommand: false
   }
@@ -404,7 +421,23 @@ test.describe("Persona assistant setup", () => {
       )
       await expect(page.getByTestId("persona-setup-handoff-card")).toBeVisible()
       await expect(page.getByText("Assistant setup complete")).toBeVisible()
-      await expect(page.getByRole("button", { name: "Adjust assistant defaults" })).toBeVisible()
+      await expect(page.getByText("Recommended next step")).toBeVisible()
+      await expect(page.getByText("Add a connection")).toBeVisible()
+
+      await page.getByRole("button", { name: "Open Connections" }).first().click()
+      await expect(page.getByRole("tab", { name: "Connections" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+      await expect(page.getByTestId("persona-setup-handoff-card")).toBeVisible()
+
+      await page.getByTestId("persona-connections-name-input").fill("Slack Alerts")
+      await page
+        .getByTestId("persona-connections-base-url-input")
+        .fill("https://hooks.example.com/incoming")
+      await page.getByTestId("persona-connections-save").click()
+
+      await expect(page.getByText("Setup complete")).toBeVisible()
     } finally {
       await context.close()
     }

--- a/apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx
@@ -46,6 +46,8 @@ type PersonaConnectionSummary = {
   secret_configured?: boolean
 }
 
+export type CommandDraftSource = "test_lab" | "setup_no_match"
+
 type CommandFormState = {
   commandId: string | null
   name: string
@@ -82,9 +84,14 @@ type CommandsPanelProps = {
   openCommandId?: string | null
   onOpenCommandHandled?: (commandId: string) => void
   draftCommandPhrase?: string | null
+  draftCommandSource?: CommandDraftSource | null
   onDraftCommandPhraseHandled?: (heardText: string) => void
   rerunAfterSaveCommandId?: string | null
   onRerunAfterSave?: (commandId: string) => void
+  onCommandSaved?: (
+    commandId: string,
+    context: { fromDraft: boolean }
+  ) => void
 }
 
 const REQUEST_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const
@@ -280,9 +287,11 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   openCommandId = null,
   onOpenCommandHandled,
   draftCommandPhrase = null,
+  draftCommandSource = null,
   onDraftCommandPhraseHandled,
   rerunAfterSaveCommandId = null,
-  onRerunAfterSave
+  onRerunAfterSave,
+  onCommandSaved
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const [commands, setCommands] = React.useState<PersonaVoiceCommand[]>([])
@@ -295,6 +304,9 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   const [formState, setFormState] =
     React.useState<CommandFormState>(DEFAULT_FORM_STATE)
   const [draftSourcePhrase, setDraftSourcePhrase] = React.useState<string | null>(null)
+  const [draftSourceKind, setDraftSourceKind] = React.useState<CommandDraftSource | null>(
+    null
+  )
   const editingCommand = React.useMemo(
     () =>
       formState.commandId
@@ -324,6 +336,7 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   const clearCommandEditor = React.useCallback(() => {
     setFormState(DEFAULT_FORM_STATE)
     setDraftSourcePhrase(null)
+    setDraftSourceKind(null)
     setValidationError(null)
   }, [])
 
@@ -436,12 +449,14 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   const handleTemplateApply = React.useCallback((template: CommandTemplate) => {
     setFormState(template.apply())
     setDraftSourcePhrase(null)
+    setDraftSourceKind(null)
     setValidationError(null)
   }, [])
 
   const handleEdit = React.useCallback((command: PersonaVoiceCommand) => {
     setFormState(toFormState(command))
     setDraftSourcePhrase(null)
+    setDraftSourceKind(null)
     setValidationError(null)
     setError(null)
   }, [])
@@ -465,10 +480,12 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
     if (!isActive || !selectedPersonaId || !normalizedDraftPhrase) return
     setFormState(toDraftFormState(normalizedDraftPhrase))
     setDraftSourcePhrase(normalizedDraftPhrase)
+    setDraftSourceKind(draftCommandSource || "test_lab")
     setValidationError(null)
     setError(null)
     onDraftCommandPhraseHandled?.(normalizedDraftPhrase)
   }, [
+    draftCommandSource,
     draftCommandPhrase,
     isActive,
     onDraftCommandPhraseHandled,
@@ -671,6 +688,7 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
     setError(null)
     try {
       const isEditing = Boolean(formState.commandId)
+      const savedFromDraft = Boolean(draftSourcePhrase) && !isEditing
       const response = await tldwClient.fetchWithAuth(
         isEditing
           ? toAllowedPath(
@@ -703,6 +721,7 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
         return next
       })
       resetForm()
+      onCommandSaved?.(saved.id, { fromDraft: savedFromDraft })
       if (
         String(rerunAfterSaveCommandId || "").trim() &&
         saved.id === String(rerunAfterSaveCommandId || "").trim()
@@ -720,7 +739,9 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
     }
   }, [
     connections,
+    draftSourcePhrase,
     formState,
+    onCommandSaved,
     onRerunAfterSave,
     resetForm,
     rerunAfterSaveCommandId,
@@ -999,10 +1020,15 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
                         data-testid="persona-commands-draft-banner"
                         className="rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-900"
                       >
-                        {t("sidepanel:personaGarden.commands.draftFromTestLab", {
-                          defaultValue:
-                            "Drafted from Test Lab. Adjust the phrase, add placeholders like {topic} if needed, then choose a target."
-                        })}
+                        {draftSourceKind === "setup_no_match"
+                          ? t("sidepanel:personaGarden.commands.draftFromSetup", {
+                              defaultValue:
+                                "Drafted from assistant setup. Save this command, then return to finish setup."
+                            })
+                          : t("sidepanel:personaGarden.commands.draftFromTestLab", {
+                              defaultValue:
+                                "Drafted from Test Lab. Adjust the phrase, add placeholders like {topic} if needed, then choose a target."
+                            })}
                       </div>
                       {draftAssistSuggestions.length > 0 ? (
                         <div className="rounded-md border border-border bg-surface px-3 py-2 text-xs text-text-muted">

--- a/apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx
@@ -40,6 +40,8 @@ type ConnectionsPanelProps = {
   selectedPersonaId: string
   selectedPersonaName: string
   isActive?: boolean
+  onConnectionSaved?: () => void
+  onConnectionTestSucceeded?: () => void
 }
 
 const DEFAULT_FORM_STATE: ConnectionFormState = {
@@ -112,7 +114,9 @@ const summarizeTestBodyPreview = (value: unknown): string | null => {
 export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
   selectedPersonaId,
   selectedPersonaName,
-  isActive = false
+  isActive = false,
+  onConnectionSaved,
+  onConnectionTestSucceeded
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const [connections, setConnections] = React.useState<PersonaConnection[]>([])
@@ -281,6 +285,7 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
       const saved = (await response.json()) as PersonaConnection
       setConnections((current) => [saved, ...current.filter((item) => item.id !== saved.id)])
       handleReset()
+      onConnectionSaved?.()
     } catch (saveError) {
       setError(
         saveError instanceof Error
@@ -292,7 +297,7 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
     } finally {
       setSaving(false)
     }
-  }, [editingConnectionId, formState, handleReset, selectedPersonaId])
+  }, [editingConnectionId, formState, handleReset, onConnectionSaved, selectedPersonaId])
 
   const handleDelete = React.useCallback(async (connectionId: string) => {
     if (!selectedPersonaId) return
@@ -358,6 +363,9 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
         ...current,
         [connectionId]: result
       }))
+      if (result.ok) {
+        onConnectionTestSucceeded?.()
+      }
     } catch (testError) {
       setTestResults((current) => ({
         ...current,
@@ -372,7 +380,7 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
     } finally {
       setTestingConnectionId(null)
     }
-  }, [selectedPersonaId])
+  }, [onConnectionTestSucceeded, selectedPersonaId])
 
   return (
     <div className="rounded-lg border border-border bg-surface p-3">

--- a/apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx
@@ -15,10 +15,18 @@ export type SetupReviewSummary = {
     | { mode: "skipped" }
 }
 
+export type SetupHandoffRecommendedAction =
+  | "add_command"
+  | "add_connection"
+  | "try_live"
+  | "review_commands"
+
 type PersonaSetupHandoffCardProps = {
   targetTab: PersonaGardenTabKey
   completionType: "dry_run" | "live_session"
   reviewSummary: SetupReviewSummary
+  recommendedAction: SetupHandoffRecommendedAction
+  compact?: boolean
   onDismiss: () => void
   onOpenCommands: () => void
   onOpenTestLab: () => void
@@ -59,10 +67,38 @@ function formatConnectionSummary(summary: SetupReviewSummary["connection"]): str
   return "No external connection yet"
 }
 
+function getRecommendedActionTitle(action: SetupHandoffRecommendedAction): string {
+  if (action === "add_command") return "Add your first command"
+  if (action === "add_connection") return "Add a connection"
+  if (action === "try_live") return "Try your first live turn"
+  return "Review starter commands"
+}
+
+function getRecommendedActionDescription(action: SetupHandoffRecommendedAction): string {
+  if (action === "add_command") {
+    return "Give your assistant one command it can reliably handle after setup."
+  }
+  if (action === "add_connection") {
+    return "Link one external tool so your assistant can take action beyond local prompts."
+  }
+  if (action === "try_live") {
+    return "Dry run worked. Confirm the same flow through a real live voice turn next."
+  }
+  return "Your assistant is already responding live. Tighten the starter pack before you branch out."
+}
+
+function getRecommendedActionButtonLabel(action: SetupHandoffRecommendedAction): string {
+  if (action === "add_command") return "Open Commands"
+  if (action === "add_connection") return "Open Connections"
+  if (action === "try_live") return "Open Live Session"
+  return "Review Commands"
+}
+
 export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = ({
-  targetTab,
   completionType,
   reviewSummary,
+  recommendedAction,
+  compact = false,
   onDismiss,
   onOpenCommands,
   onOpenTestLab,
@@ -71,30 +107,49 @@ export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = (
   onOpenConnections
 }) => {
   const primaryAction =
-    targetTab === "commands"
+    recommendedAction === "add_command" || recommendedAction === "review_commands"
       ? {
-          label: "Review starter commands",
+          label: getRecommendedActionButtonLabel(recommendedAction),
           onClick: onOpenCommands
         }
-      : targetTab === "test-lab"
+      : recommendedAction === "add_connection"
         ? {
-            label: "Open Test Lab",
-            onClick: onOpenTestLab
+            label: getRecommendedActionButtonLabel(recommendedAction),
+            onClick: onOpenConnections
           }
-      : targetTab === "live"
-        ? {
-            label: "Start live session",
+        : {
+            label: getRecommendedActionButtonLabel(recommendedAction),
             onClick: onOpenLive
           }
-        : targetTab === "connections"
-          ? {
-              label: "Review connections",
-              onClick: onOpenConnections
-            }
-        : {
-            label: "Adjust assistant defaults",
-            onClick: onOpenProfiles
-          }
+
+  if (compact) {
+    return (
+      <div
+        data-testid="persona-setup-handoff-card"
+        className="rounded-lg border border-sky-500/40 bg-sky-500/10 px-3 py-3 text-sm text-sky-100"
+      >
+        <div className="font-medium">Setup complete</div>
+        <div className="mt-1 text-xs text-sky-100/80">{getCompletionCopy(completionType)}</div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <div className="text-sm text-sky-100">{getRecommendedActionTitle(recommendedAction)}</div>
+          <button
+            type="button"
+            className="rounded-md border border-sky-500/40 px-3 py-2 text-sm font-medium text-sky-100"
+            onClick={primaryAction.onClick}
+          >
+            {primaryAction.label}
+          </button>
+          <button
+            type="button"
+            className="rounded-md border border-sky-500/40 px-3 py-2 text-sm font-medium text-sky-100"
+            onClick={onDismiss}
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -103,6 +158,28 @@ export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = (
     >
       <div className="font-medium">Assistant setup complete</div>
       <div className="mt-1 text-xs text-sky-100/80">{getCompletionCopy(completionType)}</div>
+      <div className="mt-3 rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-3">
+        <div className="text-xs font-semibold uppercase tracking-wide text-sky-100/80">
+          Recommended next step
+        </div>
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-sky-100">
+              {getRecommendedActionTitle(recommendedAction)}
+            </div>
+            <div className="text-xs text-sky-100/80">
+              {getRecommendedActionDescription(recommendedAction)}
+            </div>
+          </div>
+          <button
+            type="button"
+            className="rounded-md border border-sky-500/40 px-2 py-1 text-xs font-medium text-sky-100"
+            onClick={primaryAction.onClick}
+          >
+            {primaryAction.label}
+          </button>
+        </div>
+      </div>
       <div className="mt-3 rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-3">
         <div className="text-xs font-semibold uppercase tracking-wide text-sky-100/80">
           Starter pack review
@@ -156,13 +233,6 @@ export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = (
         </div>
       </div>
       <div className="mt-3 flex flex-wrap gap-2">
-        <button
-          type="button"
-          className="rounded-md border border-sky-500/40 px-3 py-2 text-sm font-medium text-sky-100"
-          onClick={primaryAction.onClick}
-        >
-          {primaryAction.label}
-        </button>
         <button
           type="button"
           className="rounded-md border border-sky-500/40 px-3 py-2 text-sm font-medium text-sky-100"

--- a/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
@@ -19,6 +19,7 @@ type ProfilePanelProps = {
   onResumeSetup?: () => void
   onResetSetup?: () => void
   onRerunSetup?: () => void
+  onDefaultsSaved?: () => void
   isActive?: boolean
   analytics?: PersonaVoiceAnalytics | null
   analyticsLoading?: boolean
@@ -35,6 +36,7 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
   onResumeSetup,
   onResetSetup,
   onRerunSetup,
+  onDefaultsSaved,
   isActive = false,
   analytics = null,
   analyticsLoading = false
@@ -113,6 +115,9 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
         isActive={isActive}
         analytics={analytics}
         analyticsLoading={analyticsLoading}
+        onSaved={() => {
+          onDefaultsSaved?.()
+        }}
       />
     </div>
   )

--- a/apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx
@@ -43,6 +43,10 @@ type SetupTestAndFinishStepProps = {
   outcome: SetupTestOutcome | null
   onRunDryRun: (heardText: string) => void
   onCreateCommandFromPhrase?: (heardText: string) => void
+  onRecoverInLiveSession?: (context: {
+    source: "live_unavailable" | "live_failure"
+    text: string
+  }) => void
   onConnectLive: () => void
   onSendLive: (text: string) => void
   onFinishWithDryRun: () => void
@@ -59,6 +63,7 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
   outcome,
   onRunDryRun,
   onCreateCommandFromPhrase,
+  onRecoverInLiveSession,
   onConnectLive,
   onSendLive,
   onFinishWithDryRun,
@@ -182,6 +187,21 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
                 ? "Retry live connection"
                 : "Connect live session"}
             </button>
+            {liveOutcome?.kind === "live_unavailable" ? (
+              <button
+                type="button"
+                className="rounded-md border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-200 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={saving}
+                onClick={() =>
+                  onRecoverInLiveSession?.({
+                    source: "live_unavailable",
+                    text: ""
+                  })
+                }
+              >
+                Open Live Session to fix this
+              </button>
+            ) : null}
           </>
         ) : (
           <>
@@ -200,11 +220,24 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
               Send live test
             </button>
             {liveOutcome?.kind === "live_failure" ? (
-              <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+              <div className="space-y-2 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-200">
                 <div>{liveOutcome.message}</div>
-                <div className="mt-1 text-red-100/90">
+                <div className="text-red-100/90">
                   Try sending the live test again or reconnect the live session.
                 </div>
+                <button
+                  type="button"
+                  className="rounded-md border border-red-500/40 px-3 py-2 text-sm font-medium text-red-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={saving}
+                  onClick={() =>
+                    onRecoverInLiveSession?.({
+                      source: "live_failure",
+                      text: liveOutcome.text
+                    })
+                  }
+                >
+                  Try again in Live Session
+                </button>
               </div>
             ) : null}
             {liveOutcome?.kind === "live_sent" ? (

--- a/apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/SetupTestAndFinishStep.tsx
@@ -38,8 +38,11 @@ type SetupTestAndFinishStepProps = {
   dryRunLoading: boolean
   liveConnected: boolean
   error?: string | null
+  initialHeardText?: string | null
+  notice?: string | null
   outcome: SetupTestOutcome | null
   onRunDryRun: (heardText: string) => void
+  onCreateCommandFromPhrase?: (heardText: string) => void
   onConnectLive: () => void
   onSendLive: (text: string) => void
   onFinishWithDryRun: () => void
@@ -51,8 +54,11 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
   dryRunLoading,
   liveConnected,
   error = null,
+  initialHeardText = null,
+  notice = null,
   outcome,
   onRunDryRun,
+  onCreateCommandFromPhrase,
   onConnectLive,
   onSendLive,
   onFinishWithDryRun,
@@ -60,6 +66,12 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
 }) => {
   const [dryRunHeardText, setDryRunHeardText] = React.useState("")
   const [liveText, setLiveText] = React.useState("")
+
+  React.useEffect(() => {
+    const normalizedHeardText = String(initialHeardText || "").trim()
+    if (!normalizedHeardText) return
+    setDryRunHeardText(normalizedHeardText)
+  }, [initialHeardText])
 
   const dryRunOutcome = React.useMemo(() => {
     if (!outcome || !outcome.kind.startsWith("dry_run_")) return null
@@ -83,6 +95,11 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
       {error ? (
         <div className="rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200">
           {error}
+        </div>
+      ) : null}
+      {notice ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200">
+          {notice}
         </div>
       ) : null}
 
@@ -122,6 +139,16 @@ export const SetupTestAndFinishStep: React.FC<SetupTestAndFinishStepProps> = ({
           >
             {dryRunLoading ? "Running..." : "Run dry-run test"}
           </button>
+          {dryRunOutcome?.kind === "dry_run_no_match" ? (
+            <button
+              type="button"
+              className="rounded-md border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-200 disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={saving}
+              onClick={() => onCreateCommandFromPhrase?.(dryRunOutcome.heardText)}
+            >
+              Create command from this phrase
+            </button>
+          ) : null}
           {dryRunOutcome?.kind === "dry_run_match" ? (
             <button
               type="button"

--- a/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
@@ -35,6 +35,10 @@ type PersonaCommandDryRunResult = {
   failure_phase?: string | null
 }
 
+export type TestLabDryRunCompletedResult = {
+  matched: boolean
+}
+
 type TestLabPanelProps = {
   selectedPersonaId: string
   selectedPersonaName: string
@@ -42,7 +46,7 @@ type TestLabPanelProps = {
   analytics?: PersonaVoiceAnalytics | null
   onOpenCommand?: (commandId: string, heardText: string) => void
   onCreateCommandDraft?: (heardText: string) => void
-  onDryRunCompleted?: (result: { matched: boolean }) => void
+  onDryRunCompleted?: (result: TestLabDryRunCompletedResult) => void
   initialHeardText?: string
   rerunRequestToken?: number
 }

--- a/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
@@ -42,6 +42,7 @@ type TestLabPanelProps = {
   analytics?: PersonaVoiceAnalytics | null
   onOpenCommand?: (commandId: string, heardText: string) => void
   onCreateCommandDraft?: (heardText: string) => void
+  onDryRunCompleted?: (result: { matched: boolean }) => void
   initialHeardText?: string
   rerunRequestToken?: number
 }
@@ -56,6 +57,7 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
   analytics = null,
   onOpenCommand,
   onCreateCommandDraft,
+  onDryRunCompleted,
   initialHeardText = "",
   rerunRequestToken = 0
 }) => {
@@ -136,6 +138,7 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
       }
       const payload = (await response.json()) as PersonaCommandDryRunResult
       setResult(payload)
+      onDryRunCompleted?.({ matched: Boolean(payload.matched) })
       if (
         source === "rerun" &&
         payload.matched &&
@@ -158,7 +161,7 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
       setRerunNoticeVisible(false)
       setLoading(false)
     }
-  }, [selectedPersonaId])
+  }, [onDryRunCompleted, selectedPersonaId])
 
   React.useEffect(() => {
     if (!isActive || !selectedPersonaId || rerunRequestToken <= 0) return

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
@@ -720,6 +720,28 @@ describe("CommandsPanel", () => {
     )
   })
 
+  it("renders setup-specific draft banner copy when the draft source is assistant setup", async () => {
+    renderWithQueryClient(
+      <CommandsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        draftCommandPhrase="open the pod bay doors"
+        draftCommandSource="setup_no_match"
+      />
+    )
+
+    await screen.findByText("Search Notes")
+    expect(screen.getByTestId("persona-commands-name-input")).toHaveValue(
+      "Open the pod bay doors"
+    )
+    expect(
+      screen.getByText(
+        "Drafted from assistant setup. Save this command, then return to finish setup."
+      )
+    ).toBeInTheDocument()
+  })
+
   it("applies phrase-to-slot assist suggestions for drafted commands", async () => {
     renderWithQueryClient(
       <CommandsPanel

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx
@@ -11,6 +11,26 @@ const defaultReviewSummary = {
 }
 
 describe("PersonaSetupHandoffCard", () => {
+  it("prioritizes trying a live turn after dry-run completion", () => {
+    render(
+      <PersonaSetupHandoffCard
+        targetTab="profiles"
+        completionType="dry_run"
+        reviewSummary={defaultReviewSummary}
+        recommendedAction="try_live"
+        onDismiss={vi.fn()}
+        onOpenProfiles={vi.fn()}
+        onOpenTestLab={vi.fn()}
+        onOpenLive={vi.fn()}
+        onOpenCommands={vi.fn()}
+        onOpenConnections={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Recommended next step")).toBeInTheDocument()
+    expect(screen.getByText("Try your first live turn")).toBeInTheDocument()
+  })
+
   it("renders starter pack review details and target-tab-aware actions", () => {
     const onDismiss = vi.fn()
     const onOpenProfiles = vi.fn()
@@ -22,6 +42,7 @@ describe("PersonaSetupHandoffCard", () => {
         targetTab="profiles"
         completionType="dry_run"
         reviewSummary={defaultReviewSummary}
+        recommendedAction="add_connection"
         onDismiss={onDismiss}
         onOpenProfiles={onOpenProfiles}
         onOpenTestLab={vi.fn()}
@@ -37,10 +58,11 @@ describe("PersonaSetupHandoffCard", () => {
     expect(screen.getByText("Added 3 starter commands")).toBeInTheDocument()
     expect(screen.getByText("Ask for destructive actions")).toBeInTheDocument()
     expect(screen.getByText("Connection added: Slack Alerts")).toBeInTheDocument()
+    expect(screen.getByText("Add a connection")).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
     fireEvent.click(screen.getByRole("button", { name: "Open connections" }))
-    fireEvent.click(screen.getByRole("button", { name: "Adjust assistant defaults" }))
+    fireEvent.click(screen.getByRole("button", { name: "Review safety defaults" }))
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }))
     expect(onOpenCommands).toHaveBeenCalledTimes(1)
     expect(onOpenConnections).toHaveBeenCalledTimes(1)
@@ -58,6 +80,7 @@ describe("PersonaSetupHandoffCard", () => {
           confirmationMode: "never",
           connection: { mode: "skipped" }
         }}
+        recommendedAction="add_command"
         onDismiss={vi.fn()}
         onOpenProfiles={vi.fn()}
         onOpenTestLab={vi.fn()}
@@ -71,28 +94,33 @@ describe("PersonaSetupHandoffCard", () => {
     expect(screen.getByText("Skipped starter commands")).toBeInTheDocument()
     expect(screen.getByText("Never ask")).toBeInTheDocument()
     expect(screen.getByText("No external connection yet")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Start live session" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open Commands" })).toBeInTheDocument()
   })
 
-  it("uses a test-lab-aware primary action when setup returns to test lab", () => {
-    const onOpenTestLab = vi.fn()
+  it("renders a compact variant with the recommended next step", () => {
+    const onOpenCommands = vi.fn()
 
     render(
       <PersonaSetupHandoffCard
         targetTab="test-lab"
         completionType="dry_run"
         reviewSummary={defaultReviewSummary}
+        recommendedAction="review_commands"
+        compact
         onDismiss={vi.fn()}
         onOpenProfiles={vi.fn()}
-        onOpenTestLab={onOpenTestLab}
+        onOpenTestLab={vi.fn()}
         onOpenLive={vi.fn()}
-        onOpenCommands={vi.fn()}
+        onOpenCommands={onOpenCommands}
         onOpenConnections={vi.fn()}
       />
     )
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Open Test Lab" })[0])
+    expect(screen.getByText("Setup complete")).toBeInTheDocument()
+    expect(screen.getByText("Review starter commands")).toBeInTheDocument()
 
-    expect(onOpenTestLab).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole("button", { name: "Review Commands" }))
+
+    expect(onOpenCommands).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
@@ -103,6 +103,8 @@ describe("SetupTestAndFinishStep", () => {
   })
 
   it("renders a dry-run no-match outcome with a forward action", () => {
+    const onCreateCommandFromPhrase = vi.fn()
+
     render(
       <SetupTestAndFinishStep
         saving={false}
@@ -117,10 +119,13 @@ describe("SetupTestAndFinishStep", () => {
         onSendLive={vi.fn()}
         onFinishWithDryRun={vi.fn()}
         onFinishWithLiveSession={vi.fn()}
+        onCreateCommandFromPhrase={onCreateCommandFromPhrase}
       />
     )
 
     expect(screen.getByText(/No direct command matched/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Create command from this phrase" }))
+    expect(onCreateCommandFromPhrase).toHaveBeenCalledWith("open the pod bay doors")
     expect(screen.getByRole("button", { name: "Connect live session" })).toBeInTheDocument()
   })
 
@@ -209,5 +214,30 @@ describe("SetupTestAndFinishStep", () => {
     )
 
     expect(screen.getByText("Failed to finish assistant setup")).toBeInTheDocument()
+  })
+
+  it("restores the dry-run phrase and shows a resume note when setup returns from commands", () => {
+    render(
+      <SetupTestAndFinishStep
+        saving={false}
+        dryRunLoading={false}
+        liveConnected={false}
+        initialHeardText="open the pod bay doors"
+        notice="Command saved. Run the same phrase again to confirm setup."
+        outcome={null}
+        onRunDryRun={vi.fn()}
+        onConnectLive={vi.fn()}
+        onSendLive={vi.fn()}
+        onFinishWithDryRun={vi.fn()}
+        onFinishWithLiveSession={vi.fn()}
+      />
+    )
+
+    expect(screen.getByPlaceholderText("Try a spoken phrase")).toHaveValue(
+      "open the pod bay doors"
+    )
+    expect(
+      screen.getByText("Command saved. Run the same phrase again to confirm setup.")
+    ).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx
@@ -130,6 +130,7 @@ describe("SetupTestAndFinishStep", () => {
   })
 
   it("renders a live-unavailable outcome separately from live-success", () => {
+    const onRecoverInLiveSession = vi.fn()
     const { rerender } = render(
       <SetupTestAndFinishStep
         saving={false}
@@ -141,10 +142,16 @@ describe("SetupTestAndFinishStep", () => {
         onSendLive={vi.fn()}
         onFinishWithDryRun={vi.fn()}
         onFinishWithLiveSession={vi.fn()}
+        onRecoverInLiveSession={onRecoverInLiveSession}
       />
     )
 
     expect(screen.getByText(/Live session unavailable until you connect/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open Live Session to fix this" }))
+    expect(onRecoverInLiveSession).toHaveBeenCalledWith({
+      source: "live_unavailable",
+      text: ""
+    })
     expect(
       screen.queryByRole("button", { name: "Finish with live session" })
     ).not.toBeInTheDocument()
@@ -164,6 +171,7 @@ describe("SetupTestAndFinishStep", () => {
         onSendLive={vi.fn()}
         onFinishWithDryRun={vi.fn()}
         onFinishWithLiveSession={vi.fn()}
+        onRecoverInLiveSession={onRecoverInLiveSession}
       />
     )
 
@@ -172,6 +180,7 @@ describe("SetupTestAndFinishStep", () => {
   })
 
   it("renders a live-send failure outcome with retry guidance", () => {
+    const onRecoverInLiveSession = vi.fn()
     render(
       <SetupTestAndFinishStep
         saving={false}
@@ -187,6 +196,7 @@ describe("SetupTestAndFinishStep", () => {
         onSendLive={vi.fn()}
         onFinishWithDryRun={vi.fn()}
         onFinishWithLiveSession={vi.fn()}
+        onRecoverInLiveSession={onRecoverInLiveSession}
       />
     )
 
@@ -194,6 +204,11 @@ describe("SetupTestAndFinishStep", () => {
     expect(
       screen.getByText("Try sending the live test again or reconnect the live session.")
     ).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+    expect(onRecoverInLiveSession).toHaveBeenCalledWith({
+      source: "live_failure",
+      text: "summarize my assistant setup"
+    })
     expect(screen.getByRole("button", { name: "Send live test" })).toBeInTheDocument()
   })
 

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx
@@ -284,6 +284,28 @@ describe("TestLabPanel", () => {
     )
   })
 
+  it("reports unmatched dry-runs through the completion callback without treating them as success", async () => {
+    const onDryRunCompleted = vi.fn()
+
+    render(
+      <TestLabPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        onDryRunCompleted={onDryRunCompleted}
+      />
+    )
+
+    fireEvent.change(screen.getByTestId("persona-test-lab-heard-input"), {
+      target: { value: "start a focused research sprint" }
+    })
+    fireEvent.click(screen.getByTestId("persona-test-lab-run"))
+
+    await screen.findByTestId("persona-test-lab-match-status")
+
+    expect(onDryRunCompleted).toHaveBeenCalledWith({ matched: false })
+  })
+
   it("shows recent health for the matched command from live analytics", async () => {
     render(
       <TestLabPanel

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -631,6 +631,174 @@ describe("SidepanelPersona", () => {
     )
   })
 
+  it("emits setup analytics for setup completion and handoff clicks", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+
+    let profileVersion = 3
+    let currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      run_id: "setup-run-1",
+      current_step: "commands",
+      completed_steps: ["persona", "voice"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const setupEventBodies: Array<Record<string, unknown>> = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-events") && method === "POST") {
+        setupEventBodies.push(init?.body || {})
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            event_id: init?.body?.event_id || "evt-1",
+            run_id: init?.body?.run_id || "setup-run-1",
+            event_type: init?.body?.event_type || "step_viewed",
+            deduped: false,
+            created_at: "2026-03-14T10:00:00.000Z"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ id: "cmd-search-notes" })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "conn-slack-alerts",
+            name: init?.body?.name ?? "Slack Alerts"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentVoiceDefaults = {
+            ...currentVoiceDefaults,
+            ...(init?.body?.voice_defaults || {})
+          }
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("commands")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Search Notes" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("safety")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Ask for destructive actions" }))
+    fireEvent.click(screen.getByRole("button", { name: "Add one connection now" }))
+    fireEvent.change(screen.getByLabelText("Connection name"), {
+      target: { value: "Slack Alerts" }
+    })
+    fireEvent.change(screen.getByLabelText("Base URL"), {
+      target: { value: "https://hooks.example.com/incoming" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save safety and connection" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+
+    await waitFor(() => {
+      expect(
+        setupEventBodies.some((body) => body.event_type === "setup_completed")
+      ).toBe(true)
+      expect(
+        setupEventBodies.some(
+          (body) =>
+            body.event_type === "handoff_action_clicked" &&
+            body.action_target === "commands"
+        )
+      ).toBe(true)
+    })
+  })
+
   it("keeps the commands step in place with retry guidance when starter creation fails", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=commands"
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -2002,6 +2002,261 @@ describe("SidepanelPersona", () => {
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
   })
 
+  it("keeps the setup handoff visible after a same-tab handoff action", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Review safety defaults" }))
+
+    expect(screen.getByRole("tab", { name: "Profiles" })).toHaveAttribute("aria-selected", "true")
+    expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+  })
+
+  it("retargets the setup handoff after a cross-tab handoff action", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=connections"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Commands" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+    expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+  })
+
   it("renders a dedicated companion conversation mode", () => {
     render(<SidepanelPersona mode="companion" />)
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -909,6 +909,376 @@ describe("SidepanelPersona", () => {
     ).toBeInTheDocument()
   })
 
+  it("detours setup into live for a setup live failure and returns manually", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=live"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/sessions?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path === "/api/v1/persona/session") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-setup-live",
+            persona: { id: "garden-helper" }
+          })
+        })
+      }
+      if (path.includes("/persona/sessions/sess-setup-live")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ preferences: {} })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: 2,
+            voice_defaults: {
+              confirmation_mode: "destructive_only"
+            },
+            setup: {
+              status: "in_progress",
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety"]
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect live session" }))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+    const ws = MockWebSocket.instances[0]
+    ws.emitOpen()
+
+    await screen.findByPlaceholderText("Try a live message")
+
+    ws.send.mockImplementation((payload: string) => {
+      const parsed = JSON.parse(String(payload))
+      if (parsed.type === "user_message") {
+        throw new Error("Socket send failed")
+      }
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a live message"), {
+      target: { value: "summarize my assistant setup" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send live test" }))
+
+    expect(await screen.findByText("Socket send failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+    expect(
+      screen.getByText("Finish this live test, then return to setup.")
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to setup" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+    expect(
+      screen.getByText("Live session is still available if you want to retry.")
+    ).toBeInTheDocument()
+  })
+
+  it("auto-returns setup from live detour after a successful live response", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=live"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = init?.method || "GET"
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/sessions?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path === "/api/v1/persona/session") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-setup-live",
+            persona: { id: "garden-helper" }
+          })
+        })
+      }
+      if (path.includes("/persona/sessions/sess-setup-live")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ preferences: {} })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: 2,
+            voice_defaults: {
+              confirmation_mode: "destructive_only"
+            },
+            setup: {
+              status: "in_progress",
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety"]
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect live session" }))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+    const ws = MockWebSocket.instances[0]
+    ws.emitOpen()
+
+    await screen.findByPlaceholderText("Try a live message")
+
+    let setupSendAttempts = 0
+    ws.send.mockImplementation((payload: string) => {
+      const parsed = JSON.parse(String(payload))
+      if (parsed.type === "user_message") {
+        setupSendAttempts += 1
+        if (setupSendAttempts === 1) {
+          throw new Error("Socket send failed")
+        }
+      }
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a live message"), {
+      target: { value: "summarize my assistant setup" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send live test" }))
+
+    expect(await screen.findByText("Socket send failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Ask Persona..."), {
+      target: { value: "summarize my assistant setup" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send" }))
+
+    ws.emitMessage(
+      JSON.stringify({
+        event: "assistant_delta",
+        text_delta: "Here is the answer from the live session."
+      })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+    expect(
+      screen.getByText("Live session responded. Finish setup when you're ready.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Finish with live session" })).toBeInTheDocument()
+  })
+
+  it("clears the setup live detour when setup is reset", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=live"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/sessions?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path === "/api/v1/persona/session") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-setup-live",
+            persona: { id: "garden-helper" }
+          })
+        })
+      }
+      if (path.includes("/persona/sessions/sess-setup-live")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ preferences: {} })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: {
+                confirmation_mode: "destructive_only"
+              },
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: {
+              confirmation_mode: "destructive_only"
+            },
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect live session" }))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+    const ws = MockWebSocket.instances[0]
+    ws.emitOpen()
+
+    await screen.findByPlaceholderText("Try a live message")
+
+    ws.send.mockImplementation((payload: string) => {
+      const parsed = JSON.parse(String(payload))
+      if (parsed.type === "user_message") {
+        throw new Error("Socket send failed")
+      }
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a live message"), {
+      target: { value: "summarize my assistant setup" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Send live test" }))
+
+    expect(await screen.findByText("Socket send failed")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again in Live Session" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("tab", { name: "Profiles" }))
+    expect(screen.getByRole("button", { name: "Reset setup" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset setup" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("persona")
+    })
+    expect(
+      screen.queryByText("Finish this live test, then return to setup.")
+    ).not.toBeInTheDocument()
+  })
+
   it("detours setup into commands for a dry-run no-match and returns to test after save", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=live"
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -909,6 +909,174 @@ describe("SidepanelPersona", () => {
     ).toBeInTheDocument()
   })
 
+  it("detours setup into commands for a dry-run no-match and returns to test after save", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=live"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: false,
+            failure_phase: "planner_fallback"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            commands: []
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "cmd-created-from-setup",
+            persona_id: "garden-helper",
+            name: init?.body?.name,
+            phrases: init?.body?.phrases,
+            action_type: init?.body?.action_type,
+            action_config: init?.body?.action_config,
+            priority: init?.body?.priority,
+            enabled: init?.body?.enabled,
+            requires_confirmation: init?.body?.requires_confirmation
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "open the pod bay doors" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/No direct command matched/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Create command from this phrase" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+    expect(screen.getByTestId("persona-commands-draft-banner")).toHaveTextContent(
+      "Drafted from assistant setup"
+    )
+    expect(screen.getByTestId("persona-commands-name-input")).toHaveValue(
+      "Open the pod bay doors"
+    )
+
+    fireEvent.change(screen.getByTestId("persona-commands-name-input"), {
+      target: { value: "Open Pod Bay Doors" }
+    })
+    fireEvent.change(screen.getByTestId("persona-commands-action-type-select"), {
+      target: { value: "custom" }
+    })
+    fireEvent.change(screen.getByTestId("persona-commands-custom-action-input"), {
+      target: { value: "open_pod_bay_doors" }
+    })
+    fireEvent.click(screen.getByTestId("persona-commands-save"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+    expect(screen.getByPlaceholderText("Try a spoken phrase")).toHaveValue(
+      "open the pod bay doors"
+    )
+    expect(
+      screen.getByText("Command saved. Run the same phrase again to confirm setup.")
+    ).toBeInTheDocument()
+  })
+
   it("derives handoff review details when setup resumes on the test step", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=profiles"
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -2257,6 +2257,153 @@ describe("SidepanelPersona", () => {
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
   })
 
+  it("does not collapse the setup handoff when a post-setup dry-run does not match", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=test-lab"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      run_id: "setup-run-1",
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+    const setupEventBodies: Array<Record<string, unknown>> = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-events") && method === "POST") {
+        setupEventBodies.push(init?.body || {})
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            event_id: init?.body?.event_id || "evt-1",
+            run_id: init?.body?.run_id || "setup-run-1",
+            event_type: init?.body?.event_type || "step_viewed",
+            deduped: false,
+            created_at: "2026-03-14T10:00:00.000Z"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        const heardText = String(init?.body?.heard_text || "")
+        if (heardText === "start a focused research sprint") {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              heard_text: heardText,
+              matched: false,
+              failure_phase: "planner_fallback"
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: heardText,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toHaveTextContent(
+        "Assistant setup complete"
+      )
+    })
+
+    fireEvent.change(screen.getByTestId("persona-test-lab-heard-input"), {
+      target: { value: "start a focused research sprint" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run" }))
+
+    await screen.findByText("persona fallback")
+    expect(screen.getByTestId("persona-setup-handoff-card")).toHaveTextContent(
+      "Assistant setup complete"
+    )
+    expect(
+      setupEventBodies.some(
+        (body) =>
+          body.event_type === "first_post_setup_action" &&
+          body.action_target === "test-lab"
+      )
+    ).toBe(false)
+  })
+
   it("collapses the setup handoff after the first successful post-setup action", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=connections"
 

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -909,6 +909,104 @@ describe("SidepanelPersona", () => {
     ).toBeInTheDocument()
   })
 
+  it("surfaces live_unavailable on setup connect failure and autoconnects on the detour", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=live"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    let connectAttempts = 0
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/sessions?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path === "/api/v1/persona/session") {
+        connectAttempts += 1
+        if (connectAttempts === 1) {
+          return Promise.resolve({
+            ok: false,
+            error: "Failed to create persona session",
+            json: async () => ({})
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            session_id: "sess-setup-live",
+            persona: { id: "garden-helper" }
+          })
+        })
+      }
+      if (path.includes("/persona/sessions/sess-setup-live")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ preferences: {} })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: 2,
+            voice_defaults: {
+              confirmation_mode: "destructive_only"
+            },
+            setup: {
+              status: "in_progress",
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety"]
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect live session" }))
+
+    expect(
+      await screen.findByText(/Live session unavailable until you connect/i)
+    ).toBeInTheDocument()
+    expect(MockWebSocket.instances).toHaveLength(0)
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Live Session to fix this" }))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+    expect(
+      screen.getByText("Finish this live test, then return to setup.")
+    ).toBeInTheDocument()
+  })
+
   it("detours setup into live for a setup live failure and returns manually", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=live"
     mocks.getConfig.mockResolvedValue({
@@ -1006,6 +1104,7 @@ describe("SidepanelPersona", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("assistant-setup-overlay")).not.toBeInTheDocument()
     })
+    expect(MockWebSocket.instances).toHaveLength(1)
     expect(
       screen.getByText("Finish this live test, then return to setup.")
     ).toBeInTheDocument()

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -2257,6 +2257,196 @@ describe("SidepanelPersona", () => {
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
   })
 
+  it("collapses the setup handoff after the first successful post-setup action", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=connections"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      run_id: "setup-run-1",
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+    const setupEventBodies: Array<Record<string, unknown>> = []
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-events") && method === "POST") {
+        setupEventBodies.push(init?.body || {})
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            event_id: init?.body?.event_id || "evt-1",
+            run_id: init?.body?.run_id || "setup-run-1",
+            event_type: init?.body?.event_type || "step_viewed",
+            deduped: false,
+            created_at: "2026-03-14T10:00:00.000Z"
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "cmd-hello",
+            persona_id: "garden-helper",
+            name: init?.body?.name ?? "Hello there",
+            phrases: init?.body?.phrases ?? ["hello there"],
+            action_type: init?.body?.action_type ?? "custom",
+            action_config: init?.body?.action_config ?? { action: "say_hello" },
+            priority: 50,
+            enabled: true,
+            requires_confirmation: false
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Commands" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+
+    fireEvent.change(screen.getByTestId("persona-commands-name-input"), {
+      target: { value: "Hello there" }
+    })
+    fireEvent.change(screen.getByTestId("persona-commands-phrases-input"), {
+      target: { value: "hello there" }
+    })
+    fireEvent.change(screen.getByTestId("persona-commands-action-type-select"), {
+      target: { value: "custom" }
+    })
+    fireEvent.change(screen.getByTestId("persona-commands-custom-action-input"), {
+      target: { value: "say_hello" }
+    })
+    fireEvent.click(screen.getByTestId("persona-commands-save"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Setup complete")).toBeInTheDocument()
+      expect(screen.getByText("Add your first command")).toBeInTheDocument()
+    })
+
+    expect(
+      setupEventBodies.some(
+        (body) =>
+          body.event_type === "first_post_setup_action" &&
+          body.action_target === "commands"
+      )
+    ).toBe(true)
+  })
+
   it("renders a dedicated companion conversation mode", () => {
     render(<SidepanelPersona mode="companion" />)
 

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -231,6 +231,11 @@ type SetupCommandDetourState = {
   returnStep: "test"
 }
 
+type SetupLiveDetourState = {
+  source: "live_unavailable" | "live_failure"
+  lastText: string
+}
+
 const DEFAULT_SETUP_REVIEW_SUMMARY: SetupReviewSummary = {
   starterCommands: { mode: "skipped" },
   confirmationMode: null,
@@ -597,6 +602,7 @@ const SidepanelPersona = ({
   const runtimeApprovalRowRefs = React.useRef<Map<string, HTMLDivElement | null>>(
     new Map()
   )
+  const setupLiveDetourRef = React.useRef<SetupLiveDetourState | null>(null)
   const resolvedApprovalFadeTimerRef = React.useRef<number | null>(null)
   const approvalHighlightPhaseTimerRef = React.useRef<number | null>(null)
 
@@ -634,6 +640,8 @@ const SidepanelPersona = ({
   const [lastTestLabPhrase, setLastTestLabPhrase] = React.useState("")
   const [setupCommandDetour, setSetupCommandDetour] =
     React.useState<SetupCommandDetourState | null>(null)
+  const [setupLiveDetour, setSetupLiveDetour] =
+    React.useState<SetupLiveDetourState | null>(null)
   const [setupNoMatchPhrase, setSetupNoMatchPhrase] = React.useState<string | null>(null)
   const [setupTestResumeNote, setSetupTestResumeNote] = React.useState<string | null>(null)
   const [testLabRerunToken, setTestLabRerunToken] = React.useState(0)
@@ -719,6 +727,10 @@ const SidepanelPersona = ({
     setActiveTab,
     setSelectedPersonaId
   })
+
+  React.useEffect(() => {
+    setupLiveDetourRef.current = setupLiveDetour
+  }, [setupLiveDetour])
 
   React.useEffect(() => {
     if (!isCompanionMode) return
@@ -1017,6 +1029,7 @@ const SidepanelPersona = ({
     setSetupTestOutcome(null)
     setSetupTestResumeNote(null)
     setSetupCommandDetour(null)
+    setSetupLiveDetour(null)
     setSetupNoMatchPhrase(null)
     setupWizardLastLiveTextRef.current = ""
     setupWizardAwaitingLiveResponseRef.current = false
@@ -1276,6 +1289,24 @@ const SidepanelPersona = ({
       returnStep: "test"
     })
     setActiveTab("commands")
+  }, [])
+
+  const handleRecoverSetupInLiveSession = React.useCallback(
+    (context: { source: "live_unavailable" | "live_failure"; text: string }) => {
+      setSetupLiveDetour({
+        source: context.source,
+        lastText: String(context.text || "").trim()
+      })
+      setSetupTestResumeNote(null)
+      setActiveTab("live")
+    },
+    []
+  )
+
+  const handleReturnToSetupFromLiveDetour = React.useCallback(() => {
+    setSetupLiveDetour(null)
+    setupWizardAwaitingLiveResponseRef.current = false
+    setSetupTestResumeNote("Live session is still available if you want to retry.")
   }, [])
 
   const handleOpenCommandHandled = React.useCallback((commandId: string) => {
@@ -1655,6 +1686,12 @@ const SidepanelPersona = ({
               responseText: textDelta
             })
             setupWizardAwaitingLiveResponseRef.current = false
+            if (setupLiveDetourRef.current) {
+              setSetupLiveDetour(null)
+              setSetupTestResumeNote(
+                "Live session responded. Finish setup when you're ready."
+              )
+            }
           }
         }
         appendLog("assistant", String(payload?.text_delta || ""))
@@ -1780,7 +1817,13 @@ const SidepanelPersona = ({
         appendLog("notice", "Received persona TTS audio chunk")
       }
     },
-    [appendLog, liveVoiceController, personaSetupWizard.currentStep, personaSetupWizard.isSetupRequired, sessionId]
+    [
+      appendLog,
+      liveVoiceController,
+      personaSetupWizard.currentStep,
+      personaSetupWizard.isSetupRequired,
+      sessionId,
+    ]
   )
 
   const applyPersonaStatePayload = React.useCallback((payload: PersonaStateDocsResponse) => {
@@ -2702,6 +2745,7 @@ const SidepanelPersona = ({
         setSetupTestOutcome(null)
         setSetupTestResumeNote(null)
         setSetupCommandDetour(null)
+        setSetupLiveDetour(null)
         setSetupNoMatchPhrase(null)
         setupWizardLastLiveTextRef.current = ""
       } catch (setupError: any) {
@@ -2738,6 +2782,7 @@ const SidepanelPersona = ({
       setSetupTestOutcome(null)
       setSetupTestResumeNote(null)
       setSetupCommandDetour(null)
+      setSetupLiveDetour(null)
       setSetupNoMatchPhrase(null)
       setSetupReviewSummaryDraft(DEFAULT_SETUP_REVIEW_SUMMARY)
       setupWizardLastLiveTextRef.current = ""
@@ -2875,6 +2920,10 @@ const SidepanelPersona = ({
           memory_top_k: memoryTopK
         })
       )
+      if (personaSetupWizard.isSetupRequired && setupLiveDetour) {
+        setupWizardAwaitingLiveResponseRef.current = true
+        setupWizardLastLiveTextRef.current = trimmed
+      }
       appendLog("user", trimmed)
       setInput("")
     } catch (err: any) {
@@ -2888,7 +2937,9 @@ const SidepanelPersona = ({
     memoryEnabled,
     memoryTopK,
     personaStateContextEnabled,
-    sessionId
+    personaSetupWizard.isSetupRequired,
+    sessionId,
+    setupLiveDetour
   ])
 
   const sendSetupLiveTestMessage = React.useCallback(
@@ -3594,6 +3645,18 @@ const SidepanelPersona = ({
 
   const liveSessionStatusPanels = (
     <>
+      {setupLiveDetour ? (
+        <div className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-3 text-sm text-sky-100">
+          <div>Finish this live test, then return to setup.</div>
+          <button
+            type="button"
+            className="mt-2 rounded-md border border-sky-500/40 px-3 py-2 text-sm font-medium text-sky-100"
+            onClick={handleReturnToSetupFromLiveDetour}
+          >
+            Return to setup
+          </button>
+        </div>
+      ) : null}
       {errorBanner}
       {!isCompanionMode ? (
         <PersonaPolicySummary personaId={selectedPersonaId || null} />
@@ -4306,7 +4369,7 @@ const SidepanelPersona = ({
         </div>
       ) : (
         <div className="flex flex-1 flex-col p-3">
-          {personaSetupWizard.isSetupRequired && !setupCommandDetour ? (
+          {personaSetupWizard.isSetupRequired && !setupCommandDetour && !setupLiveDetour ? (
             <AssistantSetupWizard
               catalog={catalog.map((persona) => ({
                 id: String(persona.id || ""),
@@ -4388,6 +4451,7 @@ const SidepanelPersona = ({
                     onConnectLive={() => {
                       void connect()
                     }}
+                    onRecoverInLiveSession={handleRecoverSetupInLiveSession}
                     onSendLive={(text) => {
                       sendSetupLiveTestMessage(text)
                     }}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -56,6 +56,12 @@ import {
   fetchCompanionConversationPrompts,
   isCompanionConsentRequiredResponse
 } from "@/services/companion"
+import {
+  buildSetupEventKey,
+  postPersonaSetupEvent,
+  type PersonaSetupAnalyticsEvent,
+  type PersonaSetupAnalyticsEventType
+} from "@/services/tldw/persona-setup-analytics"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { buildPersonaWebSocketUrl } from "@/services/persona-stream"
 import {
@@ -221,6 +227,7 @@ type SetupStepErrors = {
 }
 
 type SetupHandoffState = {
+  runId: string
   targetTab: PersonaGardenTabKey
   completionType: "dry_run" | "live_session"
   reviewSummary: SetupReviewSummary
@@ -602,6 +609,7 @@ const SidepanelPersona = ({
   const runtimeApprovalRowRefs = React.useRef<Map<string, HTMLDivElement | null>>(
     new Map()
   )
+  const emittedSetupEventKeysRef = React.useRef<Set<string>>(new Set())
   const setupLiveDetourRef = React.useRef<SetupLiveDetourState | null>(null)
   const resolvedApprovalFadeTimerRef = React.useRef<number | null>(null)
   const approvalHighlightPhaseTimerRef = React.useRef<number | null>(null)
@@ -924,14 +932,64 @@ const SidepanelPersona = ({
       savedPersonaSetup
     ]
   )
+  const createSetupRunId = React.useCallback(() => {
+    if (
+      typeof globalThis !== "undefined" &&
+      typeof globalThis.crypto?.randomUUID === "function"
+    ) {
+      return `setup-run-${globalThis.crypto.randomUUID()}`
+    }
+    return `setup-run-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  }, [])
+  const currentSetupRunId = React.useMemo(() => {
+    const normalized = String(savedPersonaSetup?.run_id || "").trim()
+    return normalized || null
+  }, [savedPersonaSetup?.run_id])
+  const emitSetupAnalyticsEvent = React.useCallback(
+    (event: Omit<PersonaSetupAnalyticsEvent, "runId"> & { runId?: string; personaId?: string }) => {
+      const personaId = String(event.personaId || selectedPersonaId || "").trim()
+      const runId = String(event.runId || currentSetupRunId || "").trim()
+      if (!personaId || !runId) return
+
+      const eventType = event.eventType as PersonaSetupAnalyticsEventType
+      const eventKey = buildSetupEventKey({
+        eventType,
+        step: event.step,
+        detourSource: event.detourSource || undefined
+      })
+      if (eventKey) {
+        const dedupeKey = `${personaId}:${runId}:${eventKey}`
+        if (emittedSetupEventKeysRef.current.has(dedupeKey)) return
+        emittedSetupEventKeysRef.current.add(dedupeKey)
+      }
+
+      void postPersonaSetupEvent(personaId, {
+        runId,
+        eventType,
+        step: event.step,
+        completionType: event.completionType,
+        detourSource: event.detourSource || undefined,
+        actionTarget: event.actionTarget || undefined,
+        metadata: event.metadata
+      })
+    },
+    [currentSetupRunId, selectedPersonaId]
+  )
   const setSetupStepError = React.useCallback(
     (step: PersonaSetupStep, message: string | null) => {
       setSetupStepErrors((current) => ({
         ...current,
         [step]: message
       }))
+      if (message) {
+        emitSetupAnalyticsEvent({
+          eventType: "step_error",
+          step,
+          metadata: { message }
+        })
+      }
     },
-    []
+    [emitSetupAnalyticsEvent]
   )
   const clearSetupStepError = React.useCallback(
     (step: PersonaSetupStep) => {
@@ -1035,19 +1093,38 @@ const SidepanelPersona = ({
     setupWizardAwaitingLiveResponseRef.current = false
   }, [personaSetupWizard.currentStep, personaSetupWizard.isSetupRequired])
 
+  React.useEffect(() => {
+    if (!personaSetupWizard.isSetupRequired) return
+    if (!currentSetupRunId) return
+    void emitSetupAnalyticsEvent({
+      eventType: "step_viewed",
+      step: personaSetupWizard.currentStep,
+      runId: currentSetupRunId
+    })
+  }, [
+    currentSetupRunId,
+    emitSetupAnalyticsEvent,
+    personaSetupWizard.currentStep,
+    personaSetupWizard.isSetupRequired
+  ])
+
   const buildPersonaSetupInProgress = React.useCallback(
     (
       step: PersonaSetupState["current_step"] = "voice",
-      completedSteps: PersonaSetupStep[] = []
+      completedSteps: PersonaSetupStep[] = [],
+      options?: { runId?: string | null }
     ): PersonaSetupState => ({
       status: "in_progress",
       version: 1,
+      run_id:
+        String(options?.runId || savedPersonaSetup?.run_id || "").trim() ||
+        createSetupRunId(),
       current_step: step || "voice",
       completed_steps: completedSteps,
       completed_at: null,
       last_test_type: null
     }),
-    []
+    [createSetupRunId, savedPersonaSetup?.run_id]
   )
 
   const mergeCompletedSetupSteps = React.useCallback(
@@ -1130,6 +1207,12 @@ const SidepanelPersona = ({
         }
         const payload = (await response.json()) as PersonaProfileResponse
         applyPersonaProfileResponse(payload, { setup: nextSetup })
+        void emitSetupAnalyticsEvent({
+          personaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "step_completed",
+          step: "voice"
+        })
       } catch (setupError: any) {
         setSetupStepError(
           "voice",
@@ -1144,6 +1227,7 @@ const SidepanelPersona = ({
       buildPersonaSetupInProgress,
       buildSetupProfileUpdatePath,
       clearSetupStepError,
+      emitSetupAnalyticsEvent,
       mergeCompletedSetupSteps,
       setSetupStepError,
       selectedPersonaId
@@ -1180,6 +1264,14 @@ const SidepanelPersona = ({
         }
         const payload = (await response.json()) as PersonaProfileResponse
         applyPersonaProfileResponse(payload, { setup: nextSetup })
+        if (completedStep) {
+          void emitSetupAnalyticsEvent({
+            personaId,
+            runId: nextSetup.run_id || undefined,
+            eventType: "step_completed",
+            step: completedStep
+          })
+        }
       } catch (setupError: any) {
         setSetupStepError(errorStep, String(setupError?.message || errorMessage))
       } finally {
@@ -1191,6 +1283,7 @@ const SidepanelPersona = ({
       buildPersonaSetupInProgress,
       buildSetupProfileUpdatePath,
       clearSetupStepError,
+      emitSetupAnalyticsEvent,
       mergeCompletedSetupSteps,
       setSetupStepError,
       selectedPersonaId
@@ -1289,7 +1382,12 @@ const SidepanelPersona = ({
       returnStep: "test"
     })
     setActiveTab("commands")
-  }, [])
+    void emitSetupAnalyticsEvent({
+      eventType: "detour_started",
+      step: "test",
+      detourSource: "dry_run_no_match"
+    })
+  }, [emitSetupAnalyticsEvent])
 
   const handleRecoverSetupInLiveSession = React.useCallback(
     (context: { source: "live_unavailable" | "live_failure"; text: string }) => {
@@ -1299,18 +1397,31 @@ const SidepanelPersona = ({
       })
       setSetupTestResumeNote(null)
       setActiveTab("live")
+      void emitSetupAnalyticsEvent({
+        eventType: "detour_started",
+        step: "test",
+        detourSource: context.source
+      })
       if (context.source === "live_unavailable" && !connected && !connecting) {
         setPendingRecoveryReconnectToken((current) => current + 1)
       }
     },
-    [connected, connecting]
+    [connected, connecting, emitSetupAnalyticsEvent]
   )
 
   const handleReturnToSetupFromLiveDetour = React.useCallback(() => {
+    const detourSource = setupLiveDetour?.source || null
     setSetupLiveDetour(null)
     setupWizardAwaitingLiveResponseRef.current = false
     setSetupTestResumeNote("Live session is still available if you want to retry.")
-  }, [])
+    if (detourSource) {
+      void emitSetupAnalyticsEvent({
+        eventType: "detour_returned",
+        step: "test",
+        detourSource
+      })
+    }
+  }, [emitSetupAnalyticsEvent, setupLiveDetour?.source])
 
   const handleOpenCommandHandled = React.useCallback((commandId: string) => {
     const normalizedCommandId = String(commandId || "").trim()
@@ -1344,6 +1455,11 @@ const SidepanelPersona = ({
     (_commandId: string, context: { fromDraft: boolean }) => {
       if (!setupCommandDetour || !context.fromDraft) return
       if (setupCommandDetour.returnStep !== "test") return
+      void emitSetupAnalyticsEvent({
+        eventType: "detour_returned",
+        step: "test",
+        detourSource: "dry_run_no_match"
+      })
       setSetupCommandDetour(null)
       setDraftCommandPhrase(null)
       setDraftCommandSource(null)
@@ -1356,7 +1472,7 @@ const SidepanelPersona = ({
       )
       setActiveTab(setupIntentTargetTab || "live")
     },
-    [setupCommandDetour, setupIntentTargetTab]
+    [emitSetupAnalyticsEvent, setupCommandDetour, setupIntentTargetTab]
   )
 
   React.useEffect(() => {
@@ -1690,6 +1806,11 @@ const SidepanelPersona = ({
             })
             setupWizardAwaitingLiveResponseRef.current = false
             if (setupLiveDetourRef.current) {
+              void emitSetupAnalyticsEvent({
+                eventType: "detour_returned",
+                step: "test",
+                detourSource: setupLiveDetourRef.current.source
+              })
               setSetupLiveDetour(null)
               setSetupTestResumeNote(
                 "Live session responded. Finish setup when you're ready."
@@ -2422,13 +2543,16 @@ const SidepanelPersona = ({
       }
       setSetupWizardSaving(true)
       clearSetupStepError("persona")
+      const nextSetup = buildPersonaSetupInProgress("voice", ["persona"], {
+        runId: createSetupRunId()
+      })
       try {
         const response = await tldwClient.fetchWithAuth(
           `/api/v1/persona/profiles/${encodeURIComponent(nextPersonaId)}` as any,
           {
             method: "PATCH",
             body: {
-              setup: buildPersonaSetupInProgress("voice", ["persona"])
+              setup: nextSetup
             }
           }
         )
@@ -2438,8 +2562,19 @@ const SidepanelPersona = ({
         const payload = (await response.json()) as PersonaProfileResponse
         setSelectedPersonaId(nextPersonaId)
         applyPersonaProfileResponse(payload, {
-          setup: buildPersonaSetupInProgress("voice", ["persona"]),
+          setup: nextSetup,
           voiceDefaults: payload?.voice_defaults || null
+        })
+        void emitSetupAnalyticsEvent({
+          personaId: nextPersonaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "setup_started"
+        })
+        void emitSetupAnalyticsEvent({
+          personaId: nextPersonaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "step_completed",
+          step: "persona"
         })
       } catch (setupError: any) {
         setSetupStepError(
@@ -2455,6 +2590,8 @@ const SidepanelPersona = ({
       buildPersonaSetupInProgress,
       clearSetupStepError,
       confirmDiscardUnsavedStateDrafts,
+      createSetupRunId,
+      emitSetupAnalyticsEvent,
       setSetupStepError,
       selectedPersonaId
     ]
@@ -2466,6 +2603,9 @@ const SidepanelPersona = ({
       if (!normalizedName) return
       setSetupWizardSaving(true)
       clearSetupStepError("persona")
+      const nextSetup = buildPersonaSetupInProgress("voice", ["persona"], {
+        runId: createSetupRunId()
+      })
       try {
         const response = await tldwClient.fetchWithAuth(
           "/api/v1/persona/profiles" as any,
@@ -2474,7 +2614,7 @@ const SidepanelPersona = ({
             body: {
               name: normalizedName,
               mode: "persistent_scoped",
-              setup: buildPersonaSetupInProgress("voice", ["persona"])
+              setup: nextSetup
             }
           }
         )
@@ -2498,8 +2638,19 @@ const SidepanelPersona = ({
           setSelectedPersonaId(createdPersonaId)
         }
         applyPersonaProfileResponse(payload, {
-          setup: buildPersonaSetupInProgress("voice", ["persona"]),
+          setup: nextSetup,
           voiceDefaults: payload?.voice_defaults || null
+        })
+        void emitSetupAnalyticsEvent({
+          personaId: createdPersonaId || selectedPersonaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "setup_started"
+        })
+        void emitSetupAnalyticsEvent({
+          personaId: createdPersonaId || selectedPersonaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "step_completed",
+          step: "persona"
         })
       } catch (setupError: any) {
         setSetupStepError(
@@ -2514,6 +2665,9 @@ const SidepanelPersona = ({
       applyPersonaProfileResponse,
       buildPersonaSetupInProgress,
       clearSetupStepError,
+      createSetupRunId,
+      emitSetupAnalyticsEvent,
+      selectedPersonaId,
       setSetupStepError
     ]
   )
@@ -2694,6 +2848,11 @@ const SidepanelPersona = ({
           voiceDefaults: mergedVoiceDefaults,
           setup: buildPersonaSetupInProgress("test", mergeCompletedSetupSteps("safety"))
         })
+        void emitSetupAnalyticsEvent({
+          personaId,
+          eventType: "step_completed",
+          step: "safety"
+        })
       } catch (setupError: any) {
         setSetupStepError(
           "safety",
@@ -2708,6 +2867,7 @@ const SidepanelPersona = ({
       buildPersonaSetupInProgress,
       buildSetupProfileUpdatePath,
       clearSetupStepError,
+      emitSetupAnalyticsEvent,
       mergeCompletedSetupSteps,
       savedPersonaVoiceDefaults,
       setSetupStepError,
@@ -2723,9 +2883,12 @@ const SidepanelPersona = ({
       clearSetupStepError("test")
       try {
         const resolvedReviewSummary = await resolveSetupReviewSummary(personaId)
+        const resolvedRunId =
+          String(savedPersonaSetup?.run_id || "").trim() || createSetupRunId()
         const completedSetup: PersonaSetupState = {
           status: "completed",
           version: 1,
+          run_id: resolvedRunId,
           current_step: "test",
           completed_steps: ["persona", "voice", "commands", "safety", "test"],
           completed_at: new Date().toISOString(),
@@ -2748,9 +2911,23 @@ const SidepanelPersona = ({
         const handoffTargetTab = setupIntentTargetTab || activeTab
         setActiveTab(handoffTargetTab)
         setSetupHandoff({
+          runId: resolvedRunId,
           targetTab: handoffTargetTab,
           completionType: testType,
           reviewSummary: resolvedReviewSummary
+        })
+        void emitSetupAnalyticsEvent({
+          personaId,
+          runId: resolvedRunId,
+          eventType: "step_completed",
+          step: "test"
+        })
+        void emitSetupAnalyticsEvent({
+          personaId,
+          runId: resolvedRunId,
+          eventType: "setup_completed",
+          step: "test",
+          completionType: testType
         })
         setSetupIntentPersonaId("")
         setSetupIntentTargetTab(null)
@@ -2774,7 +2951,10 @@ const SidepanelPersona = ({
       activeTab,
       buildSetupProfileUpdatePath,
       clearSetupStepError,
+      createSetupRunId,
+      emitSetupAnalyticsEvent,
       resolveSetupReviewSummary,
+      savedPersonaSetup?.run_id,
       selectedPersonaId,
       setupIntentTargetTab,
       setSetupHandoff,
@@ -2786,7 +2966,9 @@ const SidepanelPersona = ({
     async (errorMessage: string) => {
       const personaId = String(selectedPersonaId || "").trim()
       if (!personaId) return
-      const nextSetup = buildPersonaSetupInProgress("persona", [])
+      const nextSetup = buildPersonaSetupInProgress("persona", [], {
+        runId: createSetupRunId()
+      })
       setSetupWizardSaving(true)
       clearAllSetupStepErrors()
       setSetupIntentPersonaId(personaId)
@@ -2815,6 +2997,11 @@ const SidepanelPersona = ({
         }
         const payload = (await response.json()) as PersonaProfileResponse
         applyPersonaProfileResponse(payload, { setup: nextSetup })
+        void emitSetupAnalyticsEvent({
+          personaId,
+          runId: nextSetup.run_id || undefined,
+          eventType: "setup_started"
+        })
       } catch (setupError: any) {
         setSetupStepError("persona", String(setupError?.message || errorMessage))
       } finally {
@@ -2827,6 +3014,8 @@ const SidepanelPersona = ({
       buildPersonaSetupInProgress,
       buildSetupProfileUpdatePath,
       clearAllSetupStepErrors,
+      createSetupRunId,
+      emitSetupAnalyticsEvent,
       selectedPersonaId,
       setSetupHandoff,
       setSetupStepError
@@ -4062,13 +4251,26 @@ const SidepanelPersona = ({
   )
 
   const dismissSetupHandoff = React.useCallback(() => {
+    if (setupHandoff) {
+      void emitSetupAnalyticsEvent({
+        runId: setupHandoff.runId,
+        eventType: "handoff_dismissed"
+      })
+    }
     setSetupHandoff(null)
-  }, [])
+  }, [emitSetupAnalyticsEvent, setupHandoff])
 
   const openSetupHandoffTab = React.useCallback((tab: PersonaGardenTabKey) => {
+    if (setupHandoff) {
+      void emitSetupAnalyticsEvent({
+        runId: setupHandoff.runId,
+        eventType: "handoff_action_clicked",
+        actionTarget: tab
+      })
+    }
     setActiveTab(tab)
     setSetupHandoff(null)
-  }, [])
+  }, [emitSetupAnalyticsEvent, setupHandoff])
 
   const renderSetupHandoffCard = React.useCallback(
     (tab: PersonaGardenTabKey) => {

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -19,6 +19,7 @@ import { AssistantVoiceCard } from "@/components/PersonaGarden/AssistantVoiceCar
 import { AssistantDefaultsPanel } from "@/components/PersonaGarden/AssistantDefaultsPanel"
 import {
   PersonaSetupHandoffCard,
+  type SetupHandoffRecommendedAction,
   type SetupReviewSummary
 } from "@/components/PersonaGarden/PersonaSetupHandoffCard"
 import { AssistantSetupWizard } from "@/components/PersonaGarden/AssistantSetupWizard"
@@ -231,6 +232,9 @@ type SetupHandoffState = {
   targetTab: PersonaGardenTabKey
   completionType: "dry_run" | "live_session"
   reviewSummary: SetupReviewSummary
+  recommendedAction: SetupHandoffRecommendedAction
+  consumedAction: null
+  compact: boolean
 }
 
 type SetupCommandDetourState = {
@@ -301,6 +305,25 @@ const summarizeFallbackStarterCommands = (value: unknown): SetupReviewSummary["s
   }
 
   return { mode: "skipped" }
+}
+
+const deriveSetupHandoffRecommendedAction = ({
+  completionType,
+  reviewSummary
+}: {
+  completionType: "dry_run" | "live_session"
+  reviewSummary: SetupReviewSummary
+}): SetupHandoffRecommendedAction => {
+  if (reviewSummary.starterCommands.mode === "skipped") {
+    return "add_command"
+  }
+  if (reviewSummary.connection.mode === "skipped") {
+    return "add_connection"
+  }
+  if (completionType === "dry_run") {
+    return "try_live"
+  }
+  return "review_commands"
 }
 
 type PersonaStateDocsResponse = {
@@ -2909,12 +2932,19 @@ const SidepanelPersona = ({
         const payload = (await response.json()) as PersonaProfileResponse
         applyPersonaProfileResponse(payload, { setup: completedSetup })
         const handoffTargetTab = setupIntentTargetTab || activeTab
+        const recommendedAction = deriveSetupHandoffRecommendedAction({
+          completionType: testType,
+          reviewSummary: resolvedReviewSummary
+        })
         setActiveTab(handoffTargetTab)
         setSetupHandoff({
           runId: resolvedRunId,
           targetTab: handoffTargetTab,
           completionType: testType,
-          reviewSummary: resolvedReviewSummary
+          reviewSummary: resolvedReviewSummary,
+          recommendedAction,
+          consumedAction: null,
+          compact: false
         })
         void emitSetupAnalyticsEvent({
           personaId,
@@ -4269,7 +4299,16 @@ const SidepanelPersona = ({
       })
     }
     setActiveTab(tab)
-    setSetupHandoff(null)
+    setSetupHandoff((current) => {
+      if (!current) return null
+      if (current.targetTab === tab) {
+        return current
+      }
+      return {
+        ...current,
+        targetTab: tab
+      }
+    })
   }, [emitSetupAnalyticsEvent, setupHandoff])
 
   const renderSetupHandoffCard = React.useCallback(
@@ -4280,6 +4319,8 @@ const SidepanelPersona = ({
           targetTab={setupHandoff.targetTab}
           completionType={setupHandoff.completionType}
           reviewSummary={setupHandoff.reviewSummary}
+          recommendedAction={setupHandoff.recommendedAction}
+          compact={setupHandoff.compact}
           onDismiss={dismissSetupHandoff}
           onOpenCommands={() => openSetupHandoffTab("commands")}
           onOpenTestLab={() => openSetupHandoffTab("test-lab")}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -22,7 +22,10 @@ import {
   type SetupReviewSummary
 } from "@/components/PersonaGarden/PersonaSetupHandoffCard"
 import { AssistantSetupWizard } from "@/components/PersonaGarden/AssistantSetupWizard"
-import { CommandsPanel } from "@/components/PersonaGarden/CommandsPanel"
+import {
+  CommandsPanel,
+  type CommandDraftSource
+} from "@/components/PersonaGarden/CommandsPanel"
 import { ConnectionsPanel } from "@/components/PersonaGarden/ConnectionsPanel"
 import { LiveSessionPanel } from "@/components/PersonaGarden/LiveSessionPanel"
 import { PersonaGardenTabs } from "@/components/PersonaGarden/PersonaGardenTabs"
@@ -221,6 +224,11 @@ type SetupHandoffState = {
   targetTab: PersonaGardenTabKey
   completionType: "dry_run" | "live_session"
   reviewSummary: SetupReviewSummary
+}
+
+type SetupCommandDetourState = {
+  phrase: string
+  returnStep: "test"
 }
 
 const DEFAULT_SETUP_REVIEW_SUMMARY: SetupReviewSummary = {
@@ -619,9 +627,15 @@ const SidepanelPersona = ({
   const [activeTab, setActiveTab] = React.useState<PersonaGardenTabKey>("live")
   const [openCommandId, setOpenCommandId] = React.useState<string | null>(null)
   const [draftCommandPhrase, setDraftCommandPhrase] = React.useState<string | null>(null)
+  const [draftCommandSource, setDraftCommandSource] =
+    React.useState<CommandDraftSource | null>(null)
   const [rerunAfterSaveCommandId, setRerunAfterSaveCommandId] =
     React.useState<string | null>(null)
   const [lastTestLabPhrase, setLastTestLabPhrase] = React.useState("")
+  const [setupCommandDetour, setSetupCommandDetour] =
+    React.useState<SetupCommandDetourState | null>(null)
+  const [setupNoMatchPhrase, setSetupNoMatchPhrase] = React.useState<string | null>(null)
+  const [setupTestResumeNote, setSetupTestResumeNote] = React.useState<string | null>(null)
   const [testLabRerunToken, setTestLabRerunToken] = React.useState(0)
   const [pendingRecoveryReconnectToken, setPendingRecoveryReconnectToken] =
     React.useState(0)
@@ -1001,6 +1015,9 @@ const SidepanelPersona = ({
     }
     setSetupWizardDryRunLoading(false)
     setSetupTestOutcome(null)
+    setSetupTestResumeNote(null)
+    setSetupCommandDetour(null)
+    setSetupNoMatchPhrase(null)
     setupWizardLastLiveTextRef.current = ""
     setupWizardAwaitingLiveResponseRef.current = false
   }, [personaSetupWizard.currentStep, personaSetupWizard.isSetupRequired])
@@ -1227,6 +1244,7 @@ const SidepanelPersona = ({
     const normalizedHeardText = String(heardText || "").trim()
     if (!normalizedCommandId) return
     setDraftCommandPhrase(null)
+    setDraftCommandSource(null)
     setOpenCommandId(normalizedCommandId)
     setRerunAfterSaveCommandId(normalizedCommandId)
     setLastTestLabPhrase(normalizedHeardText)
@@ -1239,7 +1257,24 @@ const SidepanelPersona = ({
     setOpenCommandId(null)
     setRerunAfterSaveCommandId(null)
     setDraftCommandPhrase(normalizedHeardText)
+    setDraftCommandSource("test_lab")
     setLastTestLabPhrase(normalizedHeardText)
+    setActiveTab("commands")
+  }, [])
+
+  const handleCreateCommandFromSetupNoMatch = React.useCallback((heardText: string) => {
+    const normalizedHeardText = String(heardText || "").trim()
+    if (!normalizedHeardText) return
+    setOpenCommandId(null)
+    setRerunAfterSaveCommandId(null)
+    setDraftCommandPhrase(normalizedHeardText)
+    setDraftCommandSource("setup_no_match")
+    setSetupNoMatchPhrase(normalizedHeardText)
+    setSetupTestResumeNote(null)
+    setSetupCommandDetour({
+      phrase: normalizedHeardText,
+      returnStep: "test"
+    })
     setActiveTab("commands")
   }, [])
 
@@ -1257,6 +1292,7 @@ const SidepanelPersona = ({
     setDraftCommandPhrase((current) =>
       current === normalizedHeardText ? null : current
     )
+    setDraftCommandSource(null)
   }, [])
 
   const handleRerunAfterCommandSave = React.useCallback((commandId: string) => {
@@ -1269,6 +1305,25 @@ const SidepanelPersona = ({
     }
     setRerunAfterSaveCommandId(null)
   }, [lastTestLabPhrase, rerunAfterSaveCommandId])
+
+  const handleSetupDetourCommandSaved = React.useCallback(
+    (_commandId: string, context: { fromDraft: boolean }) => {
+      if (!setupCommandDetour || !context.fromDraft) return
+      if (setupCommandDetour.returnStep !== "test") return
+      setSetupCommandDetour(null)
+      setDraftCommandPhrase(null)
+      setDraftCommandSource(null)
+      setOpenCommandId(null)
+      setRerunAfterSaveCommandId(null)
+      setSetupTestOutcome(null)
+      setSetupWizardDryRunLoading(false)
+      setSetupTestResumeNote(
+        "Command saved. Run the same phrase again to confirm setup."
+      )
+      setActiveTab(setupIntentTargetTab || "live")
+    },
+    [setupCommandDetour, setupIntentTargetTab]
+  )
 
   React.useEffect(() => {
     let cancelled = false
@@ -2645,6 +2700,9 @@ const SidepanelPersona = ({
         setSetupIntentPersonaId("")
         setSetupIntentTargetTab(null)
         setSetupTestOutcome(null)
+        setSetupTestResumeNote(null)
+        setSetupCommandDetour(null)
+        setSetupNoMatchPhrase(null)
         setupWizardLastLiveTextRef.current = ""
       } catch (setupError: any) {
         setSetupStepError(
@@ -2678,6 +2736,9 @@ const SidepanelPersona = ({
       setSetupIntentPersonaId(personaId)
       setSetupIntentTargetTab(activeTab)
       setSetupTestOutcome(null)
+      setSetupTestResumeNote(null)
+      setSetupCommandDetour(null)
+      setSetupNoMatchPhrase(null)
       setSetupReviewSummaryDraft(DEFAULT_SETUP_REVIEW_SUMMARY)
       setupWizardLastLiveTextRef.current = ""
       setSetupHandoff(null)
@@ -2742,6 +2803,7 @@ const SidepanelPersona = ({
       if (!personaId || !normalizedHeardText) return
       setSetupWizardDryRunLoading(true)
       clearSetupStepError("test")
+      setSetupTestResumeNote(null)
       setSetupTestOutcome(null)
       try {
         const response = await tldwClient.fetchWithAuth(
@@ -3978,9 +4040,11 @@ const SidepanelPersona = ({
           openCommandId={openCommandId}
           onOpenCommandHandled={handleOpenCommandHandled}
           draftCommandPhrase={draftCommandPhrase}
+          draftCommandSource={draftCommandSource}
           onDraftCommandPhraseHandled={handleDraftCommandPhraseHandled}
           rerunAfterSaveCommandId={rerunAfterSaveCommandId}
           onRerunAfterSave={handleRerunAfterCommandSave}
+          onCommandSaved={handleSetupDetourCommandSaved}
         />
       )
     },
@@ -4242,7 +4306,7 @@ const SidepanelPersona = ({
         </div>
       ) : (
         <div className="flex flex-1 flex-col p-3">
-          {personaSetupWizard.isSetupRequired ? (
+          {personaSetupWizard.isSetupRequired && !setupCommandDetour ? (
             <AssistantSetupWizard
               catalog={catalog.map((persona) => ({
                 id: String(persona.id || ""),
@@ -4314,10 +4378,13 @@ const SidepanelPersona = ({
                     dryRunLoading={setupWizardDryRunLoading}
                     liveConnected={connected}
                     error={setupStepErrors.test || null}
+                    initialHeardText={setupNoMatchPhrase}
+                    notice={setupTestResumeNote}
                     outcome={setupTestOutcome}
                     onRunDryRun={(heardText) => {
                       void handleRunSetupDryRun(heardText)
                     }}
+                    onCreateCommandFromPhrase={handleCreateCommandFromSetupNoMatch}
                     onConnectLive={() => {
                       void connect()
                     }}

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -43,7 +43,10 @@ import {
   type SetupTestOutcome
 } from "@/components/PersonaGarden/SetupTestAndFinishStep"
 import { StateDocsPanel } from "@/components/PersonaGarden/StateDocsPanel"
-import { TestLabPanel } from "@/components/PersonaGarden/TestLabPanel"
+import {
+  TestLabPanel,
+  type TestLabDryRunCompletedResult,
+} from "@/components/PersonaGarden/TestLabPanel"
 import { VoiceExamplesPanel } from "@/components/PersonaGarden/VoiceExamplesPanel"
 import {
   getPersonaStarterCommandTemplate,
@@ -4400,8 +4403,8 @@ const SidepanelPersona = ({
     consumeSetupHandoffAction("connection_test_succeeded")
   }, [consumeSetupHandoffAction])
 
-  const handleTestLabDryRunCompleted = React.useCallback((matched: boolean) => {
-    if (!matched) return
+  const handleTestLabDryRunCompleted = React.useCallback((result: TestLabDryRunCompletedResult) => {
+    if (!result.matched) return
     consumeSetupHandoffAction("dry_run_match")
   }, [consumeSetupHandoffAction])
 

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -233,9 +233,17 @@ type SetupHandoffState = {
   completionType: "dry_run" | "live_session"
   reviewSummary: SetupReviewSummary
   recommendedAction: SetupHandoffRecommendedAction
-  consumedAction: null
+  consumedAction: SetupHandoffConsumedAction | null
   compact: boolean
 }
+
+type SetupHandoffConsumedAction =
+  | "command_saved"
+  | "connection_saved"
+  | "connection_test_succeeded"
+  | "voice_defaults_saved"
+  | "dry_run_match"
+  | "live_response_received"
 
 type SetupCommandDetourState = {
   phrase: string
@@ -324,6 +332,18 @@ const deriveSetupHandoffRecommendedAction = ({
     return "try_live"
   }
   return "review_commands"
+}
+
+const toSetupHandoffActionTarget = (
+  action: SetupHandoffConsumedAction
+): PersonaGardenTabKey => {
+  if (action === "command_saved") return "commands"
+  if (action === "connection_saved" || action === "connection_test_succeeded") {
+    return "connections"
+  }
+  if (action === "voice_defaults_saved") return "profiles"
+  if (action === "live_response_received") return "live"
+  return "test-lab"
 }
 
 type PersonaStateDocsResponse = {
@@ -634,6 +654,8 @@ const SidepanelPersona = ({
   )
   const emittedSetupEventKeysRef = React.useRef<Set<string>>(new Set())
   const setupLiveDetourRef = React.useRef<SetupLiveDetourState | null>(null)
+  const setupHandoffRef = React.useRef<SetupHandoffState | null>(null)
+  const activeTabRef = React.useRef<PersonaGardenTabKey>("live")
   const resolvedApprovalFadeTimerRef = React.useRef<number | null>(null)
   const approvalHighlightPhaseTimerRef = React.useRef<number | null>(null)
 
@@ -762,6 +784,14 @@ const SidepanelPersona = ({
   React.useEffect(() => {
     setupLiveDetourRef.current = setupLiveDetour
   }, [setupLiveDetour])
+
+  React.useEffect(() => {
+    setupHandoffRef.current = setupHandoff
+  }, [setupHandoff])
+
+  React.useEffect(() => {
+    activeTabRef.current = activeTab
+  }, [activeTab])
 
   React.useEffect(() => {
     if (!isCompanionMode) return
@@ -1474,6 +1504,36 @@ const SidepanelPersona = ({
     setRerunAfterSaveCommandId(null)
   }, [lastTestLabPhrase, rerunAfterSaveCommandId])
 
+  const consumeSetupHandoffAction = React.useCallback(
+    (action: SetupHandoffConsumedAction) => {
+      const currentHandoff = setupHandoffRef.current
+      if (!currentHandoff || currentHandoff.compact || currentHandoff.consumedAction) {
+        return
+      }
+      void emitSetupAnalyticsEvent({
+        runId: currentHandoff.runId,
+        eventType: "first_post_setup_action",
+        actionTarget: toSetupHandoffActionTarget(action)
+      })
+      setSetupHandoff((existing) => {
+        if (
+          !existing ||
+          existing.runId !== currentHandoff.runId ||
+          existing.compact ||
+          existing.consumedAction
+        ) {
+          return existing
+        }
+        return {
+          ...existing,
+          compact: true,
+          consumedAction: action
+        }
+      })
+    },
+    [emitSetupAnalyticsEvent]
+  )
+
   const handleSetupDetourCommandSaved = React.useCallback(
     (_commandId: string, context: { fromDraft: boolean }) => {
       if (!setupCommandDetour || !context.fromDraft) return
@@ -1496,6 +1556,14 @@ const SidepanelPersona = ({
       setActiveTab(setupIntentTargetTab || "live")
     },
     [emitSetupAnalyticsEvent, setupCommandDetour, setupIntentTargetTab]
+  )
+
+  const handleCommandSaved = React.useCallback(
+    (commandId: string, context: { fromDraft: boolean }) => {
+      handleSetupDetourCommandSaved(commandId, context)
+      consumeSetupHandoffAction("command_saved")
+    },
+    [consumeSetupHandoffAction, handleSetupDetourCommandSaved]
   )
 
   React.useEffect(() => {
@@ -1815,12 +1883,12 @@ const SidepanelPersona = ({
       }
 
       if (eventType === "assistant_delta") {
+        const textDelta = String(payload?.text_delta || "").trim()
         if (
           personaSetupWizard.isSetupRequired &&
           personaSetupWizard.currentStep === "test" &&
           setupWizardAwaitingLiveResponseRef.current
         ) {
-          const textDelta = String(payload?.text_delta || "").trim()
           if (textDelta) {
             setSetupTestOutcome({
               kind: "live_success",
@@ -1840,6 +1908,14 @@ const SidepanelPersona = ({
               )
             }
           }
+        }
+        if (
+          textDelta &&
+          activeTabRef.current === "live" &&
+          setupHandoffRef.current &&
+          !setupHandoffRef.current.compact
+        ) {
+          consumeSetupHandoffAction("live_response_received")
         }
         appendLog("assistant", String(payload?.text_delta || ""))
         return
@@ -1966,6 +2042,7 @@ const SidepanelPersona = ({
     },
     [
       appendLog,
+      consumeSetupHandoffAction,
       liveVoiceController,
       personaSetupWizard.currentStep,
       personaSetupWizard.isSetupRequired,
@@ -4311,6 +4388,23 @@ const SidepanelPersona = ({
     })
   }, [emitSetupAnalyticsEvent, setupHandoff])
 
+  const handleProfileDefaultsSaved = React.useCallback(() => {
+    consumeSetupHandoffAction("voice_defaults_saved")
+  }, [consumeSetupHandoffAction])
+
+  const handleConnectionSaved = React.useCallback(() => {
+    consumeSetupHandoffAction("connection_saved")
+  }, [consumeSetupHandoffAction])
+
+  const handleConnectionTestSucceeded = React.useCallback(() => {
+    consumeSetupHandoffAction("connection_test_succeeded")
+  }, [consumeSetupHandoffAction])
+
+  const handleTestLabDryRunCompleted = React.useCallback((matched: boolean) => {
+    if (!matched) return
+    consumeSetupHandoffAction("dry_run_match")
+  }, [consumeSetupHandoffAction])
+
   const renderSetupHandoffCard = React.useCallback(
     (tab: PersonaGardenTabKey) => {
       if (!setupHandoff || setupHandoff.targetTab !== tab) return null
@@ -4362,7 +4456,7 @@ const SidepanelPersona = ({
           onDraftCommandPhraseHandled={handleDraftCommandPhraseHandled}
           rerunAfterSaveCommandId={rerunAfterSaveCommandId}
           onRerunAfterSave={handleRerunAfterCommandSave}
-          onCommandSaved={handleSetupDetourCommandSaved}
+          onCommandSaved={handleCommandSaved}
         />
       )
     },
@@ -4380,6 +4474,7 @@ const SidepanelPersona = ({
           rerunRequestToken={testLabRerunToken}
           onOpenCommand={handleOpenCommandFromTestLab}
           onCreateCommandDraft={handleCreateCommandFromTestLab}
+          onDryRunCompleted={handleTestLabDryRunCompleted}
         />
       )
     },
@@ -4414,6 +4509,7 @@ const SidepanelPersona = ({
           onResumeSetup={handleResumeSetup}
           onResetSetup={handleResetSetup}
           onRerunSetup={handleRerunSetup}
+          onDefaultsSaved={handleProfileDefaultsSaved}
           isActive={activeTab === "profiles"}
           analytics={voiceAnalytics}
           analyticsLoading={voiceAnalyticsLoading}
@@ -4440,6 +4536,8 @@ const SidepanelPersona = ({
           selectedPersonaId={selectedPersonaId}
           selectedPersonaName={selectedPersonaName}
           isActive={activeTab === "connections"}
+          onConnectionSaved={handleConnectionSaved}
+          onConnectionTestSucceeded={handleConnectionTestSucceeded}
         />
       )
     },

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -1299,8 +1299,11 @@ const SidepanelPersona = ({
       })
       setSetupTestResumeNote(null)
       setActiveTab("live")
+      if (context.source === "live_unavailable" && !connected && !connecting) {
+        setPendingRecoveryReconnectToken((current) => current + 1)
+      }
     },
-    []
+    [connected, connecting]
   )
 
   const handleReturnToSetupFromLiveDetour = React.useCallback(() => {
@@ -2199,6 +2202,13 @@ const SidepanelPersona = ({
       }
     } catch (err: any) {
       const message = String(err?.message || "Failed to connect persona stream")
+      if (
+        personaSetupWizard.isSetupRequired &&
+        personaSetupWizard.currentStep === "test" &&
+        !connected
+      ) {
+        setSetupTestOutcome({ kind: "live_unavailable" })
+      }
       setError(message)
       appendLog("notice", message)
     } finally {
@@ -2216,6 +2226,8 @@ const SidepanelPersona = ({
     isCompanionMode,
     loadPersonaStateDocs,
     applySessionPreferences,
+    personaSetupWizard.currentStep,
+    personaSetupWizard.isSetupRequired,
     resetApprovalHighlightMotion,
     resumeSessionId,
     routeBootstrap.personaId,

--- a/apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn()
+}))
+
+vi.mock("../TldwApiClient", () => ({
+  tldwClient: {
+    fetchWithAuth: (...args: unknown[]) =>
+      (mocks.fetchWithAuth as (...args: unknown[]) => unknown)(...args)
+  }
+}))
+
+import {
+  buildSetupEventKey,
+  postPersonaSetupEvent
+} from "../persona-setup-analytics"
+
+describe("buildSetupEventKey", () => {
+  it("builds stable event keys for once-only setup events", () => {
+    expect(
+      buildSetupEventKey({
+        eventType: "step_viewed",
+        step: "test"
+      })
+    ).toBe("step_viewed:test")
+    expect(
+      buildSetupEventKey({
+        eventType: "step_completed",
+        step: "commands"
+      })
+    ).toBe("step_completed:commands")
+    expect(buildSetupEventKey({ eventType: "setup_started" })).toBe("setup_started")
+    expect(buildSetupEventKey({ eventType: "setup_completed" })).toBe("setup_completed")
+    expect(buildSetupEventKey({ eventType: "handoff_dismissed" })).toBe(
+      "handoff_dismissed"
+    )
+    expect(buildSetupEventKey({ eventType: "first_post_setup_action" })).toBe(
+      "first_post_setup_action"
+    )
+    expect(
+      buildSetupEventKey({
+        eventType: "detour_returned",
+        detourSource: "live_failure"
+      })
+    ).toBe("detour_returned:live_failure")
+    expect(buildSetupEventKey({ eventType: "retry_clicked" })).toBeUndefined()
+  })
+})
+
+describe("postPersonaSetupEvent", () => {
+  afterEach(() => {
+    mocks.fetchWithAuth.mockReset()
+  })
+
+  it("posts normalized setup event payloads through the tldw client", async () => {
+    mocks.fetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    })
+
+    await postPersonaSetupEvent("garden-helper", {
+      runId: "setup-run-1",
+      eventType: "step_viewed",
+      step: "test"
+    })
+
+    expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+      "/api/v1/persona/profiles/garden-helper/setup-events",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.objectContaining({
+          run_id: "setup-run-1",
+          event_type: "step_viewed",
+          step: "test",
+          event_key: "step_viewed:test"
+        })
+      })
+    )
+  })
+})

--- a/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
+++ b/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
@@ -1,0 +1,83 @@
+import { tldwClient } from "./TldwApiClient"
+
+export type PersonaSetupAnalyticsEventType =
+  | "setup_started"
+  | "step_viewed"
+  | "step_completed"
+  | "step_error"
+  | "retry_clicked"
+  | "detour_started"
+  | "detour_returned"
+  | "setup_completed"
+  | "handoff_action_clicked"
+  | "handoff_dismissed"
+  | "first_post_setup_action"
+
+export type PersonaSetupAnalyticsEvent = {
+  eventId?: string
+  runId: string
+  eventType: PersonaSetupAnalyticsEventType
+  step?: "persona" | "voice" | "commands" | "safety" | "test"
+  completionType?: "dry_run" | "live_session"
+  detourSource?: string | null
+  actionTarget?: string | null
+  metadata?: Record<string, unknown>
+}
+
+const createEventId = (): string => {
+  if (typeof globalThis !== "undefined" && typeof globalThis.crypto?.randomUUID === "function") {
+    return globalThis.crypto.randomUUID()
+  }
+  return `setup-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export const buildSetupEventKey = ({
+  eventType,
+  step,
+  detourSource
+}: Pick<PersonaSetupAnalyticsEvent, "eventType" | "step" | "detourSource">):
+  | string
+  | undefined => {
+  if (eventType === "setup_started") return "setup_started"
+  if (eventType === "setup_completed") return "setup_completed"
+  if (eventType === "handoff_dismissed") return "handoff_dismissed"
+  if (eventType === "first_post_setup_action") return "first_post_setup_action"
+  if (eventType === "step_viewed" && step) return `step_viewed:${step}`
+  if (eventType === "step_completed" && step) return `step_completed:${step}`
+  if (eventType === "detour_returned" && detourSource) {
+    return `detour_returned:${detourSource}`
+  }
+  return undefined
+}
+
+export const postPersonaSetupEvent = async (
+  personaId: string,
+  event: PersonaSetupAnalyticsEvent
+): Promise<boolean> => {
+  const normalizedPersonaId = String(personaId || "").trim()
+  const normalizedRunId = String(event.runId || "").trim()
+  if (!normalizedPersonaId || !normalizedRunId) return false
+
+  try {
+    const response = await tldwClient.fetchWithAuth(
+      `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-events` as any,
+      {
+        method: "POST",
+        body: {
+          event_id: String(event.eventId || createEventId()),
+          event_key: buildSetupEventKey(event),
+          run_id: normalizedRunId,
+          event_type: event.eventType,
+          step: event.step,
+          completion_type: event.completionType,
+          detour_source: event.detourSource || undefined,
+          action_target: event.actionTarget || undefined,
+          metadata: event.metadata || {}
+        }
+      }
+    )
+    return Boolean(response?.ok)
+  } catch {
+    return false
+  }
+}

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -3262,6 +3262,7 @@ async def get_persona_setup_analytics(
     _current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> PersonaSetupAnalyticsResponse:
+    """Return aggregated setup analytics and recent setup runs for one persona."""
     if not is_persona_enabled():
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)
@@ -3308,6 +3309,7 @@ async def create_persona_setup_event(
     _current_user: User = Depends(get_request_user),
     db: CharactersRAGDB = Depends(get_chacha_db_for_user),
 ) -> PersonaSetupEventWriteResponse:
+    """Append one persona setup analytics event and return its dedupe status."""
     if not is_persona_enabled():
         raise HTTPException(status_code=404, detail="Persona disabled")
     user_id = _require_current_user_id(_current_user)

--- a/tldw_Server_API/app/api/v1/endpoints/persona.py
+++ b/tldw_Server_API/app/api/v1/endpoints/persona.py
@@ -17,7 +17,7 @@ import uuid
 from typing import Any
 from urllib.parse import urljoin
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, WebSocket, WebSocketDisconnect, status
 from loguru import logger
 from starlette.requests import Request as StarletteRequest
 
@@ -47,6 +47,11 @@ from tldw_Server_API.app.api.v1.schemas.persona import (
     PersonaProfileCreate,
     PersonaProfileResponse,
     PersonaProfileUpdate,
+    PersonaSetupAnalyticsResponse,
+    PersonaSetupAnalyticsRunSummary,
+    PersonaSetupAnalyticsSummary,
+    PersonaSetupEventCreate,
+    PersonaSetupEventWriteResponse,
     PersonaSetupState,
     PersonaVoiceDefaults,
     PersonaStateHistoryResponse,
@@ -3241,6 +3246,104 @@ async def replace_persona_policy_rules(
         raise
     except (InputError, ConflictError, CharactersRAGDBError) as exc:
         raise _to_http_exception(exc, action="replace persona policy rules") from exc
+
+
+@router.get(
+    "/profiles/{persona_id}/setup-analytics",
+    response_model=PersonaSetupAnalyticsResponse,
+    tags=["persona"],
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def get_persona_setup_analytics(
+    persona_id: str,
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(10, ge=1, le=50),
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaSetupAnalyticsResponse:
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        await _get_persona_profile_or_404(
+            db,
+            persona_id=persona_id,
+            user_id=user_id,
+            include_deleted=False,
+        )
+        analytics = db.get_persona_setup_analytics_summary(
+            user_id=int(user_id),
+            persona_id=persona_id,
+            days=days,
+            recent_run_limit=limit,
+        )
+        return PersonaSetupAnalyticsResponse(
+            persona_id=persona_id,
+            summary=PersonaSetupAnalyticsSummary.model_validate(
+                analytics.get("summary") or {}
+            ),
+            recent_runs=[
+                PersonaSetupAnalyticsRunSummary.model_validate(item)
+                for item in analytics.get("recent_runs") or []
+            ],
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise _to_http_exception(exc, action="get persona setup analytics") from exc
+
+
+@router.post(
+    "/profiles/{persona_id}/setup-events",
+    response_model=PersonaSetupEventWriteResponse,
+    tags=["persona"],
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_rate_limit)],
+)
+async def create_persona_setup_event(
+    persona_id: str,
+    payload: PersonaSetupEventCreate = Body(...),
+    response: Response = None,
+    _current_user: User = Depends(get_request_user),
+    db: CharactersRAGDB = Depends(get_chacha_db_for_user),
+) -> PersonaSetupEventWriteResponse:
+    if not is_persona_enabled():
+        raise HTTPException(status_code=404, detail="Persona disabled")
+    user_id = _require_current_user_id(_current_user)
+    try:
+        await _get_persona_profile_or_404(
+            db,
+            persona_id=persona_id,
+            user_id=user_id,
+            include_deleted=False,
+        )
+        event_row = db.record_persona_setup_event(
+            user_id=int(user_id),
+            persona_id=persona_id,
+            event_id=payload.event_id,
+            run_id=payload.run_id,
+            event_type=payload.event_type,
+            event_key=payload.event_key,
+            step=payload.step,
+            completion_type=payload.completion_type,
+            detour_source=payload.detour_source,
+            action_target=payload.action_target,
+            metadata=payload.metadata,
+        )
+        if bool(event_row.get("deduped")) and response is not None:
+            response.status_code = status.HTTP_200_OK
+        return PersonaSetupEventWriteResponse(
+            event_id=str(event_row.get("event_id") or payload.event_id),
+            run_id=str(event_row.get("run_id") or payload.run_id),
+            event_type=str(event_row.get("event_type") or payload.event_type),
+            deduped=bool(event_row.get("deduped")),
+            created_at=str(event_row.get("created_at") or "").strip() or None,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise _to_http_exception(exc, action="record persona setup event") from exc
 
 
 @router.get(

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -158,6 +158,8 @@ class PersonaVoiceDefaults(BaseModel):
 
 
 class PersonaSetupState(BaseModel):
+    """Persisted wizard progress for one persona setup run."""
+
     status: PersonaSetupStatus = "not_started"
     version: int = Field(default=1, ge=1)
     run_id: str | None = Field(default=None, min_length=1, max_length=200)
@@ -168,6 +170,8 @@ class PersonaSetupState(BaseModel):
 
 
 class PersonaSetupEventCreate(BaseModel):
+    """Append-only setup analytics event payload sent by the UI."""
+
     event_id: str = Field(..., min_length=1, max_length=200)
     event_key: str | None = Field(default=None, min_length=1, max_length=200)
     run_id: str = Field(..., min_length=1, max_length=200)
@@ -180,6 +184,8 @@ class PersonaSetupEventCreate(BaseModel):
 
 
 class PersonaSetupEventWriteResponse(BaseModel):
+    """Write result for one setup analytics event, including dedupe outcome."""
+
     event_id: str
     run_id: str
     event_type: PersonaSetupEventType
@@ -188,6 +194,8 @@ class PersonaSetupEventWriteResponse(BaseModel):
 
 
 class PersonaSetupAnalyticsRunSummary(BaseModel):
+    """Aggregated setup outcomes for one recorded setup run."""
+
     run_id: str
     started_at: str | None = None
     completed_at: str | None = None
@@ -199,6 +207,8 @@ class PersonaSetupAnalyticsRunSummary(BaseModel):
 
 
 class PersonaSetupAnalyticsSummary(BaseModel):
+    """High-level setup funnel and handoff metrics for one persona."""
+
     total_runs: int = 0
     completed_runs: int = 0
     completion_rate: float = 0.0
@@ -212,6 +222,8 @@ class PersonaSetupAnalyticsSummary(BaseModel):
 
 
 class PersonaSetupAnalyticsResponse(BaseModel):
+    """Persona setup analytics API response with summary and recent runs."""
+
     persona_id: str
     summary: PersonaSetupAnalyticsSummary = Field(default_factory=PersonaSetupAnalyticsSummary)
     recent_runs: list[PersonaSetupAnalyticsRunSummary] = Field(default_factory=list)

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -147,6 +147,7 @@ class PersonaVoiceDefaults(BaseModel):
 class PersonaSetupState(BaseModel):
     status: PersonaSetupStatus = "not_started"
     version: int = Field(default=1, ge=1)
+    run_id: str | None = Field(default=None, min_length=1, max_length=200)
     current_step: PersonaSetupStep = "persona"
     completed_steps: list[PersonaSetupStep] = Field(default_factory=list)
     completed_at: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -21,6 +21,19 @@ PersonaConfirmationMode = Literal["always", "destructive_only", "never"]
 PersonaSetupStatus = Literal["not_started", "in_progress", "completed"]
 PersonaSetupStep = Literal["persona", "voice", "commands", "safety", "test"]
 PersonaSetupTestType = Literal["dry_run", "live_session"]
+PersonaSetupEventType = Literal[
+    "setup_started",
+    "step_viewed",
+    "step_completed",
+    "step_error",
+    "retry_clicked",
+    "detour_started",
+    "detour_returned",
+    "setup_completed",
+    "handoff_action_clicked",
+    "handoff_dismissed",
+    "first_post_setup_action",
+]
 
 
 class PersonaInfo(BaseModel):
@@ -152,6 +165,56 @@ class PersonaSetupState(BaseModel):
     completed_steps: list[PersonaSetupStep] = Field(default_factory=list)
     completed_at: str | None = None
     last_test_type: PersonaSetupTestType | None = None
+
+
+class PersonaSetupEventCreate(BaseModel):
+    event_id: str = Field(..., min_length=1, max_length=200)
+    event_key: str | None = Field(default=None, min_length=1, max_length=200)
+    run_id: str = Field(..., min_length=1, max_length=200)
+    event_type: PersonaSetupEventType
+    step: PersonaSetupStep | None = None
+    completion_type: PersonaSetupTestType | None = None
+    detour_source: str | None = Field(default=None, min_length=1, max_length=120)
+    action_target: str | None = Field(default=None, min_length=1, max_length=120)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class PersonaSetupEventWriteResponse(BaseModel):
+    event_id: str
+    run_id: str
+    event_type: PersonaSetupEventType
+    deduped: bool = False
+    created_at: str | None = None
+
+
+class PersonaSetupAnalyticsRunSummary(BaseModel):
+    run_id: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    completion_type: PersonaSetupTestType | None = None
+    terminal_step: PersonaSetupStep | None = None
+    handoff_clicked: bool = False
+    handoff_dismissed: bool = False
+    first_post_setup_action: bool = False
+
+
+class PersonaSetupAnalyticsSummary(BaseModel):
+    total_runs: int = 0
+    completed_runs: int = 0
+    completion_rate: float = 0.0
+    dry_run_completion_count: int = 0
+    live_session_completion_count: int = 0
+    most_common_dropoff_step: PersonaSetupStep | None = None
+    handoff_click_rate: float = 0.0
+    first_post_setup_action_rate: float = 0.0
+    detour_started_counts: dict[str, int] = Field(default_factory=dict)
+    detour_returned_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class PersonaSetupAnalyticsResponse(BaseModel):
+    persona_id: str
+    summary: PersonaSetupAnalyticsSummary = Field(default_factory=PersonaSetupAnalyticsSummary)
+    recent_runs: list[PersonaSetupAnalyticsRunSummary] = Field(default_factory=list)
 
 
 class PersonaProfileCreate(BaseModel):

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -4968,6 +4968,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
     def _ensure_recent_persona_schema_sqlite(self, conn: sqlite3.Connection) -> None:
         """Backfill recent persona schema columns after version-number collisions."""
         profile_cols = {row[1] for row in conn.execute("PRAGMA table_info('persona_profiles')").fetchall()}
+        if "voice_defaults_json" not in profile_cols:
+            conn.execute("ALTER TABLE persona_profiles ADD COLUMN voice_defaults_json TEXT")
+        if "setup_json" not in profile_cols:
+            conn.execute("ALTER TABLE persona_profiles ADD COLUMN setup_json TEXT")
         if "origin_character_id" not in profile_cols:
             conn.execute("ALTER TABLE persona_profiles ADD COLUMN origin_character_id INTEGER")
         if "origin_character_name" not in profile_cols:
@@ -5152,6 +5156,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not hasattr(self.backend, "execute"):
             return
         statements = [
+            "ALTER TABLE persona_profiles ADD COLUMN IF NOT EXISTS voice_defaults_json TEXT",
+            "ALTER TABLE persona_profiles ADD COLUMN IF NOT EXISTS setup_json TEXT",
             "ALTER TABLE persona_profiles ADD COLUMN IF NOT EXISTS origin_character_id INTEGER",
             "ALTER TABLE persona_profiles ADD COLUMN IF NOT EXISTS origin_character_name TEXT",
             "ALTER TABLE persona_profiles ADD COLUMN IF NOT EXISTS origin_character_snapshot_at TEXT",
@@ -9436,6 +9442,29 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not row:
             return None
         item = dict(row)
+        raw_voice_defaults = item.get("voice_defaults_json")
+        if isinstance(raw_voice_defaults, str):
+            try:
+                decoded_voice_defaults = json.loads(raw_voice_defaults)
+            except json.JSONDecodeError:
+                decoded_voice_defaults = {}
+            item["voice_defaults"] = decoded_voice_defaults if isinstance(decoded_voice_defaults, dict) else {}
+        elif isinstance(raw_voice_defaults, dict):
+            item["voice_defaults"] = raw_voice_defaults
+        else:
+            item["voice_defaults"] = {}
+
+        raw_setup = item.get("setup_json")
+        if isinstance(raw_setup, str):
+            try:
+                decoded_setup = json.loads(raw_setup)
+            except json.JSONDecodeError:
+                decoded_setup = {}
+            item["setup"] = decoded_setup if isinstance(decoded_setup, dict) else {}
+        elif isinstance(raw_setup, dict):
+            item["setup"] = raw_setup
+        else:
+            item["setup"] = {}
         item["is_active"] = self._as_bool(item.get("is_active"))
         item["use_persona_state_context_default"] = self._as_bool(
             item.get("use_persona_state_context_default", True)
@@ -9886,6 +9915,14 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         use_persona_state_context_default = self._as_bool(
             profile_data.get("use_persona_state_context_default", True)
         )
+        voice_defaults_json = self._ensure_json_string(
+            profile_data.get("voice_defaults")
+            if isinstance(profile_data.get("voice_defaults"), dict)
+            else None
+        )
+        setup_json = self._ensure_json_string(
+            profile_data.get("setup") if isinstance(profile_data.get("setup"), dict) else None
+        )
         now = self._get_current_utc_timestamp_iso()
 
         character_card_id = profile_data.get("character_card_id")
@@ -9934,9 +9971,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         query = (
             "INSERT INTO persona_profiles("
             "id, user_id, name, character_card_id, origin_character_id, origin_character_name, "
-            "origin_character_snapshot_at, mode, system_prompt, "
+            "origin_character_snapshot_at, mode, system_prompt, voice_defaults_json, setup_json, "
             "is_active, use_persona_state_context_default, created_at, last_modified, deleted, version"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         )
         params = (
             persona_id,
@@ -9948,6 +9985,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             origin_character_snapshot_at,
             mode,
             system_prompt,
+            voice_defaults_json,
+            setup_json,
             is_active_db,
             use_persona_state_context_default_db,
             profile_data.get("created_at") or now,
@@ -10041,6 +10080,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
             "character_card_id",
             "mode",
             "system_prompt",
+            "voice_defaults",
+            "setup",
             "is_active",
             "use_persona_state_context_default",
             "deleted",
@@ -10069,6 +10110,12 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     except (TypeError, ValueError) as exc:
                         raise InputError("character_card_id must be an integer when provided.") from exc  # noqa: TRY003
                 set_parts.append("character_card_id = ?")
+            elif key == "voice_defaults":
+                params.append(self._ensure_json_string(value if isinstance(value, dict) else {}))
+                set_parts.append("voice_defaults_json = ?")
+            elif key == "setup":
+                params.append(self._ensure_json_string(value if isinstance(value, dict) else {}))
+                set_parts.append("setup_json = ?")
             else:
                 params.append(value)
                 set_parts.append(f"{key} = ?")

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -8143,18 +8143,48 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
     def _persona_setup_event_row_to_dict(self, row: Any) -> dict[str, Any]:
         item = dict(row)
-        raw_metadata = item.get("metadata_json")
-        if isinstance(raw_metadata, str):
-            try:
-                decoded_metadata = json.loads(raw_metadata)
-            except json.JSONDecodeError:
-                decoded_metadata = {}
-            item["metadata"] = decoded_metadata if isinstance(decoded_metadata, dict) else {}
-        elif isinstance(raw_metadata, dict):
-            item["metadata"] = raw_metadata
-        else:
-            item["metadata"] = {}
+        event_label = str(item.get("event_id") or item.get("id") or "unknown")
+        item["metadata"] = self._decode_persona_json_object(
+            item.get("metadata_json"),
+            field_name="metadata_json",
+            context_label=f"persona setup event {event_label}",
+        )
         return item
+
+    def _decode_persona_json_object(
+        self,
+        raw_value: Any,
+        *,
+        field_name: str,
+        context_label: str,
+    ) -> dict[str, Any]:
+        """Decode one persona JSON column into a dictionary with warning logs on invalid data."""
+        if isinstance(raw_value, dict):
+            return raw_value
+        if not isinstance(raw_value, str):
+            return {}
+
+        try:
+            decoded_value = json.loads(raw_value)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Invalid JSON in {} for {}: {}",
+                field_name,
+                context_label,
+                exc,
+            )
+            return {}
+
+        if isinstance(decoded_value, dict):
+            return decoded_value
+
+        logger.warning(
+            "Expected JSON object in {} for {}, got {}.",
+            field_name,
+            context_label,
+            type(decoded_value).__name__,
+        )
+        return {}
 
     def record_persona_setup_event(
         self,
@@ -8236,7 +8266,8 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 (user_id, persona_id, event_id),
             ).fetchone()
             if not row:
-                raise CharactersRAGDBError("Failed to load inserted persona setup event.")  # noqa: TRY003
+                error_message = "Failed to load inserted persona setup event."
+                raise CharactersRAGDBError(error_message)
             item = self._persona_setup_event_row_to_dict(row)
             item["deduped"] = False
             return item
@@ -9821,29 +9852,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         if not row:
             return None
         item = dict(row)
-        raw_voice_defaults = item.get("voice_defaults_json")
-        if isinstance(raw_voice_defaults, str):
-            try:
-                decoded_voice_defaults = json.loads(raw_voice_defaults)
-            except json.JSONDecodeError:
-                decoded_voice_defaults = {}
-            item["voice_defaults"] = decoded_voice_defaults if isinstance(decoded_voice_defaults, dict) else {}
-        elif isinstance(raw_voice_defaults, dict):
-            item["voice_defaults"] = raw_voice_defaults
-        else:
-            item["voice_defaults"] = {}
-
-        raw_setup = item.get("setup_json")
-        if isinstance(raw_setup, str):
-            try:
-                decoded_setup = json.loads(raw_setup)
-            except json.JSONDecodeError:
-                decoded_setup = {}
-            item["setup"] = decoded_setup if isinstance(decoded_setup, dict) else {}
-        elif isinstance(raw_setup, dict):
-            item["setup"] = raw_setup
-        else:
-            item["setup"] = {}
+        persona_label = str(item.get("id") or item.get("name") or "unknown")
+        item["voice_defaults"] = self._decode_persona_json_object(
+            item.get("voice_defaults_json"),
+            field_name="voice_defaults_json",
+            context_label=f"persona profile {persona_label}",
+        )
+        item["setup"] = self._decode_persona_json_object(
+            item.get("setup_json"),
+            field_name="setup_json",
+            context_label=f"persona profile {persona_label}",
+        )
         item["is_active"] = self._as_bool(item.get("is_active"))
         item["use_persona_state_context_default"] = self._as_bool(
             item.get("use_persona_state_context_default", True)

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -8058,6 +8058,385 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         ).fetchone()
         return dict(row) if row else None
 
+    def _ensure_persona_setup_events_table(self) -> None:
+        """Ensure append-only persona setup analytics events exist."""
+        if self.backend_type == BackendType.SQLITE:
+            self.execute_query(
+                """
+                CREATE TABLE IF NOT EXISTS persona_setup_events(
+                  id INTEGER PRIMARY KEY AUTOINCREMENT,
+                  event_id TEXT NOT NULL UNIQUE,
+                  user_id INTEGER NOT NULL,
+                  persona_id TEXT NOT NULL,
+                  run_id TEXT NOT NULL,
+                  event_type TEXT NOT NULL,
+                  event_key TEXT,
+                  step TEXT,
+                  completion_type TEXT,
+                  detour_source TEXT,
+                  action_target TEXT,
+                  metadata_json TEXT,
+                  created_at TEXT NOT NULL
+                )
+                """,
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_persona_setup_events_event_key
+                ON persona_setup_events(user_id, persona_id, run_id, event_key)
+                WHERE event_key IS NOT NULL
+                """,
+                script=False,
+                commit=True,
+            )
+            self.execute_query(
+                """
+                CREATE INDEX IF NOT EXISTS idx_persona_setup_events_persona_created
+                ON persona_setup_events(user_id, persona_id, created_at, id)
+                """,
+                script=False,
+                commit=True,
+            )
+            return
+
+        if self.backend_type == BackendType.POSTGRESQL:
+            self.backend.execute(
+                """
+                CREATE TABLE IF NOT EXISTS persona_setup_events(
+                  id BIGSERIAL PRIMARY KEY,
+                  event_id TEXT NOT NULL UNIQUE,
+                  user_id BIGINT NOT NULL,
+                  persona_id TEXT NOT NULL,
+                  run_id TEXT NOT NULL,
+                  event_type TEXT NOT NULL,
+                  event_key TEXT,
+                  step TEXT,
+                  completion_type TEXT,
+                  detour_source TEXT,
+                  action_target TEXT,
+                  metadata_json TEXT,
+                  created_at TEXT NOT NULL
+                )
+                """
+            )
+            self.backend.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_persona_setup_events_event_key
+                ON persona_setup_events(user_id, persona_id, run_id, event_key)
+                WHERE event_key IS NOT NULL
+                """
+            )
+            self.backend.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_persona_setup_events_persona_created
+                ON persona_setup_events(user_id, persona_id, created_at, id)
+                """
+            )
+            return
+
+        raise NotImplementedError(
+            "persona_setup_events table creation not supported "
+            f"for backend {self.backend_type.value}"
+        )
+
+    def _persona_setup_event_row_to_dict(self, row: Any) -> dict[str, Any]:
+        item = dict(row)
+        raw_metadata = item.get("metadata_json")
+        if isinstance(raw_metadata, str):
+            try:
+                decoded_metadata = json.loads(raw_metadata)
+            except json.JSONDecodeError:
+                decoded_metadata = {}
+            item["metadata"] = decoded_metadata if isinstance(decoded_metadata, dict) else {}
+        elif isinstance(raw_metadata, dict):
+            item["metadata"] = raw_metadata
+        else:
+            item["metadata"] = {}
+        return item
+
+    def record_persona_setup_event(
+        self,
+        *,
+        user_id: int,
+        persona_id: str,
+        event_id: str,
+        run_id: str,
+        event_type: str,
+        event_key: str | None = None,
+        step: str | None = None,
+        completion_type: str | None = None,
+        detour_source: str | None = None,
+        action_target: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Insert one persona setup analytics event with optional once-only dedupe."""
+        self._ensure_persona_setup_events_table()
+        now = self._get_current_utc_timestamp_iso()
+        metadata_json = self._ensure_json_string(metadata if isinstance(metadata, dict) else {})
+
+        with self.transaction():
+            row = self.execute_query(
+                """
+                SELECT *
+                FROM persona_setup_events
+                WHERE user_id = ? AND persona_id = ? AND event_id = ?
+                """,
+                (user_id, persona_id, event_id),
+            ).fetchone()
+            if row:
+                item = self._persona_setup_event_row_to_dict(row)
+                item["deduped"] = True
+                return item
+
+            if event_key:
+                row = self.execute_query(
+                    """
+                    SELECT *
+                    FROM persona_setup_events
+                    WHERE user_id = ? AND persona_id = ? AND run_id = ? AND event_key = ?
+                    """,
+                    (user_id, persona_id, run_id, event_key),
+                ).fetchone()
+                if row:
+                    item = self._persona_setup_event_row_to_dict(row)
+                    item["deduped"] = True
+                    return item
+
+            self.execute_query(
+                """
+                INSERT INTO persona_setup_events(
+                    event_id, user_id, persona_id, run_id, event_type, event_key,
+                    step, completion_type, detour_source, action_target,
+                    metadata_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    user_id,
+                    persona_id,
+                    run_id,
+                    event_type,
+                    event_key,
+                    step,
+                    completion_type,
+                    detour_source,
+                    action_target,
+                    metadata_json,
+                    now,
+                ),
+            )
+            row = self.execute_query(
+                """
+                SELECT *
+                FROM persona_setup_events
+                WHERE user_id = ? AND persona_id = ? AND event_id = ?
+                """,
+                (user_id, persona_id, event_id),
+            ).fetchone()
+            if not row:
+                raise CharactersRAGDBError("Failed to load inserted persona setup event.")  # noqa: TRY003
+            item = self._persona_setup_event_row_to_dict(row)
+            item["deduped"] = False
+            return item
+
+    def list_persona_setup_events(
+        self,
+        *,
+        user_id: int,
+        persona_id: str,
+        days: int = 30,
+        run_id: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """List recent persona setup events for one persona."""
+        self._ensure_persona_setup_events_table()
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(days=max(1, int(days)))
+        ).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+        params: list[Any] = [user_id, persona_id, cutoff]
+        query = """
+            SELECT *
+            FROM persona_setup_events
+            WHERE user_id = ? AND persona_id = ? AND created_at >= ?
+        """
+        if run_id:
+            query += " AND run_id = ?"
+            params.append(run_id)
+        query += " ORDER BY created_at DESC, id DESC LIMIT ?"
+        params.append(max(1, int(limit)))
+
+        cursor = self.execute_query(query, tuple(params))
+        return [
+            self._persona_setup_event_row_to_dict(row)
+            for row in cursor.fetchall()
+            if row
+        ]
+
+    def get_persona_setup_analytics_summary(
+        self,
+        *,
+        user_id: int,
+        persona_id: str,
+        days: int = 30,
+        recent_run_limit: int = 10,
+    ) -> dict[str, Any]:
+        """Aggregate recent persona setup analytics runs and summary rates."""
+        events = self.list_persona_setup_events(
+            user_id=user_id,
+            persona_id=persona_id,
+            days=days,
+            limit=5000,
+        )
+        runs: dict[str, dict[str, Any]] = {}
+        detour_started_counts: dict[str, int] = {}
+        detour_returned_counts: dict[str, int] = {}
+
+        for event in events:
+            run_id = str(event.get("run_id") or "").strip()
+            if not run_id:
+                continue
+            run = runs.setdefault(
+                run_id,
+                {
+                    "run_id": run_id,
+                    "started_at": None,
+                    "completed_at": None,
+                    "completion_type": None,
+                    "terminal_step": None,
+                    "handoff_clicked": False,
+                    "handoff_dismissed": False,
+                    "first_post_setup_action": False,
+                    "_latest_id": -1,
+                    "_earliest_created_at": None,
+                    "_latest_step_id": -1,
+                },
+            )
+            event_id_value = int(event.get("id") or 0)
+            created_at = str(event.get("created_at") or "").strip() or None
+            event_type = str(event.get("event_type") or "").strip()
+            step = str(event.get("step") or "").strip() or None
+            detour_source = str(event.get("detour_source") or "").strip() or None
+
+            if event_id_value > int(run["_latest_id"]):
+                run["_latest_id"] = event_id_value
+            if created_at and (
+                run["_earliest_created_at"] is None
+                or created_at < str(run["_earliest_created_at"])
+            ):
+                run["_earliest_created_at"] = created_at
+            if event_type == "setup_started" and created_at and (
+                run["started_at"] is None or created_at < str(run["started_at"])
+            ):
+                run["started_at"] = created_at
+            if event_type == "setup_completed" and created_at and (
+                run["completed_at"] is None or created_at > str(run["completed_at"])
+            ):
+                run["completed_at"] = created_at
+                run["completion_type"] = (
+                    str(event.get("completion_type") or "").strip() or None
+                )
+            if step and event_id_value >= int(run["_latest_step_id"]):
+                run["_latest_step_id"] = event_id_value
+                run["terminal_step"] = step
+            if event_type == "handoff_action_clicked":
+                run["handoff_clicked"] = True
+            elif event_type == "handoff_dismissed":
+                run["handoff_dismissed"] = True
+            elif event_type == "first_post_setup_action":
+                run["first_post_setup_action"] = True
+            elif event_type == "detour_started" and detour_source:
+                detour_started_counts[detour_source] = (
+                    detour_started_counts.get(detour_source, 0) + 1
+                )
+            elif event_type == "detour_returned" and detour_source:
+                detour_returned_counts[detour_source] = (
+                    detour_returned_counts.get(detour_source, 0) + 1
+                )
+
+        recent_runs: list[dict[str, Any]] = []
+        completed_runs = 0
+        dry_run_completion_count = 0
+        live_session_completion_count = 0
+        handoff_clicked_runs = 0
+        first_post_setup_action_runs = 0
+        dropoff_counts: dict[str, int] = {}
+
+        for run in sorted(
+            runs.values(),
+            key=lambda item: int(item["_latest_id"]),
+            reverse=True,
+        ):
+            if run["started_at"] is None:
+                run["started_at"] = run["_earliest_created_at"]
+            completion_type = str(run.get("completion_type") or "").strip() or None
+            if completion_type:
+                completed_runs += 1
+                if completion_type == "dry_run":
+                    dry_run_completion_count += 1
+                elif completion_type == "live_session":
+                    live_session_completion_count += 1
+            else:
+                terminal_step = str(run.get("terminal_step") or "").strip() or None
+                if terminal_step:
+                    dropoff_counts[terminal_step] = dropoff_counts.get(terminal_step, 0) + 1
+
+            if bool(run.get("handoff_clicked")):
+                handoff_clicked_runs += 1
+            if bool(run.get("first_post_setup_action")):
+                first_post_setup_action_runs += 1
+
+            recent_runs.append(
+                {
+                    "run_id": run["run_id"],
+                    "started_at": run["started_at"],
+                    "completed_at": run["completed_at"],
+                    "completion_type": completion_type,
+                    "terminal_step": run["terminal_step"],
+                    "handoff_clicked": bool(run["handoff_clicked"]),
+                    "handoff_dismissed": bool(run["handoff_dismissed"]),
+                    "first_post_setup_action": bool(run["first_post_setup_action"]),
+                }
+            )
+
+        total_runs = len(runs)
+        most_common_dropoff_step = None
+        if dropoff_counts:
+            most_common_dropoff_step = max(
+                dropoff_counts.items(),
+                key=lambda item: (item[1], item[0]),
+            )[0]
+
+        return {
+            "summary": {
+                "total_runs": total_runs,
+                "completed_runs": completed_runs,
+                "completion_rate": (
+                    float(completed_runs) / float(total_runs)
+                    if total_runs
+                    else 0.0
+                ),
+                "dry_run_completion_count": dry_run_completion_count,
+                "live_session_completion_count": live_session_completion_count,
+                "most_common_dropoff_step": most_common_dropoff_step,
+                "handoff_click_rate": (
+                    float(handoff_clicked_runs) / float(total_runs)
+                    if total_runs
+                    else 0.0
+                ),
+                "first_post_setup_action_rate": (
+                    float(first_post_setup_action_runs) / float(total_runs)
+                    if total_runs
+                    else 0.0
+                ),
+                "detour_started_counts": detour_started_counts,
+                "detour_returned_counts": detour_returned_counts,
+            },
+            "recent_runs": recent_runs[: max(1, int(recent_run_limit))],
+        }
+
     def upsert_voice_command(
         self,
         *,

--- a/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_profiles_api.py
@@ -396,7 +396,7 @@ def test_persona_profile_voice_defaults_clamps_turn_detection_values(persona_db:
     fastapi_app.dependency_overrides.clear()
 
 
-def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGDB):
+def test_persona_profile_setup_run_id_defaults_and_roundtrip(persona_db: CharactersRAGDB):
     with _client_for_user(1, persona_db) as client:
         created = client.post(
             "/api/v1/persona/profiles",
@@ -411,6 +411,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert payload["setup"] == {
             "status": "not_started",
             "version": 1,
+            "run_id": None,
             "current_step": "persona",
             "completed_steps": [],
             "completed_at": None,
@@ -423,6 +424,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
                 "setup": {
                     "status": "in_progress",
                     "version": 1,
+                    "run_id": "setup-run-1",
                     "current_step": "commands",
                     "completed_steps": ["persona", "voice"],
                     "completed_at": None,
@@ -435,6 +437,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert updated_payload["setup"] == {
             "status": "in_progress",
             "version": 1,
+            "run_id": "setup-run-1",
             "current_step": "commands",
             "completed_steps": ["persona", "voice"],
             "completed_at": None,
@@ -447,6 +450,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
                 "setup": {
                     "status": "completed",
                     "version": 1,
+                    "run_id": "setup-run-1",
                     "current_step": "test",
                     "completed_steps": ["persona", "voice", "commands", "safety", "test"],
                     "completed_at": "2026-03-13T10:00:00Z",
@@ -459,6 +463,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert completed_payload["setup"] == {
             "status": "completed",
             "version": 1,
+            "run_id": "setup-run-1",
             "current_step": "test",
             "completed_steps": ["persona", "voice", "commands", "safety", "test"],
             "completed_at": "2026-03-13T10:00:00Z",
@@ -471,6 +476,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert fetched_payload["setup"] == {
             "status": "completed",
             "version": 1,
+            "run_id": "setup-run-1",
             "current_step": "test",
             "completed_steps": ["persona", "voice", "commands", "safety", "test"],
             "completed_at": "2026-03-13T10:00:00Z",
@@ -486,6 +492,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert listed_profile["setup"] == {
             "status": "completed",
             "version": 1,
+            "run_id": "setup-run-1",
             "current_step": "test",
             "completed_steps": ["persona", "voice", "commands", "safety", "test"],
             "completed_at": "2026-03-13T10:00:00Z",
@@ -498,6 +505,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
                 "setup": {
                     "status": "in_progress",
                     "version": 1,
+                    "run_id": "setup-run-2",
                     "current_step": "persona",
                     "completed_steps": [],
                     "completed_at": None,
@@ -510,6 +518,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert reset_payload["setup"] == {
             "status": "in_progress",
             "version": 1,
+            "run_id": "setup-run-2",
             "current_step": "persona",
             "completed_steps": [],
             "completed_at": None,
@@ -522,6 +531,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
                 "setup": {
                     "status": "completed",
                     "version": 1,
+                    "run_id": "setup-run-2",
                     "current_step": "test",
                     "completed_steps": ["persona", "voice", "commands", "safety", "test"],
                     "completed_at": "2026-03-13T10:05:00Z",
@@ -534,6 +544,7 @@ def test_persona_profile_setup_defaults_and_roundtrip(persona_db: CharactersRAGD
         assert completed_live_payload["setup"] == {
             "status": "completed",
             "version": 1,
+            "run_id": "setup-run-2",
             "current_step": "test",
             "completed_steps": ["persona", "voice", "commands", "safety", "test"],
             "completed_at": "2026-03-13T10:05:00Z",

--- a/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
@@ -17,8 +17,8 @@ fastapi_app = FastAPI()
 fastapi_app.include_router(persona_ep.router, prefix="/api/v1/persona")
 
 
-def _client_for_user(user_id: int, db: CharactersRAGDB):
-    async def override_user():
+def _client_for_user(user_id: int, db: CharactersRAGDB) -> TestClient:
+    async def override_user() -> User:
         return User(
             id=user_id,
             username=f"persona-user-{user_id}",

--- a/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
@@ -1,0 +1,232 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import check_rate_limit
+from tldw_Server_API.app.api.v1.API_Deps.ChaCha_Notes_DB_Deps import (
+    get_chacha_db_for_user,
+)
+from tldw_Server_API.app.api.v1.endpoints import persona as persona_ep
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.DB_Management.ChaChaNotes_DB import CharactersRAGDB
+
+
+pytestmark = pytest.mark.unit
+
+fastapi_app = FastAPI()
+fastapi_app.include_router(persona_ep.router, prefix="/api/v1/persona")
+
+
+def _client_for_user(user_id: int, db: CharactersRAGDB):
+    async def override_user():
+        return User(
+            id=user_id,
+            username=f"persona-user-{user_id}",
+            email=None,
+            is_active=True,
+        )
+
+    fastapi_app.dependency_overrides[get_request_user] = override_user
+    fastapi_app.dependency_overrides[get_chacha_db_for_user] = lambda: db
+    fastapi_app.dependency_overrides[check_rate_limit] = lambda: None
+    return TestClient(fastapi_app)
+
+
+@pytest.fixture()
+def persona_db(tmp_path):
+    db = CharactersRAGDB(
+        str(tmp_path / "persona_setup_analytics_api.db"),
+        client_id="persona-setup-analytics-api-tests",
+    )
+    yield db
+    db.close_connection()
+
+
+def _create_persona(client: TestClient, *, name: str) -> str:
+    response = client.post(
+        "/api/v1/persona/profiles",
+        json={
+            "name": name,
+            "mode": "persistent_scoped",
+            "setup": {
+                "status": "in_progress",
+                "version": 1,
+                "run_id": "setup-run-1",
+                "current_step": "persona",
+                "completed_steps": [],
+                "completed_at": None,
+                "last_test_type": None,
+            },
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def test_persona_setup_events_dedupe_by_event_key(persona_db: CharactersRAGDB):
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Setup Analytics Persona")
+        body = {
+            "event_id": "evt-1",
+            "event_key": "step_viewed:test",
+            "run_id": "setup-run-1",
+            "event_type": "step_viewed",
+            "step": "test",
+        }
+
+        first = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/setup-events",
+            json=body,
+        )
+        second = client.post(
+            f"/api/v1/persona/profiles/{persona_id}/setup-events",
+            json={**body, "event_id": "evt-2"},
+        )
+
+        assert first.status_code == 201, first.text
+        assert first.json()["deduped"] is False
+        assert second.status_code == 200, second.text
+        assert second.json()["deduped"] is True
+
+        rows = persona_db.execute_query(
+            """
+            SELECT event_id, run_id, event_type, event_key, step
+            FROM persona_setup_events
+            WHERE user_id = ? AND persona_id = ?
+            ORDER BY created_at ASC, event_id ASC
+            """,
+            (1, persona_id),
+        ).fetchall()
+        assert len(rows) == 1
+        assert dict(rows[0]) == {
+            "event_id": "evt-1",
+            "run_id": "setup-run-1",
+            "event_type": "step_viewed",
+            "event_key": "step_viewed:test",
+            "step": "test",
+        }
+
+    fastapi_app.dependency_overrides.clear()
+
+
+def test_persona_setup_analytics_summary_returns_recent_runs_and_rates(
+    persona_db: CharactersRAGDB,
+):
+    with _client_for_user(1, persona_db) as client:
+        persona_id = _create_persona(client, name="Setup Summary Persona")
+
+        run_one_events = [
+            {
+                "event_id": "run-1-start",
+                "event_key": "setup_started",
+                "run_id": "setup-run-1",
+                "event_type": "setup_started",
+            },
+            {
+                "event_id": "run-1-view-test",
+                "event_key": "step_viewed:test",
+                "run_id": "setup-run-1",
+                "event_type": "step_viewed",
+                "step": "test",
+            },
+            {
+                "event_id": "run-1-complete",
+                "event_key": "setup_completed",
+                "run_id": "setup-run-1",
+                "event_type": "setup_completed",
+                "step": "test",
+                "completion_type": "dry_run",
+            },
+            {
+                "event_id": "run-1-handoff-click",
+                "run_id": "setup-run-1",
+                "event_type": "handoff_action_clicked",
+                "action_target": "live",
+            },
+            {
+                "event_id": "run-1-first-action",
+                "event_key": "first_post_setup_action",
+                "run_id": "setup-run-1",
+                "event_type": "first_post_setup_action",
+                "action_target": "live",
+            },
+        ]
+        run_two_events = [
+            {
+                "event_id": "run-2-start",
+                "event_key": "setup_started",
+                "run_id": "setup-run-2",
+                "event_type": "setup_started",
+            },
+            {
+                "event_id": "run-2-view-commands",
+                "event_key": "step_viewed:commands",
+                "run_id": "setup-run-2",
+                "event_type": "step_viewed",
+                "step": "commands",
+            },
+            {
+                "event_id": "run-2-detour-start",
+                "run_id": "setup-run-2",
+                "event_type": "detour_started",
+                "step": "test",
+                "detour_source": "live_failure",
+            },
+            {
+                "event_id": "run-2-detour-return",
+                "event_key": "detour_returned:live_failure",
+                "run_id": "setup-run-2",
+                "event_type": "detour_returned",
+                "step": "test",
+                "detour_source": "live_failure",
+            },
+            {
+                "event_id": "run-2-error",
+                "run_id": "setup-run-2",
+                "event_type": "step_error",
+                "step": "commands",
+            },
+        ]
+
+        for event in [*run_one_events, *run_two_events]:
+            response = client.post(
+                f"/api/v1/persona/profiles/{persona_id}/setup-events",
+                json=event,
+            )
+            assert response.status_code in {200, 201}, response.text
+
+        analytics = client.get(f"/api/v1/persona/profiles/{persona_id}/setup-analytics")
+        assert analytics.status_code == 200, analytics.text
+        payload = analytics.json()
+
+        assert payload["persona_id"] == persona_id
+        assert payload["summary"] == {
+            "total_runs": 2,
+            "completed_runs": 1,
+            "completion_rate": 0.5,
+            "dry_run_completion_count": 1,
+            "live_session_completion_count": 0,
+            "most_common_dropoff_step": "commands",
+            "handoff_click_rate": 0.5,
+            "first_post_setup_action_rate": 0.5,
+            "detour_started_counts": {"live_failure": 1},
+            "detour_returned_counts": {"live_failure": 1},
+        }
+        assert [run["run_id"] for run in payload["recent_runs"]] == [
+            "setup-run-2",
+            "setup-run-1",
+        ]
+        assert payload["recent_runs"][0]["completed_at"] is None
+        assert payload["recent_runs"][0]["completion_type"] is None
+        assert payload["recent_runs"][0]["terminal_step"] == "commands"
+        assert payload["recent_runs"][0]["handoff_clicked"] is False
+        assert payload["recent_runs"][0]["handoff_dismissed"] is False
+        assert payload["recent_runs"][0]["first_post_setup_action"] is False
+        assert payload["recent_runs"][1]["completion_type"] == "dry_run"
+        assert payload["recent_runs"][1]["terminal_step"] == "test"
+        assert payload["recent_runs"][1]["handoff_clicked"] is True
+        assert payload["recent_runs"][1]["handoff_dismissed"] is False
+        assert payload["recent_runs"][1]["first_post_setup_action"] is True
+        assert payload["recent_runs"][1]["completed_at"]
+
+    fastapi_app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add setup recovery detours from Test and Finish into Commands and Live, including live-unavailable autoconnect
- add persona setup run ids plus setup analytics events and summary coverage
- tighten the post-setup handoff so it recommends a next step, survives follow-up navigation, and collapses after the first successful post-setup action

## Test Plan
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Persona/test_persona_profiles_api.py tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q`
- `cd apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx`
- `cd apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/AssistantSetupWizard.test.tsx src/components/PersonaGarden/__tests__/SetupStarterCommandsStep.test.tsx src/components/PersonaGarden/__tests__/SetupSafetyConnectionsStep.test.tsx src/components/PersonaGarden/__tests__/SetupTestAndFinishStep.test.tsx src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx`
- `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/api/v1/schemas/persona.py tldw_Server_API/app/api/v1/endpoints/persona.py tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py apps/packages/ui/src/components/PersonaGarden apps/packages/ui/src/routes apps/packages/ui/src/services/tldw -f json -o /tmp/bandit_persona_setup_handoff_analytics.json`
- `git diff --check`
- `cd apps/extension && export PATH=/Users/macbook-dev/.nvm/versions/node/v24.6.0/bin:$PATH && bunx playwright test tests/e2e/persona-assistant-setup.spec.ts --reporter=line` (skipped here because extension launch was unavailable in this environment)
