### PR TITLE
feat: integrate ACP runtime policy governance

### DIFF
--- a/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
@@ -14,10 +14,10 @@
 
 - Task 1: Complete
 - Task 2: Complete
-- Task 3: In Progress
-- Task 4: Not Started
-- Task 5: Not Started
-- Task 6: Not Started
+- Task 3: Complete
+- Task 4: Complete
+- Task 5: Complete
+- Task 6: Complete
 
 ### Task 1: Add ACP session snapshot persistence
 

--- a/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
@@ -13,8 +13,8 @@
 ## Status
 
 - Task 1: Complete
-- Task 2: In Progress
-- Task 3: Not Started
+- Task 2: Complete
+- Task 3: In Progress
 - Task 4: Not Started
 - Task 5: Not Started
 - Task 6: Not Started

--- a/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-acp-runtime-policy-implementation-plan.md
@@ -12,8 +12,8 @@
 
 ## Status
 
-- Task 1: Not Started
-- Task 2: Not Started
+- Task 1: Complete
+- Task 2: In Progress
 - Task 3: Not Started
 - Task 4: Not Started
 - Task 5: Not Started

--- a/apps/packages/ui/src/components/Option/ACPPlayground/ACPPermissionModal.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/ACPPermissionModal.tsx
@@ -26,6 +26,7 @@ export const ACPPermissionModal: React.FC<ACPPermissionModalProps> = ({
   const { t } = useTranslation(["playground", "common"])
 
   const [batchApprove, setBatchApprove] = useState(false)
+  const [showPolicyDetails, setShowPolicyDetails] = useState(false)
   const currentPermission = pendingPermissions[0]
 
   if (!currentPermission) {
@@ -66,6 +67,13 @@ export const ACPPermissionModal: React.FC<ACPPermissionModalProps> = ({
   const timeElapsed = Date.now() - currentPermission.requestedAt.getTime()
   const timeRemaining = Math.max(0, currentPermission.timeout_seconds * 1000 - timeElapsed)
   const progressPercent = (timeRemaining / (currentPermission.timeout_seconds * 1000)) * 100
+  const hasPolicyMetadata = Boolean(
+    currentPermission.approval_requirement
+    || currentPermission.governance_reason
+    || currentPermission.runtime_narrowing_reason
+    || currentPermission.policy_snapshot_fingerprint
+    || currentPermission.provenance_summary
+  )
 
   return (
     <Modal
@@ -137,6 +145,71 @@ export const ACPPermissionModal: React.FC<ACPPermissionModalProps> = ({
             {UI_CONFIG.TIER_DESCRIPTIONS[currentPermission.tier]}
           </div>
         </div>
+
+        {hasPolicyMetadata && (
+          <div className="rounded-lg border border-border bg-bg p-4">
+            <div className="mb-2 flex items-center justify-between">
+              <div className="text-xs font-medium uppercase text-text-muted">
+                {t("playground:acp.policySnapshot", "Policy Snapshot")}
+              </div>
+              {currentPermission.provenance_summary && (
+                <Button
+                  type="link"
+                  size="small"
+                  className="px-0"
+                  onClick={() => setShowPolicyDetails((value) => !value)}
+                >
+                  {showPolicyDetails
+                    ? t("playground:acp.hidePolicyDetails", "Hide details")
+                    : t("playground:acp.showPolicyDetails", "Show details")}
+                </Button>
+              )}
+            </div>
+            <div className="space-y-1 text-xs text-text-muted">
+              {currentPermission.approval_requirement && (
+                <div>
+                  <span className="font-medium text-text">
+                    {t("playground:acp.approvalRequirement", "Approval")}:{" "}
+                  </span>
+                  <span>{currentPermission.approval_requirement}</span>
+                </div>
+              )}
+              {currentPermission.governance_reason && (
+                <div>
+                  <span className="font-medium text-text">
+                    {t("playground:acp.governanceReason", "Reason")}:{" "}
+                  </span>
+                  <span>{currentPermission.governance_reason}</span>
+                </div>
+              )}
+              {currentPermission.runtime_narrowing_reason && (
+                <div>
+                  <span className="font-medium text-text">
+                    {t("playground:acp.runtimeConstraint", "Runtime constraint")}:{" "}
+                  </span>
+                  <span>{currentPermission.runtime_narrowing_reason}</span>
+                </div>
+              )}
+              {currentPermission.policy_snapshot_fingerprint && (
+                <div>
+                  <span className="font-medium text-text">
+                    {t("playground:acp.snapshotFingerprint", "Snapshot")}:{" "}
+                  </span>
+                  <span className="font-mono">
+                    {currentPermission.policy_snapshot_fingerprint.slice(0, 12)}
+                  </span>
+                </div>
+              )}
+            </div>
+            {showPolicyDetails && currentPermission.provenance_summary && (
+              <div className="mt-3 rounded bg-surface2 p-2">
+                <pre className="overflow-auto text-xs text-text">
+                  {JSON.stringify(currentPermission.provenance_summary, null, 2)}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Timeout progress */}
         <div className="space-y-1">

--- a/apps/packages/ui/src/components/Option/ACPPlayground/ACPSessionPanel.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/ACPSessionPanel.tsx
@@ -513,6 +513,30 @@ const getAgentTypeName = (agentType?: ACPAgentType): string => {
   return info?.name ?? agentType
 }
 
+const getPolicySummaryBadges = (session: ACPSession): string[] => {
+  const summary = (session.policySummary || null) as Record<string, unknown> | null
+  if (!summary) {
+    return []
+  }
+
+  const badges: string[] = []
+  const approvalMode = typeof summary.approval_mode === "string" ? summary.approval_mode : null
+  const allowedCount = typeof summary.allowed_tool_count === "number" ? summary.allowed_tool_count : null
+  const deniedCount = typeof summary.denied_tool_count === "number" ? summary.denied_tool_count : null
+
+  if (approvalMode) {
+    badges.push(`Policy ${approvalMode}`)
+  }
+  if (allowedCount !== null) {
+    badges.push(`Allow ${allowedCount}`)
+  }
+  if (deniedCount !== null && deniedCount > 0) {
+    badges.push(`Deny ${deniedCount}`)
+  }
+
+  return badges
+}
+
 const SessionItem: React.FC<SessionItemProps> = ({
   session,
   isActive,
@@ -527,6 +551,8 @@ const SessionItem: React.FC<SessionItemProps> = ({
   formatDate,
 }) => {
   const { t } = useTranslation(["playground", "common"])
+  const policyBadges = getPolicySummaryBadges(session)
+  const hasPolicyError = typeof session.policyRefreshError === "string" && session.policyRefreshError.length > 0
 
   // Get the last part of the path for display
   const displayPath = session.cwd.split("/").filter(Boolean).slice(-2).join("/") || session.cwd || "/"
@@ -595,6 +621,26 @@ const SessionItem: React.FC<SessionItemProps> = ({
             </Tooltip>
           )}
         </div>
+
+        {(policyBadges.length > 0 || hasPolicyError) && (
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px]">
+            {policyBadges.map((badge) => (
+              <span
+                key={`${session.id}-${badge}`}
+                className="rounded bg-primary/10 px-1.5 py-0.5 text-primary"
+              >
+                {badge}
+              </span>
+            ))}
+            {hasPolicyError && (
+              <Tooltip title={session.policyRefreshError}>
+                <span className="rounded bg-danger/10 px-1.5 py-0.5 text-danger">
+                  {t("playground:acp.sessionMeta.policyError", "Policy refresh error")}
+                </span>
+              </Tooltip>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPPermissionModal.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPPermissionModal.test.tsx
@@ -32,6 +32,11 @@ const pendingPermissions: ACPPendingPermission[] = [
     tool_name: "fs.writeTextFile",
     tool_arguments: { path: "/tmp/demo.txt" },
     tier: "batch",
+    approval_requirement: "approval_required",
+    governance_reason: "policy_approval_required",
+    provenance_summary: { source_kinds: ["capability_mapping"] },
+    runtime_narrowing_reason: "workspace_trust_required",
+    policy_snapshot_fingerprint: "snapshot-1234567890",
     timeout_seconds: 30,
     requestedAt: new Date(),
   },
@@ -81,5 +86,25 @@ describe("ACPPermissionModal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Deny" }))
     expect(denyPermission).toHaveBeenCalledWith("req-1")
+  })
+
+  it("shows compact policy metadata and expandable provenance details", () => {
+    render(
+      <ACPPermissionModal
+        pendingPermissions={pendingPermissions}
+        approvePermission={vi.fn()}
+        denyPermission={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText("Policy Snapshot")).toBeInTheDocument()
+    expect(screen.getByText("approval_required")).toBeInTheDocument()
+    expect(screen.getByText("policy_approval_required")).toBeInTheDocument()
+    expect(screen.getByText("workspace_trust_required")).toBeInTheDocument()
+    expect(screen.getByText("snapshot-123")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Show details" }))
+
+    expect(screen.getByText(/capability_mapping/)).toBeInTheDocument()
   })
 })

--- a/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPSessionPanel.test.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/__tests__/ACPSessionPanel.test.tsx
@@ -165,6 +165,38 @@ describe("ACPSessionPanel filters and sorting", () => {
     expect(screen.getAllByText("Tokens --").length).toBeGreaterThan(0)
   })
 
+  it("renders compact policy snapshot badges from server-hydrated sessions", () => {
+    const state = useACPSessionsStore.getState()
+
+    state.upsertSessionsFromServerList([
+      {
+        session_id: "server-session-1",
+        user_id: 1,
+        agent_type: "codex",
+        name: "Server Session",
+        status: "active",
+        created_at: "2024-01-01T00:00:00.000Z",
+        last_activity_at: "2024-01-01T00:01:00.000Z",
+        message_count: 2,
+        usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        tags: [],
+        has_websocket: false,
+        policy_snapshot_version: "resolved-v1",
+        policy_snapshot_fingerprint: "snapshot-123",
+        policy_snapshot_refreshed_at: "2026-03-14T12:00:00+00:00",
+        policy_summary: { allowed_tool_count: 2, denied_tool_count: 1, approval_mode: "require_approval" },
+        policy_provenance_summary: { source_kinds: ["capability_mapping"] },
+        policy_refresh_error: null,
+      },
+    ])
+
+    render(<ACPSessionPanel />)
+
+    expect(screen.getByText("Policy require_approval")).toBeInTheDocument()
+    expect(screen.getByText("Allow 2")).toBeInTheDocument()
+    expect(screen.getByText("Deny 1")).toBeInTheDocument()
+  })
+
   it("copies session id from quick action", async () => {
     const { alphaId } = seedSessions()
     render(<ACPSessionPanel />)

--- a/apps/packages/ui/src/components/Option/ACPPlayground/index.tsx
+++ b/apps/packages/ui/src/components/Option/ACPPlayground/index.tsx
@@ -142,6 +142,12 @@ export const ACPPlayground: React.FC = () => {
         tool_name: message.tool_name,
         tool_arguments: message.tool_arguments,
         tier: message.tier,
+        approval_requirement: message.approval_requirement,
+        governance_reason: message.governance_reason,
+        deny_reason: message.deny_reason,
+        provenance_summary: message.provenance_summary,
+        runtime_narrowing_reason: message.runtime_narrowing_reason,
+        policy_snapshot_fingerprint: message.policy_snapshot_fingerprint,
         timeout_seconds: message.timeout_seconds,
         requestedAt: new Date(),
       })

--- a/apps/packages/ui/src/hooks/useACPSession.tsx
+++ b/apps/packages/ui/src/hooks/useACPSession.tsx
@@ -197,6 +197,12 @@ export function useACPSession(options: UseACPSessionOptions = {}): UseACPSession
             tool_name: message.tool_name,
             tool_arguments: message.tool_arguments,
             tier: message.tier,
+            approval_requirement: message.approval_requirement,
+            governance_reason: message.governance_reason,
+            deny_reason: message.deny_reason,
+            provenance_summary: message.provenance_summary,
+            runtime_narrowing_reason: message.runtime_narrowing_reason,
+            policy_snapshot_fingerprint: message.policy_snapshot_fingerprint,
             timeout_seconds: message.timeout_seconds,
             requestedAt: new Date(),
           }

--- a/apps/packages/ui/src/services/acp/__tests__/client.test.ts
+++ b/apps/packages/ui/src/services/acp/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ACPRestClient, ACPWebSocketClient } from "@/services/acp/client"
+import type { ACPWSPermissionRequestMessage } from "@/services/acp/types"
 
 describe("ACPRestClient", () => {
   beforeEach(() => {
@@ -39,7 +40,16 @@ describe("ACPRestClient", () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ session_id: "sess-1", messages: [] }),
+        json: async () => ({
+          session_id: "sess-1",
+          messages: [],
+          policy_snapshot_version: "resolved-v1",
+          policy_snapshot_fingerprint: "snapshot-123",
+          policy_snapshot_refreshed_at: "2026-03-14T12:00:00+00:00",
+          policy_summary: { allowed_tool_count: 2, approval_mode: "require_approval" },
+          policy_provenance_summary: { source_kinds: ["capability_mapping"] },
+          policy_refresh_error: null,
+        }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -48,8 +58,13 @@ describe("ACPRestClient", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     const client = createClient()
-    await client.getSessionDetail("sess-1")
+    const detail = await client.getSessionDetail("sess-1")
     await client.getSessionUsage("sess-1")
+
+    expect(detail.policy_snapshot_version).toBe("resolved-v1")
+    expect(detail.policy_snapshot_fingerprint).toBe("snapshot-123")
+    expect(detail.policy_summary?.approval_mode).toBe("require_approval")
+    expect(detail.policy_provenance_summary?.source_kinds).toEqual(["capability_mapping"])
 
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
@@ -85,6 +100,29 @@ describe("ACPRestClient", () => {
         body: JSON.stringify({ message_index: 3, name: "Forked" }),
       })
     )
+  })
+
+  it("keeps tier while exposing permission policy metadata", () => {
+    const message: ACPWSPermissionRequestMessage = {
+      type: "permission_request",
+      request_id: "req-1",
+      session_id: "sess-1",
+      tool_name: "web.search",
+      tool_arguments: { query: "opa" },
+      tier: "individual",
+      timeout_seconds: 30,
+      approval_requirement: "approval_required",
+      governance_reason: "policy_approval_required",
+      deny_reason: undefined,
+      provenance_summary: { source_kinds: ["capability_mapping"] },
+      runtime_narrowing_reason: "workspace_trust_required",
+      policy_snapshot_fingerprint: "snapshot-123",
+    }
+
+    expect(message.tier).toBe("individual")
+    expect(message.approval_requirement).toBe("approval_required")
+    expect(message.policy_snapshot_fingerprint).toBe("snapshot-123")
+    expect(message.provenance_summary?.source_kinds).toEqual(["capability_mapping"])
   })
 })
 

--- a/apps/packages/ui/src/services/acp/types.ts
+++ b/apps/packages/ui/src/services/acp/types.ts
@@ -80,6 +80,12 @@ export interface ACPWSPermissionRequestMessage {
   tool_name: string
   tool_arguments: Record<string, unknown>
   tier: ACPPermissionTier
+  approval_requirement?: string | null
+  governance_reason?: string | null
+  deny_reason?: string | null
+  provenance_summary?: Record<string, unknown> | null
+  runtime_narrowing_reason?: string | null
+  policy_snapshot_fingerprint?: string | null
   timeout_seconds: number
 }
 
@@ -170,6 +176,12 @@ export interface ACPSessionNewResponse {
   workspace_id?: string | null
   workspace_group_id?: string | null
   scope_snapshot_id?: string | null
+  policy_snapshot_version?: string | null
+  policy_snapshot_fingerprint?: string | null
+  policy_snapshot_refreshed_at?: string | null
+  policy_summary?: Record<string, unknown> | null
+  policy_provenance_summary?: Record<string, unknown> | null
+  policy_refresh_error?: string | null
 }
 
 export interface ACPSessionPromptRequest {
@@ -226,6 +238,12 @@ export interface ACPSessionListItem {
   workspace_id?: string | null
   workspace_group_id?: string | null
   scope_snapshot_id?: string | null
+  policy_snapshot_version?: string | null
+  policy_snapshot_fingerprint?: string | null
+  policy_snapshot_refreshed_at?: string | null
+  policy_summary?: Record<string, unknown> | null
+  policy_provenance_summary?: Record<string, unknown> | null
+  policy_refresh_error?: string | null
   forked_from?: string | null
 }
 
@@ -274,6 +292,12 @@ export interface ACPSession {
   workspaceId?: string | null
   workspaceGroupId?: string | null
   scopeSnapshotId?: string | null
+  policySnapshotVersion?: string | null
+  policySnapshotFingerprint?: string | null
+  policySnapshotRefreshedAt?: Date | null
+  policySummary?: Record<string, unknown> | null
+  policyProvenanceSummary?: Record<string, unknown> | null
+  policyRefreshError?: string | null
   state: ACPSessionState
   capabilities?: Record<string, unknown>
   sandboxSessionId?: string | null
@@ -301,6 +325,12 @@ export interface ACPPendingPermission {
   tool_name: string
   tool_arguments: Record<string, unknown>
   tier: ACPPermissionTier
+  approval_requirement?: string | null
+  governance_reason?: string | null
+  deny_reason?: string | null
+  provenance_summary?: Record<string, unknown> | null
+  runtime_narrowing_reason?: string | null
+  policy_snapshot_fingerprint?: string | null
   timeout_seconds: number
   requestedAt: Date
 }

--- a/apps/packages/ui/src/store/__tests__/acp-sessions.test.ts
+++ b/apps/packages/ui/src/store/__tests__/acp-sessions.test.ts
@@ -53,6 +53,12 @@ describe("ACP sessions store", () => {
         workspace_group_id: "group-1",
         scope_snapshot_id: "scope-1",
         forked_from: "root-session",
+        policy_snapshot_version: "resolved-v1",
+        policy_snapshot_fingerprint: "snapshot-123",
+        policy_snapshot_refreshed_at: "2026-03-14T12:00:00+00:00",
+        policy_summary: { allowed_tool_count: 2, approval_mode: "require_approval" },
+        policy_provenance_summary: { source_kinds: ["capability_mapping"] },
+        policy_refresh_error: null,
       },
     ])
 
@@ -73,6 +79,12 @@ describe("ACP sessions store", () => {
       workspace_group_id: "group-1",
       scope_snapshot_id: "scope-1",
       forked_from: "root-session",
+      policy_snapshot_version: "resolved-v1",
+      policy_snapshot_fingerprint: "snapshot-123",
+      policy_snapshot_refreshed_at: "2026-03-14T12:00:00+00:00",
+      policy_summary: { allowed_tool_count: 2, approval_mode: "require_approval" },
+      policy_provenance_summary: { source_kinds: ["capability_mapping"] },
+      policy_refresh_error: null,
       fork_lineage: ["root-session"],
       messages: [],
       cwd: "/workspace/repo",
@@ -84,5 +96,9 @@ describe("ACP sessions store", () => {
     expect(session?.workspaceId).toBe("workspace-1")
     expect(session?.workspaceGroupId).toBe("group-1")
     expect(session?.scopeSnapshotId).toBe("scope-1")
+    expect(session?.policySnapshotVersion).toBe("resolved-v1")
+    expect(session?.policySnapshotFingerprint).toBe("snapshot-123")
+    expect(session?.policySummary?.approval_mode).toBe("require_approval")
+    expect(session?.policyProvenanceSummary?.source_kinds).toEqual(["capability_mapping"])
   })
 })

--- a/apps/packages/ui/src/store/acp-sessions.ts
+++ b/apps/packages/ui/src/store/acp-sessions.ts
@@ -305,6 +305,12 @@ export const useACPSessionsStore = createWithEqualityFn<ACPSessionsStore>()(
               workspaceId: serverSession.workspace_id ?? null,
               workspaceGroupId: serverSession.workspace_group_id ?? null,
               scopeSnapshotId: serverSession.scope_snapshot_id ?? null,
+              policySnapshotVersion: serverSession.policy_snapshot_version ?? null,
+              policySnapshotFingerprint: serverSession.policy_snapshot_fingerprint ?? null,
+              policySnapshotRefreshedAt: toIsoDate(serverSession.policy_snapshot_refreshed_at),
+              policySummary: serverSession.policy_summary ?? null,
+              policyProvenanceSummary: serverSession.policy_provenance_summary ?? null,
+              policyRefreshError: serverSession.policy_refresh_error ?? null,
               state: fallbackState,
               capabilities: undefined,
               sandboxSessionId: null,
@@ -340,6 +346,21 @@ export const useACPSessionsStore = createWithEqualityFn<ACPSessionsStore>()(
               workspaceId: serverSession.workspace_id ?? baseSession.workspaceId ?? null,
               workspaceGroupId: serverSession.workspace_group_id ?? baseSession.workspaceGroupId ?? null,
               scopeSnapshotId: serverSession.scope_snapshot_id ?? baseSession.scopeSnapshotId ?? null,
+              policySnapshotVersion:
+                serverSession.policy_snapshot_version ?? baseSession.policySnapshotVersion ?? null,
+              policySnapshotFingerprint:
+                serverSession.policy_snapshot_fingerprint ?? baseSession.policySnapshotFingerprint ?? null,
+              policySnapshotRefreshedAt:
+                toIsoDate(serverSession.policy_snapshot_refreshed_at)
+                ?? baseSession.policySnapshotRefreshedAt
+                ?? null,
+              policySummary: serverSession.policy_summary ?? baseSession.policySummary ?? null,
+              policyProvenanceSummary:
+                serverSession.policy_provenance_summary
+                ?? baseSession.policyProvenanceSummary
+                ?? null,
+              policyRefreshError:
+                serverSession.policy_refresh_error ?? baseSession.policyRefreshError ?? null,
               backendStatus,
               messageCount: Math.max(baseSession.messageCount ?? 0, serverSession.message_count),
               usage: mergedUsage,
@@ -383,6 +404,12 @@ export const useACPSessionsStore = createWithEqualityFn<ACPSessionsStore>()(
             workspaceId: detail.workspace_id ?? null,
             workspaceGroupId: detail.workspace_group_id ?? null,
             scopeSnapshotId: detail.scope_snapshot_id ?? null,
+            policySnapshotVersion: detail.policy_snapshot_version ?? null,
+            policySnapshotFingerprint: detail.policy_snapshot_fingerprint ?? null,
+            policySnapshotRefreshedAt: toIsoDate(detail.policy_snapshot_refreshed_at),
+            policySummary: detail.policy_summary ?? null,
+            policyProvenanceSummary: detail.policy_provenance_summary ?? null,
+            policyRefreshError: detail.policy_refresh_error ?? null,
             state: nextState,
             capabilities: undefined,
             sandboxSessionId: null,
@@ -413,6 +440,21 @@ export const useACPSessionsStore = createWithEqualityFn<ACPSessionsStore>()(
                 workspaceId: detail.workspace_id ?? baseSession.workspaceId ?? null,
                 workspaceGroupId: detail.workspace_group_id ?? baseSession.workspaceGroupId ?? null,
                 scopeSnapshotId: detail.scope_snapshot_id ?? baseSession.scopeSnapshotId ?? null,
+                policySnapshotVersion:
+                  detail.policy_snapshot_version ?? baseSession.policySnapshotVersion ?? null,
+                policySnapshotFingerprint:
+                  detail.policy_snapshot_fingerprint ?? baseSession.policySnapshotFingerprint ?? null,
+                policySnapshotRefreshedAt:
+                  toIsoDate(detail.policy_snapshot_refreshed_at)
+                  ?? baseSession.policySnapshotRefreshedAt
+                  ?? null,
+                policySummary: detail.policy_summary ?? baseSession.policySummary ?? null,
+                policyProvenanceSummary:
+                  detail.policy_provenance_summary
+                  ?? baseSession.policyProvenanceSummary
+                  ?? null,
+                policyRefreshError:
+                  detail.policy_refresh_error ?? baseSession.policyRefreshError ?? null,
                 backendStatus,
                 messageCount: Math.max(baseSession.messageCount ?? 0, detail.message_count),
                 usage: mergeUsage(baseSession.usage, detail.usage),
@@ -477,6 +519,12 @@ export const useACPSessionsStore = createWithEqualityFn<ACPSessionsStore>()(
           workspaceId: options.workspaceId ?? null,
           workspaceGroupId: options.workspaceGroupId ?? null,
           scopeSnapshotId: options.scopeSnapshotId ?? null,
+          policySnapshotVersion: null,
+          policySnapshotFingerprint: null,
+          policySnapshotRefreshedAt: null,
+          policySummary: null,
+          policyProvenanceSummary: null,
+          policyRefreshError: null,
           state: "disconnected",
           capabilities: undefined,
           sandboxSessionId: null,

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -1022,6 +1022,32 @@ async def _handle_client_message(
             })
             return
 
+        pending_metadata: dict[str, Any] = {}
+        with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
+            registry_map = getattr(client, "_ws_registry", None)
+            if isinstance(registry_map, dict):
+                registry = registry_map.get(session_id)
+                pending_map = getattr(registry, "pending_permissions", None)
+                if isinstance(pending_map, dict):
+                    pending = pending_map.get(request_id)
+                    if pending is not None:
+                        pending_metadata = {
+                            "tool_name": getattr(pending, "tool_name", None),
+                            "approval_requirement": getattr(pending, "approval_requirement", None),
+                            "governance_reason": getattr(pending, "governance_reason", None),
+                            "deny_reason": getattr(pending, "deny_reason", None),
+                            "runtime_narrowing_reason": getattr(
+                                pending,
+                                "runtime_narrowing_reason",
+                                None,
+                            ),
+                            "policy_snapshot_fingerprint": getattr(
+                                pending,
+                                "policy_snapshot_fingerprint",
+                                None,
+                            ),
+                        }
+
         success = await client.respond_to_permission(
             session_id,
             request_id,
@@ -1045,6 +1071,19 @@ async def _handle_client_message(
                     if isinstance(sess_pending, dict) and request_id in sess_pending:
                         sess_pending.pop(request_id, None)
                         success = True
+        if success and user_id is not None:
+            audit_metadata = {
+                "approved": bool(approved),
+                "request_id": str(request_id),
+                "batch_approve_tier": batch_approve_tier,
+            }
+            audit_metadata.update({k: v for k, v in pending_metadata.items() if v is not None})
+            _acp_record_audit_event(
+                action="permission_response",
+                user_id=int(user_id),
+                session_id=session_id,
+                metadata=audit_metadata,
+            )
         if not success:
             await stream.send_json({
                 "type": "error",
@@ -1713,9 +1752,10 @@ async def acp_session_new(
         resolved_scope_snapshot_id = resolved_scope_snapshot_id or sandbox_meta.get("scope_snapshot_id")
 
     # Persist session metadata and emit SSE event
+    persisted_record = None
     try:
         store = await get_acp_session_store()
-        await store.register_session(
+        persisted_record = await store.register_session(
             session_id=session_id,
             user_id=int(user.id),
             agent_type=resolved_agent_type or "custom",
@@ -1754,6 +1794,12 @@ async def acp_session_new(
         workspace_id=resolved_workspace_id,
         workspace_group_id=resolved_workspace_group_id,
         scope_snapshot_id=resolved_scope_snapshot_id,
+        policy_snapshot_version=getattr(persisted_record, "policy_snapshot_version", None),
+        policy_snapshot_fingerprint=getattr(persisted_record, "policy_snapshot_fingerprint", None),
+        policy_snapshot_refreshed_at=getattr(persisted_record, "policy_snapshot_refreshed_at", None),
+        policy_summary=getattr(persisted_record, "policy_summary", None),
+        policy_provenance_summary=getattr(persisted_record, "policy_provenance_summary", None),
+        policy_refresh_error=getattr(persisted_record, "policy_refresh_error", None),
     )
 
 

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -46,6 +46,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     ACPGovernanceDeniedError,
     get_runner_client,
 )
+from tldw_Server_API.app.services.acp_runtime_policy_service import ACPRuntimePolicyService
 from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
 from tldw_Server_API.app.core.AuthNZ.api_key_manager import get_api_key_manager
@@ -117,6 +118,24 @@ _ACP_DIAGNOSTIC_REASON_MAP: dict[str, str] = {
     "runtime_error": "failed_runtime",
     "invariant_violation": "invariant_violation",
 }
+
+
+async def _build_initial_runtime_policy_snapshot(
+    *,
+    session_store: Any,
+    session_record: Any,
+    user_id: int,
+) -> Any:
+    """Build and persist the initial ACP runtime policy snapshot for a new session."""
+    service = ACPRuntimePolicyService()
+    snapshot = await service.build_snapshot(
+        session_record=session_record,
+        user_id=int(user_id),
+    )
+    return await service.persist_snapshot(
+        session_store=session_store,
+        snapshot=snapshot,
+    )
 
 
 def _acp_env_int(name: str, default: int) -> int:
@@ -1768,6 +1787,28 @@ async def acp_session_new(
             workspace_group_id=resolved_workspace_group_id,
             scope_snapshot_id=resolved_scope_snapshot_id,
         )
+        if persisted_record is not None:
+            try:
+                persisted_record = await _build_initial_runtime_policy_snapshot(
+                    session_store=store,
+                    session_record=persisted_record,
+                    user_id=int(user.id),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to build initial ACP runtime policy snapshot for {}: {}",
+                    session_id,
+                    exc,
+                )
+                persisted_record = await store.update_policy_snapshot_state(
+                    session_id,
+                    policy_snapshot_version=None,
+                    policy_snapshot_fingerprint=None,
+                    policy_snapshot_refreshed_at=None,
+                    policy_summary=None,
+                    policy_provenance_summary=None,
+                    policy_refresh_error=str(exc),
+                )
     except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS:
         logger.warning("Failed to persist ACP session metadata for {}", session_id)
     try:

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -120,19 +120,24 @@ _ACP_DIAGNOSTIC_REASON_MAP: dict[str, str] = {
 }
 
 
+def get_acp_runtime_policy_service() -> ACPRuntimePolicyService:
+    """Provide the ACP runtime policy service for endpoint dependency injection."""
+    return ACPRuntimePolicyService()
+
+
 async def _build_initial_runtime_policy_snapshot(
     *,
     session_store: Any,
     session_record: Any,
     user_id: int,
+    runtime_policy_service: ACPRuntimePolicyService,
 ) -> Any:
     """Build and persist the initial ACP runtime policy snapshot for a new session."""
-    service = ACPRuntimePolicyService()
-    snapshot = await service.build_snapshot(
+    snapshot = await runtime_policy_service.build_snapshot(
         session_record=session_record,
         user_id=int(user_id),
     )
-    return await service.persist_snapshot(
+    return await runtime_policy_service.persist_snapshot(
         session_store=session_store,
         snapshot=snapshot,
     )
@@ -1042,30 +1047,21 @@ async def _handle_client_message(
             return
 
         pending_metadata: dict[str, Any] = {}
-        with contextlib.suppress(_ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS):
-            registry_map = getattr(client, "_ws_registry", None)
-            if isinstance(registry_map, dict):
-                registry = registry_map.get(session_id)
-                pending_map = getattr(registry, "pending_permissions", None)
-                if isinstance(pending_map, dict):
-                    pending = pending_map.get(request_id)
-                    if pending is not None:
-                        pending_metadata = {
-                            "tool_name": getattr(pending, "tool_name", None),
-                            "approval_requirement": getattr(pending, "approval_requirement", None),
-                            "governance_reason": getattr(pending, "governance_reason", None),
-                            "deny_reason": getattr(pending, "deny_reason", None),
-                            "runtime_narrowing_reason": getattr(
-                                pending,
-                                "runtime_narrowing_reason",
-                                None,
-                            ),
-                            "policy_snapshot_fingerprint": getattr(
-                                pending,
-                                "policy_snapshot_fingerprint",
-                                None,
-                            ),
-                        }
+        metadata_getter = getattr(client, "get_pending_permission_metadata", None)
+        if callable(metadata_getter):
+            try:
+                maybe_metadata = metadata_getter(session_id, request_id)
+                if inspect.isawaitable(maybe_metadata):
+                    maybe_metadata = await maybe_metadata
+                if isinstance(maybe_metadata, dict):
+                    pending_metadata = {str(k): v for k, v in maybe_metadata.items()}
+            except _ACP_ENDPOINT_NONCRITICAL_EXCEPTIONS as exc:
+                logger.warning(
+                    "Failed to load ACP pending permission metadata for session {} request {}: {}",
+                    session_id,
+                    request_id,
+                    exc,
+                )
 
         success = await client.respond_to_permission(
             session_id,
@@ -1709,6 +1705,7 @@ async def acp_session_new(
 
     # Generate session name if not provided
     session_name = payload.name or _generate_session_name(payload.cwd)
+    runtime_policy_service = get_acp_runtime_policy_service()
 
     # Convert MCP server configs to dicts for the runner client
     mcp_servers_dicts = None
@@ -1793,6 +1790,7 @@ async def acp_session_new(
                     session_store=store,
                     session_record=persisted_record,
                     user_id=int(user.id),
+                    runtime_policy_service=runtime_policy_service,
                 )
             except Exception as exc:
                 logger.warning(

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -152,6 +152,30 @@ class ACPWSPermissionRequestMessage(BaseModel):
     tool_name: str
     tool_arguments: dict[str, Any] = Field(default_factory=dict)
     tier: ACPPermissionTier = ACPPermissionTier.INDIVIDUAL
+    approval_requirement: str | None = Field(
+        default=None,
+        description="Resolved runtime approval requirement for this tool request",
+    )
+    governance_reason: str | None = Field(
+        default=None,
+        description="Human-readable reason the runtime policy required approval",
+    )
+    deny_reason: str | None = Field(
+        default=None,
+        description="Reason the runtime policy denied the request",
+    )
+    provenance_summary: dict[str, Any] | None = Field(
+        default=None,
+        description="Compact provenance summary for the runtime policy decision",
+    )
+    runtime_narrowing_reason: str | None = Field(
+        default=None,
+        description="Reason local runtime safety narrowed the effective policy",
+    )
+    policy_snapshot_fingerprint: str | None = Field(
+        default=None,
+        description="Fingerprint of the ACP runtime policy snapshot used for the decision",
+    )
     timeout_seconds: int = Field(default=300, description="Seconds until auto-cancel if no response")
 
 
@@ -278,6 +302,24 @@ class ACPSessionNewResponse(BaseModel):
     scope_snapshot_id: str | None = Field(
         default=None, description="Scope snapshot identifier bound to this ACP session"
     )
+    policy_snapshot_version: str | None = Field(
+        default=None, description="Version identifier for the current ACP policy snapshot"
+    )
+    policy_snapshot_fingerprint: str | None = Field(
+        default=None, description="Fingerprint of the current ACP policy snapshot"
+    )
+    policy_snapshot_refreshed_at: str | None = Field(
+        default=None, description="ISO 8601 timestamp when the ACP policy snapshot last refreshed"
+    )
+    policy_summary: dict[str, Any] | None = Field(
+        default=None, description="Compact summary of the ACP runtime policy snapshot"
+    )
+    policy_provenance_summary: dict[str, Any] | None = Field(
+        default=None, description="Compact provenance summary for the ACP runtime policy snapshot"
+    )
+    policy_refresh_error: str | None = Field(
+        default=None, description="Last ACP policy snapshot refresh error, if any"
+    )
 
 
 class ACPSessionPromptRequest(BaseModel):
@@ -347,6 +389,24 @@ class ACPSessionInfo(BaseModel):
     )
     scope_snapshot_id: str | None = Field(
         default=None, description="Scope snapshot identifier bound to this ACP session"
+    )
+    policy_snapshot_version: str | None = Field(
+        default=None, description="Version identifier for the current ACP policy snapshot"
+    )
+    policy_snapshot_fingerprint: str | None = Field(
+        default=None, description="Fingerprint of the current ACP policy snapshot"
+    )
+    policy_snapshot_refreshed_at: str | None = Field(
+        default=None, description="ISO 8601 timestamp when the ACP policy snapshot last refreshed"
+    )
+    policy_summary: dict[str, Any] | None = Field(
+        default=None, description="Compact summary of the ACP runtime policy snapshot"
+    )
+    policy_provenance_summary: dict[str, Any] | None = Field(
+        default=None, description="Compact provenance summary for the ACP runtime policy snapshot"
+    )
+    policy_refresh_error: str | None = Field(
+        default=None, description="Last ACP policy snapshot refresh error, if any"
     )
     forked_from: str | None = Field(default=None, description="Source session ID when this session was forked")
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -166,6 +166,137 @@ class SessionWebSocketRegistry:
     batch_approved_tiers: set[str] = field(default_factory=set)
 
 
+def _pending_permission_to_metadata(pending: PendingPermission | None) -> dict[str, Any]:
+    if pending is None:
+        return {}
+    return {
+        "tool_name": pending.tool_name,
+        "approval_requirement": pending.approval_requirement,
+        "governance_reason": pending.governance_reason,
+        "deny_reason": pending.deny_reason,
+        "runtime_narrowing_reason": pending.runtime_narrowing_reason,
+        "policy_snapshot_fingerprint": pending.policy_snapshot_fingerprint,
+    }
+
+
+class ACPRuntimePolicySupportMixin:
+    """Shared runtime policy snapshot caching and pending-permission helpers."""
+
+    _runtime_policy_service: ACPRuntimePolicyService
+    _runtime_policy_snapshots: dict[str, ACPRuntimePolicySnapshot]
+    _runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]]
+    _runtime_policy_refresh_lock: asyncio.Lock
+    _ws_registry: dict[str, SessionWebSocketRegistry]
+    _runtime_policy_log_label: str
+
+    async def _get_acp_session_store(self) -> Any:
+        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
+
+        return await get_acp_session_store()
+
+    async def _refresh_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        session_store: Any | None = None,
+        session_record: Any | None = None,
+    ) -> ACPRuntimePolicySnapshot | None:
+        label = str(getattr(self, "_runtime_policy_log_label", "ACP runtime policy"))
+
+        async def _build() -> ACPRuntimePolicySnapshot | None:
+            store = session_store or await self._get_acp_session_store()
+            record = session_record or await store.get_session(session_id)
+            if record is None:
+                return None
+            try:
+                snapshot = await self._runtime_policy_service.build_snapshot(
+                    session_record=record,
+                    user_id=int(getattr(record, "user_id")),
+                )
+                await self._runtime_policy_service.persist_snapshot(
+                    session_store=store,
+                    snapshot=snapshot,
+                )
+                self._runtime_policy_snapshots[str(session_id)] = snapshot
+                return snapshot
+            except Exception as exc:
+                logger.warning("{} refresh failed for session {}: {}", label, session_id, exc)
+                self._runtime_policy_snapshots.pop(str(session_id), None)
+                try:
+                    await store.update_policy_snapshot_state(
+                        session_id,
+                        policy_snapshot_version=None,
+                        policy_snapshot_fingerprint=None,
+                        policy_snapshot_refreshed_at=None,
+                        policy_summary=None,
+                        policy_provenance_summary=None,
+                        policy_refresh_error=str(exc),
+                    )
+                except Exception as persist_exc:
+                    logger.warning(
+                        "Failed to persist {} refresh error for session {}: {}",
+                        label.lower(),
+                        session_id,
+                        persist_exc,
+                    )
+                return None
+
+        async with self._runtime_policy_refresh_lock:
+            refresh_task = self._runtime_policy_refresh_tasks.get(str(session_id))
+            if refresh_task is None or refresh_task.done():
+                refresh_task = asyncio.create_task(_build())
+                self._runtime_policy_refresh_tasks[str(session_id)] = refresh_task
+        try:
+            return await refresh_task
+        finally:
+            async with self._runtime_policy_refresh_lock:
+                current = self._runtime_policy_refresh_tasks.get(str(session_id))
+                if current is refresh_task and refresh_task.done():
+                    self._runtime_policy_refresh_tasks.pop(str(session_id), None)
+
+    async def _get_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        store = await self._get_acp_session_store()
+        record = await store.get_session(session_id)
+        if record is None:
+            return None
+
+        cached = self._runtime_policy_snapshots.get(str(session_id))
+        persisted_fingerprint = getattr(record, "policy_snapshot_fingerprint", None)
+        if (
+            not force_refresh
+            and cached is not None
+            and (not persisted_fingerprint or persisted_fingerprint == cached.policy_snapshot_fingerprint)
+        ):
+            return cached
+
+        return await self._refresh_runtime_policy_snapshot(
+            session_id,
+            session_store=store,
+            session_record=record,
+        )
+
+    def _clear_runtime_policy_session_state(self, session_id: str) -> None:
+        self._runtime_policy_snapshots.pop(str(session_id), None)
+        refresh_task = self._runtime_policy_refresh_tasks.pop(str(session_id), None)
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+
+    def _should_force_runtime_policy_refresh(self, *, tier: str) -> bool:
+        return str(tier or "").strip().lower() != "auto"
+
+    def get_pending_permission_metadata(self, session_id: str, request_id: str) -> dict[str, Any]:
+        registry = self._ws_registry.get(str(session_id))
+        if registry is None:
+            return {}
+        pending = registry.pending_permissions.get(str(request_id))
+        return _pending_permission_to_metadata(pending)
+
+
 class ACPGovernanceDeniedError(ACPResponseError):
     """Raised when ACP governance blocks prompt execution."""
 
@@ -311,7 +442,45 @@ class ACPGovernanceCoordinator:
             return None
 
 
-class ACPRunnerClient:
+def _merge_runtime_and_governance_permission_outcome(
+    *,
+    tier: str,
+    batch_tier_approved: bool,
+    runtime_outcome: dict[str, Any],
+    governance: dict[str, Any] | None,
+) -> dict[str, Any]:
+    merged = dict(runtime_outcome or {})
+    runtime_action = str(merged.get("action") or "deny").strip().lower() or "deny"
+    if runtime_action == "deny":
+        merged["approval_requirement"] = "denied"
+        return merged
+
+    approval_outcome = ACPGovernanceCoordinator.resolve_permission_outcome(
+        tier=tier,
+        batch_tier_approved=batch_tier_approved,
+        governance=governance,
+    )
+    if approval_outcome == "deny":
+        merged["action"] = "deny"
+        merged["approval_requirement"] = "denied"
+        merged["deny_reason"] = "governance_denied"
+        merged["governance_reason"] = "governance_denied"
+        return merged
+
+    if runtime_action == "prompt" or approval_outcome == "prompt":
+        merged["action"] = "prompt"
+        merged["approval_requirement"] = "approval_required"
+        if approval_outcome == "prompt" and runtime_action != "prompt":
+            merged["governance_reason"] = "governance_approval_required"
+        return merged
+
+    merged["action"] = "approve"
+    merged["approval_requirement"] = "allow"
+    merged.pop("deny_reason", None)
+    return merged
+
+
+class ACPRunnerClient(ACPRuntimePolicySupportMixin):
     def __init__(self, config: ACPRunnerConfig) -> None:
         self.config = config
         self._client = ACPStdioClient(
@@ -329,6 +498,7 @@ class ACPRunnerClient:
         self._ws_registry: dict[str, SessionWebSocketRegistry] = {}
         self._ws_registry_lock = asyncio.Lock()
         self._governance = ACPGovernanceCoordinator()
+        self._runtime_policy_log_label = "ACP runtime policy"
         self._runtime_policy_service = ACPRuntimePolicyService()
         self._runtime_policy_snapshots: dict[str, ACPRuntimePolicySnapshot] = {}
         self._runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]] = {}
@@ -590,7 +760,7 @@ class ACPRunnerClient:
         await self._client.call("_tldw/session/close", {"sessionId": session_id})
         self._updates.pop(session_id, None)
         self._session_owners.pop(str(session_id), None)
-        self._runtime_policy_snapshots.pop(str(session_id), None)
+        self._clear_runtime_policy_session_state(session_id)
 
     def pop_updates(self, session_id: str, limit: int = 100) -> list[dict[str, Any]]:
         updates = []
@@ -705,94 +875,6 @@ class ACPRunnerClient:
         """Determine the permission tier for a tool based on policies then heuristics."""
         return determine_permission_tier(tool_name)
 
-    async def _get_acp_session_store(self) -> Any:
-        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
-
-        return await get_acp_session_store()
-
-    async def _refresh_runtime_policy_snapshot(
-        self,
-        session_id: str,
-        *,
-        session_store: Any | None = None,
-        session_record: Any | None = None,
-    ) -> ACPRuntimePolicySnapshot | None:
-        async def _build() -> ACPRuntimePolicySnapshot | None:
-            store = session_store or await self._get_acp_session_store()
-            record = session_record or await store.get_session(session_id)
-            if record is None:
-                return None
-            try:
-                snapshot = await self._runtime_policy_service.build_snapshot(
-                    session_record=record,
-                    user_id=int(getattr(record, "user_id")),
-                )
-                await self._runtime_policy_service.persist_snapshot(
-                    session_store=store,
-                    snapshot=snapshot,
-                )
-                self._runtime_policy_snapshots[str(session_id)] = snapshot
-                return snapshot
-            except Exception as exc:
-                logger.warning("ACP runtime policy refresh failed for session {}: {}", session_id, exc)
-                self._runtime_policy_snapshots.pop(str(session_id), None)
-                try:
-                    await store.update_policy_snapshot_state(
-                        session_id,
-                        policy_snapshot_version=None,
-                        policy_snapshot_fingerprint=None,
-                        policy_snapshot_refreshed_at=None,
-                        policy_summary=None,
-                        policy_provenance_summary=None,
-                        policy_refresh_error=str(exc),
-                    )
-                except Exception as persist_exc:
-                    logger.warning(
-                        "Failed to persist ACP runtime policy refresh error for session {}: {}",
-                        session_id,
-                        persist_exc,
-                    )
-                return None
-
-        async with self._runtime_policy_refresh_lock:
-            refresh_task = self._runtime_policy_refresh_tasks.get(str(session_id))
-            if refresh_task is None or refresh_task.done():
-                refresh_task = asyncio.create_task(_build())
-                self._runtime_policy_refresh_tasks[str(session_id)] = refresh_task
-        try:
-            return await refresh_task
-        finally:
-            async with self._runtime_policy_refresh_lock:
-                current = self._runtime_policy_refresh_tasks.get(str(session_id))
-                if current is refresh_task and refresh_task.done():
-                    self._runtime_policy_refresh_tasks.pop(str(session_id), None)
-
-    async def _get_runtime_policy_snapshot(
-        self,
-        session_id: str,
-        *,
-        force_refresh: bool = False,
-    ) -> ACPRuntimePolicySnapshot | None:
-        store = await self._get_acp_session_store()
-        record = await store.get_session(session_id)
-        if record is None:
-            return None
-
-        cached = self._runtime_policy_snapshots.get(str(session_id))
-        persisted_fingerprint = getattr(record, "policy_snapshot_fingerprint", None)
-        if (
-            not force_refresh
-            and cached is not None
-            and (not persisted_fingerprint or persisted_fingerprint == cached.policy_snapshot_fingerprint)
-        ):
-            return cached
-
-        return await self._refresh_runtime_policy_snapshot(
-            session_id,
-            session_store=store,
-            session_record=record,
-        )
-
     # -------------------------------------------------------------------------
     # Notification and Request Handlers
     # -------------------------------------------------------------------------
@@ -829,9 +911,11 @@ class ACPRunnerClient:
         # Determine permission tier
         tier = self._determine_permission_tier(tool_name)
         registry = self._ws_registry.get(session_id)
-        # Permission checks are the live authority boundary, so refresh here to
-        # pick up MCP Hub policy changes before deciding allow/ask/deny.
-        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id, force_refresh=True)
+        batch_tier_approved = bool(registry and tier in registry.batch_approved_tiers)
+        runtime_snapshot = await self._get_runtime_policy_snapshot(
+            session_id,
+            force_refresh=self._should_force_runtime_policy_refresh(tier=tier),
+        )
         runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,
@@ -839,13 +923,19 @@ class ACPRunnerClient:
             tool_arguments,
             tier=tier,
         )
+        permission_outcome = _merge_runtime_and_governance_permission_outcome(
+            tier=tier,
+            batch_tier_approved=batch_tier_approved,
+            runtime_outcome=runtime_outcome,
+            governance=governance,
+        )
 
-        if runtime_outcome["action"] == "deny":
+        if permission_outcome["action"] == "deny":
             outcome_payload: dict[str, Any] = {
                 "outcome": "denied",
-                "deny_reason": runtime_outcome.get("deny_reason"),
-                "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
-                "provenance_summary": runtime_outcome.get("provenance_summary"),
+                "deny_reason": permission_outcome.get("deny_reason"),
+                "policy_snapshot_fingerprint": permission_outcome.get("policy_snapshot_fingerprint"),
+                "provenance_summary": permission_outcome.get("provenance_summary"),
             }
             if isinstance(governance, dict) and governance:
                 outcome_payload["governance"] = governance
@@ -855,7 +945,7 @@ class ACPRunnerClient:
                 result={"outcome": outcome_payload},
             )
 
-        if runtime_outcome["action"] == "approve":
+        if permission_outcome["action"] == "approve":
             logger.debug("Auto-approving {} (runtime policy)", tool_name)
             return ACPMessage(
                 jsonrpc="2.0",
@@ -880,12 +970,12 @@ class ACPRunnerClient:
             tool_name=tool_name,
             tool_arguments=tool_arguments,
             acp_message_id=msg.id,
-            approval_requirement=runtime_outcome.get("approval_requirement"),
-            governance_reason=runtime_outcome.get("governance_reason"),
-            deny_reason=runtime_outcome.get("deny_reason"),
-            provenance_summary=dict(runtime_outcome.get("provenance_summary") or {}),
-            runtime_narrowing_reason=runtime_outcome.get("runtime_narrowing_reason"),
-            policy_snapshot_fingerprint=runtime_outcome.get("policy_snapshot_fingerprint"),
+            approval_requirement=permission_outcome.get("approval_requirement"),
+            governance_reason=permission_outcome.get("governance_reason"),
+            deny_reason=permission_outcome.get("deny_reason"),
+            provenance_summary=dict(permission_outcome.get("provenance_summary") or {}),
+            runtime_narrowing_reason=permission_outcome.get("runtime_narrowing_reason"),
+            policy_snapshot_fingerprint=permission_outcome.get("policy_snapshot_fingerprint"),
             future=asyncio.get_running_loop().create_future(),
         )
 
@@ -903,11 +993,11 @@ class ACPRunnerClient:
             "tool_name": tool_name,
             "tool_arguments": tool_arguments,
             "tier": tier,
-            "approval_requirement": runtime_outcome.get("approval_requirement"),
-            "governance_reason": runtime_outcome.get("governance_reason"),
-            "provenance_summary": runtime_outcome.get("provenance_summary"),
-            "runtime_narrowing_reason": runtime_outcome.get("runtime_narrowing_reason"),
-            "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
+            "approval_requirement": permission_outcome.get("approval_requirement"),
+            "governance_reason": permission_outcome.get("governance_reason"),
+            "provenance_summary": permission_outcome.get("provenance_summary"),
+            "runtime_narrowing_reason": permission_outcome.get("runtime_narrowing_reason"),
+            "policy_snapshot_fingerprint": permission_outcome.get("policy_snapshot_fingerprint"),
             "timeout_seconds": PERMISSION_TIMEOUT_SECONDS,
         }
         if isinstance(governance, dict) and governance:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import fnmatch
 import json
 import time
 import uuid
@@ -21,6 +22,10 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
     ACPMessage,
     ACPResponseError,
     ACPStdioClient,
+)
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicyService,
+    ACPRuntimePolicySnapshot,
 )
 
 # Permission timeout in seconds (5 minutes)
@@ -43,6 +48,94 @@ _ACP_GOVERNANCE_NONCRITICAL_EXCEPTIONS = (
 )
 
 
+def _policy_match_patterns(policy_document: dict[str, Any], *keys: str) -> list[str]:
+    patterns: list[str] = []
+    for key in keys:
+        value = policy_document.get(key)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if candidate:
+                patterns.append(candidate)
+        elif isinstance(value, (list, tuple, set)):
+            for entry in value:
+                candidate = str(entry or "").strip()
+                if candidate:
+                    patterns.append(candidate)
+    seen: set[str] = set()
+    out: list[str] = []
+    for pattern in patterns:
+        if pattern in seen:
+            continue
+        seen.add(pattern)
+        out.append(pattern)
+    return out
+
+
+def _tool_matches_policy(tool_name: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(tool_name, pattern) for pattern in patterns)
+
+
+def _resolve_runtime_permission_outcome(
+    snapshot: ACPRuntimePolicySnapshot | None,
+    tool_name: str,
+) -> dict[str, Any]:
+    if snapshot is None:
+        return {
+            "action": "deny",
+            "deny_reason": "policy_snapshot_unavailable",
+            "approval_requirement": "denied",
+            "policy_snapshot_fingerprint": None,
+            "provenance_summary": {},
+        }
+
+    policy_document = dict(snapshot.resolved_policy_document or {})
+    denied_patterns = _policy_match_patterns(policy_document, "denied_tools")
+    if denied_patterns and _tool_matches_policy(tool_name, denied_patterns):
+        return {
+            "action": "deny",
+            "deny_reason": "tool_denied_by_policy",
+            "approval_requirement": "denied",
+            "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+            "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+        }
+
+    allowed_patterns = _policy_match_patterns(
+        policy_document,
+        "allowed_tools",
+        "tool_names",
+        "tool_patterns",
+    )
+    if not allowed_patterns or not _tool_matches_policy(tool_name, allowed_patterns):
+        return {
+            "action": "deny",
+            "deny_reason": "tool_not_allowed_by_policy",
+            "approval_requirement": "denied",
+            "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+            "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+        }
+
+    approval_mode = str(
+        (snapshot.approval_summary or {}).get("mode")
+        or policy_document.get("approval_mode")
+        or ""
+    ).strip().lower()
+    if approval_mode in {"require_approval", "approval_required", "ask", "ask_on_broaden"}:
+        return {
+            "action": "prompt",
+            "approval_requirement": "approval_required",
+            "governance_reason": "policy_approval_required",
+            "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+            "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+        }
+
+    return {
+        "action": "approve",
+        "approval_requirement": "allow",
+        "policy_snapshot_fingerprint": snapshot.policy_snapshot_fingerprint,
+        "provenance_summary": dict(snapshot.policy_provenance_summary or {}),
+    }
+
+
 @dataclass
 class PendingPermission:
     """Tracks a pending permission request."""
@@ -51,6 +144,12 @@ class PendingPermission:
     tool_name: str
     tool_arguments: dict[str, Any]
     acp_message_id: Any  # The original ACP message ID for responding
+    approval_requirement: str | None = None
+    governance_reason: str | None = None
+    deny_reason: str | None = None
+    provenance_summary: dict[str, Any] = field(default_factory=dict)
+    runtime_narrowing_reason: str | None = None
+    policy_snapshot_fingerprint: str | None = None
     created_at: float = field(default_factory=time.monotonic)
     # Future is created when permission request is processed, not at dataclass init
     # This avoids the deprecated asyncio.get_event_loop() call
@@ -230,6 +329,10 @@ class ACPRunnerClient:
         self._ws_registry: dict[str, SessionWebSocketRegistry] = {}
         self._ws_registry_lock = asyncio.Lock()
         self._governance = ACPGovernanceCoordinator()
+        self._runtime_policy_service = ACPRuntimePolicyService()
+        self._runtime_policy_snapshots: dict[str, ACPRuntimePolicySnapshot] = {}
+        self._runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]] = {}
+        self._runtime_policy_refresh_lock = asyncio.Lock()
 
     @classmethod
     def from_config(cls) -> ACPRunnerClient:
@@ -487,6 +590,7 @@ class ACPRunnerClient:
         await self._client.call("_tldw/session/close", {"sessionId": session_id})
         self._updates.pop(session_id, None)
         self._session_owners.pop(str(session_id), None)
+        self._runtime_policy_snapshots.pop(str(session_id), None)
 
     def pop_updates(self, session_id: str, limit: int = 100) -> list[dict[str, Any]]:
         updates = []
@@ -601,6 +705,94 @@ class ACPRunnerClient:
         """Determine the permission tier for a tool based on policies then heuristics."""
         return determine_permission_tier(tool_name)
 
+    async def _get_acp_session_store(self) -> Any:
+        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
+
+        return await get_acp_session_store()
+
+    async def _refresh_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        session_store: Any | None = None,
+        session_record: Any | None = None,
+    ) -> ACPRuntimePolicySnapshot | None:
+        async def _build() -> ACPRuntimePolicySnapshot | None:
+            store = session_store or await self._get_acp_session_store()
+            record = session_record or await store.get_session(session_id)
+            if record is None:
+                return None
+            try:
+                snapshot = await self._runtime_policy_service.build_snapshot(
+                    session_record=record,
+                    user_id=int(getattr(record, "user_id")),
+                )
+                await self._runtime_policy_service.persist_snapshot(
+                    session_store=store,
+                    snapshot=snapshot,
+                )
+                self._runtime_policy_snapshots[str(session_id)] = snapshot
+                return snapshot
+            except Exception as exc:
+                logger.warning("ACP runtime policy refresh failed for session {}: {}", session_id, exc)
+                self._runtime_policy_snapshots.pop(str(session_id), None)
+                try:
+                    await store.update_policy_snapshot_state(
+                        session_id,
+                        policy_snapshot_version=None,
+                        policy_snapshot_fingerprint=None,
+                        policy_snapshot_refreshed_at=None,
+                        policy_summary=None,
+                        policy_provenance_summary=None,
+                        policy_refresh_error=str(exc),
+                    )
+                except Exception as persist_exc:
+                    logger.warning(
+                        "Failed to persist ACP runtime policy refresh error for session {}: {}",
+                        session_id,
+                        persist_exc,
+                    )
+                return None
+
+        async with self._runtime_policy_refresh_lock:
+            refresh_task = self._runtime_policy_refresh_tasks.get(str(session_id))
+            if refresh_task is None or refresh_task.done():
+                refresh_task = asyncio.create_task(_build())
+                self._runtime_policy_refresh_tasks[str(session_id)] = refresh_task
+        try:
+            return await refresh_task
+        finally:
+            async with self._runtime_policy_refresh_lock:
+                current = self._runtime_policy_refresh_tasks.get(str(session_id))
+                if current is refresh_task and refresh_task.done():
+                    self._runtime_policy_refresh_tasks.pop(str(session_id), None)
+
+    async def _get_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        store = await self._get_acp_session_store()
+        record = await store.get_session(session_id)
+        if record is None:
+            return None
+
+        cached = self._runtime_policy_snapshots.get(str(session_id))
+        persisted_fingerprint = getattr(record, "policy_snapshot_fingerprint", None)
+        if (
+            not force_refresh
+            and cached is not None
+            and (not persisted_fingerprint or persisted_fingerprint == cached.policy_snapshot_fingerprint)
+        ):
+            return cached
+
+        return await self._refresh_runtime_policy_snapshot(
+            session_id,
+            session_store=store,
+            session_record=record,
+        )
+
     # -------------------------------------------------------------------------
     # Notification and Request Handlers
     # -------------------------------------------------------------------------
@@ -637,22 +829,22 @@ class ACPRunnerClient:
         # Determine permission tier
         tier = self._determine_permission_tier(tool_name)
         registry = self._ws_registry.get(session_id)
-
-        batch_tier_approved = bool(registry and tier in registry.batch_approved_tiers)
+        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id)
+        runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,
             tool_name,
             tool_arguments,
             tier=tier,
         )
-        approval_outcome = self._governance.resolve_permission_outcome(
-            tier=tier,
-            batch_tier_approved=batch_tier_approved,
-            governance=governance,
-        )
 
-        if approval_outcome == "deny":
-            outcome_payload: dict[str, Any] = {"outcome": "denied"}
+        if runtime_outcome["action"] == "deny":
+            outcome_payload: dict[str, Any] = {
+                "outcome": "denied",
+                "deny_reason": runtime_outcome.get("deny_reason"),
+                "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
+                "provenance_summary": runtime_outcome.get("provenance_summary"),
+            }
             if isinstance(governance, dict) and governance:
                 outcome_payload["governance"] = governance
             return ACPMessage(
@@ -661,11 +853,8 @@ class ACPRunnerClient:
                 result={"outcome": outcome_payload},
             )
 
-        if approval_outcome == "approve":
-            if batch_tier_approved:
-                logger.info("Auto-approving {} (tier {} is batch-approved)", tool_name, tier)
-            else:
-                logger.debug("Auto-approving {} (auto tier)", tool_name)
+        if runtime_outcome["action"] == "approve":
+            logger.debug("Auto-approving {} (runtime policy)", tool_name)
             return ACPMessage(
                 jsonrpc="2.0",
                 id=msg.id,
@@ -689,6 +878,12 @@ class ACPRunnerClient:
             tool_name=tool_name,
             tool_arguments=tool_arguments,
             acp_message_id=msg.id,
+            approval_requirement=runtime_outcome.get("approval_requirement"),
+            governance_reason=runtime_outcome.get("governance_reason"),
+            deny_reason=runtime_outcome.get("deny_reason"),
+            provenance_summary=dict(runtime_outcome.get("provenance_summary") or {}),
+            runtime_narrowing_reason=runtime_outcome.get("runtime_narrowing_reason"),
+            policy_snapshot_fingerprint=runtime_outcome.get("policy_snapshot_fingerprint"),
             future=asyncio.get_running_loop().create_future(),
         )
 
@@ -706,6 +901,11 @@ class ACPRunnerClient:
             "tool_name": tool_name,
             "tool_arguments": tool_arguments,
             "tier": tier,
+            "approval_requirement": runtime_outcome.get("approval_requirement"),
+            "governance_reason": runtime_outcome.get("governance_reason"),
+            "provenance_summary": runtime_outcome.get("provenance_summary"),
+            "runtime_narrowing_reason": runtime_outcome.get("runtime_narrowing_reason"),
+            "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
             "timeout_seconds": PERMISSION_TIMEOUT_SECONDS,
         }
         if isinstance(governance, dict) and governance:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py
@@ -829,7 +829,9 @@ class ACPRunnerClient:
         # Determine permission tier
         tier = self._determine_permission_tier(tool_name)
         registry = self._ws_registry.get(session_id)
-        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id)
+        # Permission checks are the live authority boundary, so refresh here to
+        # pick up MCP Hub policy changes before deciding allow/ask/deny.
+        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id, force_refresh=True)
         runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -1001,7 +1001,9 @@ class ACPSandboxRunnerManager:
         tool_arguments = params.get("tool", {}).get("input", {})
 
         tier = self._determine_permission_tier(tool_name)
-        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id)
+        # Permission checks are the live authority boundary, so refresh here to
+        # pick up MCP Hub policy changes before deciding allow/ask/deny.
+        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id, force_refresh=True)
         runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -23,6 +23,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     PERMISSION_TIMEOUT_SECONDS,
     PendingPermission,
     SessionWebSocketRegistry,
+    _resolve_runtime_permission_outcome,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage, ACPResponseError
@@ -34,6 +35,10 @@ from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflig
 from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
 from tldw_Server_API.app.core.Sandbox.streams import get_hub
 from tldw_Server_API.app.core.testing import is_truthy
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicyService,
+    ACPRuntimePolicySnapshot,
+)
 
 _ACP_SANDBOX_NONCRITICAL_EXCEPTIONS = (
     ACPResponseError,
@@ -95,6 +100,10 @@ class ACPSandboxRunnerManager:
         self._ssh_ports_in_use: set[int] = set()
         self._ssh_ports_lock = asyncio.Lock()
         self._governance = ACPGovernanceCoordinator()
+        self._runtime_policy_service = ACPRuntimePolicyService()
+        self._runtime_policy_snapshots: dict[str, ACPRuntimePolicySnapshot] = {}
+        self._runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]] = {}
+        self._runtime_policy_refresh_lock = asyncio.Lock()
 
     def _control_record_from_handle(self, sess: SandboxSessionHandle) -> dict[str, Any]:
         return {
@@ -360,6 +369,94 @@ class ACPSandboxRunnerManager:
             rollout_mode=rollout_mode,
         )
         return payload
+
+    async def _get_acp_session_store(self) -> Any:
+        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
+
+        return await get_acp_session_store()
+
+    async def _refresh_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        session_store: Any | None = None,
+        session_record: Any | None = None,
+    ) -> ACPRuntimePolicySnapshot | None:
+        async def _build() -> ACPRuntimePolicySnapshot | None:
+            store = session_store or await self._get_acp_session_store()
+            record = session_record or await store.get_session(session_id)
+            if record is None:
+                return None
+            try:
+                snapshot = await self._runtime_policy_service.build_snapshot(
+                    session_record=record,
+                    user_id=int(getattr(record, "user_id")),
+                )
+                await self._runtime_policy_service.persist_snapshot(
+                    session_store=store,
+                    snapshot=snapshot,
+                )
+                self._runtime_policy_snapshots[str(session_id)] = snapshot
+                return snapshot
+            except Exception as exc:
+                logger.warning("ACP sandbox runtime policy refresh failed for session {}: {}", session_id, exc)
+                self._runtime_policy_snapshots.pop(str(session_id), None)
+                try:
+                    await store.update_policy_snapshot_state(
+                        session_id,
+                        policy_snapshot_version=None,
+                        policy_snapshot_fingerprint=None,
+                        policy_snapshot_refreshed_at=None,
+                        policy_summary=None,
+                        policy_provenance_summary=None,
+                        policy_refresh_error=str(exc),
+                    )
+                except Exception as persist_exc:
+                    logger.warning(
+                        "Failed to persist ACP sandbox runtime policy refresh error for session {}: {}",
+                        session_id,
+                        persist_exc,
+                    )
+                return None
+
+        async with self._runtime_policy_refresh_lock:
+            refresh_task = self._runtime_policy_refresh_tasks.get(str(session_id))
+            if refresh_task is None or refresh_task.done():
+                refresh_task = asyncio.create_task(_build())
+                self._runtime_policy_refresh_tasks[str(session_id)] = refresh_task
+        try:
+            return await refresh_task
+        finally:
+            async with self._runtime_policy_refresh_lock:
+                current = self._runtime_policy_refresh_tasks.get(str(session_id))
+                if current is refresh_task and refresh_task.done():
+                    self._runtime_policy_refresh_tasks.pop(str(session_id), None)
+
+    async def _get_runtime_policy_snapshot(
+        self,
+        session_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        store = await self._get_acp_session_store()
+        record = await store.get_session(session_id)
+        if record is None:
+            return None
+
+        cached = self._runtime_policy_snapshots.get(str(session_id))
+        persisted_fingerprint = getattr(record, "policy_snapshot_fingerprint", None)
+        if (
+            not force_refresh
+            and cached is not None
+            and (not persisted_fingerprint or persisted_fingerprint == cached.policy_snapshot_fingerprint)
+        ):
+            return cached
+
+        return await self._refresh_runtime_policy_snapshot(
+            session_id,
+            session_store=store,
+            session_record=record,
+        )
 
     async def start(self) -> None:
         return
@@ -904,23 +1001,22 @@ class ACPSandboxRunnerManager:
         tool_arguments = params.get("tool", {}).get("input", {})
 
         tier = self._determine_permission_tier(tool_name)
-
-        registry = self._ws_registry.get(session_id)
-        batch_tier_approved = bool(registry and tier in registry.batch_approved_tiers)
+        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id)
+        runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,
             tool_name,
             tool_arguments,
             tier=tier,
         )
-        approval_outcome = self._governance.resolve_permission_outcome(
-            tier=tier,
-            batch_tier_approved=batch_tier_approved,
-            governance=governance,
-        )
 
-        if approval_outcome == "deny":
-            outcome_payload: dict[str, Any] = {"outcome": "denied"}
+        if runtime_outcome["action"] == "deny":
+            outcome_payload: dict[str, Any] = {
+                "outcome": "denied",
+                "deny_reason": runtime_outcome.get("deny_reason"),
+                "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
+                "provenance_summary": runtime_outcome.get("provenance_summary"),
+            }
             if isinstance(governance, dict) and governance:
                 outcome_payload["governance"] = governance
             return ACPMessage(
@@ -929,11 +1025,8 @@ class ACPSandboxRunnerManager:
                 result={"outcome": outcome_payload},
             )
 
-        if approval_outcome == "approve":
-            if batch_tier_approved:
-                logger.info("Auto-approving {} (tier {} is batch-approved)", tool_name, tier)
-            else:
-                logger.debug("Auto-approving {} (auto tier)", tool_name)
+        if runtime_outcome["action"] == "approve":
+            logger.debug("Auto-approving {} (runtime policy)", tool_name)
             return ACPMessage(
                 jsonrpc="2.0",
                 id=msg.id,
@@ -955,6 +1048,12 @@ class ACPSandboxRunnerManager:
             tool_name=tool_name,
             tool_arguments=tool_arguments,
             acp_message_id=msg.id,
+            approval_requirement=runtime_outcome.get("approval_requirement"),
+            governance_reason=runtime_outcome.get("governance_reason"),
+            deny_reason=runtime_outcome.get("deny_reason"),
+            provenance_summary=dict(runtime_outcome.get("provenance_summary") or {}),
+            runtime_narrowing_reason=runtime_outcome.get("runtime_narrowing_reason"),
+            policy_snapshot_fingerprint=runtime_outcome.get("policy_snapshot_fingerprint"),
             future=asyncio.get_running_loop().create_future(),
         )
 
@@ -970,6 +1069,11 @@ class ACPSandboxRunnerManager:
             "tool_name": tool_name,
             "tool_arguments": tool_arguments,
             "tier": tier,
+            "approval_requirement": runtime_outcome.get("approval_requirement"),
+            "governance_reason": runtime_outcome.get("governance_reason"),
+            "provenance_summary": runtime_outcome.get("provenance_summary"),
+            "runtime_narrowing_reason": runtime_outcome.get("runtime_narrowing_reason"),
+            "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
             "timeout_seconds": PERMISSION_TIMEOUT_SECONDS,
         }
         if isinstance(governance, dict) and governance:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py
@@ -20,9 +20,11 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.config import ACPSandboxConf
 from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     ACPGovernanceCoordinator,
     ACPGovernanceDeniedError,
+    ACPRuntimePolicySupportMixin,
     PERMISSION_TIMEOUT_SECONDS,
     PendingPermission,
     SessionWebSocketRegistry,
+    _merge_runtime_and_governance_permission_outcome,
     _resolve_runtime_permission_outcome,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
@@ -88,7 +90,7 @@ class SandboxSessionHandle:
     scope_snapshot_id: str | None = None
 
 
-class ACPSandboxRunnerManager:
+class ACPSandboxRunnerManager(ACPRuntimePolicySupportMixin):
     def __init__(self, config: ACPSandboxConfig | None = None) -> None:
         self.config = config or load_acp_sandbox_config()
         self._sessions: dict[str, SandboxSessionHandle] = {}
@@ -100,6 +102,7 @@ class ACPSandboxRunnerManager:
         self._ssh_ports_in_use: set[int] = set()
         self._ssh_ports_lock = asyncio.Lock()
         self._governance = ACPGovernanceCoordinator()
+        self._runtime_policy_log_label = "ACP sandbox runtime policy"
         self._runtime_policy_service = ACPRuntimePolicyService()
         self._runtime_policy_snapshots: dict[str, ACPRuntimePolicySnapshot] = {}
         self._runtime_policy_refresh_tasks: dict[str, asyncio.Task[ACPRuntimePolicySnapshot | None]] = {}
@@ -369,94 +372,6 @@ class ACPSandboxRunnerManager:
             rollout_mode=rollout_mode,
         )
         return payload
-
-    async def _get_acp_session_store(self) -> Any:
-        from tldw_Server_API.app.services.admin_acp_sessions_service import get_acp_session_store
-
-        return await get_acp_session_store()
-
-    async def _refresh_runtime_policy_snapshot(
-        self,
-        session_id: str,
-        *,
-        session_store: Any | None = None,
-        session_record: Any | None = None,
-    ) -> ACPRuntimePolicySnapshot | None:
-        async def _build() -> ACPRuntimePolicySnapshot | None:
-            store = session_store or await self._get_acp_session_store()
-            record = session_record or await store.get_session(session_id)
-            if record is None:
-                return None
-            try:
-                snapshot = await self._runtime_policy_service.build_snapshot(
-                    session_record=record,
-                    user_id=int(getattr(record, "user_id")),
-                )
-                await self._runtime_policy_service.persist_snapshot(
-                    session_store=store,
-                    snapshot=snapshot,
-                )
-                self._runtime_policy_snapshots[str(session_id)] = snapshot
-                return snapshot
-            except Exception as exc:
-                logger.warning("ACP sandbox runtime policy refresh failed for session {}: {}", session_id, exc)
-                self._runtime_policy_snapshots.pop(str(session_id), None)
-                try:
-                    await store.update_policy_snapshot_state(
-                        session_id,
-                        policy_snapshot_version=None,
-                        policy_snapshot_fingerprint=None,
-                        policy_snapshot_refreshed_at=None,
-                        policy_summary=None,
-                        policy_provenance_summary=None,
-                        policy_refresh_error=str(exc),
-                    )
-                except Exception as persist_exc:
-                    logger.warning(
-                        "Failed to persist ACP sandbox runtime policy refresh error for session {}: {}",
-                        session_id,
-                        persist_exc,
-                    )
-                return None
-
-        async with self._runtime_policy_refresh_lock:
-            refresh_task = self._runtime_policy_refresh_tasks.get(str(session_id))
-            if refresh_task is None or refresh_task.done():
-                refresh_task = asyncio.create_task(_build())
-                self._runtime_policy_refresh_tasks[str(session_id)] = refresh_task
-        try:
-            return await refresh_task
-        finally:
-            async with self._runtime_policy_refresh_lock:
-                current = self._runtime_policy_refresh_tasks.get(str(session_id))
-                if current is refresh_task and refresh_task.done():
-                    self._runtime_policy_refresh_tasks.pop(str(session_id), None)
-
-    async def _get_runtime_policy_snapshot(
-        self,
-        session_id: str,
-        *,
-        force_refresh: bool = False,
-    ) -> ACPRuntimePolicySnapshot | None:
-        store = await self._get_acp_session_store()
-        record = await store.get_session(session_id)
-        if record is None:
-            return None
-
-        cached = self._runtime_policy_snapshots.get(str(session_id))
-        persisted_fingerprint = getattr(record, "policy_snapshot_fingerprint", None)
-        if (
-            not force_refresh
-            and cached is not None
-            and (not persisted_fingerprint or persisted_fingerprint == cached.policy_snapshot_fingerprint)
-        ):
-            return cached
-
-        return await self._refresh_runtime_policy_snapshot(
-            session_id,
-            session_store=store,
-            session_record=record,
-        )
 
     async def start(self) -> None:
         return
@@ -826,6 +741,7 @@ class ACPSandboxRunnerManager:
         async with self._sessions_lock:
             self._sessions.pop(session_id, None)
         self._updates.pop(session_id, None)
+        self._clear_runtime_policy_session_state(session_id)
         self._delete_control_record(session_id)
 
     def pop_updates(self, session_id: str, limit: int = 100) -> list[dict[str, Any]]:
@@ -1001,9 +917,12 @@ class ACPSandboxRunnerManager:
         tool_arguments = params.get("tool", {}).get("input", {})
 
         tier = self._determine_permission_tier(tool_name)
-        # Permission checks are the live authority boundary, so refresh here to
-        # pick up MCP Hub policy changes before deciding allow/ask/deny.
-        runtime_snapshot = await self._get_runtime_policy_snapshot(session_id, force_refresh=True)
+        registry = self._ws_registry.get(session_id)
+        batch_tier_approved = bool(registry and tier in registry.batch_approved_tiers)
+        runtime_snapshot = await self._get_runtime_policy_snapshot(
+            session_id,
+            force_refresh=self._should_force_runtime_policy_refresh(tier=tier),
+        )
         runtime_outcome = _resolve_runtime_permission_outcome(runtime_snapshot, tool_name)
         governance = await self.check_permission_governance(
             session_id,
@@ -1011,13 +930,19 @@ class ACPSandboxRunnerManager:
             tool_arguments,
             tier=tier,
         )
+        permission_outcome = _merge_runtime_and_governance_permission_outcome(
+            tier=tier,
+            batch_tier_approved=batch_tier_approved,
+            runtime_outcome=runtime_outcome,
+            governance=governance,
+        )
 
-        if runtime_outcome["action"] == "deny":
+        if permission_outcome["action"] == "deny":
             outcome_payload: dict[str, Any] = {
                 "outcome": "denied",
-                "deny_reason": runtime_outcome.get("deny_reason"),
-                "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
-                "provenance_summary": runtime_outcome.get("provenance_summary"),
+                "deny_reason": permission_outcome.get("deny_reason"),
+                "policy_snapshot_fingerprint": permission_outcome.get("policy_snapshot_fingerprint"),
+                "provenance_summary": permission_outcome.get("provenance_summary"),
             }
             if isinstance(governance, dict) and governance:
                 outcome_payload["governance"] = governance
@@ -1027,7 +952,7 @@ class ACPSandboxRunnerManager:
                 result={"outcome": outcome_payload},
             )
 
-        if runtime_outcome["action"] == "approve":
+        if permission_outcome["action"] == "approve":
             logger.debug("Auto-approving {} (runtime policy)", tool_name)
             return ACPMessage(
                 jsonrpc="2.0",
@@ -1050,12 +975,12 @@ class ACPSandboxRunnerManager:
             tool_name=tool_name,
             tool_arguments=tool_arguments,
             acp_message_id=msg.id,
-            approval_requirement=runtime_outcome.get("approval_requirement"),
-            governance_reason=runtime_outcome.get("governance_reason"),
-            deny_reason=runtime_outcome.get("deny_reason"),
-            provenance_summary=dict(runtime_outcome.get("provenance_summary") or {}),
-            runtime_narrowing_reason=runtime_outcome.get("runtime_narrowing_reason"),
-            policy_snapshot_fingerprint=runtime_outcome.get("policy_snapshot_fingerprint"),
+            approval_requirement=permission_outcome.get("approval_requirement"),
+            governance_reason=permission_outcome.get("governance_reason"),
+            deny_reason=permission_outcome.get("deny_reason"),
+            provenance_summary=dict(permission_outcome.get("provenance_summary") or {}),
+            runtime_narrowing_reason=permission_outcome.get("runtime_narrowing_reason"),
+            policy_snapshot_fingerprint=permission_outcome.get("policy_snapshot_fingerprint"),
             future=asyncio.get_running_loop().create_future(),
         )
 
@@ -1071,11 +996,11 @@ class ACPSandboxRunnerManager:
             "tool_name": tool_name,
             "tool_arguments": tool_arguments,
             "tier": tier,
-            "approval_requirement": runtime_outcome.get("approval_requirement"),
-            "governance_reason": runtime_outcome.get("governance_reason"),
-            "provenance_summary": runtime_outcome.get("provenance_summary"),
-            "runtime_narrowing_reason": runtime_outcome.get("runtime_narrowing_reason"),
-            "policy_snapshot_fingerprint": runtime_outcome.get("policy_snapshot_fingerprint"),
+            "approval_requirement": permission_outcome.get("approval_requirement"),
+            "governance_reason": permission_outcome.get("governance_reason"),
+            "provenance_summary": permission_outcome.get("provenance_summary"),
+            "runtime_narrowing_reason": permission_outcome.get("runtime_narrowing_reason"),
+            "policy_snapshot_fingerprint": permission_outcome.get("policy_snapshot_fingerprint"),
             "timeout_seconds": PERMISSION_TIMEOUT_SECONDS,
         }
         if isinstance(governance, dict) and governance:

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -100,6 +100,16 @@ _BOOL_FIELDS = frozenset({"bootstrap_ready", "needs_bootstrap"})
 # Columns that are stored as JSON TEXT but should be returned as parsed objects
 _JSON_LIST_FIELDS = frozenset({"tags", "mcp_servers"})
 _JSON_OBJECT_FIELDS = frozenset({"policy_summary", "policy_provenance_summary"})
