### PR TITLE
fix: integrate standalone modules into system (Gaps 9.1, 5.3, 3.3, 9.3, 3.2)

### DIFF
--- a/Docs/Plans/2026-03-17-pr-898-review-fixes-design.md
+++ b/Docs/Plans/2026-03-17-pr-898-review-fixes-design.md
@@ -1,0 +1,34 @@
+# PR 898 Review Fixes Design
+
+**Context**
+
+PR #898 introduces integration work for consent endpoints, audit hash chaining, billing enforcement, fair-share job scheduling, and Stripe metering. The open review comments mix concrete correctness issues with broad refactor suggestions. This fix pass targets defects that are real in the current branch and defers architectural rewrites that are disproportionate to the PR scope.
+
+**Validated Review Scope**
+
+1. Mount the consent router in the normal FastAPI startup path so `/api/v1/consent/*` exists outside minimal test mode.
+2. Resume the audit hash chain from the last persisted event during service initialization so tamper verification survives restarts.
+3. Correct fair-share priority mapping so higher fair-share urgency yields a smaller numeric job priority, matching queue ordering semantics.
+4. Make Stripe metering robust to partially migrated `usage_daily` schemas that do not yet have `bytes_in_total`.
+5. Add the documented subscription lookup fallback for organization owners.
+6. Cache overage policy parsing on `BillingEnforcer` and raise skipped-policy/fair-share failures to `warning`.
+7. Tighten the consent endpoint implementation where the review feedback is low-risk and directly improves clarity.
+
+**Deferred Comments**
+
+1. Rewriting the jobs and Stripe metering modules to route all DB access through new DB_Management abstractions.
+2. Replacing the synchronous consent manager with a new async persistence layer.
+3. Converting the new consent endpoints to a broader schema refactor beyond what is required to resolve the PR defects.
+
+These items may be worthwhile follow-up work, but they are larger architectural changes than this PR’s review-fix pass should absorb.
+
+**Approach**
+
+Use targeted tests first for each defect, then apply the minimum code change to make each test pass. Keep the fix set localized to the touched modules and add only the tests needed to prove the reported issues are resolved.
+
+**Verification**
+
+1. Run the impacted pytest files before editing to establish current failures and behavior.
+2. Add or adjust tests for each defect before implementation.
+3. Run the impacted pytest files after the changes.
+4. Run Bandit on the touched backend paths before closing out.

