### PR TITLE
Persona setup handoff targeting and analytics follow-up

### DIFF
--- a/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-design.md
@@ -1,0 +1,247 @@
+# Persona Setup Analytics Summary Card Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+Add a compact setup analytics summary card to `Profiles` so Persona Garden can
+show whether a persona's setup funnel is completing and whether the post-setup
+handoff is producing real follow-through.
+
+This slice should:
+
+- reuse the existing `/profiles/{persona_id}/setup-analytics` endpoint
+- render a compact summary card only when at least one setup run exists
+- keep setup analytics clearly separate from live voice analytics and turn
+  detection feedback
+
+## Why This Slice Exists
+
+Setup analytics now exists and already records:
+
+- completion rates
+- dry-run vs live-session completion counts
+- handoff click rate
+- handoff target reach rate
+- first post-setup action rate
+
+But that data is still invisible inside Persona Garden. The current `Profiles`
+tab shows:
+
+- profile metadata
+- setup status
+- assistant defaults
+- live tuning feedback
+
+That means there is still no product-visible way to answer:
+
+- does this persona's setup usually complete?
+- where do runs usually drop off?
+- does the handoff actually lead to a first real action?
+
+This slice closes that gap without expanding setup state machines or runtime
+voice behavior.
+
+## Scope
+
+### In scope
+
+- one compact setup analytics summary card in `Profiles`
+- route-owned fetch of existing setup analytics data
+- pure presentation component for the summary card
+- focused route/component tests
+
+### Out of scope
+
+- backend API changes
+- recent-run tables
+- charts or dashboard views
+- new setup analytics events
+- changes to voice analytics or turn-detection feedback
+
+## Review-Driven Constraints
+
+### 1. The card should stay hidden until real setup history exists
+
+This card should not render an empty analytics shell for personas with no setup
+runs. The endpoint already exposes `summary.total_runs`, so the display rule can
+be:
+
+- hide when `total_runs === 0`
+- show once at least one run exists
+
+### 2. The slice should fail closed
+
+`Profiles` already has multiple cards. If setup analytics fails to load, the
+best v1 behavior is:
+
+- no extra error banner
+- no partial placeholder state
+- simply hide the card
+
+This keeps the profile tab stable and avoids adding another top-level failure
+surface.
+
+### 3. Step labels need explicit presentation mapping
+
+`most_common_dropoff_step` comes back as setup step ids such as:
+
+- `persona`
+- `voice`
+- `commands`
+- `safety`
+- `test`
+
+The card should map these to user-facing labels:
+
+- `Persona choice`
+- `Voice defaults`
+- `Starter commands`
+- `Safety and connections`
+- `Test and finish`
+
+If the backend ever returns an unknown step value, the UI should fall back to:
+
+- a title-cased/raw label when possible, or
+- `None yet`
+
+### 4. The route should keep setup analytics separate from voice analytics
+
+`sidepanel-persona.tsx` already fetches voice analytics for:
+
+- `commands`
+- `test-lab`
+- `profiles`
+
+This slice should add separate route state for setup analytics rather than
+reusing the existing voice analytics bucket. The two data sets answer different
+questions and should not share loading/error state.
+
+### 5. Use a narrow typed response shape on the frontend
+
+The backend schema already exists in Python, but the frontend does not have a
+typed setup analytics response. The route should introduce a small explicit
+TypeScript type for the summary it consumes rather than passing anonymous JSON
+through `ProfilePanel`.
+
+## Chosen Approach
+
+Add a dedicated `PersonaSetupAnalyticsCard` to `Profiles`, backed by a separate
+route-owned fetch of the existing setup analytics endpoint.
+
+Concretely:
+
+1. Add route state for `setupAnalytics` and `setupAnalyticsLoading`.
+2. Fetch setup analytics only when `Profiles` is active and a persona is
+   selected.
+3. Pass the typed payload into `ProfilePanel`.
+4. Render a compact summary card between `PersonaSetupStatusCard` and
+   `AssistantDefaultsPanel`.
+5. Hide the card when there are no recorded setup runs.
+
+This is the smallest coherent user-facing follow-up to the completed setup
+analytics work.
+
+## Product Shape
+
+The card should answer one narrow question:
+
+> How healthy is setup and post-setup follow-through for this persona?
+
+Suggested sections:
+
+- `Completion rate`
+- `Most common drop-off`
+- `Dry run completions`
+- `Live session completions`
+- `Handoff click rate`
+- `Target reached rate`
+- `First next-step rate`
+
+The card should remain compact and text-first, similar in density to the other
+Persona Garden profile cards.
+
+## Data Flow
+
+### Route ownership
+
+In `sidepanel-persona.tsx`:
+
+- add `setupAnalytics` state
+- add `setupAnalyticsLoading` state
+- fetch `/api/v1/persona/profiles/{persona_id}/setup-analytics?days=30&limit=5`
+- only fetch when:
+  - `activeTab === "profiles"`
+  - `selectedPersonaId` is present
+
+Clear the setup analytics payload when:
+
+- no persona is selected
+- the selected persona changes
+
+### Panel composition
+
+In `ProfilePanel.tsx`:
+
+- add optional props for setup analytics payload/loading
+- render the new card between:
+  - `PersonaSetupStatusCard`
+  - `AssistantDefaultsPanel`
+
+This keeps fetching in the route and presentation in the panel/component layer.
+
+## Card Behavior
+
+Create a presentational component:
+
+- `PersonaSetupAnalyticsCard.tsx`
+
+Behavior rules:
+
+- if `loading` and no payload exists: show compact loading copy
+- if `summary.total_runs === 0`: render nothing
+- if payload exists and `total_runs > 0`: render the summary card
+- if fetch fails: render nothing
+
+Formatting rules:
+
+- rates shown as rounded percentages
+- count values shown as whole numbers
+- `most_common_dropoff_step` mapped to readable labels
+- missing drop-off step shown as `None yet`
+
+## Testing Strategy
+
+### Component tests
+
+Add `PersonaSetupAnalyticsCard.test.tsx` covering:
+
+- hidden when `total_runs === 0`
+- loading state when `loading === true` and no payload exists
+- metric rendering when payload exists
+- drop-off label mapping and fallback behavior
+
+### Route tests
+
+Extend `sidepanel-persona.test.tsx` to prove:
+
+- `Profiles` tab fetches setup analytics
+- non-`Profiles` tabs do not fetch setup analytics
+- setup analytics render the card once returned
+- personas with zero runs do not show the card
+
+### Panel/i18n coverage
+
+Update the existing Persona Garden panel i18n coverage if needed so the new
+heading is routed through `react-i18next`.
+
+## Success Criteria
+
+This slice is complete when:
+
+1. `Profiles` fetches setup analytics separately from voice analytics.
+2. A compact setup analytics card appears only for personas with recorded setup
+   history.
+3. The card presents readable drop-off and funnel metrics.
+4. No backend changes are required.
+5. Focused route/component tests pass.

--- a/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-implementation-plan.md
@@ -1,0 +1,276 @@
+# Persona Setup Analytics Summary Card Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a compact setup analytics summary card to `Profiles` using the
+existing persona setup analytics endpoint.
+
+**Architecture:** Keep this slice frontend-only. Add route-owned setup
+analytics state and fetching in `sidepanel-persona.tsx`, pass the typed payload
+through `ProfilePanel`, and render a pure `PersonaSetupAnalyticsCard`
+component when recorded setup runs exist.
+
+**Tech Stack:** React, TypeScript, Vitest.
+
+---
+
+### Task 1: Add The Setup Analytics Summary Card Component
+
+**Files:**
+- Create: `apps/packages/ui/src/components/PersonaGarden/PersonaSetupAnalyticsCard.tsx`
+- Create: `apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx`
+
+**Step 1: Write the failing component tests**
+
+Add tests proving:
+
+- the card hides when `summary.total_runs` is `0`
+- the card shows loading copy when `loading` is true and no payload exists
+- the card renders completion, handoff, and drop-off metrics
+- step labels map correctly and unknown/missing drop-off falls back cleanly
+
+Example cases:
+
+```tsx
+render(
+  <PersonaSetupAnalyticsCard
+    analytics={{
+      persona_id: "garden-helper",
+      summary: { total_runs: 0, completed_runs: 0, completion_rate: 0 },
+      recent_runs: []
+    }}
+  />
+)
+expect(screen.queryByTestId("persona-setup-analytics-card")).not.toBeInTheDocument()
+```
+
+And:
+
+```tsx
+render(<PersonaSetupAnalyticsCard loading />)
+expect(screen.getByText("Loading setup analytics...")).toBeInTheDocument()
+```
+
+**Step 2: Run the focused component test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx
+```
+
+Expected: FAIL because the component does not exist yet.
+
+**Step 3: Write the minimal component**
+
+Implement a compact presentational card that:
+
+- accepts `analytics?: PersonaSetupAnalyticsResponse | null`
+- accepts `loading?: boolean`
+- returns `null` when `total_runs === 0`
+- shows a compact loading state only when `loading && !analytics`
+- renders:
+  - completion rate
+  - most common drop-off
+  - dry-run completions
+  - live-session completions
+  - handoff click rate
+  - target reached rate
+  - first next-step rate
+
+Use a local step-label map:
+
+- `persona` -> `Persona choice`
+- `voice` -> `Voice defaults`
+- `commands` -> `Starter commands`
+- `safety` -> `Safety and connections`
+- `test` -> `Test and finish`
+
+Fallback:
+
+- unknown string -> readable title-cased/raw label
+- null/empty -> `None yet`
+
+**Step 4: Re-run the focused component test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/PersonaSetupAnalyticsCard.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx
+git commit -m "feat: add persona setup analytics summary card"
+```
+
+### Task 2: Fetch Setup Analytics In The Route And Wire Profiles
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx`
+- Test: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing route tests**
+
+Add route coverage proving:
+
+- `Profiles` fetches `/setup-analytics`
+- non-`Profiles` tabs do not fetch `/setup-analytics`
+- returned analytics render the card
+- zero-run analytics do not render the card
+
+Use the existing fetch mock pattern already used for `/voice-analytics`.
+
+**Step 2: Run the focused route test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "setup analytics"
+```
+
+Expected: FAIL because the route does not fetch or render setup analytics yet.
+
+**Step 3: Add typed route state and fetch**
+
+In `sidepanel-persona.tsx`:
+
+- define a narrow `PersonaSetupAnalyticsResponse` TypeScript type for frontend use
+- add:
+  - `setupAnalytics`
+  - `setupAnalyticsLoading`
+- add a route effect that:
+  - checks `selectedPersonaId`
+  - only fetches when `activeTab === "profiles"`
+  - calls `/api/v1/persona/profiles/{persona_id}/setup-analytics?days=30&limit=5`
+  - stores payload on success
+  - clears payload on persona change or empty persona
+  - fails closed on fetch error
+
+In `ProfilePanel.tsx`:
+
+- add optional props for setup analytics payload/loading
+- render `PersonaSetupAnalyticsCard` between:
+  - `PersonaSetupStatusCard`
+  - `AssistantDefaultsPanel`
+
+**Step 4: Re-run the focused route test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "setup analytics"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git commit -m "feat: load persona setup analytics in profiles"
+```
+
+### Task 3: Cover I18n And Panel Integration
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx`
+
+**Step 1: Add the failing i18n assertion**
+
+Extend the existing panel i18n test to assert the setup analytics card heading
+uses `react-i18next`, for example:
+
+```tsx
+expect(
+  screen.getByText("sidepanel:personaGarden.profile.setupAnalyticsHeading")
+).toBeInTheDocument()
+```
+
+Use a mock setup analytics payload in the rendered `ProfilePanel` props so the
+card appears.
+
+**Step 2: Run the focused i18n test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx
+```
+
+Expected: FAIL until the card is rendered with translated heading text.
+
+**Step 3: Adjust rendering/test wiring**
+
+Update the test fixture props and, if needed, the card heading key so the card
+participates in the existing i18n coverage.
+
+**Step 4: Re-run the focused i18n test**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx
+git commit -m "test: cover setup analytics card i18n"
+```
+
+### Task 4: Run Final Verification And Close Out
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-implementation-plan.md`
+
+**Step 1: Run focused frontend verification**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run a broader Persona Garden regression sweep**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__ src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 3: Run static verification**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder diff --check
+```
+
+Then:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/components/PersonaGarden /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/routes -f json -o /tmp/bandit_persona_setup_analytics_summary_card.json
+```
+
+Expected:
+
+- `git diff --check` clean
+- no new Bandit findings in touched frontend files
+
+**Step 4: Mark the plan complete and commit**
+
+Add a top-line completion note to this plan, then commit the slice.

--- a/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-analytics-summary-card-implementation-plan.md
@@ -1,5 +1,7 @@
 # Persona Setup Analytics Summary Card Implementation Plan
 
+**Status:** Complete on 2026-03-14.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Add a compact setup analytics summary card to `Profiles` using the

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-design.md
@@ -123,6 +123,22 @@ The setup analytics work already records:
 That is enough for this slice. It is acceptable to ship the targeting behavior
 without adding a new `handoff_target_reached` event yet.
 
+### 6. Async-loaded panels must not consume targets too early
+
+`Commands`, `Connections`, and `Assistant Defaults` all fetch data after mount.
+That means a section request can arrive before:
+
+- command rows exist
+- saved connection rows exist
+- the confirmation-mode select is ready
+
+This design requires panels to keep a request pending until they can either:
+
+- fulfill the requested target, or
+- choose a deterministic fallback after load completes
+
+The route must not clear requests on a blind “panel mounted” signal.
+
 ## Chosen Approach
 
 Use a route-owned `setupHandoffFocusRequest` model plus panel-local target refs.
@@ -148,7 +164,12 @@ Add a small route-owned request object:
 ```ts
 type SetupHandoffSectionTarget =
   | { tab: "commands"; section: "command_form" | "command_list" }
-  | { tab: "connections"; section: "connection_form" | "saved_connections" }
+  | {
+      tab: "connections"
+      section: "connection_form" | "saved_connections"
+      connectionId?: string | null
+      connectionName?: string | null
+    }
   | { tab: "profiles"; section: "assistant_defaults" | "confirmation_mode" }
   | { tab: "test-lab"; section: "dry_run_form" }
 