+_ALLOWED_MIGRATION_COLUMNS = {
+    "sessions": {
+        "policy_snapshot_version": "policy_snapshot_version TEXT",
+        "policy_snapshot_fingerprint": "policy_snapshot_fingerprint TEXT",
+        "policy_snapshot_refreshed_at": "policy_snapshot_refreshed_at TEXT",
+        "policy_summary": "policy_summary TEXT",
+        "policy_provenance_summary": "policy_provenance_summary TEXT",
+        "policy_refresh_error": "policy_refresh_error TEXT",
+    }
+}
 
 
 def _utcnow_iso() -> str:
@@ -112,12 +122,16 @@ def _ensure_column(
     column_name: str,
     column_sql: str,
 ) -> None:
+    expected_column_sql = _ALLOWED_MIGRATION_COLUMNS.get(table_name, {}).get(column_name)
+    if expected_column_sql != column_sql:
+        raise ValueError("Unsupported ACP session migration target")
+
     existing_columns = {
-        str(row[1]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()
     }
     if column_name in existing_columns:
         return
-    conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_sql}")
+    conn.execute(f'ALTER TABLE "{table_name}" ADD COLUMN {column_sql}')
 
 
 class ACPSessionsDB:

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -17,7 +17,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 3
+_SCHEMA_VERSION = 4
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -41,7 +41,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     persona_id TEXT,
     workspace_id TEXT,
     workspace_group_id TEXT,