--- a/Docs/Plans/2026-03-17-pr-898-review-fixes.md
+++ b/Docs/Plans/2026-03-17-pr-898-review-fixes.md
@@ -1,0 +1,289 @@
+# PR 898 Review Fixes Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Resolve the validated review findings on PR #898 without widening the scope into unrelated architectural refactors.
+
+**Architecture:** Keep the existing module structure intact and patch the concrete defects in-place. Use test-first changes in each affected area so the fixes stay attributable and regressions remain localized.
+
+**Tech Stack:** Python, FastAPI, pytest, aiosqlite, SQLite/PostgreSQL compatibility paths, Bandit
+
+---
+
+### Task 1: Baseline The Impacted Review Area
+
+**Files:**
+- Modify: `docs/plans/2026-03-17-pr-898-review-fixes.md`
+- Test: `tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py`
+- Test: `tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py`
+- Test: `tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Test: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Run the impacted tests before any code changes**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected:
+- Existing tests pass or reveal current branch failures that match the review findings.
+
+**Step 2: Record the baseline result in the working notes**
+
+Update this plan if unexpected failures appear that are unrelated to the review scope.
+
+### Task 2: Fix Consent Router Wiring And Endpoint Cleanup
+
+**Files:**
+- Modify: `tldw_Server_API/app/main.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/consent.py`
+- Test: `tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that verify:
+- The production import/include path in `main.py` exposes the consent router.
+- `grant_consent()` reads `request.client.host` and `request.headers.get("user-agent")` without swallowing broad exceptions.
+
+**Step 2: Run the consent tests to verify the new assertions fail**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py -v
+```
+
+Expected:
+- Failure showing the consent router is not available in the normal app path and/or the new endpoint expectation is unmet.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+- Production import/include of `consent_router` in `tldw_Server_API/app/main.py`
+- Direct `request.client.host if request.client else None`
+- Direct `request.headers.get("user-agent")`
+
+**Step 4: Run the consent tests to verify they pass**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py -v
+```
+
+Expected:
+- PASS
+
+### Task 3: Preserve Audit Chain Continuity Across Restarts
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Audit/unified_audit_service.py`
+- Test: `tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py`
+
+**Step 1: Write the failing restart-continuity test**
+
+Add a test that:
+- Flushes an initial batch to a DB
+- Stops the service
+- Creates a second service instance against the same DB
+- Flushes another batch
+- Verifies `verify_audit_chain()` succeeds across all rows
+
+**Step 2: Run the audit tests to verify the new test fails**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py -v
+```
+
+Expected:
+- Failure showing the chain breaks after service recreation.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+- A helper to load the last persisted `chain_hash`
+- Initialization logic that hydrates `self._last_chain_hash` after schema setup
+- Deterministic ordering compatible with persisted insertion order
+
+**Step 4: Run the audit tests to verify they pass**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py -v
+```
+
+Expected:
+- PASS
+
+### Task 4: Correct Billing Enforcement Policy Handling
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Billing/enforcement.py`
+- Test: `tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that verify:
+- `OveragePolicy.from_env()` is not called on every `check_limit()` invocation
+- Overage-policy evaluation failures are logged at warning level
+
+**Step 2: Run the billing tests to verify the new assertions fail**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py -v
+```
+
+Expected:
+- Failure showing repeated env parsing or insufficient logging.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+- Cached policy initialization in `BillingEnforcer.__init__`
+- `warning` level logging when policy evaluation is skipped
+
+**Step 4: Run the billing tests to verify they pass**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py -v
+```
+
+Expected:
+- PASS
+
+### Task 5: Correct Fair-Share Priority Semantics
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+
+**Step 1: Write the failing priority-direction test**
+
+Add a test that verifies a user with lower active job count gets a smaller numeric stored priority than a neutral explicit value when fair-share boosts urgency.
+
+**Step 2: Run the jobs tests to verify the new assertion fails**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py -v
+```
+
+Expected:
+- Failure showing fair-share currently pushes the numeric priority in the wrong direction.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+- Fair-share score to DB priority mapping where larger score becomes smaller numeric priority
+- `min(priority, mapped_fair_priority)`
+- `warning` level logging when fair-share checks are skipped
+
+**Step 4: Run the jobs tests to verify they pass**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py -v
+```
+
+Expected:
+- PASS
+
+### Task 6: Harden Stripe Metering Compatibility
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
+- Test: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that verify:
+- `_query_usage_for_date()` falls back cleanly when `bytes_in_total` is unavailable
+- `_query_user_subscription()` can find an active org subscription through `organizations.owner_user_id`
+
+**Step 2: Run the Stripe metering tests to verify the new assertions fail**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected:
+- Failure showing the schema fallback and owner lookup are missing.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+- Legacy-schema fallback in `_query_usage_for_date()`
+- Owner fallback query in `_query_user_subscription()`
+
+**Step 4: Run the Stripe metering tests to verify they pass**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected:
+- PASS
+
+### Task 7: Final Verification
+
+**Files:**
+- Modify: `docs/plans/2026-03-17-pr-898-review-fixes.md`
+- Test: `tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py`
+- Test: `tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py`
+- Test: `tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Test: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Run the full impacted test subset**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected:
+- PASS
+
+**Step 2: Run Bandit on the touched paths**
+
+Run:
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/endpoints/consent.py \
+  tldw_Server_API/app/core/Audit/unified_audit_service.py \
+  tldw_Server_API/app/core/Billing/enforcement.py \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  -f json -o /tmp/bandit_pr898_review_fixes.json
+```
+
+Expected:
+- No new security findings in touched code

--- a/Docs/Plans/2026-03-17-pr898-open-review-cleanup-design.md
+++ b/Docs/Plans/2026-03-17-pr898-open-review-cleanup-design.md
@@ -1,0 +1,108 @@
+# PR 898 Open Review Cleanup Design
+
+## Context
+
+PR 898 already contains the first round of production-readiness fixes at commit `1b35062ee`, but the pull request still has open review comments.
+
+Those comments split into three categories:
+
+- Remaining correctness gaps on the live PR branch.
+- Low-risk review cleanup and test hygiene comments.
+- Broader Jobs and Stripe DB-boundary refactors that have already been implemented separately in PR 908.
+
+This pass keeps PR 898 narrowly scoped. It clears the remaining product and review issues without backporting the repository-boundary redesign from PR 908.
+
+## Goals
+
+- Fix the remaining correctness and reliability issues still open on PR 898.
+- Fold in the low-risk bot-review cleanup items that are reasonable to land on the same branch.
+- Update PR 898 review threads so the architecture comments are explicitly closed out by reference to PR 908.
+- Preserve the current user-visible behavior of PR 898 except where an open review comment identifies a real bug.
+
+## Non-Goals
+
+- Moving Jobs fair-share DB access into `DB_Management` on PR 898.
+- Moving Stripe metering SQL and schema ownership into `DB_Management` on PR 898.
+- Reworking PR 898 into the broader repository/session architecture already staged in PR 908.
+
+## Scope
+
+### 1. API and Policy Fixes
+
+- `storage_quota_guard.py`
+  - Log when quota enforcement falls back to `user_id = 0`.
+  - Replace the header-assignment `try/except` with `contextlib.suppress`.
+- `consent.py`
+  - Cache the `ConsentManager` instance instead of rebuilding it per request.
+- `consent_schemas.py`
+  - Use typed datetime fields for temporal values.
+- `main.py`
+  - Route the consent router through `_include_if_enabled(...)`.
+  - Replace the eager f-string in the minimal-app logger call with Loguru lazy formatting.
+- `ingest_jobs.py`
+  - Add a second storage-quota enforcement check after remote content is staged so URL-only submits cannot bypass the pre-check.
+
+### 2. Jobs and Stripe Correctness Fixes
+
+- `JobManager.create_job()`
+  - Stop coercing `owner_user_id` to `int` during fair-share checks.
+  - Raise `BadRequestError` instead of `ValueError` for admission-control rejections.
+- `stripe_metering_service.py`
+  - Pass real `datetime.date` values to PostgreSQL DATE bindings.
+  - Only swallow the Stripe “resource missing” case when retrieving subscription items; re-raise the other Stripe API failures.
+  - Make `is_enabled` reflect both env configuration and Stripe runtime availability.
+
+### 3. Test and Review Cleanup
+
+- Make the metering “yesterday” tests deterministic.
+- Apply the fixture/style/test-helper cleanups still open in:
+  - `tests/AuthNZ/test_audit_chain_integration.py`
+  - `tests/Billing/test_overage_enforcement_integration.py`
+  - `tests/Billing/test_storage_quota_guard.py`
+  - `tests/Jobs/test_fair_share_integration.py`
+  - `tests/test_stripe_metering.py`
+- Add the missing fair-share test marker and tighten the notify-only overage tests so they do not pass accidentally because of default thresholds.
+
+## Approach
+
+### Keep PR 898 narrow
+
+The existing open threads on raw SQL and connection reuse in `JobManager` and `StripeMeteringService` are technically valid, but they are architecture comments now covered by PR 908. Reimplementing that redesign in PR 898 would broaden scope and create duplicate review surface.
+
+Instead, this pass will:
+
+- fix the correctness bugs directly on `feat/production-readiness-gaps`,
+- land the cheap cleanup items that are still open on the same branch,
+- and resolve the three architecture threads with an explicit pointer to PR 908.
+
+### Prefer targeted fixes over large refactors
+
+Where a comment points to a real bug, the implementation should stay local:
+
+- ingest quota hard-stop added to the staging path instead of a wider ingestion redesign,
+- fair-share owner handling fixed in-place,
+- Stripe metering date and exception behavior corrected in the service without backporting the repository boundary,
+- test cleanup folded into the existing test modules rather than moving everything into new helper layers.
+
+## Risks
+
+- The URL-ingest quota fix touches a user-facing path and must be tested carefully against the existing staging flow.
+- Changing consent datetime schema types could affect tests or response serialization if any callers rely on raw strings.
+- The “fix every open issue” scope includes some low-value cleanup; care is needed to keep those changes boring and non-invasive.
+
+## Verification Plan
+
+- Targeted red/green tests for each correctness fix where feasible.
+- Expanded regression covering:
+  - consent endpoints
+  - audit chain integration
+  - overage enforcement
+  - storage quota guard
+  - fair-share integration
+  - stripe metering
+- Bandit on touched backend files before final push.
+
+## Review Thread Handling
+
+- Resolve PR 898 architecture threads `2936292840`, `2936295005`, and `2936295007` with a note that the DB-boundary redesign is implemented and ready in PR 908.
+- Resolve the remaining open PR 898 threads directly against the new code changes in this pass.

--- a/Docs/Plans/2026-03-17-pr898-open-review-cleanup.md
+++ b/Docs/Plans/2026-03-17-pr898-open-review-cleanup.md
@@ -1,0 +1,298 @@
+# PR 898 Open Review Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Clear the remaining non-architecture PR 898 review issues while keeping the branch narrowly scoped and deferring the DB-boundary redesign to PR 908.
+
+**Architecture:** Apply targeted fixes directly on `feat/production-readiness-gaps` for the remaining correctness gaps, then fold in the low-risk review cleanup items the bots still have open. Close the three architecture comments by explicitly pointing them at PR 908 instead of duplicating that refactor on PR 898.
+
+**Tech Stack:** Python 3.11, FastAPI, pytest, loguru, SQLite, PostgreSQL/asyncpg, stripe-python, Bandit
+
+**Execution Status:** Complete on 2026-03-17.
+
+**Implementation Notes:**
+- Task 2 landed in the actual URL-download processing path instead of a dedicated endpoint/worker-only branch: `process_batch_media(...)` now threads `user_id` into audio/video processors, and quota enforcement runs immediately after URL downloads in `Audio_Files.py` and `Video_DL_Ingestion_Lib.py`.
+- The regression coverage for Task 2 therefore lives in:
+  - `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_files_preflight.py`
+  - `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py`
+  - `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_process_batch_media_precheck_regressions.py`
+- Final verification used the expanded targeted suite plus Bandit on the touched backend files; both completed successfully.
+
+---
+
+### Task 1: Fix Consent, Storage Guard, And Main Router Review Items
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/consent.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/consent_schemas.py`
+- Modify: `tldw_Server_API/app/main.py`
+- Test: `tldw_Server_API/tests/Billing/test_storage_quota_guard.py`
+- Test: `tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+
+- logging when `guard_storage_quota` falls back to `user_id = 0`
+- consent-manager reuse/caching in `consent.py`
+- datetime parsing/serialization in `ConsentRecordResponse`
+- consent router inclusion respecting `_include_if_enabled(...)`
+
+**Step 2: Run the focused tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Billing/test_storage_quota_guard.py \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py -v
+```
+
+Expected: failures for the new coverage.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+
+- debug logging around the `user_id = 0` fallback path
+- `contextlib.suppress(_NONCRITICAL)` around the warning-header assignment
+- cached/singleton `ConsentManager` construction
+- `datetime | None` consent schema fields
+- `_include_if_enabled("consent", ...)` plus lazy Loguru formatting for `_consent_min_err`
+
+**Step 4: Run the focused tests again**
+
+Run the same pytest command and confirm it passes.
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py \
+  tldw_Server_API/app/api/v1/endpoints/consent.py \
+  tldw_Server_API/app/api/v1/schemas/consent_schemas.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/tests/Billing/test_storage_quota_guard.py \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
+git commit -m "fix: close consent and quota review gaps"
+```
+
+### Task 2: Add Post-Staging Quota Enforcement For URL Ingest
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py`
+- Modify: `tldw_Server_API/app/services/media_ingest_jobs_worker.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py`
+- Test: `tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py`
+
+**Step 1: Write the failing tests**
+
+Add one regression test that proves URL-only ingest cannot bypass quota after staging/download. The test should exercise the path that creates or processes a URL ingest job and fail once the real staged size exceeds remaining quota.
+
+**Step 2: Run the targeted ingest tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py -v
+```
+
+Expected: the new quota-bypass regression test fails.
+
+**Step 3: Write the minimal implementation**
+
+Add a second quota enforcement after remote content has been staged/downloaded and the real byte size is known. Keep the existing request-time `guard_storage_quota` pre-check intact.
+
+**Step 4: Run the targeted ingest tests again**
+
+Run the same pytest command and confirm it passes.
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+  tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py
+git commit -m "fix: enforce media ingest quota after staging"
+```
+
+### Task 3: Fix Remaining Jobs And Stripe Correctness Issues
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Test: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Write the failing tests**
+
+Add focused tests for:
+
+- non-numeric `owner_user_id` not crashing fair-share checks
+- admission-control rejection raising `BadRequestError`
+- PostgreSQL DATE parameters converted to `datetime.date`
+- `_get_subscription_metered_item()` re-raising non-missing Stripe errors
+- `is_enabled` reporting false when Stripe runtime is unavailable
+- deterministic “yesterday” handling in the metering tests
+
+**Step 2: Run the focused Jobs/Stripe tests to verify failure**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: the new regression tests fail.
+
+**Step 3: Write the minimal implementation**
+
+Implement:
+
+- use `owner_user_id` as a string in fair-share scheduling
+- replace the admission-control `ValueError` with `BadRequestError`
+- normalize bound date strings to `datetime.date` before PostgreSQL queries
+- catch only the Stripe “resource missing” case in `_get_subscription_metered_item`
+- include `STRIPE_AVAILABLE` in `is_enabled`
+- freeze or monkeypatch time in the affected metering tests
+
+**Step 4: Run the focused Jobs/Stripe tests again**
+
+Run the same pytest command and confirm it passes.
+
+**Step 5: Commit**
+
+```bash
+git add \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py
+git commit -m "fix: close jobs and stripe correctness gaps"
+```
+
+### Task 4: Close The Remaining Test Hygiene And Review Nit Threads
+
+**Files:**
+- Modify: `tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py`
+- Modify: `tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py`
+- Modify: `tldw_Server_API/tests/Billing/test_storage_quota_guard.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Modify: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Write or update the tests first**
+
+Add or adjust tests to cover:
+
+- deterministic `soft_limit_percent` behavior in the notify-only overage tests
+- any public-behavior assertions needed if the fair-share active-count tests are decoupled from private helpers
+
+The style-only cleanups should be done in the same task:
+
+- remove unused imports
+- remove `@pytest.fixture()` parentheses
+- add missing return annotations where warranted
+- replace the list-building loop with a comprehension
+- simplify `_fake_user`
+- add the integration marker for `test_fair_share_integration.py`
+- convert metering shared scaffolding into pytest fixtures if that remains low-risk after Task 3
+
+**Step 2: Run the affected test modules**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Billing/test_storage_quota_guard.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: pass.
+
+**Step 3: Commit**
+
+```bash
+git add \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Billing/test_storage_quota_guard.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py
+git commit -m "test: clear remaining pr898 review nits"
+```
+
+### Task 5: Verify, Push, And Update PR 898 Threads
+
+**Files:**
+- Review: touched source/test files from Tasks 1-4
+- Modify: `Docs/Plans/2026-03-17-pr898-open-review-cleanup-design.md` only if implementation scope changes
+- Modify: this plan only if execution deviates materially
+
+**Step 1: Run the expanded regression suite**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Billing/test_storage_quota_guard.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_endpoint.py \
+  tldw_Server_API/tests/MediaIngestion_NEW/unit/test_media_ingest_jobs_worker.py -v
+```
+
+Expected: all pass.
+
+**Step 2: Run Bandit on touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py \
+  tldw_Server_API/app/api/v1/endpoints/consent.py \
+  tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py \
+  tldw_Server_API/app/api/v1/schemas/consent_schemas.py \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/main.py \
+  tldw_Server_API/app/services/media_ingest_jobs_worker.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  -f json -o /tmp/bandit_pr898_open_review_cleanup.json
+```
+
+Expected: `0` new findings in touched code.
+
+**Step 3: Push and update PR 898**
+
+- Push `feat/production-readiness-gaps`.
+- Reply on the substantive threads with the implemented fix details.
+- Resolve the three architecture threads by pointing to PR 908.
+- Resolve the remaining bot-review threads with the landed fixes.
+
+**Step 4: Commit doc updates if needed**
+
+```bash
+git add Docs/Plans/2026-03-17-pr898-open-review-cleanup-design.md Docs/Plans/2026-03-17-pr898-open-review-cleanup.md
+git commit -m "docs: finalize pr898 cleanup notes"
+```
+
+Plan complete and saved to `Docs/Plans/2026-03-17-pr898-open-review-cleanup.md`. Defaulting to the in-session implementation path from here.

--- a/tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py
@@ -13,6 +13,7 @@ Usage::
 """
 from __future__ import annotations
 
+from contextlib import suppress
 import os
 
 from fastapi import Depends, HTTPException, Request, Response, UploadFile, status
@@ -85,10 +86,12 @@ async def guard_storage_quota(
     except _NONCRITICAL:
         pass
 
+    raw_user_id = getattr(current_user, "id", None)
     try:
-        user_id = int(current_user.id) if current_user.id is not None else 0
+        user_id = int(raw_user_id) if raw_user_id is not None else 0
     except (TypeError, ValueError):
         user_id = 0
+        logger.warning("Storage quota guard falling back to anonymous user_id=0 for user {}", raw_user_id)
 
     try:
         db_pool = await get_db_pool()
@@ -120,7 +123,5 @@ async def guard_storage_quota(
 
     # Soft-limit warning header
     if "soft limit" in result.get("reason", "").lower():
-        try:
+        with suppress(*_NONCRITICAL):
             response.headers["X-Storage-Warning"] = result["reason"]
-        except _NONCRITICAL:
-            pass

--- a/tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/storage_quota_guard.py
@@ -1,0 +1,126 @@
+"""
+Storage quota enforcement dependency for upload endpoints.
+
+Checks the authenticated user's org/team storage quota before allowing
+file uploads.  When the user is already at or above their hard limit the
+request is rejected with 413 (Payload Too Large).  A soft-limit warning
+is communicated via the ``X-Storage-Warning`` response header.
+
+Usage::
+
+    @router.post("/process-videos", dependencies=[Depends(guard_storage_quota)])
+    async def process_videos_endpoint(...): ...
+"""
+from __future__ import annotations
+
+import os
+
+from fastapi import Depends, HTTPException, Request, Response, UploadFile, status
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.settings import is_single_user_profile_mode
+from tldw_Server_API.app.core.Storage.quota_enforcement import check_storage_quota
+
+_NONCRITICAL = (
+    AttributeError,
+    ConnectionError,
+    KeyError,
+    OSError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    ValueError,
+)
+
+
+def _is_enabled() -> bool:
+    """Return True unless storage quota enforcement is explicitly disabled."""
+    val = os.getenv("STORAGE_QUOTA_ENFORCEMENT", "1").strip().lower()
+    return val not in ("0", "false", "no", "off")
+
+
+async def guard_storage_quota(
+    request: Request,
+    response: Response,
+    current_user: User = Depends(get_request_user),
+) -> None:
+    """FastAPI dependency that blocks requests when storage quota is exceeded.
+
+    Behaviour:
+    * Disabled in single-user profile mode (local / desktop).
+    * Disabled when ``STORAGE_QUOTA_ENFORCEMENT=0``.
+    * Fail-open: if the quota check itself errors, the request proceeds.
+    * Adds ``X-Storage-Warning`` header when the soft limit is reached.
+    * Returns HTTP 413 when the hard limit is reached or remaining quota is 0.
+    """
+    if not _is_enabled():
+        return
+
+    # Skip enforcement for single-user / local deployments
+    try:
+        if is_single_user_profile_mode():
+            return
+    except _NONCRITICAL:
+        pass
+
+    # Resolve org_id from request state (set by auth middleware)
+    org_id: int | None = None
+    try:
+        org_id = getattr(request.state, "org_id", None)
+        if org_id is None and hasattr(current_user, "active_org_id"):
+            org_id = current_user.active_org_id
+        if org_id is None and hasattr(current_user, "org_ids") and current_user.org_ids:
+            org_id = current_user.org_ids[0]
+    except _NONCRITICAL:
+        pass
+
+    # Estimate upload size from Content-Length (best-effort; 0 if unavailable)
+    upload_bytes: int = 0
+    try:
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            upload_bytes = int(cl)
+    except _NONCRITICAL:
+        pass
+
+    try:
+        user_id = int(current_user.id) if current_user.id is not None else 0
+    except (TypeError, ValueError):
+        user_id = 0
+
+    try:
+        db_pool = await get_db_pool()
+        result = await check_storage_quota(
+            user_id=user_id,
+            file_size_bytes=upload_bytes,
+            db_pool=db_pool,
+            org_id=org_id,
+        )
+    except _NONCRITICAL as exc:
+        # Fail-open: log and allow
+        logger.warning("Storage quota guard failed (fail-open): {}", exc)
+        return
+
+    if not result.get("allowed", True):
+        reason = result.get("reason", "Storage quota exceeded")
+        used_mb = result.get("used_mb", 0)
+        quota_mb = result.get("quota_mb", 0)
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail={
+                "error": "storage_quota_exceeded",
+                "message": reason,
+                "used_mb": used_mb,
+                "quota_mb": quota_mb,
+                "remaining_mb": result.get("remaining_mb", 0),
+            },
+        )
+
+    # Soft-limit warning header
+    if "soft limit" in result.get("reason", "").lower():
+        try:
+            response.headers["X-Storage-Warning"] = result["reason"]
+        except _NONCRITICAL:
+            pass

--- a/tldw_Server_API/app/api/v1/endpoints/consent.py
+++ b/tldw_Server_API/app/api/v1/endpoints/consent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from functools import lru_cache
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -54,10 +55,16 @@ def _get_consent_db_path() -> str:
         return str(db_dir / "consent.db")
 
 
+@lru_cache(maxsize=4)
+def _build_consent_manager(db_path: str) -> ConsentManager:
+    """Cache consent manager instances by database path."""
+    return ConsentManager(db_path)
+
+
 def _get_consent_manager() -> ConsentManager:
     """Get or create a ConsentManager instance."""
     db_path = _get_consent_db_path()
-    return ConsentManager(db_path)
+    return _build_consent_manager(db_path)
 
 
 def _resolve_user_id(principal: AuthPrincipal) -> int:

--- a/tldw_Server_API/app/api/v1/endpoints/consent.py
+++ b/tldw_Server_API/app/api/v1/endpoints/consent.py
@@ -1,0 +1,148 @@
+"""
+consent.py
+
+GDPR consent management endpoints.
+Allows users to view, grant, and withdraw consent for data processing purposes.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.consent_manager import ConsentManager
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+router = APIRouter(
+    prefix="/consent",
+    tags=["consent"],
+    responses={
+        401: {"description": "Not authenticated"},
+    },
+)
+
+_CONSENT_NONCRITICAL_EXCEPTIONS = (
+    AttributeError,
+    KeyError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
+
+def _get_consent_db_path() -> str:
+    """Resolve the consent database path from env or default."""
+    env_path = os.environ.get("CONSENT_DB_PATH")
+    if env_path:
+        return env_path
+    try:
+        from tldw_Server_API.app.core.DB_Management.db_path_utils import DatabasePaths
+        base = DatabasePaths.get_shared_audit_db_path().parent
+        return str(base / "consent.db")
+    except _CONSENT_NONCRITICAL_EXCEPTIONS:
+        db_dir = Path("./Databases")
+        db_dir.mkdir(parents=True, exist_ok=True)
+        return str(db_dir / "consent.db")
+
+
+def _get_consent_manager() -> ConsentManager:
+    """Get or create a ConsentManager instance."""
+    db_path = _get_consent_db_path()
+    return ConsentManager(db_path)
+
+
+def _resolve_user_id(principal: AuthPrincipal) -> int:
+    """Extract integer user_id from the auth principal."""
+    if principal.user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User identification required for consent management.",
+        )
+    return principal.user_id
+
+
+@router.get("/preferences")
+async def get_consent_preferences(
+    principal: AuthPrincipal = Depends(get_auth_principal),
+):
+    """Get current user's consent preferences."""
+    user_id = _resolve_user_id(principal)
+    try:
+        mgr = _get_consent_manager()
+        records = mgr.get_user_consents(user_id)
+        return {
+            "user_id": user_id,
+            "consents": records,
+        }
+    except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error("Failed to get consent preferences for user {}: {}", user_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to retrieve consent preferences.",
+        ) from exc
+
+
+@router.post("/preferences/{purpose}")
+async def grant_consent(
+    purpose: str,
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+):
+    """Grant consent for a specific purpose."""
+    user_id = _resolve_user_id(principal)
+    ip_address = None
+    user_agent = None
+    try:
+        ip_address = request.client.host if request.client else None
+    except _CONSENT_NONCRITICAL_EXCEPTIONS:
+        pass
+    try:
+        user_agent = request.headers.get("user-agent")
+    except _CONSENT_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    try:
+        mgr = _get_consent_manager()
+        result = mgr.grant_consent(
+            user_id,
+            purpose,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+        return result
+    except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error("Failed to grant consent for user {} purpose {}: {}", user_id, purpose, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record consent.",
+        ) from exc
+
+
+@router.delete("/preferences/{purpose}")
+async def withdraw_consent(
+    purpose: str,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+):
+    """Withdraw consent for a specific purpose."""
+    user_id = _resolve_user_id(principal)
+    try:
+        mgr = _get_consent_manager()
+        result = mgr.withdraw_consent(user_id, purpose)
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No active consent found for purpose '{purpose}'.",
+            )
+        return result
+    except HTTPException:
+        raise
+    except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error("Failed to withdraw consent for user {} purpose {}: {}", user_id, purpose, exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to withdraw consent.",
+        ) from exc

--- a/tldw_Server_API/app/api/v1/endpoints/consent.py
+++ b/tldw_Server_API/app/api/v1/endpoints/consent.py
@@ -6,6 +6,7 @@ Allows users to view, grant, and withdraw consent for data processing purposes.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 from pathlib import Path
 
@@ -13,6 +14,10 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from loguru import logger
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.schemas.consent_schemas import (
+    ConsentPreferencesResponse,
+    ConsentRecordResponse,
+)
 from tldw_Server_API.app.core.AuthNZ.consent_manager import ConsentManager
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -65,19 +70,19 @@ def _resolve_user_id(principal: AuthPrincipal) -> int:
     return principal.user_id
 
 
-@router.get("/preferences")
+@router.get("/preferences", response_model=ConsentPreferencesResponse)
 async def get_consent_preferences(
     principal: AuthPrincipal = Depends(get_auth_principal),
-):
+) -> ConsentPreferencesResponse:
     """Get current user's consent preferences."""
     user_id = _resolve_user_id(principal)
     try:
         mgr = _get_consent_manager()
-        records = mgr.get_user_consents(user_id)
-        return {
-            "user_id": user_id,
-            "consents": records,
-        }
+        records = await asyncio.to_thread(mgr.get_user_consents, user_id)
+        return ConsentPreferencesResponse(
+            user_id=user_id,
+            consents=[ConsentRecordResponse.model_validate(record) for record in records],
+        )
     except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:
         logger.error("Failed to get consent preferences for user {}: {}", user_id, exc)
         raise HTTPException(
@@ -86,34 +91,27 @@ async def get_consent_preferences(
         ) from exc
 
 
-@router.post("/preferences/{purpose}")
+@router.post("/preferences/{purpose}", response_model=ConsentRecordResponse)
 async def grant_consent(
     purpose: str,
     request: Request,
     principal: AuthPrincipal = Depends(get_auth_principal),
-):
+) -> ConsentRecordResponse:
     """Grant consent for a specific purpose."""
     user_id = _resolve_user_id(principal)
-    ip_address = None
-    user_agent = None
-    try:
-        ip_address = request.client.host if request.client else None
-    except _CONSENT_NONCRITICAL_EXCEPTIONS:
-        pass
-    try:
-        user_agent = request.headers.get("user-agent")
-    except _CONSENT_NONCRITICAL_EXCEPTIONS:
-        pass
+    ip_address = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
 
     try:
         mgr = _get_consent_manager()
-        result = mgr.grant_consent(
+        result = await asyncio.to_thread(
+            mgr.grant_consent,
             user_id,
             purpose,
             ip_address=ip_address,
             user_agent=user_agent,
         )
-        return result
+        return ConsentRecordResponse.model_validate(result)
     except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:
         logger.error("Failed to grant consent for user {} purpose {}: {}", user_id, purpose, exc)
         raise HTTPException(
@@ -122,22 +120,22 @@ async def grant_consent(
         ) from exc
 
 
-@router.delete("/preferences/{purpose}")
+@router.delete("/preferences/{purpose}", response_model=ConsentRecordResponse)
 async def withdraw_consent(
     purpose: str,
     principal: AuthPrincipal = Depends(get_auth_principal),
-):
+) -> ConsentRecordResponse:
     """Withdraw consent for a specific purpose."""
     user_id = _resolve_user_id(principal)
     try:
         mgr = _get_consent_manager()
-        result = mgr.withdraw_consent(user_id, purpose)
+        result = await asyncio.to_thread(mgr.withdraw_consent, user_id, purpose)
         if result is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"No active consent found for purpose '{purpose}'.",
             )
-        return result
+        return ConsentRecordResponse.model_validate(result)
     except HTTPException:
         raise
     except _CONSENT_NONCRITICAL_EXCEPTIONS as exc:

--- a/tldw_Server_API/app/api/v1/endpoints/media/add.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/add.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Request, UploadFile
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import rbac_rate_limit, require_permissions
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_add_deps import get_add_media_form
 from tldw_Server_API.app.api.v1.API_Deps.personalization_deps import (
@@ -26,6 +27,7 @@ router = APIRouter()
     dependencies=[
         Depends(require_permissions(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
+        Depends(guard_storage_quota),
     ],
     summary="Add media (URLs/files) with processing and persistence",
     tags=["Media Ingestion & Persistence"],

--- a/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/ingest_jobs.py
@@ -24,6 +24,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     rbac_rate_limit,
     require_permissions,
 )
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.media_add_deps import get_add_media_form
 from tldw_Server_API.app.api.v1.API_Deps.validations_deps import file_validator_instance
 from tldw_Server_API.app.api.v1.schemas.media_request_models import AddMediaForm
@@ -357,6 +358,7 @@ def _resolve_batch_or_session_id(
     dependencies=[
         Depends(require_permissions(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
+        Depends(guard_storage_quota),
     ],
 )
 async def submit_media_ingest_jobs(

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_audios.py
@@ -15,6 +15,7 @@ from fastapi import (
 from loguru import logger
 from starlette.responses import JSONResponse
 
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_audios_form,
@@ -52,6 +53,7 @@ router = APIRouter()
     "/process-audios",
     summary="Transcribe / chunk / analyse audio and return full artefacts (no DB write)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_audios_endpoint(
     background_tasks: BackgroundTasks,

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_code.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_code.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, File, UploadFile, status
 from loguru import logger
 from starlette.responses import JSONResponse
 
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_code_deps import get_process_code_form
 from tldw_Server_API.app.api.v1.endpoints import media as media_mod
@@ -42,6 +43,7 @@ router = APIRouter()
     "/process-code",
     summary="Process code files (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_code_endpoint(
     db: MediaDatabase = Depends(get_media_db_for_user),  # Parity with legacy signature

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_documents.py
@@ -10,6 +10,7 @@ from loguru import logger
 from starlette.responses import JSONResponse
 
 import tldw_Server_API.app.core.Ingestion_Media_Processing.Plaintext.Plaintext_Files as docs
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_documents_form,
@@ -66,6 +67,7 @@ ALLOWED_DOC_EXTENSIONS = [
     "/process-documents",
     summary="Extract, chunk, analyse Documents (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_documents_endpoint(
     db: MediaDatabase = Depends(get_media_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_ebooks.py
@@ -15,6 +15,7 @@ from fastapi import (
 from loguru import logger
 from starlette.responses import JSONResponse
 
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_ebooks_form,
@@ -131,6 +132,7 @@ def _process_single_ebook(
     "/process-ebooks",
     summary="Extract, chunk, analyse EPUBs (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_ebooks_endpoint(
     db: MediaDatabase = Depends(get_media_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_emails.py
@@ -10,6 +10,7 @@ from loguru import logger
 from starlette.responses import JSONResponse
 
 import tldw_Server_API.app.core.Ingestion_Media_Processing.Email.Email_Processing_Lib as email_lib  # type: ignore
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_emails_form,
@@ -38,6 +39,7 @@ router = APIRouter()
     "/process-emails",
     summary="Extract, chunk, analyse Emails (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_emails_endpoint(
     db: MediaDatabase = Depends(get_media_db_for_user),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_mediawiki.py
@@ -16,6 +16,7 @@ from starlette.responses import StreamingResponse
 from tldw_Server_API.app.api.v1.API_Deps.backpressure import (
     guard_backpressure_and_quota,
 )
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.media_mediawiki_deps import (
     get_mediawiki_form_data,
 )
@@ -238,7 +239,7 @@ async def _process_mediawiki_dump(
     "/mediawiki/ingest-dump",
     summary="Ingest and process a MediaWiki XML dump, storing results to database and vector store.",
     tags=["MediaWiki Processing"],
-    dependencies=[Depends(guard_backpressure_and_quota)],
+    dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
 )
 async def ingest_mediawiki_dump_endpoint(
     form_data: MediaWikiDumpOptionsForm = Depends(get_mediawiki_form_data),
@@ -266,7 +267,7 @@ async def ingest_mediawiki_dump_endpoint(
     "/mediawiki/process-dump",
     summary="Process a MediaWiki XML dump and return structured content without database storage.",
     tags=["MediaWiki Processing"],
-    dependencies=[Depends(guard_backpressure_and_quota)],
+    dependencies=[Depends(guard_backpressure_and_quota), Depends(guard_storage_quota)],
 )
 async def process_mediawiki_dump_ephemeral_endpoint(
     form_data: MediaWikiDumpOptionsForm = Depends(get_mediawiki_form_data),

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_pdfs.py
@@ -16,6 +16,7 @@ from fastapi import (
 from loguru import logger
 from starlette.responses import JSONResponse
 
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_pdfs_form,
@@ -68,6 +69,7 @@ ALLOWED_PDF_EXTENSIONS = [".pdf"]
     "/process-pdfs",
     summary="Extract, chunk, analyse PDFs (NO DB Persistence)",
     tags=["Media Processing (No DB)"],
+    dependencies=[Depends(guard_storage_quota)],
 )
 async def process_pdfs_endpoint(
     background_tasks: BackgroundTasks,  # Parity with legacy endpoint signature

--- a/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
+++ b/tldw_Server_API/app/api/v1/endpoints/media/process_videos.py
@@ -19,6 +19,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     rbac_rate_limit,
     require_permissions,
 )
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import guard_storage_quota
 from tldw_Server_API.app.api.v1.API_Deps.DB_Deps import get_media_db_for_user
 from tldw_Server_API.app.api.v1.API_Deps.media_processing_deps import (
     get_process_videos_form,
@@ -62,6 +63,7 @@ router = APIRouter()
     dependencies=[
         Depends(require_permissions(MEDIA_CREATE)),
         Depends(rbac_rate_limit("media.create")),
+        Depends(guard_storage_quota),
     ],
 )
 async def process_videos_endpoint(

--- a/tldw_Server_API/app/api/v1/schemas/consent_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/consent_schemas.py
@@ -1,6 +1,8 @@
 """Pydantic schemas for consent endpoints."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -12,8 +14,8 @@ class ConsentRecordResponse(BaseModel):
     id: int | None = None
     user_id: int
     purpose: str
-    granted_at: str | None = None
-    withdrawn_at: str | None = None
+    granted_at: datetime | None = None
+    withdrawn_at: datetime | None = None
     ip_address: str | None = None
     user_agent: str | None = None
     metadata: str | None = None

--- a/tldw_Server_API/app/api/v1/schemas/consent_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/consent_schemas.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for consent endpoints."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ConsentRecordResponse(BaseModel):
+    """Serializable consent record returned by the consent endpoints."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    user_id: int
+    purpose: str
+    granted_at: str | None = None
+    withdrawn_at: str | None = None
+    ip_address: str | None = None
+    user_agent: str | None = None
+    metadata: str | None = None
+
+
+class ConsentPreferencesResponse(BaseModel):
+    """List response for a user's consent preferences."""
+
+    user_id: int
+    consents: list[ConsentRecordResponse]

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -51,6 +51,7 @@ from uuid import uuid4
 # 3rd-Party Imports
 import aiosqlite
 from loguru import logger
+from tldw_Server_API.app.core.AuthNZ.audit_integrity import compute_event_hash
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection_async,
 )
@@ -469,6 +470,9 @@ class AuditEvent:
     # Additional metadata
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    # Hash chain for tamper-proofing
+    chain_hash: str = ""
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for storage"""
         normalized_metadata = _normalize_json_value(self.metadata)
@@ -495,6 +499,7 @@ class AuditEvent:
             "pii_detected": self.pii_detected,
             "compliance_flags": json.dumps(normalized_flags, ensure_ascii=False),
             "metadata": json.dumps(normalized_metadata, ensure_ascii=False),
+            "chain_hash": self.chain_hash,
         }
 
         # Add context fields
@@ -1034,6 +1039,9 @@ class UnifiedAuditService:
         self.event_buffer: list[AuditEvent] = []
         self.buffer_lock = asyncio.Lock()
 
+        # Hash chain state for tamper-proofing
+        self._last_chain_hash: str = ""
+
         # Background tasks
         self._flush_task: Optional[asyncio.Task] = None
         self._cleanup_task: Optional[asyncio.Task] = None
@@ -1093,6 +1101,7 @@ class UnifiedAuditService:
             "resource_type", "resource_id", "action", "result", "error_message",
             "duration_ms", "tokens_used", "estimated_cost", "result_count",
             "risk_score", "pii_detected", "compliance_flags", "metadata",
+            "chain_hash",
         ])
         return columns
 
@@ -1191,7 +1200,10 @@ class UnifiedAuditService:
                     compliance_flags TEXT,
 
                     -- Metadata
-                    metadata TEXT
+                    metadata TEXT,
+
+                    -- Hash chain for tamper-proofing
+                    chain_hash TEXT
                 )
             """
         else:
@@ -1233,7 +1245,10 @@ class UnifiedAuditService:
                     compliance_flags TEXT,
 
                     -- Metadata
-                    metadata TEXT
+                    metadata TEXT,
+
+                    -- Hash chain for tamper-proofing
+                    chain_hash TEXT
                 )
             """
         expected_types = {
@@ -1265,6 +1280,7 @@ class UnifiedAuditService:
             "pii_detected": "BOOLEAN",
             "compliance_flags": "TEXT",
             "metadata": "TEXT",
+            "chain_hash": "TEXT",
         }
         if not self._shared_mode:
             expected_types.pop("tenant_user_id", None)
@@ -2330,6 +2346,26 @@ class UnifiedAuditService:
             return deduped
         return [event for event in deduped if event.event_id not in existing_ids]
 
+    def _apply_chain_hashes(self, records: list[dict[str, Any]]) -> None:
+        """Compute and assign chain hashes to a batch of event records.
+
+        Mutates each record in-place, setting the ``chain_hash`` key.
+        Updates ``self._last_chain_hash`` so subsequent batches continue
+        the chain.
+        """
+        prev = self._last_chain_hash
+        for rec in records:
+            event_dict = {
+                "action": rec.get("action", ""),
+                "user_id": rec.get("context_user_id"),
+                "timestamp": rec.get("timestamp", ""),
+                "detail": rec.get("event_type", ""),
+            }
+            h = compute_event_hash(event_dict, prev)
+            rec["chain_hash"] = h
+            prev = h
+        self._last_chain_hash = prev
+
     async def flush(self, *, raise_on_failure: bool = False) -> bool:
         """Flush buffered events to database.
 
@@ -2362,6 +2398,7 @@ class UnifiedAuditService:
                             # Prepare batch data
                             records = [event.to_dict() for event in new_events]
                             self._ensure_record_tenant_ids(records)
+                            self._apply_chain_hashes(records)
                             await db.executemany(self._event_insert_sql, records)
                             await self._update_daily_stats(db, new_events)
                             await db.commit()
@@ -2376,6 +2413,7 @@ class UnifiedAuditService:
 
                             # Batch insert
                             self._ensure_record_tenant_ids(records)
+                            self._apply_chain_hashes(records)
                             await db.executemany(self._event_insert_sql, records)
 
                             # Update daily statistics

--- a/tldw_Server_API/app/core/Audit/unified_audit_service.py
+++ b/tldw_Server_API/app/core/Audit/unified_audit_service.py
@@ -351,9 +351,9 @@ class AuditEventType(Enum):
     AUTH_LOGIN_SUCCESS = "auth.login.success"
     AUTH_LOGIN_FAILURE = "auth.login.failure"
     AUTH_LOGOUT = "auth.logout"
-    AUTH_TOKEN_CREATED = "auth.token.created"
-    AUTH_TOKEN_REFRESHED = "auth.token.refreshed"
-    AUTH_TOKEN_REVOKED = "auth.token.revoked"
+    AUTH_TOKEN_CREATED = "auth.token.created"  # nosec B105
+    AUTH_TOKEN_REFRESHED = "auth.token.refreshed"  # nosec B105
+    AUTH_TOKEN_REVOKED = "auth.token.revoked"  # nosec B105
     AUTH_SESSION_EXPIRED = "auth.session.expired"
 
     # User Management
@@ -362,8 +362,8 @@ class AuditEventType(Enum):
     USER_DELETED = "user.deleted"
     USER_ACTIVATED = "user.activated"
     USER_DEACTIVATED = "user.deactivated"
-    USER_PASSWORD_CHANGED = "user.password.changed"
-    USER_PASSWORD_RESET = "user.password.reset"
+    USER_PASSWORD_CHANGED = "user.password.changed"  # nosec B105
+    USER_PASSWORD_RESET = "user.password.reset"  # nosec B105
 
     # Data Operations
     DATA_READ = "data.read"
@@ -538,7 +538,7 @@ class PIIDetector:
         "bank_account": r"(?:\b\d{9}[-\s]?\d{8,17}\b|(?:account|acct|routing)[\s#:]*\d{8,17}\b)",
         "iban": r"\b[A-Z]{2}\d{2}[A-Z0-9]{4}\d{7}(?:[A-Z0-9]?){0,16}\b",
         "api_key": r"\b(?:sk|pk|api[_-]?key)[_-]?[A-Za-z0-9]{32,}\b",
-        "jwt_token": r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b",
+        "jwt_token": r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b",  # nosec B105
     }
 
     # Back-compat for modules that read PIIDetector.PII_PATTERNS directly
@@ -1077,6 +1077,7 @@ class UnifiedAuditService:
         """
         self._owner_loop = asyncio.get_running_loop()
         await self._init_database()
+        self._last_chain_hash = await self._load_last_chain_hash()
         # In test mode, avoid opening a persistent pooled connection to prevent
         # lingering aiosqlite worker threads that can keep the interpreter alive.
         # Non-test mode uses a pooled connection for performance.
@@ -1087,6 +1088,24 @@ class UnifiedAuditService:
         # tight loops and starve the event loop.
         if start_background_tasks and not self._test_mode:
             await self.start_background_tasks()
+
+    async def _load_last_chain_hash(self) -> str:
+        """Resume the tamper-evident chain from the most recently inserted event."""
+        try:
+            async with self._read_db() as db:
+                async with db.execute(
+                    "SELECT chain_hash FROM audit_events "
+                    "WHERE chain_hash IS NOT NULL AND chain_hash != '' "
+                    "ORDER BY rowid DESC LIMIT 1"
+                ) as cursor:
+                    row = await cursor.fetchone()
+        except _AUDIT_NONCRITICAL_EXCEPTIONS as exc:
+            logger.warning(f"Failed to resume audit hash chain: {exc}")
+            return ""
+
+        if not row:
+            return ""
+        return str(row[0] or "")
 
     def _build_event_columns(self) -> list[str]:
         columns = [

--- a/tldw_Server_API/app/core/Billing/enforcement.py
+++ b/tldw_Server_API/app/core/Billing/enforcement.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 # Environment variable for cache TTL (default 60 seconds)
 BILLING_CACHE_TTL_SECONDS = float(os.environ.get("BILLING_CACHE_TTL_SECONDS", "60.0"))
 
+from tldw_Server_API.app.core.Billing.overage_config import OveragePolicy
 from tldw_Server_API.app.core.Billing.plan_limits import SOFT_LIMIT_PERCENT
 from tldw_Server_API.app.core.Billing.stripe_client import is_billing_enabled
 
@@ -757,36 +758,54 @@ class BillingEnforcer:
         after_operation = current + requested_units
         percent_used = (after_operation / limit_value * 100) if limit_value > 0 else 100
 
-        # Determine action
+        # Determine base action
         if after_operation > limit_value:
             # Would exceed limit
-            return LimitCheckResult(
-                category=category.value,
-                action=EnforcementAction.SOFT_BLOCK,
-                current=current,
-                limit=limit_value,
-                percent_used=percent_used,
-                message=f"Limit exceeded for {category.value}. Current: {current}, Limit: {limit_value}",
-            )
+            action = EnforcementAction.SOFT_BLOCK
+            message = f"Limit exceeded for {category.value}. Current: {current}, Limit: {limit_value}"
         elif percent_used >= self.soft_limit_percent:
             # Approaching limit - warn
-            return LimitCheckResult(
-                category=category.value,
-                action=EnforcementAction.WARN,
-                current=current,
-                limit=limit_value,
-                percent_used=percent_used,
-                message=f"Approaching limit for {category.value}: {percent_used:.0f}% used",
-            )
+            action = EnforcementAction.WARN
+            message = f"Approaching limit for {category.value}: {percent_used:.0f}% used"
         else:
             # Well within limits
-            return LimitCheckResult(
-                category=category.value,
-                action=EnforcementAction.ALLOW,
-                current=current,
-                limit=limit_value,
-                percent_used=percent_used,
-            )
+            action = EnforcementAction.ALLOW
+            message = None
+
+        # Apply overage policy to potentially upgrade the enforcement action
+        try:
+            overage_policy = OveragePolicy.from_env()
+            overage_result = overage_policy.evaluate(percent_used)
+
+            if overage_result["blocked"]:
+                action = EnforcementAction.HARD_BLOCK
+                message = (
+                    f"Hard blocked by overage policy for {category.value}: "
+                    f"{percent_used:.0f}% used (mode={overage_result['mode']})"
+                )
+            elif overage_result["degraded"]:
+                action = EnforcementAction.SOFT_BLOCK
+                message = (
+                    f"Degraded by overage policy for {category.value}: "
+                    f"{percent_used:.0f}% used (mode={overage_result['mode']})"
+                )
+            elif overage_result["notify"] and action == EnforcementAction.ALLOW:
+                action = EnforcementAction.WARN
+                message = (
+                    f"Overage notification for {category.value}: "
+                    f"{percent_used:.0f}% used"
+                )
+        except _BILLING_ENFORCEMENT_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"Overage policy evaluation skipped: {exc}")
+
+        return LimitCheckResult(
+            category=category.value,
+            action=action,
+            current=current,
+            limit=limit_value,
+            percent_used=percent_used,
+            message=message,
+        )
 
     async def check_feature_access(
         self,

--- a/tldw_Server_API/app/core/Billing/enforcement.py
+++ b/tldw_Server_API/app/core/Billing/enforcement.py
@@ -52,6 +52,7 @@ _BILLING_ENFORCEMENT_NONCRITICAL_EXCEPTIONS = (
 _BILLING_ENFORCEMENT_FAILURE_MODE_ENV = "BILLING_ENFORCEMENT_FAILURE_MODE"
 _BILLING_ENFORCEMENT_FAILURE_MODE_OPEN = "open"
 _BILLING_ENFORCEMENT_FAILURE_MODE_CLOSED = "closed"
+_BILLING_ENFORCEMENT_POLICY_UNSET = object()
 
 try:  # pragma: no cover - optional dependency guard
     import asyncpg  # type: ignore
@@ -141,6 +142,7 @@ class BillingEnforcer:
         self._limits_cache: dict[int, tuple[dict[str, Any], float]] = {}
         # Use provided TTL, env var, or default to 60s
         self._cache_ttl = cache_ttl if cache_ttl is not None else BILLING_CACHE_TTL_SECONDS
+        self._overage_policy: Any = _BILLING_ENFORCEMENT_POLICY_UNSET
 
     @staticmethod
     def _is_postgres_pool(pool: Any) -> bool:
@@ -178,6 +180,16 @@ class BillingEnforcer:
             _BILLING_ENFORCEMENT_FAILURE_MODE_OPEN,
         )
         return _BILLING_ENFORCEMENT_FAILURE_MODE_OPEN
+
+    def _get_overage_policy(self) -> OveragePolicy | None:
+        """Load the configured overage policy once per enforcer instance."""
+        if self._overage_policy is _BILLING_ENFORCEMENT_POLICY_UNSET:
+            try:
+                self._overage_policy = OveragePolicy.from_env()
+            except _BILLING_ENFORCEMENT_NONCRITICAL_EXCEPTIONS as exc:
+                logger.warning(f"Overage policy initialization skipped: {exc}")
+                self._overage_policy = None
+        return self._overage_policy
 
     @classmethod
     def _fail_closed_on_data_error(cls) -> bool:
@@ -774,7 +786,9 @@ class BillingEnforcer:
 
         # Apply overage policy to potentially upgrade the enforcement action
         try:
-            overage_policy = OveragePolicy.from_env()
+            overage_policy = self._get_overage_policy()
+            if overage_policy is None:
+                raise RuntimeError("overage policy unavailable")
             overage_result = overage_policy.evaluate(percent_used)
 
             if overage_result["blocked"]:
@@ -796,7 +810,7 @@ class BillingEnforcer:
                     f"{percent_used:.0f}% used"
                 )
         except _BILLING_ENFORCEMENT_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug(f"Overage policy evaluation skipped: {exc}")
+            logger.warning(f"Overage policy evaluation skipped: {exc}")
 
         return LimitCheckResult(
             category=category.value,

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Files.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Audio/Audio_Files.py
@@ -22,6 +22,7 @@
 #
 #########################################
 # Imports
+import asyncio
 import json
 import os
 import string
@@ -138,6 +139,34 @@ _AUDIO_FILES_NONCRITICAL_EXCEPTIONS = (
 #######################################################################################################################
 # Function Definitions
 #
+
+
+def _enforce_download_quota(user_id: int | None, file_path: Path) -> None:
+    """Raise ValueError when a downloaded URL payload would exceed storage quota."""
+    if user_id is None:
+        return
+
+    from tldw_Server_API.app.services.storage_quota_service import get_storage_quota_service
+
+    async def _check_quota() -> None:
+        quota_service = get_storage_quota_service()
+        size_bytes = file_path.stat().st_size
+        has_quota, info = await quota_service.check_quota(
+            user_id,
+            size_bytes,
+            raise_on_exceed=False,
+        )
+        if has_quota:
+            return
+        raise ValueError(
+            "Storage quota exceeded. Current: "
+            f"{info['current_usage_mb']}MB, "
+            f"New: {info['new_size_mb']}MB, "
+            f"Quota: {info['quota_mb']}MB, "
+            f"Available: {info['available_mb']}MB"
+        )
+
+    asyncio.run(_check_quota())
 
 def check_transcription_model_status(model_name: str) -> dict[str, Any]:
     """
@@ -685,6 +714,7 @@ def process_audio_files(
     custom_title: Optional[str] = None,
     author: Optional[str] = None,
     temp_dir: Optional[str] = None,
+    user_id: Optional[int] = None,
     cancel_check: Optional[Callable[[], bool]] = None,
 ) -> dict[str, Any]:
     """
@@ -1030,7 +1060,9 @@ def process_audio_files(
                      raise RuntimeError("Audio file path is missing or invalid after download/copy check.")
 
                 if is_url:
-                    _validate_downloaded_url_audio_file(Path(current_audio_path))
+                    downloaded_audio_path = Path(current_audio_path)
+                    _validate_downloaded_url_audio_file(downloaded_audio_path)
+                    _enforce_download_quota(user_id, downloaded_audio_path)
 
                 # 2. Convert to WAV using the library function (skip if already WAV)
                 if Path(current_audio_path).suffix.lower() == '.wav':

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/Video/Video_DL_Ingestion_Lib.py
@@ -24,6 +24,7 @@ import json
 #
 ####################
 # Import necessary libraries to run solo for testing
+import asyncio
 import os
 import re
 import shutil
@@ -190,6 +191,34 @@ def _validate_downloaded_url_video_file(downloaded_path: Path) -> None:
         media_mod=None,
         allowed_extensions=None,
     )
+
+
+def _enforce_download_quota(user_id: Optional[int], downloaded_path: Path) -> None:
+    """Raise ValueError when a downloaded URL payload would exceed storage quota."""
+    if user_id is None:
+        return
+
+    from tldw_Server_API.app.services.storage_quota_service import get_storage_quota_service
+
+    async def _check_quota() -> None:
+        quota_service = get_storage_quota_service()
+        size_bytes = downloaded_path.stat().st_size
+        has_quota, info = await quota_service.check_quota(
+            user_id,
+            size_bytes,
+            raise_on_exceed=False,
+        )
+        if has_quota:
+            return
+        raise ValueError(
+            "Storage quota exceeded. Current: "
+            f"{info['current_usage_mb']}MB, "
+            f"New: {info['new_size_mb']}MB, "
+            f"Quota: {info['quota_mb']}MB, "
+            f"Available: {info['available_mb']}MB"
+        )
+
+    asyncio.run(_check_quota())
 
 
 def _safe_remove_file(file_path: Path) -> None:
@@ -1354,6 +1383,7 @@ def process_single_video(
                     "Downloaded file path rejected outside temp directory."
                 )
             _validate_downloaded_url_video_file(safe_downloaded)
+            _enforce_download_quota(user_id, safe_downloaded)
             local_file_path_for_transcription = str(safe_downloaded)
             # *** Update only the processing_source, keep original input_ref ***
             processing_result["processing_source"] = local_file_path_for_transcription

--- a/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
+++ b/tldw_Server_API/app/core/Ingestion_Media_Processing/persistence.py
@@ -2451,6 +2451,7 @@ async def add_media_orchestrate(
                     db_path=db_path_for_workers,
                     client_id=client_id_for_workers,
                     temp_dir=temp_dir_path,
+                    user_id=int(current_user.id) if str(getattr(current_user, "id", "")).isdigit() else None,
                 )
                 results.extend(batch_results)
             else:
@@ -3292,6 +3293,7 @@ async def process_batch_media(
     db_path: str,
     client_id: str,
     temp_dir: FilePath,
+    user_id: int | None = None,
     cancel_check: Callable[[], bool] | None = None,
 ) -> list[dict[str, Any]]:
     """
@@ -3725,6 +3727,7 @@ async def process_batch_media(
                     False,
                 ),
                 "keep_original": getattr(form_data, "keep_original_file", False),
+                "user_id": user_id,
                 "cancel_check": cancel_check,
             }
             if attach_chunk_options:
@@ -3801,6 +3804,7 @@ async def process_batch_media(
                 "keep_original": getattr(form_data, "keep_original_file", False),
                 "custom_title": getattr(form_data, "title", None),
                 "author": getattr(form_data, "author", None),
+                "user_id": user_id,
                 "cancel_check": cancel_check,
             }
             if attach_chunk_options:

--- a/tldw_Server_API/app/core/Jobs/fair_share.py
+++ b/tldw_Server_API/app/core/Jobs/fair_share.py
@@ -40,7 +40,7 @@ class FairShareScheduler:
     # Admission control
     # ------------------------------------------------------------------
 
-    def can_submit(self, user_id: int, active_count: int) -> bool:
+    def can_submit(self, user_id: Any, active_count: int) -> bool:
         """Check if user can submit a new job.
 
         Args:
@@ -70,7 +70,7 @@ class FairShareScheduler:
 
     def calculate_priority(
         self,
-        user_id: int,
+        user_id: Any,
         active_count: int,
         wait_seconds: float = 0,
     ) -> int:

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -256,6 +256,15 @@ class JobManager:
         finally:
             conn.close()
 
+    @staticmethod
+    def _map_fair_share_score_to_priority(score: int) -> int:
+        """Convert a higher fair-share score into a higher queue priority.
+
+        Queue priority is stored as 1..10 where lower numbers run first.
+        """
+        clamped_score = max(0, min(100, int(score)))
+        return max(1, 10 - min(9, clamped_score // 10))
+
     def _get_allowed_queues(self, domain: str | None = None) -> list[str]:
         allowed = list(self.STANDARD_QUEUES)
         if domain:
@@ -1099,13 +1108,12 @@ class JobManager:
                         f"({scheduler.max_per_user})"
                     )
                 fair_priority = scheduler.calculate_priority(int(owner_user_id), active_count)
-                # Clamp fair-share priority to DB-valid range (1-10)
-                fair_priority_clamped = max(1, min(10, fair_priority // 10))
-                priority = max(priority, fair_priority_clamped)
+                fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
+                priority = min(priority, fair_priority_mapped)
             except ValueError:
                 raise
             except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
-                logger.debug(f"Fair-share scheduling check skipped: {_fs_exc}")
+                logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
 
         # Secret hygiene (reject/redact)
         try:

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -33,6 +33,7 @@ from tldw_Server_API.app.core.testing import (
 )
 
 from .audit_bridge import submit_job_audit_event
+from .fair_share import FairShareScheduler
 from .event_stream import emit_job_event
 from .metrics import (
     ensure_jobs_metrics_registered,
@@ -77,6 +78,17 @@ _JOB_NONCRITICAL_EXCEPTIONS: tuple[type[BaseException], ...] = (
     sqlite3.Error,
     *_PG_ERRORS,
 )
+
+# Module-level fair-share scheduler instance (lazy singleton)
+_fair_share: FairShareScheduler | None = None
+
+
+def _get_fair_share() -> FairShareScheduler:
+    """Return the module-level FairShareScheduler, creating it on first use."""
+    global _fair_share
+    if _fair_share is None:
+        _fair_share = FairShareScheduler()
+    return _fair_share
 
 
 def _parse_dt(v: Any) -> datetime | None:
@@ -212,6 +224,37 @@ class JobManager:
     def set_acquire_gate(cls, enabled: bool) -> None:
         """Globally gate new acquisitions during graceful shutdown."""
         cls._ACQUIRE_GATE_ENABLED = bool(enabled)
+
+    def _count_active_jobs_for_user(self, user_id: str) -> int:
+        """Count jobs with active status (queued or processing) for a user.
+
+        Args:
+            user_id: The owner_user_id to count active jobs for.
+
+        Returns:
+            Number of active jobs for this user.
+        """
+        conn = self._connect()
+        try:
+            if self.backend == "postgres":
+                with self._pg_cursor(conn) as cur:
+                    cur.execute(
+                        "SELECT COUNT(*) AS c FROM jobs WHERE owner_user_id = %s AND status IN ('queued', 'processing')",
+                        (user_id,),
+                    )
+                    row = cur.fetchone()
+                    return int(row["c"] if isinstance(row, dict) else (row[0] if row else 0))
+            else:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM jobs WHERE owner_user_id = ? AND status IN ('queued', 'processing')",
+                    (user_id,),
+                ).fetchone()
+                return int(row[0] if row else 0)
+        except _JOB_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"Failed to count active jobs for user {user_id}: {exc}")
+            return 0
+        finally:
+            conn.close()
 
     def _get_allowed_queues(self, domain: str | None = None) -> list[str]:
         allowed = list(self.STANDARD_QUEUES)
@@ -1044,6 +1087,25 @@ class JobManager:
         allowed_queues = self._get_allowed_queues(domain)
         if queue not in allowed_queues:
             raise ValueError(f"Queue '{queue}' not allowed for domain '{domain}'. Allowed: {allowed_queues}")  # noqa: TRY003
+
+        # Fair-share scheduling: enforce per-user concurrency limits and adjust priority
+        if owner_user_id:
+            try:
+                scheduler = _get_fair_share()
+                active_count = self._count_active_jobs_for_user(owner_user_id)
+                if not scheduler.can_submit(int(owner_user_id), active_count):
+                    raise ValueError(  # noqa: TRY003
+                        f"User {owner_user_id} has reached the maximum concurrent job limit "
+                        f"({scheduler.max_per_user})"
+                    )
+                fair_priority = scheduler.calculate_priority(int(owner_user_id), active_count)
+                # Clamp fair-share priority to DB-valid range (1-10)
+                fair_priority_clamped = max(1, min(10, fair_priority // 10))
+                priority = max(priority, fair_priority_clamped)
+            except ValueError:
+                raise
+            except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
+                logger.debug(f"Fair-share scheduling check skipped: {_fs_exc}")
 
         # Secret hygiene (reject/redact)
         try:

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -1102,15 +1102,15 @@ class JobManager:
             try:
                 scheduler = _get_fair_share()
                 active_count = self._count_active_jobs_for_user(owner_user_id)
-                if not scheduler.can_submit(int(owner_user_id), active_count):
-                    raise ValueError(  # noqa: TRY003
+                if not scheduler.can_submit(owner_user_id, active_count):
+                    raise BadRequestError(
                         f"User {owner_user_id} has reached the maximum concurrent job limit "
                         f"({scheduler.max_per_user})"
                     )
-                fair_priority = scheduler.calculate_priority(int(owner_user_id), active_count)
+                fair_priority = scheduler.calculate_priority(owner_user_id, active_count)
                 fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
                 priority = min(priority, fair_priority_mapped)
-            except ValueError:
+            except BadRequestError:
                 raise
             except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
                 logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -5699,7 +5699,7 @@ elif _MINIMAL_TEST_APP:
 
         app.include_router(consent_router, prefix=f"{API_V1_PREFIX}", tags=["consent"])
     except _IMPORT_EXCEPTIONS as _consent_min_err:
-        logger.debug(f"Skipping consent router in minimal test app: {_consent_min_err}")
+        logger.debug("Skipping consent router in minimal test app: {}", _consent_min_err)
     # Collections endpoints (treated as lightweight; always included in minimal app)
     try:
         from tldw_Server_API.app.api.v1.endpoints.outputs_templates import router as outputs_templates_router
@@ -6183,7 +6183,7 @@ else:
 
     _include_if_enabled("audit", audit_router, prefix=f"{API_V1_PREFIX}", tags=["audit"])
     _include_if_enabled("auth", auth_router, prefix=f"{API_V1_PREFIX}", tags=["authentication"])
-    app.include_router(consent_router, prefix=f"{API_V1_PREFIX}", tags=["consent"])
+    _include_if_enabled("consent", consent_router, prefix=f"{API_V1_PREFIX}", tags=["consent"])
     logger.info("Auth router consolidated: endpoints/auth.py")
     if "users_router" in locals() and users_router is not None:
         _include_if_enabled("users", users_router, prefix=f"{API_V1_PREFIX}", tags=["users"])

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1215,6 +1215,7 @@ else:
     # Users Endpoint (NEW)
     # Chatbooks Endpoint
     from tldw_Server_API.app.api.v1.endpoints.chatbooks import router as chatbooks_router
+    from tldw_Server_API.app.api.v1.endpoints.consent import router as consent_router
 
     # Flashcards Endpoint (V5 - ChaChaNotes)
     from tldw_Server_API.app.api.v1.endpoints.flashcards import router as flashcards_router
@@ -6182,6 +6183,7 @@ else:
 
     _include_if_enabled("audit", audit_router, prefix=f"{API_V1_PREFIX}", tags=["audit"])
     _include_if_enabled("auth", auth_router, prefix=f"{API_V1_PREFIX}", tags=["authentication"])
+    app.include_router(consent_router, prefix=f"{API_V1_PREFIX}", tags=["consent"])
     logger.info("Auth router consolidated: endpoints/auth.py")
     if "users_router" in locals() and users_router is not None:
         _include_if_enabled("users", users_router, prefix=f"{API_V1_PREFIX}", tags=["users"])

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -5692,6 +5692,13 @@ elif _MINIMAL_TEST_APP:
         app.include_router(billing_webhooks_router, prefix=f"{API_V1_PREFIX}", tags=["billing"])
     except _IMPORT_EXCEPTIONS as _billing_webhooks_min_err:
         logger.debug(f"Skipping billing webhooks router in minimal test app: {_billing_webhooks_min_err}")
+    # Consent management endpoints
+    try:
+        from tldw_Server_API.app.api.v1.endpoints.consent import router as consent_router
+
+        app.include_router(consent_router, prefix=f"{API_V1_PREFIX}", tags=["consent"])
+    except _IMPORT_EXCEPTIONS as _consent_min_err:
+        logger.debug(f"Skipping consent router in minimal test app: {_consent_min_err}")
     # Collections endpoints (treated as lightweight; always included in minimal app)
     try:
         from tldw_Server_API.app.api.v1.endpoints.outputs_templates import router as outputs_templates_router

--- a/tldw_Server_API/app/services/media_ingest_jobs_worker.py
+++ b/tldw_Server_API/app/services/media_ingest_jobs_worker.py
@@ -252,6 +252,7 @@ async def _handle_job(job: dict[str, Any], jm: JobManager, progress: _ProgressSt
                 db_path=str(db_path),
                 client_id=str(client_id),
                 temp_dir=temp_dir,
+                user_id=int(user_id) if user_id.isdigit() else None,
                 cancel_check=cancel_check,
             )
         else:

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -6,11 +6,22 @@ Runs as a periodic background task to keep billing in sync.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from loguru import logger
+
+# Stripe import is optional - mirrors stripe_client.py pattern
+try:
+    import stripe
+    import stripe.error
+
+    STRIPE_AVAILABLE = True
+except ImportError:
+    stripe = None  # type: ignore[assignment]
+    STRIPE_AVAILABLE = False
 
 
 class StripeMeteringService:
@@ -19,6 +30,261 @@ class StripeMeteringService:
     def __init__(self) -> None:
         self._enabled = os.getenv("BILLING_ENABLED", "false").lower() in ("1", "true")
         self._stripe_key = os.getenv("STRIPE_API_KEY", "")
+        self._meter_event_name = os.getenv("STRIPE_METER_EVENT_NAME", "api_requests")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _get_db_pool(self) -> Any:
+        """Lazily acquire the AuthNZ database pool."""
+        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+        return await get_db_pool()
+
+    @staticmethod
+    def _is_postgres(conn: Any) -> bool:
+        """Detect whether *conn* is a PostgreSQL connection (asyncpg)."""
+        return hasattr(conn, "fetchrow")
+
+    async def _query_usage_for_date(self, pool: Any, target_date: str) -> list[dict[str, Any]]:
+        """Fetch usage_daily rows for *target_date*.
+
+        Returns a list of dicts with keys: user_id, requests, errors,
+        bytes_total, bytes_in_total, latency_avg_ms.
+        """
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                rows = await conn.fetch(
+                    "SELECT user_id, requests, errors, bytes_total, "
+                    "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                    "FROM usage_daily WHERE day = $1",
+                    target_date,
+                )
+                return [dict(r) for r in rows]
+            else:
+                cur = await conn.execute(
+                    "SELECT user_id, requests, errors, bytes_total, "
+                    "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                    "FROM usage_daily WHERE day = ?",
+                    (target_date,),
+                )
+                raw_rows = await cur.fetchall()
+                if not raw_rows:
+                    return []
+                columns = [col[0] for col in cur.description]
+                return [dict(zip(columns, row)) for row in raw_rows]
+
+    async def _query_user_subscription(
+        self, pool: Any, user_id: int
+    ) -> dict[str, Any] | None:
+        """Look up the active Stripe subscription for a user.
+
+        Joins through org_members -> org_subscriptions to find the user's
+        organisation subscription that has a Stripe subscription ID.
+        Falls back to checking the ``organizations.owner_user_id`` path.
+        """
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                row = await conn.fetchrow(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN org_members om ON om.org_id = os.org_id
+                    WHERE om.user_id = $1
+                      AND om.status = 'active'
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    user_id,
+                )
+                return dict(row) if row else None
+            else:
+                cur = await conn.execute(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN org_members om ON om.org_id = os.org_id
+                    WHERE om.user_id = ?
+                      AND om.status = 'active'
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    (user_id,),
+                )
+                row = await cur.fetchone()
+                if not row:
+                    return None
+                columns = [col[0] for col in cur.description]
+                return dict(zip(columns, row))
+
+    async def _get_subscription_metered_item(
+        self, subscription_id: str
+    ) -> str | None:
+        """Return the first metered subscription-item ID on *subscription_id*.
+
+        Stripe usage records are attached to a *subscription item*, not the
+        subscription itself.  This helper retrieves the subscription and picks
+        the first item whose price has ``usage_type == 'metered'``.
+        """
+        if not STRIPE_AVAILABLE:
+            return None
+        try:
+            sub = await asyncio.to_thread(
+                stripe.Subscription.retrieve,
+                subscription_id,
+                expand=["items.data.price"],
+            )
+            for item in sub.get("items", {}).get("data", []):
+                price = item.get("price", {})
+                if price.get("recurring", {}).get("usage_type") == "metered":
+                    return item["id"]
+            # No metered item found — return None so caller can skip
+            return None
+        except Exception as exc:
+            logger.warning(
+                "Failed to retrieve subscription items for {}: {}",
+                subscription_id,
+                exc,
+            )
+            return None
+
+    async def _ensure_metering_sync_table(self, pool: Any) -> None:
+        """Create the ``metering_sync_log`` tracking table if it does not exist."""
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS metering_sync_log (
+                        user_id INTEGER NOT NULL,
+                        day DATE NOT NULL,
+                        stripe_subscription_id TEXT NOT NULL,
+                        requests_synced INTEGER DEFAULT 0,
+                        bytes_synced BIGINT DEFAULT 0,
+                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (user_id, day, stripe_subscription_id)
+                    )
+                    """
+                )
+            else:
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS metering_sync_log (
+                        user_id INTEGER NOT NULL,
+                        day DATE NOT NULL,
+                        stripe_subscription_id TEXT NOT NULL,
+                        requests_synced INTEGER DEFAULT 0,
+                        bytes_synced INTEGER DEFAULT 0,
+                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (user_id, day, stripe_subscription_id)
+                    )
+                    """
+                )
+                await conn.commit()
+
+    async def _already_synced(
+        self, pool: Any, user_id: int, day: str, subscription_id: str
+    ) -> bool:
+        """Return True if usage for this user/day/subscription was already synced."""
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                row = await conn.fetchval(
+                    "SELECT 1 FROM metering_sync_log "
+                    "WHERE user_id = $1 AND day = $2 AND stripe_subscription_id = $3",
+                    user_id,
+                    day,
+                    subscription_id,
+                )
+                return row is not None
+            else:
+                cur = await conn.execute(
+                    "SELECT 1 FROM metering_sync_log "
+                    "WHERE user_id = ? AND day = ? AND stripe_subscription_id = ?",
+                    (user_id, day, subscription_id),
+                )
+                return (await cur.fetchone()) is not None
+
+    async def _record_sync(
+        self,
+        pool: Any,
+        user_id: int,
+        day: str,
+        subscription_id: str,
+        requests: int,
+        bytes_total: int,
+    ) -> None:
+        """Record a successful sync in metering_sync_log."""
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                await conn.execute(
+                    "INSERT INTO metering_sync_log "
+                    "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
+                    "VALUES ($1, $2, $3, $4, $5) "
+                    "ON CONFLICT (user_id, day, stripe_subscription_id) DO UPDATE "
+                    "SET requests_synced = EXCLUDED.requests_synced, "
+                    "    bytes_synced = EXCLUDED.bytes_synced, "
+                    "    synced_at = CURRENT_TIMESTAMP",
+                    user_id,
+                    day,
+                    subscription_id,
+                    requests,
+                    bytes_total,
+                )
+            else:
+                await conn.execute(
+                    "INSERT OR REPLACE INTO metering_sync_log "
+                    "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
+                    "VALUES (?, ?, ?, ?, ?)",
+                    (user_id, day, subscription_id, requests, bytes_total),
+                )
+                await conn.commit()
+
+    async def _report_usage_to_stripe(
+        self, subscription_item_id: str, quantity: int, timestamp: int
+    ) -> None:
+        """Create a Stripe usage record on the given subscription item.
+
+        Uses the legacy ``SubscriptionItem.create_usage_record`` API which is
+        widely supported across stripe-python versions.
+        """
+        if not STRIPE_AVAILABLE:
+            raise RuntimeError("stripe package is not installed")
+
+        await asyncio.to_thread(
+            stripe.SubscriptionItem.create_usage_record,
+            subscription_item_id,
+            quantity=quantity,
+            timestamp=timestamp,
+            action="set",
+        )
+
+    async def _query_sync_totals(self, pool: Any, target_date: str) -> list[dict[str, Any]]:
+        """Fetch synced totals from metering_sync_log for *target_date*."""
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                rows = await conn.fetch(
+                    "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
+                    "FROM metering_sync_log WHERE day = $1",
+                    target_date,
+                )
+                return [dict(r) for r in rows]
+            else:
+                cur = await conn.execute(
+                    "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
+                    "FROM metering_sync_log WHERE day = ?",
+                    (target_date,),
+                )
+                raw = await cur.fetchall()
+                if not raw:
+                    return []
+                cols = [c[0] for c in cur.description]
+                return [dict(zip(cols, r)) for r in raw]
 
     # ------------------------------------------------------------------
     # Public API
@@ -36,26 +302,164 @@ class StripeMeteringService:
         if not self._enabled or not self._stripe_key:
             return {"status": "skipped", "reason": "billing_not_enabled"}
 
+        if not STRIPE_AVAILABLE:
+            return {"status": "skipped", "reason": "stripe_package_not_installed"}
+
         target_date = date or (
             datetime.now(timezone.utc) - timedelta(days=1)
         ).strftime("%Y-%m-%d")
 
         logger.info("Stripe metering sync for {}: started", target_date)
 
+        # Configure stripe key (stripe is guaranteed non-None since STRIPE_AVAILABLE is True)
+        stripe.api_key = self._stripe_key  # type: ignore[union-attr]
+
+        # Acquire DB pool
+        try:
+            pool = await self._get_db_pool()
+        except Exception as exc:
+            logger.error("Stripe metering sync: failed to get DB pool: {}", exc)
+            return {
+                "status": "error",
+                "date": target_date,
+                "error": f"db_pool_unavailable: {exc}",
+            }
+
+        # Ensure tracking table exists
+        try:
+            await self._ensure_metering_sync_table(pool)
+        except Exception as exc:
+            logger.warning(
+                "Stripe metering sync: could not ensure sync table: {}", exc
+            )
+            # Non-fatal — table may already exist, or usage_daily may not exist either
+
+        # Query usage for the target date
+        try:
+            usage_rows = await self._query_usage_for_date(pool, target_date)
+        except Exception as exc:
+            logger.error(
+                "Stripe metering sync for {}: failed to query usage: {}",
+                target_date,
+                exc,
+            )
+            return {
+                "status": "error",
+                "date": target_date,
+                "error": f"usage_query_failed: {exc}",
+            }
+
+        if not usage_rows:
+            logger.info("Stripe metering sync for {}: no usage data", target_date)
+            return {
+                "status": "completed",
+                "date": target_date,
+                "synced_users": 0,
+                "skipped_users": 0,
+                "errors": 0,
+                "message": "no_usage_data",
+            }
+
+        # Compute the epoch timestamp for end-of-day (23:59:59 UTC)
+        try:
+            dt = datetime.strptime(target_date, "%Y-%m-%d").replace(
+                hour=23, minute=59, second=59, tzinfo=timezone.utc
+            )
+            usage_timestamp = int(dt.timestamp())
+        except ValueError:
+            usage_timestamp = int(datetime.now(timezone.utc).timestamp())
+
         synced = 0
+        skipped = 0
         errors = 0
 
-        # Implementation would:
-        # 1. Query usage_daily for the target date
-        # 2. For each user with a Stripe subscription:
-        #    - Report usage via stripe.billing.MeterEvent.create()
-        #    - Track what was synced to prevent double-counting
-        # 3. Log results
+        for row in usage_rows:
+            user_id = row["user_id"]
+            requests = row.get("requests", 0) or 0
+            bytes_total = row.get("bytes_total", 0) or 0
+
+            if requests == 0:
+                skipped += 1
+                continue
+
+            try:
+                # Look up user's Stripe subscription
+                sub_info = await self._query_user_subscription(pool, user_id)
+                if not sub_info:
+                    skipped += 1
+                    continue
+
+                subscription_id = sub_info["stripe_subscription_id"]
+
+                # Check for duplicate sync
+                try:
+                    if await self._already_synced(
+                        pool, user_id, target_date, subscription_id
+                    ):
+                        logger.debug(
+                            "Skipping already-synced user {} for {}",
+                            user_id,
+                            target_date,
+                        )
+                        skipped += 1
+                        continue
+                except Exception:
+                    # Table might not exist; proceed with sync
+                    pass
+
+                # Find the metered subscription item
+                item_id = await self._get_subscription_metered_item(subscription_id)
+                if not item_id:
+                    logger.debug(
+                        "No metered item on subscription {} for user {}",
+                        subscription_id,
+                        user_id,
+                    )
+                    skipped += 1
+                    continue
+
+                # Report usage to Stripe
+                await self._report_usage_to_stripe(
+                    item_id, requests, usage_timestamp
+                )
+
+                logger.debug(
+                    "Synced usage for user {}: requests={}, bytes={}",
+                    user_id,
+                    requests,
+                    bytes_total,
+                )
+
+                # Record the sync to prevent double-counting
+                try:
+                    await self._record_sync(
+                        pool,
+                        user_id,
+                        target_date,
+                        subscription_id,
+                        requests,
+                        bytes_total,
+                    )
+                except Exception as rec_exc:
+                    logger.warning(
+                        "Failed to record sync for user {}: {}",
+                        user_id,
+                        rec_exc,
+                    )
+
+                synced += 1
+
+            except Exception as exc:
+                logger.error(
+                    "Failed to sync usage for user {}: {}", user_id, exc
+                )
+                errors += 1
 
         logger.info(
-            "Stripe metering sync for {}: completed (synced={}, errors={})",
+            "Stripe metering sync for {}: completed (synced={}, skipped={}, errors={})",
             target_date,
             synced,
+            skipped,
             errors,
         )
 
@@ -63,13 +467,14 @@ class StripeMeteringService:
             "status": "completed",
             "date": target_date,
             "synced_users": synced,
+            "skipped_users": skipped,
             "errors": errors,
         }
 
     async def check_reconciliation(
         self, date: str | None = None
     ) -> dict[str, Any]:
-        """Compare local usage totals with Stripe's records for drift detection.
+        """Compare local usage totals with synced records for drift detection.
 
         Args:
             date: ISO date string (YYYY-MM-DD). Defaults to yesterday.
@@ -84,15 +489,94 @@ class StripeMeteringService:
             datetime.now(timezone.utc) - timedelta(days=1)
         ).strftime("%Y-%m-%d")
 
-        # Implementation would:
-        # 1. Fetch local usage totals for the date
-        # 2. Fetch Stripe meter event summaries
-        # 3. Compare and report discrepancies
+        # Acquire DB pool
+        try:
+            pool = await self._get_db_pool()
+        except Exception as exc:
+            logger.error("Reconciliation check: failed to get DB pool: {}", exc)
+            return {
+                "status": "error",
+                "date": target_date,
+                "error": f"db_pool_unavailable: {exc}",
+                "discrepancies": [],
+            }
+
+        # Fetch local usage totals
+        try:
+            usage_rows = await self._query_usage_for_date(pool, target_date)
+        except Exception as exc:
+            logger.error(
+                "Reconciliation for {}: failed to query usage: {}",
+                target_date,
+                exc,
+            )
+            return {
+                "status": "error",
+                "date": target_date,
+                "error": f"usage_query_failed: {exc}",
+                "discrepancies": [],
+            }
+
+        # Fetch synced totals
+        try:
+            sync_rows = await self._query_sync_totals(pool, target_date)
+        except Exception as exc:
+            logger.warning(
+                "Reconciliation for {}: sync log query failed (table may not exist): {}",
+                target_date,
+                exc,
+            )
+            sync_rows = []
+
+        # Build lookup: user_id -> synced requests
+        synced_by_user: dict[int, int] = {}
+        for sr in sync_rows:
+            uid = sr["user_id"]
+            synced_by_user[uid] = synced_by_user.get(uid, 0) + sr.get(
+                "requests_synced", 0
+            )
+
+        # Compare
+        discrepancies: list[dict[str, Any]] = []
+        total_local_requests = 0
+        total_synced_requests = 0
+
+        for row in usage_rows:
+            uid = row["user_id"]
+            local_requests = row.get("requests", 0) or 0
+            synced_requests = synced_by_user.pop(uid, 0)
+
+            total_local_requests += local_requests
+            total_synced_requests += synced_requests
+
+            if local_requests != synced_requests:
+                discrepancies.append(
+                    {
+                        "user_id": uid,
+                        "local_requests": local_requests,
+                        "synced_requests": synced_requests,
+                        "drift": local_requests - synced_requests,
+                    }
+                )
+
+        # Any users in sync log but not in usage_daily (shouldn't happen normally)
+        for uid, extra_synced in synced_by_user.items():
+            total_synced_requests += extra_synced
+            discrepancies.append(
+                {
+                    "user_id": uid,
+                    "local_requests": 0,
+                    "synced_requests": extra_synced,
+                    "drift": -extra_synced,
+                }
+            )
 
         return {
             "status": "completed",
             "date": target_date,
-            "discrepancies": [],
+            "total_local_requests": total_local_requests,
+            "total_synced_requests": total_synced_requests,
+            "discrepancies": discrepancies,
         }
 
     @property

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -47,6 +47,32 @@ class StripeMeteringService:
         """Detect whether *conn* is a PostgreSQL connection (asyncpg)."""
         return hasattr(conn, "fetchrow")
 
+    @staticmethod
+    def _is_missing_usage_column_error(exc: Exception) -> bool:
+        """Return True when *exc* indicates legacy usage_daily schema."""
+        message = str(exc).lower()
+        return "bytes_in_total" in message and (
+            "no such column" in message
+            or "does not exist" in message
+            or "undefined column" in message
+        )
+
+    @staticmethod
+    def _sqlite_rows_to_dicts(
+        raw_rows: list[tuple[Any, ...]],
+        description: list[tuple[Any, ...]] | None,
+        *,
+        include_bytes_in_total: bool,
+    ) -> list[dict[str, Any]]:
+        if not raw_rows:
+            return []
+        columns = [col[0] for col in (description or [])]
+        rows = [dict(zip(columns, row)) for row in raw_rows]
+        if not include_bytes_in_total:
+            for row in rows:
+                row["bytes_in_total"] = 0
+        return rows
+
     async def _query_usage_for_date(self, pool: Any, target_date: str) -> list[dict[str, Any]]:
         """Fetch usage_daily rows for *target_date*.
 
@@ -55,25 +81,54 @@ class StripeMeteringService:
         """
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
-                rows = await conn.fetch(
-                    "SELECT user_id, requests, errors, bytes_total, "
-                    "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
-                    "FROM usage_daily WHERE day = $1",
-                    target_date,
-                )
-                return [dict(r) for r in rows]
+                try:
+                    rows = await conn.fetch(
+                        "SELECT user_id, requests, errors, bytes_total, "
+                        "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = $1",
+                        target_date,
+                    )
+                    return [dict(r) for r in rows]
+                except Exception as exc:
+                    if not self._is_missing_usage_column_error(exc):
+                        raise
+                    rows = await conn.fetch(
+                        "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = $1",
+                        target_date,
+                    )
+                    legacy_rows = [dict(r) for r in rows]
+                    for row in legacy_rows:
+                        row["bytes_in_total"] = 0
+                    return legacy_rows
             else:
-                cur = await conn.execute(
-                    "SELECT user_id, requests, errors, bytes_total, "
-                    "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
-                    "FROM usage_daily WHERE day = ?",
-                    (target_date,),
-                )
-                raw_rows = await cur.fetchall()
-                if not raw_rows:
-                    return []
-                columns = [col[0] for col in cur.description]
-                return [dict(zip(columns, row)) for row in raw_rows]
+                try:
+                    cur = await conn.execute(
+                        "SELECT user_id, requests, errors, bytes_total, "
+                        "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = ?",
+                        (target_date,),
+                    )
+                    raw_rows = await cur.fetchall()
+                    return self._sqlite_rows_to_dicts(
+                        raw_rows,
+                        cur.description,
+                        include_bytes_in_total=True,
+                    )
+                except Exception as exc:
+                    if not self._is_missing_usage_column_error(exc):
+                        raise
+                    cur = await conn.execute(
+                        "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = ?",
+                        (target_date,),
+                    )
+                    raw_rows = await cur.fetchall()
+                    return self._sqlite_rows_to_dicts(
+                        raw_rows,
+                        cur.description,
+                        include_bytes_in_total=False,
+                    )
 
     async def _query_user_subscription(
         self, pool: Any, user_id: int
@@ -101,6 +156,22 @@ class StripeMeteringService:
                     """,
                     user_id,
                 )
+                if row:
+                    return dict(row)
+                row = await conn.fetchrow(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN organizations o ON o.id = os.org_id
+                    WHERE o.owner_user_id = $1
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    user_id,
+                )
                 return dict(row) if row else None
             else:
                 cur = await conn.execute(
@@ -112,6 +183,24 @@ class StripeMeteringService:
                     JOIN org_members om ON om.org_id = os.org_id
                     WHERE om.user_id = ?
                       AND om.status = 'active'
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    (user_id,),
+                )
+                row = await cur.fetchone()
+                if row:
+                    columns = [col[0] for col in cur.description]
+                    return dict(zip(columns, row))
+                cur = await conn.execute(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN organizations o ON o.id = os.org_id
+                    WHERE o.owner_user_id = ?
                       AND os.status = 'active'
                       AND os.stripe_subscription_id IS NOT NULL
                     LIMIT 1
@@ -403,9 +492,14 @@ class StripeMeteringService:
                         )
                         skipped += 1
                         continue
-                except Exception:
-                    # Table might not exist; proceed with sync
-                    pass
+                except Exception as exc:
+                    # Table might not exist yet; continue without duplicate-sync protection.
+                    logger.debug(
+                        "Metering sync precheck unavailable for user {} on {}: {}",
+                        user_id,
+                        target_date,
+                        exc,
+                    )
 
                 # Find the metered subscription item
                 item_id = await self._get_subscription_metered_item(subscription_id)

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
 from loguru import logger
@@ -73,7 +73,23 @@ class StripeMeteringService:
                 row["bytes_in_total"] = 0
         return rows
 
-    async def _query_usage_for_date(self, pool: Any, target_date: str) -> list[dict[str, Any]]:
+    @staticmethod
+    def _coerce_day(value: str | date) -> date:
+        """Return a real date object for PostgreSQL DATE bindings."""
+        if isinstance(value, date):
+            return value
+        return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+    @staticmethod
+    def _is_missing_stripe_resource_error(exc: Exception) -> bool:
+        """Return True when Stripe reports a missing subscription/resource."""
+        code = str(getattr(exc, "code", "") or "").lower()
+        if code == "resource_missing":
+            return True
+        message = str(exc).lower()
+        return "no such subscription" in message or "resource missing" in message
+
+    async def _query_usage_for_date(self, pool: Any, target_date: str | date) -> list[dict[str, Any]]:
         """Fetch usage_daily rows for *target_date*.
 
         Returns a list of dicts with keys: user_id, requests, errors,
@@ -81,12 +97,13 @@ class StripeMeteringService:
         """
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(target_date)
                 try:
                     rows = await conn.fetch(
                         "SELECT user_id, requests, errors, bytes_total, "
                         "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
                         "FROM usage_daily WHERE day = $1",
-                        target_date,
+                        pg_day,
                     )
                     return [dict(r) for r in rows]
                 except Exception as exc:
@@ -95,7 +112,7 @@ class StripeMeteringService:
                     rows = await conn.fetch(
                         "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
                         "FROM usage_daily WHERE day = $1",
-                        target_date,
+                        pg_day,
                     )
                     legacy_rows = [dict(r) for r in rows]
                     for row in legacy_rows:
@@ -237,12 +254,18 @@ class StripeMeteringService:
             # No metered item found — return None so caller can skip
             return None
         except Exception as exc:
+            if self._is_missing_stripe_resource_error(exc):
+                logger.warning(
+                    "Stripe subscription {} is missing; skipping metering sync",
+                    subscription_id,
+                )
+                return None
             logger.warning(
                 "Failed to retrieve subscription items for {}: {}",
                 subscription_id,
                 exc,
             )
-            return None
+            raise
 
     async def _ensure_metering_sync_table(self, pool: Any) -> None:
         """Create the ``metering_sync_log`` tracking table if it does not exist."""
@@ -278,16 +301,17 @@ class StripeMeteringService:
                 await conn.commit()
 
     async def _already_synced(
-        self, pool: Any, user_id: int, day: str, subscription_id: str
+        self, pool: Any, user_id: int, day: str | date, subscription_id: str
     ) -> bool:
         """Return True if usage for this user/day/subscription was already synced."""
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(day)
                 row = await conn.fetchval(
                     "SELECT 1 FROM metering_sync_log "
                     "WHERE user_id = $1 AND day = $2 AND stripe_subscription_id = $3",
                     user_id,
-                    day,
+                    pg_day,
                     subscription_id,
                 )
                 return row is not None
@@ -303,7 +327,7 @@ class StripeMeteringService:
         self,
         pool: Any,
         user_id: int,
-        day: str,
+        day: str | date,
         subscription_id: str,
         requests: int,
         bytes_total: int,
@@ -311,6 +335,7 @@ class StripeMeteringService:
         """Record a successful sync in metering_sync_log."""
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(day)
                 await conn.execute(
                     "INSERT INTO metering_sync_log "
                     "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
@@ -320,7 +345,7 @@ class StripeMeteringService:
                     "    bytes_synced = EXCLUDED.bytes_synced, "
                     "    synced_at = CURRENT_TIMESTAMP",
                     user_id,
-                    day,
+                    pg_day,
                     subscription_id,
                     requests,
                     bytes_total,
@@ -353,14 +378,15 @@ class StripeMeteringService:
             action="set",
         )
 
-    async def _query_sync_totals(self, pool: Any, target_date: str) -> list[dict[str, Any]]:
+    async def _query_sync_totals(self, pool: Any, target_date: str | date) -> list[dict[str, Any]]:
         """Fetch synced totals from metering_sync_log for *target_date*."""
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(target_date)
                 rows = await conn.fetch(
                     "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
                     "FROM metering_sync_log WHERE day = $1",
-                    target_date,
+                    pg_day,
                 )
                 return [dict(r) for r in rows]
             else:
@@ -676,4 +702,4 @@ class StripeMeteringService:
     @property
     def is_enabled(self) -> bool:
         """Whether Stripe metering is enabled."""
-        return self._enabled and bool(self._stripe_key)
+        return self._enabled and bool(self._stripe_key) and STRIPE_AVAILABLE

--- a/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
+++ b/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
@@ -1,0 +1,188 @@
+"""
+Tests for audit hash chain integration with UnifiedAuditService.
+
+Verifies that:
+- Events flushed to DB include computed chain_hash values
+- Chain hashes form a valid verifiable chain
+- The chain continues across multiple flush batches
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import aiosqlite
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.audit_integrity import verify_audit_chain
+from tldw_Server_API.app.core.Audit.unified_audit_service import (
+    AuditContext,
+    AuditEvent,
+    AuditEventType,
+    UnifiedAuditService,
+)
+
+
+@pytest.fixture()
+def audit_db_path(tmp_path):
+    """Return path for a temporary audit database."""
+    return str(tmp_path / "audit_chain_test.db")
+
+
+@pytest.fixture()
+def event_loop():
+    """Provide a fresh event loop for async tests."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+def _run(coro, loop=None):
+    """Helper to run a coroutine synchronously."""
+    if loop:
+        return loop.run_until_complete(coro)
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestAuditChainIntegration:
+    """Verify chain_hash is populated when events are flushed."""
+
+    def test_chain_hash_populated_after_flush(self, audit_db_path, event_loop, monkeypatch):
+        monkeypatch.setenv("TEST_MODE", "true")
+
+        async def _test():
+            service = UnifiedAuditService(
+                db_path=audit_db_path,
+                enable_pii_detection=False,
+                enable_risk_scoring=False,
+                buffer_size=100,
+            )
+            await service.initialize(start_background_tasks=False)
+
+            # Log two events
+            await service.log_event(
+                AuditEventType.AUTH_LOGIN_SUCCESS,
+                context=AuditContext(user_id="1"),
+                action="login",
+            )
+            await service.log_event(
+                AuditEventType.DATA_EXPORT,
+                context=AuditContext(user_id="1"),
+                action="export",
+            )
+
+            # Force flush
+            await service.flush()
+
+            # Read events from DB and check chain_hash
+            async with aiosqlite.connect(audit_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                async with db.execute(
+                    "SELECT * FROM audit_events ORDER BY timestamp ASC"
+                ) as cur:
+                    rows = [dict(r) for r in await cur.fetchall()]
+
+            assert len(rows) == 2
+            for row in rows:
+                assert row.get("chain_hash"), f"chain_hash missing on event {row['event_id']}"
+                assert len(row["chain_hash"]) == 64  # SHA-256 hex
+
+            await service.stop()
+
+        _run(_test(), event_loop)
+
+    def test_chain_is_verifiable(self, audit_db_path, event_loop, monkeypatch):
+        monkeypatch.setenv("TEST_MODE", "true")
+
+        async def _test():
+            service = UnifiedAuditService(
+                db_path=audit_db_path,
+                enable_pii_detection=False,
+                enable_risk_scoring=False,
+                buffer_size=100,
+            )
+            await service.initialize(start_background_tasks=False)
+
+            # Log several events
+            for i in range(5):
+                await service.log_event(
+                    AuditEventType.AUTH_LOGIN_SUCCESS,
+                    context=AuditContext(user_id=str(i)),
+                    action=f"action_{i}",
+                )
+
+            await service.flush()
+
+            # Read events and verify chain
+            async with aiosqlite.connect(audit_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                async with db.execute(
+                    "SELECT * FROM audit_events ORDER BY timestamp ASC"
+                ) as cur:
+                    rows = [dict(r) for r in await cur.fetchall()]
+
+            # Build verification events from stored data
+            verify_events = []
+            for row in rows:
+                verify_events.append({
+                    "action": row.get("action", ""),
+                    "user_id": row.get("context_user_id"),
+                    "timestamp": row.get("timestamp", ""),
+                    "detail": row.get("event_type", ""),
+                    "chain_hash": row.get("chain_hash", ""),
+                })
+
+            result = verify_audit_chain(verify_events)
+            assert result["valid"] is True
+            assert result["checked"] == 5
+
+            await service.stop()
+
+        _run(_test(), event_loop)
+
+    def test_chain_continues_across_flushes(self, audit_db_path, event_loop, monkeypatch):
+        monkeypatch.setenv("TEST_MODE", "true")
+
+        async def _test():
+            service = UnifiedAuditService(
+                db_path=audit_db_path,
+                enable_pii_detection=False,
+                enable_risk_scoring=False,
+                buffer_size=100,
+            )
+            await service.initialize(start_background_tasks=False)
+
+            # First batch
+            await service.log_event(
+                AuditEventType.AUTH_LOGIN_SUCCESS,
+                context=AuditContext(user_id="1"),
+                action="login",
+            )
+            await service.flush()
+
+            # Second batch
+            await service.log_event(
+                AuditEventType.DATA_EXPORT,
+                context=AuditContext(user_id="1"),
+                action="export",
+            )
+            await service.flush()
+
+            # Read all events
+            async with aiosqlite.connect(audit_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                async with db.execute(
+                    "SELECT * FROM audit_events ORDER BY timestamp ASC"
+                ) as cur:
+                    rows = [dict(r) for r in await cur.fetchall()]
+
+            assert len(rows) == 2
+            # Second event's chain_hash should differ from first (it chains)
+            assert rows[0]["chain_hash"] != rows[1]["chain_hash"]
+            # Both should be valid SHA-256
+            assert len(rows[0]["chain_hash"]) == 64
+            assert len(rows[1]["chain_hash"]) == 64
+
+            await service.stop()
+
+        _run(_test(), event_loop)

--- a/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
+++ b/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
@@ -9,7 +9,8 @@ Verifies that:
 from __future__ import annotations
 
 import asyncio
-import os
+from collections.abc import Awaitable
+from typing import TypeVar
 
 import aiosqlite
 import pytest
@@ -22,14 +23,16 @@ from tldw_Server_API.app.core.Audit.unified_audit_service import (
     UnifiedAuditService,
 )
 
+_T = TypeVar("_T")
 
-@pytest.fixture()
+
+@pytest.fixture
 def audit_db_path(tmp_path):
     """Return path for a temporary audit database."""
     return str(tmp_path / "audit_chain_test.db")
 
 
-@pytest.fixture()
+@pytest.fixture
 def event_loop():
     """Provide a fresh event loop for async tests."""
     loop = asyncio.new_event_loop()
@@ -37,11 +40,9 @@ def event_loop():
     loop.close()
 
 
-def _run(coro, loop=None):
+def _run(coro: Awaitable[_T], loop: asyncio.AbstractEventLoop) -> _T:
     """Helper to run a coroutine synchronously."""
-    if loop:
-        return loop.run_until_complete(coro)
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return loop.run_until_complete(coro)
 
 
 class TestAuditChainIntegration:
@@ -122,15 +123,16 @@ class TestAuditChainIntegration:
                     rows = [dict(r) for r in await cur.fetchall()]
 
             # Build verification events from stored data
-            verify_events = []
-            for row in rows:
-                verify_events.append({
+            verify_events = [
+                {
                     "action": row.get("action", ""),
                     "user_id": row.get("context_user_id"),
                     "timestamp": row.get("timestamp", ""),
                     "detail": row.get("event_type", ""),
                     "chain_hash": row.get("chain_hash", ""),
-                })
+                }
+                for row in rows
+            ]
 
             result = verify_audit_chain(verify_events)
             assert result["valid"] is True

--- a/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
+++ b/tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py
@@ -186,3 +186,63 @@ class TestAuditChainIntegration:
             await service.stop()
 
         _run(_test(), event_loop)
+
+    def test_chain_survives_service_restart(self, audit_db_path, event_loop, monkeypatch):
+        monkeypatch.setenv("TEST_MODE", "true")
+
+        async def _test():
+            service = UnifiedAuditService(
+                db_path=audit_db_path,
+                enable_pii_detection=False,
+                enable_risk_scoring=False,
+                buffer_size=100,
+            )
+            await service.initialize(start_background_tasks=False)
+            await service.log_event(
+                AuditEventType.AUTH_LOGIN_SUCCESS,
+                context=AuditContext(user_id="1"),
+                action="login",
+            )
+            await service.flush()
+            await service.stop()
+
+            restarted = UnifiedAuditService(
+                db_path=audit_db_path,
+                enable_pii_detection=False,
+                enable_risk_scoring=False,
+                buffer_size=100,
+            )
+            await restarted.initialize(start_background_tasks=False)
+            await restarted.log_event(
+                AuditEventType.DATA_EXPORT,
+                context=AuditContext(user_id="1"),
+                action="export",
+            )
+            await restarted.flush()
+
+            async with aiosqlite.connect(audit_db_path) as db:
+                db.row_factory = aiosqlite.Row
+                async with db.execute(
+                    "SELECT action, context_user_id, timestamp, event_type, chain_hash "
+                    "FROM audit_events ORDER BY timestamp ASC, event_id ASC"
+                ) as cur:
+                    rows = [dict(r) for r in await cur.fetchall()]
+
+            verify_events = [
+                {
+                    "action": row.get("action", ""),
+                    "user_id": row.get("context_user_id"),
+                    "timestamp": row.get("timestamp", ""),
+                    "detail": row.get("event_type", ""),
+                    "chain_hash": row.get("chain_hash", ""),
+                }
+                for row in rows
+            ]
+
+            result = verify_audit_chain(verify_events)
+            assert result["valid"] is True
+            assert result["checked"] == 2
+
+            await restarted.stop()
+
+        _run(_test(), event_loop)

--- a/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
+++ b/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
@@ -1,0 +1,159 @@
+"""
+Tests for consent management endpoints.
+
+Verifies that:
+- GET /consent/preferences returns user consents
+- POST /consent/preferences/{purpose} grants consent
+- DELETE /consent/preferences/{purpose} withdraws consent
+- Proper error handling for missing consent
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints.consent import (
+    _get_consent_db_path,
+    _get_consent_manager,
+    _resolve_user_id,
+)
+from tldw_Server_API.app.core.AuthNZ.consent_manager import ConsentManager
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+
+from fastapi import HTTPException
+
+
+@pytest.fixture()
+def consent_db(tmp_path, monkeypatch):
+    """Set up a temporary consent database."""
+    db_path = str(tmp_path / "consent_test.db")
+    monkeypatch.setenv("CONSENT_DB_PATH", db_path)
+    return db_path
+
+
+@pytest.fixture()
+def principal():
+    """Create a test auth principal."""
+    return AuthPrincipal(kind="user", user_id=42, username="testuser")
+
+
+class TestResolveUserId:
+    def test_valid_principal(self, principal):
+        assert _resolve_user_id(principal) == 42
+
+    def test_none_user_id_raises(self):
+        p = AuthPrincipal(kind="anonymous", user_id=None)
+        with pytest.raises(HTTPException) as exc_info:
+            _resolve_user_id(p)
+        assert exc_info.value.status_code == 401
+
+
+class TestGetConsentDbPath:
+    def test_env_var_used(self, monkeypatch):
+        monkeypatch.setenv("CONSENT_DB_PATH", "/tmp/custom_consent.db")
+        assert _get_consent_db_path() == "/tmp/custom_consent.db"
+
+    def test_fallback_path(self, monkeypatch):
+        monkeypatch.delenv("CONSENT_DB_PATH", raising=False)
+        path = _get_consent_db_path()
+        assert "consent.db" in path
+
+
+class TestConsentEndpointLogic:
+    """Test the consent manager integration directly (unit-level)."""
+
+    def test_grant_and_get_preferences(self, consent_db):
+        mgr = _get_consent_manager()
+        mgr.grant_consent(42, "analytics")
+        mgr.grant_consent(42, "marketing")
+
+        records = mgr.get_user_consents(42)
+        assert len(records) == 2
+        purposes = {r["purpose"] for r in records}
+        assert purposes == {"analytics", "marketing"}
+
+    def test_withdraw_consent(self, consent_db):
+        mgr = _get_consent_manager()
+        mgr.grant_consent(42, "analytics")
+
+        result = mgr.withdraw_consent(42, "analytics")
+        assert result is not None
+        assert result["purpose"] == "analytics"
+
+        # Verify withdrawn
+        assert not mgr.check_consent(42, "analytics")
+
+    def test_withdraw_nonexistent_returns_none(self, consent_db):
+        mgr = _get_consent_manager()
+        result = mgr.withdraw_consent(42, "nonexistent")
+        assert result is None
+
+    def test_grant_with_metadata(self, consent_db):
+        mgr = _get_consent_manager()
+        result = mgr.grant_consent(
+            42, "tracking",
+            ip_address="10.0.0.1",
+            user_agent="TestBot/1.0",
+        )
+        assert result["purpose"] == "tracking"
+        assert result["user_id"] == 42
+
+    def test_get_empty_preferences(self, consent_db):
+        mgr = _get_consent_manager()
+        records = mgr.get_user_consents(999)
+        assert records == []
+
+
+class TestConsentEndpointAsync:
+    """Test the async endpoint functions."""
+
+    @pytest.mark.asyncio
+    async def test_get_preferences_endpoint(self, consent_db, principal):
+        from tldw_Server_API.app.api.v1.endpoints.consent import get_consent_preferences
+
+        # Grant some consent first
+        mgr = _get_consent_manager()
+        mgr.grant_consent(42, "analytics")
+
+        result = await get_consent_preferences(principal=principal)
+        assert result["user_id"] == 42
+        assert len(result["consents"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_grant_consent_endpoint(self, consent_db, principal):
+        from unittest.mock import MagicMock
+        from tldw_Server_API.app.api.v1.endpoints.consent import grant_consent
+
+        mock_request = MagicMock()
+        mock_request.client = MagicMock()
+        mock_request.client.host = "127.0.0.1"
+        mock_request.headers = {"user-agent": "TestBot/1.0"}
+
+        result = await grant_consent(
+            purpose="analytics",
+            request=mock_request,
+            principal=principal,
+        )
+        assert result["user_id"] == 42
+        assert result["purpose"] == "analytics"
+
+    @pytest.mark.asyncio
+    async def test_withdraw_consent_endpoint(self, consent_db, principal):
+        from tldw_Server_API.app.api.v1.endpoints.consent import withdraw_consent
+
+        # Grant first
+        mgr = _get_consent_manager()
+        mgr.grant_consent(42, "analytics")
+
+        result = await withdraw_consent(purpose="analytics", principal=principal)
+        assert result["purpose"] == "analytics"
+        assert "withdrawn_at" in result
+
+    @pytest.mark.asyncio
+    async def test_withdraw_missing_raises_404(self, consent_db, principal):
+        from tldw_Server_API.app.api.v1.endpoints.consent import withdraw_consent
+
+        with pytest.raises(HTTPException) as exc_info:
+            await withdraw_consent(purpose="nonexistent", principal=principal)
+        assert exc_info.value.status_code == 404

--- a/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
+++ b/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
@@ -9,6 +9,7 @@ Verifies that:
 """
 from __future__ import annotations
 
+import importlib
 import os
 
 import pytest
@@ -117,8 +118,8 @@ class TestConsentEndpointAsync:
         mgr.grant_consent(42, "analytics")
 
         result = await get_consent_preferences(principal=principal)
-        assert result["user_id"] == 42
-        assert len(result["consents"]) == 1
+        assert result.user_id == 42
+        assert len(result.consents) == 1
 
     @pytest.mark.asyncio
     async def test_grant_consent_endpoint(self, consent_db, principal):
@@ -135,8 +136,8 @@ class TestConsentEndpointAsync:
             request=mock_request,
             principal=principal,
         )
-        assert result["user_id"] == 42
-        assert result["purpose"] == "analytics"
+        assert result.user_id == 42
+        assert result.purpose == "analytics"
 
     @pytest.mark.asyncio
     async def test_withdraw_consent_endpoint(self, consent_db, principal):
@@ -147,8 +148,8 @@ class TestConsentEndpointAsync:
         mgr.grant_consent(42, "analytics")
 
         result = await withdraw_consent(purpose="analytics", principal=principal)
-        assert result["purpose"] == "analytics"
-        assert "withdrawn_at" in result
+        assert result.purpose == "analytics"
+        assert result.withdrawn_at is not None
 
     @pytest.mark.asyncio
     async def test_withdraw_missing_raises_404(self, consent_db, principal):
@@ -157,3 +158,16 @@ class TestConsentEndpointAsync:
         with pytest.raises(HTTPException) as exc_info:
             await withdraw_consent(purpose="nonexistent", principal=principal)
         assert exc_info.value.status_code == 404
+
+
+class TestConsentRouterWiring:
+    def test_production_app_includes_consent_routes(self, monkeypatch):
+        monkeypatch.setenv("MINIMAL_TEST_APP", "0")
+        monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+
+        from tldw_Server_API.app import main as app_main
+
+        reloaded = importlib.reload(app_main)
+        route_paths = {getattr(route, "path", "") for route in reloaded.app.routes}
+
+        assert "/api/v1/consent/preferences" in route_paths

--- a/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
+++ b/tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py
@@ -9,6 +9,7 @@ Verifies that:
 """
 from __future__ import annotations
 
+from datetime import datetime
 import importlib
 import os
 
@@ -19,6 +20,7 @@ from tldw_Server_API.app.api.v1.endpoints.consent import (
     _get_consent_manager,
     _resolve_user_id,
 )
+from tldw_Server_API.app.api.v1.schemas.consent_schemas import ConsentRecordResponse
 from tldw_Server_API.app.core.AuthNZ.consent_manager import ConsentManager
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
@@ -59,6 +61,29 @@ class TestGetConsentDbPath:
         monkeypatch.delenv("CONSENT_DB_PATH", raising=False)
         path = _get_consent_db_path()
         assert "consent.db" in path
+
+    def test_consent_manager_is_cached_per_db_path(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CONSENT_DB_PATH", str(tmp_path / "cached-consent.db"))
+
+        first = _get_consent_manager()
+        second = _get_consent_manager()
+
+        assert first is second
+
+
+class TestConsentSchemas:
+    def test_consent_record_parses_datetime_fields(self):
+        record = ConsentRecordResponse.model_validate(
+            {
+                "user_id": 42,
+                "purpose": "analytics",
+                "granted_at": "2026-03-17T12:34:56Z",
+                "withdrawn_at": "2026-03-18T01:02:03Z",
+            }
+        )
+
+        assert isinstance(record.granted_at, datetime)
+        assert isinstance(record.withdrawn_at, datetime)
 
 
 class TestConsentEndpointLogic:
@@ -164,10 +189,29 @@ class TestConsentRouterWiring:
     def test_production_app_includes_consent_routes(self, monkeypatch):
         monkeypatch.setenv("MINIMAL_TEST_APP", "0")
         monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+        monkeypatch.delenv("ROUTES_DISABLE", raising=False)
+        monkeypatch.delenv("ROUTES_ENABLE", raising=False)
 
+        from tldw_Server_API.app.core import config as config_mod
         from tldw_Server_API.app import main as app_main
 
+        config_mod.clear_config_cache()
         reloaded = importlib.reload(app_main)
         route_paths = {getattr(route, "path", "") for route in reloaded.app.routes}
 
         assert "/api/v1/consent/preferences" in route_paths
+
+    def test_production_app_omits_consent_routes_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("MINIMAL_TEST_APP", "0")
+        monkeypatch.setenv("ULTRA_MINIMAL_APP", "0")
+        monkeypatch.setenv("ROUTES_DISABLE", "consent")
+        monkeypatch.delenv("ROUTES_ENABLE", raising=False)
+
+        from tldw_Server_API.app.core import config as config_mod
+        from tldw_Server_API.app import main as app_main
+
+        config_mod.clear_config_cache()
+        reloaded = importlib.reload(app_main)
+        route_paths = {getattr(route, "path", "") for route in reloaded.app.routes}
+
+        assert "/api/v1/consent/preferences" not in route_paths

--- a/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
+++ b/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
@@ -1,0 +1,146 @@
+"""
+Tests for overage policy integration with BillingEnforcer.check_limit().
+
+Verifies that:
+- Hard-block overage policy upgrades SOFT_BLOCK to HARD_BLOCK
+- Degraded overage policy upgrades ALLOW to SOFT_BLOCK when over grace
+- Notify-only policy upgrades ALLOW to WARN when above threshold
+- Default notify_only mode does not block
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tldw_Server_API.app.core.Billing.enforcement import (
+    BillingEnforcer,
+    EnforcementAction,
+    LimitCategory,
+    UsageSummary,
+)
+
+
+@pytest.fixture()
+def enforcer():
+    """Create a BillingEnforcer with short cache TTL for testing."""
+    return BillingEnforcer(cache_ttl=0)
+
+
+class TestOverageHardBlock:
+    """Overage mode=hard_block should escalate to HARD_BLOCK."""
+
+    @pytest.mark.asyncio
+    async def test_hard_block_when_over_grace(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "hard_block")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "5")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        # Mock org limits and usage so usage is 115% (over 105% grace threshold)
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=114)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            assert result.action == EnforcementAction.HARD_BLOCK
+            assert "Hard blocked" in (result.message or "")
+
+    @pytest.mark.asyncio
+    async def test_no_hard_block_within_grace(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "hard_block")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "10")
+
+        # Usage at 105% -- within 10% grace
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=104)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            # Should be SOFT_BLOCK (base behavior) not HARD_BLOCK
+            assert result.action == EnforcementAction.SOFT_BLOCK
+
+
+class TestOverageDegraded:
+    """Overage mode=degraded should escalate to SOFT_BLOCK."""
+
+    @pytest.mark.asyncio
+    async def test_degraded_when_over_grace(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "degraded")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "5")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        # Usage at 106% -- over 5% grace threshold
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=105)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            assert result.action == EnforcementAction.SOFT_BLOCK
+
+
+class TestOverageNotifyOnly:
+    """Overage mode=notify_only should upgrade ALLOW to WARN."""
+
+    @pytest.mark.asyncio
+    async def test_notify_upgrades_allow_to_warn(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        # Usage at 85% -- above 80% notify threshold but under limit
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=84)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            assert result.action == EnforcementAction.WARN
+
+    @pytest.mark.asyncio
+    async def test_notify_only_never_blocks(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        # Usage at 150% -- way over limit
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=149)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            # Base action is SOFT_BLOCK (over limit), overage notify_only doesn't upgrade to HARD
+            assert result.action == EnforcementAction.SOFT_BLOCK
+            assert result.action != EnforcementAction.HARD_BLOCK
+
+    @pytest.mark.asyncio
+    async def test_no_warn_below_threshold(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        # Usage at 50% -- well under threshold
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": 100}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=49)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            assert result.action == EnforcementAction.ALLOW
+
+
+class TestOverageUnlimited:
+    """Unlimited limits should bypass overage checks."""
+
+    @pytest.mark.asyncio
+    async def test_unlimited_ignores_overage(self, enforcer, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "hard_block")
+
+        with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+             patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+            mock_limits.return_value = {"api_calls_day": -1}
+            mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=999999)
+
+            result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+            assert result.action == EnforcementAction.ALLOW
+            assert result.unlimited is True

--- a/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
+++ b/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
@@ -9,10 +9,11 @@ Verifies that:
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tldw_Server_API.app.core.Billing import enforcement as enforcement_module
 from tldw_Server_API.app.core.Billing.enforcement import (
     BillingEnforcer,
     EnforcementAction,
@@ -144,3 +145,48 @@ class TestOverageUnlimited:
             result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
             assert result.action == EnforcementAction.ALLOW
             assert result.unlimited is True
+
+
+class TestOveragePolicyLifecycle:
+    @pytest.mark.asyncio
+    async def test_overage_policy_is_loaded_once(self, monkeypatch):
+        monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
+        monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+
+        policy = MagicMock()
+        policy.evaluate.return_value = {
+            "blocked": False,
+            "degraded": False,
+            "notify": False,
+            "mode": "notify_only",
+        }
+
+        with patch.object(enforcement_module.OveragePolicy, "from_env", return_value=policy) as mock_from_env:
+            enforcer = BillingEnforcer(cache_ttl=0)
+            with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+                 patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+                mock_limits.return_value = {"api_calls_day": 100}
+                mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=10)
+
+                await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+                await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+
+        assert mock_from_env.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_when_overage_policy_evaluation_is_skipped(self):
+        policy = MagicMock()
+        policy.evaluate.side_effect = RuntimeError("broken policy")
+
+        with patch.object(enforcement_module.OveragePolicy, "from_env", return_value=policy):
+            enforcer = BillingEnforcer(cache_ttl=0)
+            with patch.object(enforcement_module.logger, "warning") as mock_warning, \
+                 patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
+                 patch.object(enforcer, "get_org_usage", new_callable=AsyncMock) as mock_usage:
+                mock_limits.return_value = {"api_calls_day": 100}
+                mock_usage.return_value = UsageSummary(org_id=1, api_calls_today=10)
+
+                result = await enforcer.check_limit(1, LimitCategory.API_CALLS_DAY)
+
+        assert result.action == EnforcementAction.ALLOW
+        mock_warning.assert_called_once()

--- a/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
+++ b/tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py
@@ -22,10 +22,10 @@ from tldw_Server_API.app.core.Billing.enforcement import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def enforcer():
     """Create a BillingEnforcer with short cache TTL for testing."""
-    return BillingEnforcer(cache_ttl=0)
+    return BillingEnforcer(cache_ttl=0, soft_limit_percent=80)
 
 
 class TestOverageHardBlock:
@@ -89,6 +89,7 @@ class TestOverageNotifyOnly:
     async def test_notify_upgrades_allow_to_warn(self, enforcer, monkeypatch):
         monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
         monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "5")
 
         # Usage at 85% -- above 80% notify threshold but under limit
         with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
@@ -103,6 +104,7 @@ class TestOverageNotifyOnly:
     async def test_notify_only_never_blocks(self, enforcer, monkeypatch):
         monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
         monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "5")
 
         # Usage at 150% -- way over limit
         with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \
@@ -119,6 +121,7 @@ class TestOverageNotifyOnly:
     async def test_no_warn_below_threshold(self, enforcer, monkeypatch):
         monkeypatch.setenv("BILLING_OVERAGE_MODE", "notify_only")
         monkeypatch.setenv("BILLING_OVERAGE_NOTIFY_PCT", "80")
+        monkeypatch.setenv("BILLING_OVERAGE_GRACE_PCT", "5")
 
         # Usage at 50% -- well under threshold
         with patch.object(enforcer, "get_org_limits", new_callable=AsyncMock) as mock_limits, \

--- a/tldw_Server_API/tests/Billing/test_storage_quota_guard.py
+++ b/tldw_Server_API/tests/Billing/test_storage_quota_guard.py
@@ -1,6 +1,7 @@
 """Tests for the storage quota enforcement FastAPI dependency."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -12,14 +13,18 @@ from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import (
 )
 
 
-def _fake_user(*, user_id: int = 1, org_ids: list[int] | None = None, active_org_id: int | None = None):
+def _fake_user(
+    *,
+    user_id: int | str = 1,
+    org_ids: Sequence[int] | None = None,
+    active_org_id: int | None = None,
+) -> SimpleNamespace:
     """Return a minimal User-like object."""
-    u = SimpleNamespace(
+    return SimpleNamespace(
         id=user_id,
-        org_ids=org_ids or [],
+        org_ids=list(org_ids or []),
         active_org_id=active_org_id,
     )
-    return u
 
 
 def _fake_request(*, org_id: int | None = None, content_length: str | None = None):
@@ -293,3 +298,32 @@ async def test_guard_passes_content_length_as_file_size(_pool, mock_check, _mode
     )
     call_kwargs = mock_check.call_args.kwargs
     assert call_kwargs["file_size_bytes"] == 5242880
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={"allowed": True, "reason": "Quota check passed", "used_mb": 0, "quota_mb": 1024, "remaining_mb": 1024},
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+@patch("tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.logger.warning")
+async def test_guard_logs_when_user_id_falls_back_to_zero(_warning, _pool, mock_check, _mode):
+    """Invalid user ids fall back to 0 and emit a warning for operator visibility."""
+    await guard_storage_quota(
+        request=_fake_request(org_id=10),
+        response=_fake_response(),
+        current_user=_fake_user(user_id="not-an-int", org_ids=[10]),
+    )
+
+    call_kwargs = mock_check.call_args.kwargs
+    assert call_kwargs["user_id"] == 0
+    _warning.assert_any_call("Storage quota guard falling back to anonymous user_id=0 for user {}", "not-an-int")

--- a/tldw_Server_API/tests/Billing/test_storage_quota_guard.py
+++ b/tldw_Server_API/tests/Billing/test_storage_quota_guard.py
@@ -1,0 +1,295 @@
+"""Tests for the storage quota enforcement FastAPI dependency."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard import (
+    guard_storage_quota,
+)
+
+
+def _fake_user(*, user_id: int = 1, org_ids: list[int] | None = None, active_org_id: int | None = None):
+    """Return a minimal User-like object."""
+    u = SimpleNamespace(
+        id=user_id,
+        org_ids=org_ids or [],
+        active_org_id=active_org_id,
+    )
+    return u
+
+
+def _fake_request(*, org_id: int | None = None, content_length: str | None = None):
+    """Return a minimal Request-like object."""
+    state = SimpleNamespace()
+    if org_id is not None:
+        state.org_id = org_id
+    headers = {}
+    if content_length is not None:
+        headers["content-length"] = content_length
+    return SimpleNamespace(state=state, headers=headers)
+
+
+def _fake_response():
+    return SimpleNamespace(headers={})
+
+
+# ---------------------------------------------------------------------------
+# Disabled / skipped paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard._is_enabled", return_value=False)
+async def test_guard_skips_when_disabled(_mock_enabled):
+    """When STORAGE_QUOTA_ENFORCEMENT=0 the guard is a no-op."""
+    result = await guard_storage_quota(
+        request=_fake_request(),
+        response=_fake_response(),
+        current_user=_fake_user(),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=True,
+)
+async def test_guard_skips_single_user_mode(_mock_mode):
+    """Single-user / desktop deployments skip enforcement."""
+    result = await guard_storage_quota(
+        request=_fake_request(),
+        response=_fake_response(),
+        current_user=_fake_user(),
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Quota allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={"allowed": True, "reason": "Quota check passed", "used_mb": 50, "quota_mb": 1024, "remaining_mb": 974},
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_allows_when_under_quota(_pool, _check, _mode):
+    """Upload proceeds when quota is not exceeded."""
+    result = await guard_storage_quota(
+        request=_fake_request(org_id=10),
+        response=_fake_response(),
+        current_user=_fake_user(user_id=1, org_ids=[10]),
+    )
+    assert result is None
+    _check.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Quota exceeded → HTTP 413
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={
+        "allowed": False,
+        "reason": "Storage quota exceeded (at hard limit)",
+        "used_mb": 1024,
+        "quota_mb": 1024,
+        "remaining_mb": 0,
+    },
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_blocks_when_quota_exceeded(_pool, _check, _mode):
+    """Upload is rejected with 413 when storage is at hard limit."""
+    with pytest.raises(HTTPException) as exc_info:
+        await guard_storage_quota(
+            request=_fake_request(org_id=10),
+            response=_fake_response(),
+            current_user=_fake_user(user_id=1, org_ids=[10]),
+        )
+    assert exc_info.value.status_code == 413
+    assert "storage_quota_exceeded" in str(exc_info.value.detail)
+
+
+# ---------------------------------------------------------------------------
+# Soft limit → warning header
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={
+        "allowed": True,
+        "reason": "Warning: Approaching storage limit (soft limit reached)",
+        "used_mb": 900,
+        "quota_mb": 1024,
+        "remaining_mb": 124,
+    },
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_sets_warning_header_at_soft_limit(_pool, _check, _mode):
+    """Soft limit adds X-Storage-Warning header but allows request."""
+    resp = _fake_response()
+    result = await guard_storage_quota(
+        request=_fake_request(org_id=10),
+        response=resp,
+        current_user=_fake_user(user_id=1, org_ids=[10]),
+    )
+    assert result is None
+    assert "X-Storage-Warning" in resp.headers
+    assert "soft limit" in resp.headers["X-Storage-Warning"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Fail-open on errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    side_effect=ConnectionError("db unavailable"),
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_fails_open_on_error(_pool, _check, _mode):
+    """When the quota check itself fails, the request is allowed (fail-open)."""
+    result = await guard_storage_quota(
+        request=_fake_request(org_id=10),
+        response=_fake_response(),
+        current_user=_fake_user(user_id=1, org_ids=[10]),
+    )
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Org resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={"allowed": True, "reason": "No quota limit set", "used_mb": 0, "quota_mb": None, "remaining_mb": None},
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_resolves_org_from_active_org_id(_pool, mock_check, _mode):
+    """When request.state has no org_id, falls back to user.active_org_id."""
+    await guard_storage_quota(
+        request=_fake_request(),  # no org_id on state
+        response=_fake_response(),
+        current_user=_fake_user(user_id=1, active_org_id=42),
+    )
+    call_kwargs = mock_check.call_args.kwargs
+    assert call_kwargs["org_id"] == 42
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={"allowed": True, "reason": "No quota limit set", "used_mb": 0, "quota_mb": None, "remaining_mb": None},
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_resolves_org_from_org_ids_list(_pool, mock_check, _mode):
+    """When request.state and active_org_id are absent, falls back to org_ids[0]."""
+    await guard_storage_quota(
+        request=_fake_request(),
+        response=_fake_response(),
+        current_user=_fake_user(user_id=1, org_ids=[99, 100]),
+    )
+    call_kwargs = mock_check.call_args.kwargs
+    assert call_kwargs["org_id"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Content-Length estimation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.is_single_user_profile_mode",
+    return_value=False,
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.check_storage_quota",
+    new_callable=AsyncMock,
+    return_value={"allowed": True, "reason": "Quota check passed", "used_mb": 0, "quota_mb": 1024, "remaining_mb": 1024},
+)
+@patch(
+    "tldw_Server_API.app.api.v1.API_Deps.storage_quota_guard.get_db_pool",
+    new_callable=AsyncMock,
+    return_value=MagicMock(),
+)
+async def test_guard_passes_content_length_as_file_size(_pool, mock_check, _mode):
+    """Content-Length header is used as an upload size estimate."""
+    await guard_storage_quota(
+        request=_fake_request(org_id=10, content_length="5242880"),
+        response=_fake_response(),
+        current_user=_fake_user(user_id=1, org_ids=[10]),
+    )
+    call_kwargs = mock_check.call_args.kwargs
+    assert call_kwargs["file_size_bytes"] == 5242880

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -13,11 +13,14 @@ from unittest.mock import patch
 
 import pytest
 
-from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
+from tldw_Server_API.app.core.exceptions import BadRequestError
+from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 
+pytestmark = pytest.mark.integration
 
-@pytest.fixture()
+
+@pytest.fixture
 def job_manager(tmp_path, monkeypatch):
     """Create a JobManager backed by a temporary SQLite database."""
     monkeypatch.delenv("JOBS_DISABLE_LEASE_ENFORCEMENT", raising=False)
@@ -61,7 +64,7 @@ class TestFairShareAdmissionControl:
         )
 
         # Third job should be blocked
-        with pytest.raises(ValueError, match="maximum concurrent job limit"):
+        with pytest.raises(BadRequestError, match="maximum concurrent job limit"):
             job_manager.create_job(
                 domain="chatbooks", queue="default", job_type="export",
                 payload={}, owner_user_id="42",
@@ -96,10 +99,22 @@ class TestFairShareAdmissionControl:
             domain="chatbooks", queue="default", job_type="export",
             payload={}, owner_user_id=None,
         )
-        job_manager.create_job(
-            domain="chatbooks", queue="default", job_type="export",
-            payload={}, owner_user_id=None,
+
+    def test_non_numeric_owner_user_id_does_not_require_int_cast(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "3")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        job = job_manager.create_job(
+            domain="chatbooks",
+            queue="default",
+            job_type="export",
+            payload={},
+            owner_user_id="user-abc-123",
         )
+
+        assert job is not None
+        assert job.get("status") in ("queued", None) or "uuid" in job
 
 
 class TestFairSharePriorityAdjustment:
@@ -137,24 +152,15 @@ class TestFairSharePriorityAdjustment:
         assert job is not None
         mock_warning.assert_called_once()
 
+    def test_completing_a_job_restores_capacity(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
 
-class TestCountActiveJobs:
-    """Verify the _count_active_jobs_for_user helper."""
-
-    def test_counts_queued_jobs(self, job_manager):
-        job_manager.create_job(
-            domain="chatbooks", queue="default", job_type="export",
-            payload={}, owner_user_id="99",
-        )
-        count = job_manager._count_active_jobs_for_user("99")
-        assert count == 1
-
-    def test_does_not_count_completed_jobs(self, job_manager):
         job = job_manager.create_job(
             domain="chatbooks", queue="default", job_type="export",
             payload={}, owner_user_id="99",
         )
-        # Acquire and complete the job
         acq = job_manager.acquire_next_job(
             domain="chatbooks", queue="default", lease_seconds=60, worker_id="w1",
         )
@@ -165,9 +171,11 @@ class TestCountActiveJobs:
                 worker_id="w1",
                 lease_id=str(acq.get("lease_id")),
             )
-        count = job_manager._count_active_jobs_for_user("99")
-        assert count == 0
 
-    def test_counts_zero_for_unknown_user(self, job_manager):
-        count = job_manager._count_active_jobs_for_user("nonexistent")
-        assert count == 0
+        next_job = job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="99",
+        )
+
+        assert job is not None
+        assert next_job is not None

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -9,6 +9,8 @@ Verifies that:
 """
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
@@ -108,15 +110,32 @@ class TestFairSharePriorityAdjustment:
         import tldw_Server_API.app.core.Jobs.manager as mgr_mod
         mgr_mod._fair_share = None
 
-        # With 0 active jobs, fair-share priority = 100
-        # The explicit priority of 5 should be overridden to 100
         job = job_manager.create_job(
             domain="chatbooks", queue="default", job_type="export",
             payload={}, owner_user_id="42", priority=5,
         )
-        # The job should have been created with priority >= 100
-        # (max of explicit 5 and fair-share 100)
+        stored = job_manager.get_job(int(job["id"]))
+        assert stored is not None
+        assert int(stored["priority"]) < 5
+
+    def test_warns_when_fair_share_check_is_skipped(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        with patch.object(JobManager, "_count_active_jobs_for_user", side_effect=RuntimeError("boom")), \
+             patch.object(mgr_mod.logger, "warning") as mock_warning:
+            job = job_manager.create_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload={},
+                owner_user_id="42",
+                priority=5,
+            )
+
         assert job is not None
+        mock_warning.assert_called_once()
 
 
 class TestCountActiveJobs:

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -1,0 +1,154 @@
+"""
+Tests for fair-share scheduler integration with JobManager.
+
+Verifies that:
+- create_job enforces per-user concurrency limits via FairShareScheduler
+- create_job adjusts priority using fair-share calculation
+- Jobs are allowed when under the limit
+- Jobs are blocked when at or over the limit
+"""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
+from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+
+
+@pytest.fixture()
+def job_manager(tmp_path, monkeypatch):
+    """Create a JobManager backed by a temporary SQLite database."""
+    monkeypatch.delenv("JOBS_DISABLE_LEASE_ENFORCEMENT", raising=False)
+    db_path = tmp_path / "jobs_fs.db"
+    ensure_jobs_tables(db_path)
+    return JobManager(db_path)
+
+
+class TestFairShareAdmissionControl:
+    """Verify that create_job blocks users who exceed the concurrency limit."""
+
+    def test_allows_job_under_limit(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "3")
+        # Reset the cached scheduler so it picks up new env
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        job = job_manager.create_job(
+            domain="chatbooks",
+            queue="default",
+            job_type="export",
+            payload={"test": True},
+            owner_user_id="42",
+        )
+        assert job is not None
+        assert job.get("status") in ("queued", None) or "uuid" in job
+
+    def test_blocks_when_at_limit(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "2")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        # Create 2 jobs (at the limit)
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="42",
+        )
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="42",
+        )
+
+        # Third job should be blocked
+        with pytest.raises(ValueError, match="maximum concurrent job limit"):
+            job_manager.create_job(
+                domain="chatbooks", queue="default", job_type="export",
+                payload={}, owner_user_id="42",
+            )
+
+    def test_different_users_independent(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        # User 1 creates a job
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="1",
+        )
+
+        # User 2 should still be allowed
+        job2 = job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="2",
+        )
+        assert job2 is not None
+
+    def test_no_owner_skips_fair_share(self, job_manager, monkeypatch):
+        """Jobs without an owner_user_id bypass fair-share checks."""
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        # Should not raise even though limit is 1
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id=None,
+        )
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id=None,
+        )
+
+
+class TestFairSharePriorityAdjustment:
+    """Verify that priority is adjusted upward based on fair-share calculation."""
+
+    def test_priority_boosted_for_low_active_count(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        # With 0 active jobs, fair-share priority = 100
+        # The explicit priority of 5 should be overridden to 100
+        job = job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="42", priority=5,
+        )
+        # The job should have been created with priority >= 100
+        # (max of explicit 5 and fair-share 100)
+        assert job is not None
+
+
+class TestCountActiveJobs:
+    """Verify the _count_active_jobs_for_user helper."""
+
+    def test_counts_queued_jobs(self, job_manager):
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="99",
+        )
+        count = job_manager._count_active_jobs_for_user("99")
+        assert count == 1
+
+    def test_does_not_count_completed_jobs(self, job_manager):
+        job = job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="99",
+        )
+        # Acquire and complete the job
+        acq = job_manager.acquire_next_job(
+            domain="chatbooks", queue="default", lease_seconds=60, worker_id="w1",
+        )
+        if acq:
+            job_manager.complete_job(
+                int(acq["id"]),
+                result={"ok": True},
+                worker_id="w1",
+                lease_id=str(acq.get("lease_id")),
+            )
+        count = job_manager._count_active_jobs_for_user("99")
+        assert count == 0
+
+    def test_counts_zero_for_unknown_user(self, job_manager):
+        count = job_manager._count_active_jobs_for_user("nonexistent")
+        assert count == 0

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_files_preflight.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_audio_files_preflight.py
@@ -1,4 +1,5 @@
 import wave
+from types import SimpleNamespace
 
 import pytest
 
@@ -160,3 +161,68 @@ def test_process_audio_files_url_post_download_validation_rejected(monkeypatch, 
     assert "downloaded file failed validation" in str(
         result["results"][0].get("error", "")
     ).lower()
+
+
+@pytest.mark.unit
+def test_process_audio_files_url_rejects_when_downloaded_file_exceeds_quota(monkeypatch, tmp_path):
+    downloaded_wav = tmp_path / "session_ab12cd34.wav"
+    with wave.open(str(downloaded_wav), "wb") as wave_file:
+        wave_file.setnchannels(1)
+        wave_file.setsampwidth(2)
+        wave_file.setframerate(8000)
+        wave_file.writeframes(b"\x00\x00" * 16)
+
+    monkeypatch.setattr(
+        audio_files,
+        "download_audio_file",
+        lambda *args, **kwargs: str(downloaded_wav),
+    )
+    monkeypatch.setattr(
+        audio_files,
+        "check_transcription_model_status",
+        lambda _model_name: {
+            "available": True,
+            "message": "ok",
+            "model": "base",
+        },
+    )
+
+    class _RejectingQuotaService:
+        async def check_quota(self, user_id: int, new_bytes: int, raise_on_exceed: bool = False):
+            assert user_id == 42
+            assert new_bytes == downloaded_wav.stat().st_size
+            return False, {
+                "current_usage_mb": 10,
+                "new_size_mb": 1,
+                "quota_mb": 10,
+                "available_mb": 0,
+            }
+
+    fake_quota_module = SimpleNamespace(
+        get_storage_quota_service=lambda: _RejectingQuotaService()
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "tldw_Server_API.app.services.storage_quota_service",
+        fake_quota_module,
+    )
+
+    def _unexpected_stt(**_kwargs):
+        raise AssertionError("speech_to_text should not run when quota is exceeded")
+
+    monkeypatch.setattr(audio_files, "speech_to_text", _unexpected_stt)
+
+    result = audio_files.process_audio_files(
+        inputs=["https://example.com/audio.wav"],
+        transcription_model="base",
+        transcription_language="en",
+        perform_chunking=False,
+        perform_analysis=False,
+        temp_dir=str(tmp_path),
+        user_id=42,
+    )
+
+    assert result["processed_count"] == 0
+    assert result["errors_count"] == 1
+    assert result["results"][0]["status"] == "Error"
+    assert "storage quota exceeded" in str(result["results"][0].get("error", "")).lower()

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_process_batch_media_precheck_regressions.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_process_batch_media_precheck_regressions.py
@@ -181,3 +181,92 @@ async def test_process_batch_media_precheck_closes_db_on_query_error(
     assert observed["closed"] >= 1
     assert len(results) == 1
     assert results[0]["status"] == "Success"
+
+
+@pytest.mark.asyncio
+async def test_process_batch_media_passes_user_id_to_audio_processor(
+    monkeypatch,
+    tmp_path,
+):
+    source = "https://example.com/audio.mp3"
+    monkeypatch.setattr(
+        "tldw_Server_API.app.core.Security.egress.evaluate_url_policy",
+        lambda *_args, **_kwargs: SimpleNamespace(allowed=True, reason=None),
+        raising=True,
+    )
+
+    observed: dict[str, object] = {}
+
+    from tldw_Server_API.app.core.Ingestion_Media_Processing.Audio import (
+        Audio_Files as audio_files_mod,
+    )
+
+    def _fake_process_audio_files(**kwargs):
+        observed["user_id"] = kwargs.get("user_id")
+        src = kwargs["inputs"][0]
+        return {
+            "results": [
+                {
+                    "status": "Success",
+                    "input_ref": src,
+                    "processing_source": src,
+                    "media_type": "audio",
+                    "metadata": {},
+                    "content": "ok",
+                    "analysis_details": {},
+                    "warnings": None,
+                    "error": None,
+                }
+            ],
+            "processed_count": 1,
+            "errors_count": 0,
+            "errors": [],
+        }
+
+    async def _fake_persist_primary_av_item(**kwargs):
+        process_result = kwargs["process_result"]
+        process_result["db_id"] = None
+        process_result["db_message"] = "patched"
+        process_result["media_uuid"] = None
+
+    async def _fake_extract_claims_if_requested(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        audio_files_mod,
+        "process_audio_files",
+        _fake_process_audio_files,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        ingestion_persistence,
+        "persist_primary_av_item",
+        _fake_persist_primary_av_item,
+        raising=True,
+    )
+    monkeypatch.setattr(
+        ingestion_persistence,
+        "extract_claims_if_requested",
+        _fake_extract_claims_if_requested,
+        raising=True,
+    )
+
+    form_data = SimpleNamespace(overwrite_existing=False, transcription_model="whisper-test")
+
+    results = await ingestion_persistence.process_batch_media(
+        media_type="audio",
+        urls=[source],
+        uploaded_file_paths=[],
+        source_to_ref_map={source: source},
+        form_data=form_data,
+        chunk_options=None,
+        loop=asyncio.get_running_loop(),
+        db_path="unused.db",
+        client_id="test_client",
+        temp_dir=tmp_path,
+        user_id=42,
+    )
+
+    assert observed["user_id"] == 42
+    assert len(results) == 1
+    assert results[0]["status"] == "Success"

--- a/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
+++ b/tldw_Server_API/tests/MediaIngestion_NEW/unit/test_video_ingestion.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 import wave
 
@@ -485,6 +486,79 @@ def test_process_single_video_remote_download_validation_rejected(
 
     assert result["status"] == "Error"
     assert "downloaded file failed validation" in str(result.get("error", "")).lower()
+
+
+@patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.perform_transcription")
+@patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.download_video")
+@patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.extract_metadata")
+def test_process_single_video_remote_download_rejects_when_quota_exceeded(
+    mock_extract_metadata,
+    mock_download,
+    mock_transcribe,
+    monkeypatch,
+    tmp_path,
+):
+    mock_extract_metadata.return_value = {"title": "Online Clip"}
+
+    downloaded_file = tmp_path / "downloaded.wav"
+    with wave.open(str(downloaded_file), "wb") as wave_file:
+        wave_file.setnchannels(1)
+        wave_file.setsampwidth(2)
+        wave_file.setframerate(8000)
+        wave_file.writeframes(b"\x00\x00" * 8)
+    mock_download.return_value = str(downloaded_file)
+    mock_transcribe.side_effect = AssertionError(
+        "perform_transcription should not run when quota is exceeded"
+    )
+
+    class _RejectingQuotaService:
+        async def check_quota(self, user_id: int, new_bytes: int, raise_on_exceed: bool = False):
+            assert user_id == 42
+            assert new_bytes == downloaded_file.stat().st_size
+            return False, {
+                "current_usage_mb": 10,
+                "new_size_mb": 1,
+                "quota_mb": 10,
+                "available_mb": 0,
+            }
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "tldw_Server_API.app.services.storage_quota_service",
+        SimpleNamespace(get_storage_quota_service=lambda: _RejectingQuotaService()),
+    )
+
+    result = process_single_video(
+        video_input="https://example.com/video",
+        start_seconds=0,
+        end_seconds=None,
+        diarize=False,
+        vad_use=False,
+        transcription_model="whisper-small",
+        transcription_language="en",
+        perform_analysis=False,
+        custom_prompt=None,
+        system_prompt=None,
+        perform_chunking=False,
+        chunk_method=None,
+        max_chunk_size=1000,
+        chunk_overlap=0,
+        use_adaptive_chunking=False,
+        use_multi_level_chunking=False,
+        chunk_language=None,
+        summarize_recursively=False,
+        api_name=None,
+        use_cookies=False,
+        cookies=None,
+        timestamp_option=False,
+        temp_dir=str(tmp_path),
+        keep_intermediate_audio=False,
+        perform_diarization=False,
+        user_id=42,
+    )
+
+    assert result["status"] == "Error"
+    assert "storage quota exceeded" in str(result.get("error", "")).lower()
 
 
 @patch("tldw_Server_API.app.core.Ingestion_Media_Processing.Video.Video_DL_Ingestion_Lib.process_single_video")

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -12,7 +12,7 @@ Covers:
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,21 +20,18 @@ import pytest
 from tldw_Server_API.app.services import stripe_metering_service as _sms_module
 from tldw_Server_API.app.services.stripe_metering_service import StripeMeteringService
 
-# Mock stripe module for environments where stripe is not installed
-_mock_stripe = MagicMock()
-_mock_stripe.api_key = None
+@pytest.fixture
+def mock_stripe() -> MagicMock:
+    mock = MagicMock()
+    mock.api_key = None
+    return mock
 
 
-def _stripe_ok():
-    """Context manager stack: pretend stripe is installed and provide a mock module."""
-    from contextlib import ExitStack
-
-    stack = ExitStack()
-    stack.enter_context(patch.object(_sms_module, "STRIPE_AVAILABLE", True))
-    # Only patch stripe if it's actually None (not installed)
-    if _sms_module.stripe is None:
-        stack.enter_context(patch.object(_sms_module, "stripe", _mock_stripe))
-    return stack
+@pytest.fixture
+def stripe_enabled(monkeypatch: pytest.MonkeyPatch, mock_stripe: MagicMock) -> MagicMock:
+    monkeypatch.setattr(_sms_module, "STRIPE_AVAILABLE", True)
+    monkeypatch.setattr(_sms_module, "stripe", mock_stripe)
+    return mock_stripe
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +53,7 @@ class TestStripeMeteringServiceInit:
         with patch.dict(
             "os.environ",
             {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-        ):
+        ), patch.object(_sms_module, "STRIPE_AVAILABLE", True):
             svc = StripeMeteringService()
             assert svc.is_enabled is True
 
@@ -65,7 +62,7 @@ class TestStripeMeteringServiceInit:
         with patch.dict(
             "os.environ",
             {"BILLING_ENABLED": "1", "STRIPE_API_KEY": "sk_test_abc"},
-        ):
+        ), patch.object(_sms_module, "STRIPE_AVAILABLE", True):
             svc = StripeMeteringService()
             assert svc.is_enabled is True
 
@@ -75,19 +72,63 @@ class TestStripeMeteringServiceInit:
             svc = StripeMeteringService()
             assert svc.is_enabled is False
 
+    def test_not_enabled_when_stripe_package_is_unavailable(self):
+        with patch.dict(
+            "os.environ",
+            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
+            clear=True,
+        ), patch.object(_sms_module, "STRIPE_AVAILABLE", False):
+            svc = StripeMeteringService()
+            assert svc.is_enabled is False
+
 
 # ---------------------------------------------------------------------------
 # sync_daily_usage tests
 # ---------------------------------------------------------------------------
 
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None):
+        base = datetime(2026, 3, 14, 12, 0, 0, tzinfo=timezone.utc)
+        if tz is None:
+            return base.replace(tzinfo=None)
+        return base.astimezone(tz)
 
-def _make_enabled_svc() -> StripeMeteringService:
-    """Create a StripeMeteringService with billing enabled."""
+
+@pytest.fixture
+def enabled_service() -> StripeMeteringService:
     with patch.dict(
         "os.environ",
-            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-        ):
-            return StripeMeteringService()
+        {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
+    ):
+        return StripeMeteringService()
+
+
+@pytest.fixture
+def frozen_utc_now(monkeypatch: pytest.MonkeyPatch) -> str:
+    monkeypatch.setattr(_sms_module, "datetime", _FrozenDateTime)
+    return "2026-03-13"
+
+
+@pytest.fixture
+def fake_pool():
+    def _make(conn):
+        return _FakePool(conn)
+
+    return _make
+
+
+@pytest.fixture
+def fake_sqlite_conn():
+    def _make(execute_side_effect):
+        return _FakeSqliteConn(execute_side_effect)
+
+    return _make
+
+
+@pytest.fixture
+def fake_postgres_conn() -> _FakePostgresConn:
+    return _FakePostgresConn()
 
 
 class _AcquireContext:
@@ -109,6 +150,30 @@ class _FakePool:
         return _AcquireContext(self._conn)
 
 
+class _FakePostgresConn:
+    def __init__(self):
+        self.fetch_calls = []
+        self.fetchval_calls = []
+        self.execute_calls = []
+        self.fetchrow_calls = []
+
+    async def fetch(self, query, *params):
+        self.fetch_calls.append((query, params))
+        return []
+
+    async def fetchrow(self, query, *params):
+        self.fetchrow_calls.append((query, params))
+        return None
+
+    async def fetchval(self, query, *params):
+        self.fetchval_calls.append((query, params))
+        return None
+
+    async def execute(self, query, *params):
+        self.execute_calls.append((query, params))
+        return None
+
+
 class _FakeSqliteConn:
     def __init__(self, execute_side_effect):
         self.execute = AsyncMock(side_effect=execute_side_effect)
@@ -128,9 +193,9 @@ class TestSyncDailyUsage:
         assert result["reason"] == "billing_not_enabled"
 
     @pytest.mark.asyncio
-    async def test_skips_when_stripe_not_installed(self):
+    async def test_skips_when_stripe_not_installed(self, enabled_service):
         """Returns skip status when stripe package is not installed."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         with patch.object(_sms_module, "STRIPE_AVAILABLE", False):
             result = await svc.sync_daily_usage(date="2026-03-13")
 
@@ -138,15 +203,14 @@ class TestSyncDailyUsage:
         assert result["reason"] == "stripe_package_not_installed"
 
     @pytest.mark.asyncio
-    async def test_returns_completed_no_usage(self):
+    async def test_returns_completed_no_usage(self, enabled_service, stripe_enabled):
         """Returns completed with zero synced_users when no usage data exists."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[])
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["status"] == "completed"
         assert result["date"] == "2026-03-13"
@@ -155,26 +219,21 @@ class TestSyncDailyUsage:
         assert result["message"] == "no_usage_data"
 
     @pytest.mark.asyncio
-    async def test_defaults_to_yesterday(self):
+    async def test_defaults_to_yesterday(self, enabled_service, frozen_utc_now, stripe_enabled):
         """When no date is specified, defaults to yesterday."""
-        yesterday = (
-            datetime.now(timezone.utc) - timedelta(days=1)
-        ).strftime("%Y-%m-%d")
-
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[])
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage()
+        result = await svc.sync_daily_usage()
 
-        assert result["date"] == yesterday
+        assert result["date"] == frozen_utc_now
 
     @pytest.mark.asyncio
-    async def test_syncs_user_with_subscription(self):
+    async def test_syncs_user_with_subscription(self, enabled_service, stripe_enabled):
         """Successfully syncs usage for a user with an active Stripe subscription."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -191,8 +250,7 @@ class TestSyncDailyUsage:
         svc._report_usage_to_stripe = AsyncMock()
         svc._record_sync = AsyncMock()
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["status"] == "completed"
         assert result["synced_users"] == 1
@@ -205,9 +263,9 @@ class TestSyncDailyUsage:
         svc._record_sync.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_skips_already_synced_user(self):
+    async def test_skips_already_synced_user(self, enabled_service, stripe_enabled):
         """Skips users whose usage was already synced (prevents double-counting)."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -221,16 +279,15 @@ class TestSyncDailyUsage:
         })
         svc._already_synced = AsyncMock(return_value=True)
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["synced_users"] == 0
         assert result["skipped_users"] == 1
 
     @pytest.mark.asyncio
-    async def test_skips_user_without_subscription(self):
+    async def test_skips_user_without_subscription(self, enabled_service, stripe_enabled):
         """Skips users who have no active Stripe subscription."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -239,16 +296,15 @@ class TestSyncDailyUsage:
         ])
         svc._query_user_subscription = AsyncMock(return_value=None)
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["synced_users"] == 0
         assert result["skipped_users"] == 1
 
     @pytest.mark.asyncio
-    async def test_skips_user_with_zero_requests(self):
+    async def test_skips_user_with_zero_requests(self, enabled_service, stripe_enabled):
         """Skips users with zero requests."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -256,16 +312,15 @@ class TestSyncDailyUsage:
              "bytes_in_total": 0, "latency_avg_ms": 0},
         ])
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["synced_users"] == 0
         assert result["skipped_users"] == 1
 
     @pytest.mark.asyncio
-    async def test_handles_stripe_error(self):
+    async def test_handles_stripe_error(self, enabled_service, stripe_enabled):
         """Counts errors when Stripe API call fails."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -283,28 +338,26 @@ class TestSyncDailyUsage:
             side_effect=RuntimeError("Stripe API error")
         )
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["errors"] == 1
         assert result["synced_users"] == 0
 
     @pytest.mark.asyncio
-    async def test_db_pool_error_returns_error_status(self):
+    async def test_db_pool_error_returns_error_status(self, enabled_service, stripe_enabled):
         """Returns error status when DB pool is unavailable."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(side_effect=RuntimeError("no pool"))
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["status"] == "error"
         assert "db_pool_unavailable" in result["error"]
 
     @pytest.mark.asyncio
-    async def test_skips_user_without_metered_item(self):
+    async def test_skips_user_without_metered_item(self, enabled_service, stripe_enabled):
         """Skips users whose subscription has no metered item."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._ensure_metering_sync_table = AsyncMock()
         svc._query_usage_for_date = AsyncMock(return_value=[
@@ -319,15 +372,14 @@ class TestSyncDailyUsage:
         svc._already_synced = AsyncMock(return_value=False)
         svc._get_subscription_metered_item = AsyncMock(return_value=None)
 
-        with _stripe_ok():
-            result = await svc.sync_daily_usage(date="2026-03-13")
+        result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["synced_users"] == 0
         assert result["skipped_users"] == 1
 
     @pytest.mark.asyncio
-    async def test_query_usage_for_date_falls_back_when_bytes_in_total_missing(self):
-        svc = _make_enabled_svc()
+    async def test_query_usage_for_date_falls_back_when_bytes_in_total_missing(self, enabled_service, fake_pool, fake_sqlite_conn):
+        svc = enabled_service
         legacy_cursor = MagicMock()
         legacy_cursor.description = [
             ("user_id",),
@@ -338,14 +390,14 @@ class TestSyncDailyUsage:
         ]
         legacy_cursor.fetchall = AsyncMock(return_value=[(7, 12, 1, 4096, 25.0)])
 
-        conn = _FakeSqliteConn(
+        conn = fake_sqlite_conn(
             [
                 sqlite3.OperationalError("no such column: bytes_in_total"),
                 legacy_cursor,
             ]
         )
 
-        rows = await svc._query_usage_for_date(_FakePool(conn), "2026-03-13")
+        rows = await svc._query_usage_for_date(fake_pool(conn), "2026-03-13")
 
         assert rows == [
             {
@@ -359,8 +411,8 @@ class TestSyncDailyUsage:
         ]
 
     @pytest.mark.asyncio
-    async def test_query_user_subscription_falls_back_to_org_owner(self):
-        svc = _make_enabled_svc()
+    async def test_query_user_subscription_falls_back_to_org_owner(self, enabled_service, fake_pool, fake_sqlite_conn):
+        svc = enabled_service
         miss_cursor = MagicMock()
         miss_cursor.fetchone = AsyncMock(return_value=None)
 
@@ -372,15 +424,72 @@ class TestSyncDailyUsage:
         ]
         owner_cursor.fetchone = AsyncMock(return_value=("cus_owner", "sub_owner", 9))
 
-        conn = _FakeSqliteConn([miss_cursor, owner_cursor])
+        conn = fake_sqlite_conn([miss_cursor, owner_cursor])
 
-        result = await svc._query_user_subscription(_FakePool(conn), 42)
+        result = await svc._query_user_subscription(fake_pool(conn), 42)
 
         assert result == {
             "stripe_customer_id": "cus_owner",
             "stripe_subscription_id": "sub_owner",
             "org_id": 9,
         }
+
+    @pytest.mark.asyncio
+    async def test_postgres_usage_queries_bind_real_date_objects(self, enabled_service, fake_pool, fake_postgres_conn):
+        svc = enabled_service
+        conn = fake_postgres_conn
+        pool = fake_pool(conn)
+
+        await svc._query_usage_for_date(pool, "2026-03-13")
+        await svc._query_sync_totals(pool, "2026-03-13")
+
+        assert isinstance(conn.fetch_calls[0][1][0], date)
+        assert isinstance(conn.fetch_calls[1][1][0], date)
+
+    @pytest.mark.asyncio
+    async def test_postgres_sync_log_helpers_bind_real_date_objects(self, enabled_service, fake_pool, fake_postgres_conn):
+        svc = enabled_service
+        conn = fake_postgres_conn
+        pool = fake_pool(conn)
+
+        await svc._already_synced(pool, 7, "2026-03-13", "sub_123")
+        await svc._record_sync(pool, 7, "2026-03-13", "sub_123", 11, 2048)
+
+        assert isinstance(conn.fetchval_calls[0][1][1], date)
+        assert isinstance(conn.execute_calls[0][1][1], date)
+
+    @pytest.mark.asyncio
+    async def test_get_subscription_metered_item_returns_none_for_missing_subscription(self, enabled_service):
+        svc = enabled_service
+
+        class _MissingStripeResource(Exception):
+            code = "resource_missing"
+
+        fake_stripe = MagicMock()
+        fake_stripe.Subscription.retrieve.side_effect = _MissingStripeResource(
+            "No such subscription: 'sub_missing'"
+        )
+
+        with patch.object(_sms_module, "STRIPE_AVAILABLE", True), patch.object(
+            _sms_module, "stripe", fake_stripe
+        ):
+            assert await svc._get_subscription_metered_item("sub_missing") is None
+
+    @pytest.mark.asyncio
+    async def test_get_subscription_metered_item_propagates_non_missing_stripe_errors(self, enabled_service):
+        svc = enabled_service
+
+        class _StripeAPIError(Exception):
+            code = "api_error"
+
+        fake_stripe = MagicMock()
+        fake_stripe.Subscription.retrieve.side_effect = _StripeAPIError("rate limited")
+
+        with patch.object(_sms_module, "STRIPE_AVAILABLE", True), patch.object(
+            _sms_module, "stripe", fake_stripe
+        ):
+            with pytest.raises(_StripeAPIError, match="rate limited"):
+                await svc._get_subscription_metered_item("sub_problem")
 
 
 # ---------------------------------------------------------------------------
@@ -401,9 +510,9 @@ class TestCheckReconciliation:
         assert result["status"] == "skipped"
 
     @pytest.mark.asyncio
-    async def test_returns_completed_no_discrepancies(self):
+    async def test_returns_completed_no_discrepancies(self, enabled_service):
         """Returns completed with no discrepancies when usage matches synced data."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._query_usage_for_date = AsyncMock(return_value=[
             {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
@@ -424,9 +533,9 @@ class TestCheckReconciliation:
         assert result["total_synced_requests"] == 100
 
     @pytest.mark.asyncio
-    async def test_detects_drift(self):
+    async def test_detects_drift(self, enabled_service):
         """Detects discrepancies between local usage and synced records."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._query_usage_for_date = AsyncMock(return_value=[
             {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
@@ -452,9 +561,9 @@ class TestCheckReconciliation:
         assert d2["drift"] == 50
 
     @pytest.mark.asyncio
-    async def test_handles_sync_log_table_missing(self):
+    async def test_handles_sync_log_table_missing(self, enabled_service):
         """Gracefully handles missing metering_sync_log table."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._query_usage_for_date = AsyncMock(return_value=[
             {"user_id": 1, "requests": 50, "errors": 0, "bytes_total": 1000,
@@ -472,25 +581,21 @@ class TestCheckReconciliation:
         assert result["discrepancies"][0]["drift"] == 50
 
     @pytest.mark.asyncio
-    async def test_defaults_to_yesterday(self):
+    async def test_defaults_to_yesterday(self, enabled_service, frozen_utc_now):
         """When no date is specified, defaults to yesterday."""
-        yesterday = (
-            datetime.now(timezone.utc) - timedelta(days=1)
-        ).strftime("%Y-%m-%d")
-
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(return_value=MagicMock())
         svc._query_usage_for_date = AsyncMock(return_value=[])
         svc._query_sync_totals = AsyncMock(return_value=[])
 
         result = await svc.check_reconciliation()
 
-        assert result["date"] == yesterday
+        assert result["date"] == frozen_utc_now
 
     @pytest.mark.asyncio
-    async def test_db_pool_error_returns_error(self):
+    async def test_db_pool_error_returns_error(self, enabled_service):
         """Returns error status when DB pool is unavailable."""
-        svc = _make_enabled_svc()
+        svc = enabled_service
         svc._get_db_pool = AsyncMock(side_effect=RuntimeError("no pool"))
 
         result = await svc.check_reconciliation(date="2026-03-13")

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -11,6 +11,7 @@ Covers:
 """
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -84,9 +85,33 @@ def _make_enabled_svc() -> StripeMeteringService:
     """Create a StripeMeteringService with billing enabled."""
     with patch.dict(
         "os.environ",
-        {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-    ):
-        return StripeMeteringService()
+            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
+        ):
+            return StripeMeteringService()
+
+
+class _AcquireContext:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AcquireContext(self._conn)
+
+
+class _FakeSqliteConn:
+    def __init__(self, execute_side_effect):
+        self.execute = AsyncMock(side_effect=execute_side_effect)
 
 
 class TestSyncDailyUsage:
@@ -299,6 +324,63 @@ class TestSyncDailyUsage:
 
         assert result["synced_users"] == 0
         assert result["skipped_users"] == 1
+
+    @pytest.mark.asyncio
+    async def test_query_usage_for_date_falls_back_when_bytes_in_total_missing(self):
+        svc = _make_enabled_svc()
+        legacy_cursor = MagicMock()
+        legacy_cursor.description = [
+            ("user_id",),
+            ("requests",),
+            ("errors",),
+            ("bytes_total",),
+            ("latency_avg_ms",),
+        ]
+        legacy_cursor.fetchall = AsyncMock(return_value=[(7, 12, 1, 4096, 25.0)])
+
+        conn = _FakeSqliteConn(
+            [
+                sqlite3.OperationalError("no such column: bytes_in_total"),
+                legacy_cursor,
+            ]
+        )
+
+        rows = await svc._query_usage_for_date(_FakePool(conn), "2026-03-13")
+
+        assert rows == [
+            {
+                "user_id": 7,
+                "requests": 12,
+                "errors": 1,
+                "bytes_total": 4096,
+                "bytes_in_total": 0,
+                "latency_avg_ms": 25.0,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_query_user_subscription_falls_back_to_org_owner(self):
+        svc = _make_enabled_svc()
+        miss_cursor = MagicMock()
+        miss_cursor.fetchone = AsyncMock(return_value=None)
+
+        owner_cursor = MagicMock()
+        owner_cursor.description = [
+            ("stripe_customer_id",),
+            ("stripe_subscription_id",),
+            ("org_id",),
+        ]
+        owner_cursor.fetchone = AsyncMock(return_value=("cus_owner", "sub_owner", 9))
+
+        conn = _FakeSqliteConn([miss_cursor, owner_cursor])
+
+        result = await svc._query_user_subscription(_FakePool(conn), 42)
+
+        assert result == {
+            "stripe_customer_id": "cus_owner",
+            "stripe_subscription_id": "sub_owner",
+            "org_id": 9,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -4,18 +4,36 @@ Tests for Stripe usage metering reconciliation service.
 Covers:
 - Service initialization and configuration
 - Billing-disabled skip behavior
-- sync_daily_usage returns expected structure
-- check_reconciliation returns expected structure
+- sync_daily_usage with mocked DB and Stripe calls
+- check_reconciliation with mocked DB
 - Default date handling (yesterday)
+- Double-counting prevention
 """
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tldw_Server_API.app.services import stripe_metering_service as _sms_module
 from tldw_Server_API.app.services.stripe_metering_service import StripeMeteringService
+
+# Mock stripe module for environments where stripe is not installed
+_mock_stripe = MagicMock()
+_mock_stripe.api_key = None
+
+
+def _stripe_ok():
+    """Context manager stack: pretend stripe is installed and provide a mock module."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(patch.object(_sms_module, "STRIPE_AVAILABLE", True))
+    # Only patch stripe if it's actually None (not installed)
+    if _sms_module.stripe is None:
+        stack.enter_context(patch.object(_sms_module, "stripe", _mock_stripe))
+    return stack
 
 
 # ---------------------------------------------------------------------------
@@ -62,6 +80,15 @@ class TestStripeMeteringServiceInit:
 # ---------------------------------------------------------------------------
 
 
+def _make_enabled_svc() -> StripeMeteringService:
+    """Create a StripeMeteringService with billing enabled."""
+    with patch.dict(
+        "os.environ",
+        {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
+    ):
+        return StripeMeteringService()
+
+
 class TestSyncDailyUsage:
     """Tests for StripeMeteringService.sync_daily_usage."""
 
@@ -76,19 +103,31 @@ class TestSyncDailyUsage:
         assert result["reason"] == "billing_not_enabled"
 
     @pytest.mark.asyncio
-    async def test_returns_completed_with_date(self):
-        """Returns completed status with the specified date."""
-        with patch.dict(
-            "os.environ",
-            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-        ):
-            svc = StripeMeteringService()
+    async def test_skips_when_stripe_not_installed(self):
+        """Returns skip status when stripe package is not installed."""
+        svc = _make_enabled_svc()
+        with patch.object(_sms_module, "STRIPE_AVAILABLE", False):
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "stripe_package_not_installed"
+
+    @pytest.mark.asyncio
+    async def test_returns_completed_no_usage(self):
+        """Returns completed with zero synced_users when no usage data exists."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[])
+
+        with _stripe_ok():
             result = await svc.sync_daily_usage(date="2026-03-13")
 
         assert result["status"] == "completed"
         assert result["date"] == "2026-03-13"
         assert result["synced_users"] == 0
         assert result["errors"] == 0
+        assert result["message"] == "no_usage_data"
 
     @pytest.mark.asyncio
     async def test_defaults_to_yesterday(self):
@@ -97,14 +136,169 @@ class TestSyncDailyUsage:
             datetime.now(timezone.utc) - timedelta(days=1)
         ).strftime("%Y-%m-%d")
 
-        with patch.dict(
-            "os.environ",
-            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-        ):
-            svc = StripeMeteringService()
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[])
+
+        with _stripe_ok():
             result = await svc.sync_daily_usage()
 
         assert result["date"] == yesterday
+
+    @pytest.mark.asyncio
+    async def test_syncs_user_with_subscription(self):
+        """Successfully syncs usage for a user with an active Stripe subscription."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 100, "errors": 2, "bytes_total": 5000,
+             "bytes_in_total": 3000, "latency_avg_ms": 50.0},
+        ])
+        svc._query_user_subscription = AsyncMock(return_value={
+            "stripe_customer_id": "cus_test1",
+            "stripe_subscription_id": "sub_test1",
+            "org_id": 10,
+        })
+        svc._already_synced = AsyncMock(return_value=False)
+        svc._get_subscription_metered_item = AsyncMock(return_value="si_item1")
+        svc._report_usage_to_stripe = AsyncMock()
+        svc._record_sync = AsyncMock()
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["status"] == "completed"
+        assert result["synced_users"] == 1
+        assert result["errors"] == 0
+
+        svc._report_usage_to_stripe.assert_called_once()
+        call_args = svc._report_usage_to_stripe.call_args
+        assert call_args[0][0] == "si_item1"
+        assert call_args[0][1] == 100  # requests quantity
+        svc._record_sync.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_already_synced_user(self):
+        """Skips users whose usage was already synced (prevents double-counting)."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 50, "errors": 0, "bytes_total": 1000,
+             "bytes_in_total": 500, "latency_avg_ms": 30.0},
+        ])
+        svc._query_user_subscription = AsyncMock(return_value={
+            "stripe_customer_id": "cus_test1",
+            "stripe_subscription_id": "sub_test1",
+            "org_id": 10,
+        })
+        svc._already_synced = AsyncMock(return_value=True)
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["synced_users"] == 0
+        assert result["skipped_users"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_user_without_subscription(self):
+        """Skips users who have no active Stripe subscription."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 99, "requests": 10, "errors": 0, "bytes_total": 100,
+             "bytes_in_total": 50, "latency_avg_ms": 10.0},
+        ])
+        svc._query_user_subscription = AsyncMock(return_value=None)
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["synced_users"] == 0
+        assert result["skipped_users"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_user_with_zero_requests(self):
+        """Skips users with zero requests."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 0, "errors": 0, "bytes_total": 0,
+             "bytes_in_total": 0, "latency_avg_ms": 0},
+        ])
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["synced_users"] == 0
+        assert result["skipped_users"] == 1
+
+    @pytest.mark.asyncio
+    async def test_handles_stripe_error(self):
+        """Counts errors when Stripe API call fails."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
+             "bytes_in_total": 3000, "latency_avg_ms": 50.0},
+        ])
+        svc._query_user_subscription = AsyncMock(return_value={
+            "stripe_customer_id": "cus_test1",
+            "stripe_subscription_id": "sub_test1",
+            "org_id": 10,
+        })
+        svc._already_synced = AsyncMock(return_value=False)
+        svc._get_subscription_metered_item = AsyncMock(return_value="si_item1")
+        svc._report_usage_to_stripe = AsyncMock(
+            side_effect=RuntimeError("Stripe API error")
+        )
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["errors"] == 1
+        assert result["synced_users"] == 0
+
+    @pytest.mark.asyncio
+    async def test_db_pool_error_returns_error_status(self):
+        """Returns error status when DB pool is unavailable."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(side_effect=RuntimeError("no pool"))
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["status"] == "error"
+        assert "db_pool_unavailable" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_skips_user_without_metered_item(self):
+        """Skips users whose subscription has no metered item."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._ensure_metering_sync_table = AsyncMock()
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
+             "bytes_in_total": 3000, "latency_avg_ms": 50.0},
+        ])
+        svc._query_user_subscription = AsyncMock(return_value={
+            "stripe_customer_id": "cus_test1",
+            "stripe_subscription_id": "sub_test1",
+            "org_id": 10,
+        })
+        svc._already_synced = AsyncMock(return_value=False)
+        svc._get_subscription_metered_item = AsyncMock(return_value=None)
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["synced_users"] == 0
+        assert result["skipped_users"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -125,16 +319,100 @@ class TestCheckReconciliation:
         assert result["status"] == "skipped"
 
     @pytest.mark.asyncio
-    async def test_returns_completed_structure(self):
-        """Returns expected reconciliation structure."""
-        with patch.dict(
-            "os.environ",
-            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
-        ):
-            svc = StripeMeteringService()
-            result = await svc.check_reconciliation(date="2026-03-13")
+    async def test_returns_completed_no_discrepancies(self):
+        """Returns completed with no discrepancies when usage matches synced data."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
+             "bytes_in_total": 3000, "latency_avg_ms": 50.0},
+        ])
+        svc._query_sync_totals = AsyncMock(return_value=[
+            {"user_id": 1, "stripe_subscription_id": "sub_1",
+             "requests_synced": 100, "bytes_synced": 5000},
+        ])
+
+        result = await svc.check_reconciliation(date="2026-03-13")
 
         assert result["status"] == "completed"
         assert result["date"] == "2026-03-13"
         assert isinstance(result["discrepancies"], list)
         assert len(result["discrepancies"]) == 0
+        assert result["total_local_requests"] == 100
+        assert result["total_synced_requests"] == 100
+
+    @pytest.mark.asyncio
+    async def test_detects_drift(self):
+        """Detects discrepancies between local usage and synced records."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 100, "errors": 0, "bytes_total": 5000,
+             "bytes_in_total": 3000, "latency_avg_ms": 50.0},
+            {"user_id": 2, "requests": 50, "errors": 0, "bytes_total": 1000,
+             "bytes_in_total": 500, "latency_avg_ms": 20.0},
+        ])
+        svc._query_sync_totals = AsyncMock(return_value=[
+            {"user_id": 1, "stripe_subscription_id": "sub_1",
+             "requests_synced": 80, "bytes_synced": 4000},
+            # user_id 2 has no sync record
+        ])
+
+        result = await svc.check_reconciliation(date="2026-03-13")
+
+        assert result["status"] == "completed"
+        assert len(result["discrepancies"]) == 2
+        # User 1: 100 local, 80 synced => drift of 20
+        d1 = next(d for d in result["discrepancies"] if d["user_id"] == 1)
+        assert d1["drift"] == 20
+        # User 2: 50 local, 0 synced => drift of 50
+        d2 = next(d for d in result["discrepancies"] if d["user_id"] == 2)
+        assert d2["drift"] == 50
+
+    @pytest.mark.asyncio
+    async def test_handles_sync_log_table_missing(self):
+        """Gracefully handles missing metering_sync_log table."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._query_usage_for_date = AsyncMock(return_value=[
+            {"user_id": 1, "requests": 50, "errors": 0, "bytes_total": 1000,
+             "bytes_in_total": 500, "latency_avg_ms": 10.0},
+        ])
+        svc._query_sync_totals = AsyncMock(
+            side_effect=Exception("no such table: metering_sync_log")
+        )
+
+        result = await svc.check_reconciliation(date="2026-03-13")
+
+        assert result["status"] == "completed"
+        # All usage shows as drift since no sync records
+        assert len(result["discrepancies"]) == 1
+        assert result["discrepancies"][0]["drift"] == 50
+
+    @pytest.mark.asyncio
+    async def test_defaults_to_yesterday(self):
+        """When no date is specified, defaults to yesterday."""
+        yesterday = (
+            datetime.now(timezone.utc) - timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(return_value=MagicMock())
+        svc._query_usage_for_date = AsyncMock(return_value=[])
+        svc._query_sync_totals = AsyncMock(return_value=[])
+
+        result = await svc.check_reconciliation()
+
+        assert result["date"] == yesterday
+
+    @pytest.mark.asyncio
+    async def test_db_pool_error_returns_error(self):
+        """Returns error status when DB pool is unavailable."""
+        svc = _make_enabled_svc()
+        svc._get_db_pool = AsyncMock(side_effect=RuntimeError("no pool"))
+
+        result = await svc.check_reconciliation(date="2026-03-13")
+
+        assert result["status"] == "error"
+        assert "db_pool_unavailable" in result["error"]
+        assert isinstance(result["discrepancies"], list)


### PR DESCRIPTION
## Summary

Fixes 5 integration gaps identified during the production readiness audit — modules that existed as standalone code but weren't wired into the actual system.

- **Gap 9.1**: Replace Stripe metering stub with real implementation (queries `usage_daily`, syncs to Stripe via `UsageRecord` API, tracks synced records to prevent double-counting, includes reconciliation with drift detection)
- **Gap 5.3**: Integrate `FairShareScheduler` into `JobManager.create_job()` — enforces per-user concurrent job limits and adjusts priority based on active job count
- **Gap 3.3**: Integrate `compute_event_hash()` into `UnifiedAuditService` flush — builds SHA-256 hash chains across audit event batches for tamper detection
- **Gap 9.3**: Integrate `OveragePolicy` into `BillingEnforcer.check_limit()` — applies configurable overage modes (hard_block/degraded/notify_only) after base enforcement
- **Gap 3.2**: Add `/consent/preferences` API endpoints wiring `ConsentManager` — grant, withdraw, and list GDPR Article 7 consent records per user

## Test plan

- [ ] `python -m pytest tldw_Server_API/tests/test_stripe_metering.py -v` — 21 tests covering sync, double-counting prevention, reconciliation
- [ ] `python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py -v` — 8 tests covering admission control and priority adjustment
- [ ] `python -m pytest tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py -v` — 3 tests verifying hash chain generation
- [ ] `python -m pytest tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py -v` — 7 tests for all overage modes
- [ ] `python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py -v` — 13 tests for consent CRUD endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)