@@ -156,6 +177,8 @@ type SetupHandoffFocusRequest = {
   tab: SetupHandoffSectionTarget["tab"]
   section: SetupHandoffSectionTarget["section"]
   token: number
+  connectionId?: string | null
+  connectionName?: string | null
 }
 ```
 
@@ -194,7 +217,8 @@ This slice maps them to concrete destinations.
 - approval mode row -> `profiles.confirmation_mode`
 - connection row:
   - `skipped` -> `connections.connection_form`
-  - `created` or `available` -> `connections.saved_connections`
+  - `created` or `available` -> `connections.saved_connections` with the frozen
+    connection name, and id when available later
 - `Open Test Lab` -> `test-lab.dry_run_form`
 
 This keeps the action model specific to what setup just produced, rather than
@@ -240,9 +264,19 @@ The focus request is transient UI state. It should clear when:
 - the persona changes
 - setup context changes
 - the handoff is dismissed
-- the destination panel reports it has consumed the request
+- the destination panel reports that it has fulfilled or deterministically
+  fallen back from the request
 
 It should not clear simply because the handoff remains visible.
+
+Add an explicit route callback, for example:
+
+```ts
+onSetupHandoffFocusConsumed(token: number): void
+```
+
+The route should ignore stale tokens and only clear the current request when the
+reported token matches the active one.
 
 ## Panel Contracts
 
@@ -265,7 +299,14 @@ Panel behavior on a fresh request:
 1. scroll the section container into view
 2. focus the first useful control inside that section
 3. apply a short visual highlight phase
-4. optionally notify the route that the request was consumed
+4. notify the route that the request token was consumed
+
+Panels should only consume a token after:
+
+- the requested control is ready, or
+- a documented fallback target has been used after load settled
+
+They should not consume tokens just because the panel rendered.
 
 ### Commands
 
@@ -277,8 +318,8 @@ Targets:
 Destination behavior:
 
 - `command_form`: focus `persona-commands-name-input`
-- `command_list`: focus the first command row if present; otherwise focus the
-  empty-state block or fall back to the form
+- `command_list`: focus the first actionable control in the first command row,
+  preferably the `Edit` button; otherwise fall back to the command form
 
 ### Connections
 
@@ -290,8 +331,10 @@ Targets:
 Destination behavior:
 
 - `connection_form`: focus `persona-connections-name-input`
-- `saved_connections`: focus the first saved connection row if present;
-  otherwise fall back to the form
+- `saved_connections`: if a target connection id or name is present, focus that
+  row’s first actionable control, preferably `Edit`; otherwise focus the first
+  saved connection’s `Edit` button; if no saved rows exist, fall back to the
+  connection form
 
 ### Profiles
 
@@ -302,7 +345,8 @@ Targets:
 
 Destination behavior:
 
-- `assistant_defaults`: focus the panel root
+- `assistant_defaults`: focus the first meaningful control in
+  `AssistantDefaultsPanel`, not a passive wrapper
 - `confirmation_mode`: focus the confirmation-mode select inside
   `AssistantDefaultsPanel`
 
@@ -349,8 +393,8 @@ Examples:
 - `commands.command_list` with no commands -> focus command form
 - `connections.saved_connections` with no saved rows -> focus connection form
 - `profiles.confirmation_mode` while defaults are not loaded yet -> focus the
-  assistant defaults panel root first, then the select once available if
-  possible
+  first meaningful defaults control once the panel is ready; if the select still
+  is not available, use the first defaults input as the fallback
 
 ## Testing Strategy
 
@@ -372,7 +416,11 @@ is focused:
 - `AssistantDefaultsPanel.test.tsx`
 - `TestLabPanel.test.tsx`
 
-Each should also cover replay via a newer request token.
+Each should also cover:
+
+- replay via a newer request token
+- async-loaded targets that only consume after data is ready
+- fallback behavior when the preferred target is unavailable
 
 ### Handoff card tests
 

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-design.md
@@ -1,0 +1,390 @@
+# Persona Setup Handoff Target Anchors Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+Finish the remaining post-setup handoff gap in Persona Garden by making handoff
+actions land on the exact section the user needs, not just the right tab.
+
+This slice should:
+
+- add stable, explicit handoff targets for the existing setup completion card
+- let same-tab handoff actions scroll, focus, and briefly highlight the relevant
+  section
+- preserve the current handoff lifecycle, analytics, and first-success collapse
+  behavior
+
+## Why This Slice Exists
+
+The setup wizard, retry flows, detours, handoff persistence, and setup analytics
+are now in place. The remaining friction is narrower.
+
+Today:
+
+- the handoff card can recommend `Commands`, `Connections`, `Profiles`, or
+  `Test Lab`
+- route actions can retarget the handoff to another tab
+- the card stays visible until a real post-setup success collapses it
+
+But:
+
+- same-tab actions do not land on the exact section the user should use next
+- cross-tab actions still stop at tab navigation, not a concrete destination
+- destination panels do not expose a stable contract for “focus this setup
+  handoff target”
+
+That makes the current handoff informative, but still slightly indirect.
+
+## Scope
+
+### In scope
+
+- route-owned handoff target requests
+- stable focus/scroll targets in `Commands`, `Connections`, `Profiles`, and
+  `Test Lab`
+- handoff action mapping from review rows and recommended CTA to concrete
+  sections
+- brief destination highlight to confirm arrival
+- focused frontend tests
+
+### Out of scope
+
+- new backend endpoints or analytics schemas
+- another setup state model change
+- new setup wizard steps
+- generic cross-app focus/anchor infrastructure
+- live-session runtime behavior changes
+
+## Review-Driven Constraints
+
+### 1. The route should not query the DOM blindly
+
+The route already owns setup handoff state, but it should not start using
+`querySelector` against child panel internals. That would be brittle and hard to
+test.
+
+This design uses an explicit panel contract instead:
+
+- the route emits a typed focus request
+- the active destination panel receives that request as props
+- the panel owns the refs, scroll, focus, and temporary highlight
+
+### 2. Targets must be explicit and small
+
+This slice should not invent a generic “scroll to anything” mechanism.
+
+Instead, each relevant panel gets a short, local set of supported targets:
+
+- `Commands`: `command_form`, `command_list`
+- `Connections`: `connection_form`, `saved_connections`
+- `Profiles`: `assistant_defaults`, `confirmation_mode`
+- `Test Lab`: `dry_run_form`
+
+Anything outside that list stays out of scope.
+
+### 3. Same-tab and cross-tab behavior should share one model
+
+The current route already distinguishes:
+
+- same-tab action: keep the handoff visible
+- cross-tab action: retarget the handoff to the destination tab
+
+This design keeps that rule and adds one more layer:
+
+- every handoff action may also carry a `section` target
+- same-tab actions focus immediately
+- cross-tab actions focus after the destination panel mounts
+
+### 4. Handoff clicks are still navigation, not success
+
+This slice must not change the current meaning of
+`first_post_setup_action`.
+
+Success remains domain-level:
+
+- command saved
+- connection saved
+- connection test succeeded
+- voice defaults saved
+- dry-run match
+- live response received
+
+Scrolling to a target or focusing an input does not collapse the handoff.
+
+### 5. No backend changes are needed in V1
+
+The setup analytics work already records:
+
+- handoff clicks
+- dismiss
+- first post-setup success
+
+That is enough for this slice. It is acceptable to ship the targeting behavior
+without adding a new `handoff_target_reached` event yet.
+
+## Chosen Approach
+
+Use a route-owned `setupHandoffFocusRequest` model plus panel-local target refs.
+
+Concretely:
+
+1. Add a typed `section` target model for post-setup handoff actions.
+2. Teach the route to open a handoff target, not just a tab.
+3. Pass the current focus request into the active panel.
+4. In each panel, scroll to the requested section, focus the first useful
+   control, and show a brief highlight.
+5. Keep the existing handoff card visible until a real success event collapses
+   it.
+
+This keeps the feature frontend-only, predictable, and easy to test.
+
+## Target Model
+
+### Focus request type
+
+Add a small route-owned request object:
+
+```ts
+type SetupHandoffSectionTarget =
+  | { tab: "commands"; section: "command_form" | "command_list" }
+  | { tab: "connections"; section: "connection_form" | "saved_connections" }
+  | { tab: "profiles"; section: "assistant_defaults" | "confirmation_mode" }
+  | { tab: "test-lab"; section: "dry_run_form" }
+
+type SetupHandoffFocusRequest = {
+  tab: SetupHandoffSectionTarget["tab"]
+  section: SetupHandoffSectionTarget["section"]
+  token: number
+}
+```
+
+`token` is important. It lets the route intentionally replay the same handoff
+target twice, for example if the user clicks `Review commands` again while
+already on `Commands`.
+
+### Why `live` is excluded
+
+The `Live Session` tab already opens at the relevant control surface. This slice
+keeps `live` tab actions as plain tab switches. Only the panels that need
+section-level landing behavior get the new contract.
+
+## Handoff Action Mapping
+
+The current handoff card exposes these user actions:
+
+- recommended primary CTA
+- `Review commands`
+- `Review safety defaults`
+- `Open connections`
+- `Open Test Lab`
+
+This slice maps them to concrete destinations.
+
+### Recommended CTA
+
+- `add_command` -> `commands.command_form`
+- `review_commands` -> `commands.command_list`
+- `add_connection` -> `connections.connection_form`
+- `try_live` -> plain `live` tab navigation only
+
+### Starter pack review rows
+
+- starter commands row -> `commands.command_list`
+- approval mode row -> `profiles.confirmation_mode`
+- connection row:
+  - `skipped` -> `connections.connection_form`
+  - `created` or `available` -> `connections.saved_connections`
+- `Open Test Lab` -> `test-lab.dry_run_form`
+
+This keeps the action model specific to what setup just produced, rather than
+one fixed destination per tab.
+
+## Route Behavior
+
+### New route state
+
+Add:
+
+```ts
+const [setupHandoffFocusRequest, setSetupHandoffFocusRequest] =
+  React.useState<SetupHandoffFocusRequest | null>(null)
+```
+
+### Opening a handoff target
+
+Replace `openSetupHandoffTab(tab)` with a slightly richer helper:
+
+```ts
+openSetupHandoffTarget(
+  target:
+    | { tab: "live" }
+    | SetupHandoffSectionTarget
+)
+```
+
+Behavior:
+
+- emit the existing `handoff_action_clicked` analytics event
+- switch tabs as needed
+- if the target includes a section:
+  - increment a token
+  - store `setupHandoffFocusRequest`
+- preserve the current handoff on same-tab actions
+- retarget the handoff to the destination tab on cross-tab actions
+
+### Clearing focus requests
+
+The focus request is transient UI state. It should clear when:
+
+- the persona changes
+- setup context changes
+- the handoff is dismissed
+- the destination panel reports it has consumed the request
+
+It should not clear simply because the handoff remains visible.
+
+## Panel Contracts
+
+Each panel gets:
+
+```ts
+type SetupHandoffPanelTarget<TSection extends string> = {
+  section: TSection
+  token: number
+} | null
+```
+
+Panels only react when:
+
+- they are active
+- the request token is newer than the last handled token
+
+Panel behavior on a fresh request:
+
+1. scroll the section container into view
+2. focus the first useful control inside that section
+3. apply a short visual highlight phase
+4. optionally notify the route that the request was consumed
+
+### Commands
+
+Targets:
+
+- `command_form`
+- `command_list`
+
+Destination behavior:
+
+- `command_form`: focus `persona-commands-name-input`
+- `command_list`: focus the first command row if present; otherwise focus the
+  empty-state block or fall back to the form
+
+### Connections
+
+Targets:
+
+- `connection_form`
+- `saved_connections`
+
+Destination behavior:
+
+- `connection_form`: focus `persona-connections-name-input`
+- `saved_connections`: focus the first saved connection row if present;
+  otherwise fall back to the form
+
+### Profiles
+
+Targets:
+
+- `assistant_defaults`
+- `confirmation_mode`
+
+Destination behavior:
+
+- `assistant_defaults`: focus the panel root
+- `confirmation_mode`: focus the confirmation-mode select inside
+  `AssistantDefaultsPanel`
+
+This keeps the existing `ProfilePanel` structure, but adds a focused path for
+the current `Review safety defaults` action.
+
+### Test Lab
+
+Target:
+
+- `dry_run_form`
+
+Destination behavior:
+
+- focus `persona-test-lab-heard-input`
+
+## Visual Confirmation
+
+Each target section should get a short arrival treatment:
+
+- a stronger border or ring
+- subtle background tint
+- no layout movement
+
+The highlight should:
+
+- replay when the same target is requested again with a new token
+- decay back to the normal state after a short timeout
+- disable animation under `prefers-reduced-motion`
+
+This is not a new “success” state. It only confirms that the handoff landed in
+the intended place.
+
+## Error Handling And Fallbacks
+
+If a panel cannot satisfy the ideal target:
+
+- it should fall back to the nearest useful section in the same panel
+- it should not throw
+- it should still consume the request so the route does not keep replaying it
+
+Examples:
+
+- `commands.command_list` with no commands -> focus command form
+- `connections.saved_connections` with no saved rows -> focus connection form
+- `profiles.confirmation_mode` while defaults are not loaded yet -> focus the
+  assistant defaults panel root first, then the select once available if
+  possible
+
+## Testing Strategy
+
+### Route tests
+
+In `sidepanel-persona.test.tsx`, cover:
+
+- same-tab handoff action keeps the card visible and emits a focus request
+- cross-tab handoff action retargets the card and focuses the destination panel
+- `try_live` remains tab-only and does not create a focus request
+
+### Panel tests
+
+Add focused tests that mock `scrollIntoView` and assert the destination control
+is focused:
+
+- `CommandsPanel.test.tsx`
+- `ConnectionsPanel.test.tsx`
+- `AssistantDefaultsPanel.test.tsx`
+- `TestLabPanel.test.tsx`
+
+Each should also cover replay via a newer request token.
+
+### Handoff card tests
+
+Only add/adjust tests if the card action wiring changes. The card itself should
+remain mostly presentational.
+
+## Success Criteria
+
+This slice is done when:
+
+- each handoff action lands on a concrete destination, not just a tab
+- same-tab actions replay cleanly
+- the handoff lifecycle and compact-success behavior stay unchanged
+- no backend work is required
+- focused route and panel tests pass

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
@@ -1,5 +1,7 @@
 # Persona Setup Handoff Target Anchors Implementation Plan
 
+Status: Complete on 2026-03-14.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** Make post-setup handoff actions in Persona Garden land on the exact section the user needs in Commands, Connections, Profiles, and Test Lab instead of only switching tabs.

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
@@ -69,7 +69,12 @@ token:
 ```ts
 type SetupHandoffSectionTarget =
   | { tab: "commands"; section: "command_form" | "command_list" }
-  | { tab: "connections"; section: "connection_form" | "saved_connections" }
+  | {
+      tab: "connections"
+      section: "connection_form" | "saved_connections"
+      connectionId?: string | null
+      connectionName?: string | null
+    }
   | { tab: "profiles"; section: "assistant_defaults" | "confirmation_mode" }
   | { tab: "test-lab"; section: "dry_run_form" }
 
@@ -77,6 +82,8 @@ type SetupHandoffFocusRequest = {
   tab: SetupHandoffSectionTarget["tab"]
   section: SetupHandoffSectionTarget["section"]
   token: number
+  connectionId?: string | null
+  connectionName?: string | null
 }
 ```
 
@@ -96,6 +103,8 @@ that:
 - preserves the handoff for same-tab actions
 - retargets the handoff for cross-tab actions
 - stores a section request when the action has a concrete destination
+- only clears a request after the active panel reports the matching token as
+  consumed
 
 **Step 4: Re-run the targeted route tests**
 
@@ -105,7 +114,8 @@ Run:
 cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff visible and issues a focus request|retargets the handoff to connections|try_live"
 ```
 
-Expected: still FAIL until the destination panels consume the request.
+Expected: still FAIL until the destination panels consume the request through a
+real callback.
 
 **Step 5: Commit**
 
@@ -135,7 +145,9 @@ it("focuses the command name input for command_form requests", async () => {
     />
   )
 
-  expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+  await waitFor(() =>
+    expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+  )
 })
 ```
 
@@ -144,6 +156,8 @@ Also add:
 - `command_list` focuses the first command row when commands exist
 - `command_list` falls back to the form when commands are empty
 - a newer token replays the highlight/focus
+
+Mock the panel loads explicitly so the target is asserted after data is ready.
 
 **Step 2: Run the targeted Commands tests to verify they fail**
 
@@ -168,7 +182,7 @@ handoffFocusRequest?: {
 
 Add refs for:
 
-- command list container / first command row
+- command list container / first row `Edit` button
 - empty-state container
 - command form root
 - command name input
@@ -178,10 +192,12 @@ React to fresh tokens with an effect that:
 - scrolls the chosen section into view
 - focuses the best control
 - sets a short-lived highlight state
+- calls `onSetupHandoffFocusConsumed(token)` only after the final destination is
+  chosen
 
 Keep the fallback rules small:
 
-- `command_list` with rows -> first row
+- `command_list` with rows -> first row `Edit` button
 - `command_list` without rows -> command form
 
 **Step 4: Re-run the targeted Commands tests**
@@ -212,7 +228,7 @@ git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice
 Add tests that prove:
 
 - `connection_form` focuses `persona-connections-name-input`
-- `saved_connections` focuses the first saved connection row
+- `saved_connections` focuses the requested saved connection’s `Edit` button
 - `saved_connections` falls back to the form when the list is empty
 
 Example:
@@ -228,7 +244,9 @@ it("focuses the connection form for connection_form requests", async () => {
     />
   )
 
-  expect(screen.getByTestId("persona-connections-name-input")).toHaveFocus()
+  await waitFor(() =>
+    expect(screen.getByTestId("persona-connections-name-input")).toHaveFocus()
+  )
 })
 ```
 
@@ -257,9 +275,19 @@ Add refs for:
 
 - connection form root
 - name input
-- saved-connections container / first row
+- saved-connections container
+- saved row `Edit` buttons keyed by connection id
 
 Use the same token-driven effect pattern as `CommandsPanel`.
+
+When `section === "saved_connections"`:
+
+- prefer the requested `connectionId`
+- otherwise try to match by `connectionName`
+- otherwise use the first saved row
+- otherwise fall back to the connection form
+
+Only call `onSetupHandoffFocusConsumed(token)` after that choice is complete.
 
 **Step 4: Re-run the targeted Connections tests**
 
@@ -292,7 +320,7 @@ git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice
 Add tests that prove:
 
 - `confirmation_mode` focuses the confirmation mode select
-- `assistant_defaults` focuses the defaults panel root
+- `assistant_defaults` focuses the first meaningful defaults control
 - `dry_run_form` focuses `persona-test-lab-heard-input`
 
 Example:
@@ -308,9 +336,9 @@ it("focuses confirmation mode for setup handoff requests", async () => {
     />
   )
 
-  expect(
-    screen.getByLabelText("Confirmation mode")
-  ).toHaveFocus()
+  await waitFor(() =>
+    expect(screen.getByLabelText("Confirmation mode")).toHaveFocus()
+  )
 })
 ```
 
@@ -337,7 +365,7 @@ handoffFocusRequest?: {
 
 Add refs for:
 
-- panel root
+- first meaningful defaults control
 - confirmation mode select
 
 In `ProfilePanel.tsx`, thread the target through to `AssistantDefaultsPanel`.
@@ -352,6 +380,9 @@ handoffFocusRequest?: {
 ```
 
 and focus the heard-text textarea on fresh requests.
+
+In all async-loaded panels, mock `tldwClient.fetchWithAuth` in the tests and
+assert focus after the loaded state renders.
 
 **Step 4: Re-run the targeted panel tests**
 
@@ -385,7 +416,8 @@ Add route tests that prove action mapping is specific:
 - `Open connections` focuses the form when the frozen summary says
   `connection.mode === "skipped"`
 - `Open connections` focuses saved connections when the frozen summary says
-  `connection.mode === "created"` or `"available"`
+  `connection.mode === "created"` or `"available"` and prefers the matching
+  saved connection by id or name
 - `Open Test Lab` focuses the dry-run input
 
 Example:
@@ -403,7 +435,9 @@ it("opens saved connections for handoff review when a connection already exists"
 
   await user.click(screen.getByRole("button", { name: "Open connections" }))
 
-  expect(screen.getByTestId("persona-connections-row-slack")).toHaveFocus()
+  await waitFor(() =>
+    expect(screen.getByTestId(`persona-connections-edit-${slackId}`)).toHaveFocus()
+  )
 })
 ```
 
@@ -424,6 +458,7 @@ In `sidepanel-persona.tsx`:
 - replace the old tab-only callbacks with target-aware callbacks
 - map recommended action and review rows to concrete targets
 - pass the panel-specific request down only to the active destination panel
+- pass a consume callback down with the request
 - keep `try_live` tab-only
 
 In `PersonaSetupHandoffCard.tsx`:

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-anchors-implementation-plan.md
@@ -1,0 +1,479 @@
+# Persona Setup Handoff Target Anchors Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make post-setup handoff actions in Persona Garden land on the exact section the user needs in Commands, Connections, Profiles, and Test Lab instead of only switching tabs.
+
+**Architecture:** Keep the slice frontend-only. Extend the route handoff action model with typed section targets and a replayable focus-request token, then pass panel-specific focus requests into Commands, Connections, Profile/Assistant Defaults, and Test Lab. Each panel owns its refs, scroll/focus behavior, and transient highlight.
+
+**Tech Stack:** React, TypeScript, Vitest, React Testing Library, Bun.
+
+---
+
+### Task 1: Add Route-Level Handoff Target Requests
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing route tests**
+
+Add route coverage for the new target-aware behavior:
+
+```tsx
+it("keeps the handoff visible and issues a focus request for same-tab command actions", async () => {
+  renderPersonaGardenOnCommandsWithSetupHandoff({
+    recommendedAction: "add_command"
+  })
+
+  await user.click(screen.getByRole("button", { name: "Open Commands" }))
+
+  expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+})
+```
+
+Add cross-tab coverage too:
+
+```tsx
+it("retargets the handoff to connections and focuses the connection form", async () => {
+  renderPersonaGardenWithSetupHandoffOnProfiles({
+    recommendedAction: "add_connection"
+  })
+
+  await user.click(screen.getByRole("button", { name: "Open Connections" }))
+
+  expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+  expect(screen.getByTestId("persona-connections-name-input")).toHaveFocus()
+})
+```
+
+Also add a guard proving `try_live` still just opens Live without a section-focus
+request.
+
+**Step 2: Run the targeted route tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff visible and issues a focus request|retargets the handoff to connections|try_live"
+```
+
+Expected: FAIL because the route only opens tabs today.
+
+**Step 3: Add the target request model in the route**
+
+In `sidepanel-persona.tsx`, add typed section targets and a replayable request
+token:
+
+```ts
+type SetupHandoffSectionTarget =
+  | { tab: "commands"; section: "command_form" | "command_list" }
+  | { tab: "connections"; section: "connection_form" | "saved_connections" }
+  | { tab: "profiles"; section: "assistant_defaults" | "confirmation_mode" }
+  | { tab: "test-lab"; section: "dry_run_form" }
+
+type SetupHandoffFocusRequest = {
+  tab: SetupHandoffSectionTarget["tab"]
+  section: SetupHandoffSectionTarget["section"]
+  token: number
+}
+```
+
+Add:
+
+```ts
+const [setupHandoffFocusRequest, setSetupHandoffFocusRequest] =
+  React.useState<SetupHandoffFocusRequest | null>(null)
+const setupHandoffFocusTokenRef = React.useRef(0)
+```
+
+Replace the current `openSetupHandoffTab(tab)` logic with a target-aware helper
+that:
+
+- emits the existing `handoff_action_clicked` analytics event
+- switches tabs as needed
+- preserves the handoff for same-tab actions
+- retargets the handoff for cross-tab actions
+- stores a section request when the action has a concrete destination
+
+**Step 4: Re-run the targeted route tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff visible and issues a focus request|retargets the handoff to connections|try_live"
+```
+
+Expected: still FAIL until the destination panels consume the request.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder add apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder commit -m "feat: add setup handoff target requests"
+```
+
+### Task 2: Add Commands Panel Target Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx`
+
+**Step 1: Write the failing Commands panel tests**
+
+Add focused panel tests for the new props:
+
+```tsx
+it("focuses the command name input for command_form requests", async () => {
+  render(
+    <CommandsPanel
+      selectedPersonaId="garden-helper"
+      selectedPersonaName="Garden Helper"
+      isActive
+      handoffFocusRequest={{ section: "command_form", token: 1 }}
+    />
+  )
+
+  expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+})
+```
+
+Also add:
+
+- `command_list` focuses the first command row when commands exist
+- `command_list` falls back to the form when commands are empty
+- a newer token replays the highlight/focus
+
+**Step 2: Run the targeted Commands tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx -t "command_form requests|command_list focuses|falls back to the form|replays"
+```
+
+Expected: FAIL because `CommandsPanel` does not accept handoff requests.
+
+**Step 3: Add the minimal panel contract**
+
+In `CommandsPanel.tsx`, add props:
+
+```ts
+handoffFocusRequest?: {
+  section: "command_form" | "command_list"
+  token: number
+} | null
+```
+
+Add refs for:
+
+- command list container / first command row
+- empty-state container
+- command form root
+- command name input
+
+React to fresh tokens with an effect that:
+
+- scrolls the chosen section into view
+- focuses the best control
+- sets a short-lived highlight state
+
+Keep the fallback rules small:
+
+- `command_list` with rows -> first row
+- `command_list` without rows -> command form
+
+**Step 4: Re-run the targeted Commands tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx -t "command_form requests|command_list focuses|falls back to the form|replays"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder add apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder commit -m "feat: add commands handoff targets"
+```
+
+### Task 3: Add Connections Panel Target Contract
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx`
+
+**Step 1: Write the failing Connections panel tests**
+
+Add tests that prove:
+
+- `connection_form` focuses `persona-connections-name-input`
+- `saved_connections` focuses the first saved connection row
+- `saved_connections` falls back to the form when the list is empty
+
+Example:
+
+```tsx
+it("focuses the connection form for connection_form requests", async () => {
+  render(
+    <ConnectionsPanel
+      selectedPersonaId="garden-helper"
+      selectedPersonaName="Garden Helper"
+      isActive
+      handoffFocusRequest={{ section: "connection_form", token: 1 }}
+    />
+  )
+
+  expect(screen.getByTestId("persona-connections-name-input")).toHaveFocus()
+})
+```
+
+**Step 2: Run the targeted Connections tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx -t "connection_form requests|saved_connections focuses|falls back to the form"
+```
+
+Expected: FAIL because `ConnectionsPanel` has no target-aware focus contract.
+
+**Step 3: Add the minimal panel contract**
+
+In `ConnectionsPanel.tsx`, add:
+
+```ts
+handoffFocusRequest?: {
+  section: "connection_form" | "saved_connections"
+  token: number
+} | null
+```
+
+Add refs for:
+
+- connection form root
+- name input
+- saved-connections container / first row
+
+Use the same token-driven effect pattern as `CommandsPanel`.
+
+**Step 4: Re-run the targeted Connections tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx -t "connection_form requests|saved_connections focuses|falls back to the form"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder add apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder commit -m "feat: add connections handoff targets"
+```
+
+### Task 4: Add Profiles And Test Lab Target Contracts
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx`
+- Modify: `apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx`
+
+**Step 1: Write the failing panel tests**
+
+Add tests that prove:
+
+- `confirmation_mode` focuses the confirmation mode select
+- `assistant_defaults` focuses the defaults panel root
+- `dry_run_form` focuses `persona-test-lab-heard-input`
+
+Example:
+
+```tsx
+it("focuses confirmation mode for setup handoff requests", async () => {
+  render(
+    <AssistantDefaultsPanel
+      selectedPersonaId="garden-helper"
+      selectedPersonaName="Garden Helper"
+      isActive
+      handoffFocusRequest={{ section: "confirmation_mode", token: 1 }}
+    />
+  )
+
+  expect(
+    screen.getByLabelText("Confirmation mode")
+  ).toHaveFocus()
+})
+```
+
+**Step 2: Run the targeted panel tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx -t "confirmation mode|assistant defaults|dry_run_form"
+```
+
+Expected: FAIL because these panels do not accept target props.
+
+**Step 3: Add the minimal target props**
+
+In `AssistantDefaultsPanel.tsx`, add:
+
+```ts
+handoffFocusRequest?: {
+  section: "assistant_defaults" | "confirmation_mode"
+  token: number
+} | null
+```
+
+Add refs for:
+
+- panel root
+- confirmation mode select
+
+In `ProfilePanel.tsx`, thread the target through to `AssistantDefaultsPanel`.
+
+In `TestLabPanel.tsx`, add:
+
+```ts
+handoffFocusRequest?: {
+  section: "dry_run_form"
+  token: number
+} | null
+```
+
+and focus the heard-text textarea on fresh requests.
+
+**Step 4: Re-run the targeted panel tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx -t "confirmation mode|assistant defaults|dry_run_form"
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder add apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder commit -m "feat: add profile and test lab handoff targets"
+```
+
+### Task 5: Wire Handoff Actions To Concrete Targets And Verify The Full Flow
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx`
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing integration tests**
+
+Add route tests that prove action mapping is specific:
+
+- `Review safety defaults` focuses confirmation mode
+- `Open connections` focuses the form when the frozen summary says
+  `connection.mode === "skipped"`
+- `Open connections` focuses saved connections when the frozen summary says
+  `connection.mode === "created"` or `"available"`
+- `Open Test Lab` focuses the dry-run input
+
+Example:
+
+```tsx
+it("opens saved connections for handoff review when a connection already exists", async () => {
+  renderPersonaGardenWithCompletedSetupHandoff({
+    targetTab: "connections",
+    reviewSummary: {
+      starterCommands: { mode: "added", count: 2 },
+      confirmationMode: "destructive_only",
+      connection: { mode: "created", name: "Slack" }
+    }
+  })
+
+  await user.click(screen.getByRole("button", { name: "Open connections" }))
+
+  expect(screen.getByTestId("persona-connections-row-slack")).toHaveFocus()
+})
+```
+
+**Step 2: Run the targeted integration tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "Review safety defaults|Open connections|Open Test Lab"
+```
+
+Expected: FAIL until the action mapping is fully wired.
+
+**Step 3: Finish the route/card wiring**
+
+In `sidepanel-persona.tsx`:
+
+- replace the old tab-only callbacks with target-aware callbacks
+- map recommended action and review rows to concrete targets
+- pass the panel-specific request down only to the active destination panel
+- keep `try_live` tab-only
+
+In `PersonaSetupHandoffCard.tsx`:
+
+- keep the visual design
+- only adjust callback names/signatures if needed so the route can distinguish
+  the concrete actions
+
+**Step 4: Run the focused route suite**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 5: Run the broader Persona Garden frontend regression sweep**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 6: Run final verification**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder diff --check
+```
+
+Then run Bandit on the touched frontend scope:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/components/PersonaGarden /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/routes -f json -o /tmp/bandit_persona_handoff_targets.json
+```
+
+Expected:
+
+- `git diff --check` clean
+- no new Bandit findings in changed source files
+
+**Step 7: Commit**
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder add apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx apps/packages/ui/src/routes/sidepanel-persona.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder commit -m "feat: target setup handoff actions to panel sections"
+```

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-design.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-design.md
@@ -1,0 +1,314 @@
+# Persona Setup Handoff Target Reached Analytics Design
+
+**Date:** 2026-03-14
+
+## Goal
+
+Add one analytics-only follow-up to the setup handoff system so Persona Garden
+can measure whether a handoff click actually lands the user on the intended
+panel section.
+
+This slice should:
+
+- emit `handoff_target_reached` when a setup handoff focus request is actually
+  consumed by a destination panel
+- dedupe that event by setup run and concrete target identity
+- extend setup analytics summaries with both run-level and per-target reach
+  metrics
+
+## Why This Slice Exists
+
+The current setup funnel already records:
+
+- `handoff_action_clicked`
+- `handoff_dismissed`
+- `first_post_setup_action`
+
+The recent handoff-target work now makes the UI land on exact sections inside:
+
+- `Commands`
+- `Profiles`
+- `Connections`
+- `Test Lab`
+
+But there is still one analytics blind spot:
+
+- we know a handoff action was clicked
+- we know whether a later success happened
+- we do not know whether the destination section was actually reached
+
+That makes it hard to tell whether failures are caused by:
+
+- weak CTA selection
+- bad section-target delivery
+- or poor follow-through after landing
+
+## Scope
+
+### In scope
+
+- one new setup analytics event type: `handoff_target_reached`
+- route-owned emission when a focus token is consumed
+- target-aware setup event dedupe keys
+- backend summary aggregation for run-level and per-target reach
+- focused frontend/backend tests
+
+### Out of scope
+
+- UI changes
+- new banners or visible “landed here” cues
+- runtime voice analytics changes
+- a new analytics dashboard
+- any `Live Session` target-reached event
+
+## Review-Driven Constraints
+
+### 1. Dedupe must be target-aware
+
+The existing setup analytics helper only builds stable keys from:
+
+- `eventType`
+- `step`
+- `detourSource`
+
+That is not sufficient for `handoff_target_reached`. Different destinations
+like:
+
+- `commands.command_form`
+- `profiles.confirmation_mode`
+- `connections.saved_connections`
+
+would collapse incorrectly unless the key includes the concrete target.
+
+### 2. Emission should remain route-owned
+
+Panels already report token consumption through
+`onSetupHandoffFocusConsumed(token)`.
+
+That is the right boundary:
+
+- panels own refs, focus, and readiness
+- the route owns setup handoff state and analytics emission
+
+This slice should not copy analytics posting logic into each panel.
+
+### 3. The route must emit from a request snapshot
+
+`handleSetupHandoffFocusConsumed(token)` currently clears the active request.
+If analytics is built from state after that clear, the route can lose:
+
+- target tab
+- section
+- connection item detail
+
+So emission must use a snapshot of the matched request before state is cleared.
+
+### 4. V1 should track target-level usefulness
+
+A single run-level boolean is not enough. The point of this slice is to learn
+which anchored destinations help.
+
+That means the backend summary should expose:
+
+- run-level `handoff_target_reached`
+- per-target counts such as:
+  - `commands.command_form`
+  - `commands.command_list`
+  - `profiles.confirmation_mode`
+  - `profiles.assistant_defaults`
+  - `connections.connection_form`
+  - `connections.saved_connections`
+  - `test-lab.dry_run_form`
+
+### 5. The reach rate should be conditional
+
+`handoff_target_reach_rate` should be:
+
+- runs with at least one `handoff_target_reached`
+- divided by runs with `handoff_action_clicked`
+
+It should not use all setup runs as the denominator, because many runs never use
+the handoff at all.
+
+## Chosen Approach
+
+Add a new append-only setup event type, emit it from the route when a panel
+consumes a handoff token, and aggregate both run-level and per-target reach
+metrics in the existing persona setup analytics summary.
+
+Concretely:
+
+1. Extend setup analytics event enums with `handoff_target_reached`.
+2. Extend the event-key helper so this event dedupes by concrete target.
+3. In the route, emit once when a matching focus request is consumed.
+4. Persist the event through the existing setup-events endpoint/table.
+5. Aggregate both:
+   - `handoff_target_reached` boolean per run
+   - `handoff_target_reached_counts` per target
+   - `handoff_target_reach_rate` across runs with a handoff click
+
+This keeps the slice small, measurable, and consistent with the current setup
+analytics pipeline.
+
+## Event Model
+
+### New event type
+
+Add:
+
+```ts
+"handoff_target_reached"
+```
+
+to the shared setup analytics event type lists in frontend and backend.
+
+### Event payload
+
+Reuse existing fields:
+
+- `run_id`
+- `event_type`
+- `action_target`
+- `metadata`
+
+For this event, define:
+
+- `action_target`: stable destination key such as:
+  - `commands.command_form`
+  - `commands.command_list`
+  - `profiles.confirmation_mode`
+  - `profiles.assistant_defaults`
+  - `connections.connection_form`
+  - `connections.saved_connections`
+  - `test-lab.dry_run_form`
+- `metadata`: optional target item detail when present
+  - `connection_id`
+  - `connection_name`
+  - `recommended_action`
+  - `completion_type`
+
+This avoids adding new top-level schema fields for a narrow analytics event.
+
+### Event key
+
+The key for `handoff_target_reached` should be target-aware:
+
+```ts
+handoff_target_reached:${actionTarget}
+handoff_target_reached:${actionTarget}:${connectionId}
+handoff_target_reached:${actionTarget}:${connectionName}
+```
+
+Use item identity only for cases where one generic target can refer to multiple
+frozen entities, specifically `connections.saved_connections`.
+
+That gives once-only semantics per concrete destination for one setup run.
+
+## Route Behavior
+
+### Emission point
+
+Keep emission in `sidepanel-persona.tsx`.
+
+When `handleSetupHandoffFocusConsumed(token)` is called:
+
+1. find the active `setupHandoffFocusRequest`
+2. ignore the callback if the token does not match
+3. build an analytics snapshot from the request before clearing it
+4. emit `handoff_target_reached`
+5. clear the request
+
+### Action target formatting
+
+Build `action_target` from the request:
+
+```ts
+`${request.tab}.${request.section}`
+```
+
+Examples:
+
+- `commands.command_form`
+- `connections.saved_connections`
+
+### Metadata
+
+If the request carries item detail, include it in metadata:
+
+```ts
+{
+  connection_id: request.connectionId ?? undefined,
+  connection_name: request.connectionName ?? undefined,
+  recommended_action: setupHandoff?.recommendedAction ?? undefined,
+  completion_type: setupHandoff?.completionType ?? undefined
+}
+```
+
+This is advisory analytics detail only. It must not affect handoff behavior.
+
+### What remains excluded
+
+Do not emit `handoff_target_reached` for `live` tab actions. The current
+handoff-target slice does not define a section-level focus contract there.
+
+## Backend Aggregation
+
+### Recent runs
+
+Extend each recent run summary with:
+
+- `handoff_target_reached: bool`
+
+This means a run is marked reached if it has at least one
+`handoff_target_reached` event.
+
+### Summary metrics
+
+Extend the summary with:
+
+- `handoff_target_reach_rate: float`
+- `handoff_target_reached_counts: dict[str, int]`
+
+Definitions:
+
+- `handoff_target_reached_counts[target]`:
+  count of runs with at least one reach event for that target
+- `handoff_target_reach_rate`:
+  `reached_runs / handoff_clicked_runs`
+
+If `handoff_clicked_runs == 0`, the rate is `0.0`.
+
+This preserves the current run-based funnel semantics while still exposing
+target-level usefulness.
+
+## Testing Strategy
+
+### Frontend
+
+- service tests for stable event keys:
+  - `handoff_target_reached:commands.command_form`
+  - `handoff_target_reached:connections.saved_connections:conn-123`
+- route test:
+  - consuming a matching token posts `handoff_target_reached`
+- route dedupe test:
+  - repeated consume/re-render for the same token does not post a duplicate
+
+### Backend
+
+- schema/API test:
+  - `handoff_target_reached` is accepted by the setup-events endpoint
+- analytics summary test:
+  - a run with `handoff_action_clicked` and `handoff_target_reached` sets:
+    - `handoff_target_reached = true`
+    - `handoff_target_reach_rate` correctly
+    - target count for the expected `action_target`
+
+## Success Criteria
+
+This slice is complete when:
+
+- setup handoff target consumption emits one append-only analytics event
+- duplicate consume callbacks do not create duplicate rows
+- setup analytics summaries expose both reach rate and per-target counts
+- existing handoff behavior remains unchanged
+

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-implementation-plan.md
@@ -1,0 +1,230 @@
+# Persona Setup Handoff Target Reached Analytics Implementation Plan
+
+**Goal:** Record when setup handoff actions actually land on their intended
+panel sections, and extend persona setup analytics summaries with reach metrics.
+
+**Architecture:** Keep this slice analytics-only. Emit a route-owned
+`handoff_target_reached` event when a handoff focus token is consumed, dedupe
+it by concrete target identity, and aggregate both run-level and per-target
+reach metrics in the existing setup analytics summary.
+
+**Tech Stack:** React, TypeScript, Vitest, FastAPI, Pydantic, SQLite, Pytest.
+
+---
+
+### Task 1: Extend Setup Analytics Event Types And Keys
+
+**Files:**
+- Modify: `apps/packages/ui/src/services/tldw/persona-setup-analytics.ts`
+- Modify: `apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts`
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+
+**Step 1: Write the failing frontend key tests**
+
+Add tests proving:
+
+- `handoff_target_reached` builds a stable key from `actionTarget`
+- `connections.saved_connections` can include item identity
+
+Example:
+
+```ts
+expect(
+  buildSetupEventKey({
+    eventType: "handoff_target_reached",
+    actionTarget: "commands.command_form"
+  })
+).toBe("handoff_target_reached:commands.command_form")
+```
+
+And:
+
+```ts
+expect(
+  buildSetupEventKey({
+    eventType: "handoff_target_reached",
+    actionTarget: "connections.saved_connections",
+    metadata: { connection_id: "conn-123" }
+  })
+).toBe("handoff_target_reached:connections.saved_connections:conn-123")
+```
+
+**Step 2: Run the focused frontend service tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts
+```
+
+Expected: FAIL until the helper supports the new event type.
+
+**Step 3: Extend the shared event types**
+
+Add `handoff_target_reached` to:
+
+- frontend `PersonaSetupAnalyticsEventType`
+- backend `PersonaSetupEventType`
+
+Extend the frontend helper so `buildSetupEventKey(...)` accepts:
+
+- `actionTarget`
+- `metadata`
+
+for this event type and returns the target-aware key.
+
+**Step 4: Re-run the focused frontend tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts
+```
+
+Expected: PASS.
+
+### Task 2: Emit Route-Owned `handoff_target_reached`
+
+**Files:**
+- Modify: `apps/packages/ui/src/routes/sidepanel-persona.tsx`
+- Modify: `apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx`
+
+**Step 1: Write the failing route tests**
+
+Add tests proving:
+
+- consuming a matching handoff token posts `handoff_target_reached`
+- repeated consume paths do not post duplicate events
+
+Use existing handoff-target route flows and assert on setup-event POST bodies.
+
+**Step 2: Run the focused route tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff_target_reached|does not duplicate handoff target reach"
+```
+
+Expected: FAIL until the route emits the new event.
+
+**Step 3: Add route-side snapshot emission**
+
+In `sidepanel-persona.tsx`:
+
+- snapshot the matched `setupHandoffFocusRequest` before clearing it
+- build:
+  - `actionTarget = ${tab}.${section}`
+  - metadata from optional item detail plus current handoff context
+- emit `handoff_target_reached`
+- clear the request afterward
+
+Do not emit for `live`.
+
+**Step 4: Re-run the focused route tests**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/routes/__tests__/sidepanel-persona.test.tsx -t "handoff_target_reached|does not duplicate handoff target reach"
+```
+
+Expected: PASS.
+
+### Task 3: Extend Backend Setup Analytics Aggregation
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/persona.py`
+- Modify: `tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py`
+
+**Step 1: Write the failing backend tests**
+
+Add API coverage proving:
+
+- the endpoint accepts `handoff_target_reached`
+- summaries include:
+  - run-level `handoff_target_reached`
+  - `handoff_target_reach_rate`
+  - `handoff_target_reached_counts`
+
+**Step 2: Run the focused backend tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: FAIL until the backend schema and aggregation are updated.
+
+**Step 3: Update backend summaries**
+
+In the setup analytics aggregation:
+
+- track run-level `handoff_target_reached`
+- track unique reached targets per run
+- accumulate summary counts by `action_target`
+- compute `handoff_target_reach_rate` as:
+  - `runs_with_target_reached / runs_with_handoff_clicked`
+
+Extend the response schemas to expose the new fields.
+
+**Step 4: Re-run the focused backend tests**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: PASS.
+
+### Task 4: Run Final Verification
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-implementation-plan.md`
+
+**Step 1: Run focused frontend verification**
+
+Run:
+
+```bash
+cd /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui && bunx vitest run src/services/tldw/__tests__/persona-setup-analytics.test.ts src/routes/__tests__/sidepanel-persona.test.tsx
+```
+
+Expected: PASS.
+
+**Step 2: Run focused backend verification**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q
+```
+
+Expected: PASS.
+
+**Step 3: Run static verification**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder diff --check
+```
+
+Then:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/routes /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/apps/packages/ui/src/services/tldw /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/app/api/v1/schemas /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/app/core/DB_Management -f json -o /tmp/bandit_persona_handoff_target_reached.json
+```
+
+Expected:
+
+- `git diff --check` clean
+- no new Bandit findings in changed source files
+
+**Step 4: Mark the plan complete and commit**
+
+Add a top-line completion note to this plan, then commit the slice.
+

