### PR TITLE
feat: add governance pack upgrade rebase workflow

### DIFF
--- a/.github/workflows/frontend-e2e-tiers.yml
+++ b/.github/workflows/frontend-e2e-tiers.yml
@@ -60,6 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Install FFmpeg and PortAudio (Linux)
+        uses: ./.github/actions/setup-ffmpeg
+        with:
+          install-portaudio: 'true'
+
       - name: Setup Python and backend
         uses: ./.github/actions/setup-python-deps
         with:
@@ -69,9 +74,6 @@ jobs:
             pyproject.toml
             uv.lock
           extras: dev
-
-      - name: Install FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
 
       - name: Start backend server
         run: |
@@ -148,6 +150,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Install FFmpeg and PortAudio (Linux)
+        uses: ./.github/actions/setup-ffmpeg
+        with:
+          install-portaudio: 'true'
+
       - name: Setup Python and backend
         uses: ./.github/actions/setup-python-deps
         with:
@@ -157,9 +164,6 @@ jobs:
             pyproject.toml
             uv.lock
           extras: dev
-
-      - name: Install FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
 
       - name: Start backend server
         run: |
@@ -228,6 +232,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
+      - name: Install FFmpeg and PortAudio (Linux)
+        uses: ./.github/actions/setup-ffmpeg
+        with:
+          install-portaudio: 'true'
+
       - name: Setup Python and backend
         uses: ./.github/actions/setup-python-deps
         with:
@@ -237,9 +246,6 @@ jobs:
             pyproject.toml
             uv.lock
           extras: dev
-
-      - name: Install FFmpeg
-        uses: ./.github/actions/setup-ffmpeg
 
       - name: Start backend server
         run: |

--- a/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/GovernancePacksTab.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useMemo, useState } from "react"
-import { Alert, Button, Card, Descriptions, Empty, Input, List, Space, Tag, Typography } from "antd"
+import { Alert, Button, Card, Descriptions, Empty, Input, List, Modal, Space, Tag, Typography } from "antd"
 
 import {
   dryRunGovernancePack,
+  dryRunGovernancePackUpgrade,
+  executeGovernancePackUpgrade,
   getGovernancePackDetail,
   importGovernancePack,
+  listGovernancePackUpgradeHistory,
   listGovernancePacks,
   type McpHubGovernancePackDetail,
   type McpHubGovernancePackDocument,
   type McpHubGovernancePackDryRunReport,
+  type McpHubGovernancePackUpgradeHistoryEntry,
+  type McpHubGovernancePackUpgradeObjectDiff,
+  type McpHubGovernancePackUpgradePlan,
   type McpHubGovernancePackSummary
 } from "@/services/tldw/mcp-hub"
 
@@ -44,16 +50,32 @@ const describeItems = (values: string[], emptyLabel: string) => {
   )
 }
 