-    scope_snapshot_id TEXT
+    scope_snapshot_id TEXT,
+    policy_snapshot_version TEXT,
+    policy_snapshot_fingerprint TEXT,
+    policy_snapshot_refreshed_at TEXT,
+    policy_summary TEXT,
+    policy_provenance_summary TEXT,
+    policy_refresh_error TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_user_status ON sessions(user_id, status);
 CREATE INDEX IF NOT EXISTS idx_sessions_created ON sessions(created_at DESC);
@@ -92,11 +98,26 @@ CREATE INDEX IF NOT EXISTS idx_health_agent_time
 _BOOL_FIELDS = frozenset({"bootstrap_ready", "needs_bootstrap"})
 
 # Columns that are stored as JSON TEXT but should be returned as parsed objects
-_JSON_FIELDS = frozenset({"tags", "mcp_servers"})
+_JSON_LIST_FIELDS = frozenset({"tags", "mcp_servers"})
+_JSON_OBJECT_FIELDS = frozenset({"policy_summary", "policy_provenance_summary"})
 
 
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_column(
+    conn: sqlite3.Connection,
+    table_name: str,
+    column_name: str,
+    column_sql: str,
+) -> None:
+    existing_columns = {
+        str(row[1]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+    if column_name in existing_columns:
+        return
+    conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_sql}")
 
 
 class ACPSessionsDB:
@@ -173,6 +194,43 @@ class ACPSessionsDB:
                     CREATE INDEX IF NOT EXISTS idx_health_agent_time
                         ON agent_health_history(agent_type, checked_at DESC);
                 """)
+            if current_version < 4:
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_snapshot_version",
+                    "policy_snapshot_version TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_snapshot_fingerprint",
+                    "policy_snapshot_fingerprint TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_snapshot_refreshed_at",
+                    "policy_snapshot_refreshed_at TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_summary",
+                    "policy_summary TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_provenance_summary",
+                    "policy_provenance_summary TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "sessions",
+                    "policy_refresh_error",
+                    "policy_refresh_error TEXT",
+                )
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
             self._initialized = True
@@ -188,12 +246,18 @@ class ACPSessionsDB:
         for field in _BOOL_FIELDS:
             if field in d:
                 d[field] = bool(d[field])
-        for field in _JSON_FIELDS:
+        for field in _JSON_LIST_FIELDS:
             if field in d and isinstance(d[field], str):
                 try:
                     d[field] = json.loads(d[field])
                 except (json.JSONDecodeError, TypeError):
                     d[field] = []
+        for field in _JSON_OBJECT_FIELDS:
+            if field in d and isinstance(d[field], str):
+                try:
+                    d[field] = json.loads(d[field])
+                except (json.JSONDecodeError, TypeError):
+                    d[field] = None
         return d
 
     # ------------------------------------------------------------------
@@ -213,6 +277,12 @@ class ACPSessionsDB:
         workspace_id: str | None = None,
         workspace_group_id: str | None = None,
         scope_snapshot_id: str | None = None,
+        policy_snapshot_version: str | None = None,
+        policy_snapshot_fingerprint: str | None = None,
+        policy_snapshot_refreshed_at: str | None = None,
+        policy_summary: dict[str, Any] | None = None,
+        policy_provenance_summary: dict[str, Any] | None = None,
+        policy_refresh_error: str | None = None,
         forked_from: str | None = None,
         needs_bootstrap: bool = False,
     ) -> dict[str, Any]:
@@ -226,8 +296,10 @@ class ACPSessionsDB:
                 created_at, last_activity_at,
                 tags, mcp_servers,
                 persona_id, workspace_id, workspace_group_id, scope_snapshot_id,
+                policy_snapshot_version, policy_snapshot_fingerprint, policy_snapshot_refreshed_at,
+                policy_summary, policy_provenance_summary, policy_refresh_error,
                 forked_from, needs_bootstrap
-            ) VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, 'active', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id, user_id, agent_type, name, cwd,
@@ -235,11 +307,59 @@ class ACPSessionsDB:
                 json.dumps(tags or []),
                 json.dumps(mcp_servers or []),
                 persona_id, workspace_id, workspace_group_id, scope_snapshot_id,
+                policy_snapshot_version,
+                policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at,
+                json.dumps(policy_summary) if policy_summary is not None else None,
+                json.dumps(policy_provenance_summary)
+                if policy_provenance_summary is not None
+                else None,
+                policy_refresh_error,
                 forked_from, int(needs_bootstrap),
             ),
         )
         conn.commit()
         return self.get_session(session_id)  # type: ignore[return-value]
+
+    def update_policy_snapshot_state(
+        self,
+        session_id: str,
+        *,
+        policy_snapshot_version: str | None,
+        policy_snapshot_fingerprint: str | None,
+        policy_snapshot_refreshed_at: str | None,
+        policy_summary: dict[str, Any] | None,
+        policy_provenance_summary: dict[str, Any] | None,
+        policy_refresh_error: str | None,
+    ) -> None:
+        """Update persisted ACP policy snapshot metadata for a session."""
+        conn = self._get_conn()
+        conn.execute(
+            """
+            UPDATE sessions
+            SET policy_snapshot_version = ?,
+                policy_snapshot_fingerprint = ?,
+                policy_snapshot_refreshed_at = ?,
+                policy_summary = ?,
+                policy_provenance_summary = ?,
+                policy_refresh_error = ?,
+                last_activity_at = ?
+            WHERE session_id = ?
+            """,
+            (
+                policy_snapshot_version,
+                policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at,
+                json.dumps(policy_summary) if policy_summary is not None else None,
+                json.dumps(policy_provenance_summary)
+                if policy_provenance_summary is not None
+                else None,
+                policy_refresh_error,
+                _utcnow_iso(),
+                session_id,
+            ),
+        )
+        conn.commit()
 
     def get_session(self, session_id: str) -> dict[str, Any] | None:
         """Fetch a single session by ID, or None if not found."""

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -431,30 +431,72 @@ class ACPSessionsDB:
     ) -> tuple[list[dict[str, Any]], int]:
         """List sessions with optional filters. Returns (rows, total_count)."""
         conn = self._get_conn()
-        conditions: list[str] = []
         params: list[Any] = []
 
-        if user_id is not None:
-            conditions.append("user_id = ?")
-            params.append(user_id)
-        if status is not None:
-            conditions.append("status = ?")
-            params.append(status)
-        if agent_type is not None:
-            conditions.append("agent_type = ?")
-            params.append(agent_type)
+        query_key = (user_id is not None, status is not None, agent_type is not None)
+        match query_key:
+            case (False, False, False):
+                count_query = "SELECT COUNT(*) FROM sessions"
+                rows_query = "SELECT * FROM sessions ORDER BY created_at DESC LIMIT ? OFFSET ?"
+            case (True, False, False):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE user_id = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE user_id = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.append(user_id)
+            case (False, True, False):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE status = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE status = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.append(status)
+            case (False, False, True):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE agent_type = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE agent_type = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.append(agent_type)
+            case (True, True, False):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE user_id = ? AND status = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE user_id = ? AND status = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.extend([user_id, status])
+            case (True, False, True):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE user_id = ? AND agent_type = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE user_id = ? AND agent_type = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.extend([user_id, agent_type])
+            case (False, True, True):
+                count_query = "SELECT COUNT(*) FROM sessions WHERE status = ? AND agent_type = ?"
+                rows_query = (
+                    "SELECT * FROM sessions WHERE status = ? AND agent_type = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.extend([status, agent_type])
+            case _:
+                count_query = (
+                    "SELECT COUNT(*) FROM sessions "
+                    "WHERE user_id = ? AND status = ? AND agent_type = ?"
+                )
+                rows_query = (
+                    "SELECT * FROM sessions "
+                    "WHERE user_id = ? AND status = ? AND agent_type = ? "
+                    "ORDER BY created_at DESC LIMIT ? OFFSET ?"
+                )
+                params.extend([user_id, status, agent_type])
 
-        where = " AND ".join(conditions) if conditions else "1=1"
-
-        # Total count
-        count_row = conn.execute(
-            f"SELECT COUNT(*) FROM sessions WHERE {where}", params
-        ).fetchone()
+        count_row = conn.execute(count_query, params).fetchone()
         total = count_row[0] if count_row else 0
 
-        # Paginated results
         rows = conn.execute(
-            f"SELECT * FROM sessions WHERE {where} ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            rows_query,
             params + [limit, offset],
         ).fetchall()
 

--- a/tldw_Server_API/app/services/acp_runtime_policy_service.py
+++ b/tldw_Server_API/app/services/acp_runtime_policy_service.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_str_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    items: list[str] = []
+    for entry in value:
+        cleaned = str(entry or "").strip()
+        if cleaned:
+            items.append(cleaned)
+    return items
+
+
+def _unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+class ACPRuntimePolicySnapshot(BaseModel):
+    session_id: str
+    user_id: int
+    policy_snapshot_version: str
+    policy_snapshot_fingerprint: str
+    policy_snapshot_refreshed_at: str
+    policy_summary: dict[str, Any] = Field(default_factory=dict)
+    policy_provenance_summary: dict[str, Any] = Field(default_factory=dict)
+    resolved_policy_document: dict[str, Any] = Field(default_factory=dict)
+    approval_summary: dict[str, Any] = Field(default_factory=dict)
+    context_summary: dict[str, Any] = Field(default_factory=dict)
+    execution_config: dict[str, Any] = Field(default_factory=dict)
+    refresh_error: str | None = None
+
+
+class ACPRuntimePolicyService:
+    """Build and persist ACP runtime policy snapshots from MCP Hub policy."""
+
+    def __init__(
+        self,
+        *,
+        policy_resolver: Any | None = None,
+        mcp_hub_service: Any | None = None,
+    ) -> None:
+        if policy_resolver is None:
+            repo = McpHubRepo(get_db_pool())
+            policy_resolver = McpHubPolicyResolver(repo)
+        self.policy_resolver = policy_resolver
+        self.mcp_hub_service = mcp_hub_service
+
+    @staticmethod
+    def _parse_acp_profile(acp_profile: Any) -> tuple[int | None, dict[str, Any], dict[str, Any]]:
+        if not isinstance(acp_profile, dict):
+            return None, {}, {}
+
+        profile_id: int | None = None
+        raw_profile_id = acp_profile.get("id")
+        try:
+            if raw_profile_id is not None:
+                profile_id = int(raw_profile_id)
+        except (TypeError, ValueError):
+            profile_id = None
+
+        if isinstance(acp_profile.get("profile"), dict):
+            payload = dict(acp_profile["profile"])
+        elif isinstance(acp_profile.get("profile_json"), str):
+            try:
+                payload = _as_dict(json.loads(acp_profile["profile_json"]))
+            except json.JSONDecodeError:
+                payload = {}
+        else:
+            payload = {
+                key: value
+                for key, value in acp_profile.items()
+                if key not in {"id", "name", "description", "owner_scope_type", "owner_scope_id"}
+            }
+
+        execution_config = _as_dict(payload.get("execution_config")) or {
+            key: value for key, value in payload.items() if key != "policy_hints"
+        }
+        policy_hints = _as_dict(payload.get("policy_hints"))
+        return profile_id, execution_config, policy_hints
+
+    async def _load_acp_profile(
+        self,
+        *,
+        acp_profile_id: int | None,
+        acp_profile: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        if acp_profile is not None:
+            return acp_profile
+        if acp_profile_id is None or self.mcp_hub_service is None:
+            return None
+        getter = getattr(self.mcp_hub_service, "get_acp_profile", None)
+        if getter is None:
+            return None
+        return await getter(int(acp_profile_id))
+
+    async def build_resolution_metadata(
+        self,
+        *,
+        session_record: Any,
+        acp_profile_id: int | None = None,
+        acp_profile: dict[str, Any] | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        loaded_profile = await self._load_acp_profile(
+            acp_profile_id=acp_profile_id,
+            acp_profile=acp_profile,
+        )
+        parsed_profile_id, execution_config, policy_hints = self._parse_acp_profile(loaded_profile)
+        effective_profile_id = acp_profile_id if acp_profile_id is not None else parsed_profile_id
+
+        metadata: dict[str, Any] = {"mcp_policy_context_enabled": True}
+        for key in (
+            "persona_id",
+            "workspace_id",
+            "workspace_group_id",
+            "scope_snapshot_id",
+        ):
+            value = getattr(session_record, key, None)
+            if value:
+                metadata[key] = value
+
+        mcp_servers = getattr(session_record, "mcp_servers", None)
+        if mcp_servers:
+            metadata["mcp_servers"] = list(mcp_servers)
+
+        if effective_profile_id is not None:
+            metadata["acp_profile_id"] = int(effective_profile_id)
+
+        hint_tags = _unique(
+            _as_str_list(policy_hints.get("tags"))
+            + _as_str_list(loaded_profile.get("hint_tags") if isinstance(loaded_profile, dict) else None)
+        )
+        if hint_tags:
+            metadata["acp_profile_hint_tags"] = hint_tags
+
+        for key, value in dict(extra_metadata or {}).items():
+            if value is not None:
+                metadata[key] = value
+
+        return metadata, execution_config
+
+    async def build_snapshot(
+        self,
+        *,
+        session_record: Any,
+        user_id: int,
+        acp_profile_id: int | None = None,
+        acp_profile: dict[str, Any] | None = None,
+        extra_metadata: dict[str, Any] | None = None,
+    ) -> ACPRuntimePolicySnapshot:
+        metadata, execution_config = await self.build_resolution_metadata(
+            session_record=session_record,
+            acp_profile_id=acp_profile_id,
+            acp_profile=acp_profile,
+            extra_metadata=extra_metadata,
+        )
+        effective_policy = await self.policy_resolver.resolve_for_context(
+            user_id=user_id,
+            metadata=metadata,
+        )
+
+        resolved_policy_document = _as_dict(
+            effective_policy.get("resolved_policy_document")
+            or effective_policy.get("policy_document")
+        )
+        allowed_tools = _unique(_as_str_list(resolved_policy_document.get("allowed_tools")))
+        denied_tools = _unique(_as_str_list(resolved_policy_document.get("denied_tools")))
+        capabilities = _unique(_as_str_list(resolved_policy_document.get("capabilities")))
+
+        sources = list(effective_policy.get("sources") or [])
+        provenance = list(effective_policy.get("provenance") or [])
+        source_kinds = sorted(
+            _unique(
+                [
+                    str(item.get("source_kind") or "").strip()
+                    for item in sources + provenance
+                    if str(item.get("source_kind") or "").strip()
+                ]
+            )
+        )
+        policy_summary = {
+            "allowed_tool_count": len(allowed_tools),
+            "denied_tool_count": len(denied_tools),
+            "capability_count": len(capabilities),
+            "approval_mode": str(resolved_policy_document.get("approval_mode") or "").strip() or None,
+            "path_scope_mode": str(resolved_policy_document.get("path_scope_mode") or "").strip() or None,
+        }
+        approval_summary = {
+            "mode": policy_summary["approval_mode"],
+            "approval_policy_id": effective_policy.get("approval_policy_id")
+            or resolved_policy_document.get("approval_policy_id"),
+        }
+        policy_provenance_summary = {
+            "source_count": len(sources),
+            "provenance_entry_count": len(provenance),
+            "source_kinds": source_kinds,
+        }
+        context_summary = dict(metadata)
+        fingerprint_payload = {
+            "context_summary": context_summary,
+            "resolved_policy_document": resolved_policy_document,
+            "approval_summary": approval_summary,
+            "policy_version": effective_policy.get("policy_version") or "resolved-v1",
+        }
+        fingerprint = hashlib.sha256(_canonical_json(fingerprint_payload).encode("utf-8")).hexdigest()
+
+        return ACPRuntimePolicySnapshot(
+            session_id=str(getattr(session_record, "session_id")),
+            user_id=int(user_id),
+            policy_snapshot_version=str(effective_policy.get("policy_version") or "resolved-v1"),
+            policy_snapshot_fingerprint=fingerprint,
+            policy_snapshot_refreshed_at=_utcnow_iso(),
+            policy_summary=policy_summary,
+            policy_provenance_summary=policy_provenance_summary,
+            resolved_policy_document=resolved_policy_document,
+            approval_summary=approval_summary,
+            context_summary=context_summary,
+            execution_config=execution_config,
+        )
+
+    async def persist_snapshot(
+        self,
+        *,
+        session_store: Any,
+        snapshot: ACPRuntimePolicySnapshot,
+    ) -> Any:
+        return await session_store.update_policy_snapshot_state(
+            snapshot.session_id,
+            policy_snapshot_version=snapshot.policy_snapshot_version,
+            policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+            policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+            policy_summary=snapshot.policy_summary,
+            policy_provenance_summary=snapshot.policy_provenance_summary,
+            policy_refresh_error=snapshot.refresh_error,
+        )

--- a/tldw_Server_API/app/services/acp_runtime_policy_service.py
+++ b/tldw_Server_API/app/services/acp_runtime_policy_service.py
@@ -73,11 +73,14 @@ class ACPRuntimePolicyService:
         policy_resolver: Any | None = None,
         mcp_hub_service: Any | None = None,
     ) -> None:
-        if policy_resolver is None:
-            repo = McpHubRepo(get_db_pool())
-            policy_resolver = McpHubPolicyResolver(repo)
         self.policy_resolver = policy_resolver
         self.mcp_hub_service = mcp_hub_service
+
+    async def _get_policy_resolver(self) -> Any:
+        if self.policy_resolver is None:
+            repo = McpHubRepo(await get_db_pool())
+            self.policy_resolver = McpHubPolicyResolver(repo)
+        return self.policy_resolver
 
     @staticmethod
     def _parse_acp_profile(acp_profile: Any) -> tuple[int | None, dict[str, Any], dict[str, Any]]:
@@ -188,7 +191,8 @@ class ACPRuntimePolicyService:
             acp_profile=acp_profile,
             extra_metadata=extra_metadata,
         )
-        effective_policy = await self.policy_resolver.resolve_for_context(
+        policy_resolver = await self._get_policy_resolver()
+        effective_policy = await policy_resolver.resolve_for_context(
             user_id=user_id,
             metadata=metadata,
         )

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -416,6 +416,7 @@ class ACPSessionStore:
         policy_summary: dict[str, Any] | None = None,
         policy_provenance_summary: dict[str, Any] | None = None,
         policy_refresh_error: str | None = None,
+        forked_from: str | None = None,
     ) -> SessionRecord:
         d = self._db.register_session(
             session_id=session_id,
@@ -435,6 +436,7 @@ class ACPSessionStore:
             policy_summary=policy_summary,
             policy_provenance_summary=policy_provenance_summary,
             policy_refresh_error=policy_refresh_error,
+            forked_from=forked_from,
         )
         logger.debug("Registered ACP session {} for user {}", session_id, user_id)
         return self._dict_to_record(d)

--- a/tldw_Server_API/app/services/admin_acp_sessions_service.py
+++ b/tldw_Server_API/app/services/admin_acp_sessions_service.py
@@ -64,6 +64,12 @@ class SessionRecord:
     workspace_id: str | None = None
     workspace_group_id: str | None = None
     scope_snapshot_id: str | None = None
+    policy_snapshot_version: str | None = None
+    policy_snapshot_fingerprint: str | None = None
+    policy_snapshot_refreshed_at: str | None = None
+    policy_summary: dict[str, Any] | None = None
+    policy_provenance_summary: dict[str, Any] | None = None
+    policy_refresh_error: str | None = None
     bootstrap_ready: bool = True
     needs_bootstrap: bool = False
     # Forking lineage
@@ -86,6 +92,12 @@ class SessionRecord:
             "workspace_id": self.workspace_id,
             "workspace_group_id": self.workspace_group_id,
             "scope_snapshot_id": self.scope_snapshot_id,
+            "policy_snapshot_version": self.policy_snapshot_version,
+            "policy_snapshot_fingerprint": self.policy_snapshot_fingerprint,
+            "policy_snapshot_refreshed_at": self.policy_snapshot_refreshed_at,
+            "policy_summary": self.policy_summary,
+            "policy_provenance_summary": self.policy_provenance_summary,
+            "policy_refresh_error": self.policy_refresh_error,
             "forked_from": self.forked_from,
         }
 
@@ -306,6 +318,12 @@ class ACPSessionStore:
             workspace_id=d.get("workspace_id"),
             workspace_group_id=d.get("workspace_group_id"),
             scope_snapshot_id=d.get("scope_snapshot_id"),
+            policy_snapshot_version=d.get("policy_snapshot_version"),
+            policy_snapshot_fingerprint=d.get("policy_snapshot_fingerprint"),
+            policy_snapshot_refreshed_at=d.get("policy_snapshot_refreshed_at"),
+            policy_summary=d.get("policy_summary"),
+            policy_provenance_summary=d.get("policy_provenance_summary"),
+            policy_refresh_error=d.get("policy_refresh_error"),
             bootstrap_ready=d.get("bootstrap_ready", True),
             needs_bootstrap=d.get("needs_bootstrap", False),
             forked_from=d.get("forked_from"),
@@ -392,6 +410,12 @@ class ACPSessionStore:
         workspace_id: str | None = None,
         workspace_group_id: str | None = None,
         scope_snapshot_id: str | None = None,
+        policy_snapshot_version: str | None = None,
+        policy_snapshot_fingerprint: str | None = None,
+        policy_snapshot_refreshed_at: str | None = None,
+        policy_summary: dict[str, Any] | None = None,
+        policy_provenance_summary: dict[str, Any] | None = None,
+        policy_refresh_error: str | None = None,
     ) -> SessionRecord:
         d = self._db.register_session(
             session_id=session_id,
@@ -405,9 +429,37 @@ class ACPSessionStore:
             workspace_id=workspace_id,
             workspace_group_id=workspace_group_id,
             scope_snapshot_id=scope_snapshot_id,
+            policy_snapshot_version=policy_snapshot_version,
+            policy_snapshot_fingerprint=policy_snapshot_fingerprint,
+            policy_snapshot_refreshed_at=policy_snapshot_refreshed_at,
+            policy_summary=policy_summary,
+            policy_provenance_summary=policy_provenance_summary,
+            policy_refresh_error=policy_refresh_error,
         )
         logger.debug("Registered ACP session {} for user {}", session_id, user_id)
         return self._dict_to_record(d)
+
+    async def update_policy_snapshot_state(
+        self,
+        session_id: str,
+        *,
+        policy_snapshot_version: str | None,
+        policy_snapshot_fingerprint: str | None,
+        policy_snapshot_refreshed_at: str | None,
+        policy_summary: dict[str, Any] | None,
+        policy_provenance_summary: dict[str, Any] | None,
+        policy_refresh_error: str | None,
+    ) -> SessionRecord | None:
+        self._db.update_policy_snapshot_state(
+            session_id,
+            policy_snapshot_version=policy_snapshot_version,
+            policy_snapshot_fingerprint=policy_snapshot_fingerprint,
+            policy_snapshot_refreshed_at=policy_snapshot_refreshed_at,
+            policy_summary=policy_summary,
+            policy_provenance_summary=policy_provenance_summary,
+            policy_refresh_error=policy_refresh_error,
+        )
+        return await self.get_session(session_id)
 
     async def close_session(self, session_id: str) -> None:
         self._db.close_session(session_id)

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -2506,6 +2506,17 @@ class McpHubService:
             owner_scope_id=owner_scope_id,
         )
 
+    async def get_acp_profile(self, profile_id: int) -> dict[str, Any] | None:
+        row = await self.repo.get_acp_profile(int(profile_id))
+        if not row:
+            return None
+        normalized = dict(row)
+        try:
+            normalized["profile"] = json.loads(str(normalized.get("profile_json") or "{}"))
+        except json.JSONDecodeError:
+            normalized["profile"] = {}
+        return normalized
+
     async def update_acp_profile(
         self,
         profile_id: int,

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -168,7 +168,12 @@ def test_acp_session_new_success(client_user_only, stub_runner_client, tmp_path,
                 policy_refresh_error=snapshot.refresh_error,
             )
 
-    monkeypatch.setattr(acp_endpoints, "ACPRuntimePolicyService", _RuntimePolicyService, raising=False)
+    monkeypatch.setattr(
+        acp_endpoints,
+        "get_acp_runtime_policy_service",
+        lambda: _RuntimePolicyService(),
+        raising=False,
+    )
 
     resp = client_user_only.post(
         "/api/v1/acp/sessions/new",

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
+from tldw_Server_API.app.services.acp_runtime_policy_service import ACPRuntimePolicySnapshot
 
 pytestmark = pytest.mark.unit
 
@@ -132,7 +133,43 @@ def stub_runner_client(monkeypatch, tmp_path):
     return stub
 
 
-def test_acp_session_new_success(client_user_only, stub_runner_client, tmp_path):
+def test_acp_session_new_success(client_user_only, stub_runner_client, tmp_path, monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+
+    captured: dict[str, object] = {}
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, *, session_record, user_id: int, **kwargs):
+            del kwargs
+            captured["session_id"] = session_record.session_id
+            captured["user_id"] = user_id
+            return ACPRuntimePolicySnapshot(
+                session_id=session_record.session_id,
+                user_id=int(user_id),
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint="snapshot-created-at-session-start",
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"allowed_tool_count": 1, "approval_mode": "allow"},
+                policy_provenance_summary={"source_kinds": ["profile"]},
+                resolved_policy_document={"allowed_tools": ["web.search"]},
+                approval_summary={"mode": "allow"},
+                context_summary={"persona_id": getattr(session_record, "persona_id", None)},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    monkeypatch.setattr(acp_endpoints, "ACPRuntimePolicyService", _RuntimePolicyService, raising=False)
+
     resp = client_user_only.post(
         "/api/v1/acp/sessions/new",
         json={"cwd": str(tmp_path)},
@@ -141,11 +178,12 @@ def test_acp_session_new_success(client_user_only, stub_runner_client, tmp_path)
     payload = resp.json()
     assert payload["session_id"] == "session-123"
     assert payload["agent_capabilities"] == {"promptCapabilities": {"image": False}}
-    assert payload["policy_snapshot_version"] is None
-    assert payload["policy_snapshot_fingerprint"] is None
-    assert payload["policy_snapshot_refreshed_at"] is None
-    assert payload["policy_summary"] is None
-    assert payload["policy_provenance_summary"] is None
+    assert payload["policy_snapshot_version"] == "resolved-v1"
+    assert payload["policy_snapshot_fingerprint"] == "snapshot-created-at-session-start"
+    assert payload["policy_snapshot_refreshed_at"] == "2026-03-14T12:00:00+00:00"
+    assert payload["policy_summary"] == {"allowed_tool_count": 1, "approval_mode": "allow"}
+    assert payload["policy_provenance_summary"] == {"source_kinds": ["profile"]}
+    assert captured == {"session_id": "session-123", "user_id": 1}
     assert stub_runner_client.create_session_calls
     assert isinstance(stub_runner_client.create_session_calls[0]["user_id"], int)
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py
@@ -141,6 +141,11 @@ def test_acp_session_new_success(client_user_only, stub_runner_client, tmp_path)
     payload = resp.json()
     assert payload["session_id"] == "session-123"
     assert payload["agent_capabilities"] == {"promptCapabilities": {"image": False}}
+    assert payload["policy_snapshot_version"] is None
+    assert payload["policy_snapshot_fingerprint"] is None
+    assert payload["policy_snapshot_refreshed_at"] is None
+    assert payload["policy_summary"] is None
+    assert payload["policy_provenance_summary"] is None
     assert stub_runner_client.create_session_calls
     assert isinstance(stub_runner_client.create_session_calls[0]["user_id"], int)
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_governance_coordinator.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_governance_coordinator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.machinery
 import sys
 import types
@@ -15,6 +16,9 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     SessionWebSocketRegistry,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicySnapshot,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -210,6 +214,31 @@ async def test_permission_request_uses_single_unified_approval_path(monkeypatch)
 
     monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
 
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id=session_id,
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-unified",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"approval_mode": "require_approval"},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={
+                "allowed_tools": ["fs.read"],
+                "approval_mode": "require_approval",
+            },
+            approval_summary={"mode": "require_approval"},
+            context_summary={},
+            execution_config={},
+        )
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+
     prompts: list[dict[str, Any]] = []
 
     async def _fake_broadcast(sid: str, message: dict[str, Any]) -> None:
@@ -233,6 +262,205 @@ async def test_permission_request_uses_single_unified_approval_path(monkeypatch)
 
     assert response.result == {"outcome": {"outcome": "approved"}}
     assert len(prompts) == 1
+
+
+@pytest.mark.asyncio
+async def test_permission_request_uses_runtime_policy_snapshot_authority(monkeypatch):
+    client = _new_runner_client_for_permissions()
+    session_id = "session-policy-prompt"
+
+    async def _send(_payload: dict[str, Any]) -> None:
+        return None
+
+    registry = SessionWebSocketRegistry(session_id=session_id)
+    registry.websockets.add(_send)
+    client._ws_registry[session_id] = registry
+
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id=session_id,
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-123",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"approval_mode": "require_approval"},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={
+                "allowed_tools": ["fs.read"],
+                "approval_mode": "require_approval",
+            },
+            approval_summary={"mode": "require_approval"},
+            context_summary={"persona_id": "persona-1"},
+            execution_config={},
+        )
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+    async def _fake_check_permission_governance(*args, **kwargs) -> dict[str, Any]:
+        del args, kwargs
+        return {"action": "allow", "status": "allow"}
+
+    monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
+
+    prompts: list[dict[str, Any]] = []
+
+    async def _fake_broadcast(sid: str, message: dict[str, Any]) -> None:
+        if message.get("type") == "permission_request":
+            prompts.append(message)
+            await client.respond_to_permission(sid, str(message["request_id"]), True)
+
+    monkeypatch.setattr(client, "_broadcast_to_session", _fake_broadcast)
+
+    response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-policy-1",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "fs.read", "input": {"path": "README.md"}},
+            },
+        )
+    )
+
+    assert response.result == {"outcome": {"outcome": "approved"}}
+    assert len(prompts) == 1
+    assert prompts[0]["approval_requirement"] == "approval_required"
+    assert prompts[0]["policy_snapshot_fingerprint"] == "snapshot-123"
+    assert prompts[0]["provenance_summary"] == {"source_kinds": ["profile"]}
+
+
+@pytest.mark.asyncio
+async def test_denied_tool_from_runtime_snapshot_returns_denied_without_prompt(monkeypatch):
+    client = _new_runner_client_for_permissions()
+
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id="session-policy-deny",
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-deny",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={"denied_tools": ["fs.delete"]},
+            approval_summary={},
+            context_summary={},
+            execution_config={},
+        )
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
+
+    response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-policy-2",
+            method="session/request_permission",
+            params={
+                "sessionId": "session-policy-deny",
+                "tool": {"name": "fs.delete", "input": {"path": "README.md"}},
+            },
+        )
+    )
+
+    assert response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "tool_denied_by_policy",
+            "policy_snapshot_fingerprint": "snapshot-deny",
+            "provenance_summary": {"source_kinds": ["profile"]},
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_policy_snapshot_refresh_is_singleflight(monkeypatch):
+    client = _new_runner_client_for_permissions()
+    calls = {"count": 0}
+
+    class _Store:
+        async def get_session(self, session_id: str):
+            from tldw_Server_API.app.services.admin_acp_sessions_service import SessionRecord, SessionTokenUsage
+
+            return SessionRecord(
+                session_id=session_id,
+                user_id=7,
+                usage=SessionTokenUsage(),
+            )
+
+        async def update_policy_snapshot_state(self, session_id: str, **kwargs):
+            from tldw_Server_API.app.services.admin_acp_sessions_service import SessionRecord, SessionTokenUsage
+
+            return SessionRecord(
+                session_id=session_id,
+                user_id=7,
+                usage=SessionTokenUsage(),
+                policy_snapshot_version=kwargs.get("policy_snapshot_version"),
+                policy_snapshot_fingerprint=kwargs.get("policy_snapshot_fingerprint"),
+                policy_snapshot_refreshed_at=kwargs.get("policy_snapshot_refreshed_at"),
+                policy_summary=kwargs.get("policy_summary"),
+                policy_provenance_summary=kwargs.get("policy_provenance_summary"),
+                policy_refresh_error=kwargs.get("policy_refresh_error"),
+            )
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            calls["count"] += 1
+            await asyncio.sleep(0)
+            return ACPRuntimePolicySnapshot(
+                session_id="session-refresh",
+                user_id=7,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint="snapshot-refresh",
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={},
+                policy_provenance_summary={},
+                resolved_policy_document={"allowed_tools": ["fs.read"]},
+                approval_summary={},
+                context_summary={},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    async def _get_store():
+        return _Store()
+
+    monkeypatch.setattr(client, "_get_acp_session_store", _get_store, raising=False)
+    monkeypatch.setattr(client, "_runtime_policy_service", _RuntimePolicyService(), raising=False)
+
+    first, second = await asyncio.gather(
+        client._get_runtime_policy_snapshot("session-refresh", force_refresh=True),
+        client._get_runtime_policy_snapshot("session-refresh", force_refresh=True),
+    )
+
+    assert calls["count"] == 1
+    assert first is second
 
 
 @pytest.mark.asyncio
@@ -263,6 +491,31 @@ async def test_governance_require_approval_plus_batch_tier_creates_one_prompt(mo
         }
 
     monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
+
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id=session_id,
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-batch",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"approval_mode": "require_approval"},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={
+                "allowed_tools": ["fs.write"],
+                "approval_mode": "require_approval",
+            },
+            approval_summary={"mode": "require_approval"},
+            context_summary={},
+            execution_config={},
+        )
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
 
     prompts: list[dict[str, Any]] = []
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_governance_coordinator.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_governance_coordinator.py
@@ -335,6 +335,142 @@ async def test_permission_request_uses_runtime_policy_snapshot_authority(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_permission_request_governance_deny_enforced_blocks_runtime_allow(monkeypatch):
+    client = _new_runner_client_for_permissions()
+
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id="session-governance-deny",
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-allow",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"approval_mode": "allow"},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={"allowed_tools": ["fs.read"]},
+            approval_summary={"mode": "allow"},
+            context_summary={},
+            execution_config={},
+        )
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return {
+            "action": "deny",
+            "status": "deny",
+            "rollout_mode": "enforce",
+            "category": "acp",
+        }
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+    monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
+
+    response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-governance-deny",
+            method="session/request_permission",
+            params={
+                "sessionId": "session-governance-deny",
+                "tool": {"name": "fs.read", "input": {"path": "README.md"}},
+            },
+        )
+    )
+
+    assert response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "governance_denied",
+            "policy_snapshot_fingerprint": "snapshot-allow",
+            "provenance_summary": {"source_kinds": ["profile"]},
+            "governance": {
+                "action": "deny",
+                "status": "deny",
+                "rollout_mode": "enforce",
+                "category": "acp",
+            },
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_permission_request_governance_require_approval_prompts_runtime_allow(monkeypatch):
+    client = _new_runner_client_for_permissions()
+    session_id = "session-governance-prompt"
+
+    async def _send(_payload: dict[str, Any]) -> None:
+        return None
+
+    registry = SessionWebSocketRegistry(session_id=session_id)
+    registry.websockets.add(_send)
+    client._ws_registry[session_id] = registry
+
+    async def _fake_snapshot(
+        sid: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del sid, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id=session_id,
+            user_id=7,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="snapshot-allow",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"approval_mode": "allow"},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={"allowed_tools": ["fs.read"]},
+            approval_summary={"mode": "allow"},
+            context_summary={},
+            execution_config={},
+        )
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return {
+            "action": "require_approval",
+            "status": "require_approval",
+            "rollout_mode": "enforce",
+            "category": "acp",
+        }
+
+    prompts: list[dict[str, Any]] = []
+
+    async def _fake_broadcast(sid: str, message: dict[str, Any]) -> None:
+        if message.get("type") == "permission_request":
+            prompts.append(message)
+            await client.respond_to_permission(sid, str(message["request_id"]), True)
+
+    monkeypatch.setattr(client, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+    monkeypatch.setattr(client, "check_permission_governance", _fake_check_permission_governance, raising=False)
+    monkeypatch.setattr(client, "_broadcast_to_session", _fake_broadcast)
+
+    response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-governance-prompt",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "fs.read", "input": {"path": "README.md"}},
+            },
+        )
+    )
+
+    assert response.result == {"outcome": {"outcome": "approved"}}
+    assert len(prompts) == 1
+    assert prompts[0]["approval_requirement"] == "approval_required"
+    assert prompts[0]["governance_reason"] == "governance_approval_required"
+    assert prompts[0]["policy_snapshot_fingerprint"] == "snapshot-allow"
+    assert prompts[0]["governance"]["action"] == "require_approval"
+
+
+@pytest.mark.asyncio
 async def test_denied_tool_from_runtime_snapshot_returns_denied_without_prompt(monkeypatch):
     client = _new_runner_client_for_permissions()
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py
@@ -14,6 +14,8 @@ from tldw_Server_API.app.core.DB_Management.Orchestration_DB import Orchestratio
 from tldw_Server_API.app.core.Agent_Orchestration.models import TaskStatus, RunStatus
 from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
 from tldw_Server_API.app.core.Agent_Client_Protocol.health_monitor import AgentHealthMonitor
+from tldw_Server_API.app.services.acp_runtime_policy_service import ACPRuntimePolicyService
+from tldw_Server_API.app.services.admin_acp_sessions_service import ACPSessionStore
 
 pytestmark = [pytest.mark.unit]
 
@@ -158,6 +160,37 @@ class TestSessionPersistenceFlow:
         assert evicted == 1
         session = session_db.get_session("expiring")
         assert session["status"] == "closed"
+
+    @pytest.mark.asyncio
+    async def test_runtime_policy_snapshot_persists_to_session_store(self, session_db):
+        store = ACPSessionStore(db=session_db)
+        await store.register_session(
+            session_id="runtime-policy",
+            user_id=42,
+            persona_id="persona-1",
+            workspace_id="workspace-1",
+        )
+        session = await store.get_session("runtime-policy")
+        assert session is not None
+
+        class _Resolver:
+            async def resolve_for_context(self, *, user_id, metadata):
+                return {
+                    "policy_document": {
+                        "allowed_tools": ["web.search"],
+                        "approval_mode": "require_approval",
+                    },
+                    "sources": [{"source_kind": "profile"}],
+                    "provenance": [{"source_kind": "profile"}],
+                }
+
+        service = ACPRuntimePolicyService(policy_resolver=_Resolver())
+        snapshot = await service.build_snapshot(session_record=session, user_id=42)
+        persisted = await service.persist_snapshot(session_store=store, snapshot=snapshot)
+
+        assert persisted is not None
+        assert persisted.policy_snapshot_fingerprint == snapshot.policy_snapshot_fingerprint
+        assert persisted.policy_summary == snapshot.policy_summary
 
 
 class TestOrchestrationPersistenceFlow:

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
@@ -208,6 +208,7 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
 
     client._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
     client._get_acp_session_store = _get_store  # type: ignore[assignment]
+    client._should_force_runtime_policy_refresh = lambda *, tier: True  # type: ignore[assignment]
 
     allowed_response = await client._handle_request(
         ACPMessage(
@@ -246,6 +247,109 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
         }
     }
     assert call_count["build_snapshot"] == 2
+
+
+@pytest.mark.unit
+async def test_low_risk_permission_reuses_cached_runtime_snapshot() -> None:
+    client = _new_runner_client_for_permissions()
+    session_id = "session-refresh-cache"
+    policy_state = {"allowed_tools": ["web.search"], "fingerprint": "snap-cache"}
+    call_count = {"build_snapshot": 0}
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    client.check_permission_governance = _fake_check_permission_governance  # type: ignore[assignment]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.record = SimpleNamespace(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_fingerprint=None,
+                policy_snapshot_version=None,
+                policy_snapshot_refreshed_at=None,
+                policy_summary=None,
+                policy_provenance_summary=None,
+                policy_refresh_error=None,
+            )
+
+        async def get_session(self, _session_id: str):
+            return self.record
+
+        async def update_policy_snapshot_state(self, _session_id: str, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self.record, key, value)
+            return self.record
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            call_count["build_snapshot"] += 1
+            return ACPRuntimePolicySnapshot(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint=policy_state["fingerprint"],
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"allowed_tool_count": len(policy_state["allowed_tools"])},
+                policy_provenance_summary={"source_kinds": ["capability_mapping"]},
+                resolved_policy_document={"allowed_tools": list(policy_state["allowed_tools"])},
+                approval_summary={"mode": "allow"},
+                context_summary={},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    store = _Store()
+
+    async def _get_store():
+        return store
+
+    client._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
+    client._get_acp_session_store = _get_store  # type: ignore[assignment]
+
+    first = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-cache-1",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert first.result == {"outcome": {"outcome": "approved"}}
+    assert call_count["build_snapshot"] == 1
+
+    policy_state["allowed_tools"] = ["fs.read"]
+    policy_state["fingerprint"] = "snap-cache-updated"
+
+    second = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-cache-2",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert second.result == {"outcome": {"outcome": "approved"}}
+    assert call_count["build_snapshot"] == 1
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
@@ -8,12 +8,18 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 
+from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import ACPRunnerClient
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
     ACPStdioClient,
     ACPResponseError,
+)
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicySnapshot,
 )
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
@@ -119,3 +125,216 @@ async def test_client_is_running(client):
     assert client.is_running
     await client.close()
     assert not client.is_running
+
+
+def _new_runner_client_for_permissions() -> ACPRunnerClient:
+    cfg = SimpleNamespace(
+        command="echo",
+        args=[],
+        env={},
+        cwd=None,
+        startup_timeout_sec=0,
+    )
+    return ACPRunnerClient(cfg)
+
+
+@pytest.mark.unit
+async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
+    client = _new_runner_client_for_permissions()
+    session_id = "session-refresh-policy"
+    policy_state = {"allowed_tools": ["web.search"], "fingerprint": "snap-allow"}
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    client.check_permission_governance = _fake_check_permission_governance  # type: ignore[assignment]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.record = SimpleNamespace(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_fingerprint=None,
+                policy_snapshot_version=None,
+                policy_snapshot_refreshed_at=None,
+                policy_summary=None,
+                policy_provenance_summary=None,
+                policy_refresh_error=None,
+            )
+
+        async def get_session(self, _session_id: str):
+            return self.record
+
+        async def update_policy_snapshot_state(self, _session_id: str, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self.record, key, value)
+            return self.record
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            return ACPRuntimePolicySnapshot(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint=policy_state["fingerprint"],
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"allowed_tool_count": len(policy_state["allowed_tools"])},
+                policy_provenance_summary={"source_kinds": ["capability_mapping"]},
+                resolved_policy_document={"allowed_tools": list(policy_state["allowed_tools"])},
+                approval_summary={"mode": "allow"},
+                context_summary={},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    store = _Store()
+
+    async def _get_store():
+        return store
+
+    client._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
+    client._get_acp_session_store = _get_store  # type: ignore[assignment]
+
+    first = await client._get_runtime_policy_snapshot(session_id, force_refresh=True)
+    assert first is not None
+    assert first.policy_snapshot_fingerprint == "snap-allow"
+
+    allowed_response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-allow",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert allowed_response.result == {"outcome": {"outcome": "approved"}}
+
+    policy_state["allowed_tools"] = ["fs.read"]
+    policy_state["fingerprint"] = "snap-updated"
+
+    refreshed = await client._get_runtime_policy_snapshot(session_id, force_refresh=True)
+    assert refreshed is not None
+    assert refreshed.policy_snapshot_fingerprint == "snap-updated"
+
+    denied_response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-deny",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert denied_response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "tool_not_allowed_by_policy",
+            "policy_snapshot_fingerprint": "snap-updated",
+            "provenance_summary": {"source_kinds": ["capability_mapping"]},
+        }
+    }
+
+
+@pytest.mark.unit
+async def test_failed_runtime_policy_refresh_fails_closed() -> None:
+    client = _new_runner_client_for_permissions()
+    session_id = "session-refresh-failure"
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    client.check_permission_governance = _fake_check_permission_governance  # type: ignore[assignment]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.record = SimpleNamespace(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_fingerprint="stale-snapshot",
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_refreshed_at="2026-03-14T11:59:00+00:00",
+                policy_summary={"allowed_tool_count": 1},
+                policy_provenance_summary={"source_kinds": ["profile"]},
+                policy_refresh_error=None,
+            )
+
+        async def get_session(self, _session_id: str):
+            return self.record
+
+        async def update_policy_snapshot_state(self, _session_id: str, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self.record, key, value)
+            return self.record
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            raise RuntimeError("policy_refresh_failed")
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            del session_store, snapshot
+            raise AssertionError("persist_snapshot should not run on refresh failure")
+
+    store = _Store()
+
+    async def _get_store():
+        return store
+
+    client._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
+    client._get_acp_session_store = _get_store  # type: ignore[assignment]
+    client._runtime_policy_snapshots[session_id] = ACPRuntimePolicySnapshot(
+        session_id=session_id,
+        user_id=7,
+        policy_snapshot_version="resolved-v1",
+        policy_snapshot_fingerprint="stale-snapshot",
+        policy_snapshot_refreshed_at="2026-03-14T11:59:00+00:00",
+        policy_summary={"allowed_tool_count": 1},
+        policy_provenance_summary={"source_kinds": ["profile"]},
+        resolved_policy_document={"allowed_tools": ["exec.run"]},
+        approval_summary={"mode": "allow"},
+        context_summary={},
+        execution_config={},
+    )
+
+    refreshed = await client._get_runtime_policy_snapshot(session_id, force_refresh=True)
+    assert refreshed is None
+    assert store.record.policy_snapshot_fingerprint is None
+    assert store.record.policy_refresh_error == "policy_refresh_failed"
+
+    response = await client._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-fail-closed",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "exec.run", "input": {"command": "whoami"}},
+            },
+        )
+    )
+    assert response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "policy_snapshot_unavailable",
+            "policy_snapshot_fingerprint": None,
+            "provenance_summary": {},
+        }
+    }

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py
@@ -143,6 +143,7 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
     client = _new_runner_client_for_permissions()
     session_id = "session-refresh-policy"
     policy_state = {"allowed_tools": ["web.search"], "fingerprint": "snap-allow"}
+    call_count = {"build_snapshot": 0}
 
     async def _fake_check_permission_governance(*args, **kwargs):
         del args, kwargs
@@ -174,6 +175,7 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
     class _RuntimePolicyService:
         async def build_snapshot(self, **kwargs):
             del kwargs
+            call_count["build_snapshot"] += 1
             return ACPRuntimePolicySnapshot(
                 session_id=session_id,
                 user_id=7,
@@ -207,10 +209,6 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
     client._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
     client._get_acp_session_store = _get_store  # type: ignore[assignment]
 
-    first = await client._get_runtime_policy_snapshot(session_id, force_refresh=True)
-    assert first is not None
-    assert first.policy_snapshot_fingerprint == "snap-allow"
-
     allowed_response = await client._handle_request(
         ACPMessage(
             jsonrpc="2.0",
@@ -223,13 +221,10 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
         )
     )
     assert allowed_response.result == {"outcome": {"outcome": "approved"}}
+    assert store.record.policy_snapshot_fingerprint == "snap-allow"
 
     policy_state["allowed_tools"] = ["fs.read"]
     policy_state["fingerprint"] = "snap-updated"
-
-    refreshed = await client._get_runtime_policy_snapshot(session_id, force_refresh=True)
-    assert refreshed is not None
-    assert refreshed.policy_snapshot_fingerprint == "snap-updated"
 
     denied_response = await client._handle_request(
         ACPMessage(
@@ -250,6 +245,7 @@ async def test_runtime_policy_refresh_applies_updated_permissions() -> None:
             "provenance_summary": {"source_kinds": ["capability_mapping"]},
         }
     }
+    assert call_count["build_snapshot"] == 2
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.services.admin_acp_sessions_service import (
+    SessionRecord,
+    SessionTokenUsage,
+)
+
+
+class _StubPolicyResolver:
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def resolve_for_context(
+        self,
+        *,
+        user_id: int | str | None,
+        metadata: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        self.calls.append({"user_id": user_id, "metadata": dict(metadata or {})})
+        if not self._responses:
+            raise AssertionError("No stub responses left")
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_uses_normalized_context_and_profile_hints():
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    session = SessionRecord(
+        session_id="session-1",
+        user_id=42,
+        agent_type="codex",
+        name="Policy Session",
+        cwd="/tmp/project",
+        usage=SessionTokenUsage(),
+        mcp_servers=[{"name": "filesystem", "type": "stdio"}],
+        persona_id="persona-1",
+        workspace_id="workspace-1",
+        workspace_group_id="group-1",
+        scope_snapshot_id="scope-1",
+    )
+    resolver = _StubPolicyResolver(
+        [
+            {
+                "policy_document": {
+                    "allowed_tools": ["web.search"],
+                    "denied_tools": ["shell.exec"],
+                    "approval_mode": "require_approval",
+                    "capabilities": ["tool.invoke.research"],
+                },
+                "allowed_tools": ["web.search"],
+                "denied_tools": ["shell.exec"],
+                "sources": [{"source_kind": "profile", "profile_id": 7}],
+                "provenance": [{"source_kind": "capability_mapping", "field": "allowed_tools"}],
+            }
+        ]
+    )
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+
+    snapshot = await service.build_snapshot(
+        session_record=session,
+        user_id=42,
+        acp_profile={
+            "id": 7,
+            "profile": {
+                "execution_config": {"sandbox_mode": "workspace-write"},
+                "policy_hints": {"tags": ["researcher"]},
+            },
+        },
+        extra_metadata={"team_id": 9, "org_id": 4},
+    )
+
+    assert snapshot.context_summary["persona_id"] == "persona-1"
+    assert snapshot.execution_config == {"sandbox_mode": "workspace-write"}
+    assert snapshot.policy_provenance_summary["source_kinds"] == [
+        "capability_mapping",
+        "profile",
+    ]
+    assert snapshot.policy_summary["allowed_tool_count"] == 1
+    assert resolver.calls[0]["metadata"]["mcp_policy_context_enabled"] is True
+    assert resolver.calls[0]["metadata"]["acp_profile_id"] == 7
+    assert resolver.calls[0]["metadata"]["acp_profile_hint_tags"] == ["researcher"]
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_fingerprint_changes_when_effective_policy_changes():
+    from tldw_Server_API.app.services.acp_runtime_policy_service import (
+        ACPRuntimePolicyService,
+    )
+
+    session = SessionRecord(
+        session_id="session-2",
+        user_id=7,
+        usage=SessionTokenUsage(),
+    )
+    resolver = _StubPolicyResolver(
+        [
+            {"policy_document": {"allowed_tools": ["web.search"]}, "sources": [], "provenance": []},
+            {"policy_document": {"allowed_tools": ["docs.search"]}, "sources": [], "provenance": []},
+        ]
+    )
+    service = ACPRuntimePolicyService(policy_resolver=resolver)
+
+    first = await service.build_snapshot(session_record=session, user_id=7)
+    second = await service.build_snapshot(session_record=session, user_id=7)
+
+    assert first.policy_snapshot_fingerprint != second.policy_snapshot_fingerprint
+

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -464,6 +464,7 @@ async def test_sandbox_permission_request_refreshes_runtime_snapshot_when_policy
 
     manager._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
     manager._get_acp_session_store = _get_store  # type: ignore[assignment]
+    manager._should_force_runtime_policy_refresh = lambda *, tier: True  # type: ignore[assignment]
 
     allowed_response = await manager._handle_request(
         ACPMessage(
@@ -501,6 +502,119 @@ async def test_sandbox_permission_request_refreshes_runtime_snapshot_when_policy
         }
     }
     assert call_count["build_snapshot"] == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_low_risk_permission_reuses_cached_runtime_snapshot(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    session_id = "sandbox-refresh-cache"
+    policy_state = {"allowed_tools": ["web.search"], "fingerprint": "sandbox-cache"}
+    call_count = {"build_snapshot": 0}
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    manager.check_permission_governance = _fake_check_permission_governance  # type: ignore[assignment]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.record = type(
+                "_Record",
+                (),
+                {
+                    "session_id": session_id,
+                    "user_id": 9,
+                    "policy_snapshot_fingerprint": None,
+                    "policy_snapshot_version": None,
+                    "policy_snapshot_refreshed_at": None,
+                    "policy_summary": None,
+                    "policy_provenance_summary": None,
+                    "policy_refresh_error": None,
+                },
+            )()
+
+        async def get_session(self, _session_id: str):
+            return self.record
+
+        async def update_policy_snapshot_state(self, _session_id: str, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self.record, key, value)
+            return self.record
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            call_count["build_snapshot"] += 1
+            return ACPRuntimePolicySnapshot(
+                session_id=session_id,
+                user_id=9,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint=policy_state["fingerprint"],
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"allowed_tool_count": len(policy_state["allowed_tools"])},
+                policy_provenance_summary={"source_kinds": ["capability_mapping"]},
+                resolved_policy_document={"allowed_tools": list(policy_state["allowed_tools"])},
+                approval_summary={"mode": "allow"},
+                context_summary={},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    store = _Store()
+
+    async def _get_store():
+        return store
+
+    manager._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
+    manager._get_acp_session_store = _get_store  # type: ignore[assignment]
+
+    first = await manager._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="sandbox-perm-cache-1",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert first.result == {"outcome": {"outcome": "approved"}}
+    assert call_count["build_snapshot"] == 1
+
+    policy_state["allowed_tools"] = ["fs.read"]
+    policy_state["fingerprint"] = "sandbox-cache-updated"
+
+    second = await manager._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="sandbox-perm-cache-2",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert second.result == {"outcome": {"outcome": "approved"}}
+    assert call_count["build_snapshot"] == 1
 
 
 @pytest.mark.unit
@@ -746,3 +860,47 @@ async def test_close_session_falls_back_to_persisted_control(monkeypatch) -> Non
     assert fake_service.destroyed == ["sandbox-session-3"]
     assert released_ports == [4044]
     assert deleted["value"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_close_session_clears_runtime_policy_cache_and_refresh_task(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    session_id = "acp-session-runtime-cache"
+
+    monkeypatch.setattr(manager, "_get_session", lambda sid, required=False: asyncio.sleep(0, result=None))
+    monkeypatch.setattr(manager, "_load_control_record", lambda sid: {"id": session_id, "user_id": "1"})
+    monkeypatch.setattr(manager, "_delete_control_record", lambda sid: True)
+
+    manager._runtime_policy_snapshots[session_id] = ACPRuntimePolicySnapshot(
+        session_id=session_id,
+        user_id=1,
+        policy_snapshot_version="resolved-v1",
+        policy_snapshot_fingerprint="snapshot-cache",
+        policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+        policy_summary={},
+        policy_provenance_summary={},
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        approval_summary={},
+        context_summary={},
+        execution_config={},
+    )
+
+    async def _pending_refresh() -> ACPRuntimePolicySnapshot | None:
+        await asyncio.sleep(10)
+        return None
+
+    refresh_task = asyncio.create_task(_pending_refresh())
+    manager._runtime_policy_refresh_tasks[session_id] = refresh_task
+
+    await manager.close_session(session_id)
+    await asyncio.sleep(0)
+
+    assert session_id not in manager._runtime_policy_snapshots
+    assert session_id not in manager._runtime_policy_refresh_tasks
+    assert refresh_task.cancelled() is True

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -12,10 +12,14 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_runner_client import
     SandboxSessionHandle,
     _is_self_referential_agent_command,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
 from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPResponseError
 from tldw_Server_API.app.core.Sandbox.models import RuntimeType
 from tldw_Server_API.app.core.Sandbox.runtime_capabilities import RuntimePreflightResult
 from tldw_Server_API.app.core.Sandbox.runners.lima_runner import LimaRunner
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicySnapshot,
+)
 
 
 @pytest.mark.unit
@@ -318,30 +322,66 @@ async def test_create_session_propagates_non_root_read_only_and_internal_ssh_por
     run_spec = capture.get("run_spec")
     if session_spec is None:
         pytest.fail("Expected sandbox session spec capture")
-    if run_spec is None:
-        pytest.fail("Expected sandbox run spec capture")
-    if getattr(session_spec, "network_policy", None) != "deny_all":
-        pytest.fail(f"Expected session spec network_policy='deny_all', got {getattr(session_spec, 'network_policy', None)!r}")
-    if getattr(run_spec, "run_as_root", None) is not False:
-        pytest.fail(f"Expected run spec run_as_root=False, got {getattr(run_spec, 'run_as_root', None)!r}")
-    if getattr(run_spec, "read_only_root", None) is not True:
-        pytest.fail(f"Expected run spec read_only_root=True, got {getattr(run_spec, 'read_only_root', None)!r}")
-    if getattr(run_spec, "network_policy", None) != "deny_all":
-        pytest.fail(f"Expected run spec network_policy='deny_all', got {getattr(run_spec, 'network_policy', None)!r}")
-    run_env = getattr(run_spec, "env", {}) or {}
-    if run_env.get("ACP_RUNTIME_HOME") != "/workspace/.acp-home":
-        pytest.fail(f"Expected ACP_RUNTIME_HOME=/workspace/.acp-home, got {run_env.get('ACP_RUNTIME_HOME')!r}")
-    if run_env.get("ACP_SSH_PORT") != "2222":
-        pytest.fail(f"Expected ACP_SSH_PORT='2222', got {run_env.get('ACP_SSH_PORT')!r}")
-    port_mappings = list(getattr(run_spec, "port_mappings", []) or [])
-    if not port_mappings:
-        pytest.fail("Expected ACP run spec to include SSH port mapping")
-    if port_mappings[0].get("container_port") != 2222:
-        pytest.fail(f"Expected container_port=2222, got {port_mappings[0].get('container_port')!r}")
-    if port_mappings[0].get("host_port") != 4567:
-        pytest.fail(f"Expected host_port=4567, got {port_mappings[0].get('host_port')!r}")
 
-    await manager.close_session(session_id)
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sandbox_permission_request_denies_tool_from_runtime_snapshot(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+
+    async def _fake_snapshot(
+        session_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> ACPRuntimePolicySnapshot | None:
+        del session_id, force_refresh
+        return ACPRuntimePolicySnapshot(
+            session_id="sandbox-session",
+            user_id=55,
+            policy_snapshot_version="resolved-v1",
+            policy_snapshot_fingerprint="sandbox-deny",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={},
+            policy_provenance_summary={"source_kinds": ["profile"]},
+            resolved_policy_document={"denied_tools": ["exec.run"]},
+            approval_summary={},
+            context_summary={},
+            execution_config={},
+        )
+
+    monkeypatch.setattr(manager, "_get_runtime_policy_snapshot", _fake_snapshot, raising=False)
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    monkeypatch.setattr(manager, "check_permission_governance", _fake_check_permission_governance, raising=False)
+
+    response = await manager._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="perm-sandbox-deny",
+            method="session/request_permission",
+            params={
+                "sessionId": "sandbox-session",
+                "tool": {"name": "exec.run", "input": {"command": "whoami"}},
+            },
+        )
+    )
+
+    assert response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "tool_denied_by_policy",
+            "policy_snapshot_fingerprint": "sandbox-deny",
+            "provenance_summary": {"source_kinds": ["profile"]},
+        }
+    }
 
 
 @pytest.mark.unit

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py
@@ -386,6 +386,125 @@ async def test_sandbox_permission_request_denies_tool_from_runtime_snapshot(monk
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_sandbox_permission_request_refreshes_runtime_snapshot_when_policy_changes(monkeypatch) -> None:
+    manager = ACPSandboxRunnerManager(
+        ACPSandboxConfig(
+            enabled=True,
+            agent_command="/usr/local/bin/codex",
+        )
+    )
+    session_id = "sandbox-refresh-policy"
+    policy_state = {"allowed_tools": ["web.search"], "fingerprint": "sandbox-allow"}
+    call_count = {"build_snapshot": 0}
+
+    async def _fake_check_permission_governance(*args, **kwargs):
+        del args, kwargs
+        return None
+
+    manager.check_permission_governance = _fake_check_permission_governance  # type: ignore[assignment]
+
+    class _Store:
+        def __init__(self) -> None:
+            self.record = type(
+                "_Record",
+                (),
+                {
+                    "session_id": session_id,
+                    "user_id": 9,
+                    "policy_snapshot_fingerprint": None,
+                    "policy_snapshot_version": None,
+                    "policy_snapshot_refreshed_at": None,
+                    "policy_summary": None,
+                    "policy_provenance_summary": None,
+                    "policy_refresh_error": None,
+                },
+            )()
+
+        async def get_session(self, _session_id: str):
+            return self.record
+
+        async def update_policy_snapshot_state(self, _session_id: str, **kwargs):
+            for key, value in kwargs.items():
+                setattr(self.record, key, value)
+            return self.record
+
+    class _RuntimePolicyService:
+        async def build_snapshot(self, **kwargs):
+            del kwargs
+            call_count["build_snapshot"] += 1
+            return ACPRuntimePolicySnapshot(
+                session_id=session_id,
+                user_id=9,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint=policy_state["fingerprint"],
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"allowed_tool_count": len(policy_state["allowed_tools"])},
+                policy_provenance_summary={"source_kinds": ["capability_mapping"]},
+                resolved_policy_document={"allowed_tools": list(policy_state["allowed_tools"])},
+                approval_summary={"mode": "allow"},
+                context_summary={},
+                execution_config={},
+            )
+
+        async def persist_snapshot(self, *, session_store, snapshot):
+            return await session_store.update_policy_snapshot_state(
+                snapshot.session_id,
+                policy_snapshot_version=snapshot.policy_snapshot_version,
+                policy_snapshot_fingerprint=snapshot.policy_snapshot_fingerprint,
+                policy_snapshot_refreshed_at=snapshot.policy_snapshot_refreshed_at,
+                policy_summary=snapshot.policy_summary,
+                policy_provenance_summary=snapshot.policy_provenance_summary,
+                policy_refresh_error=snapshot.refresh_error,
+            )
+
+    store = _Store()
+
+    async def _get_store():
+        return store
+
+    manager._runtime_policy_service = _RuntimePolicyService()  # type: ignore[assignment]
+    manager._get_acp_session_store = _get_store  # type: ignore[assignment]
+
+    allowed_response = await manager._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="sandbox-perm-allow",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert allowed_response.result == {"outcome": {"outcome": "approved"}}
+
+    policy_state["allowed_tools"] = ["fs.read"]
+    policy_state["fingerprint"] = "sandbox-updated"
+
+    denied_response = await manager._handle_request(
+        ACPMessage(
+            jsonrpc="2.0",
+            id="sandbox-perm-deny",
+            method="session/request_permission",
+            params={
+                "sessionId": session_id,
+                "tool": {"name": "web.search", "input": {"query": "opa"}},
+            },
+        )
+    )
+    assert denied_response.result == {
+        "outcome": {
+            "outcome": "denied",
+            "deny_reason": "tool_not_allowed_by_policy",
+            "policy_snapshot_fingerprint": "sandbox-updated",
+            "provenance_summary": {"source_kinds": ["capability_mapping"]},
+        }
+    }
+    assert call_count["build_snapshot"] == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_create_session_rolls_back_when_control_record_persist_fails(monkeypatch) -> None:
     manager = ACPSandboxRunnerManager(
         ACPSandboxConfig(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
@@ -342,3 +342,128 @@ async def test_permission_response_audit_records_policy_snapshot_fingerprint(mon
     assert event["metadata"]["approved"] is True
     assert event["metadata"]["policy_snapshot_fingerprint"] == "snapshot-audit-123"
     assert event["metadata"]["approval_requirement"] == "approval_required"
+
+
+@pytest.mark.asyncio
+async def test_permission_response_audit_uses_client_metadata_accessor(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+
+    recorded: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        acp_endpoints,
+        "_acp_record_audit_event",
+        lambda *, action, user_id, session_id, metadata=None: recorded.append(
+            {
+                "action": action,
+                "user_id": user_id,
+                "session_id": session_id,
+                "metadata": metadata or {},
+            }
+        ),
+    )
+
+    class _Client:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, bool, str | None]] = []
+
+        def get_pending_permission_metadata(self, session_id: str, request_id: str) -> dict[str, object]:
+            assert session_id == "audit-accessor-session"
+            assert request_id == "perm-accessor"
+            return {
+                "tool_name": "fs.read",
+                "approval_requirement": "approval_required",
+                "policy_snapshot_fingerprint": "snapshot-accessor",
+            }
+
+        async def respond_to_permission(
+            self,
+            session_id: str,
+            request_id: str,
+            approved: bool,
+            batch_approve_tier: str | None = None,
+        ) -> bool:
+            self.calls.append((session_id, request_id, approved, batch_approve_tier))
+            return True
+
+    class _Stream:
+        async def send_json(self, payload):
+            raise AssertionError(f"unexpected error payload: {payload}")
+
+    client = _Client()
+    await acp_endpoints._handle_client_message(
+        client,
+        "audit-accessor-session",
+        {
+            "type": "permission_response",
+            "request_id": "perm-accessor",
+            "approved": True,
+        },
+        _Stream(),
+        user_id=11,
+    )
+
+    assert client.calls == [("audit-accessor-session", "perm-accessor", True, None)]
+    assert recorded[-1]["metadata"]["tool_name"] == "fs.read"
+    assert recorded[-1]["metadata"]["policy_snapshot_fingerprint"] == "snapshot-accessor"
+
+
+@pytest.mark.asyncio
+async def test_permission_response_audit_logs_metadata_accessor_failure(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+
+    warnings: list[str] = []
+    recorded: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        acp_endpoints,
+        "_acp_record_audit_event",
+        lambda *, action, user_id, session_id, metadata=None: recorded.append(
+            {
+                "action": action,
+                "user_id": user_id,
+                "session_id": session_id,
+                "metadata": metadata or {},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        acp_endpoints.logger,
+        "warning",
+        lambda message, *args: warnings.append(str(message).format(*args)),
+    )
+
+    class _Client:
+        def get_pending_permission_metadata(self, session_id: str, request_id: str) -> dict[str, object]:
+            del session_id, request_id
+            raise RuntimeError("metadata lookup failed")
+
+        async def respond_to_permission(
+            self,
+            session_id: str,
+            request_id: str,
+            approved: bool,
+            batch_approve_tier: str | None = None,
+        ) -> bool:
+            del session_id, request_id, approved, batch_approve_tier
+            return True
+
+    class _Stream:
+        async def send_json(self, payload):
+            raise AssertionError(f"unexpected error payload: {payload}")
+
+    await acp_endpoints._handle_client_message(
+        _Client(),
+        "audit-accessor-failure",
+        {
+            "type": "permission_response",
+            "request_id": "perm-accessor-failure",
+            "approved": False,
+        },
+        _Stream(),
+        user_id=13,
+    )
+
+    assert recorded[-1]["metadata"]["approved"] is False
+    assert "policy_snapshot_fingerprint" not in recorded[-1]["metadata"]
+    assert any("Failed to load ACP pending permission metadata" in warning for warning in warnings)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py
@@ -7,6 +7,7 @@ import os
 import sys
 import tempfile
 import types
+from types import SimpleNamespace
 
 import pytest
 
@@ -267,3 +268,77 @@ def test_audit_db_double_flush_is_idempotent():
         assert db.flush() == 1
         assert db.flush() == 0  # No new events
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_permission_response_audit_records_policy_snapshot_fingerprint(monkeypatch):
+    import tldw_Server_API.app.api.v1.endpoints.agent_client_protocol as acp_endpoints
+    from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
+        ACPRunnerClient,
+        PendingPermission,
+        SessionWebSocketRegistry,
+    )
+
+    cfg = SimpleNamespace(
+        command="echo",
+        args=[],
+        env={},
+        cwd=None,
+        startup_timeout_sec=0,
+    )
+    client = ACPRunnerClient(cfg)
+    session_id = "audit-session"
+    request_id = "perm-1"
+    future = asyncio.get_running_loop().create_future()
+
+    registry = SessionWebSocketRegistry(session_id=session_id)
+    registry.pending_permissions[request_id] = PendingPermission(
+        request_id=request_id,
+        session_id=session_id,
+        tool_name="fs.write",
+        tool_arguments={"path": "README.md"},
+        acp_message_id="acp-1",
+        future=future,
+        policy_snapshot_fingerprint="snapshot-audit-123",
+        approval_requirement="approval_required",
+        governance_reason="policy_approval_required",
+    )
+    client._ws_registry[session_id] = registry
+
+    recorded: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        acp_endpoints,
+        "_acp_record_audit_event",
+        lambda *, action, user_id, session_id, metadata=None: recorded.append(
+            {
+                "action": action,
+                "user_id": user_id,
+                "session_id": session_id,
+                "metadata": metadata or {},
+            }
+        ),
+    )
+
+    class _Stream:
+        async def send_json(self, payload):
+            raise AssertionError(f"unexpected error payload: {payload}")
+
+    await acp_endpoints._handle_client_message(
+        client,
+        session_id,
+        {
+            "type": "permission_response",
+            "request_id": request_id,
+            "approved": True,
+        },
+        _Stream(),
+        user_id=7,
+    )
+
+    assert recorded
+    event = recorded[-1]
+    assert event["action"] == "permission_response"
+    assert event["metadata"]["approved"] is True
+    assert event["metadata"]["policy_snapshot_fingerprint"] == "snapshot-audit-123"
+    assert event["metadata"]["approval_requirement"] == "approval_required"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_store.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_store.py
@@ -46,6 +46,38 @@ async def test_register_and_record_prompt_preserve_creation_config_and_bootstrap
 
 
 @pytest.mark.asyncio
+async def test_session_store_exposes_policy_snapshot_fields_in_info_and_detail_dict(tmp_path):
+    _db = ACPSessionsDB(db_path=str(tmp_path / "store_test.db"))
+    store = ACPSessionStore(db=_db)
+
+    await store.register_session(
+        session_id="session-policy",
+        user_id=7,
+        agent_type="codex",
+        name="Policy Session",
+        cwd="/tmp/project",
+        policy_snapshot_version="v1",
+        policy_snapshot_fingerprint="policy-fingerprint",
+        policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+        policy_summary={"allowed_tools": 3},
+        policy_provenance_summary={"sources": ["mcp_hub"]},
+        policy_refresh_error="stale snapshot",
+    )
+
+    record = await store.get_session("session-policy")
+    assert record is not None
+    assert record.policy_snapshot_version == "v1"
+    assert record.policy_snapshot_fingerprint == "policy-fingerprint"
+
+    info = record.to_info_dict()
+    detail = record.to_detail_dict()
+    assert info["policy_snapshot_refreshed_at"] == "2026-03-14T12:00:00+00:00"
+    assert info["policy_summary"] == {"allowed_tools": 3}
+    assert info["policy_provenance_summary"] == {"sources": ["mcp_hub"]}
+    assert detail["policy_refresh_error"] == "stale snapshot"
+
+
+@pytest.mark.asyncio
 async def test_record_prompt_marks_session_non_bootstrappable_when_assistant_text_cannot_be_normalized(tmp_path):
     _db = ACPSessionsDB(db_path=str(tmp_path / "store_test.db"))
     store = ACPSessionStore(db=_db)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
@@ -73,6 +73,65 @@ class TestSessionCRUD:
         assert rec["tags"] == ["workflow", "test"]
         assert rec["mcp_servers"] == [{"name": "fs", "type": "stdio"}]
 
+    def test_register_session_with_policy_snapshot_fields(self, db):
+        row = db.register_session(
+            session_id="s1",
+            user_id=1,
+            policy_snapshot_version="v1",
+            policy_snapshot_fingerprint="fingerprint-1",
+            policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+            policy_summary={"allowed_tools": 2, "denied_tools": 1},
+            policy_provenance_summary={"sources": ["mcp_hub"]},
+            policy_refresh_error="temporary mismatch",
+        )
+        assert row["policy_snapshot_version"] == "v1"
+        assert row["policy_snapshot_fingerprint"] == "fingerprint-1"
+        assert row["policy_snapshot_refreshed_at"] == "2026-03-14T12:00:00+00:00"
+        assert row["policy_summary"] == {"allowed_tools": 2, "denied_tools": 1}
+        assert row["policy_provenance_summary"] == {"sources": ["mcp_hub"]}
+        assert row["policy_refresh_error"] == "temporary mismatch"
+
+    def test_update_policy_snapshot_fields_can_set_and_clear_values(self, db):
+        db.register_session(session_id="s1", user_id=1)
+
+        db.update_policy_snapshot_state(
+            "s1",
+            policy_snapshot_version="v2",
+            policy_snapshot_fingerprint="fingerprint-2",
+            policy_snapshot_refreshed_at="2026-03-14T13:00:00+00:00",
+            policy_summary={"approval_required": True},
+            policy_provenance_summary={"resolved_capabilities": ["tool.invoke.research"]},
+            policy_refresh_error="refresh failed",
+        )
+
+        updated = db.get_session("s1")
+        assert updated["policy_snapshot_version"] == "v2"
+        assert updated["policy_snapshot_fingerprint"] == "fingerprint-2"
+        assert updated["policy_snapshot_refreshed_at"] == "2026-03-14T13:00:00+00:00"
+        assert updated["policy_summary"] == {"approval_required": True}
+        assert updated["policy_provenance_summary"] == {
+            "resolved_capabilities": ["tool.invoke.research"]
+        }
+        assert updated["policy_refresh_error"] == "refresh failed"
+
+        db.update_policy_snapshot_state(
+            "s1",
+            policy_snapshot_version=None,
+            policy_snapshot_fingerprint=None,
+            policy_snapshot_refreshed_at=None,
+            policy_summary=None,
+            policy_provenance_summary=None,
+            policy_refresh_error=None,
+        )
+
+        cleared = db.get_session("s1")
+        assert cleared["policy_snapshot_version"] is None
+        assert cleared["policy_snapshot_fingerprint"] is None
+        assert cleared["policy_snapshot_refreshed_at"] is None
+        assert cleared["policy_summary"] is None
+        assert cleared["policy_provenance_summary"] is None
+        assert cleared["policy_refresh_error"] is None
+
     def test_update_session_activity(self, db):
         db.register_session(session_id="s1", user_id=1)
         original = db.get_session("s1")

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py
@@ -5,7 +5,7 @@ import tempfile
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB
+from tldw_Server_API.app.core.DB_Management.ACP_Sessions_DB import ACPSessionsDB, _ensure_column
 
 
 @pytest.fixture
@@ -178,6 +178,16 @@ class TestSessionCRUD:
         assert row["completion_tokens"] == 0
         assert row["total_tokens"] == 0
         assert row["bootstrap_ready"] is True
+
+
+def test_ensure_column_rejects_unknown_table_or_definition(db):
+    conn = db._get_conn()
+
+    with pytest.raises(ValueError, match="Unsupported ACP session migration target"):
+        _ensure_column(conn, "unknown_table", "policy_snapshot_version", "policy_snapshot_version TEXT")
+
+    with pytest.raises(ValueError, match="Unsupported ACP session migration target"):
+        _ensure_column(conn, "sessions", "policy_snapshot_version", "policy_snapshot_version INTEGER")
         assert row["needs_bootstrap"] is False
         assert row["forked_from"] is None
         assert row["persona_id"] is None

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py
@@ -76,6 +76,11 @@ class _StubSessionRecord:
         self.workspace_group_id = "wsg-2"
         self.scope_snapshot_id = "scope-3"
         self.forked_from = "session-root"
+        self.policy_snapshot_version = "resolved-v1"
+        self.policy_snapshot_fingerprint = "snapshot-123"
+        self.policy_snapshot_refreshed_at = "2026-03-14T12:00:00+00:00"
+        self.policy_summary = {"allowed_tool_count": 2, "approval_mode": "require_approval"}
+        self.policy_provenance_summary = {"source_kinds": ["governance_pack", "capability_mapping"]}
         self.cwd = "/tmp/test-project"
         self.messages = [
             {"role": "user", "content": {"text": "hi"}, "timestamp": "2026-02-26T00:00:01+00:00"},
@@ -110,6 +115,11 @@ class _StubSessionRecord:
             "workspace_group_id": self.workspace_group_id,
             "scope_snapshot_id": self.scope_snapshot_id,
             "forked_from": self.forked_from,
+            "policy_snapshot_version": self.policy_snapshot_version,
+            "policy_snapshot_fingerprint": self.policy_snapshot_fingerprint,
+            "policy_snapshot_refreshed_at": self.policy_snapshot_refreshed_at,
+            "policy_summary": self.policy_summary,
+            "policy_provenance_summary": self.policy_provenance_summary,
         }
 
     def to_detail_dict(self, *, has_websocket: bool = False, fork_lineage: list[str] | None = None) -> dict:
@@ -185,6 +195,13 @@ def test_acp_list_sessions_status_schema_includes_tenancy(client_user_only, stub
     assert session["workspace_group_id"] == "wsg-2"
     assert session["scope_snapshot_id"] == "scope-3"
     assert session["forked_from"] == "session-root"
+    assert session["policy_snapshot_version"] == "resolved-v1"
+    assert session["policy_snapshot_fingerprint"] == "snapshot-123"
+    assert session["policy_snapshot_refreshed_at"] == "2026-03-14T12:00:00+00:00"
+    assert session["policy_summary"] == {"allowed_tool_count": 2, "approval_mode": "require_approval"}
+    assert session["policy_provenance_summary"] == {
+        "source_kinds": ["governance_pack", "capability_mapping"]
+    }
     assert session["usage"]["total_tokens"] == 30
 
 
@@ -201,6 +218,41 @@ def test_acp_session_detail_status_schema_includes_tenancy(client_user_only, stu
     assert payload["workspace_group_id"] == "wsg-2"
     assert payload["scope_snapshot_id"] == "scope-3"
     assert payload["forked_from"] == "session-root"
+    assert payload["policy_snapshot_version"] == "resolved-v1"
+    assert payload["policy_snapshot_fingerprint"] == "snapshot-123"
+    assert payload["policy_snapshot_refreshed_at"] == "2026-03-14T12:00:00+00:00"
+    assert payload["policy_summary"] == {"allowed_tool_count": 2, "approval_mode": "require_approval"}
+    assert payload["policy_provenance_summary"] == {
+        "source_kinds": ["governance_pack", "capability_mapping"]
+    }
+
+
+def test_permission_request_schema_keeps_tier_and_adds_policy_fields():
+    from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+        ACPPermissionTier,
+        ACPWSPermissionRequestMessage,
+    )
+
+    payload = ACPWSPermissionRequestMessage(
+        request_id="perm-1",
+        session_id="session-123",
+        tool_name="web.search",
+        tool_arguments={"query": "opa acp"},
+        tier=ACPPermissionTier.INDIVIDUAL,
+        approval_requirement="approval_required",
+        governance_reason="policy_approval_required",
+        deny_reason=None,
+        provenance_summary={"source_kinds": ["capability_mapping"]},
+        runtime_narrowing_reason="workspace_trust_required",
+        policy_snapshot_fingerprint="snapshot-123",
+    )
+
+    assert payload.tier == ACPPermissionTier.INDIVIDUAL
+    assert payload.approval_requirement == "approval_required"
+    assert payload.governance_reason == "policy_approval_required"
+    assert payload.provenance_summary == {"source_kinds": ["capability_mapping"]}
+    assert payload.runtime_narrowing_reason == "workspace_trust_required"
+    assert payload.policy_snapshot_fingerprint == "snapshot-123"
 
 
 def test_acp_session_usage_schema(client_user_only, stub_acp_store):

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py
@@ -23,6 +23,10 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.runner_client import (
     PendingPermission,
     SessionWebSocketRegistry,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+from tldw_Server_API.app.services.acp_runtime_policy_service import (
+    ACPRuntimePolicySnapshot,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -852,3 +856,74 @@ class TestACPRunnerClientPermissions:
         assert client._determine_permission_tier("fs.write") == "batch"
         assert client._determine_permission_tier("git.commit") == "batch"
         assert client._determine_permission_tier("modify_file") == "batch"
+
+    @pytest.mark.asyncio
+    async def test_permission_request_message_includes_runtime_policy_metadata(self):
+        mock_config = MagicMock()
+        mock_config.command = "echo"
+        mock_config.args = []
+        mock_config.env = {}
+        mock_config.cwd = None
+        mock_config.startup_timeout_sec = 10
+
+        client = ACPRunnerClient(mock_config)
+        session_id = "session-policy-message"
+
+        async def _send(_payload: dict[str, Any]) -> None:
+            return None
+
+        registry = SessionWebSocketRegistry(session_id=session_id)
+        registry.websockets.add(_send)
+        client._ws_registry[session_id] = registry
+
+        async def _fake_snapshot(
+            sid: str,
+            *,
+            force_refresh: bool = False,
+        ) -> ACPRuntimePolicySnapshot | None:
+            del sid, force_refresh
+            return ACPRuntimePolicySnapshot(
+                session_id=session_id,
+                user_id=7,
+                policy_snapshot_version="resolved-v1",
+                policy_snapshot_fingerprint="snapshot-message",
+                policy_snapshot_refreshed_at="2026-03-14T12:00:00+00:00",
+                policy_summary={"approval_mode": "require_approval"},
+                policy_provenance_summary={"source_kinds": ["profile"]},
+                resolved_policy_document={
+                    "allowed_tools": ["web.search"],
+                    "approval_mode": "require_approval",
+                },
+                approval_summary={"mode": "require_approval"},
+                context_summary={},
+                execution_config={},
+            )
+
+        client._get_runtime_policy_snapshot = _fake_snapshot  # type: ignore[attr-defined]
+
+        prompts: list[dict[str, Any]] = []
+
+        async def _fake_broadcast(sid: str, message: dict[str, Any]) -> None:
+            if message.get("type") == "permission_request":
+                prompts.append(message)
+                await client.respond_to_permission(sid, str(message["request_id"]), True)
+
+        client._broadcast_to_session = _fake_broadcast  # type: ignore[method-assign]
+
+        response = await client._handle_request(
+            ACPMessage(
+                jsonrpc="2.0",
+                id="perm-message-1",
+                method="session/request_permission",
+                params={
+                    "sessionId": session_id,
+                    "tool": {"name": "web.search", "input": {"query": "opa"}},
+                },
+            )
+        )
+
+        assert response.result == {"outcome": {"outcome": "approved"}}
+        assert len(prompts) == 1
+        assert prompts[0]["approval_requirement"] == "approval_required"
+        assert prompts[0]["provenance_summary"] == {"source_kinds": ["profile"]}
+        assert prompts[0]["policy_snapshot_fingerprint"] == "snapshot-message"


### PR DESCRIPTION
## Summary
- make MCP Hub effective-policy snapshots the ACP runtime authority for tool permission checks
- persist ACP policy snapshot metadata and surface it through ACP API responses and session admin views
- expose policy summary and expandable provenance details in the ACP UI permission/session surfaces

## Verification
- `source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_runtime_policy_service.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sessions_db.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_store.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_sandbox_runner_client.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_governance_coordinator.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_websocket.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_endpoints.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_status_schema.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_stub.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_session_management.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_e2e_smoke.py -q`
- `bunx vitest run src/services/acp/__tests__/client.test.ts src/store/__tests__/acp-sessions.test.ts src/components/Option/ACPPlayground/__tests__/ACPPermissionModal.test.tsx src/components/Option/ACPPlayground/__tests__/ACPSessionPanel.test.tsx`
- `source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/acp_runtime_policy_service.py tldw_Server_API/app/core/Agent_Client_Protocol/runner_client.py tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_runner_client.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/services/admin_acp_sessions_service.py -f json -o /tmp/bandit_acp_runtime_policy.json`
- `git diff --check`

## Review Status
Draft pending two blocker findings from the final review pass:
1. Session creation persists ACP metadata but never builds the initial MCP Hub policy snapshot, so new sessions start with `policy_snapshot_*` fields unset instead of resolving policy at session start.
2. Active sessions do not refresh when MCP Hub policy changes: the runtime only refreshes on explicit `force_refresh`, and there is no high-risk or policy-version-triggered refresh path wired into live permission checks.