--- a/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-implementation-plan.md
+++ b/Docs/Plans/2026-03-14-persona-setup-handoff-target-reached-analytics-implementation-plan.md
@@ -1,5 +1,7 @@
 # Persona Setup Handoff Target Reached Analytics Implementation Plan
 
+**Status:** Complete on 2026-03-14.
+
 **Goal:** Record when setup handoff actions actually land on their intended
 panel sections, and extend persona setup analytics summaries with reach metrics.
 
@@ -227,4 +229,3 @@ Expected:
 **Step 4: Mark the plan complete and commit**
 
 Add a top-line completion note to this plan, then commit the slice.
-

--- a/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/AssistantDefaultsPanel.tsx
@@ -23,6 +23,11 @@ type AssistantDefaultsPanelProps = {
   isActive?: boolean
   analytics?: PersonaVoiceAnalytics | null
   analyticsLoading?: boolean
+  handoffFocusRequest?: {
+    section: "assistant_defaults" | "confirmation_mode"
+    token: number
+  } | null
+  onSetupHandoffFocusConsumed?: (token: number) => void
   onSaved?: (voiceDefaults: PersonaVoiceDefaults) => void
 }
 
@@ -153,6 +158,8 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
   isActive = false,
   analytics = null,
   analyticsLoading = false,
+  handoffFocusRequest = null,
+  onSetupHandoffFocusConsumed,
   onSaved
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
@@ -162,6 +169,9 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
   const [success, setSuccess] = React.useState<string | null>(null)
   const [formState, setFormState] =
     React.useState<AssistantDefaultsFormState>(DEFAULT_FORM_STATE)
+  const sttLanguageInputRef = React.useRef<HTMLInputElement | null>(null)
+  const confirmationModeRef = React.useRef<HTMLSelectElement | null>(null)
+  const lastHandledHandoffTokenRef = React.useRef<number | null>(null)
 
   React.useEffect(() => {
     let cancelled = false
@@ -219,6 +229,29 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
       cancelled = true
     }
   }, [isActive, selectedPersonaId])