+const getInstallStateTag = (pack: Pick<McpHubGovernancePackSummary, "is_active_install">) =>
+  pack.is_active_install ? (
+    <Tag color="green">Active install</Tag>
+  ) : (
+    <Tag color="default">Inactive install</Tag>
+  )
+
+const describeUpgradeDiffs = (diffs: McpHubGovernancePackUpgradeObjectDiff[]) =>
+  diffs.map((diff) => `${diff.object_type}:${diff.source_object_id}`)
+
 export const GovernancePacksTab = () => {
   const [packs, setPacks] = useState<McpHubGovernancePackSummary[]>([])
   const [selectedPackId, setSelectedPackId] = useState<number | null>(null)
   const [selectedPack, setSelectedPack] = useState<McpHubGovernancePackDetail | null>(null)
+  const [upgradeHistory, setUpgradeHistory] = useState<McpHubGovernancePackUpgradeHistoryEntry[]>([])
   const [report, setReport] = useState<McpHubGovernancePackDryRunReport | null>(null)
+  const [upgradePlan, setUpgradePlan] = useState<McpHubGovernancePackUpgradePlan | null>(null)
   const [packJson, setPackJson] = useState(DEFAULT_PACK_JSON)
   const [loadingInventory, setLoadingInventory] = useState(false)
   const [loadingDetail, setLoadingDetail] = useState(false)
+  const [loadingHistory, setLoadingHistory] = useState(false)
   const [previewing, setPreviewing] = useState(false)
+  const [previewingUpgrade, setPreviewingUpgrade] = useState(false)
   const [importing, setImporting] = useState(false)
+  const [executingUpgrade, setExecutingUpgrade] = useState(false)
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
 
@@ -89,6 +111,7 @@ export const GovernancePacksTab = () => {
       setPacks([])
       setSelectedPackId(null)
       setSelectedPack(null)
+      setUpgradeHistory([])
       setErrorMessage("Failed to load governance packs.")
     } finally {
       setLoadingInventory(false)
@@ -104,24 +127,32 @@ export const GovernancePacksTab = () => {
     const loadDetail = async () => {
       if (!selectedPackId) {
         setSelectedPack(null)
+        setUpgradeHistory([])
         setErrorMessage((current) => (current === DETAIL_LOAD_ERROR ? null : current))
         return
       }
       setLoadingDetail(true)
+      setLoadingHistory(true)
       try {
-        const detail = await getGovernancePackDetail(selectedPackId)
+        const [detail, history] = await Promise.all([
+          getGovernancePackDetail(selectedPackId),
+          listGovernancePackUpgradeHistory(selectedPackId)
+        ])
         if (!cancelled) {
           setSelectedPack(detail)
+          setUpgradeHistory(Array.isArray(history) ? history : [])
           setErrorMessage((current) => (current === DETAIL_LOAD_ERROR ? null : current))
         }
       } catch {
         if (!cancelled) {
           setSelectedPack(null)
+          setUpgradeHistory([])
           setErrorMessage(DETAIL_LOAD_ERROR)
         }
       } finally {
         if (!cancelled) {
           setLoadingDetail(false)
+          setLoadingHistory(false)
         }
       }
     }
@@ -178,7 +209,88 @@ export const GovernancePacksTab = () => {
     }
   }
 
+  const handlePreviewUpgrade = async () => {
+    setSuccessMessage(null)
+    if (!selectedPackId) {
+      setErrorMessage("Select an installed governance pack before previewing an upgrade.")
+      setUpgradePlan(null)
+      return
+    }
+    if (!parsedPack) {
+      setErrorMessage("Governance pack JSON must be valid JSON.")
+      setUpgradePlan(null)
+      return
+    }
+    setUpgradeModalOpen(true)
+    setPreviewingUpgrade(true)
+    setErrorMessage(null)
+    try {
+      const response = await dryRunGovernancePackUpgrade({
+        source_governance_pack_id: selectedPackId,
+        owner_scope_type: "user",
+        pack: parsedPack
+      })
+      setUpgradePlan(response.plan)
+    } catch {
+      setUpgradePlan(null)
+      setUpgradeModalOpen(false)
+      setErrorMessage("Failed to preview governance pack upgrade.")
+    } finally {
+      setPreviewingUpgrade(false)
+    }
+  }
+
+  const handleExecuteUpgrade = async () => {
+    setSuccessMessage(null)
+    if (!selectedPackId || !parsedPack || !upgradePlan) {
+      return
+    }
+    setExecutingUpgrade(true)
+    setErrorMessage(null)
+    try {
+      const response = await executeGovernancePackUpgrade({
+        source_governance_pack_id: selectedPackId,
+        owner_scope_type: "user",
+        planner_inputs_fingerprint: upgradePlan.planner_inputs_fingerprint,
+        adapter_state_fingerprint: upgradePlan.adapter_state_fingerprint,
+        pack: parsedPack
+      })
+      setUpgradeModalOpen(false)
+      setUpgradePlan(null)
+      setSelectedPackId(response.target_governance_pack_id)
+      setSuccessMessage(
+        `Executed upgrade ${response.from_pack_version} -> ${response.to_pack_version}.`
+      )
+      await loadInventory()
+    } catch {
+      setErrorMessage("Failed to execute governance pack upgrade.")
+    } finally {
+      setExecutingUpgrade(false)
+    }
+  }
+
   const canImport = !importing && report?.verdict === "importable" && Boolean(parsedPack)
+  const addedDiffs = useMemo(
+    () => (upgradePlan?.object_diff ?? []).filter((diff) => diff.change_type === "added"),
+    [upgradePlan]
+  )
+  const modifiedDiffs = useMemo(
+    () => (upgradePlan?.object_diff ?? []).filter((diff) => diff.change_type === "modified"),
+    [upgradePlan]
+  )
+  const removedDiffs = useMemo(
+    () => (upgradePlan?.object_diff ?? []).filter((diff) => diff.change_type === "removed"),
+    [upgradePlan]
+  )
+  const blockingConflicts = useMemo(
+    () => [...(upgradePlan?.structural_conflicts ?? []), ...(upgradePlan?.behavioral_conflicts ?? [])],
+    [upgradePlan]
+  )
+  const canExecuteUpgrade =
+    Boolean(parsedPack) &&
+    Boolean(selectedPackId) &&
+    Boolean(upgradePlan?.upgradeable) &&
+    !executingUpgrade
 
   return (
     <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
@@ -208,6 +320,7 @@ export const GovernancePacksTab = () => {
                     <Typography.Text strong>{pack.title}</Typography.Text>
                     <Tag>{pack.owner_scope_type}</Tag>
                     <Tag color="blue">{`${pack.pack_id}@${pack.pack_version}`}</Tag>
+                    {getInstallStateTag(pack)}
                   </Space>
                   {pack.description ? (
                     <Typography.Text type="secondary">{pack.description}</Typography.Text>
@@ -220,26 +333,58 @@ export const GovernancePacksTab = () => {
 
         <Card
           title="Pack Details"
-          loading={loadingDetail}
+          loading={loadingDetail || loadingHistory}
           style={{ flex: 1, minWidth: 320 }}
         >
           {selectedPack ? (
-            <Descriptions column={1} size="small">
-              <Descriptions.Item label="Pack">
-                {`${selectedPack.pack_id}@${selectedPack.pack_version}`}
-              </Descriptions.Item>
-              <Descriptions.Item label="Digest">
-                <Typography.Text code>{selectedPack.bundle_digest}</Typography.Text>
-              </Descriptions.Item>
-              <Descriptions.Item label="Imported Objects">
-                {describeItems(
-                  selectedPack.imported_objects.map(
-                    (item) => `${item.object_type}:${item.source_object_id}`
-                  ),
-                  "No imported objects recorded."
-                )}
-              </Descriptions.Item>
-            </Descriptions>
+            <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+              <Descriptions column={1} size="small">
+                <Descriptions.Item label="Pack">
+                  {`${selectedPack.pack_id}@${selectedPack.pack_version}`}
+                </Descriptions.Item>
+                <Descriptions.Item label="Install state">
+                  {getInstallStateTag(selectedPack)}
+                </Descriptions.Item>
+                <Descriptions.Item label="Digest">
+                  <Typography.Text code>{selectedPack.bundle_digest}</Typography.Text>
+                </Descriptions.Item>
+                <Descriptions.Item label="Imported Objects">
+                  {describeItems(
+                    selectedPack.imported_objects.map(
+                      (item) => `${item.object_type}:${item.source_object_id}`
+                    ),
+                    "No imported objects recorded."
+                  )}
+                </Descriptions.Item>
+              </Descriptions>
+
+              <div>
+                <Typography.Title level={5} style={{ marginTop: 0 }}>
+                  Upgrade History
+                </Typography.Title>
+                <List
+                  size="small"
+                  bordered
+                  dataSource={upgradeHistory}
+                  locale={{ emptyText: <Empty description="No upgrade history recorded." /> }}
+                  renderItem={(entry) => (
+                    <List.Item>
+                      <Space orientation="vertical" size={2} style={{ width: "100%" }}>
+                        <Space wrap>
+                          <Typography.Text strong>{`${entry.from_pack_version} -> ${entry.to_pack_version}`}</Typography.Text>
+                          <Tag color={entry.status === "executed" ? "green" : "default"}>
+                            {entry.status}
+                          </Tag>
+                        </Space>
+                        <Typography.Text type="secondary">
+                          {`Object diffs: ${String(entry.plan_summary.object_diff_count ?? 0)}, dependency impacts: ${String(entry.plan_summary.dependency_impact_count ?? 0)}`}
+                        </Typography.Text>
+                      </Space>
+                    </List.Item>
+                  )}
+                />
+              </div>
+            </Space>
           ) : (
             <Empty description="Select a governance pack to inspect its imported objects." />
           )}
@@ -262,6 +407,13 @@ export const GovernancePacksTab = () => {
           <Space>
             <Button type="primary" onClick={() => void handlePreview()} loading={previewing}>
               Preview Pack
+            </Button>
+            <Button
+              onClick={() => void handlePreviewUpgrade()}
+              disabled={!selectedPackId || !parsedPack}
+              loading={previewingUpgrade}
+            >
+              Preview Upgrade
             </Button>
             <Button onClick={() => void handleImport()} disabled={!canImport} loading={importing}>
               Import Pack
@@ -291,6 +443,88 @@ export const GovernancePacksTab = () => {
           ) : null}
         </Space>
       </Card>
+
+      <Modal
+        title="Governance Pack Upgrade"
+        open={upgradeModalOpen}
+        onCancel={() => {
+          setUpgradeModalOpen(false)
+          setUpgradePlan(null)
+        }}
+        onOk={() => void handleExecuteUpgrade()}
+        okText="Execute Upgrade"
+        okButtonProps={{ disabled: !canExecuteUpgrade }}
+        confirmLoading={executingUpgrade}
+      >
+        {upgradePlan ? (
+          <Space orientation="vertical" size="middle" style={{ width: "100%" }}>
+            <Descriptions bordered column={1} size="small">
+              <Descriptions.Item label="Source pack">
+                {String(upgradePlan.source_manifest.pack_version ?? "")}
+              </Descriptions.Item>
+              <Descriptions.Item label="Target pack">
+                {String(upgradePlan.target_manifest.pack_version ?? "")}
+              </Descriptions.Item>
+              <Descriptions.Item label="Upgradeable">
+                <Tag color={upgradePlan.upgradeable ? "green" : "red"}>
+                  {upgradePlan.upgradeable ? "Ready to execute" : "Blocked"}
+                </Tag>
+              </Descriptions.Item>
+            </Descriptions>
+
+            {modifiedDiffs.length ? (
+              <div>
+                <Typography.Title level={5}>Modified objects</Typography.Title>
+                {describeItems(describeUpgradeDiffs(modifiedDiffs), "None")}
+              </div>
+            ) : null}
+            {addedDiffs.length ? (
+              <div>
+                <Typography.Title level={5}>Added objects</Typography.Title>
+                {describeItems(describeUpgradeDiffs(addedDiffs), "None")}
+              </div>
+            ) : null}
+            {removedDiffs.length ? (
+              <div>
+                <Typography.Title level={5}>Removed objects</Typography.Title>
+                {describeItems(describeUpgradeDiffs(removedDiffs), "None")}
+              </div>
+            ) : null}
+            {!upgradePlan.object_diff.length ? (
+              <Typography.Text type="secondary">No runtime object changes detected.</Typography.Text>
+            ) : null}
+
+            {blockingConflicts.length ? (
+              <div>
+                <Typography.Title level={5}>Blocking conflicts</Typography.Title>
+                {describeItems(blockingConflicts, "None")}
+              </div>
+            ) : null}
+            {upgradePlan.warnings.length ? (
+              <div>
+                <Typography.Title level={5}>Warnings</Typography.Title>
+                {describeItems(upgradePlan.warnings, "None")}
+              </div>
+            ) : null}
+            {upgradePlan.dependency_impact.length ? (
+              <div>
+                <Typography.Title level={5}>Dependency impacts</Typography.Title>
+                {describeItems(
+                  upgradePlan.dependency_impact.map(
+                    (impact) =>
+                      `${impact.dependent_type}:${impact.dependent_id} via ${impact.reference_field}`
+                  ),
+                  "None"
+                )}
+              </div>
+            ) : null}
+          </Space>
+        ) : (
+          <Typography.Text type="secondary">
+            {previewingUpgrade ? "Loading upgrade preview..." : "Run an upgrade dry-run to inspect the plan."}
+          </Typography.Text>
+        )}
+      </Modal>
     </Space>
   )
 }

--- a/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
+++ b/apps/packages/ui/src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
@@ -7,14 +7,20 @@ const mocks = vi.hoisted(() => ({
   listGovernancePacks: vi.fn(),
   getGovernancePackDetail: vi.fn(),
   dryRunGovernancePack: vi.fn(),
-  importGovernancePack: vi.fn()
+  importGovernancePack: vi.fn(),
+  dryRunGovernancePackUpgrade: vi.fn(),
+  executeGovernancePackUpgrade: vi.fn(),
+  listGovernancePackUpgradeHistory: vi.fn()
 }))
 
 vi.mock("@/services/tldw/mcp-hub", () => ({
   listGovernancePacks: (...args: unknown[]) => mocks.listGovernancePacks(...args),
   getGovernancePackDetail: (...args: unknown[]) => mocks.getGovernancePackDetail(...args),
   dryRunGovernancePack: (...args: unknown[]) => mocks.dryRunGovernancePack(...args),
-  importGovernancePack: (...args: unknown[]) => mocks.importGovernancePack(...args)
+  importGovernancePack: (...args: unknown[]) => mocks.importGovernancePack(...args),
+  dryRunGovernancePackUpgrade: (...args: unknown[]) => mocks.dryRunGovernancePackUpgrade(...args),
+  executeGovernancePackUpgrade: (...args: unknown[]) => mocks.executeGovernancePackUpgrade(...args),
+  listGovernancePackUpgradeHistory: (...args: unknown[]) => mocks.listGovernancePackUpgradeHistory(...args)
 }))
 
 import { GovernancePacksTab } from "../GovernancePacksTab"
@@ -32,9 +38,27 @@ describe("GovernancePacksTab", () => {
         owner_scope_type: "user",
         owner_scope_id: 7,
         bundle_digest: "a".repeat(64),
+        is_active_install: true,
         manifest: {
           pack_id: "researcher-pack",
           pack_version: "1.0.0",
+          title: "Researcher Pack"
+        }
+      },
+      {
+        id: 80,
+        pack_id: "researcher-pack",
+        pack_version: "0.9.0",
+        title: "Researcher Pack",
+        description: "Superseded pack",
+        owner_scope_type: "user",
+        owner_scope_id: 7,
+        bundle_digest: "b".repeat(64),
+        is_active_install: false,
+        superseded_by_governance_pack_id: 81,
+        manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "0.9.0",
           title: "Researcher Pack"
         }
       }
@@ -48,6 +72,7 @@ describe("GovernancePacksTab", () => {
       owner_scope_type: "user",
       owner_scope_id: 7,
       bundle_digest: "a".repeat(64),
+      is_active_install: true,
       manifest: {
         pack_id: "researcher-pack",
         pack_version: "1.0.0",
@@ -65,6 +90,76 @@ describe("GovernancePacksTab", () => {
           source_object_id: "researcher.profile"
         }
       ]
+    })
+    mocks.listGovernancePackUpgradeHistory.mockResolvedValue([
+      {
+        id: 12,
+        pack_id: "researcher-pack",
+        owner_scope_type: "user",
+        owner_scope_id: 7,
+        from_governance_pack_id: 80,
+        to_governance_pack_id: 81,
+        from_pack_version: "0.9.0",
+        to_pack_version: "1.0.0",
+        status: "executed",
+        plan_summary: {
+          object_diff_count: 2,
+          dependency_impact_count: 1
+        },
+        accepted_resolutions: {},
+        planned_at: "2026-03-14T00:00:00Z",
+        executed_at: "2026-03-14T00:05:00Z"
+      }
+    ])
+    mocks.dryRunGovernancePackUpgrade.mockResolvedValue({
+      plan: {
+        source_governance_pack_id: 81,
+        source_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack"
+        },
+        target_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.1.0",
+          title: "Researcher Pack"
+        },
+        object_diff: [
+          {
+            object_type: "permission_profile",
+            source_object_id: "researcher.profile",
+            change_type: "modified",
+            previous_digest: "1".repeat(64),
+            next_digest: "2".repeat(64)
+          }
+        ],
+        dependency_impact: [],
+        structural_conflicts: [],
+        behavioral_conflicts: [],
+        warnings: [],
+        planner_inputs_fingerprint: "plan-fingerprint",
+        adapter_state_fingerprint: "adapter-fingerprint",
+        upgradeable: true
+      }
+    })
+    mocks.executeGovernancePackUpgrade.mockResolvedValue({
+      upgrade_id: 13,
+      source_governance_pack_id: 81,
+      target_governance_pack_id: 82,
+      from_pack_version: "1.0.0",
+      to_pack_version: "1.1.0",
+      planner_inputs_fingerprint: "plan-fingerprint",
+      adapter_state_fingerprint: "adapter-fingerprint",
+      imported_object_ids: {
+        approval_policies: [31],
+        permission_profiles: [41],
+        policy_assignments: [51]
+      },
+      imported_object_counts: {
+        approval_policies: 1,
+        permission_profiles: 1,
+        policy_assignments: 1
+      }
     })
     mocks.dryRunGovernancePack.mockResolvedValue({
       report: {
@@ -111,7 +206,7 @@ describe("GovernancePacksTab", () => {
     const user = userEvent.setup()
     render(<GovernancePacksTab />)
 
-    expect(await screen.findByText("Researcher Pack")).toBeTruthy()
+    expect((await screen.findAllByText("Researcher Pack")).length).toBeGreaterThan(0)
 
     fireEvent.change(screen.getByLabelText(/governance pack json/i), {
       target: {
@@ -153,7 +248,7 @@ describe("GovernancePacksTab", () => {
 
     render(<GovernancePacksTab />)
 
-    expect(await screen.findByText("Researcher Pack")).toBeTruthy()
+    expect((await screen.findAllByText("Researcher Pack")).length).toBeGreaterThan(0)
     expect(await screen.findByText("Failed to load pack details.")).toBeTruthy()
     expect(screen.getByText("Installed Packs")).toBeTruthy()
   })
@@ -165,5 +260,100 @@ describe("GovernancePacksTab", () => {
 
     expect(await screen.findByText("No governance packs imported yet")).toBeTruthy()
     expect(screen.getByText("Installed Packs")).toBeTruthy()
+  })
+
+  it("renders install state badges and upgrade history for the selected pack", async () => {
+    render(<GovernancePacksTab />)
+
+    expect(await screen.findByText("Active install")).toBeTruthy()
+    expect(await screen.findByText("Inactive install")).toBeTruthy()
+    expect(await screen.findByText("Upgrade History")).toBeTruthy()
+    expect(screen.getByText("0.9.0 -> 1.0.0")).toBeTruthy()
+  })
+
+  it("opens the upgrade modal and renders dry-run object diffs", async () => {
+    const user = userEvent.setup()
+    render(<GovernancePacksTab />)
+
+    expect((await screen.findAllByText("Researcher Pack")).length).toBeGreaterThan(0)
+    fireEvent.change(screen.getByLabelText(/governance pack json/i), {
+      target: {
+        value: JSON.stringify({
+          manifest: {
+            pack_id: "researcher-pack",
+            pack_version: "1.1.0",
+            pack_schema_version: 1,
+            capability_taxonomy_version: 1,
+            adapter_contract_version: 1,
+            title: "Researcher Pack"
+          },
+          profiles: [],
+          approvals: [],
+          personas: [],
+          assignments: []
+        })
+      }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview upgrade/i }))
+
+    expect(await screen.findByRole("dialog")).toBeTruthy()
+    expect(await screen.findByText("Modified objects")).toBeTruthy()
+    expect((await screen.findAllByText("permission_profile:researcher.profile")).length).toBeGreaterThan(0)
+    expect(screen.getByRole("button", { name: /execute upgrade/i })).toBeEnabled()
+  })
+
+  it("blocks execute upgrade when the dry-run reports conflicts", async () => {
+    mocks.dryRunGovernancePackUpgrade.mockResolvedValueOnce({
+      plan: {
+        source_governance_pack_id: 81,
+        source_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.0.0",
+          title: "Researcher Pack"
+        },
+        target_manifest: {
+          pack_id: "researcher-pack",
+          pack_version: "1.1.0",
+          title: "Researcher Pack"
+        },
+        object_diff: [],
+        dependency_impact: [],
+        structural_conflicts: [],
+        behavioral_conflicts: ["permission_profile:researcher.profile changed"],
+        warnings: [],
+        planner_inputs_fingerprint: "plan-fingerprint",
+        adapter_state_fingerprint: "adapter-fingerprint",
+        upgradeable: false
+      }
+    })
+    const user = userEvent.setup()
+    render(<GovernancePacksTab />)
+
+    expect((await screen.findAllByText("Researcher Pack")).length).toBeGreaterThan(0)
+    fireEvent.change(screen.getByLabelText(/governance pack json/i), {
+      target: {
+        value: JSON.stringify({
+          manifest: {
+            pack_id: "researcher-pack",
+            pack_version: "1.1.0",
+            pack_schema_version: 1,
+            capability_taxonomy_version: 1,
+            adapter_contract_version: 1,
+            title: "Researcher Pack"
+          },
+          profiles: [],
+          approvals: [],
+          personas: [],
+          assignments: []
+        })
+      }
+    })
+
+    await user.click(screen.getByRole("button", { name: /preview upgrade/i }))
+
+    expect(await screen.findByText("Blocking conflicts")).toBeTruthy()
+    expect(screen.getByText("permission_profile:researcher.profile changed")).toBeTruthy()
+    expect(screen.getByRole("button", { name: /execute upgrade/i })).toBeDisabled()
   })
 })

--- a/apps/packages/ui/src/services/tldw/mcp-hub.ts
+++ b/apps/packages/ui/src/services/tldw/mcp-hub.ts
@@ -774,6 +774,77 @@ export type McpHubGovernancePackDryRunResponse = {
   report: McpHubGovernancePackDryRunReport
 }
 
+export type McpHubGovernancePackUpgradeObjectDiff = {
+  object_type: string
+  source_object_id: string
+  change_type: string
+  previous_digest?: string | null
+  next_digest?: string | null
+}
+
+export type McpHubGovernancePackUpgradeDependencyImpact = {
+  object_type: string
+  source_object_id: string
+  change_type: string
+  impact: string
+  dependent_type: string
+  dependent_id: number
+  reference_field: string
+  target_type?: string | null
+  target_id?: string | null
+}
+
+export type McpHubGovernancePackUpgradePlan = {
+  source_governance_pack_id: number
+  source_manifest: Record<string, unknown>
+  target_manifest: Record<string, unknown>
+  object_diff: McpHubGovernancePackUpgradeObjectDiff[]
+  dependency_impact: McpHubGovernancePackUpgradeDependencyImpact[]
+  structural_conflicts: string[]
+  behavioral_conflicts: string[]
+  warnings: string[]
+  planner_inputs_fingerprint: string
+  adapter_state_fingerprint: string
+  upgradeable: boolean
+}
+
+export type McpHubGovernancePackUpgradeDryRunResponse = {
+  plan: McpHubGovernancePackUpgradePlan
+}
+
+export type McpHubGovernancePackUpgradeExecutionResponse = {
+  upgrade_id: number
+  source_governance_pack_id: number
+  target_governance_pack_id: number
+  from_pack_version: string
+  to_pack_version: string
+  planner_inputs_fingerprint: string
+  adapter_state_fingerprint: string
+  imported_object_ids: Record<string, number[]>
+  imported_object_counts: Record<string, number>
+}
+
+export type McpHubGovernancePackUpgradeHistoryEntry = {
+  id: number
+  pack_id: string
+  owner_scope_type: McpHubScopeType
+  owner_scope_id?: number | null
+  from_governance_pack_id: number
+  to_governance_pack_id: number
+  from_pack_version: string
+  to_pack_version: string
+  status: string
+  planned_by?: number | null
+  executed_by?: number | null
+  planner_inputs_fingerprint?: string | null
+  adapter_state_fingerprint?: string | null
+  plan_summary: Record<string, unknown>
+  accepted_resolutions: Record<string, unknown>
+  failure_summary?: string | null
+  planned_at?: string | null
+  executed_at?: string | null
+}
+
 export type McpHubGovernancePackObjectProvenance = {
   object_type: string
   object_id: string
@@ -790,6 +861,9 @@ export type McpHubGovernancePackSummary = {
   owner_scope_id?: number | null
   bundle_digest: string
   manifest: Record<string, unknown>
+  is_active_install: boolean
+  superseded_by_governance_pack_id?: number | null
+  installed_from_upgrade_id?: number | null
   created_by?: number | null
   updated_by?: number | null
   created_at?: string | null
@@ -1584,6 +1658,19 @@ export const dryRunGovernancePack = async (payload: {
   })
 }
 
+export const dryRunGovernancePackUpgrade = async (payload: {
+  source_governance_pack_id: number
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  pack: McpHubGovernancePackDocument
+}): Promise<McpHubGovernancePackUpgradeDryRunResponse> => {
+  return await bgRequestClient<McpHubGovernancePackUpgradeDryRunResponse>({
+    path: "/api/v1/mcp/hub/governance-packs/dry-run-upgrade",
+    method: "POST",
+    body: payload
+  })
+}
+
 export const importGovernancePack = async (payload: {
   owner_scope_type?: McpHubScopeType
   owner_scope_id?: number | null
@@ -1593,5 +1680,29 @@ export const importGovernancePack = async (payload: {
     path: "/api/v1/mcp/hub/governance-packs/import",
     method: "POST",
     body: payload
+  })
+}
+
+export const executeGovernancePackUpgrade = async (payload: {
+  source_governance_pack_id: number
+  owner_scope_type?: McpHubScopeType
+  owner_scope_id?: number | null
+  planner_inputs_fingerprint: string
+  adapter_state_fingerprint: string
+  pack: McpHubGovernancePackDocument
+}): Promise<McpHubGovernancePackUpgradeExecutionResponse> => {
+  return await bgRequestClient<McpHubGovernancePackUpgradeExecutionResponse>({
+    path: "/api/v1/mcp/hub/governance-packs/execute-upgrade",
+    method: "POST",
+    body: payload
+  })
+}
+
+export const listGovernancePackUpgradeHistory = async (
+  governancePackId: number
+): Promise<McpHubGovernancePackUpgradeHistoryEntry[]> => {
+  return await bgRequestClient<McpHubGovernancePackUpgradeHistoryEntry[]>({
+    path: `/api/v1/mcp/hub/governance-packs/${governancePackId}/upgrade-history`,
+    method: "GET"
   })
 }

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -43,6 +43,11 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     GovernancePackDryRunResponse,
     GovernancePackImportRequest,
     GovernancePackImportResponse,
+    GovernancePackUpgradeDryRunRequest,
+    GovernancePackUpgradeDryRunResponse,
+    GovernancePackUpgradeExecuteRequest,
+    GovernancePackUpgradeExecutionResponse,
+    GovernancePackUpgradeHistoryEntryResponse,
     GovernancePackSummaryResponse,
     GovernanceAuditFindingListResponse,
     MCPHubDeleteResponse,
@@ -85,6 +90,8 @@ from tldw_Server_API.app.services.mcp_hub_capability_adapter_service import (
 )
 from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
     GovernancePackAlreadyExistsError,
+    GovernancePackUpgradeConflictError,
+    GovernancePackUpgradeStaleError,
     McpHubGovernancePackService,
 )
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
@@ -1471,6 +1478,43 @@ async def dry_run_governance_pack(
     return GovernancePackDryRunResponse.model_validate({"report": report_payload})
 
 
+@router.post("/governance-packs/dry-run-upgrade", response_model=GovernancePackUpgradeDryRunResponse)
+async def dry_run_governance_pack_upgrade(
+    payload: GovernancePackUpgradeDryRunRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> GovernancePackUpgradeDryRunResponse:
+    """Validate a governance-pack upgrade plan for an installed pack in the same scope."""
+    _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_governance_pack_mutation_scope(
+        principal=principal,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    pack_document = payload.pack.model_dump()
+    pack_id, pack_version = _governance_pack_manifest_summary(pack_document)
+    try:
+        plan = await svc.dry_run_upgrade_document(
+            source_governance_pack_id=payload.source_governance_pack_id,
+            document=pack_document,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
+        )
+    except ValueError as exc:
+        logger.warning(
+            "Governance pack upgrade dry-run rejected for source {} target {}@{} in scope {}:{}: {}",
+            payload.source_governance_pack_id,
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    plan_payload = plan.model_dump() if hasattr(plan, "model_dump") else dict(plan)
+    return GovernancePackUpgradeDryRunResponse.model_validate({"plan": plan_payload})
+
+
 @router.post("/governance-packs/import", response_model=GovernancePackImportResponse, status_code=201)
 async def import_governance_pack(
     payload: GovernancePackImportRequest,
@@ -1517,6 +1561,58 @@ async def import_governance_pack(
     return GovernancePackImportResponse.model_validate(result)
 
 
+@router.post("/governance-packs/execute-upgrade", response_model=GovernancePackUpgradeExecutionResponse)
+async def execute_governance_pack_upgrade(
+    payload: GovernancePackUpgradeExecuteRequest,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> GovernancePackUpgradeExecutionResponse:
+    """Execute a previously dry-run governance-pack upgrade when the planner state is unchanged."""
+    _require_mutation_permission(principal)
+    resolved_scope_type, resolved_scope_id = _resolve_governance_pack_mutation_scope(
+        principal=principal,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+    )
+    pack_document = payload.pack.model_dump()
+    _require_grant_authority(principal, _governance_pack_grant_document(pack_document))
+    pack_id, pack_version = _governance_pack_manifest_summary(pack_document)
+    try:
+        result = await svc.execute_upgrade_document(
+            source_governance_pack_id=payload.source_governance_pack_id,
+            document=pack_document,
+            owner_scope_type=resolved_scope_type,
+            owner_scope_id=resolved_scope_id,
+            actor_id=principal.user_id,
+            planner_inputs_fingerprint=payload.planner_inputs_fingerprint,
+            adapter_state_fingerprint=payload.adapter_state_fingerprint,
+        )
+    except (GovernancePackAlreadyExistsError, GovernancePackUpgradeConflictError, GovernancePackUpgradeStaleError) as exc:
+        logger.warning(
+            "Governance pack upgrade execute conflict for source {} target {}@{} in scope {}:{}: {}",
+            payload.source_governance_pack_id,
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        logger.warning(
+            "Governance pack upgrade execute rejected for source {} target {}@{} in scope {}:{}: {}",
+            payload.source_governance_pack_id,
+            pack_id,
+            pack_version,
+            resolved_scope_type,
+            resolved_scope_id,
+            exc,
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    result_payload = result.model_dump() if hasattr(result, "model_dump") else dict(result)
+    return GovernancePackUpgradeExecutionResponse.model_validate(result_payload)
+
+
 @router.get("/governance-packs", response_model=list[GovernancePackSummaryResponse])
 async def list_governance_packs(
     owner_scope_type: str | None = None,
@@ -1540,6 +1636,28 @@ async def list_governance_packs(
         )
     rows = _dedupe_rows(rows)
     return [GovernancePackSummaryResponse.model_validate(row) for row in rows]
+
+
+@router.get(
+    "/governance-packs/{governance_pack_id}/upgrade-history",
+    response_model=list[GovernancePackUpgradeHistoryEntryResponse],
+)
+async def list_governance_pack_upgrade_history(
+    governance_pack_id: int,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubGovernancePackService = Depends(get_mcp_hub_governance_pack_service),
+) -> list[GovernancePackUpgradeHistoryEntryResponse]:
+    """List the recorded upgrade lineage for the governance-pack identity installed in this scope."""
+    row = await svc.get_governance_pack_detail(governance_pack_id)
+    if not row:
+        raise HTTPException(status_code=404, detail=f"mcp_governance_pack '{governance_pack_id}' was not found")
+    _assert_principal_can_access_scope(
+        principal,
+        owner_scope_type=str(row.get("owner_scope_type") or "global"),
+        owner_scope_id=row.get("owner_scope_id"),
+    )
+    history = await svc.list_governance_pack_upgrade_history(governance_pack_id)
+    return [GovernancePackUpgradeHistoryEntryResponse.model_validate(item) for item in history]
 
 
 @router.get("/governance-packs/{governance_pack_id}", response_model=GovernancePackDetailResponse)

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -828,6 +828,48 @@ class GovernancePackUpgradeDryRunResponse(BaseModel):
     plan: GovernancePackUpgradePlanResponse
 
 
+class GovernancePackUpgradeExecuteRequest(BaseModel):
+    source_governance_pack_id: int = Field(..., ge=1)
+    owner_scope_type: ScopeType = Field(default="user")
+    owner_scope_id: int | None = None
+    planner_inputs_fingerprint: str = Field(..., min_length=1)
+    adapter_state_fingerprint: str = Field(..., min_length=1)
+    pack: GovernancePackDocumentRequest
+
+
+class GovernancePackUpgradeExecutionResponse(BaseModel):
+    upgrade_id: int
+    source_governance_pack_id: int
+    target_governance_pack_id: int
+    from_pack_version: str
+    to_pack_version: str
+    planner_inputs_fingerprint: str
+    adapter_state_fingerprint: str
+    imported_object_ids: dict[str, list[int]] = Field(default_factory=dict)
+    imported_object_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class GovernancePackUpgradeHistoryEntryResponse(BaseModel):
+    id: int
+    pack_id: str
+    owner_scope_type: ScopeType
+    owner_scope_id: int | None = None
+    from_governance_pack_id: int
+    to_governance_pack_id: int
+    from_pack_version: str
+    to_pack_version: str
+    status: str
+    planned_by: int | None = None
+    executed_by: int | None = None
+    planner_inputs_fingerprint: str | None = None
+    adapter_state_fingerprint: str | None = None
+    plan_summary: dict[str, Any] = Field(default_factory=dict)
+    accepted_resolutions: dict[str, Any] = Field(default_factory=dict)
+    failure_summary: str | None = None
+    planned_at: datetime | str | None = None
+    executed_at: datetime | str | None = None
+
+
 class GovernancePackObjectProvenanceResponse(BaseModel):
     object_type: str
     object_id: str
@@ -844,6 +886,9 @@ class GovernancePackSummaryResponse(BaseModel):
     owner_scope_id: int | None = None
     bundle_digest: str
     manifest: dict[str, Any] = Field(default_factory=dict)
+    is_active_install: bool = True
+    superseded_by_governance_pack_id: int | None = None
+    installed_from_upgrade_id: int | None = None
     created_by: int | None = None
     updated_by: int | None = None
     created_at: datetime | str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -760,6 +760,8 @@ class GovernancePackImportRequest(BaseModel):
 
 
 class GovernancePackUpgradeDryRunRequest(BaseModel):
+    """Request body for governance-pack upgrade planning."""
+
     source_governance_pack_id: int = Field(..., ge=1)
     owner_scope_type: ScopeType = Field(default="user")
     owner_scope_id: int | None = None
@@ -767,6 +769,8 @@ class GovernancePackUpgradeDryRunRequest(BaseModel):
 
 
 class GovernancePackReportManifestResponse(BaseModel):
+    """Manifest summary returned in governance-pack dry-run reports."""
+
     pack_id: str
     pack_version: str
     title: str
@@ -774,6 +778,8 @@ class GovernancePackReportManifestResponse(BaseModel):
 
 
 class GovernancePackDryRunReportResponse(BaseModel):
+    """Portable governance-pack dry-run validation report."""
+
     manifest: GovernancePackReportManifestResponse
     digest: str
     resolved_capabilities: list[str] = Field(default_factory=list)
@@ -787,10 +793,14 @@ class GovernancePackDryRunReportResponse(BaseModel):
 
 
 class GovernancePackDryRunResponse(BaseModel):
+    """Envelope for governance-pack import dry-run responses."""
+
     report: GovernancePackDryRunReportResponse
 
 
 class GovernancePackUpgradeObjectDiffResponse(BaseModel):
+    """Object-level diff entry produced by governance-pack upgrade planning."""
+
     object_type: str
     source_object_id: str
     change_type: str
@@ -799,6 +809,8 @@ class GovernancePackUpgradeObjectDiffResponse(BaseModel):
 
 
 class GovernancePackUpgradeDependencyImpactResponse(BaseModel):
+    """Dependency impact entry produced by governance-pack upgrade planning."""
+
     object_type: str
     source_object_id: str
     change_type: str
@@ -811,6 +823,8 @@ class GovernancePackUpgradeDependencyImpactResponse(BaseModel):
 
 
 class GovernancePackUpgradePlanResponse(BaseModel):
+    """Planner output for a governance-pack upgrade dry run."""
+
     source_governance_pack_id: int
     source_manifest: dict[str, Any] = Field(default_factory=dict)
     target_manifest: dict[str, Any] = Field(default_factory=dict)
@@ -825,10 +839,14 @@ class GovernancePackUpgradePlanResponse(BaseModel):
 
 
 class GovernancePackUpgradeDryRunResponse(BaseModel):
+    """Envelope for governance-pack upgrade dry-run responses."""
+
     plan: GovernancePackUpgradePlanResponse
 
 
 class GovernancePackUpgradeExecuteRequest(BaseModel):
+    """Request body for transactional governance-pack upgrade execution."""
+
     source_governance_pack_id: int = Field(..., ge=1)
     owner_scope_type: ScopeType = Field(default="user")
     owner_scope_id: int | None = None
@@ -838,6 +856,8 @@ class GovernancePackUpgradeExecuteRequest(BaseModel):
 
 
 class GovernancePackUpgradeExecutionResponse(BaseModel):
+    """Execution result for a completed governance-pack upgrade."""
+
     upgrade_id: int
     source_governance_pack_id: int
     target_governance_pack_id: int
@@ -850,6 +870,8 @@ class GovernancePackUpgradeExecutionResponse(BaseModel):
 
 
 class GovernancePackUpgradeHistoryEntryResponse(BaseModel):
+    """Lineage entry describing a past governance-pack upgrade."""
+
     id: int
     pack_id: str
     owner_scope_type: ScopeType

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -759,6 +759,13 @@ class GovernancePackImportRequest(BaseModel):
     pack: GovernancePackDocumentRequest
 
 
+class GovernancePackUpgradeDryRunRequest(BaseModel):
+    source_governance_pack_id: int = Field(..., ge=1)
+    owner_scope_type: ScopeType = Field(default="user")
+    owner_scope_id: int | None = None
+    pack: GovernancePackDocumentRequest
+
+
 class GovernancePackReportManifestResponse(BaseModel):
     pack_id: str
     pack_version: str
@@ -781,6 +788,44 @@ class GovernancePackDryRunReportResponse(BaseModel):
 
 class GovernancePackDryRunResponse(BaseModel):
     report: GovernancePackDryRunReportResponse
+
+
+class GovernancePackUpgradeObjectDiffResponse(BaseModel):
+    object_type: str
+    source_object_id: str
+    change_type: str
+    previous_digest: str | None = None
+    next_digest: str | None = None
+
+
+class GovernancePackUpgradeDependencyImpactResponse(BaseModel):
+    object_type: str
+    source_object_id: str
+    change_type: str
+    impact: str
+    dependent_type: str
+    dependent_id: int
+    reference_field: str
+    target_type: str | None = None
+    target_id: str | None = None
+
+
+class GovernancePackUpgradePlanResponse(BaseModel):
+    source_governance_pack_id: int
+    source_manifest: dict[str, Any] = Field(default_factory=dict)
+    target_manifest: dict[str, Any] = Field(default_factory=dict)
+    object_diff: list[GovernancePackUpgradeObjectDiffResponse] = Field(default_factory=list)
+    dependency_impact: list[GovernancePackUpgradeDependencyImpactResponse] = Field(default_factory=list)
+    structural_conflicts: list[str] = Field(default_factory=list)
+    behavioral_conflicts: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    planner_inputs_fingerprint: str
+    adapter_state_fingerprint: str
+    upgradeable: bool
+
+
+class GovernancePackUpgradeDryRunResponse(BaseModel):
+    plan: GovernancePackUpgradePlanResponse
 
 
 class GovernancePackObjectProvenanceResponse(BaseModel):

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -2145,11 +2145,27 @@ def migration_071_add_governance_pack_upgrade_lineage(conn: sqlite3.Connection) 
             "ALTER TABLE mcp_governance_packs ADD COLUMN installed_from_upgrade_id INTEGER"
         )
 
-    conn.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_active_scope "
-        "ON mcp_governance_packs(pack_id, owner_scope_type, IFNULL(owner_scope_id, -1)) "
-        "WHERE is_active_install = 1"
-    )
+    governance_pack_indexes = {
+        str(row[1]) for row in conn.execute("PRAGMA index_list(mcp_governance_packs)").fetchall()
+    }
+    if "uq_mcp_governance_packs_active_scope" not in governance_pack_indexes:
+        conn.execute("UPDATE mcp_governance_packs SET is_active_install = 0")
+        conn.execute(
+            """
+            UPDATE mcp_governance_packs
+            SET is_active_install = 1
+            WHERE id IN (
+                SELECT MAX(id)
+                FROM mcp_governance_packs
+                GROUP BY pack_id, owner_scope_type, IFNULL(owner_scope_id, -1)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_active_scope "
+            "ON mcp_governance_packs(pack_id, owner_scope_type, IFNULL(owner_scope_id, -1)) "
+            "WHERE is_active_install = 1"
+        )
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS mcp_governance_pack_upgrades (

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -2126,6 +2126,65 @@ def migration_070_add_mcp_capability_adapter_mappings(conn: sqlite3.Connection) 
     logger.info("Migration 070: Added MCP capability adapter mapping schema")
 
 
+def migration_071_add_governance_pack_upgrade_lineage(conn: sqlite3.Connection) -> None:
+    """Add governance-pack install-state and upgrade-lineage tracking."""
+
+    governance_pack_columns = {
+        str(row[1]) for row in conn.execute("PRAGMA table_info(mcp_governance_packs)").fetchall()
+    }
+    if "is_active_install" not in governance_pack_columns:
+        conn.execute(
+            "ALTER TABLE mcp_governance_packs ADD COLUMN is_active_install INTEGER NOT NULL DEFAULT 1"
+        )
+    if "superseded_by_governance_pack_id" not in governance_pack_columns:
+        conn.execute(
+            "ALTER TABLE mcp_governance_packs ADD COLUMN superseded_by_governance_pack_id INTEGER"
+        )
+    if "installed_from_upgrade_id" not in governance_pack_columns:
+        conn.execute(
+            "ALTER TABLE mcp_governance_packs ADD COLUMN installed_from_upgrade_id INTEGER"
+        )
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_active_scope "
+        "ON mcp_governance_packs(pack_id, owner_scope_type, IFNULL(owner_scope_id, -1)) "
+        "WHERE is_active_install = 1"
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_pack_upgrades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pack_id TEXT NOT NULL,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER,
+            from_governance_pack_id INTEGER NOT NULL,
+            to_governance_pack_id INTEGER NOT NULL,
+            from_pack_version TEXT NOT NULL,
+            to_pack_version TEXT NOT NULL,
+            status TEXT NOT NULL,
+            planned_by INTEGER,
+            executed_by INTEGER,
+            planner_inputs_fingerprint TEXT,
+            adapter_state_fingerprint TEXT,
+            plan_summary_json TEXT NOT NULL DEFAULT '{}',
+            accepted_resolutions_json TEXT NOT NULL DEFAULT '{}',
+            failure_summary TEXT,
+            planned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            executed_at TIMESTAMP,
+            FOREIGN KEY (from_governance_pack_id) REFERENCES mcp_governance_packs(id) ON DELETE CASCADE,
+            FOREIGN KEY (to_governance_pack_id) REFERENCES mcp_governance_packs(id) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_pack_upgrades_scope "
+        "ON mcp_governance_pack_upgrades(pack_id, owner_scope_type, owner_scope_id)"
+    )
+
+    conn.commit()
+    logger.info("Migration 071: Added governance-pack upgrade lineage schema")
+
+
 def rollback_053_drop_byok_oauth_state(conn: sqlite3.Connection) -> None:
     """Rollback migration 053 by dropping the byok_oauth_state table."""
     conn.execute("DROP TABLE IF EXISTS byok_oauth_state")
@@ -3963,6 +4022,11 @@ def get_authnz_migrations() -> list[Migration]:
             70,
             "Add MCP capability adapter mapping schema",
             migration_070_add_mcp_capability_adapter_mappings,
+        ),
+        Migration(
+            71,
+            "Add governance pack upgrade lineage schema",
+            migration_071_add_governance_pack_upgrade_lineage,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -534,6 +534,27 @@ _CREATE_MCP_HUB_TABLES = [
         (),
     ),
     (
+        "ALTER TABLE mcp_governance_packs "
+        "ADD COLUMN IF NOT EXISTS is_active_install BOOLEAN NOT NULL DEFAULT TRUE",
+        (),
+    ),
+    (
+        "ALTER TABLE mcp_governance_packs "
+        "ADD COLUMN IF NOT EXISTS superseded_by_governance_pack_id INTEGER NULL",
+        (),
+    ),
+    (
+        "ALTER TABLE mcp_governance_packs "
+        "ADD COLUMN IF NOT EXISTS installed_from_upgrade_id INTEGER NULL",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_active_scope "
+        "ON mcp_governance_packs(pack_id, owner_scope_type, COALESCE(owner_scope_id, -1)) "
+        "WHERE is_active_install",
+        (),
+    ),
+    (
         """
         CREATE TABLE IF NOT EXISTS mcp_governance_pack_objects (
             id SERIAL PRIMARY KEY,
@@ -559,6 +580,36 @@ _CREATE_MCP_HUB_TABLES = [
     (
         "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_pack_objects_object "
         "ON mcp_governance_pack_objects(object_type, object_id)",
+        (),
+    ),
+    (
+        """
+        CREATE TABLE IF NOT EXISTS mcp_governance_pack_upgrades (
+            id SERIAL PRIMARY KEY,
+            pack_id TEXT NOT NULL,
+            owner_scope_type TEXT NOT NULL DEFAULT 'user',
+            owner_scope_id INTEGER NULL,
+            from_governance_pack_id INTEGER NOT NULL REFERENCES mcp_governance_packs(id) ON DELETE CASCADE,
+            to_governance_pack_id INTEGER NOT NULL REFERENCES mcp_governance_packs(id) ON DELETE CASCADE,
+            from_pack_version TEXT NOT NULL,
+            to_pack_version TEXT NOT NULL,
+            status TEXT NOT NULL,
+            planned_by INTEGER NULL,
+            executed_by INTEGER NULL,
+            planner_inputs_fingerprint TEXT NULL,
+            adapter_state_fingerprint TEXT NULL,
+            plan_summary_json TEXT NOT NULL DEFAULT '{}',
+            accepted_resolutions_json TEXT NOT NULL DEFAULT '{}',
+            failure_summary TEXT NULL,
+            planned_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            executed_at TIMESTAMPTZ NULL
+        )
+        """,
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_mcp_governance_pack_upgrades_scope "
+        "ON mcp_governance_pack_upgrades(pack_id, owner_scope_type, owner_scope_id)",
         (),
     ),
     (

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -549,6 +549,32 @@ _CREATE_MCP_HUB_TABLES = [
         (),
     ),
     (
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1
+                FROM pg_indexes
+                WHERE indexname = 'uq_mcp_governance_packs_active_scope'
+                  AND schemaname = ANY (current_schemas(false))
+            ) THEN
+                UPDATE mcp_governance_packs
+                SET is_active_install = FALSE;
+
+                WITH latest AS (
+                    SELECT MAX(id) AS id
+                    FROM mcp_governance_packs
+                    GROUP BY pack_id, owner_scope_type, COALESCE(owner_scope_id, -1)
+                )
+                UPDATE mcp_governance_packs
+                SET is_active_install = TRUE
+                WHERE id IN (SELECT id FROM latest);
+            END IF;
+        END $$;
+        """,
+        (),
+    ),
+    (
         "CREATE UNIQUE INDEX IF NOT EXISTS uq_mcp_governance_packs_active_scope "
         "ON mcp_governance_packs(pack_id, owner_scope_type, COALESCE(owner_scope_id, -1)) "
         "WHERE is_active_install",

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -7,7 +7,12 @@ from typing import Any
 
 from loguru import logger
 
-from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.database import (
+    DatabasePool,
+    _convert_question_mark_to_dollar,
+    _flatten_params,
+    _normalize_sqlite_sql,
+)
 
 _VALID_SCOPE_TYPES = {"global", "org", "team", "user"}
 _VALID_CAPABILITY_ADAPTER_SCOPE_TYPES = {"global", "org", "team"}
@@ -440,6 +445,36 @@ class McpHubRepo:
             return rowcount > 0
         return False
 
+    async def _conn_execute(self, conn: Any, query: str, params: tuple[Any, ...]) -> Any:
+        if getattr(self.db_pool, "pool", None) is not None:
+            flat_params = _flatten_params((params,))
+            pg_query = _convert_question_mark_to_dollar(query, flat_params)
+            return await conn.execute(pg_query, *flat_params)
+        normalized_query = _normalize_sqlite_sql(query)
+        return await conn.execute(normalized_query, params)
+
+    async def _conn_fetchone(self, conn: Any, query: str, params: tuple[Any, ...]) -> dict[str, Any] | None:
+        if getattr(self.db_pool, "pool", None) is not None:
+            flat_params = _flatten_params((params,))
+            pg_query = _convert_question_mark_to_dollar(query, flat_params)
+            row = await conn.fetchrow(pg_query, *flat_params)
+            return self._row_to_dict(row) if row else None
+        normalized_query = _normalize_sqlite_sql(query)
+        cursor = await conn.execute(normalized_query, params)
+        row = await cursor.fetchone()
+        return self._row_to_dict(row) if row else None
+
+    async def _conn_fetchall(self, conn: Any, query: str, params: tuple[Any, ...]) -> list[dict[str, Any]]:
+        if getattr(self.db_pool, "pool", None) is not None:
+            flat_params = _flatten_params((params,))
+            pg_query = _convert_question_mark_to_dollar(query, flat_params)
+            rows = await conn.fetch(pg_query, *flat_params)
+            return [self._row_to_dict(row) for row in rows]
+        normalized_query = _normalize_sqlite_sql(query)
+        cursor = await conn.execute(normalized_query, params)
+        rows = await cursor.fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
     async def create_governance_pack(
         self,
         *,
@@ -457,6 +492,7 @@ class McpHubRepo:
         normalized_ir: dict[str, Any],
         actor_id: int | None,
         is_active_install: bool = True,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         now = datetime.now(timezone.utc)
@@ -464,37 +500,172 @@ class McpHubRepo:
         active_install_value: bool | int = (
             is_active_install if getattr(self.db_pool, "pool", None) is not None else int(is_active_install)
         )
-        await self.db_pool.execute(
-            """
+        params = (
+            str(pack_id or "").strip(),
+            str(pack_version or "").strip(),
+            int(pack_schema_version),
+            int(capability_taxonomy_version),
+            int(adapter_contract_version),
+            str(title or "").strip(),
+            description,
+            scope_type,
+            owner_scope_id,
+            str(bundle_digest or "").strip(),
+            json.dumps(manifest or {}),
+            json.dumps(normalized_ir or {}),
+            active_install_value,
+            actor_id,
+            actor_id,
+            ts,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_governance_packs (
                 pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
                 adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
                 bundle_digest, manifest_json, normalized_ir_json, is_active_install, created_by,
                 updated_by, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                str(pack_id or "").strip(),
-                str(pack_version or "").strip(),
-                int(pack_schema_version),
-                int(capability_taxonomy_version),
-                int(adapter_contract_version),
-                str(title or "").strip(),
-                description,
-                scope_type,
-                owner_scope_id,
-                str(bundle_digest or "").strip(),
-                json.dumps(manifest or {}),
-                json.dumps(normalized_ir or {}),
-                active_install_value,
-                actor_id,
-                actor_id,
-                ts,
-                ts,
-            ),
-        )
-        row = await self.db_pool.fetchone(
             """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM mcp_governance_packs
+                WHERE pack_id = ?
+                  AND pack_version = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    str(pack_id or "").strip(),
+                    str(pack_version or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT id
+                FROM mcp_governance_packs
+                WHERE pack_id = ?
+                  AND pack_version = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    str(pack_id or "").strip(),
+                    str(pack_version or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
+        if not row:
+            return {}
+        created = await self.get_governance_pack(int(row["id"]), conn=conn)
+        return created or {}
+
+    async def get_governance_pack(self, governance_pack_id: int, *, conn: Any | None = None) -> dict[str, Any] | None:
+        query = """
+            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
+                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
+                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
+                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
+                   created_at, updated_at
+            FROM mcp_governance_packs
+            WHERE id = ?
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(governance_pack_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(governance_pack_id),))
+        )
+        return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
+
+    async def update_governance_pack_install_state(
+        self,
+        governance_pack_id: int,
+        *,
+        is_active_install: bool | object = _UNSET,
+        superseded_by_governance_pack_id: int | None | object = _UNSET,
+        installed_from_upgrade_id: int | None | object = _UNSET,
+        actor_id: int | None = None,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_governance_pack(governance_pack_id, conn=conn)
+        if not existing:
+            return None
+
+        next_is_active = (
+            _to_bool(existing.get("is_active_install"))
+            if is_active_install is _UNSET
+            else _to_bool(is_active_install)
+        )
+        next_superseded_by = (
+            existing.get("superseded_by_governance_pack_id")
+            if superseded_by_governance_pack_id is _UNSET
+            else superseded_by_governance_pack_id
+        )
+        next_installed_from_upgrade_id = (
+            existing.get("installed_from_upgrade_id")
+            if installed_from_upgrade_id is _UNSET
+            else installed_from_upgrade_id
+        )
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        active_value: bool | int = (
+            next_is_active if getattr(self.db_pool, "pool", None) is not None else int(next_is_active)
+        )
+        params = (
+            active_value,
+            next_superseded_by,
+            next_installed_from_upgrade_id,
+            actor_id,
+            ts,
+            int(governance_pack_id),
+        )
+        query = """
+            UPDATE mcp_governance_packs
+            SET is_active_install = ?,
+                superseded_by_governance_pack_id = ?,
+                installed_from_upgrade_id = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE id = ?
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_governance_pack(governance_pack_id, conn=conn)
+
+    async def get_governance_pack_by_identity(
+        self,
+        *,
+        pack_id: str,
+        pack_version: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        query = """
             SELECT id
             FROM mcp_governance_packs
             WHERE pack_id = ?
@@ -506,71 +677,34 @@ class McpHubRepo:
               )
             ORDER BY id DESC
             LIMIT 1
-            """,
-            (
-                str(pack_id or "").strip(),
-                str(pack_version or "").strip(),
-                scope_type,
-                owner_scope_id,
-                owner_scope_id,
-            ),
+            """
+        row = (
+            await self.db_pool.fetchone(
+                query,
+                (
+                    str(pack_id or "").strip(),
+                    str(pack_version or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
+            if conn is None
+            else await self._conn_fetchone(
+                conn,
+                query,
+                (
+                    str(pack_id or "").strip(),
+                    str(pack_version or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
         )
         if not row:
-            return {}
-        created = await self.get_governance_pack(int(row["id"]))
-        return created or {}
-
-    async def get_governance_pack(self, governance_pack_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
-            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
-                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
-                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
-                   created_at, updated_at
-            FROM mcp_governance_packs
-            WHERE id = ?
-            """,
-            (int(governance_pack_id),),
-        )
-        return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
-
-    async def get_governance_pack_by_identity(
-        self,
-        *,
-        pack_id: str,
-        pack_version: str,
-        owner_scope_type: str,
-        owner_scope_id: int | None,
-    ) -> dict[str, Any] | None:
-        scope_type = _normalize_scope_type(owner_scope_type)
-        row = await self.db_pool.fetchone(
-            """
-            SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
-                   adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
-                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
-                   created_at, updated_at
-            FROM mcp_governance_packs
-            WHERE pack_id = ?
-              AND pack_version = ?
-              AND owner_scope_type = ?
-              AND (
-                (owner_scope_id IS NULL AND ? IS NULL)
-                OR owner_scope_id = ?
-              )
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (
-                str(pack_id or "").strip(),
-                str(pack_version or "").strip(),
-                scope_type,
-                owner_scope_id,
-                owner_scope_id,
-            ),
-        )
-        return self._normalize_governance_pack_row(self._row_to_dict(row) if row else None)
+            return None
+        return await self.get_governance_pack(int(row["id"]), conn=conn)
 
     async def list_governance_packs(
         self,
@@ -635,6 +769,7 @@ class McpHubRepo:
         accepted_resolutions: dict[str, Any] | None = None,
         failure_summary: str | None = None,
         executed_at: datetime | str | None = None,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         now = datetime.now(timezone.utc)
@@ -642,63 +777,90 @@ class McpHubRepo:
         executed_ts = executed_at
         if getattr(self.db_pool, "pool", None) is None and isinstance(executed_at, datetime):
             executed_ts = executed_at.isoformat()
-        await self.db_pool.execute(
-            """
+        params = (
+            str(pack_id or "").strip(),
+            scope_type,
+            owner_scope_id,
+            int(from_governance_pack_id),
+            int(to_governance_pack_id),
+            str(from_pack_version or "").strip(),
+            str(to_pack_version or "").strip(),
+            str(status or "").strip(),
+            planned_by,
+            executed_by,
+            str(planner_inputs_fingerprint).strip() if planner_inputs_fingerprint else None,
+            str(adapter_state_fingerprint).strip() if adapter_state_fingerprint else None,
+            json.dumps(plan_summary or {}),
+            json.dumps(accepted_resolutions or {}),
+            failure_summary,
+            planned_ts,
+            executed_ts,
+        )
+        query = """
             INSERT INTO mcp_governance_pack_upgrades (
                 pack_id, owner_scope_type, owner_scope_id, from_governance_pack_id, to_governance_pack_id,
                 from_pack_version, to_pack_version, status, planned_by, executed_by,
                 planner_inputs_fingerprint, adapter_state_fingerprint, plan_summary_json,
                 accepted_resolutions_json, failure_summary, planned_at, executed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                str(pack_id or "").strip(),
-                scope_type,
-                owner_scope_id,
-                int(from_governance_pack_id),
-                int(to_governance_pack_id),
-                str(from_pack_version or "").strip(),
-                str(to_pack_version or "").strip(),
-                str(status or "").strip(),
-                planned_by,
-                executed_by,
-                str(planner_inputs_fingerprint).strip() if planner_inputs_fingerprint else None,
-                str(adapter_state_fingerprint).strip() if adapter_state_fingerprint else None,
-                json.dumps(plan_summary or {}),
-                json.dumps(accepted_resolutions or {}),
-                failure_summary,
-                planned_ts,
-                executed_ts,
-            ),
-        )
-        row = await self.db_pool.fetchone(
             """
-            SELECT id
-            FROM mcp_governance_pack_upgrades
-            WHERE pack_id = ?
-              AND owner_scope_type = ?
-              AND (
-                (owner_scope_id IS NULL AND ? IS NULL)
-                OR owner_scope_id = ?
-              )
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (
-                str(pack_id or "").strip(),
-                scope_type,
-                owner_scope_id,
-                owner_scope_id,
-            ),
-        )
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM mcp_governance_pack_upgrades
+                WHERE pack_id = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    str(pack_id or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT id
+                FROM mcp_governance_pack_upgrades
+                WHERE pack_id = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    str(pack_id or "").strip(),
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
         if not row:
             return {}
-        created = await self.get_governance_pack_upgrade(int(row["id"]))
+        created = await self.get_governance_pack_upgrade(int(row["id"]), conn=conn)
         return created or {}
 
-    async def get_governance_pack_upgrade(self, governance_pack_upgrade_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+    async def get_governance_pack_upgrade(
+        self,
+        governance_pack_upgrade_id: int,
+        *,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
+        query = """
             SELECT id, pack_id, owner_scope_type, owner_scope_id, from_governance_pack_id,
                    to_governance_pack_id, from_pack_version, to_pack_version, status,
                    planned_by, executed_by, planner_inputs_fingerprint, adapter_state_fingerprint,
@@ -706,8 +868,11 @@ class McpHubRepo:
                    planned_at, executed_at
             FROM mcp_governance_pack_upgrades
             WHERE id = ?
-            """,
-            (int(governance_pack_upgrade_id),),
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(governance_pack_upgrade_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(governance_pack_upgrade_id),))
         )
         return self._normalize_governance_pack_upgrade_row(self._row_to_dict(row) if row else None)
 
@@ -754,30 +919,34 @@ class McpHubRepo:
         object_type: str,
         object_id: int | str,
         source_object_id: str,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         normalized_object_type = str(object_type or "").strip().lower()
         normalized_object_id = str(object_id).strip()
         normalized_source_object_id = str(source_object_id or "").strip()
-        await self.db_pool.execute(
-            """
+        params = (
+            int(governance_pack_id),
+            normalized_object_type,
+            normalized_object_id,
+            normalized_source_object_id,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_governance_pack_objects (
                 governance_pack_id, object_type, object_id, source_object_id, created_at
             ) VALUES (?, ?, ?, ?, ?)
-            """,
-            (
-                int(governance_pack_id),
-                normalized_object_type,
-                normalized_object_id,
-                normalized_source_object_id,
-                ts,
-            ),
-        )
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
         return (
             await self.get_governance_pack_object(
                 object_type=normalized_object_type,
                 object_id=normalized_object_id,
+                conn=conn,
             )
             or {}
         )
@@ -787,15 +956,25 @@ class McpHubRepo:
         *,
         object_type: str,
         object_id: int | str,
+        conn: Any | None = None,
     ) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+        query = """
             SELECT id, governance_pack_id, object_type, object_id, source_object_id, created_at
             FROM mcp_governance_pack_objects
             WHERE object_type = ?
               AND object_id = ?
-            """,
-            (str(object_type or "").strip().lower(), str(object_id).strip()),
+            """
+        row = (
+            await self.db_pool.fetchone(
+                query,
+                (str(object_type or "").strip().lower(), str(object_id).strip()),
+            )
+            if conn is None
+            else await self._conn_fetchone(
+                conn,
+                query,
+                (str(object_type or "").strip().lower(), str(object_id).strip()),
+            )
         )
         return self._normalize_governance_pack_object_row(self._row_to_dict(row) if row else None)
 
@@ -1311,6 +1490,7 @@ class McpHubRepo:
         description: str | None = None,
         is_active: bool = True,
         is_immutable: bool = False,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         profile_mode = _normalize_profile_mode(mode)
@@ -1320,59 +1500,79 @@ class McpHubRepo:
         immutable_value: bool | int = (
             is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
         )
-        await self.db_pool.execute(
-            """
+        params = (
+            name.strip(),
+            description,
+            scope_type,
+            owner_scope_id,
+            profile_mode,
+            path_scope_object_id,
+            json.dumps(policy_document or {}),
+            active_value,
+            immutable_value,
+            actor_id,
+            actor_id,
+            ts,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_permission_profiles (
                 name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id,
                 policy_document_json, is_active, is_immutable, created_by, updated_by, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                name.strip(),
-                description,
-                scope_type,
-                owner_scope_id,
-                profile_mode,
-                path_scope_object_id,
-                json.dumps(policy_document or {}),
-                active_value,
-                immutable_value,
-                actor_id,
-                actor_id,
-                ts,
-                ts,
-            ),
-        )
-        row = await self.db_pool.fetchone(
             """
-            SELECT id
-            FROM mcp_permission_profiles
-            WHERE name = ?
-              AND owner_scope_type = ?
-              AND (
-                (owner_scope_id IS NULL AND ? IS NULL)
-                OR owner_scope_id = ?
-              )
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (name.strip(), scope_type, owner_scope_id, owner_scope_id),
-        )
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM mcp_permission_profiles
+                WHERE name = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (name.strip(), scope_type, owner_scope_id, owner_scope_id),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT id
+                FROM mcp_permission_profiles
+                WHERE name = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (name.strip(), scope_type, owner_scope_id, owner_scope_id),
+            )
         if not row:
             return {}
-        created = await self.get_permission_profile(int(row["id"]))
+        created = await self.get_permission_profile(int(row["id"]), conn=conn)
         return created or {}
 
-    async def get_permission_profile(self, profile_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+    async def get_permission_profile(self, profile_id: int, *, conn: Any | None = None) -> dict[str, Any] | None:
+        query = """
             SELECT id, name, description, owner_scope_type, owner_scope_id, mode, path_scope_object_id,
                    policy_document_json, is_active, is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_permission_profiles
             WHERE id = ?
-            """,
-            (int(profile_id),),
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(profile_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(profile_id),))
         )
         return self._normalize_permission_profile_row(self._row_to_dict(row) if row else None)
 
@@ -1423,8 +1623,9 @@ class McpHubRepo:
         policy_document: dict[str, Any] | None | object = _UNSET,
         is_active: bool | object = _UNSET,
         actor_id: int | None = None,
+        conn: Any | None = None,
     ) -> dict[str, Any] | None:
-        existing = await self.get_permission_profile(profile_id)
+        existing = await self.get_permission_profile(profile_id, conn=conn)
         if not existing:
             return None
 
@@ -1452,8 +1653,20 @@ class McpHubRepo:
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = next_active if getattr(self.db_pool, "pool", None) is not None else int(next_active)
 
-        await self.db_pool.execute(
-            """
+        params = (
+            next_name,
+            next_description,
+            next_scope,
+            next_scope_id,
+            next_mode,
+            next_path_scope_object_id,
+            json.dumps(next_policy_document or {}),
+            active_value,
+            actor_id,
+            ts,
+            int(profile_id),
+        )
+        query = """
             UPDATE mcp_permission_profiles
             SET name = ?,
                 description = ?,
@@ -1466,22 +1679,12 @@ class McpHubRepo:
                 updated_by = ?,
                 updated_at = ?
             WHERE id = ?
-            """,
-            (
-                next_name,
-                next_description,
-                next_scope,
-                next_scope_id,
-                next_mode,
-                next_path_scope_object_id,
-                json.dumps(next_policy_document or {}),
-                active_value,
-                actor_id,
-                ts,
-                int(profile_id),
-            ),
-        )
-        return await self.get_permission_profile(profile_id)
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_permission_profile(profile_id, conn=conn)
 
     async def delete_permission_profile(self, profile_id: int) -> bool:
         cursor = await self.db_pool.execute(
@@ -2076,6 +2279,7 @@ class McpHubRepo:
         actor_id: int | None,
         is_active: bool = True,
         is_immutable: bool = False,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         normalized_target_type = _normalize_target_type(target_type)
         normalized_target_id = str(target_id).strip() if target_id is not None else None
@@ -2086,68 +2290,96 @@ class McpHubRepo:
         immutable_value: bool | int = (
             is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
         )
-        await self.db_pool.execute(
-            """
+        params = (
+            normalized_target_type,
+            normalized_target_id,
+            scope_type,
+            owner_scope_id,
+            profile_id,
+            path_scope_object_id,
+            str(workspace_source_mode or "").strip().lower() or None,
+            workspace_set_object_id,
+            json.dumps(inline_policy_document or {}),
+            approval_policy_id,
+            active_value,
+            immutable_value,
+            actor_id,
+            actor_id,
+            ts,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_policy_assignments (
                 target_type, target_id, owner_scope_type, owner_scope_id, profile_id,
                 path_scope_object_id, workspace_source_mode, workspace_set_object_id,
                 inline_policy_document_json, approval_policy_id, is_active, is_immutable,
                 created_by, updated_by, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                normalized_target_type,
-                normalized_target_id,
-                scope_type,
-                owner_scope_id,
-                profile_id,
-                path_scope_object_id,
-                str(workspace_source_mode or "").strip().lower() or None,
-                workspace_set_object_id,
-                json.dumps(inline_policy_document or {}),
-                approval_policy_id,
-                active_value,
-                immutable_value,
-                actor_id,
-                actor_id,
-                ts,
-                ts,
-            ),
-        )
-        row = await self.db_pool.fetchone(
             """
-            SELECT id
-            FROM mcp_policy_assignments
-            WHERE target_type = ?
-              AND (
-                (target_id IS NULL AND ? IS NULL)
-                OR target_id = ?
-              )
-              AND owner_scope_type = ?
-              AND (
-                (owner_scope_id IS NULL AND ? IS NULL)
-                OR owner_scope_id = ?
-              )
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (
-                normalized_target_type,
-                normalized_target_id,
-                normalized_target_id,
-                scope_type,
-                owner_scope_id,
-                owner_scope_id,
-            ),
-        )
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM mcp_policy_assignments
+                WHERE target_type = ?
+                  AND (
+                    (target_id IS NULL AND ? IS NULL)
+                    OR target_id = ?
+                  )
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    normalized_target_type,
+                    normalized_target_id,
+                    normalized_target_id,
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT id
+                FROM mcp_policy_assignments
+                WHERE target_type = ?
+                  AND (
+                    (target_id IS NULL AND ? IS NULL)
+                    OR target_id = ?
+                  )
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (
+                    normalized_target_type,
+                    normalized_target_id,
+                    normalized_target_id,
+                    scope_type,
+                    owner_scope_id,
+                    owner_scope_id,
+                ),
+            )
         if not row:
             return {}
-        created = await self.get_policy_assignment(int(row["id"]))
+        created = await self.get_policy_assignment(int(row["id"]), conn=conn)
         return created or {}
 
-    async def get_policy_assignment(self, assignment_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+    async def get_policy_assignment(self, assignment_id: int, *, conn: Any | None = None) -> dict[str, Any] | None:
+        query = """
             SELECT a.id, a.target_type, a.target_id, a.owner_scope_type, a.owner_scope_id, a.profile_id,
                    a.path_scope_object_id, a.workspace_source_mode, a.workspace_set_object_id,
                    a.inline_policy_document_json, a.approval_policy_id, a.is_active, a.is_immutable,
@@ -2159,8 +2391,11 @@ class McpHubRepo:
             FROM mcp_policy_assignments AS a
             LEFT JOIN mcp_policy_overrides AS o ON o.assignment_id = a.id
             WHERE a.id = ?
-            """,
-            (int(assignment_id),),
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(assignment_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(assignment_id),))
         )
         return self._normalize_policy_assignment_row(self._row_to_dict(row) if row else None)
 
@@ -2234,8 +2469,9 @@ class McpHubRepo:
         approval_policy_id: int | None | object = _UNSET,
         is_active: bool | object = _UNSET,
         actor_id: int | None = None,
+        conn: Any | None = None,
     ) -> dict[str, Any] | None:
-        existing = await self.get_policy_assignment(assignment_id)
+        existing = await self.get_policy_assignment(assignment_id, conn=conn)
         if not existing:
             return None
 
@@ -2287,8 +2523,23 @@ class McpHubRepo:
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = next_active if getattr(self.db_pool, "pool", None) is not None else int(next_active)
 
-        await self.db_pool.execute(
-            """
+        params = (
+            next_target_type,
+            next_target_id,
+            next_scope,
+            next_scope_id,
+            next_profile_id,
+            next_path_scope_object_id,
+            next_workspace_source_mode,
+            next_workspace_set_object_id,
+            json.dumps(next_inline_policy_document or {}),
+            next_approval_policy_id,
+            active_value,
+            actor_id,
+            ts,
+            int(assignment_id),
+        )
+        query = """
             UPDATE mcp_policy_assignments
             SET target_type = ?,
                 target_id = ?,
@@ -2304,25 +2555,12 @@ class McpHubRepo:
                 updated_by = ?,
                 updated_at = ?
             WHERE id = ?
-            """,
-            (
-                next_target_type,
-                next_target_id,
-                next_scope,
-                next_scope_id,
-                next_profile_id,
-                next_path_scope_object_id,
-                next_workspace_source_mode,
-                next_workspace_set_object_id,
-                json.dumps(next_inline_policy_document or {}),
-                next_approval_policy_id,
-                active_value,
-                actor_id,
-                ts,
-                int(assignment_id),
-            ),
-        )
-        return await self.get_policy_assignment(assignment_id)
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_policy_assignment(assignment_id, conn=conn)
 
     async def delete_policy_assignment(self, assignment_id: int) -> bool:
         cursor = await self.db_pool.execute(
@@ -2353,27 +2591,40 @@ class McpHubRepo:
         *,
         workspace_id: str,
         actor_id: int | None,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         workspace_value = str(workspace_id or "").strip()
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
-        await self.db_pool.execute(
-            """
+        params = (int(assignment_id), workspace_value, actor_id, ts)
+        query = """
             INSERT INTO mcp_policy_assignment_workspaces (
                 assignment_id, workspace_id, created_by, created_at
             ) VALUES (?, ?, ?, ?)
-            """,
-            (int(assignment_id), workspace_value, actor_id, ts),
-        )
-        row = await self.db_pool.fetchone(
             """
-            SELECT assignment_id, workspace_id, created_by, created_at
-            FROM mcp_policy_assignment_workspaces
-            WHERE assignment_id = ?
-              AND workspace_id = ?
-            """,
-            (int(assignment_id), workspace_value),
-        )
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT assignment_id, workspace_id, created_by, created_at
+                FROM mcp_policy_assignment_workspaces
+                WHERE assignment_id = ?
+                  AND workspace_id = ?
+                """,
+                (int(assignment_id), workspace_value),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT assignment_id, workspace_id, created_by, created_at
+                FROM mcp_policy_assignment_workspaces
+                WHERE assignment_id = ?
+                  AND workspace_id = ?
+                """,
+                (int(assignment_id), workspace_value),
+            )
         return self._normalize_policy_assignment_workspace_row(self._row_to_dict(row) if row else None) or {}
 
     async def delete_policy_assignment_workspace(self, assignment_id: int, workspace_id: str) -> bool:
@@ -2388,15 +2639,22 @@ class McpHubRepo:
         rowcount = getattr(cursor, "rowcount", 0)
         return bool(rowcount and rowcount > 0)
 
-    async def get_policy_override_by_assignment(self, assignment_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+    async def get_policy_override_by_assignment(
+        self,
+        assignment_id: int,
+        *,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
+        query = """
             SELECT id, assignment_id, override_document_json, is_active, broadens_access,
                    grant_authority_snapshot_json, created_by, updated_by, created_at, updated_at
             FROM mcp_policy_overrides
             WHERE assignment_id = ?
-            """,
-            (int(assignment_id),),
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(assignment_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(assignment_id),))
         )
         return self._normalize_policy_override_row(self._row_to_dict(row) if row else None)
 
@@ -2409,8 +2667,9 @@ class McpHubRepo:
         grant_authority_snapshot: dict[str, Any],
         actor_id: int | None,
         is_active: bool = True,
+        conn: Any | None = None,
     ) -> dict[str, Any] | None:
-        assignment = await self.get_policy_assignment(int(assignment_id))
+        assignment = await self.get_policy_assignment(int(assignment_id), conn=conn)
         if assignment is None:
             return None
 
@@ -2421,8 +2680,18 @@ class McpHubRepo:
             broadens_access if getattr(self.db_pool, "pool", None) is not None else int(broadens_access)
         )
 
-        await self.db_pool.execute(
-            """
+        params = (
+            int(assignment_id),
+            json.dumps(override_policy_document or {}),
+            active_value,
+            broadens_value,
+            json.dumps(grant_authority_snapshot or {}),
+            actor_id,
+            actor_id,
+            ts,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_policy_overrides (
                 assignment_id, override_document_json, is_active, broadens_access,
                 grant_authority_snapshot_json, created_by, updated_by, created_at, updated_at
@@ -2434,20 +2703,59 @@ class McpHubRepo:
                 grant_authority_snapshot_json = excluded.grant_authority_snapshot_json,
                 updated_by = excluded.updated_by,
                 updated_at = excluded.updated_at
-            """,
-            (
-                int(assignment_id),
-                json.dumps(override_policy_document or {}),
-                active_value,
-                broadens_value,
-                json.dumps(grant_authority_snapshot or {}),
-                actor_id,
-                actor_id,
-                ts,
-                ts,
-            ),
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_policy_override_by_assignment(int(assignment_id), conn=conn)
+
+    async def rebind_policy_override_assignment(
+        self,
+        *,
+        old_assignment_id: int,
+        new_assignment_id: int,
+        actor_id: int | None,
+        conn: Any | None = None,
+    ) -> dict[str, Any] | None:
+        existing = await self.get_policy_override_by_assignment(old_assignment_id, conn=conn)
+        if existing is None:
+            return None
+        now = datetime.now(timezone.utc)
+        ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        params = (int(new_assignment_id), actor_id, ts, int(old_assignment_id))
+        query = """
+            UPDATE mcp_policy_overrides
+            SET assignment_id = ?,
+                updated_by = ?,
+                updated_at = ?
+            WHERE assignment_id = ?
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_policy_override_by_assignment(int(new_assignment_id), conn=conn)
+
+    async def rebind_policy_assignment_workspaces(
+        self,
+        *,
+        old_assignment_id: int,
+        new_assignment_id: int,
+        conn: Any | None = None,
+    ) -> bool:
+        params = (int(new_assignment_id), int(old_assignment_id))
+        query = """
+            UPDATE mcp_policy_assignment_workspaces
+            SET assignment_id = ?
+            WHERE assignment_id = ?
+            """
+        result = (
+            await self.db_pool.execute(query, params)
+            if conn is None
+            else await self._conn_execute(conn, query, params)
         )
-        return await self.get_policy_override_by_assignment(int(assignment_id))
+        return self._command_touched_rows(result)
 
     async def delete_policy_override_by_assignment(self, assignment_id: int) -> bool:
         cursor = await self.db_pool.execute(
@@ -2469,6 +2777,7 @@ class McpHubRepo:
         description: str | None = None,
         is_active: bool = True,
         is_immutable: bool = False,
+        conn: Any | None = None,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         approval_mode = _normalize_approval_mode(mode)
@@ -2478,58 +2787,78 @@ class McpHubRepo:
         immutable_value: bool | int = (
             is_immutable if getattr(self.db_pool, "pool", None) is not None else int(is_immutable)
         )
-        await self.db_pool.execute(
-            """
+        params = (
+            name.strip(),
+            description,
+            scope_type,
+            owner_scope_id,
+            approval_mode,
+            json.dumps(rules or {}),
+            active_value,
+            immutable_value,
+            actor_id,
+            actor_id,
+            ts,
+            ts,
+        )
+        query = """
             INSERT INTO mcp_approval_policies (
                 name, description, owner_scope_type, owner_scope_id, mode, rules_json, is_active,
                 is_immutable, created_by, updated_by, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                name.strip(),
-                description,
-                scope_type,
-                owner_scope_id,
-                approval_mode,
-                json.dumps(rules or {}),
-                active_value,
-                immutable_value,
-                actor_id,
-                actor_id,
-                ts,
-                ts,
-            ),
-        )
-        row = await self.db_pool.fetchone(
             """
-            SELECT id
-            FROM mcp_approval_policies
-            WHERE name = ?
-              AND owner_scope_type = ?
-              AND (
-                (owner_scope_id IS NULL AND ? IS NULL)
-                OR owner_scope_id = ?
-              )
-            ORDER BY id DESC
-            LIMIT 1
-            """,
-            (name.strip(), scope_type, owner_scope_id, owner_scope_id),
-        )
+        if conn is None:
+            await self.db_pool.execute(query, params)
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id
+                FROM mcp_approval_policies
+                WHERE name = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (name.strip(), scope_type, owner_scope_id, owner_scope_id),
+            )
+        else:
+            await self._conn_execute(conn, query, params)
+            row = await self._conn_fetchone(
+                conn,
+                """
+                SELECT id
+                FROM mcp_approval_policies
+                WHERE name = ?
+                  AND owner_scope_type = ?
+                  AND (
+                    (owner_scope_id IS NULL AND ? IS NULL)
+                    OR owner_scope_id = ?
+                  )
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (name.strip(), scope_type, owner_scope_id, owner_scope_id),
+            )
         if not row:
             return {}
-        created = await self.get_approval_policy(int(row["id"]))
+        created = await self.get_approval_policy(int(row["id"]), conn=conn)
         return created or {}
 
-    async def get_approval_policy(self, approval_policy_id: int) -> dict[str, Any] | None:
-        row = await self.db_pool.fetchone(
-            """
+    async def get_approval_policy(self, approval_policy_id: int, *, conn: Any | None = None) -> dict[str, Any] | None:
+        query = """
             SELECT id, name, description, owner_scope_type, owner_scope_id, mode, rules_json, is_active,
                    is_immutable,
                    created_by, updated_by, created_at, updated_at
             FROM mcp_approval_policies
             WHERE id = ?
-            """,
-            (int(approval_policy_id),),
+            """
+        row = (
+            await self.db_pool.fetchone(query, (int(approval_policy_id),))
+            if conn is None
+            else await self._conn_fetchone(conn, query, (int(approval_policy_id),))
         )
         return self._normalize_approval_policy_row(self._row_to_dict(row) if row else None)
 
@@ -2579,8 +2908,9 @@ class McpHubRepo:
         rules: dict[str, Any] | None | object = _UNSET,
         is_active: bool | object = _UNSET,
         actor_id: int | None = None,
+        conn: Any | None = None,
     ) -> dict[str, Any] | None:
-        existing = await self.get_approval_policy(approval_policy_id)
+        existing = await self.get_approval_policy(approval_policy_id, conn=conn)
         if not existing:
             return None
 
@@ -2607,8 +2937,19 @@ class McpHubRepo:
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         active_value: bool | int = next_active if getattr(self.db_pool, "pool", None) is not None else int(next_active)
 
-        await self.db_pool.execute(
-            """
+        params = (
+            next_name,
+            next_description,
+            next_scope,
+            next_scope_id,
+            next_mode,
+            json.dumps(next_rules or {}),
+            active_value,
+            actor_id,
+            ts,
+            int(approval_policy_id),
+        )
+        query = """
             UPDATE mcp_approval_policies
             SET name = ?,
                 description = ?,
@@ -2620,21 +2961,12 @@ class McpHubRepo:
                 updated_by = ?,
                 updated_at = ?
             WHERE id = ?
-            """,
-            (
-                next_name,
-                next_description,
-                next_scope,
-                next_scope_id,
-                next_mode,
-                json.dumps(next_rules or {}),
-                active_value,
-                actor_id,
-                ts,
-                int(approval_policy_id),
-            ),
-        )
-        return await self.get_approval_policy(approval_policy_id)
+            """
+        if conn is None:
+            await self.db_pool.execute(query, params)
+        else:
+            await self._conn_execute(conn, query, params)
+        return await self.get_approval_policy(approval_policy_id, conn=conn)
 
     async def delete_approval_policy(self, approval_policy_id: int) -> bool:
         cursor = await self.db_pool.execute(

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -382,6 +382,9 @@ class McpHubRepo:
         if row is None:
             return None
         out = dict(row)
+        out["is_active_install"] = _to_bool(out.get("is_active_install"))
+        out["superseded_by_governance_pack_id"] = out.get("superseded_by_governance_pack_id")
+        out["installed_from_upgrade_id"] = out.get("installed_from_upgrade_id")
         out["manifest"] = _load_json_dict(out.pop("manifest_json", None))
         out["normalized_ir"] = _load_json_dict(out.pop("normalized_ir_json", None))
         return out
@@ -394,6 +397,15 @@ class McpHubRepo:
         out["object_type"] = str(out.get("object_type") or "").strip().lower()
         out["object_id"] = str(out.get("object_id") or "").strip()
         out["source_object_id"] = str(out.get("source_object_id") or "").strip()
+        return out
+
+    @staticmethod
+    def _normalize_governance_pack_upgrade_row(row: dict[str, Any] | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        out = dict(row)
+        out["plan_summary"] = _load_json_dict(out.pop("plan_summary_json", None))
+        out["accepted_resolutions"] = _load_json_dict(out.pop("accepted_resolutions_json", None))
         return out
 
     @staticmethod
@@ -444,18 +456,22 @@ class McpHubRepo:
         manifest: dict[str, Any],
         normalized_ir: dict[str, Any],
         actor_id: int | None,
+        is_active_install: bool = True,
     ) -> dict[str, Any]:
         scope_type = _normalize_scope_type(owner_scope_type)
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        active_install_value: bool | int = (
+            is_active_install if getattr(self.db_pool, "pool", None) is not None else int(is_active_install)
+        )
         await self.db_pool.execute(
             """
             INSERT INTO mcp_governance_packs (
                 pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
                 adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                bundle_digest, manifest_json, normalized_ir_json, is_active_install, created_by,
+                updated_by, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 str(pack_id or "").strip(),
@@ -470,6 +486,7 @@ class McpHubRepo:
                 str(bundle_digest or "").strip(),
                 json.dumps(manifest or {}),
                 json.dumps(normalized_ir or {}),
+                active_install_value,
                 actor_id,
                 actor_id,
                 ts,
@@ -508,7 +525,8 @@ class McpHubRepo:
             """
             SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
                    adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
+                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
                    created_at, updated_at
             FROM mcp_governance_packs
             WHERE id = ?
@@ -530,7 +548,8 @@ class McpHubRepo:
             """
             SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
                    adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
+                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
                    created_at, updated_at
             FROM mcp_governance_packs
             WHERE pack_id = ?
@@ -569,7 +588,8 @@ class McpHubRepo:
             """
             SELECT id, pack_id, pack_version, pack_schema_version, capability_taxonomy_version,
                    adapter_contract_version, title, description, owner_scope_type, owner_scope_id,
-                   bundle_digest, manifest_json, normalized_ir_json, created_by, updated_by,
+                   bundle_digest, manifest_json, normalized_ir_json, is_active_install,
+                   superseded_by_governance_pack_id, installed_from_upgrade_id, created_by, updated_by,
                    created_at, updated_at
             FROM mcp_governance_packs
             WHERE (? IS NULL OR owner_scope_type = ?)
@@ -595,6 +615,137 @@ class McpHubRepo:
         )
         rowcount = getattr(cursor, "rowcount", 0)
         return bool(rowcount and rowcount > 0)
+
+    async def create_governance_pack_upgrade(
+        self,
+        *,
+        pack_id: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        from_governance_pack_id: int,
+        to_governance_pack_id: int,
+        from_pack_version: str,
+        to_pack_version: str,
+        status: str,
+        planned_by: int | None = None,
+        executed_by: int | None = None,
+        planner_inputs_fingerprint: str | None = None,
+        adapter_state_fingerprint: str | None = None,
+        plan_summary: dict[str, Any] | None = None,
+        accepted_resolutions: dict[str, Any] | None = None,
+        failure_summary: str | None = None,
+        executed_at: datetime | str | None = None,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        now = datetime.now(timezone.utc)
+        planned_ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
+        executed_ts = executed_at
+        if getattr(self.db_pool, "pool", None) is None and isinstance(executed_at, datetime):
+            executed_ts = executed_at.isoformat()
+        await self.db_pool.execute(
+            """
+            INSERT INTO mcp_governance_pack_upgrades (
+                pack_id, owner_scope_type, owner_scope_id, from_governance_pack_id, to_governance_pack_id,
+                from_pack_version, to_pack_version, status, planned_by, executed_by,
+                planner_inputs_fingerprint, adapter_state_fingerprint, plan_summary_json,
+                accepted_resolutions_json, failure_summary, planned_at, executed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(pack_id or "").strip(),
+                scope_type,
+                owner_scope_id,
+                int(from_governance_pack_id),
+                int(to_governance_pack_id),
+                str(from_pack_version or "").strip(),
+                str(to_pack_version or "").strip(),
+                str(status or "").strip(),
+                planned_by,
+                executed_by,
+                str(planner_inputs_fingerprint).strip() if planner_inputs_fingerprint else None,
+                str(adapter_state_fingerprint).strip() if adapter_state_fingerprint else None,
+                json.dumps(plan_summary or {}),
+                json.dumps(accepted_resolutions or {}),
+                failure_summary,
+                planned_ts,
+                executed_ts,
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id
+            FROM mcp_governance_pack_upgrades
+            WHERE pack_id = ?
+              AND owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (
+                str(pack_id or "").strip(),
+                scope_type,
+                owner_scope_id,
+                owner_scope_id,
+            ),
+        )
+        if not row:
+            return {}
+        created = await self.get_governance_pack_upgrade(int(row["id"]))
+        return created or {}
+
+    async def get_governance_pack_upgrade(self, governance_pack_upgrade_id: int) -> dict[str, Any] | None:
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, pack_id, owner_scope_type, owner_scope_id, from_governance_pack_id,
+                   to_governance_pack_id, from_pack_version, to_pack_version, status,
+                   planned_by, executed_by, planner_inputs_fingerprint, adapter_state_fingerprint,
+                   plan_summary_json, accepted_resolutions_json, failure_summary,
+                   planned_at, executed_at
+            FROM mcp_governance_pack_upgrades
+            WHERE id = ?
+            """,
+            (int(governance_pack_upgrade_id),),
+        )
+        return self._normalize_governance_pack_upgrade_row(self._row_to_dict(row) if row else None)
+
+    async def list_governance_pack_upgrades(
+        self,
+        *,
+        pack_id: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> list[dict[str, Any]]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        rows = await self.db_pool.fetchall(
+            """
+            SELECT id, pack_id, owner_scope_type, owner_scope_id, from_governance_pack_id,
+                   to_governance_pack_id, from_pack_version, to_pack_version, status,
+                   planned_by, executed_by, planner_inputs_fingerprint, adapter_state_fingerprint,
+                   plan_summary_json, accepted_resolutions_json, failure_summary,
+                   planned_at, executed_at
+            FROM mcp_governance_pack_upgrades
+            WHERE pack_id = ?
+              AND owner_scope_type = ?
+              AND (
+                (owner_scope_id IS NULL AND ? IS NULL)
+                OR owner_scope_id = ?
+              )
+            ORDER BY id
+            """,
+            (
+                str(pack_id or "").strip(),
+                scope_type,
+                owner_scope_id,
+                owner_scope_id,
+            ),
+        )
+        return [
+            self._normalize_governance_pack_upgrade_row(self._row_to_dict(row)) or {}
+            for row in rows
+        ]
 
     async def create_governance_pack_object(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -804,51 +804,23 @@ class McpHubRepo:
                 accepted_resolutions_json, failure_summary, planned_at, executed_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
+        row: dict[str, Any] | None = None
         if conn is None:
-            await self.db_pool.execute(query, params)
-            row = await self.db_pool.fetchone(
-                """
-                SELECT id
-                FROM mcp_governance_pack_upgrades
-                WHERE pack_id = ?
-                  AND owner_scope_type = ?
-                  AND (
-                    (owner_scope_id IS NULL AND ? IS NULL)
-                    OR owner_scope_id = ?
-                  )
-                ORDER BY id DESC
-                LIMIT 1
-                """,
-                (
-                    str(pack_id or "").strip(),
-                    scope_type,
-                    owner_scope_id,
-                    owner_scope_id,
-                ),
-            )
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(f"{query} RETURNING id", params)
+            else:
+                cursor = await self.db_pool.execute(query, params)
+                inserted_id = getattr(cursor, "lastrowid", None)
+                if inserted_id is not None:
+                    row = {"id": inserted_id}
         else:
-            await self._conn_execute(conn, query, params)
-            row = await self._conn_fetchone(
-                conn,
-                """
-                SELECT id
-                FROM mcp_governance_pack_upgrades
-                WHERE pack_id = ?
-                  AND owner_scope_type = ?
-                  AND (
-                    (owner_scope_id IS NULL AND ? IS NULL)
-                    OR owner_scope_id = ?
-                  )
-                ORDER BY id DESC
-                LIMIT 1
-                """,
-                (
-                    str(pack_id or "").strip(),
-                    scope_type,
-                    owner_scope_id,
-                    owner_scope_id,
-                ),
-            )
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self._conn_fetchone(conn, f"{query} RETURNING id", params)
+            else:
+                cursor = await self._conn_execute(conn, query, params)
+                inserted_id = getattr(cursor, "lastrowid", None)
+                if inserted_id is not None:
+                    row = {"id": inserted_id}
         if not row:
             return {}
         created = await self.get_governance_pack_upgrade(int(row["id"]), conn=conn)

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
+from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
@@ -64,6 +68,20 @@ class GovernancePackDryRunReport(BaseModel):
     verdict: str
 
 
+class GovernancePackUpgradePlan(BaseModel):
+    source_governance_pack_id: int
+    source_manifest: dict[str, Any] = Field(default_factory=dict)
+    target_manifest: dict[str, Any] = Field(default_factory=dict)
+    object_diff: list[dict[str, Any]] = Field(default_factory=list)
+    dependency_impact: list[dict[str, Any]] = Field(default_factory=list)
+    structural_conflicts: list[str] = Field(default_factory=list)
+    behavioral_conflicts: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    planner_inputs_fingerprint: str
+    adapter_state_fingerprint: str
+    upgradeable: bool
+
+
 class GovernancePackAlreadyExistsError(ValueError):
     """Raised when a governance pack identity already exists in the target scope."""
 
@@ -95,6 +113,64 @@ def _is_duplicate_governance_pack_error(exc: Exception) -> bool:
         or "unique constraint failed: mcp_governance_packs" in message
         or "duplicate key value violates unique constraint" in message
     )
+
+
+def _stable_digest(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _governance_pack_ref(document: dict[str, Any]) -> tuple[str, str] | None:
+    metadata = dict(document.get("governance_pack") or {})
+    pack_id = str(metadata.get("pack_id") or "").strip()
+    pack_version = str(metadata.get("pack_version") or "").strip()
+    if not pack_id or not pack_version:
+        return None
+    return pack_id, pack_version
+
+
+def _source_object_key(object_type: str, item: dict[str, Any]) -> str:
+    if object_type == "approval_policy":
+        return str(item.get("approval_template_id") or "").strip()
+    if object_type == "permission_profile":
+        return str(item.get("profile_id") or "").strip()
+    if object_type == "policy_assignment":
+        return str(item.get("assignment_template_id") or "").strip()
+    return ""
+
+
+def _normalized_runtime_object_maps(normalized_ir: dict[str, Any]) -> dict[str, dict[str, dict[str, Any]]]:
+    data = dict(normalized_ir.get("data") or {})
+    object_map: dict[str, dict[str, dict[str, Any]]] = {
+        "approval_policy": {},
+        "permission_profile": {},
+        "policy_assignment": {},
+    }
+    for object_type, items in (
+        ("approval_policy", data.get("approvals") or []),
+        ("permission_profile", data.get("profiles") or []),
+        ("policy_assignment", data.get("assignments") or []),
+    ):
+        for raw_item in items:
+            item = dict(raw_item or {})
+            source_object_id = _source_object_key(object_type, item)
+            if source_object_id:
+                object_map[object_type][source_object_id] = item
+    return object_map
+
+
+def _normalize_string_values(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for value in values:
+        cleaned = str(value or "").strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        normalized.append(cleaned)
+    return normalized
 
 
 class McpHubGovernancePackService:
@@ -133,6 +209,123 @@ class McpHubGovernancePackService:
         if owner_scope_type == "org" and owner_scope_id is not None:
             return {"org_id": owner_scope_id}
         return {}
+
+    @staticmethod
+    def _semantic_runtime_object(object_type: str, item: dict[str, Any]) -> dict[str, Any]:
+        payload = dict(item or {})
+        if object_type == "permission_profile":
+            capabilities = dict(payload.get("capabilities") or {})
+            return {
+                "capabilities": {
+                    "allow": _normalize_string_values(capabilities.get("allow")),
+                    "deny": _normalize_string_values(capabilities.get("deny")),
+                },
+                "approval_intent": str(payload.get("approval_intent") or "").strip(),
+                "environment_requirements": _normalize_string_values(
+                    payload.get("environment_requirements")
+                ),
+            }
+        if object_type == "approval_policy":
+            return {
+                "mode": str(payload.get("mode") or "").strip().lower(),
+            }
+        if object_type == "policy_assignment":
+            return {
+                "target_type": str(payload.get("target_type") or "").strip().lower(),
+                "capability_profile_id": str(payload.get("capability_profile_id") or "").strip(),
+                "persona_template_id": str(payload.get("persona_template_id") or "").strip(),
+                "approval_template_id": str(payload.get("approval_template_id") or "").strip(),
+            }
+        return payload
+
+    async def _collect_upgrade_dependencies(
+        self,
+        *,
+        governance_pack_id: int,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> tuple[list[dict[str, Any]], dict[tuple[str, str], list[dict[str, Any]]]]:
+        imported_objects = await self.repo.list_governance_pack_objects(governance_pack_id)
+        assignments = await self.repo.list_policy_assignments(
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+        assignment_rows_by_id = {
+            str(item.get("id")): item
+            for item in assignments
+            if item.get("id") is not None
+        }
+        mutable_assignments = [
+            item for item in assignments if not bool(item.get("is_immutable"))
+        ]
+        mutable_assignments_by_profile: dict[str, list[dict[str, Any]]] = {}
+        mutable_assignments_by_approval: dict[str, list[dict[str, Any]]] = {}
+        for assignment in mutable_assignments:
+            profile_id = assignment.get("profile_id")
+            if profile_id is not None:
+                mutable_assignments_by_profile.setdefault(str(profile_id), []).append(assignment)
+            approval_policy_id = assignment.get("approval_policy_id")
+            if approval_policy_id is not None:
+                mutable_assignments_by_approval.setdefault(
+                    str(approval_policy_id),
+                    [],
+                ).append(assignment)
+
+        dependencies: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for imported_object in imported_objects:
+            object_type = str(imported_object.get("object_type") or "").strip().lower()
+            source_object_id = str(imported_object.get("source_object_id") or "").strip()
+            object_id = str(imported_object.get("object_id") or "").strip()
+            dependents: list[dict[str, Any]] = []
+            if object_type == "permission_profile":
+                for assignment in mutable_assignments_by_profile.get(object_id, []):
+                    dependents.append(
+                        {
+                            "dependent_type": "policy_assignment",
+                            "dependent_id": int(assignment["id"]),
+                            "reference_field": "profile_id",
+                            "target_type": assignment.get("target_type"),
+                            "target_id": assignment.get("target_id"),
+                        }
+                    )
+            elif object_type == "approval_policy":
+                for assignment in mutable_assignments_by_approval.get(object_id, []):
+                    dependents.append(
+                        {
+                            "dependent_type": "policy_assignment",
+                            "dependent_id": int(assignment["id"]),
+                            "reference_field": "approval_policy_id",
+                            "target_type": assignment.get("target_type"),
+                            "target_id": assignment.get("target_id"),
+                        }
+                    )
+            elif object_type == "policy_assignment":
+                assignment = assignment_rows_by_id.get(object_id)
+                if assignment and assignment.get("has_override") and assignment.get("override_active"):
+                    dependents.append(
+                        {
+                            "dependent_type": "policy_override",
+                            "dependent_id": int(assignment["override_id"]),
+                            "reference_field": "assignment_id",
+                            "target_type": assignment.get("target_type"),
+                            "target_id": assignment.get("target_id"),
+                        }
+                    )
+            dependencies[(object_type, source_object_id)] = dependents
+        return imported_objects, dependencies
+
+    @staticmethod
+    def _version_compare(source_version: str, target_version: str) -> int | None:
+        try:
+            source = Version(str(source_version or "").strip())
+            target = Version(str(target_version or "").strip())
+        except InvalidVersion:
+            return None
+        if target > source:
+            return 1
+        if target < source:
+            return -1
+        return 0
 
     async def _rollback_import(
         self,
@@ -327,6 +520,235 @@ class McpHubGovernancePackService:
     ) -> GovernancePackDryRunReport:
         pack = self.build_pack_from_document(document)
         return await self.dry_run_pack(
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+
+    async def dry_run_upgrade_pack(
+        self,
+        *,
+        source_governance_pack_id: int,
+        pack: GovernancePack,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> GovernancePackUpgradePlan:
+        validation = validate_governance_pack(pack)
+        if validation.errors:
+            raise ValueError("; ".join(validation.errors))
+
+        source_pack = await self.repo.get_governance_pack(source_governance_pack_id)
+        if source_pack is None:
+            raise ValueError(
+                f"mcp_governance_pack '{source_governance_pack_id}' was not found"
+            )
+
+        source_scope_type = str(source_pack.get("owner_scope_type") or "").strip().lower()
+        source_scope_id = source_pack.get("owner_scope_id")
+        structural_conflicts: list[str] = []
+        behavioral_conflicts: list[str] = []
+        warnings: list[str] = []
+        object_diff: list[dict[str, Any]] = []
+        dependency_impact: list[dict[str, Any]] = []
+
+        if not bool(source_pack.get("is_active_install")):
+            structural_conflicts.append(
+                "Only active governance pack installs can be upgraded in place"
+            )
+        if (
+            str(owner_scope_type or "").strip().lower() != source_scope_type
+            or owner_scope_id != source_scope_id
+        ):
+            structural_conflicts.append(
+                "Target upgrade must use the same owner scope as the installed governance pack"
+            )
+
+        target_manifest = {
+            "pack_id": pack.manifest.pack_id,
+            "pack_version": pack.manifest.pack_version,
+            "title": pack.manifest.title,
+            "description": pack.manifest.description,
+        }
+        source_manifest = dict(source_pack.get("manifest") or {})
+        if str(pack.manifest.pack_id or "").strip() != str(source_pack.get("pack_id") or "").strip():
+            structural_conflicts.append(
+                "Target upgrade must keep the same pack_id as the installed governance pack"
+            )
+
+        version_compare = self._version_compare(
+            str(source_pack.get("pack_version") or ""),
+            str(pack.manifest.pack_version or ""),
+        )
+        if version_compare is None:
+            structural_conflicts.append(
+                "Governance pack upgrades require semantic versions for both installed and target versions"
+            )
+        elif version_compare <= 0:
+            structural_conflicts.append(
+                "Target governance pack version must be newer than the installed version"
+            )
+
+        existing_target = await self.repo.get_governance_pack_by_identity(
+            pack_id=pack.manifest.pack_id,
+            pack_version=pack.manifest.pack_version,
+            owner_scope_type=source_scope_type,
+            owner_scope_id=source_scope_id,
+        )
+        if existing_target is not None and int(existing_target["id"]) != int(source_governance_pack_id):
+            structural_conflicts.append(
+                f"Governance pack '{pack.manifest.pack_id}@{pack.manifest.pack_version}' is already installed in this scope"
+            )
+
+        report = await self.dry_run_pack(
+            pack=pack,
+            owner_scope_type=str(owner_scope_type or "").strip().lower(),
+            owner_scope_id=owner_scope_id,
+        )
+        if report.verdict != "importable":
+            structural_conflicts.append(
+                "Target governance pack is not importable under the current adapter mapping state"
+            )
+        warnings = self._unique(
+            warnings
+            + list(report.warnings)
+            + [
+                f"unresolved capability:{name}"
+                for name in report.unresolved_capabilities
+            ]
+            + [f"blocked object:{name}" for name in report.blocked_objects]
+        )
+
+        source_object_maps = _normalized_runtime_object_maps(
+            dict(source_pack.get("normalized_ir") or {})
+        )
+        target_ir = normalize_governance_pack(pack).to_dict()
+        target_object_maps = _normalized_runtime_object_maps(target_ir)
+
+        _, dependencies_by_object = await self._collect_upgrade_dependencies(
+            governance_pack_id=source_governance_pack_id,
+            owner_scope_type=source_scope_type,
+            owner_scope_id=source_scope_id,
+        )
+
+        for object_type in ("approval_policy", "permission_profile", "policy_assignment"):
+            source_items = source_object_maps.get(object_type, {})
+            target_items = target_object_maps.get(object_type, {})
+            for source_object_id in sorted(set(source_items) | set(target_items)):
+                source_item = source_items.get(source_object_id)
+                target_item = target_items.get(source_object_id)
+                change_type = "unchanged"
+                if source_item is None and target_item is not None:
+                    change_type = "added"
+                elif source_item is not None and target_item is None:
+                    change_type = "removed"
+                elif (
+                    source_item is not None
+                    and target_item is not None
+                    and self._semantic_runtime_object(object_type, source_item)
+                    != self._semantic_runtime_object(object_type, target_item)
+                ):
+                    change_type = "modified"
+
+                if change_type == "unchanged":
+                    continue
+
+                object_diff.append(
+                    {
+                        "object_type": object_type,
+                        "source_object_id": source_object_id,
+                        "change_type": change_type,
+                        "previous_digest": (
+                            _stable_digest(self._semantic_runtime_object(object_type, source_item))
+                            if source_item is not None
+                            else None
+                        ),
+                        "next_digest": (
+                            _stable_digest(self._semantic_runtime_object(object_type, target_item))
+                            if target_item is not None
+                            else None
+                        ),
+                    }
+                )
+
+                dependents = dependencies_by_object.get((object_type, source_object_id), [])
+                if not dependents:
+                    continue
+                for dependent in dependents:
+                    impact = "structural_conflict" if change_type == "removed" else "behavioral_conflict"
+                    dependency_impact.append(
+                        {
+                            "object_type": object_type,
+                            "source_object_id": source_object_id,
+                            "change_type": change_type,
+                            "impact": impact,
+                            **dependent,
+                        }
+                    )
+                    if change_type == "removed":
+                        structural_conflicts.append(
+                            f"{object_type}:{source_object_id} is removed but dependent "
+                            f"{dependent['dependent_type'].replace('_', ' ')} {dependent['dependent_id']} "
+                            f"still references it via {dependent['reference_field']}"
+                        )
+                    else:
+                        behavioral_conflicts.append(
+                            f"{object_type}:{source_object_id} materially changes while dependent "
+                            f"{dependent['dependent_type'].replace('_', ' ')} {dependent['dependent_id']} "
+                            f"still references it via {dependent['reference_field']}"
+                        )
+
+        planner_inputs_fingerprint = _stable_digest(
+            {
+                "source_governance_pack_id": int(source_governance_pack_id),
+                "source_manifest": source_manifest,
+                "target_manifest": target_manifest,
+                "source_scope_type": source_scope_type,
+                "source_scope_id": source_scope_id,
+                "requested_scope_type": str(owner_scope_type or "").strip().lower(),
+                "requested_scope_id": owner_scope_id,
+                "object_diff": object_diff,
+                "dependency_impact": dependency_impact,
+            }
+        )
+        adapter_state_fingerprint = _stable_digest(
+            {
+                "digest": report.digest,
+                "resolved_capabilities": report.resolved_capabilities,
+                "unresolved_capabilities": report.unresolved_capabilities,
+                "capability_mapping_summary": report.capability_mapping_summary,
+                "supported_environment_requirements": report.supported_environment_requirements,
+                "unsupported_environment_requirements": report.unsupported_environment_requirements,
+                "warnings": report.warnings,
+                "blocked_objects": report.blocked_objects,
+                "verdict": report.verdict,
+            }
+        )
+
+        return GovernancePackUpgradePlan(
+            source_governance_pack_id=int(source_governance_pack_id),
+            source_manifest=source_manifest,
+            target_manifest=target_manifest,
+            object_diff=object_diff,
+            dependency_impact=dependency_impact,
+            structural_conflicts=self._unique(structural_conflicts),
+            behavioral_conflicts=self._unique(behavioral_conflicts),
+            warnings=self._unique(warnings),
+            planner_inputs_fingerprint=planner_inputs_fingerprint,
+            adapter_state_fingerprint=adapter_state_fingerprint,
+            upgradeable=not structural_conflicts and not behavioral_conflicts,
+        )
+
+    async def dry_run_upgrade_document(
+        self,
+        *,
+        source_governance_pack_id: int,
+        document: dict[str, Any],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> GovernancePackUpgradePlan:
+        pack = self.build_pack_from_document(document)
+        return await self.dry_run_upgrade_pack(
+            source_governance_pack_id=source_governance_pack_id,
             pack=pack,
             owner_scope_type=owner_scope_type,
             owner_scope_id=owner_scope_id,

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -318,6 +318,8 @@ class McpHubGovernancePackService:
                             "reference_field": "profile_id",
                             "target_type": assignment.get("target_type"),
                             "target_id": assignment.get("target_id"),
+                            "conflict_on_removed": True,
+                            "conflict_on_modified": True,
                         }
                     )
             elif object_type == "approval_policy":
@@ -329,6 +331,8 @@ class McpHubGovernancePackService:
                             "reference_field": "approval_policy_id",
                             "target_type": assignment.get("target_type"),
                             "target_id": assignment.get("target_id"),
+                            "conflict_on_removed": True,
+                            "conflict_on_modified": True,
                         }
                     )
             elif object_type == "policy_assignment":
@@ -341,8 +345,23 @@ class McpHubGovernancePackService:
                             "reference_field": "assignment_id",
                             "target_type": assignment.get("target_type"),
                             "target_id": assignment.get("target_id"),
+                            "conflict_on_removed": True,
+                            "conflict_on_modified": True,
                         }
                     )
+                if object_id.isdigit():
+                    for workspace in await self.repo.list_policy_assignment_workspaces(int(object_id)):
+                        dependents.append(
+                            {
+                                "dependent_type": "policy_assignment_workspace",
+                                "dependent_id": int(object_id),
+                                "reference_field": "assignment_id",
+                                "target_type": assignment.get("target_type") if assignment else None,
+                                "target_id": workspace.get("workspace_id"),
+                                "conflict_on_removed": True,
+                                "conflict_on_modified": False,
+                            }
+                        )
             dependencies[(object_type, source_object_id)] = dependents
         return imported_objects, dependencies
 
@@ -706,23 +725,33 @@ class McpHubGovernancePackService:
                 if not dependents:
                     continue
                 for dependent in dependents:
-                    impact = "structural_conflict" if change_type == "removed" else "behavioral_conflict"
+                    public_dependent = {
+                        key: value
+                        for key, value in dependent.items()
+                        if key not in {"conflict_on_removed", "conflict_on_modified"}
+                    }
+                    conflict_on_removed = bool(dependent.get("conflict_on_removed", True))
+                    conflict_on_modified = bool(dependent.get("conflict_on_modified", True))
+                    if change_type == "removed":
+                        impact = "structural_conflict" if conflict_on_removed else "rebind_required"
+                    else:
+                        impact = "behavioral_conflict" if conflict_on_modified else "rebind_required"
                     dependency_impact.append(
                         {
                             "object_type": object_type,
                             "source_object_id": source_object_id,
                             "change_type": change_type,
                             "impact": impact,
-                            **dependent,
+                            **public_dependent,
                         }
                     )
-                    if change_type == "removed":
+                    if change_type == "removed" and conflict_on_removed:
                         structural_conflicts.append(
                             f"{object_type}:{source_object_id} is removed but dependent "
                             f"{dependent['dependent_type'].replace('_', ' ')} {dependent['dependent_id']} "
                             f"still references it via {dependent['reference_field']}"
                         )
-                    else:
+                    elif change_type != "removed" and conflict_on_modified:
                         behavioral_conflicts.append(
                             f"{object_type}:{source_object_id} materially changes while dependent "
                             f"{dependent['dependent_type'].replace('_', ' ')} {dependent['dependent_id']} "

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,7 @@ from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, Field
 
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.AuthNZ.exceptions import TransactionError
 from tldw_Server_API.app.core.MCP_unified.governance_packs import (
     ApprovalTemplate,
     AssignmentTemplate,
@@ -48,6 +50,16 @@ def _imported_name(display_name: str, *, pack_id: str, source_object_id: str) ->
     return f"{display_name} [{pack_id}:{source_object_id}]"
 
 
+def _imported_upgrade_name(
+    display_name: str,
+    *,
+    pack_id: str,
+    pack_version: str,
+    source_object_id: str,
+) -> str:
+    return f"{display_name} [{pack_id}:{source_object_id}@{pack_version}]"
+
+
 class GovernancePackImportResult(BaseModel):
     governance_pack_id: int
     imported_object_ids: dict[str, list[int]] = Field(default_factory=dict)
@@ -82,6 +94,18 @@ class GovernancePackUpgradePlan(BaseModel):
     upgradeable: bool
 
 
+class GovernancePackUpgradeExecutionResult(BaseModel):
+    upgrade_id: int
+    source_governance_pack_id: int
+    target_governance_pack_id: int
+    from_pack_version: str
+    to_pack_version: str
+    planner_inputs_fingerprint: str
+    adapter_state_fingerprint: str
+    imported_object_ids: dict[str, list[int]] = Field(default_factory=dict)
+    imported_object_counts: dict[str, int] = Field(default_factory=dict)
+
+
 class GovernancePackAlreadyExistsError(ValueError):
     """Raised when a governance pack identity already exists in the target scope."""
 
@@ -104,6 +128,14 @@ class GovernancePackAlreadyExistsError(ValueError):
         self.pack_version = pack_version
         self.owner_scope_type = owner_scope_type
         self.owner_scope_id = owner_scope_id
+
+
+class GovernancePackUpgradeConflictError(ValueError):
+    """Raised when an upgrade plan has blocking conflicts."""
+
+
+class GovernancePackUpgradeStaleError(ValueError):
+    """Raised when execute-upgrade inputs no longer match current planner state."""
 
 
 def _is_duplicate_governance_pack_error(exc: Exception) -> bool:
@@ -708,6 +740,12 @@ class McpHubGovernancePackService:
                 "requested_scope_id": owner_scope_id,
                 "object_diff": object_diff,
                 "dependency_impact": dependency_impact,
+                "dependency_snapshot": {
+                    f"{object_type}:{source_object_id}": dependents
+                    for (object_type, source_object_id), dependents in sorted(
+                        dependencies_by_object.items()
+                    )
+                },
             }
         )
         adapter_state_fingerprint = _stable_digest(
@@ -752,6 +790,409 @@ class McpHubGovernancePackService:
             pack=pack,
             owner_scope_type=owner_scope_type,
             owner_scope_id=owner_scope_id,
+        )
+
+    async def _stage_upgrade_import(
+        self,
+        *,
+        conn: Any,
+        pack: GovernancePack,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+    ) -> tuple[GovernancePackImportResult, dict[str, dict[str, int]]]:
+        normalized_ir = normalize_governance_pack(pack)
+        bundle = build_opa_bundle(pack)
+        manifest = pack.manifest
+        pack_row = await self.repo.create_governance_pack(
+            pack_id=manifest.pack_id,
+            pack_version=manifest.pack_version,
+            pack_schema_version=manifest.pack_schema_version,
+            capability_taxonomy_version=manifest.capability_taxonomy_version,
+            adapter_contract_version=manifest.adapter_contract_version,
+            title=manifest.title,
+            description=manifest.description,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            bundle_digest=bundle.digest,
+            manifest=_dump_model(manifest),
+            normalized_ir=normalized_ir.to_dict(),
+            actor_id=actor_id,
+            is_active_install=False,
+            conn=conn,
+        )
+        if not pack_row:
+            raise RuntimeError("Failed to stage governance pack upgrade manifest")
+
+        governance_pack_id = int(pack_row["id"])
+        imported_object_ids: dict[str, list[int]] = {
+            "approval_policies": [],
+            "permission_profiles": [],
+            "policy_assignments": [],
+        }
+        runtime_id_map: dict[str, dict[str, int]] = {
+            "approval_policy": {},
+            "permission_profile": {},
+            "policy_assignment": {},
+        }
+        approval_policy_ids_by_template: dict[str, int] = {}
+        profile_ids_by_template: dict[str, int] = {}
+        persona_ids_by_template: dict[str, str] = {
+            persona.persona_template_id: persona.persona_template_id
+            for persona in pack.personas
+        }
+        persona_approval_ids: dict[str, str] = {
+            persona.persona_template_id: persona.approval_template_id
+            for persona in pack.personas
+        }
+
+        for approval in pack.approvals:
+            runtime_mode = _RUNTIME_APPROVAL_MODE_MAP.get(str(approval.mode or "").strip().lower())
+            if runtime_mode is None:
+                raise RuntimeError(
+                    f"approval template '{approval.approval_template_id}' cannot map to a local runtime approval mode"
+                )
+            created = await self.repo.create_approval_policy(
+                name=_imported_upgrade_name(
+                    approval.name,
+                    pack_id=manifest.pack_id,
+                    pack_version=manifest.pack_version,
+                    source_object_id=approval.approval_template_id,
+                ),
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                mode=runtime_mode,
+                rules={
+                    "portable_mode": approval.mode,
+                    "approval_template_id": approval.approval_template_id,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": approval.approval_template_id,
+                    },
+                },
+                actor_id=actor_id,
+                description=approval.name,
+                is_active=True,
+                is_immutable=True,
+                conn=conn,
+            )
+            approval_id = int(created["id"])
+            approval_policy_ids_by_template[approval.approval_template_id] = approval_id
+            runtime_id_map["approval_policy"][approval.approval_template_id] = approval_id
+            imported_object_ids["approval_policies"].append(approval_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=governance_pack_id,
+                object_type="approval_policy",
+                object_id=approval_id,
+                source_object_id=approval.approval_template_id,
+                conn=conn,
+            )
+
+        for profile in pack.profiles:
+            created = await self.repo.create_permission_profile(
+                name=_imported_upgrade_name(
+                    profile.name,
+                    pack_id=manifest.pack_id,
+                    pack_version=manifest.pack_version,
+                    source_object_id=profile.profile_id,
+                ),
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                mode="preset",
+                policy_document={
+                    "capabilities": list(profile.capabilities.allow),
+                    "denied_capabilities": list(profile.capabilities.deny),
+                    "environment_requirements": list(profile.environment_requirements),
+                    "approval_intent": profile.approval_intent,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": profile.profile_id,
+                    },
+                },
+                actor_id=actor_id,
+                description=profile.description,
+                is_active=True,
+                is_immutable=True,
+                conn=conn,
+            )
+            profile_id = int(created["id"])
+            profile_ids_by_template[profile.profile_id] = profile_id
+            runtime_id_map["permission_profile"][profile.profile_id] = profile_id
+            imported_object_ids["permission_profiles"].append(profile_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=governance_pack_id,
+                object_type="permission_profile",
+                object_id=profile_id,
+                source_object_id=profile.profile_id,
+                conn=conn,
+            )
+
+        for assignment in pack.assignments:
+            profile_id = profile_ids_by_template.get(assignment.capability_profile_id)
+            if profile_id is None:
+                raise RuntimeError(
+                    f"assignment template '{assignment.assignment_template_id}' has no staged capability profile"
+                )
+
+            approval_template_id = assignment.approval_template_id
+            if approval_template_id is None and assignment.persona_template_id is not None:
+                approval_template_id = persona_approval_ids.get(assignment.persona_template_id)
+            approval_policy_id = (
+                approval_policy_ids_by_template.get(approval_template_id)
+                if approval_template_id is not None
+                else None
+            )
+            if approval_template_id is not None and approval_policy_id is None:
+                raise RuntimeError(
+                    f"assignment template '{assignment.assignment_template_id}' has no staged approval policy"
+                )
+
+            target_id = None
+            if assignment.target_type == "persona" and assignment.persona_template_id is not None:
+                target_id = persona_ids_by_template.get(assignment.persona_template_id)
+
+            created = await self.repo.create_policy_assignment(
+                target_type=assignment.target_type,
+                target_id=target_id,
+                owner_scope_type=owner_scope_type,
+                owner_scope_id=owner_scope_id,
+                profile_id=profile_id,
+                inline_policy_document={
+                    "persona_template_id": assignment.persona_template_id,
+                    "approval_template_id": approval_template_id,
+                    "capability_profile_id": assignment.capability_profile_id,
+                    "governance_pack": {
+                        "pack_id": manifest.pack_id,
+                        "pack_version": manifest.pack_version,
+                        "source_object_id": assignment.assignment_template_id,
+                    },
+                },
+                approval_policy_id=approval_policy_id,
+                actor_id=actor_id,
+                is_active=True,
+                is_immutable=True,
+                conn=conn,
+            )
+            assignment_id = int(created["id"])
+            runtime_id_map["policy_assignment"][assignment.assignment_template_id] = assignment_id
+            imported_object_ids["policy_assignments"].append(assignment_id)
+            await self.repo.create_governance_pack_object(
+                governance_pack_id=governance_pack_id,
+                object_type="policy_assignment",
+                object_id=assignment_id,
+                source_object_id=assignment.assignment_template_id,
+                conn=conn,
+            )
+
+        return (
+            GovernancePackImportResult(
+                governance_pack_id=governance_pack_id,
+                imported_object_ids=imported_object_ids,
+                imported_object_counts={
+                    key: len(value) for key, value in imported_object_ids.items()
+                },
+                blocked_objects=[],
+            ),
+            runtime_id_map,
+        )
+
+    async def execute_upgrade_pack(
+        self,
+        *,
+        source_governance_pack_id: int,
+        pack: GovernancePack,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+        planner_inputs_fingerprint: str,
+        adapter_state_fingerprint: str,
+    ) -> GovernancePackUpgradeExecutionResult:
+        plan = await self.dry_run_upgrade_pack(
+            source_governance_pack_id=source_governance_pack_id,
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+        )
+        if (
+            str(planner_inputs_fingerprint).strip() != plan.planner_inputs_fingerprint
+            or str(adapter_state_fingerprint).strip() != plan.adapter_state_fingerprint
+        ):
+            raise GovernancePackUpgradeStaleError(
+                "Governance pack upgrade plan is stale; rerun dry-run-upgrade"
+            )
+        if not plan.upgradeable:
+            raise GovernancePackUpgradeConflictError(
+                "Governance pack upgrade has blocking conflicts"
+            )
+
+        source_pack = await self.repo.get_governance_pack(source_governance_pack_id)
+        if source_pack is None:
+            raise ValueError(
+                f"mcp_governance_pack '{source_governance_pack_id}' was not found"
+            )
+
+        source_scope_type = str(source_pack.get("owner_scope_type") or "").strip().lower()
+        source_scope_id = source_pack.get("owner_scope_id")
+        imported_objects, dependencies_by_object = await self._collect_upgrade_dependencies(
+            governance_pack_id=source_governance_pack_id,
+            owner_scope_type=source_scope_type,
+            owner_scope_id=source_scope_id,
+        )
+
+        try:
+            async with self.repo.db_pool.transaction() as conn:
+                source_pack_tx = await self.repo.get_governance_pack(
+                    source_governance_pack_id,
+                    conn=conn,
+                )
+                if source_pack_tx is None or not bool(source_pack_tx.get("is_active_install")):
+                    raise GovernancePackUpgradeStaleError(
+                        "Governance pack upgrade source install is no longer active"
+                    )
+                existing_target = await self.repo.get_governance_pack_by_identity(
+                    pack_id=pack.manifest.pack_id,
+                    pack_version=pack.manifest.pack_version,
+                    owner_scope_type=source_scope_type,
+                    owner_scope_id=source_scope_id,
+                    conn=conn,
+                )
+                if existing_target is not None:
+                    raise GovernancePackAlreadyExistsError(
+                        pack.manifest.pack_id,
+                        pack.manifest.pack_version,
+                        source_scope_type,
+                        source_scope_id,
+                    )
+
+                staged_import, runtime_id_map = await self._stage_upgrade_import(
+                    conn=conn,
+                    pack=pack,
+                    owner_scope_type=source_scope_type,
+                    owner_scope_id=source_scope_id,
+                    actor_id=actor_id,
+                )
+                for imported_object in imported_objects:
+                    object_type = str(imported_object.get("object_type") or "").strip().lower()
+                    source_object_id = str(imported_object.get("source_object_id") or "").strip()
+                    old_object_id = int(imported_object["object_id"])
+                    new_object_id = runtime_id_map.get(object_type, {}).get(source_object_id)
+                    if new_object_id is None:
+                        continue
+                    dependents = dependencies_by_object.get((object_type, source_object_id), [])
+                    if object_type == "permission_profile":
+                        for dependent in dependents:
+                            if dependent["dependent_type"] != "policy_assignment":
+                                continue
+                            await self.repo.update_policy_assignment(
+                                int(dependent["dependent_id"]),
+                                profile_id=new_object_id,
+                                actor_id=actor_id,
+                                conn=conn,
+                            )
+                    elif object_type == "approval_policy":
+                        for dependent in dependents:
+                            if dependent["dependent_type"] != "policy_assignment":
+                                continue
+                            await self.repo.update_policy_assignment(
+                                int(dependent["dependent_id"]),
+                                approval_policy_id=new_object_id,
+                                actor_id=actor_id,
+                                conn=conn,
+                            )
+                    elif object_type == "policy_assignment":
+                        await self.repo.rebind_policy_assignment_workspaces(
+                            old_assignment_id=old_object_id,
+                            new_assignment_id=new_object_id,
+                            conn=conn,
+                        )
+                        for dependent in dependents:
+                            if dependent["dependent_type"] != "policy_override":
+                                continue
+                            await self.repo.rebind_policy_override_assignment(
+                                old_assignment_id=old_object_id,
+                                new_assignment_id=new_object_id,
+                                actor_id=actor_id,
+                                conn=conn,
+                            )
+
+                executed_at = datetime.now(timezone.utc)
+                upgrade_row = await self.repo.create_governance_pack_upgrade(
+                    pack_id=str(source_pack_tx.get("pack_id") or ""),
+                    owner_scope_type=source_scope_type,
+                    owner_scope_id=source_scope_id,
+                    from_governance_pack_id=int(source_governance_pack_id),
+                    to_governance_pack_id=int(staged_import.governance_pack_id),
+                    from_pack_version=str(source_pack_tx.get("pack_version") or ""),
+                    to_pack_version=pack.manifest.pack_version,
+                    status="executed",
+                    planned_by=actor_id,
+                    executed_by=actor_id,
+                    planner_inputs_fingerprint=plan.planner_inputs_fingerprint,
+                    adapter_state_fingerprint=plan.adapter_state_fingerprint,
+                    plan_summary={
+                        "object_diff_count": len(plan.object_diff),
+                        "dependency_impact_count": len(plan.dependency_impact),
+                    },
+                    accepted_resolutions={},
+                    executed_at=executed_at,
+                    conn=conn,
+                )
+                if not upgrade_row:
+                    raise RuntimeError("Failed to persist governance pack upgrade lineage")
+
+                await self.repo.update_governance_pack_install_state(
+                    int(source_governance_pack_id),
+                    is_active_install=False,
+                    superseded_by_governance_pack_id=int(staged_import.governance_pack_id),
+                    actor_id=actor_id,
+                    conn=conn,
+                )
+                await self.repo.update_governance_pack_install_state(
+                    int(staged_import.governance_pack_id),
+                    is_active_install=True,
+                    installed_from_upgrade_id=int(upgrade_row["id"]),
+                    actor_id=actor_id,
+                    conn=conn,
+                )
+        except TransactionError as exc:
+            if exc.__cause__ is not None:
+                raise exc.__cause__
+            raise
+
+        return GovernancePackUpgradeExecutionResult(
+            upgrade_id=int(upgrade_row["id"]),
+            source_governance_pack_id=int(source_governance_pack_id),
+            target_governance_pack_id=int(staged_import.governance_pack_id),
+            from_pack_version=str(source_pack.get("pack_version") or ""),
+            to_pack_version=pack.manifest.pack_version,
+            planner_inputs_fingerprint=plan.planner_inputs_fingerprint,
+            adapter_state_fingerprint=plan.adapter_state_fingerprint,
+            imported_object_ids=staged_import.imported_object_ids,
+            imported_object_counts=staged_import.imported_object_counts,
+        )
+
+    async def execute_upgrade_document(
+        self,
+        *,
+        source_governance_pack_id: int,
+        document: dict[str, Any],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+        planner_inputs_fingerprint: str,
+        adapter_state_fingerprint: str,
+    ) -> GovernancePackUpgradeExecutionResult:
+        pack = self.build_pack_from_document(document)
+        return await self.execute_upgrade_pack(
+            source_governance_pack_id=source_governance_pack_id,
+            pack=pack,
+            owner_scope_type=owner_scope_type,
+            owner_scope_id=owner_scope_id,
+            actor_id=actor_id,
+            planner_inputs_fingerprint=planner_inputs_fingerprint,
+            adapter_state_fingerprint=adapter_state_fingerprint,
         )
 
     async def import_pack_document(

--- a/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_governance_pack_service.py
@@ -1244,6 +1244,19 @@ class McpHubGovernancePackService:
             "imported_objects": await self.repo.list_governance_pack_objects(governance_pack_id),
         }
 
+    async def list_governance_pack_upgrade_history(
+        self,
+        governance_pack_id: int,
+    ) -> list[dict[str, Any]]:
+        pack_row = await self.repo.get_governance_pack(governance_pack_id)
+        if pack_row is None:
+            return []
+        return await self.repo.list_governance_pack_upgrades(
+            pack_id=str(pack_row.get("pack_id") or ""),
+            owner_scope_type=str(pack_row.get("owner_scope_type") or "global"),
+            owner_scope_id=pack_row.get("owner_scope_id"),
+        )
+
     async def import_pack(
         self,
         *,

--- a/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_policy_resolver.py
@@ -75,6 +75,26 @@ def _collect_scope_ids(metadata: dict[str, Any], singular_key: str, plural_key: 
     return sorted(out)
 
 
+def _normalize_scope_id(value: Any) -> int | None:
+    """Return an integer scope id when present and parseable."""
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _governance_pack_reference(document: dict[str, Any]) -> tuple[str, str] | None:
+    """Extract governance-pack identity metadata from a stored policy document."""
+    metadata = _as_dict(document.get("governance_pack"))
+    pack_id = str(metadata.get("pack_id") or "").strip()
+    pack_version = str(metadata.get("pack_version") or "").strip()
+    if not pack_id or not pack_version:
+        return None
+    return pack_id, pack_version
+
+
 def _extract_targets(metadata: dict[str, Any]) -> list[tuple[str, str | None]]:
     """Return the ordered assignment targets applicable to the runtime metadata."""
     targets: list[tuple[str, str | None]] = [("default", None)]
@@ -247,6 +267,44 @@ class McpHubPolicyResolver:
             repo=repo
         )
 
+    async def _document_uses_active_governance_pack(
+        self,
+        *,
+        document: dict[str, Any],
+        owner_scope_type: str | None,
+        owner_scope_id: Any,
+        cache: dict[tuple[str, str, str, int | None], bool],
+    ) -> bool:
+        pack_ref = _governance_pack_reference(document)
+        if pack_ref is None:
+            return True
+        scope_type = str(owner_scope_type or "global").strip().lower() or "global"
+        scope_id = _normalize_scope_id(owner_scope_id)
+        cache_key = (pack_ref[0], pack_ref[1], scope_type, scope_id)
+        if cache_key not in cache:
+            pack_row = await self.repo.get_governance_pack_by_identity(
+                pack_id=pack_ref[0],
+                pack_version=pack_ref[1],
+                owner_scope_type=scope_type,
+                owner_scope_id=scope_id,
+            )
+            cache[cache_key] = bool(pack_row and pack_row.get("is_active_install"))
+        return cache[cache_key]
+
+    async def _row_uses_active_governance_pack(
+        self,
+        *,
+        row: dict[str, Any],
+        document_field: str,
+        cache: dict[tuple[str, str, str, int | None], bool],
+    ) -> bool:
+        return await self._document_uses_active_governance_pack(
+            document=_as_dict(row.get(document_field)),
+            owner_scope_type=row.get("owner_scope_type"),
+            owner_scope_id=row.get("owner_scope_id"),
+            cache=cache,
+        )
+
     async def resolve_for_context(
         self,
         *,
@@ -286,8 +344,16 @@ class McpHubPolicyResolver:
         selected_workspace_scope_id: int | None = None
         path_scope_object_cache: dict[int, dict[str, Any] | None] = {}
         workspace_set_object_cache: dict[int, dict[str, Any] | None] = {}
+        approval_policy_cache: dict[int, dict[str, Any] | None] = {}
+        governance_pack_activity_cache: dict[tuple[str, str, str, int | None], bool] = {}
 
         for assignment in assignments:
+            if not await self._row_uses_active_governance_pack(
+                row=assignment,
+                document_field="inline_policy_document",
+                cache=governance_pack_activity_cache,
+            ):
+                continue
             assignment_document: dict[str, Any] = {}
             profile_id = assignment.get("profile_id")
             profile_key: int | None = int(profile_id) if profile_id is not None else None
@@ -296,7 +362,11 @@ class McpHubPolicyResolver:
                 if profile_key not in profile_cache:
                     profile_cache[profile_key] = await self.repo.get_permission_profile(profile_key)
                 profile_row = profile_cache.get(profile_key) or {}
-                if bool(profile_row.get("is_active", True)):
+                if bool(profile_row.get("is_active", True)) and await self._row_uses_active_governance_pack(
+                    row=profile_row,
+                    document_field="policy_document",
+                    cache=governance_pack_activity_cache,
+                ):
                     profile_path_scope_object_id = profile_row.get("path_scope_object_id")
                     profile_path_scope_key = (
                         int(profile_path_scope_object_id)
@@ -402,7 +472,18 @@ class McpHubPolicyResolver:
             merged_policy_document = _merge_policy_documents(merged_policy_document, assignment_document)
             approval_policy_id = assignment.get("approval_policy_id")
             if approval_policy_id is not None:
-                resolved_approval_policy_id = int(approval_policy_id)
+                approval_policy_key = int(approval_policy_id)
+                if approval_policy_key not in approval_policy_cache:
+                    approval_policy_cache[approval_policy_key] = await self.repo.get_approval_policy(
+                        approval_policy_key
+                    )
+                approval_policy_row = approval_policy_cache.get(approval_policy_key) or {}
+                if bool(approval_policy_row.get("is_active", True)) and await self._row_uses_active_governance_pack(
+                    row=approval_policy_row,
+                    document_field="rules",
+                    cache=governance_pack_activity_cache,
+                ):
+                    resolved_approval_policy_id = approval_policy_key
             selected_assignment_id = assignment_id
             selected_workspace_scope_type = str(assignment.get("owner_scope_type") or "global")
             selected_workspace_scope_id = assignment.get("owner_scope_id")
@@ -456,6 +537,9 @@ class McpHubPolicyResolver:
                     "path_scope_object_id": assignment.get("path_scope_object_id"),
                 }
             )
+
+        if not sources:
+            return self._disabled_policy()
 
         authored_policy_document = deepcopy(merged_policy_document)
         allow_capability_resolution = await self.capability_resolution_service.resolve_capabilities(

--- a/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_governance_pack_migrations.py
+++ b/tldw_Server_API/tests/AuthNZ_SQLite/test_mcp_hub_governance_pack_migrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -60,3 +61,93 @@ async def test_mcp_hub_governance_pack_tables_exist_after_authnz_migrations_sqli
     approval_columns = await pool.fetchall("PRAGMA table_info(mcp_approval_policies)")
     approval_column_names = {str(row["name"]) for row in approval_columns}
     assert "is_immutable" in approval_column_names
+
+
+def test_governance_pack_upgrade_lineage_migration_normalizes_existing_active_installs(
+    tmp_path,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.migrations import (
+        migration_071_add_governance_pack_upgrade_lineage,
+    )
+
+    db_path = tmp_path / "legacy-users.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE mcp_governance_packs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                pack_id TEXT NOT NULL,
+                pack_version TEXT NOT NULL,
+                pack_schema_version INTEGER NOT NULL DEFAULT 1,
+                capability_taxonomy_version INTEGER NOT NULL DEFAULT 1,
+                adapter_contract_version INTEGER NOT NULL DEFAULT 1,
+                title TEXT NOT NULL,
+                description TEXT,
+                owner_scope_type TEXT NOT NULL DEFAULT 'user',
+                owner_scope_id INTEGER,
+                bundle_digest TEXT NOT NULL,
+                manifest_json TEXT NOT NULL DEFAULT '{}',
+                normalized_ir_json TEXT NOT NULL DEFAULT '{}',
+                created_by INTEGER,
+                updated_by INTEGER,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO mcp_governance_packs (
+                pack_id, pack_version, title, owner_scope_type, owner_scope_id, bundle_digest
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("researcher-pack", "1.0.0", "Researcher Pack", "team", 21, "a" * 64),
+        )
+        conn.execute(
+            """
+            INSERT INTO mcp_governance_packs (
+                pack_id, pack_version, title, owner_scope_type, owner_scope_id, bundle_digest
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("researcher-pack", "1.1.0", "Researcher Pack", "team", 21, "b" * 64),
+        )
+        conn.execute(
+            """
+            INSERT INTO mcp_governance_packs (
+                pack_id, pack_version, title, owner_scope_type, owner_scope_id, bundle_digest
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("writer-pack", "1.0.0", "Writer Pack", "team", 22, "c" * 64),
+        )
+        conn.commit()
+
+        migration_071_add_governance_pack_upgrade_lineage(conn)
+
+        rows = conn.execute(
+            """
+            SELECT id, pack_version, is_active_install
+            FROM mcp_governance_packs
+            WHERE pack_id = ?
+              AND owner_scope_type = ?
+              AND owner_scope_id = ?
+            ORDER BY id
+            """,
+            ("researcher-pack", "team", 21),
+        ).fetchall()
+        assert [(row[1], row[2]) for row in rows] == [("1.0.0", 0), ("1.1.0", 1)]
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                UPDATE mcp_governance_packs
+                SET is_active_install = 1
+                WHERE pack_id = ?
+                  AND pack_version = ?
+                  AND owner_scope_type = ?
+                  AND owner_scope_id = ?
+                """,
+                ("researcher-pack", "1.0.0", "team", 21),
+            )
+    finally:
+        conn.close()

--- a/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
+++ b/tldw_Server_API/tests/CI/test_required_workflow_contracts.py
@@ -22,6 +22,16 @@ def _assert_ffmpeg_portaudio_setup(path: str, job_name: str) -> None:
     assert install_step["with"]["install-portaudio"] == "true"
 
 
+def _assert_portaudio_installed_before_python_setup(path: str, job_name: str) -> None:
+    workflow = _load(path)
+    steps = workflow["jobs"][job_name]["steps"]
+    install_step = _get_step(steps, "Install FFmpeg and PortAudio (Linux)")
+    setup_step = _get_step(steps, "Setup Python and backend")
+    assert install_step["uses"] == "./.github/actions/setup-ffmpeg"
+    assert install_step["with"]["install-portaudio"] == "true"
+    assert steps.index(install_step) < steps.index(setup_step)
+
+
 def test_backend_required_has_noop_and_execute_paths() -> None:
     workflow = _load(".github/workflows/backend-required.yml")
     jobs = workflow["jobs"]
@@ -117,6 +127,14 @@ def test_e2e_required_explicitly_loads_pytest_asyncio_plugin() -> None:
     retry = _get_step(steps, "Run critical e2e suite (retry)")
     assert "-p pytest_asyncio.plugin" in primary["run"]
     assert "-p pytest_asyncio.plugin" in retry["run"]
+
+
+def test_frontend_e2e_tiers_install_portaudio_before_backend_dependency_setup() -> None:
+    for job_name in ("critical", "features", "admin"):
+        _assert_portaudio_installed_before_python_setup(
+            ".github/workflows/frontend-e2e-tiers.yml",
+            job_name,
+        )
 
 
 def test_security_required_lane_exists_and_uses_threshold_policy() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py
@@ -13,6 +13,8 @@ from tldw_Server_API.app.core.AuthNZ.permissions import SYSTEM_CONFIGURE
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
     GovernancePackAlreadyExistsError,
+    GovernancePackUpgradeConflictError,
+    GovernancePackUpgradeStaleError,
 )
 
 
@@ -77,6 +79,8 @@ class _FakeGovernancePackService:
     def __init__(self) -> None:
         self.dry_run_calls: list[dict] = []
         self.import_calls: list[dict] = []
+        self.upgrade_dry_run_calls: list[dict] = []
+        self.upgrade_execute_calls: list[dict] = []
         self.report = {
             "manifest": {
                 "pack_id": "researcher-pack",
@@ -147,6 +151,87 @@ class _FakeGovernancePackService:
                 },
             ],
         }
+        self.upgrade_plan = {
+            "source_governance_pack_id": 81,
+            "source_manifest": self.inventory[0]["manifest"],
+            "target_manifest": {
+                "pack_id": "researcher-pack",
+                "pack_version": "1.1.0",
+                "title": "Researcher Pack",
+            },
+            "object_diff": [
+                {
+                    "object_type": "permission_profile",
+                    "source_object_id": "researcher.profile",
+                    "change_type": "modified",
+                    "previous_digest": "1" * 64,
+                    "next_digest": "2" * 64,
+                }
+            ],
+            "dependency_impact": [
+                {
+                    "object_type": "permission_profile",
+                    "source_object_id": "researcher.profile",
+                    "change_type": "modified",
+                    "impact": "behavioral_conflict",
+                    "dependent_type": "policy_assignment",
+                    "dependent_id": 91,
+                    "reference_field": "profile_id",
+                    "target_type": "permission_profile",
+                    "target_id": "researcher.profile",
+                }
+            ],
+            "structural_conflicts": [],
+            "behavioral_conflicts": [],
+            "warnings": [],
+            "planner_inputs_fingerprint": "plan-fingerprint",
+            "adapter_state_fingerprint": "adapter-fingerprint",
+            "upgradeable": True,
+        }
+        self.upgrade_result = {
+            "upgrade_id": 12,
+            "source_governance_pack_id": 81,
+            "target_governance_pack_id": 82,
+            "from_pack_version": "1.0.0",
+            "to_pack_version": "1.1.0",
+            "planner_inputs_fingerprint": "plan-fingerprint",
+            "adapter_state_fingerprint": "adapter-fingerprint",
+            "imported_object_ids": {
+                "approval_policies": [31],
+                "permission_profiles": [41],
+                "policy_assignments": [51],
+            },
+            "imported_object_counts": {
+                "approval_policies": 1,
+                "permission_profiles": 1,
+                "policy_assignments": 1,
+            },
+        }
+        self.upgrade_history = [
+            {
+                "id": 12,
+                "pack_id": "researcher-pack",
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "from_governance_pack_id": 81,
+                "to_governance_pack_id": 82,
+                "from_pack_version": "1.0.0",
+                "to_pack_version": "1.1.0",
+                "status": "executed",
+                "planned_by": 7,
+                "executed_by": 7,
+                "planner_inputs_fingerprint": "plan-fingerprint",
+                "adapter_state_fingerprint": "adapter-fingerprint",
+                "plan_summary": {
+                    "object_diff_count": 1,
+                    "dependency_impact_count": 1,
+                },
+                "accepted_resolutions": {},
+                "failure_summary": None,
+                "planned_at": datetime.now(timezone.utc).isoformat(),
+                "executed_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ]
 
     async def dry_run_pack_document(
         self,
@@ -204,6 +289,55 @@ class _FakeGovernancePackService:
         if int(governance_pack_id) == 81:
             return dict(self.detail)
         return None
+
+    async def dry_run_upgrade_document(
+        self,
+        *,
+        source_governance_pack_id: int,
+        document: dict[str, object],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict[str, object]:
+        self.upgrade_dry_run_calls.append(
+            {
+                "source_governance_pack_id": source_governance_pack_id,
+                "document": dict(document),
+                "owner_scope_type": owner_scope_type,
+                "owner_scope_id": owner_scope_id,
+            }
+        )
+        return dict(self.upgrade_plan)
+
+    async def execute_upgrade_document(
+        self,
+        *,
+        source_governance_pack_id: int,
+        document: dict[str, object],
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        actor_id: int | None,
+        planner_inputs_fingerprint: str,
+        adapter_state_fingerprint: str,
+    ) -> dict[str, object]:
+        self.upgrade_execute_calls.append(
+            {
+                "source_governance_pack_id": source_governance_pack_id,
+                "document": dict(document),
+                "owner_scope_type": owner_scope_type,
+                "owner_scope_id": owner_scope_id,
+                "actor_id": actor_id,
+                "planner_inputs_fingerprint": planner_inputs_fingerprint,
+                "adapter_state_fingerprint": adapter_state_fingerprint,
+            }
+        )
+        return dict(self.upgrade_result)
+
+    async def list_governance_pack_upgrade_history(
+        self,
+        governance_pack_id: int,
+    ) -> list[dict[str, object]]:
+        assert governance_pack_id == 81
+        return list(self.upgrade_history)
 
 
 def _build_app(
@@ -324,6 +458,206 @@ def test_governance_pack_import_returns_import_result() -> None:
     assert payload["governance_pack_id"] == 81
     assert payload["imported_object_counts"]["permission_profiles"] == 1
     assert governance_service.import_calls
+
+
+def test_governance_pack_upgrade_dry_run_returns_plan() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    upgraded_pack = _minimal_pack_document()
+    upgraded_pack["manifest"]["pack_version"] = "1.1.0"
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/dry-run-upgrade",
+            json={
+                "source_governance_pack_id": 81,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "pack": upgraded_pack,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["plan"]["source_governance_pack_id"] == 81
+    assert payload["plan"]["upgradeable"] is True
+    assert governance_service.upgrade_dry_run_calls[0]["owner_scope_id"] == 7
+
+
+def test_governance_pack_execute_upgrade_returns_result() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    upgraded_pack = _minimal_pack_document()
+    upgraded_pack["manifest"]["pack_version"] = "1.1.0"
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/execute-upgrade",
+            json={
+                "source_governance_pack_id": 81,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "planner_inputs_fingerprint": "plan-fingerprint",
+                "adapter_state_fingerprint": "adapter-fingerprint",
+                "pack": upgraded_pack,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["upgrade_id"] == 12
+    assert payload["target_governance_pack_id"] == 82
+    assert governance_service.upgrade_execute_calls[0]["actor_id"] == 7
+
+
+def test_governance_pack_execute_upgrade_requires_grant_authority() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read"]),
+        governance_service=governance_service,
+    )
+
+    upgraded_pack = _minimal_pack_document()
+    upgraded_pack["manifest"]["pack_version"] = "1.1.0"
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/execute-upgrade",
+            json={
+                "source_governance_pack_id": 81,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "planner_inputs_fingerprint": "plan-fingerprint",
+                "adapter_state_fingerprint": "adapter-fingerprint",
+                "pack": upgraded_pack,
+            },
+        )
+
+    assert resp.status_code == 403
+    assert "grant.tool.invoke" in resp.json()["detail"]
+    assert governance_service.upgrade_execute_calls == []
+
+
+def test_governance_pack_execute_upgrade_returns_conflict_for_blocking_plan() -> None:
+    class _ConflictGovernancePackService(_FakeGovernancePackService):
+        async def execute_upgrade_document(
+            self,
+            *,
+            source_governance_pack_id: int,
+            document: dict[str, object],
+            owner_scope_type: str,
+            owner_scope_id: int | None,
+            actor_id: int | None,
+            planner_inputs_fingerprint: str,
+            adapter_state_fingerprint: str,
+        ) -> dict[str, object]:
+            del (
+                source_governance_pack_id,
+                document,
+                owner_scope_type,
+                owner_scope_id,
+                actor_id,
+                planner_inputs_fingerprint,
+                adapter_state_fingerprint,
+            )
+            raise GovernancePackUpgradeConflictError("blocking conflicts")
+
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=_ConflictGovernancePackService(),
+    )
+
+    upgraded_pack = _minimal_pack_document()
+    upgraded_pack["manifest"]["pack_version"] = "1.1.0"
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/execute-upgrade",
+            json={
+                "source_governance_pack_id": 81,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "planner_inputs_fingerprint": "plan-fingerprint",
+                "adapter_state_fingerprint": "adapter-fingerprint",
+                "pack": upgraded_pack,
+            },
+        )
+
+    assert resp.status_code == 409
+    assert "blocking conflicts" in resp.json()["detail"]
+
+
+def test_governance_pack_execute_upgrade_returns_conflict_for_stale_plan() -> None:
+    class _StaleGovernancePackService(_FakeGovernancePackService):
+        async def execute_upgrade_document(
+            self,
+            *,
+            source_governance_pack_id: int,
+            document: dict[str, object],
+            owner_scope_type: str,
+            owner_scope_id: int | None,
+            actor_id: int | None,
+            planner_inputs_fingerprint: str,
+            adapter_state_fingerprint: str,
+        ) -> dict[str, object]:
+            del (
+                source_governance_pack_id,
+                document,
+                owner_scope_type,
+                owner_scope_id,
+                actor_id,
+                planner_inputs_fingerprint,
+                adapter_state_fingerprint,
+            )
+            raise GovernancePackUpgradeStaleError("stale plan")
+
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=_StaleGovernancePackService(),
+    )
+
+    upgraded_pack = _minimal_pack_document()
+    upgraded_pack["manifest"]["pack_version"] = "1.1.0"
+
+    with TestClient(app) as client:
+        resp = client.post(
+            "/api/v1/mcp/hub/governance-packs/execute-upgrade",
+            json={
+                "source_governance_pack_id": 81,
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
+                "planner_inputs_fingerprint": "plan-fingerprint",
+                "adapter_state_fingerprint": "adapter-fingerprint",
+                "pack": upgraded_pack,
+            },
+        )
+
+    assert resp.status_code == 409
+    assert "stale plan" in resp.json()["detail"]
+
+
+def test_governance_pack_upgrade_history_returns_lineage() -> None:
+    governance_service = _FakeGovernancePackService()
+    app = _build_app(
+        _make_principal(permissions=[SYSTEM_CONFIGURE, "grant.filesystem.read", "grant.tool.invoke"]),
+        governance_service=governance_service,
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/v1/mcp/hub/governance-packs/81/upgrade-history")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload[0]["from_pack_version"] == "1.0.0"
+    assert payload[0]["to_pack_version"] == "1.1.0"
 
 
 def test_governance_pack_dry_run_defaults_user_scope_id_from_principal() -> None:

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -184,6 +184,7 @@ async def test_import_governance_pack_materializes_immutable_base_objects_with_p
     assert governance_pack is not None
     assert governance_pack["pack_id"] == "researcher-pack"
     assert governance_pack["pack_version"] == "1.0.0"
+    assert governance_pack["is_active_install"] is True
     assert len(str(governance_pack["bundle_digest"])) == 64
 
     approval_policy = await repo.get_approval_policy(result.imported_object_ids["approval_policies"][0])

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -685,3 +685,256 @@ async def test_dry_run_upgrade_blocks_semantic_profile_change_with_local_assignm
         and item["impact"] == "behavioral_conflict"
         for item in plan.dependency_impact
     )
+
+
+@pytest.mark.asyncio
+async def test_execute_upgrade_rebinds_dependents_and_marks_pack_lineage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    local_assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="local.persona",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=imported.imported_object_ids["permission_profiles"][0],
+        inline_policy_document={"source": "local-overlay"},
+        approval_policy_id=imported.imported_object_ids["approval_policies"][0],
+        actor_id=8,
+        is_active=True,
+        is_immutable=False,
+    )
+    await repo.upsert_policy_override(
+        int(imported.imported_object_ids["policy_assignments"][0]),
+        override_policy_document={"allowed_tools": ["Read"]},
+        broadens_access=False,
+        grant_authority_snapshot={"source": "local-overlay"},
+        actor_id=8,
+        is_active=True,
+    )
+    await repo.add_policy_assignment_workspace(
+        int(imported.imported_object_ids["policy_assignments"][0]),
+        workspace_id="workspace-alpha",
+        actor_id=8,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.0.1"
+    target_pack.manifest.description = "Upgrade target"
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    result = await service.execute_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+        planner_inputs_fingerprint=plan.planner_inputs_fingerprint,
+        adapter_state_fingerprint=plan.adapter_state_fingerprint,
+    )
+
+    assert result.from_pack_version == "1.0.0"
+    assert result.to_pack_version == "1.0.1"
+
+    old_pack = await repo.get_governance_pack(imported.governance_pack_id)
+    new_pack = await repo.get_governance_pack(result.target_governance_pack_id)
+    assert old_pack is not None and new_pack is not None
+    assert old_pack["is_active_install"] is False
+    assert old_pack["superseded_by_governance_pack_id"] == result.target_governance_pack_id
+    assert new_pack["is_active_install"] is True
+    assert new_pack["installed_from_upgrade_id"] == result.upgrade_id
+
+    new_objects = await repo.list_governance_pack_objects(result.target_governance_pack_id)
+    new_profile_id = int(
+        next(
+            item["object_id"]
+            for item in new_objects
+            if item["object_type"] == "permission_profile"
+            and item["source_object_id"] == "researcher.profile"
+        )
+    )
+    new_approval_id = int(
+        next(
+            item["object_id"]
+            for item in new_objects
+            if item["object_type"] == "approval_policy"
+            and item["source_object_id"] == "researcher.ask"
+        )
+    )
+    new_assignment_id = int(
+        next(
+            item["object_id"]
+            for item in new_objects
+            if item["object_type"] == "policy_assignment"
+            and item["source_object_id"] == "researcher.default"
+        )
+    )
+
+    rebound_assignment = await repo.get_policy_assignment(int(local_assignment["id"]))
+    assert rebound_assignment is not None
+    assert int(rebound_assignment["profile_id"]) == new_profile_id
+    assert int(rebound_assignment["approval_policy_id"]) == new_approval_id
+
+    assert (
+        await repo.get_policy_override_by_assignment(
+            int(imported.imported_object_ids["policy_assignments"][0])
+        )
+        is None
+    )
+    rebound_override = await repo.get_policy_override_by_assignment(new_assignment_id)
+    assert rebound_override is not None
+    assert rebound_override["override_policy_document"]["allowed_tools"] == ["Read"]
+    assert await repo.list_policy_assignment_workspaces(
+        int(imported.imported_object_ids["policy_assignments"][0])
+    ) == []
+    assert [item["workspace_id"] for item in await repo.list_policy_assignment_workspaces(new_assignment_id)] == [
+        "workspace-alpha"
+    ]
+
+    history = await repo.list_governance_pack_upgrades(
+        pack_id="researcher-pack",
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+    assert history[-1]["status"] == "executed"
+
+
+@pytest.mark.asyncio
+async def test_execute_upgrade_rejects_stale_plan_fingerprints(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.0.1"
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="late.local.persona",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=imported.imported_object_ids["permission_profiles"][0],
+        inline_policy_document={"source": "late-local-overlay"},
+        approval_policy_id=None,
+        actor_id=8,
+        is_active=True,
+        is_immutable=False,
+    )
+
+    with pytest.raises(ValueError, match="stale"):
+        await service.execute_upgrade_pack(
+            source_governance_pack_id=imported.governance_pack_id,
+            pack=target_pack,
+            owner_scope_type="user",
+            owner_scope_id=7,
+            actor_id=7,
+            planner_inputs_fingerprint=plan.planner_inputs_fingerprint,
+            adapter_state_fingerprint=plan.adapter_state_fingerprint,
+        )
+
+    source_row = await repo.get_governance_pack(imported.governance_pack_id)
+    assert source_row is not None
+    assert source_row["is_active_install"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_upgrade_rolls_back_when_staging_insert_fails(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.0.1"
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    original_create_policy_assignment = repo.create_policy_assignment
+
+    async def _boom_create_policy_assignment(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("upgrade assignment insert failed")
+
+    repo.create_policy_assignment = _boom_create_policy_assignment  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="upgrade assignment insert failed"):
+            await service.execute_upgrade_pack(
+                source_governance_pack_id=imported.governance_pack_id,
+                pack=target_pack,
+                owner_scope_type="user",
+                owner_scope_id=7,
+                actor_id=7,
+                planner_inputs_fingerprint=plan.planner_inputs_fingerprint,
+                adapter_state_fingerprint=plan.adapter_state_fingerprint,
+            )
+    finally:
+        repo.create_policy_assignment = original_create_policy_assignment  # type: ignore[method-assign]
+
+    inventory = await repo.list_governance_packs(owner_scope_type="user", owner_scope_id=7)
+    assert [(item["pack_version"], item["is_active_install"]) for item in inventory] == [("1.0.0", True)]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 
-async def _make_repo(tmp_path, monkeypatch):
+
+async def _make_repo(tmp_path, monkeypatch) -> McpHubRepo:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
     from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
@@ -27,7 +31,11 @@ async def _make_repo(tmp_path, monkeypatch):
     return repo
 
 
-async def _seed_research_capability_mappings(repo, *, actor_id: int = 7) -> None:
+async def _seed_research_capability_mappings(
+    repo: McpHubRepo,
+    *,
+    actor_id: int = 7,
+) -> None:
     await repo.create_capability_adapter_mapping(
         mapping_id="filesystem.read.global",
         owner_scope_type="global",
@@ -683,6 +691,60 @@ async def test_dry_run_upgrade_blocks_semantic_profile_change_with_local_assignm
         item["object_type"] == "permission_profile"
         and item["source_object_id"] == "researcher.profile"
         and item["impact"] == "behavioral_conflict"
+        for item in plan.dependency_impact
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_upgrade_reports_workspace_rebind_for_modified_assignment(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    await repo.add_policy_assignment_workspace(
+        int(imported.imported_object_ids["policy_assignments"][0]),
+        workspace_id="workspace-alpha",
+        actor_id=8,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.0.1"
+    target_pack.assignments[0].approval_template_id = None
+
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    assert plan.upgradeable is True
+    assert plan.structural_conflicts == []
+    assert plan.behavioral_conflicts == []
+    assert any(
+        item["object_type"] == "policy_assignment"
+        and item["source_object_id"] == "researcher.default"
+        and item["impact"] == "rebind_required"
+        and item["dependent_type"] == "policy_assignment_workspace"
+        and item["reference_field"] == "assignment_id"
+        and item["target_id"] == "workspace-alpha"
         for item in plan.dependency_impact
     )
 

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -24,6 +25,31 @@ async def _make_repo(tmp_path, monkeypatch):
     repo = McpHubRepo(pool)
     await repo.ensure_tables()
     return repo
+
+
+async def _seed_research_capability_mappings(repo, *, actor_id: int = 7) -> None:
+    await repo.create_capability_adapter_mapping(
+        mapping_id="filesystem.read.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="filesystem.read",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["files.read"]},
+        supported_environment_requirements=["workspace_bounded_read"],
+        is_active=True,
+        actor_id=actor_id,
+    )
+    await repo.create_capability_adapter_mapping(
+        mapping_id="tool.invoke.research.global",
+        owner_scope_type="global",
+        owner_scope_id=None,
+        capability_name="tool.invoke.research",
+        adapter_contract_version=1,
+        resolved_policy_document={"allowed_tools": ["web.search"]},
+        supported_environment_requirements=[],
+        is_active=True,
+        actor_id=actor_id,
+    )
 
 
 @pytest.mark.asyncio
@@ -450,3 +476,212 @@ async def test_import_governance_pack_rolls_back_partial_objects_on_failure(
     assert await repo.list_permission_profiles(owner_scope_type="user", owner_scope_id=7) == []
     assert await repo.list_approval_policies(owner_scope_type="user", owner_scope_id=7) == []
     assert await repo.list_policy_assignments(owner_scope_type="user", owner_scope_id=7) == []
+
+
+@pytest.mark.asyncio
+async def test_dry_run_upgrade_accepts_newer_same_pack_and_reports_fingerprints(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.0.1"
+    target_pack.manifest.description = "Minor pack refresh"
+
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    assert plan.upgradeable is True
+    assert plan.source_manifest["pack_version"] == "1.0.0"
+    assert plan.target_manifest["pack_version"] == "1.0.1"
+    assert plan.structural_conflicts == []
+    assert plan.behavioral_conflicts == []
+    assert len(plan.planner_inputs_fingerprint) == 64
+    assert len(plan.adapter_state_fingerprint) == 64
+
+
+@pytest.mark.asyncio
+async def test_dry_run_upgrade_rejects_equal_version_and_cross_scope_target(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    same_version_plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=deepcopy(source_pack),
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+    assert same_version_plan.upgradeable is False
+    assert any("newer than the installed version" in item for item in same_version_plan.structural_conflicts)
+
+    moved_scope_pack = deepcopy(source_pack)
+    moved_scope_pack.manifest.pack_version = "1.0.1"
+    moved_scope_plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=moved_scope_pack,
+        owner_scope_type="team",
+        owner_scope_id=21,
+    )
+    assert moved_scope_plan.upgradeable is False
+    assert any("same owner scope" in item for item in moved_scope_plan.structural_conflicts)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_upgrade_blocks_removed_profile_with_local_assignment_dependency(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="local.persona",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=imported.imported_object_ids["permission_profiles"][0],
+        inline_policy_document={"source": "local-overlay"},
+        approval_policy_id=imported.imported_object_ids["approval_policies"][0],
+        actor_id=8,
+        is_active=True,
+        is_immutable=False,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.1.0"
+    target_pack.profiles[0].profile_id = "researcher.profile.v2"
+    target_pack.personas[0].capability_profile_id = "researcher.profile.v2"
+    target_pack.assignments[0].capability_profile_id = "researcher.profile.v2"
+
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    assert plan.upgradeable is False
+    assert any(
+        "permission_profile:researcher.profile" in item and "policy assignment" in item
+        for item in plan.structural_conflicts
+    )
+    assert any(
+        item["object_type"] == "permission_profile"
+        and item["source_object_id"] == "researcher.profile"
+        and item["impact"] == "structural_conflict"
+        for item in plan.dependency_impact
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_upgrade_blocks_semantic_profile_change_with_local_assignment_dependency(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.MCP_unified.governance_packs import (
+        load_governance_pack_fixture,
+    )
+    from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
+        McpHubGovernancePackService,
+    )
+
+    repo = await _make_repo(tmp_path, monkeypatch)
+    await _seed_research_capability_mappings(repo)
+    service = McpHubGovernancePackService(repo=repo)
+    source_pack = load_governance_pack_fixture("minimal_researcher_pack")
+    imported = await service.import_pack(
+        pack=source_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+        actor_id=7,
+    )
+
+    await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="local.persona",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        profile_id=imported.imported_object_ids["permission_profiles"][0],
+        inline_policy_document={"source": "local-overlay"},
+        approval_policy_id=imported.imported_object_ids["approval_policies"][0],
+        actor_id=8,
+        is_active=True,
+        is_immutable=False,
+    )
+
+    target_pack = deepcopy(source_pack)
+    target_pack.manifest.pack_version = "1.1.0"
+    target_pack.profiles[0].environment_requirements = []
+
+    plan = await service.dry_run_upgrade_pack(
+        source_governance_pack_id=imported.governance_pack_id,
+        pack=target_pack,
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    assert plan.upgradeable is False
+    assert any(
+        "permission_profile:researcher.profile" in item and "materially changes" in item
+        for item in plan.behavioral_conflicts
+    )
+    assert any(
+        item["object_type"] == "permission_profile"
+        and item["source_object_id"] == "researcher.profile"
+        and item["impact"] == "behavioral_conflict"
+        for item in plan.dependency_impact
+    )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py
@@ -232,6 +232,75 @@ async def test_import_governance_pack_materializes_immutable_base_objects_with_p
 
 
 @pytest.mark.asyncio
+async def test_governance_pack_repo_tracks_active_install_state_and_upgrade_lineage(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    repo = await _make_repo(tmp_path, monkeypatch)
+
+    created = await repo.create_governance_pack(
+        pack_id="researcher-pack",
+        pack_version="1.0.0",
+        pack_schema_version=1,
+        capability_taxonomy_version=1,
+        adapter_contract_version=1,
+        title="Researcher Pack",
+        description="Initial install",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        bundle_digest="a" * 64,
+        manifest={"pack_id": "researcher-pack", "pack_version": "1.0.0"},
+        normalized_ir={"profiles": []},
+        actor_id=7,
+    )
+
+    assert created["is_active_install"] is True
+    assert created["superseded_by_governance_pack_id"] is None
+
+    upgraded = await repo.create_governance_pack(
+        pack_id="researcher-pack",
+        pack_version="1.1.0",
+        pack_schema_version=1,
+        capability_taxonomy_version=1,
+        adapter_contract_version=1,
+        title="Researcher Pack",
+        description="Upgrade target",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        bundle_digest="b" * 64,
+        manifest={"pack_id": "researcher-pack", "pack_version": "1.1.0"},
+        normalized_ir={"profiles": []},
+        actor_id=7,
+        is_active_install=False,
+    )
+
+    lineage = await repo.create_governance_pack_upgrade(
+        pack_id="researcher-pack",
+        owner_scope_type="user",
+        owner_scope_id=7,
+        from_governance_pack_id=int(created["id"]),
+        to_governance_pack_id=int(upgraded["id"]),
+        from_pack_version="1.0.0",
+        to_pack_version="1.1.0",
+        status="planned",
+        planned_by=7,
+        plan_summary={"changed_objects": 2},
+    )
+
+    assert lineage["from_pack_version"] == "1.0.0"
+    assert lineage["to_pack_version"] == "1.1.0"
+    assert lineage["status"] == "planned"
+
+    history = await repo.list_governance_pack_upgrades(
+        pack_id="researcher-pack",
+        owner_scope_type="user",
+        owner_scope_id=7,
+    )
+
+    assert [item["to_pack_version"] for item in history] == ["1.1.0"]
+
+
+@pytest.mark.asyncio
 async def test_import_governance_pack_rejects_duplicate_scope_identity(
     tmp_path,
     monkeypatch,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py
@@ -9,6 +9,8 @@ class _FakeRepo:
             1: {
                 "id": 1,
                 "name": "Default Read",
+                "owner_scope_type": "global",
+                "owner_scope_id": None,
                 "policy_document": {
                     "allowed_tools": ["notes.search"],
                     "capabilities": ["filesystem.read"],
@@ -21,6 +23,8 @@ class _FakeRepo:
             2: {
                 "id": 2,
                 "name": "Group External",
+                "owner_scope_type": "user",
+                "owner_scope_id": 7,
                 "policy_document": {
                     "allowed_tools": ["external.servers.list"],
                     "capabilities": ["network.external"],
@@ -28,6 +32,7 @@ class _FakeRepo:
                 "path_scope_object_id": None,
             },
         }
+        self.approval_policies: dict[int, dict] = {}
         self.path_scope_objects = {
             100: {
                 "id": 100,
@@ -91,6 +96,7 @@ class _FakeRepo:
         self.overrides: dict[int, dict] = {}
         self.assignment_workspaces: dict[int, list[str]] = {}
         self.capability_mappings: dict[tuple[str, int | None, str], dict] = {}
+        self.governance_packs: dict[tuple[str, str, str, int | None], dict] = {}
 
     async def list_policy_assignments(
         self,
@@ -120,6 +126,9 @@ class _FakeRepo:
     async def get_path_scope_object(self, path_scope_object_id: int) -> dict | None:
         return self.path_scope_objects.get(path_scope_object_id)
 
+    async def get_approval_policy(self, approval_policy_id: int) -> dict | None:
+        return self.approval_policies.get(approval_policy_id)
+
     async def list_policy_assignment_workspaces(self, assignment_id: int) -> list[dict]:
         return [
             {"assignment_id": assignment_id, "workspace_id": workspace_id}
@@ -134,6 +143,18 @@ class _FakeRepo:
         capability_name: str,
     ) -> dict | None:
         return self.capability_mappings.get((owner_scope_type, owner_scope_id, capability_name))
+
+    async def get_governance_pack_by_identity(
+        self,
+        *,
+        pack_id: str,
+        pack_version: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict | None:
+        return self.governance_packs.get(
+            (pack_id, pack_version, owner_scope_type, owner_scope_id)
+        )
 
 
 @pytest.mark.asyncio
@@ -184,6 +205,100 @@ async def test_policy_resolver_returns_disabled_policy_when_no_assignments_apply
     assert policy["allowed_tools"] == []
     assert policy["denied_tools"] == []
     assert policy["sources"] == []
+
+
+@pytest.mark.asyncio
+async def test_policy_resolver_ignores_superseded_governance_pack_objects() -> None:
+    from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver
+
+    repo = _FakeRepo()
+    repo.governance_packs = {
+        ("legacy-pack", "0.9.0", "user", 7): {
+            "id": 90,
+            "is_active_install": False,
+        },
+    }
+    repo.assignments.append(
+        {
+            "id": 13,
+            "target_type": "group",
+            "target_id": "ops",
+            "owner_scope_type": "user",
+            "owner_scope_id": 7,
+            "profile_id": None,
+            "path_scope_object_id": None,
+            "inline_policy_document": {
+                "allowed_tools": ["legacy.assignment"],
+                "governance_pack": {
+                    "pack_id": "legacy-pack",
+                    "pack_version": "0.9.0",
+                    "source_object_id": "legacy.assignment",
+                },
+            },
+            "approval_policy_id": None,
+            "is_active": True,
+        }
+    )
+    repo.profiles[3] = {
+        "id": 3,
+        "name": "Legacy Profile",
+        "owner_scope_type": "user",
+        "owner_scope_id": 7,
+        "policy_document": {
+            "allowed_tools": ["legacy.profile"],
+            "governance_pack": {
+                "pack_id": "legacy-pack",
+                "pack_version": "0.9.0",
+                "source_object_id": "legacy.profile",
+            },
+        },
+        "path_scope_object_id": None,
+        "is_active": True,
+    }
+    repo.assignments.append(
+        {
+            "id": 14,
+            "target_type": "persona",
+            "target_id": "researcher",
+            "owner_scope_type": "user",
+            "owner_scope_id": 7,
+            "profile_id": 3,
+            "path_scope_object_id": None,
+            "inline_policy_document": {},
+            "approval_policy_id": 55,
+            "is_active": True,
+        }
+    )
+    repo.approval_policies[55] = {
+        "id": 55,
+        "name": "Legacy Approval",
+        "owner_scope_type": "user",
+        "owner_scope_id": 7,
+        "mode": "ask_every_time",
+        "rules": {
+            "governance_pack": {
+                "pack_id": "legacy-pack",
+                "pack_version": "0.9.0",
+                "source_object_id": "legacy.approval",
+            }
+        },
+        "is_active": True,
+    }
+    resolver = McpHubPolicyResolver(repo=repo)
+
+    policy = await resolver.resolve_for_context(
+        user_id=7,
+        metadata={
+            "mcp_policy_context_enabled": True,
+            "group_id": "ops",
+            "persona_id": "researcher",
+        },
+    )
+
+    assert "legacy.assignment" not in policy["allowed_tools"]
+    assert "legacy.profile" not in policy["allowed_tools"]
+    assert policy["approval_policy_id"] is None
+    assert [source["assignment_id"] for source in policy["sources"]] == [10, 11, 12, 14]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add governance-pack install state, active-only runtime filtering, and upgrade planning/execution with lineage tracking
- add upgrade dry-run, execute, and history APIs for MCP Hub governance packs
- add MCP Hub governance-pack UI for install state, upgrade preview, blocking conflicts, execute flow, and history visibility

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_import.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_governance_pack_api.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_policy_resolver.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py -q
- bunx vitest run src/components/Option/MCPHub/__tests__/GovernancePacksTab.test.tsx
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/mcp_hub_governance_pack_service.py tldw_Server_API/app/services/mcp_hub_policy_resolver.py tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py -f json -o /tmp/bandit_governance_pack_upgrade_final.json
- git diff --check