+
+  React.useEffect(() => {
+    if (!isActive || !selectedPersonaId || !handoffFocusRequest || loading) return
+    if (lastHandledHandoffTokenRef.current === handoffFocusRequest.token) return
+
+    const focusTarget =
+      handoffFocusRequest.section === "confirmation_mode"
+        ? confirmationModeRef.current
+        : sttLanguageInputRef.current
+
+    if (!focusTarget || focusTarget.disabled) return
+
+    focusTarget.scrollIntoView?.({ block: "nearest", behavior: "smooth" })
+    focusTarget.focus()
+    lastHandledHandoffTokenRef.current = handoffFocusRequest.token
+    onSetupHandoffFocusConsumed?.(handoffFocusRequest.token)
+  }, [
+    handoffFocusRequest,
+    isActive,
+    loading,
+    onSetupHandoffFocusConsumed,
+    selectedPersonaId
+  ])
 
   const resolvedDefaults = useResolvedPersonaVoiceDefaults(buildPayload(formState))
   const savedVadPreset = React.useMemo(
@@ -350,6 +383,7 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           </span>
           <input
             id="persona-assistant-defaults-stt-language"
+            ref={sttLanguageInputRef}
             className="rounded-md border border-border bg-surface2 px-3 py-2 text-sm text-text"
             value={formState.sttLanguage}
             onChange={(event) => updateField("sttLanguage", event.target.value)}
@@ -420,6 +454,7 @@ export const AssistantDefaultsPanel: React.FC<AssistantDefaultsPanelProps> = ({
           </span>
           <select
             id="persona-assistant-defaults-confirmation-mode"
+            ref={confirmationModeRef}
             className="rounded-md border border-border bg-surface2 px-3 py-2 text-sm text-text"
             value={formState.confirmationMode}
             onChange={(event) =>

--- a/apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/CommandsPanel.tsx
@@ -81,6 +81,11 @@ type CommandsPanelProps = {
   isActive?: boolean
   analytics?: PersonaVoiceAnalytics | null
   analyticsLoading?: boolean
+  handoffFocusRequest?: {
+    section: "command_form" | "command_list"
+    token: number
+  } | null
+  onSetupHandoffFocusConsumed?: (token: number) => void
   openCommandId?: string | null
   onOpenCommandHandled?: (commandId: string) => void
   draftCommandPhrase?: string | null
@@ -284,6 +289,8 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   isActive = false,
   analytics = null,
   analyticsLoading = false,
+  handoffFocusRequest = null,
+  onSetupHandoffFocusConsumed,
   openCommandId = null,
   onOpenCommandHandled,
   draftCommandPhrase = null,
@@ -307,6 +314,12 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
   const [draftSourceKind, setDraftSourceKind] = React.useState<CommandDraftSource | null>(
     null
   )
+  const commandNameInputRef = React.useRef<HTMLInputElement | null>(null)
+  const commandFormRef = React.useRef<HTMLDivElement | null>(null)
+  const commandEditButtonRefs = React.useRef<Map<string, HTMLButtonElement | null>>(
+    new Map()
+  )
+  const lastHandledHandoffTokenRef = React.useRef(0)
   const editingCommand = React.useMemo(
     () =>
       formState.commandId
@@ -518,6 +531,47 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
     isActive,
     onOpenCommandHandled,
     openCommandId,
+    selectedPersonaId
+  ])
+
+  React.useEffect(() => {
+    if (!isActive || !selectedPersonaId || !handoffFocusRequest) return
+    if (lastHandledHandoffTokenRef.current === handoffFocusRequest.token) return
+
+    const focusCommandForm = () => {
+      commandFormRef.current?.scrollIntoView?.({ block: "start", behavior: "smooth" })
+      commandNameInputRef.current?.focus()
+    }
+
+    if (handoffFocusRequest.section === "command_form") {
+      focusCommandForm()
+      lastHandledHandoffTokenRef.current = handoffFocusRequest.token
+      onSetupHandoffFocusConsumed?.(handoffFocusRequest.token)
+      return
+    }
+
+    if (!commandsLoaded) return
+
+    const firstCommandId = commands[0]?.id
+    const firstEditButton = firstCommandId
+      ? commandEditButtonRefs.current.get(firstCommandId)
+      : null
+
+    if (firstEditButton) {
+      firstEditButton.scrollIntoView?.({ block: "start", behavior: "smooth" })
+      firstEditButton.focus()
+    } else {
+      focusCommandForm()
+    }
+
+    lastHandledHandoffTokenRef.current = handoffFocusRequest.token
+    onSetupHandoffFocusConsumed?.(handoffFocusRequest.token)
+  }, [
+    commands,
+    commandsLoaded,
+    handoffFocusRequest,
+    isActive,
+    onSetupHandoffFocusConsumed,
     selectedPersonaId
   ])
 
@@ -938,6 +992,9 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
                           <button
                             type="button"
                             data-testid={`persona-commands-edit-${command.id}`}
+                            ref={(node) => {
+                              commandEditButtonRefs.current.set(command.id, node)
+                            }}
                             className="rounded-md border border-border px-2 py-1 text-xs text-text transition hover:bg-surface2"
                             onClick={() => handleEdit(command)}
                           >
@@ -990,7 +1047,10 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
                 )}
               </div>
 
-              <div className="rounded-md border border-border bg-bg p-3">
+              <div
+                ref={commandFormRef}
+                className="rounded-md border border-border bg-bg p-3"
+              >
                 <div className="flex items-center justify-between gap-2">
                   <div className="text-sm font-medium text-text">
                     {formState.commandId
@@ -1062,6 +1122,7 @@ export const CommandsPanel: React.FC<CommandsPanelProps> = ({
                       defaultValue: "Command name"
                     })}
                     <input
+                      ref={commandNameInputRef}
                       data-testid="persona-commands-name-input"
                       className="mt-1 w-full rounded-md border border-border bg-surface px-2 py-1 text-sm text-text"
                       value={formState.name}

--- a/apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ConnectionsPanel.tsx
@@ -42,6 +42,13 @@ type ConnectionsPanelProps = {
   isActive?: boolean
   onConnectionSaved?: () => void
   onConnectionTestSucceeded?: () => void
+  handoffFocusRequest?: {
+    section: "connection_form" | "saved_connections"
+    token: number
+    connectionId?: string | null
+    connectionName?: string | null
+  } | null
+  onSetupHandoffFocusConsumed?: (token: number) => void
 }
 
 const DEFAULT_FORM_STATE: ConnectionFormState = {
@@ -116,10 +123,13 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
   selectedPersonaName,
   isActive = false,
   onConnectionSaved,
-  onConnectionTestSucceeded
+  onConnectionTestSucceeded,
+  handoffFocusRequest = null,
+  onSetupHandoffFocusConsumed
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const [connections, setConnections] = React.useState<PersonaConnection[]>([])
+  const [connectionsLoaded, setConnectionsLoaded] = React.useState(false)
   const [loading, setLoading] = React.useState(false)
   const [saving, setSaving] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
@@ -130,6 +140,9 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
   const [testResults, setTestResults] = React.useState<Record<string, PersonaConnectionTestResult>>({})
   const [formState, setFormState] =
     React.useState<ConnectionFormState>(DEFAULT_FORM_STATE)
+  const connectionNameInputRef = React.useRef<HTMLInputElement | null>(null)
+  const connectionEditButtonRefs = React.useRef<Record<string, HTMLButtonElement | null>>({})
+  const lastHandledHandoffTokenRef = React.useRef<number | null>(null)
 
   const resetConnectionUiState = React.useCallback(() => {
     setEditingConnectionId(null)
@@ -146,11 +159,13 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
     const load = async () => {
       if (!isActive || !selectedPersonaId) {
         setConnections([])
+        setConnectionsLoaded(false)
         setError(null)
         resetConnectionUiState()
         return
       }
       setLoading(true)
+      setConnectionsLoaded(false)
       try {
         const response = await tldwClient.fetchWithAuth(
           toAllowedPath(
@@ -190,6 +205,7 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
       } finally {
         if (!cancelled) {
           setLoading(false)
+          setConnectionsLoaded(true)
         }
       }
     }
@@ -199,6 +215,59 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
       cancelled = true
     }
   }, [isActive, resetConnectionUiState, selectedPersonaId])
+
+  React.useEffect(() => {
+    if (!isActive || !selectedPersonaId || !handoffFocusRequest || loading) return
+    if (lastHandledHandoffTokenRef.current === handoffFocusRequest.token) return
+
+    const consume = () => {
+      lastHandledHandoffTokenRef.current = handoffFocusRequest.token
+      onSetupHandoffFocusConsumed?.(handoffFocusRequest.token)
+    }
+
+    const focusConnectionForm = () => {
+      const formTarget = connectionNameInputRef.current
+      if (!formTarget) return false
+      formTarget.scrollIntoView?.({ block: "nearest", behavior: "smooth" })
+      formTarget.focus()
+      consume()
+      return true
+    }
+
+    if (handoffFocusRequest.section === "connection_form") {
+      focusConnectionForm()
+      return
+    }
+
+    if (!connectionsLoaded) return
+
+    const normalizedConnectionId = String(handoffFocusRequest.connectionId || "").trim()
+    const normalizedConnectionName = String(handoffFocusRequest.connectionName || "").trim()
+
+    const matchedConnection = connections.find((connection) => {
+      if (normalizedConnectionId && connection.id === normalizedConnectionId) return true
+      return normalizedConnectionName.length > 0 && connection.name === normalizedConnectionName
+    })
+
+    if (matchedConnection) {
+      const editButton = connectionEditButtonRefs.current[matchedConnection.id]
+      if (!editButton) return
+      editButton.scrollIntoView?.({ block: "nearest", behavior: "smooth" })
+      editButton.focus()
+      consume()
+      return
+    }
+
+    focusConnectionForm()
+  }, [
+    connections,
+    connectionsLoaded,
+    handoffFocusRequest,
+    isActive,
+    loading,
+    onSetupHandoffFocusConsumed,
+    selectedPersonaId
+  ])
 
   const updateField = React.useCallback(
     (field: keyof ConnectionFormState, value: string) => {
@@ -438,6 +507,7 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
                     defaultValue: "Connection name"
                   })}
                   <input
+                    ref={connectionNameInputRef}
                     data-testid="persona-connections-name-input"
                     className="mt-1 w-full rounded-md border border-border bg-surface px-2 py-1 text-sm text-text"
                     value={formState.name}
@@ -627,6 +697,9 @@ export const ConnectionsPanel: React.FC<ConnectionsPanelProps> = ({
                     <div className="mt-3 flex flex-wrap gap-2">
                       <button
                         type="button"
+                        ref={(node) => {
+                          connectionEditButtonRefs.current[connection.id] = node
+                        }}
                         data-testid={`persona-connections-edit-${connection.id}`}
                         className="rounded-md border border-border px-2 py-1 text-xs text-text transition hover:bg-surface2"
                         onClick={() => loadConnectionIntoForm(connection)}

--- a/apps/packages/ui/src/components/PersonaGarden/PersonaSetupAnalyticsCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PersonaSetupAnalyticsCard.tsx
@@ -1,0 +1,154 @@
+import React from "react"
+import { useTranslation } from "react-i18next"
+
+export type PersonaSetupAnalyticsSummary = {
+  total_runs: number
+  completed_runs: number
+  completion_rate: number
+  dry_run_completion_count: number
+  live_session_completion_count: number
+  most_common_dropoff_step: string | null
+  handoff_click_rate: number
+  handoff_target_reach_rate: number
+  first_post_setup_action_rate: number
+  handoff_target_reached_counts: Record<string, number>
+  detour_started_counts: Record<string, number>
+  detour_returned_counts: Record<string, number>
+}
+
+export type PersonaSetupAnalyticsRunSummary = {
+  run_id: string
+  started_at?: string | null
+  completed_at?: string | null
+  completion_type?: "dry_run" | "live_session" | null
+  terminal_step?: string | null
+  handoff_clicked: boolean
+  handoff_target_reached: boolean
+  handoff_dismissed: boolean
+  first_post_setup_action: boolean
+}
+
+export type PersonaSetupAnalyticsResponse = {
+  persona_id: string
+  summary: PersonaSetupAnalyticsSummary
+  recent_runs: PersonaSetupAnalyticsRunSummary[]
+}
+
+type PersonaSetupAnalyticsCardProps = {
+  analytics?: PersonaSetupAnalyticsResponse | null
+  loading?: boolean
+}
+
+const DROP_OFF_LABELS: Record<string, string> = {
+  persona: "Persona choice",
+  voice: "Voice defaults",
+  commands: "Starter commands",
+  safety: "Safety and connections",
+  test: "Test and finish"
+}
+
+const formatPercent = (value: number): string =>
+  `${Math.round(Math.min(1, Math.max(0, Number(value) || 0)) * 100)}%`
+
+const formatDropoffStep = (value: string | null | undefined): string => {
+  const normalized = String(value || "").trim()
+  if (!normalized) return "None yet"
+  if (DROP_OFF_LABELS[normalized]) return DROP_OFF_LABELS[normalized]
+  const readable = normalized.replace(/[_-]+/g, " ").trim()
+  if (!readable) return "None yet"
+  return readable.charAt(0).toUpperCase() + readable.slice(1).toLowerCase()
+}
+
+const Stat: React.FC<{ label: string; value: string | number }> = ({ label, value }) => (
+  <div>
+    <div className="text-[11px] uppercase tracking-wide text-text-subtle">{label}</div>
+    <div className="mt-1 text-sm font-medium text-text">{value}</div>
+  </div>
+)
+
+export const PersonaSetupAnalyticsCard: React.FC<PersonaSetupAnalyticsCardProps> = ({
+  analytics = null,
+  loading = false
+}) => {
+  const { t } = useTranslation(["sidepanel", "common"])
+
+  if (loading && !analytics) {
+    return (
+      <div
+        data-testid="persona-setup-analytics-card"
+        className="rounded-lg border border-border bg-surface p-3"
+      >
+        <div className="text-xs font-semibold uppercase tracking-wide text-text-subtle">
+          {t("sidepanel:personaGarden.profile.setupAnalyticsHeading", {
+            defaultValue: "Setup analytics"
+          })}
+        </div>
+        <div className="mt-2 text-xs text-text-muted">
+          {t("sidepanel:personaGarden.profile.setupAnalyticsLoading", {
+            defaultValue: "Loading setup analytics..."
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  const summary = analytics?.summary
+  if (!summary || summary.total_runs <= 0) return null
+
+  return (
+    <div
+      data-testid="persona-setup-analytics-card"
+      className="rounded-lg border border-border bg-surface p-3"
+    >
+      <div className="text-xs font-semibold uppercase tracking-wide text-text-subtle">
+        {t("sidepanel:personaGarden.profile.setupAnalyticsHeading", {
+          defaultValue: "Setup analytics"
+        })}
+      </div>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsCompletionRate", {
+            defaultValue: "Completion rate"
+          })}
+          value={formatPercent(summary.completion_rate)}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsDropoff", {
+            defaultValue: "Most common drop-off"
+          })}
+          value={formatDropoffStep(summary.most_common_dropoff_step)}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsDryRunCompletions", {
+            defaultValue: "Dry run completions"
+          })}
+          value={summary.dry_run_completion_count}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsLiveCompletions", {
+            defaultValue: "Live session completions"
+          })}
+          value={summary.live_session_completion_count}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsHandoffClicks", {
+            defaultValue: "Handoff click rate"
+          })}
+          value={formatPercent(summary.handoff_click_rate)}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsTargetReached", {
+            defaultValue: "Target reached rate"
+          })}
+          value={formatPercent(summary.handoff_target_reach_rate)}
+        />
+        <Stat
+          label={t("sidepanel:personaGarden.profile.setupAnalyticsFirstAction", {
+            defaultValue: "First next-step rate"
+          })}
+          value={formatPercent(summary.first_post_setup_action_rate)}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/PersonaSetupHandoffCard.tsx
@@ -28,6 +28,7 @@ type PersonaSetupHandoffCardProps = {
   recommendedAction: SetupHandoffRecommendedAction
   compact?: boolean
   onDismiss: () => void
+  onAddCommand: () => void
   onOpenCommands: () => void
   onOpenTestLab: () => void
   onOpenLive: () => void
@@ -100,6 +101,7 @@ export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = (
   recommendedAction,
   compact = false,
   onDismiss,
+  onAddCommand,
   onOpenCommands,
   onOpenTestLab,
   onOpenLive,
@@ -107,12 +109,17 @@ export const PersonaSetupHandoffCard: React.FC<PersonaSetupHandoffCardProps> = (
   onOpenConnections
 }) => {
   const primaryAction =
-    recommendedAction === "add_command" || recommendedAction === "review_commands"
+    recommendedAction === "add_command"
       ? {
           label: getRecommendedActionButtonLabel(recommendedAction),
-          onClick: onOpenCommands
+          onClick: onAddCommand
         }
-      : recommendedAction === "add_connection"
+      : recommendedAction === "review_commands"
+        ? {
+            label: getRecommendedActionButtonLabel(recommendedAction),
+            onClick: onOpenCommands
+          }
+        : recommendedAction === "add_connection"
         ? {
             label: getRecommendedActionButtonLabel(recommendedAction),
             onClick: onOpenConnections

--- a/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
@@ -23,6 +23,11 @@ type ProfilePanelProps = {
   isActive?: boolean
   analytics?: PersonaVoiceAnalytics | null
   analyticsLoading?: boolean
+  handoffFocusRequest?: {
+    section: "assistant_defaults" | "confirmation_mode"
+    token: number
+  } | null
+  onSetupHandoffFocusConsumed?: (token: number) => void
 }
 
 export const ProfilePanel: React.FC<ProfilePanelProps> = ({
@@ -39,7 +44,9 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
   onDefaultsSaved,
   isActive = false,
   analytics = null,
-  analyticsLoading = false
+  analyticsLoading = false,
+  handoffFocusRequest = null,
+  onSetupHandoffFocusConsumed
 }) => {
   const { t } = useTranslation(["sidepanel", "common"])
   const setupProgressItems = React.useMemo(() => buildPersonaSetupProgress(setup), [setup])
@@ -115,6 +122,8 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
         isActive={isActive}
         analytics={analytics}
         analyticsLoading={analyticsLoading}
+        handoffFocusRequest={handoffFocusRequest}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
         onSaved={() => {
           onDefaultsSaved?.()
         }}

--- a/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/ProfilePanel.tsx
@@ -2,6 +2,10 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { AssistantDefaultsPanel } from "@/components/PersonaGarden/AssistantDefaultsPanel"
+import {
+  PersonaSetupAnalyticsCard,
+  type PersonaSetupAnalyticsResponse
+} from "@/components/PersonaGarden/PersonaSetupAnalyticsCard"
 import type { PersonaVoiceAnalytics } from "@/components/PersonaGarden/CommandAnalyticsSummary"
 import { PersonaSetupStatusCard } from "@/components/PersonaGarden/PersonaSetupStatusCard"
 import type { PersonaSetupState } from "@/hooks/usePersonaSetupWizard"
@@ -21,6 +25,8 @@ type ProfilePanelProps = {
   onRerunSetup?: () => void
   onDefaultsSaved?: () => void
   isActive?: boolean
+  setupAnalytics?: PersonaSetupAnalyticsResponse | null
+  setupAnalyticsLoading?: boolean
   analytics?: PersonaVoiceAnalytics | null
   analyticsLoading?: boolean
   handoffFocusRequest?: {
@@ -43,6 +49,8 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
   onRerunSetup,
   onDefaultsSaved,
   isActive = false,
+  setupAnalytics = null,
+  setupAnalyticsLoading = false,
   analytics = null,
   analyticsLoading = false,
   handoffFocusRequest = null,
@@ -115,6 +123,10 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({
         onResumeSetup={onResumeSetup}
         onResetSetup={onResetSetup}
         onRerunSetup={onRerunSetup}
+      />
+      <PersonaSetupAnalyticsCard
+        analytics={setupAnalytics}
+        loading={setupAnalyticsLoading}
       />
       <AssistantDefaultsPanel
         selectedPersonaId={selectedPersonaId}

--- a/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/TestLabPanel.tsx
@@ -44,6 +44,11 @@ type TestLabPanelProps = {
   selectedPersonaName: string
   isActive?: boolean
   analytics?: PersonaVoiceAnalytics | null
+  handoffFocusRequest?: {
+    section: "dry_run_form"
+    token: number
+  } | null
+  onSetupHandoffFocusConsumed?: (token: number) => void
   onOpenCommand?: (commandId: string, heardText: string) => void
   onCreateCommandDraft?: (heardText: string) => void
   onDryRunCompleted?: (result: TestLabDryRunCompletedResult) => void
@@ -59,6 +64,8 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
   selectedPersonaName,
   isActive = false,
   analytics = null,
+  handoffFocusRequest = null,
+  onSetupHandoffFocusConsumed,
   onOpenCommand,
   onCreateCommandDraft,
   onDryRunCompleted,
@@ -74,6 +81,8 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
   const [repairConfirmedVisible, setRepairConfirmedVisible] = React.useState(false)
   const heardTextRef = React.useRef(heardText)
   const lastHandledRerunTokenRef = React.useRef(0)
+  const heardTextInputRef = React.useRef<HTMLTextAreaElement | null>(null)
+  const lastHandledHandoffTokenRef = React.useRef<number | null>(null)
   const hasMissingConnection = Boolean(
     result &&
       (result.connection_status === "missing" ||
@@ -97,6 +106,22 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
     if (!isActive) return
     setError(null)
   }, [isActive])
+
+  React.useEffect(() => {
+    if (!isActive || !selectedPersonaId || !handoffFocusRequest) return
+    if (lastHandledHandoffTokenRef.current === handoffFocusRequest.token) return
+    const target = heardTextInputRef.current
+    if (!target) return
+    target.scrollIntoView?.({ block: "nearest", behavior: "smooth" })
+    target.focus()
+    lastHandledHandoffTokenRef.current = handoffFocusRequest.token
+    onSetupHandoffFocusConsumed?.(handoffFocusRequest.token)
+  }, [
+    handoffFocusRequest,
+    isActive,
+    onSetupHandoffFocusConsumed,
+    selectedPersonaId
+  ])
 
   React.useEffect(() => {
     heardTextRef.current = heardText
@@ -252,6 +277,7 @@ export const TestLabPanel: React.FC<TestLabPanelProps> = ({
                 defaultValue: "Heard text"
               })}
               <textarea
+                ref={heardTextInputRef}
                 data-testid="persona-test-lab-heard-input"
                 className="mt-1 min-h-[88px] w-full rounded-md border border-border bg-bg px-2 py-1 text-sm text-text"
                 value={heardText}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/AssistantDefaultsPanel.test.tsx
@@ -197,6 +197,10 @@ const buildVoiceAnalytics = (recentSessions: MockRecentLiveSession[]) => ({
 
 describe("AssistantDefaultsPanel", () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn()
+    })
     mocks.fetchWithAuth.mockReset()
     mocks.resolvedDefaults = {
       sttLanguage: "en-US",
@@ -707,5 +711,43 @@ describe("AssistantDefaultsPanel", () => {
     expect(
       screen.getByText("Suggestion: current settings look healthy")
     ).toBeInTheDocument()
+  })
+
+  it("focuses confirmation mode for setup handoff requests after defaults load", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    render(
+      <AssistantDefaultsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Helper"
+        isActive
+        handoffFocusRequest={{ section: "confirmation_mode", token: 1 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Confirmation mode")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(1)
+  })
+
+  it("focuses the first assistant defaults control for assistant_defaults handoff requests", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    render(
+      <AssistantDefaultsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Helper"
+        isActive
+        handoffFocusRequest={{ section: "assistant_defaults", token: 2 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("STT language")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(2)
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/CommandsPanel.test.tsx
@@ -188,6 +188,10 @@ const analytics = {
 
 describe("CommandsPanel", () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn()
+    })
     mocks.fetchWithAuth.mockReset()
     mocks.serverCapabilities = {
       capabilities: { hasMcp: true },
@@ -904,5 +908,72 @@ describe("CommandsPanel", () => {
     expect(screen.getByTestId("persona-commands-analytics-cmd-external")).toHaveTextContent(
       "1 run"
     )
+  })
+
+  it("focuses the command name input for handoff command_form requests", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    renderWithQueryClient(
+      <CommandsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        handoffFocusRequest={{ section: "command_form", token: 1 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await screen.findByText("Search Notes")
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(1)
+  })
+
+  it("falls back to the command form for handoff command_list requests when no commands exist", async () => {
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string }) => {
+      if (
+        path === "/api/v1/persona/profiles/persona-1/voice-commands" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path === "/api/v1/persona/profiles/persona-1/connections" &&
+        (!init?.method || init.method === "GET")
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `Unhandled path: ${path}`
+      })
+    })
+
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    renderWithQueryClient(
+      <CommandsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        handoffFocusRequest={{ section: "command_list", token: 2 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await screen.findByTestId("persona-commands-empty")
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(2)
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/ConnectionsPanel.test.tsx
@@ -44,6 +44,10 @@ const createDeferred = <T,>() => {
 
 describe("ConnectionsPanel", () => {
   beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn()
+    })
     mocks.fetchWithAuth.mockReset()
     let connections = [
       {
@@ -424,5 +428,49 @@ describe("ConnectionsPanel", () => {
     ])
 
     expect(await screen.findByText("Other API")).toBeInTheDocument()
+  })
+
+  it("focuses the connection form for handoff connection_form requests", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    render(
+      <ConnectionsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        handoffFocusRequest={{ section: "connection_form", token: 1 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-connections-name-input")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(1)
+  })
+
+  it("focuses the targeted saved connection action after rows load", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    render(
+      <ConnectionsPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        handoffFocusRequest={{
+          section: "saved_connections",
+          token: 2,
+          connectionName: "Existing API"
+        }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("persona-connections-edit-conn-existing")
+      ).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(2)
   })
 })

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx
@@ -68,6 +68,24 @@ describe("Persona Garden panel i18n", () => {
           connected={false}
           sessionId={null}
           isActive={false}
+          setupAnalytics={{
+            persona_id: "persona-1",
+            summary: {
+              total_runs: 1,
+              completed_runs: 1,
+              completion_rate: 1,
+              dry_run_completion_count: 1,
+              live_session_completion_count: 0,
+              most_common_dropoff_step: null,
+              handoff_click_rate: 1,
+              handoff_target_reach_rate: 1,
+              first_post_setup_action_rate: 1,
+              handoff_target_reached_counts: {},
+              detour_started_counts: {},
+              detour_returned_counts: {}
+            },
+            recent_runs: []
+          }}
         />
         <CommandsPanel
           selectedPersonaId=""
@@ -102,6 +120,9 @@ describe("Persona Garden panel i18n", () => {
     ).not.toBeInTheDocument()
     expect(
       screen.getByText("sidepanel:personaGarden.profile.assistantDefaultsHeading")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("sidepanel:personaGarden.profile.setupAnalyticsHeading")
     ).toBeInTheDocument()
     expect(
       screen.getByText("sidepanel:personaGarden.commands.heading")

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx
@@ -1,0 +1,113 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      defaultValueOrOptions?:
+        | string
+        | {
+            defaultValue?: string
+          }
+    ) => {
+      if (typeof defaultValueOrOptions === "string") return defaultValueOrOptions
+      if (defaultValueOrOptions?.defaultValue) return defaultValueOrOptions.defaultValue
+      return key
+    }
+  })
+}))
+
+import {
+  PersonaSetupAnalyticsCard,
+  type PersonaSetupAnalyticsResponse
+} from "../PersonaSetupAnalyticsCard"
+
+const buildAnalytics = (
+  overrides: Partial<PersonaSetupAnalyticsResponse["summary"]> = {}
+): PersonaSetupAnalyticsResponse => ({
+  persona_id: "garden-helper",
+  summary: {
+    total_runs: 4,
+    completed_runs: 3,
+    completion_rate: 0.75,
+    dry_run_completion_count: 2,
+    live_session_completion_count: 1,
+    most_common_dropoff_step: "commands",
+    handoff_click_rate: 0.5,
+    handoff_target_reach_rate: 0.25,
+    first_post_setup_action_rate: 0.5,
+    handoff_target_reached_counts: {},
+    detour_started_counts: {},
+    detour_returned_counts: {},
+    ...overrides
+  },
+  recent_runs: []
+})
+
+describe("PersonaSetupAnalyticsCard", () => {
+  it("hides when there are no recorded setup runs", () => {
+    render(
+      <PersonaSetupAnalyticsCard
+        analytics={buildAnalytics({
+          total_runs: 0,
+          completed_runs: 0,
+          completion_rate: 0,
+          dry_run_completion_count: 0,
+          live_session_completion_count: 0,
+          most_common_dropoff_step: null,
+          handoff_click_rate: 0,
+          handoff_target_reach_rate: 0,
+          first_post_setup_action_rate: 0
+        })}
+      />
+    )
+
+    expect(screen.queryByTestId("persona-setup-analytics-card")).not.toBeInTheDocument()
+  })
+
+  it("shows a compact loading state before analytics are available", () => {
+    render(<PersonaSetupAnalyticsCard loading />)
+
+    expect(screen.getByText("Loading setup analytics...")).toBeInTheDocument()
+  })
+
+  it("renders the compact setup funnel metrics", () => {
+    render(<PersonaSetupAnalyticsCard analytics={buildAnalytics()} />)
+
+    expect(screen.getByTestId("persona-setup-analytics-card")).toBeInTheDocument()
+    expect(screen.getByText("Setup analytics")).toBeInTheDocument()
+    expect(screen.getByText("Completion rate").parentElement).toHaveTextContent("75%")
+    expect(screen.getByText("Most common drop-off").parentElement).toHaveTextContent(
+      "Starter commands"
+    )
+    expect(screen.getByText("Dry run completions").parentElement).toHaveTextContent("2")
+    expect(screen.getByText("Live session completions").parentElement).toHaveTextContent("1")
+    expect(screen.getByText("Handoff click rate").parentElement).toHaveTextContent("50%")
+    expect(screen.getByText("Target reached rate").parentElement).toHaveTextContent("25%")
+    expect(screen.getByText("First next-step rate").parentElement).toHaveTextContent("50%")
+  })
+
+  it("falls back cleanly for missing and unknown drop-off steps", () => {
+    const view = render(
+      <PersonaSetupAnalyticsCard
+        analytics={buildAnalytics({ most_common_dropoff_step: null })}
+      />
+    )
+
+    expect(screen.getByText("Most common drop-off").parentElement).toHaveTextContent(
+      "None yet"
+    )
+
+    view.rerender(
+      <PersonaSetupAnalyticsCard
+        analytics={buildAnalytics({ most_common_dropoff_step: "mystery_phase" as never })}
+      />
+    )
+
+    expect(screen.getByText("Most common drop-off").parentElement).toHaveTextContent(
+      "Mystery phase"
+    )
+  })
+})

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupHandoffCard.test.tsx
@@ -19,6 +19,7 @@ describe("PersonaSetupHandoffCard", () => {
         reviewSummary={defaultReviewSummary}
         recommendedAction="try_live"
         onDismiss={vi.fn()}
+        onAddCommand={vi.fn()}
         onOpenProfiles={vi.fn()}
         onOpenTestLab={vi.fn()}
         onOpenLive={vi.fn()}
@@ -44,6 +45,7 @@ describe("PersonaSetupHandoffCard", () => {
         reviewSummary={defaultReviewSummary}
         recommendedAction="add_connection"
         onDismiss={onDismiss}
+        onAddCommand={vi.fn()}
         onOpenProfiles={onOpenProfiles}
         onOpenTestLab={vi.fn()}
         onOpenLive={vi.fn()}
@@ -71,6 +73,8 @@ describe("PersonaSetupHandoffCard", () => {
   })
 
   it("renders skipped starter pack items for live-session completion", () => {
+    const onAddCommand = vi.fn()
+
     render(
       <PersonaSetupHandoffCard
         targetTab="live"
@@ -82,6 +86,7 @@ describe("PersonaSetupHandoffCard", () => {
         }}
         recommendedAction="add_command"
         onDismiss={vi.fn()}
+        onAddCommand={onAddCommand}
         onOpenProfiles={vi.fn()}
         onOpenTestLab={vi.fn()}
         onOpenLive={vi.fn()}
@@ -95,6 +100,10 @@ describe("PersonaSetupHandoffCard", () => {
     expect(screen.getByText("Never ask")).toBeInTheDocument()
     expect(screen.getByText("No external connection yet")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Open Commands" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Commands" }))
+
+    expect(onAddCommand).toHaveBeenCalledTimes(1)
   })
 
   it("renders a compact variant with the recommended next step", () => {
@@ -108,6 +117,7 @@ describe("PersonaSetupHandoffCard", () => {
         recommendedAction="review_commands"
         compact
         onDismiss={vi.fn()}
+        onAddCommand={vi.fn()}
         onOpenProfiles={vi.fn()}
         onOpenTestLab={vi.fn()}
         onOpenLive={vi.fn()}

--- a/apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx
+++ b/apps/packages/ui/src/components/PersonaGarden/__tests__/TestLabPanel.test.tsx
@@ -410,4 +410,23 @@ describe("TestLabPanel", () => {
       expect(mocks.fetchWithAuth).toHaveBeenCalledTimes(1)
     })
   })
+
+  it("focuses the dry-run form for setup handoff requests", async () => {
+    const onSetupHandoffFocusConsumed = vi.fn()
+
+    render(
+      <TestLabPanel
+        selectedPersonaId="persona-1"
+        selectedPersonaName="Garden Helper"
+        isActive
+        handoffFocusRequest={{ section: "dry_run_form", token: 1 }}
+        onSetupHandoffFocusConsumed={onSetupHandoffFocusConsumed}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-test-lab-heard-input")).toHaveFocus()
+    )
+    expect(onSetupHandoffFocusConsumed).toHaveBeenCalledWith(1)
+  })
 })

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -2145,6 +2145,7 @@ describe("SidepanelPersona", () => {
     const currentVoiceDefaults = {
       confirmation_mode: "destructive_only"
     }
+    const setupEventBodies: Array<Record<string, unknown>> = []
 
     mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
       const method = String(init?.method || "GET").toUpperCase()
@@ -2152,6 +2153,19 @@ describe("SidepanelPersona", () => {
         return Promise.resolve({
           ok: true,
           json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-events") && method === "POST") {
+        setupEventBodies.push(init?.body || {})
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            event_id: init?.body?.event_id || "evt-1",
+            run_id: init?.body?.run_id || "setup-run-1",
+            event_type: init?.body?.event_type || "step_viewed",
+            deduped: false,
+            created_at: "2026-03-14T10:00:00.000Z"
+          })
         })
       }
       if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
@@ -2261,6 +2275,26 @@ describe("SidepanelPersona", () => {
     await waitFor(() => {
       expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
     })
+    expect(
+      setupEventBodies.filter(
+        (body) =>
+          body.event_type === "handoff_target_reached" &&
+          body.action_target === "commands.command_list"
+      )
+    ).toHaveLength(1)
+
+    fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+    })
+    expect(
+      setupEventBodies.filter(
+        (body) =>
+          body.event_type === "handoff_target_reached" &&
+          body.action_target === "commands.command_list"
+      )
+    ).toHaveLength(1)
   })
 
   it("retargets the setup handoff and targets the saved connection action after a cross-tab handoff action", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -2002,7 +2002,7 @@ describe("SidepanelPersona", () => {
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
   })
 
-  it("keeps the setup handoff visible after a same-tab handoff action", async () => {
+  it("keeps the setup handoff visible and targets confirmation mode after a same-tab handoff action", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=profiles"
 
     let profileVersion = 2
@@ -2125,9 +2125,12 @@ describe("SidepanelPersona", () => {
 
     expect(screen.getByRole("tab", { name: "Profiles" })).toHaveAttribute("aria-selected", "true")
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByLabelText("Confirmation mode")).toHaveFocus()
+    })
   })
 
-  it("retargets the setup handoff after a cross-tab handoff action", async () => {
+  it("retargets the setup handoff and targets the command editor after a cross-tab handoff action", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=connections"
 
     let profileVersion = 2
@@ -2255,6 +2258,285 @@ describe("SidepanelPersona", () => {
       )
     })
     expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
+    })
+  })
+
+  it("retargets the setup handoff and targets the saved connection action after a cross-tab handoff action", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [
+            {
+              id: "conn-existing",
+              persona_id: "garden-helper",
+              name: "Existing API",
+              base_url: "https://existing.example.com",
+              auth_type: "bearer"
+            }
+          ]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Open connections" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Connections" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+    expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("persona-connections-edit-conn-existing")
+      ).toHaveFocus()
+    })
+  })
+
+  it("retargets the setup handoff and targets the dry-run form after a cross-tab handoff action", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+
+    let profileVersion = 2
+    let currentSetup = {
+      status: "in_progress",
+      version: 1,
+      current_step: "test",
+      completed_steps: ["persona", "voice", "commands", "safety"],
+      completed_at: null,
+      last_test_type: null
+    }
+    const currentVoiceDefaults = {
+      confirmation_mode: "destructive_only"
+    }
+
+    mocks.fetchWithAuth.mockImplementation((path: string, init?: { method?: string; body?: any }) => {
+      const method = String(init?.method || "GET").toUpperCase()
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_runs: 0, matched_runs: 0, fallback_runs: 0 }
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands/test") &&
+        method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            heard_text: init?.body?.heard_text,
+            matched: true,
+            command_name: "Search Notes"
+          })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/voice-commands") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ commands: [] })
+        })
+      }
+      if (
+        path.includes("/persona/profiles/garden-helper/connections") &&
+        method === "GET"
+      ) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => []
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        if (method === "PATCH") {
+          profileVersion += 1
+          currentSetup = {
+            ...currentSetup,
+            ...(init?.body?.setup || {})
+          }
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              version: profileVersion,
+              voice_defaults: currentVoiceDefaults,
+              setup: currentSetup,
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            version: profileVersion,
+            voice_defaults: currentVoiceDefaults,
+            setup: currentSetup,
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assistant-setup-current-step")).toHaveTextContent("test")
+    })
+
+    fireEvent.change(screen.getByPlaceholderText("Try a spoken phrase"), {
+      target: { value: "search notes for project alpha" }
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Run dry-run test" }))
+
+    await screen.findByText(/Matched Search Notes/i)
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish with dry-run test" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Test Lab" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Test Lab" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+    expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-test-lab-heard-input")).toHaveFocus()
+    })
   })
 
   it("does not collapse the setup handoff when a post-setup dry-run does not match", async () => {

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -469,6 +469,245 @@ describe("SidepanelPersona", () => {
     )
   })
 
+  it("loads and renders setup analytics in profiles", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: {
+              total_runs: 4,
+              completed_runs: 3,
+              completion_rate: 0.75,
+              dry_run_completion_count: 2,
+              live_session_completion_count: 1,
+              most_common_dropoff_step: "commands",
+              handoff_click_rate: 0.5,
+              handoff_target_reach_rate: 0.25,
+              first_post_setup_action_rate: 0.5,
+              handoff_target_reached_counts: {},
+              detour_started_counts: {},
+              detour_returned_counts: {}
+            },
+            recent_runs: []
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_events: 0, direct_command_count: 0, planner_fallback_count: 0 }
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            voice_defaults: {},
+            setup: {
+              status: "completed",
+              version: 1,
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety", "test"],
+              completed_at: "2026-03-14T10:00:00Z",
+              last_test_type: "dry_run"
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona-setup-analytics-card")).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId("persona-setup-analytics-card")).toHaveTextContent("75%")
+    expect(
+      mocks.fetchWithAuth.mock.calls.some(([path]) =>
+        String(path).includes("/persona/profiles/garden-helper/setup-analytics")
+      )
+    ).toBe(true)
+  })
+
+  it("hides setup analytics in profiles when the persona has no recorded runs", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/setup-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: {
+              total_runs: 0,
+              completed_runs: 0,
+              completion_rate: 0,
+              dry_run_completion_count: 0,
+              live_session_completion_count: 0,
+              most_common_dropoff_step: null,
+              handoff_click_rate: 0,
+              handoff_target_reach_rate: 0,
+              first_post_setup_action_rate: 0,
+              handoff_target_reached_counts: {},
+              detour_started_counts: {},
+              detour_returned_counts: {}
+            },
+            recent_runs: []
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_events: 0, direct_command_count: 0, planner_fallback_count: 0 }
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            voice_defaults: {},
+            setup: {
+              status: "completed",
+              version: 1,
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety", "test"],
+              completed_at: "2026-03-14T10:00:00Z",
+              last_test_type: "dry_run"
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Assistant Defaults")).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId("persona-setup-analytics-card")).not.toBeInTheDocument()
+    expect(
+      mocks.fetchWithAuth.mock.calls.some(([path]) =>
+        String(path).includes("/persona/profiles/garden-helper/setup-analytics")
+      )
+    ).toBe(true)
+  })
+
+  it("does not fetch setup analytics outside profiles", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=commands"
+    mocks.getConfig.mockResolvedValue({
+      serverUrl: "http://127.0.0.1:8000",
+      authMode: "single-user",
+      apiKey: ""
+    })
+
+    mocks.fetchWithAuth.mockImplementation((path: string) => {
+      if (path.includes("/persona/catalog")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            persona_id: "garden-helper",
+            summary: { total_events: 0, direct_command_count: 0, planner_fallback_count: 0 },
+            commands: [],
+            fallbacks: { total_invocations: 0 }
+          })
+        })
+      }
+      if (path.includes("/persona/profiles/garden-helper")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            id: "garden-helper",
+            voice_defaults: {},
+            setup: {
+              status: "completed",
+              version: 1,
+              current_step: "test",
+              completed_steps: ["persona", "voice", "commands", "safety", "test"],
+              completed_at: "2026-03-14T10:00:00Z",
+              last_test_type: "dry_run"
+            },
+            use_persona_state_context_default: true
+          })
+        })
+      }
+      return Promise.resolve({
+        ok: false,
+        error: `unhandled path: ${path}`,
+        json: async () => ({})
+      })
+    })
+
+    render(<SidepanelPersona />)
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Commands" })).toHaveAttribute(
+        "aria-selected",
+        "true"
+      )
+    })
+
+    expect(
+      mocks.fetchWithAuth.mock.calls.some(([path]) =>
+        String(path).includes("/persona/profiles/garden-helper/setup-analytics")
+      )
+    ).toBe(false)
+  })
+
   it("captures starter command and safety choices into the setup handoff summary", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=profiles"
     mocks.getConfig.mockResolvedValue({

--- a/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
+++ b/apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
@@ -549,10 +549,10 @@ describe("SidepanelPersona", () => {
 
     expect(screen.getByTestId("persona-setup-analytics-card")).toHaveTextContent("75%")
     expect(
-      mocks.fetchWithAuth.mock.calls.some(([path]) =>
+      mocks.fetchWithAuth.mock.calls.filter(([path]) =>
         String(path).includes("/persona/profiles/garden-helper/setup-analytics")
       )
-    ).toBe(true)
+    ).toHaveLength(1)
   })
 
   it("hides setup analytics in profiles when the persona has no recorded runs", async () => {
@@ -706,6 +706,73 @@ describe("SidepanelPersona", () => {
         String(path).includes("/persona/profiles/garden-helper/setup-analytics")
       )
     ).toBe(false)
+  })
+
+  it("fails closed and warns when setup analytics loading fails in profiles", async () => {
+    mocks.location.search = "?persona_id=garden-helper&tab=profiles"
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      mocks.fetchWithAuth.mockImplementation((path: string) => {
+        if (path.includes("/persona/catalog")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => [{ id: "garden-helper", name: "Garden Helper" }]
+          })
+        }
+        if (path.includes("/persona/profiles/garden-helper/setup-analytics")) {
+          return Promise.reject(new Error("setup analytics offline"))
+        }
+        if (path.includes("/persona/profiles/garden-helper/voice-analytics")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              persona_id: "garden-helper",
+              summary: { total_events: 0, direct_command_count: 0, planner_fallback_count: 0 }
+            })
+          })
+        }
+        if (path.includes("/persona/profiles/garden-helper")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              id: "garden-helper",
+              voice_defaults: {},
+              setup: {
+                status: "completed",
+                version: 1,
+                current_step: "test",
+                completed_steps: ["persona", "voice", "commands", "safety", "test"],
+                completed_at: "2026-03-14T10:00:00Z",
+                last_test_type: "dry_run"
+              },
+              use_persona_state_context_default: true
+            })
+          })
+        }
+        return Promise.resolve({
+          ok: false,
+          error: `unhandled path: ${path}`,
+          json: async () => ({})
+        })
+      })
+
+      render(<SidepanelPersona />)
+
+      await waitFor(() => {
+        expect(screen.getByText("Assistant Defaults")).toBeInTheDocument()
+      })
+
+      expect(screen.queryByTestId("persona-setup-analytics-card")).not.toBeInTheDocument()
+      expect(warnSpy).toHaveBeenCalledWith(
+        "tldw_server: failed to load persona setup analytics",
+        expect.objectContaining({
+          personaId: "garden-helper",
+          error: expect.any(Error)
+        })
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it("captures starter command and safety choices into the setup handoff summary", async () => {
@@ -2369,7 +2436,7 @@ describe("SidepanelPersona", () => {
     })
   })
 
-  it("retargets the setup handoff and targets the command editor after a cross-tab handoff action", async () => {
+  it("retargets the setup handoff and opens the command form for the add-command CTA", async () => {
     mocks.location.search = "?persona_id=garden-helper&tab=connections"
 
     let profileVersion = 2
@@ -2502,7 +2569,7 @@ describe("SidepanelPersona", () => {
       expect(screen.getByTestId("persona-setup-handoff-card")).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open Commands" }))
 
     await waitFor(() => {
       expect(screen.getByRole("tab", { name: "Commands" })).toHaveAttribute(
@@ -2514,26 +2581,30 @@ describe("SidepanelPersona", () => {
     await waitFor(() => {
       expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
     })
-    expect(
-      setupEventBodies.filter(
-        (body) =>
-          body.event_type === "handoff_target_reached" &&
-          body.action_target === "commands.command_list"
-      )
-    ).toHaveLength(1)
+    await waitFor(() => {
+      expect(
+        setupEventBodies.filter(
+          (body) =>
+            body.event_type === "handoff_target_reached" &&
+            body.action_target === "commands.command_form"
+        )
+      ).toHaveLength(1)
+    })
 
     fireEvent.click(screen.getByRole("button", { name: "Review commands" }))
 
     await waitFor(() => {
       expect(screen.getByTestId("persona-commands-name-input")).toHaveFocus()
     })
-    expect(
-      setupEventBodies.filter(
-        (body) =>
-          body.event_type === "handoff_target_reached" &&
-          body.action_target === "commands.command_list"
-      )
-    ).toHaveLength(1)
+    await waitFor(() => {
+      expect(
+        setupEventBodies.filter(
+          (body) =>
+            body.event_type === "handoff_target_reached" &&
+            body.action_target === "commands.command_list"
+        )
+      ).toHaveLength(1)
+    })
   })
 
   it("retargets the setup handoff and targets the saved connection action after a cross-tab handoff action", async () => {

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -67,6 +67,7 @@ import {
   type PersonaSetupAnalyticsEvent,
   type PersonaSetupAnalyticsEventType
 } from "@/services/tldw/persona-setup-analytics"
+import { toAllowedPath } from "@/services/tldw/path-utils"
 import { tldwClient } from "@/services/tldw/TldwApiClient"
 import { buildPersonaWebSocketUrl } from "@/services/persona-stream"
 import {
@@ -1675,7 +1676,9 @@ const SidepanelPersona = ({
     const loadSetupAnalytics = async () => {
       try {
         const response = await tldwClient.fetchWithAuth(
-          `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-analytics?days=30&limit=5` as any,
+          toAllowedPath(
+            `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-analytics?days=30&limit=5`
+          ),
           { method: "GET" }
         )
         if (!response.ok) {
@@ -1685,7 +1688,11 @@ const SidepanelPersona = ({
         if (!cancelled) {
           setSetupAnalytics(payload)
         }
-      } catch {
+      } catch (fetchError) {
+        console.warn("tldw_server: failed to load persona setup analytics", {
+          personaId: normalizedPersonaId,
+          error: fetchError
+        })
         if (!cancelled) {
           setSetupAnalytics(null)
         }
@@ -1700,7 +1707,7 @@ const SidepanelPersona = ({
     return () => {
       cancelled = true
     }
-  }, [activeTab, selectedPersonaId, setupAnalytics?.persona_id])
+  }, [activeTab, selectedPersonaId])
 
   React.useEffect(() => {
     if (!isCompanionMode || capsLoading || !capabilities?.hasPersonalization) {
@@ -4492,19 +4499,20 @@ const SidepanelPersona = ({
   }, [emitSetupAnalyticsEvent])
 
   const handleSetupHandoffFocusConsumed = React.useCallback((token: number) => {
-    const currentRequest = setupHandoffFocusRequestRef.current
+    const currentRequest = setupHandoffFocusRequestRef.current || setupHandoffFocusRequest
     if (!currentRequest || currentRequest.token !== token) return
+    const currentHandoff = setupHandoffRef.current || setupHandoff
 
     const actionTarget = `${currentRequest.tab}.${currentRequest.section}`
     void emitSetupAnalyticsEvent({
-      runId: setupHandoffRef.current?.runId,
+      runId: currentHandoff?.runId,
       eventType: "handoff_target_reached",
       actionTarget,
       metadata: {
         connection_id: currentRequest.connectionId || undefined,
         connection_name: currentRequest.connectionName || undefined,
-        recommended_action: setupHandoffRef.current?.recommendedAction || undefined,
-        completion_type: setupHandoffRef.current?.completionType || undefined
+        recommended_action: currentHandoff?.recommendedAction || undefined,
+        completion_type: currentHandoff?.completionType || undefined
       }
     })
 
@@ -4513,7 +4521,7 @@ const SidepanelPersona = ({
       if (current.token !== token) return current
       return null
     })
-  }, [emitSetupAnalyticsEvent])
+  }, [emitSetupAnalyticsEvent, setupHandoff, setupHandoffFocusRequest])
 
   const handleProfileDefaultsSaved = React.useCallback(() => {
     consumeSetupHandoffAction("voice_defaults_saved")
@@ -4543,6 +4551,9 @@ const SidepanelPersona = ({
           recommendedAction={setupHandoff.recommendedAction}
           compact={setupHandoff.compact}
           onDismiss={dismissSetupHandoff}
+          onAddCommand={() =>
+            openSetupHandoffTarget({ tab: "commands", section: "command_form" })
+          }
           onOpenCommands={() =>
             openSetupHandoffTarget({ tab: "commands", section: "command_list" })
           }

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -678,6 +678,7 @@ const SidepanelPersona = ({
   const emittedSetupEventKeysRef = React.useRef<Set<string>>(new Set())
   const setupLiveDetourRef = React.useRef<SetupLiveDetourState | null>(null)
   const setupHandoffRef = React.useRef<SetupHandoffState | null>(null)
+  const setupHandoffFocusRequestRef = React.useRef<SetupHandoffFocusRequest | null>(null)
   const activeTabRef = React.useRef<PersonaGardenTabKey>("live")
   const resolvedApprovalFadeTimerRef = React.useRef<number | null>(null)
   const approvalHighlightPhaseTimerRef = React.useRef<number | null>(null)
@@ -813,6 +814,10 @@ const SidepanelPersona = ({
   React.useEffect(() => {
     setupHandoffRef.current = setupHandoff
   }, [setupHandoff])
+
+  React.useEffect(() => {
+    setupHandoffFocusRequestRef.current = setupHandoffFocusRequest
+  }, [setupHandoffFocusRequest])
 
   React.useEffect(() => {
     activeTabRef.current = activeTab
@@ -1033,7 +1038,9 @@ const SidepanelPersona = ({
       const eventKey = buildSetupEventKey({
         eventType,
         step: event.step,
-        detourSource: event.detourSource || undefined
+        detourSource: event.detourSource || undefined,
+        actionTarget: event.actionTarget || undefined,
+        metadata: event.metadata
       })
       if (eventKey) {
         const dedupeKey = `${personaId}:${runId}:${eventKey}`
@@ -4430,12 +4437,28 @@ const SidepanelPersona = ({
   }, [emitSetupAnalyticsEvent])
 
   const handleSetupHandoffFocusConsumed = React.useCallback((token: number) => {
+    const currentRequest = setupHandoffFocusRequestRef.current
+    if (!currentRequest || currentRequest.token !== token) return
+
+    const actionTarget = `${currentRequest.tab}.${currentRequest.section}`
+    void emitSetupAnalyticsEvent({
+      runId: setupHandoffRef.current?.runId,
+      eventType: "handoff_target_reached",
+      actionTarget,
+      metadata: {
+        connection_id: currentRequest.connectionId || undefined,
+        connection_name: currentRequest.connectionName || undefined,
+        recommended_action: setupHandoffRef.current?.recommendedAction || undefined,
+        completion_type: setupHandoffRef.current?.completionType || undefined
+      }
+    })
+
     setSetupHandoffFocusRequest((current) => {
       if (!current) return current
       if (current.token !== token) return current
       return null
     })
-  }, [])
+  }, [emitSetupAnalyticsEvent])
 
   const handleProfileDefaultsSaved = React.useCallback(() => {
     consumeSetupHandoffAction("voice_defaults_saved")

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -240,6 +240,25 @@ type SetupHandoffState = {
   compact: boolean
 }
 
+type SetupHandoffSectionTarget =
+  | { tab: "commands"; section: "command_form" | "command_list" }
+  | {
+      tab: "connections"
+      section: "connection_form" | "saved_connections"
+      connectionId?: string | null
+      connectionName?: string | null
+    }
+  | { tab: "profiles"; section: "assistant_defaults" | "confirmation_mode" }
+  | { tab: "test-lab"; section: "dry_run_form" }
+
+type SetupHandoffFocusRequest = {
+  tab: SetupHandoffSectionTarget["tab"]
+  section: SetupHandoffSectionTarget["section"]
+  token: number
+  connectionId?: string | null
+  connectionName?: string | null
+}
+
 type SetupHandoffConsumedAction =
   | "command_saved"
   | "connection_saved"
@@ -655,6 +674,7 @@ const SidepanelPersona = ({
   const runtimeApprovalRowRefs = React.useRef<Map<string, HTMLDivElement | null>>(
     new Map()
   )
+  const setupHandoffFocusTokenRef = React.useRef(0)
   const emittedSetupEventKeysRef = React.useRef<Set<string>>(new Set())
   const setupLiveDetourRef = React.useRef<SetupLiveDetourState | null>(null)
   const setupHandoffRef = React.useRef<SetupHandoffState | null>(null)
@@ -682,6 +702,8 @@ const SidepanelPersona = ({
   const setupWizardAwaitingLiveResponseRef = React.useRef(false)
   const setupWizardLastLiveTextRef = React.useRef("")
   const [setupHandoff, setSetupHandoff] = React.useState<SetupHandoffState | null>(null)
+  const [setupHandoffFocusRequest, setSetupHandoffFocusRequest] =
+    React.useState<SetupHandoffFocusRequest | null>(null)
   const [setupReviewSummaryDraft, setSetupReviewSummaryDraft] =
     React.useState<SetupReviewSummary>(DEFAULT_SETUP_REVIEW_SUMMARY)
   const [liveSessionVoiceDefaultsBaseline, setLiveSessionVoiceDefaultsBaseline] =
@@ -4367,18 +4389,34 @@ const SidepanelPersona = ({
         eventType: "handoff_dismissed"
       })
     }
+    setSetupHandoffFocusRequest(null)
     setSetupHandoff(null)
   }, [emitSetupAnalyticsEvent, setupHandoff])
 
-  const openSetupHandoffTab = React.useCallback((tab: PersonaGardenTabKey) => {
-    if (setupHandoff) {
+  const openSetupHandoffTarget = React.useCallback((target: { tab: "live" } | SetupHandoffSectionTarget) => {
+    const tab = target.tab
+    const currentHandoff = setupHandoffRef.current
+    if (currentHandoff) {
       void emitSetupAnalyticsEvent({
-        runId: setupHandoff.runId,
+        runId: currentHandoff.runId,
         eventType: "handoff_action_clicked",
         actionTarget: tab
       })
     }
     setActiveTab(tab)
+    if ("section" in target) {
+      setupHandoffFocusTokenRef.current += 1
+      setSetupHandoffFocusRequest({
+        tab: target.tab,
+        section: target.section,
+        token: setupHandoffFocusTokenRef.current,
+        connectionId: "connectionId" in target ? (target.connectionId ?? null) : null,
+        connectionName:
+          "connectionName" in target ? (target.connectionName ?? null) : null
+      })
+    } else {
+      setSetupHandoffFocusRequest(null)
+    }
     setSetupHandoff((current) => {
       if (!current) return null
       if (current.targetTab === tab) {
@@ -4389,7 +4427,15 @@ const SidepanelPersona = ({
         targetTab: tab
       }
     })
-  }, [emitSetupAnalyticsEvent, setupHandoff])
+  }, [emitSetupAnalyticsEvent])
+
+  const handleSetupHandoffFocusConsumed = React.useCallback((token: number) => {
+    setSetupHandoffFocusRequest((current) => {
+      if (!current) return current
+      if (current.token !== token) return current
+      return null
+    })
+  }, [])
 
   const handleProfileDefaultsSaved = React.useCallback(() => {
     consumeSetupHandoffAction("voice_defaults_saved")
@@ -4419,15 +4465,39 @@ const SidepanelPersona = ({
           recommendedAction={setupHandoff.recommendedAction}
           compact={setupHandoff.compact}
           onDismiss={dismissSetupHandoff}
-          onOpenCommands={() => openSetupHandoffTab("commands")}
-          onOpenTestLab={() => openSetupHandoffTab("test-lab")}
-          onOpenLive={() => openSetupHandoffTab("live")}
-          onOpenProfiles={() => openSetupHandoffTab("profiles")}
-          onOpenConnections={() => openSetupHandoffTab("connections")}
+          onOpenCommands={() =>
+            openSetupHandoffTarget({ tab: "commands", section: "command_list" })
+          }
+          onOpenTestLab={() =>
+            openSetupHandoffTarget({ tab: "test-lab", section: "dry_run_form" })
+          }
+          onOpenLive={() => openSetupHandoffTarget({ tab: "live" })}
+          onOpenProfiles={() =>
+            openSetupHandoffTarget({
+              tab: "profiles",
+              section: "confirmation_mode"
+            })
+          }
+          onOpenConnections={() =>
+            setupHandoff.reviewSummary.connection.mode === "skipped"
+              ? openSetupHandoffTarget({
+                  tab: "connections",
+                  section: "connection_form"
+                })
+              : openSetupHandoffTarget({
+                  tab: "connections",
+                  section: "saved_connections",
+                  connectionName:
+                    setupHandoff.reviewSummary.connection.mode === "created" ||
+                    setupHandoff.reviewSummary.connection.mode === "available"
+                      ? setupHandoff.reviewSummary.connection.name
+                      : null
+                })
+          }
         />
       )
     },
-    [dismissSetupHandoff, openSetupHandoffTab, setupHandoff]
+    [dismissSetupHandoff, openSetupHandoffTarget, setupHandoff]
   )
 
   const withSetupHandoff = React.useCallback(
@@ -4452,6 +4522,15 @@ const SidepanelPersona = ({
           isActive={activeTab === "commands"}
           analytics={voiceAnalytics}
           analyticsLoading={voiceAnalyticsLoading}
+          handoffFocusRequest={
+            setupHandoffFocusRequest?.tab === "commands"
+              ? {
+                  section: setupHandoffFocusRequest.section as "command_form" | "command_list",
+                  token: setupHandoffFocusRequest.token
+                }
+              : null
+          }
+          onSetupHandoffFocusConsumed={handleSetupHandoffFocusConsumed}
           openCommandId={openCommandId}
           onOpenCommandHandled={handleOpenCommandHandled}
           draftCommandPhrase={draftCommandPhrase}
@@ -4473,6 +4552,15 @@ const SidepanelPersona = ({
           selectedPersonaName={selectedPersonaName}
           isActive={activeTab === "test-lab"}
           analytics={voiceAnalytics}
+          handoffFocusRequest={
+            setupHandoffFocusRequest?.tab === "test-lab"
+              ? {
+                  section: setupHandoffFocusRequest.section as "dry_run_form",
+                  token: setupHandoffFocusRequest.token
+                }
+              : null
+          }
+          onSetupHandoffFocusConsumed={handleSetupHandoffFocusConsumed}
           initialHeardText={lastTestLabPhrase}
           rerunRequestToken={testLabRerunToken}
           onOpenCommand={handleOpenCommandFromTestLab}
@@ -4516,6 +4604,17 @@ const SidepanelPersona = ({
           isActive={activeTab === "profiles"}
           analytics={voiceAnalytics}
           analyticsLoading={voiceAnalyticsLoading}
+          handoffFocusRequest={
+            setupHandoffFocusRequest?.tab === "profiles"
+              ? {
+                  section: setupHandoffFocusRequest.section as
+                    | "assistant_defaults"
+                    | "confirmation_mode",
+                  token: setupHandoffFocusRequest.token
+                }
+              : null
+          }
+          onSetupHandoffFocusConsumed={handleSetupHandoffFocusConsumed}
         />
       )
     },
@@ -4541,6 +4640,19 @@ const SidepanelPersona = ({
           isActive={activeTab === "connections"}
           onConnectionSaved={handleConnectionSaved}
           onConnectionTestSucceeded={handleConnectionTestSucceeded}
+          handoffFocusRequest={
+            setupHandoffFocusRequest?.tab === "connections"
+              ? {
+                  section: setupHandoffFocusRequest.section as
+                    | "connection_form"
+                    | "saved_connections",
+                  token: setupHandoffFocusRequest.token,
+                  connectionId: setupHandoffFocusRequest.connectionId ?? null,
+                  connectionName: setupHandoffFocusRequest.connectionName ?? null
+                }
+              : null
+          }
+          onSetupHandoffFocusConsumed={handleSetupHandoffFocusConsumed}
         />
       )
     },

--- a/apps/packages/ui/src/routes/sidepanel-persona.tsx
+++ b/apps/packages/ui/src/routes/sidepanel-persona.tsx
@@ -14,6 +14,7 @@ import { PersonaPolicySummary } from "@/components/Option/MCPHub"
 import {
   type PersonaVoiceAnalytics
 } from "@/components/PersonaGarden/CommandAnalyticsSummary"
+import type { PersonaSetupAnalyticsResponse } from "@/components/PersonaGarden/PersonaSetupAnalyticsCard"
 import type { PersonaTurnDetectionValues } from "@/components/PersonaGarden/PersonaTurnDetectionControls"
 import { AssistantVoiceCard } from "@/components/PersonaGarden/AssistantVoiceCard"
 import { AssistantDefaultsPanel } from "@/components/PersonaGarden/AssistantDefaultsPanel"
@@ -730,6 +731,9 @@ const SidepanelPersona = ({
     null
   )
   const [voiceAnalyticsLoading, setVoiceAnalyticsLoading] = React.useState(false)
+  const [setupAnalytics, setSetupAnalytics] =
+    React.useState<PersonaSetupAnalyticsResponse | null>(null)
+  const [setupAnalyticsLoading, setSetupAnalyticsLoading] = React.useState(false)
   const [savingLiveVoiceDefaults, setSavingLiveVoiceDefaults] = React.useState(false)
   const [setupIntentTargetTab, setSetupIntentTargetTab] =
     React.useState<PersonaGardenTabKey | null>(null)
@@ -1646,6 +1650,57 @@ const SidepanelPersona = ({
       cancelled = true
     }
   }, [activeTab, selectedPersonaId])
+
+  React.useEffect(() => {
+    let cancelled = false
+    const normalizedPersonaId = String(selectedPersonaId || "").trim()
+
+    if (!normalizedPersonaId) {
+      setSetupAnalytics(null)
+      setSetupAnalyticsLoading(false)
+      return
+    }
+
+    if (setupAnalytics?.persona_id !== normalizedPersonaId) {
+      setSetupAnalytics(null)
+    }
+
+    if (activeTab !== "profiles") {
+      setSetupAnalyticsLoading(false)
+      return
+    }
+
+    setSetupAnalyticsLoading(true)
+
+    const loadSetupAnalytics = async () => {
+      try {
+        const response = await tldwClient.fetchWithAuth(
+          `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-analytics?days=30&limit=5` as any,
+          { method: "GET" }
+        )
+        if (!response.ok) {
+          throw new Error(response.error || "Failed to load persona setup analytics.")
+        }
+        const payload = (await response.json()) as PersonaSetupAnalyticsResponse
+        if (!cancelled) {
+          setSetupAnalytics(payload)
+        }
+      } catch {
+        if (!cancelled) {
+          setSetupAnalytics(null)
+        }
+      } finally {
+        if (!cancelled) {
+          setSetupAnalyticsLoading(false)
+        }
+      }
+    }
+
+    void loadSetupAnalytics()
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab, selectedPersonaId, setupAnalytics?.persona_id])
 
   React.useEffect(() => {
     if (!isCompanionMode || capsLoading || !capabilities?.hasPersonalization) {
@@ -4625,6 +4680,8 @@ const SidepanelPersona = ({
           onRerunSetup={handleRerunSetup}
           onDefaultsSaved={handleProfileDefaultsSaved}
           isActive={activeTab === "profiles"}
+          setupAnalytics={setupAnalytics}
+          setupAnalyticsLoading={setupAnalyticsLoading}
           analytics={voiceAnalytics}
           analyticsLoading={voiceAnalyticsLoading}
           handoffFocusRequest={

--- a/apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts
+++ b/apps/packages/ui/src/services/tldw/__tests__/persona-setup-analytics.test.ts
@@ -44,6 +44,19 @@ describe("buildSetupEventKey", () => {
         detourSource: "live_failure"
       })
     ).toBe("detour_returned:live_failure")
+    expect(
+      buildSetupEventKey({
+        eventType: "handoff_target_reached",
+        actionTarget: "commands.command_form"
+      })
+    ).toBe("handoff_target_reached:commands.command_form")
+    expect(
+      buildSetupEventKey({
+        eventType: "handoff_target_reached",
+        actionTarget: "connections.saved_connections",
+        metadata: { connection_id: "conn-123" }
+      })
+    ).toBe("handoff_target_reached:connections.saved_connections:conn-123")
     expect(buildSetupEventKey({ eventType: "retry_clicked" })).toBeUndefined()
   })
 })

--- a/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
+++ b/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
@@ -10,6 +10,7 @@ export type PersonaSetupAnalyticsEventType =
   | "detour_returned"
   | "setup_completed"
   | "handoff_action_clicked"
+  | "handoff_target_reached"
   | "handoff_dismissed"
   | "first_post_setup_action"
 
@@ -34,14 +35,32 @@ const createEventId = (): string => {
 export const buildSetupEventKey = ({
   eventType,
   step,
-  detourSource
-}: Pick<PersonaSetupAnalyticsEvent, "eventType" | "step" | "detourSource">):
+  detourSource,
+  actionTarget,
+  metadata
+}: Pick<
+  PersonaSetupAnalyticsEvent,
+  "eventType" | "step" | "detourSource" | "actionTarget" | "metadata"
+>):
   | string
   | undefined => {
   if (eventType === "setup_started") return "setup_started"
   if (eventType === "setup_completed") return "setup_completed"
   if (eventType === "handoff_dismissed") return "handoff_dismissed"
   if (eventType === "first_post_setup_action") return "first_post_setup_action"
+  if (eventType === "handoff_target_reached" && actionTarget) {
+    const metadataRecord =
+      metadata && typeof metadata === "object" ? metadata : undefined
+    const connectionId = String(metadataRecord?.connection_id || "").trim()
+    if (connectionId) {
+      return `handoff_target_reached:${actionTarget}:${connectionId}`
+    }
+    const connectionName = String(metadataRecord?.connection_name || "").trim()
+    if (connectionName) {
+      return `handoff_target_reached:${actionTarget}:${connectionName}`
+    }
+    return `handoff_target_reached:${actionTarget}`
+  }
   if (eventType === "step_viewed" && step) return `step_viewed:${step}`
   if (eventType === "step_completed" && step) return `step_completed:${step}`
   if (eventType === "detour_returned" && detourSource) {

--- a/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
+++ b/apps/packages/ui/src/services/tldw/persona-setup-analytics.ts
@@ -1,4 +1,5 @@
 import { tldwClient } from "./TldwApiClient"
+import { toAllowedPath } from "./path-utils"
 
 export type PersonaSetupAnalyticsEventType =
   | "setup_started"
@@ -79,7 +80,9 @@ export const postPersonaSetupEvent = async (
 
   try {
     const response = await tldwClient.fetchWithAuth(
-      `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-events` as any,
+      toAllowedPath(
+        `/api/v1/persona/profiles/${encodeURIComponent(normalizedPersonaId)}/setup-events`
+      ),
       {
         method: "POST",
         body: {

--- a/tldw_Server_API/app/api/v1/schemas/persona.py
+++ b/tldw_Server_API/app/api/v1/schemas/persona.py
@@ -31,6 +31,7 @@ PersonaSetupEventType = Literal[
     "detour_returned",
     "setup_completed",
     "handoff_action_clicked",
+    "handoff_target_reached",
     "handoff_dismissed",
     "first_post_setup_action",
 ]
@@ -202,6 +203,7 @@ class PersonaSetupAnalyticsRunSummary(BaseModel):
     completion_type: PersonaSetupTestType | None = None
     terminal_step: PersonaSetupStep | None = None
     handoff_clicked: bool = False
+    handoff_target_reached: bool = False
     handoff_dismissed: bool = False
     first_post_setup_action: bool = False
 
@@ -216,7 +218,9 @@ class PersonaSetupAnalyticsSummary(BaseModel):
     live_session_completion_count: int = 0
     most_common_dropoff_step: PersonaSetupStep | None = None
     handoff_click_rate: float = 0.0
+    handoff_target_reach_rate: float = 0.0
     first_post_setup_action_rate: float = 0.0
+    handoff_target_reached_counts: dict[str, int] = Field(default_factory=dict)
     detour_started_counts: dict[str, int] = Field(default_factory=dict)
     detour_returned_counts: dict[str, int] = Field(default_factory=dict)
 

--- a/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ChaChaNotes_DB.py
@@ -8462,8 +8462,10 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     "completion_type": None,
                     "terminal_step": None,
                     "handoff_clicked": False,
+                    "handoff_target_reached": False,
                     "handoff_dismissed": False,
                     "first_post_setup_action": False,
+                    "_reached_targets": set(),
                     "_latest_id": -1,
                     "_earliest_created_at": None,
                     "_latest_step_id": -1,
@@ -8498,6 +8500,13 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                 run["terminal_step"] = step
             if event_type == "handoff_action_clicked":
                 run["handoff_clicked"] = True
+            elif event_type == "handoff_target_reached":
+                run["handoff_target_reached"] = True
+                action_target = str(event.get("action_target") or "").strip()
+                if action_target:
+                    reached_targets = run["_reached_targets"]
+                    if isinstance(reached_targets, set):
+                        reached_targets.add(action_target)
             elif event_type == "handoff_dismissed":
                 run["handoff_dismissed"] = True
             elif event_type == "first_post_setup_action":
@@ -8516,7 +8525,9 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
         dry_run_completion_count = 0
         live_session_completion_count = 0
         handoff_clicked_runs = 0
+        handoff_target_reached_runs = 0
         first_post_setup_action_runs = 0
+        handoff_target_reached_counts: dict[str, int] = {}
         dropoff_counts: dict[str, int] = {}
 
         for run in sorted(
@@ -8540,8 +8551,16 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
 
             if bool(run.get("handoff_clicked")):
                 handoff_clicked_runs += 1
+            if bool(run.get("handoff_target_reached")):
+                handoff_target_reached_runs += 1
             if bool(run.get("first_post_setup_action")):
                 first_post_setup_action_runs += 1
+            reached_targets = run.get("_reached_targets")
+            if isinstance(reached_targets, set):
+                for action_target in reached_targets:
+                    handoff_target_reached_counts[action_target] = (
+                        handoff_target_reached_counts.get(action_target, 0) + 1
+                    )
 
             recent_runs.append(
                 {
@@ -8551,6 +8570,7 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     "completion_type": completion_type,
                     "terminal_step": run["terminal_step"],
                     "handoff_clicked": bool(run["handoff_clicked"]),
+                    "handoff_target_reached": bool(run["handoff_target_reached"]),
                     "handoff_dismissed": bool(run["handoff_dismissed"]),
                     "first_post_setup_action": bool(run["first_post_setup_action"]),
                 }
@@ -8581,11 +8601,17 @@ ALTER TABLE messages ALTER COLUMN content DROP NOT NULL;
                     if total_runs
                     else 0.0
                 ),
+                "handoff_target_reach_rate": (
+                    float(handoff_target_reached_runs) / float(handoff_clicked_runs)
+                    if handoff_clicked_runs
+                    else 0.0
+                ),
                 "first_post_setup_action_rate": (
                     float(first_post_setup_action_runs) / float(total_runs)
                     if total_runs
                     else 0.0
                 ),
+                "handoff_target_reached_counts": handoff_target_reached_counts,
                 "detour_started_counts": detour_started_counts,
                 "detour_returned_counts": detour_returned_counts,
             },

--- a/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
+++ b/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py
@@ -144,6 +144,13 @@ def test_persona_setup_analytics_summary_returns_recent_runs_and_rates(
                 "action_target": "live",
             },
             {
+                "event_id": "run-1-handoff-target",
+                "event_key": "handoff_target_reached:commands.command_list",
+                "run_id": "setup-run-1",
+                "event_type": "handoff_target_reached",
+                "action_target": "commands.command_list",
+            },
+            {
                 "event_id": "run-1-first-action",
                 "event_key": "first_post_setup_action",
                 "run_id": "setup-run-1",
@@ -208,7 +215,9 @@ def test_persona_setup_analytics_summary_returns_recent_runs_and_rates(
             "live_session_completion_count": 0,
             "most_common_dropoff_step": "commands",
             "handoff_click_rate": 0.5,
+            "handoff_target_reach_rate": 1.0,
             "first_post_setup_action_rate": 0.5,
+            "handoff_target_reached_counts": {"commands.command_list": 1},
             "detour_started_counts": {"live_failure": 1},
             "detour_returned_counts": {"live_failure": 1},
         }
@@ -220,11 +229,13 @@ def test_persona_setup_analytics_summary_returns_recent_runs_and_rates(
         assert payload["recent_runs"][0]["completion_type"] is None
         assert payload["recent_runs"][0]["terminal_step"] == "commands"
         assert payload["recent_runs"][0]["handoff_clicked"] is False
+        assert payload["recent_runs"][0]["handoff_target_reached"] is False
         assert payload["recent_runs"][0]["handoff_dismissed"] is False
         assert payload["recent_runs"][0]["first_post_setup_action"] is False
         assert payload["recent_runs"][1]["completion_type"] == "dry_run"
         assert payload["recent_runs"][1]["terminal_step"] == "test"
         assert payload["recent_runs"][1]["handoff_clicked"] is True
+        assert payload["recent_runs"][1]["handoff_target_reached"] is True
         assert payload["recent_runs"][1]["handoff_dismissed"] is False
         assert payload["recent_runs"][1]["first_post_setup_action"] is True
         assert payload["recent_runs"][1]["completed_at"]


### PR DESCRIPTION
## Summary
- target post-setup handoff actions to exact Commands, Profiles, Connections, and Test Lab sections
- record handoff target reached analytics and surface a compact setup analytics card in Profiles
- add focused route/component/backend coverage for the new setup follow-through metrics

## Test Plan
- bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaSetupAnalyticsCard.test.tsx apps/packages/ui/src/components/PersonaGarden/__tests__/PersonaGardenPanels.i18n.test.tsx apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
- bunx vitest run apps/packages/ui/src/components/PersonaGarden/__tests__ apps/packages/ui/src/routes/__tests__/sidepanel-persona.test.tsx
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/persona-voice-assistant-builder/tldw_Server_API/tests/Persona/test_persona_setup_analytics_api.py -q