### PR TITLE
feat(acp): multi-protocol agent workspace harness (Phase A)

### DIFF
--- a/Docs/Plans/2026-03-16-acp-agent-workspace-harness-design.md
+++ b/Docs/Plans/2026-03-16-acp-agent-workspace-harness-design.md
@@ -1,0 +1,549 @@
+# ACP Agent Workspace Harness — Design Document
+
+**Date**: 2026-03-16
+**Status**: Approved
+**Scope**: Multi-protocol agent harness with event bus architecture, accessible from WebUI/extension via ACP module
+
+---
+
+## 1. Overview
+
+Enable users to run any agent backend from the tldw WebUI/extension through the ACP module. The agent harness supports multiple wire protocols (ACP-stdio, MCP, OpenAI tool-use), provides full transparency with configurable verbosity, and delegates isolation to the existing Sandbox module.
+
+### Key Decisions
+
+| Decision | Choice |
+|----------|--------|
+| UX model | Dedicated Agent Workspace panel — full interactive, Claude-Code-like experience in the browser |
+| Agent backends | Generic protocol adapters, no agent-specific code in the harness |
+| Isolation | Local process (single-user) or Sandbox module (Docker/VM for multi-user). Existing Sandbox module is the execution backend. |
+| Introspection | Full transparency with configurable verbosity (full/structured/summary) |
+| Wire protocols | Multi-protocol from day one: ACP-stdio, MCP, OpenAI tool-use via `ProtocolAdapter` interface |
+| Architecture | ACP = user-facing orchestration layer, Sandbox = pure execution backend |
+| Protocol translation | Server-side adapters in ACP, uniform `AgentEvent` stream to UI |
+| Event architecture | Hybrid Approach 1→2: adapter layer first, event bus introduced when second consumer is wired |
+| First deliverable | Protocol adapter layer + event schema, then WebUI |
+
+---
+
+## 2. AgentEvent Schema
+
+The core contract. Every protocol adapter produces these, every consumer reads them.
+
+```
+AgentEvent
+├── session_id: str
+├── sequence: int              # monotonic per session, assigned by bus
+├── timestamp: datetime
+├── kind: AgentEventKind       # enum
+├── payload: dict              # kind-specific, documented not enforced
+└── metadata: dict             # optional (adapter name, protocol, latency)
+```
+
+### Event Kinds
+
+| Kind | Payload fields |
+|------|---------------|
+| `thinking` | `text: str`, `is_partial: bool` |
+| `tool_call` | `tool_id: str`, `tool_name: str`, `arguments: dict`, `permission_tier: str` |
+| `tool_result` | `tool_id: str`, `tool_name: str`, `output: str`, `is_error: bool`, `duration_ms: int` |
+| `file_change` | `path: str`, `action: create\|modify\|delete`, `diff: str\|null`, `content: str\|null` |
+| `terminal_output` | `command: str`, `output: str`, `exit_code: int\|null`, `is_partial: bool` |
+| `permission_request` | `request_id: str`, `tool_name: str`, `arguments: dict`, `tier: str`, `timeout_sec: int` |
+| `permission_response` | `request_id: str`, `decision: approve\|deny`, `reason: str\|null` |
+| `completion` | `text: str`, `stop_reason: str` |
+| `error` | `code: str`, `message: str`, `recoverable: bool` |
+| `status_change` | `from_status: str`, `to_status: str` |
+| `token_usage` | `prompt_tokens: int`, `completion_tokens: int`, `total_tokens: int` |
+| `heartbeat` | `elapsed_sec: int`, `state: thinking\|executing\|waiting` |
+| `lifecycle` | `event: agent_started\|agent_ready\|agent_exited\|sandbox_provisioned\|sandbox_destroyed`, `exit_code: int\|null` |
+
+### Design Rationale
+
+- `sequence` is per-session monotonic — enables exactly-once delivery, gap detection, and replay from any point
+- `payload` is a dict, not a union type — extensible without breaking consumers that ignore unknown kinds
+- `file_change` is first-class — the Agent Workspace needs to show diffs in real-time
+- `permission_request`/`permission_response` are events in the stream, not a side-channel
+- `heartbeat` distinguishes "agent is working silently" from "adapter is disconnected" — adapters emit every 15s (configurable) while processing
+- `lifecycle` tracks agent process and sandbox environment state transitions — enables the UI to show provisioning progress and clean exit vs crash
+
+---
+
+## 3. ProtocolAdapter Interface
+
+```python
+class ProtocolAdapter(ABC):
+    protocol_name: str  # "stdio", "mcp", "openai_tool_use"
+
+    async def connect(self, config: AdapterConfig) -> None
+    async def disconnect(self) -> None
+    async def send_prompt(self, messages: list[dict], options: PromptOptions) -> None
+    async def send_tool_result(self, tool_id: str, result: str, is_error: bool) -> None
+    async def cancel(self) -> None
+    is_connected: bool  # property
+    supports_streaming: bool  # property
+```
+
+### AdapterConfig
+
+```python
+@dataclass
+class AdapterConfig:
+    event_callback: Callable[[AgentEvent], Awaitable[None]]
+    session_id: str
+    protocol_config: dict  # adapter-specific, validated by the adapter on connect()
+```
+
+Each adapter defines and validates its own config shape from `protocol_config`:
+
+| Adapter | Expected `protocol_config` keys |
+|---------|-------------------------------|
+| `StdioAdapter` | `process: asyncio.subprocess.Process` |
+| `MCPAdapter` | `mcp_endpoint: str`, `mcp_transport: "stdio"\|"sse"\|"streamable_http"`, optionally `process` for stdio transport |
+| `OpenAIToolUseAdapter` | `api_base_url: str`, `api_key: str\|null`, `model: str`, `tools: list[dict]\|null` |
+
+This keeps `AdapterConfig` generic — adding a 4th protocol doesn't change the dataclass.
+
+### `send_prompt()` Contract
+
+`send_prompt()` is async and may run for an extended period — the agent's full turn, which can involve many internal tool calls and reasoning steps. Events stream via `event_callback` throughout execution. The method returns when the agent's turn is complete (final `completion` event) or on unrecoverable error. Callers should not assume it returns quickly.
+
+### Three Adapters
+
+**StdioAdapter**: Wraps existing `ACPStdioClient`. JSON-framed messages over stdin/stdout. Works with Claude Code, Aider, any CLI agent. The agent drives its own execution loop internally.
+
+**MCPAdapter**: Acts as an MCP **client** connecting to the agent's MCP **server**. The agent exposes its capabilities (tools, resources) via MCP; the adapter discovers and invokes them. Supports stdio, SSE, and streamable HTTP transports. Leverages patterns from existing `MCP_unified` module. Note: agents that want to *consume* tldw's tools connect to tldw's existing MCP Unified module separately — that is out of scope for the adapter layer.
+
+**OpenAIToolUseAdapter**: HTTP client to OpenAI-compatible chat completions endpoint. Drives a multi-turn loop internally: send prompt → receive streaming tool_call chunks → execute tools (via ToolExecutor) → send results back → repeat until final completion. Works with vLLM, Ollama, LiteLLM, any compatible server.
+
+### Tool Execution Ownership
+
+Different agents handle tool execution differently. The `tool_execution_mode` field on the agent registry entry determines who executes tools:
+
+| Mode | Behavior | Typical agents |
+|------|----------|---------------|
+| `agent_side` | Agent executes tools internally (bash, file I/O, etc.). Adapter observes and reports `tool_call`/`tool_result` events. GovernanceFilter can block by withholding approval before the agent acts. | Claude Code, Aider, Open Interpreter |
+| `server_side` | Agent requests tool calls, server executes them via `ToolExecutor`, sends results back via `adapter.send_tool_result()`. | OpenAI-compatible models, MCP agents exposing tool requests |
+| `hybrid` | Agent has local tools it executes itself, plus server-provided tools (e.g., RAG search, media ingestion). Tool routing by name prefix or registry lookup. | Custom agents with tldw integration |
+
+```python
+class ToolExecutor(ABC):
+    """Executes tools on behalf of agents in server_side/hybrid mode."""
+
+    async def execute(self, tool_name: str, arguments: dict) -> ToolResult:
+        """Run a tool and return its result."""
+
+    async def list_tools(self) -> list[ToolDefinition]:
+        """Return available server-side tools."""
+```
+
+The default `ToolExecutor` implementation delegates to tldw's existing tool registry (RAG search, media processing, etc.). Custom executors can be registered per-session.
+
+### Adapter Instantiation
+
+```
+Agent Registry Entry (protocol + tool_execution_mode) → AdapterFactory → ProtocolAdapter instance
+If sandboxed: Sandbox module provides container → adapter connects to process/endpoint inside
+If local: spawn process directly → adapter connects
+ToolExecutor wired based on tool_execution_mode
+```
+
+---
+
+## 4. Session Event Bus
+
+Per-session async event fan-out. Starts as `asyncio.Queue` with fan-out, grows into the system backbone.
+
+**Important**: GovernanceFilter is a **pipeline stage** between the adapter and the bus, not a bus consumer. It must be able to intercept `tool_call` events and hold them (preventing downstream delivery) until a permission decision arrives. A subscriber pattern cannot block delivery to other subscribers.
+
+```
+ProtocolAdapter → GovernanceFilter (intercepts, gates tool_calls) → SessionEventBus → fan-out → Consumers
+                        ▲                                                ▲
+                        │ permission_response                            │ inject()
+                        └────────────────────────────────────────────────┘
+```
+
+The adapter's `event_callback` points to `GovernanceFilter.process()`, which either forwards events to the bus immediately (most events) or holds `tool_call` events pending approval. When a `permission_response` arrives via `bus.inject()`, the bus routes it back to the GovernanceFilter, which resolves the pending tool and forwards the original `tool_call` to the bus.
+
+### SessionEventBus API
+
+```python
+class SessionEventBus:
+    def __init__(self, session_id: str, max_buffer: int = 10_000)
+    async def publish(self, event: AgentEvent) -> None        # assign sequence, distribute
+    def subscribe(self, consumer_id: str, from_sequence: int = 0) -> asyncio.Queue
+    def unsubscribe(self, consumer_id: str) -> None
+    async def inject(self, event: AgentEvent) -> None          # external events (governance)
+    def snapshot(self, from_sequence: int = 0) -> list[AgentEvent]  # replay for late joiners
+```
+
+### Design Rationale
+
+- One bus per session, not global — sessions are independent
+- Bounded history buffer (configurable per session, default 10k events) — enables late-join replay without unbounded memory
+- Backpressure via bounded subscriber queues (1000 events) — slow consumers evicted after 30s
+- `inject()` for external events — governance decisions flow back into the same stream
+- No persistence in the bus — `AuditLogger` consumer handles durable storage
+
+### Replay Fallback for Long Sessions
+
+For long-running sessions that exceed the bus buffer (e.g., 500+ tool calls with verbose output), a WebSocket reconnecting after buffer rotation would get an incomplete replay. Two-tier replay strategy:
+
+1. **Fast path**: `bus.snapshot(from_sequence)` — serves from in-memory ring buffer. Works for recent events.
+2. **Slow path**: If `from_sequence` is older than the buffer's earliest event, `WSBroadcaster` falls back to replaying from `ACP_Audit_DB` (the `AuditLogger` consumer's durable store). Slower but complete.
+
+The `WSBroadcaster` detects the gap (requested sequence < buffer's min sequence) and transparently switches to the slow path. The client sees a seamless stream regardless of source.
+
+### GovernanceFilter (Pipeline Stage)
+
+```python
+class GovernanceFilter:
+    """Pipeline stage between adapter and bus. NOT a bus consumer."""
+
+    def __init__(self, bus: SessionEventBus, policy: PermissionPolicy):
+        self._bus = bus
+        self._policy = policy
+        self._pending: dict[str, PendingToolCall] = {}  # request_id → held tool_call
+
+    async def process(self, event: AgentEvent) -> None:
+        """Called by adapter's event_callback. Gates tool_calls, forwards everything else."""
+        if event.kind == "tool_call":
+            tier = self._policy.resolve_tier(event.payload["tool_name"])
+            if tier == "auto":
+                await self._bus.publish(event)  # auto-approved, pass through
+            else:
+                request_id = str(uuid4())
+                self._pending[request_id] = PendingToolCall(event, tier)
+                await self._bus.publish(AgentEvent(kind="permission_request", ...))
+        else:
+            await self._bus.publish(event)  # non-tool events pass through immediately
+
+    async def on_permission_response(self, request_id: str, decision: str) -> None:
+        """Called when bus routes a permission_response back to the filter."""
+        pending = self._pending.pop(request_id)
+        if decision == "approve":
+            await self._bus.publish(pending.event)  # release the held tool_call
+        else:
+            await self._bus.publish(AgentEvent(kind="tool_result", payload={
+                "tool_id": pending.event.payload["tool_id"],
+                "is_error": True, "output": f"Permission denied: {decision}"
+            }))
+```
+
+### Bus Consumers
+
+| Consumer | Role |
+|----------|------|
+| `WSBroadcaster` | Forwards events to WebSockets with verbosity filtering |
+| `AuditLogger` | Persists events to `ACP_Audit_DB`, batched writes (flush every 100 events or 5s) |
+| `MetricsRecorder` | Updates Prometheus counters/histograms from `token_usage`, `tool_call`, `error` events |
+| `OrchestratorSink` | Updates orchestration task/run state (only active for orchestrated sessions) |
+
+All bus consumers are non-blocking. GovernanceFilter is the only component that can hold events, and it operates as a pipeline stage before the bus, not as a subscriber.
+
+### Consumer Interface
+
+```python
+class EventConsumer(ABC):
+    consumer_id: str
+    async def on_event(self, event: AgentEvent) -> None
+    async def start(self, bus: SessionEventBus) -> None
+    async def stop(self) -> None
+```
+
+### Governance Flow
+
+1. Adapter emits `tool_call` with `tool_name` → delivered to `GovernanceFilter.process()`
+2. GovernanceFilter checks policy, resolves permission tier
+3. If `auto`: forwards `tool_call` to bus immediately
+4. If `batch`/`individual`: holds `tool_call` in pending map, publishes `permission_request` to bus
+5. `WSBroadcaster` (bus consumer) forwards `permission_request` to WebUI
+6. User clicks approve → server calls `governance_filter.on_permission_response()`
+7. GovernanceFilter releases held `tool_call` to bus
+8. For `agent_side` execution: agent already has the tool result (it executed locally); adapter emits `tool_result`
+9. For `server_side` execution: `ToolExecutor` runs the tool, result sent back via `adapter.send_tool_result()`, adapter emits `tool_result`
+10. All bus consumers see `tool_result` normally
+
+---
+
+## 5. ACPRunnerClient Refactor
+
+Evolves from god object to thin coordinator.
+
+### New Architecture
+
+```
+WebSocket/REST → ACPRunnerClient → SessionEventBus → consumers (WS, audit, metrics, orchestrator)
+                       │                  ▲
+                       │                  │ events (gated)
+                       │           GovernanceFilter (pipeline stage)
+                       │                  ▲
+                       ▼                  │ raw events
+                 ProtocolAdapter ─────────┘
+                       │
+                       ▼
+                 subprocess / HTTP endpoint / MCP server
+                       │
+                 (ToolExecutor for server_side/hybrid mode)
+```
+
+### What Moves Out
+
+- Direct `ACPStdioClient` usage → replaced by `ProtocolAdapter`
+- Inline governance → `GovernanceFilter` pipeline stage
+- Inline WebSocket routing → `WSBroadcaster` consumer
+- Inline audit recording → `AuditLogger` consumer
+- Inline metrics → `MetricsRecorder` consumer
+- `PendingPermission` map → `GovernanceFilter`
+- `SessionWebSocketRegistry` → `WSBroadcaster`
+
+### What Stays
+
+- Session lifecycle (create, close, teardown)
+- Adapter + bus + consumer wiring
+- Sandbox delegation via `SandboxBridge`
+- Session state map
+- Fork/reconciliation
+
+### Migration Path (No Big Bang)
+
+- **Phase A**: `StdioAdapter` wraps existing `ACPStdioClient`. All 133 tests pass, behavior identical.
+- **Phase B**: `SessionEventBus` + `GovernanceFilter`. Permission logic moves out of runner.
+- **Phase C**: WSBroadcaster, AuditLogger, MetricsRecorder become consumers. Runner is thin.
+- **Phase D**: Add `MCPAdapter` and `OpenAIToolUseAdapter`. They just work.
+
+### Backward Compatibility
+
+- All existing REST/WebSocket endpoints unchanged
+- `agents.yaml` entries without `protocol` default to `"stdio"`
+- Existing session store, audit DB, metrics untouched
+
+---
+
+## 6. Sandbox Integration
+
+ACP delegates to the Sandbox module for isolated execution via `SandboxBridge`.
+
+### SandboxBridge
+
+```python
+class SandboxBridge:
+    def __init__(self, sandbox_service: SandboxService)
+    async def provision(self, request: SandboxProvisionRequest) -> SandboxHandle
+    async def teardown(self, handle: SandboxHandle) -> None
+    async def snapshot(self, handle: SandboxHandle) -> str
+    async def restore(self, handle: SandboxHandle, snapshot_id: str) -> None
+```
+
+### SandboxHandle
+
+```python
+@dataclass
+class SandboxHandle:
+    sandbox_session_id: str
+    run_id: str
+    process_stdin: StreamWriter | None    # for stdio adapter
+    process_stdout: StreamReader | None   # for stdio adapter
+    endpoint: str | None                  # for MCP/OpenAI adapter
+    ssh_endpoint: str | None              # for terminal access
+```
+
+### Adapter + Sandbox Connection
+
+| Protocol | How it connects through sandbox |
+|----------|-------------------------------|
+| stdio | Container starts agent binary, stdin/stdout piped to adapter |
+| MCP | Container starts agent in MCP server mode, port mapped, adapter connects to endpoint |
+| OpenAI tool-use | Container starts OpenAI-compatible server, adapter sends to endpoint |
+
+### Runtime Selection
+
+| Mode | Runtime | Rationale |
+|------|---------|-----------|
+| Single-user, local | None (no sandbox) | Direct process, adapter connects locally |
+| Single-user, wants isolation | Docker or seatbelt | User opts in |
+| Multi-user | Docker (default) | Always sandboxed |
+| Multi-user, heavy workload | Firecracker / Lima | Admin configures per-agent |
+
+### Deprecation
+
+`sandbox_runner_client.py` is deprecated. `SandboxBridge` replaces it as the integration seam.
+
+---
+
+## 7. Agent Registry Extension
+
+### New YAML Fields
+
+```yaml
+agents:
+  - type: claude-code
+    protocol: stdio                        # NEW: stdio | mcp | openai_tool_use
+    tool_execution_mode: agent_side        # NEW: agent executes tools internally
+    command: claude
+    args: ["--chat"]
+    # ... existing fields ...
+
+  - type: local-mcp-agent
+    protocol: mcp
+    tool_execution_mode: server_side       # NEW: server executes tools via ToolExecutor
+    mcp_transport: stdio                   # NEW: stdio | sse | streamable_http
+    command: /usr/local/bin/my-agent
+
+  - type: ollama-agent
+    protocol: openai_tool_use
+    tool_execution_mode: server_side       # NEW: server drives the tool call loop
+    api_base_url: http://localhost:11434/v1  # NEW
+    model: llama3.1                          # NEW
+    tools_from: auto                         # NEW: auto | static | none
+    sandbox: required                        # NEW: required | optional | none
+    trust_level: untrusted                   # NEW: untrusted | standard | trusted
+
+  - type: custom-hybrid-agent
+    protocol: stdio
+    tool_execution_mode: hybrid            # NEW: agent has local tools + server-provided tools
+    command: /usr/local/bin/my-hybrid-agent
+    sandbox: optional
+```
+
+### New Fields on AgentRegistryEntry
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `protocol` | `stdio \| mcp \| openai_tool_use` | `stdio` | Which adapter to use |
+| `tool_execution_mode` | `agent_side \| server_side \| hybrid` | `agent_side` | Who executes tools (see Section 3) |
+| `mcp_transport` | `stdio \| sse \| streamable_http` | `stdio` | MCP transport variant |
+| `api_base_url` | `str \| null` | null | HTTP-based protocol endpoint |
+| `model` | `str \| null` | null | Model ID for OpenAI adapter |
+| `tools_from` | `auto \| static \| none` | `auto` | Tool definition source |
+| `sandbox` | `required \| optional \| none` | `none` | Sandbox enforcement |
+| `trust_level` | `untrusted \| standard \| trusted` | `standard` | Default sandbox trust |
+
+### Availability Checks Per-Protocol
+
+- `stdio`: binary on PATH (existing)
+- `mcp`: binary on PATH or endpoint reachable
+- `openai_tool_use`: endpoint reachable + model exists
+
+---
+
+## 8. WebUI Event Contract
+
+### Verbosity Levels
+
+| Level | Events delivered |
+|-------|----------------|
+| `full` | Everything unfiltered |
+| `structured` | `tool_call`, `tool_result`, `file_change`, `permission_*`, `completion`, `error`, `status_change`. Thinking summarized. Terminal grouped. |
+| `summary` | `completion`, `error`, `permission_*`, `status_change` only |
+
+### WebSocket Protocol
+
+```json
+// Client → Server: configure on connect
+{"type": "configure", "verbosity": "full", "replay_from_sequence": 0}
+
+// Client → Server: change verbosity mid-session
+{"type": "configure", "verbosity": "structured"}
+
+// Client → Server: permission approval
+{"type": "permission_response", "request_id": "r1", "decision": "approve"}
+
+// Server → Client: AgentEvent stream (filtered by verbosity)
+{"session_id": "...", "sequence": 42, "kind": "tool_call", "payload": {...}, ...}
+```
+
+### Design Rationale
+
+- Verbosity is a UI concern — bus carries all events, WSBroadcaster filters per-connection
+- Replay on reconnect via `replay_from_sequence`
+- Reuses existing `WS /acp/sessions/{session_id}/stream` endpoint
+
+---
+
+## 9. Error Handling
+
+### Adapter Failures
+
+Adapter disconnect → `error {code: "adapter_disconnect", recoverable: true}` → ACPRunnerClient retries (max 3, exponential backoff) → if exhausted: `error {recoverable: false}`, session fails.
+
+### Sandbox Crashes
+
+Container exits → SandboxBridge detects → `error {code: "sandbox_crash", recoverable: false}` → session cleaned up, audit preserved → UI can offer restore-and-retry if snapshot exists.
+
+### Backpressure
+
+Subscriber queue full (1000 events) → warning logged → after 30s still full: consumer evicted → WSBroadcaster eviction closes WebSocket with 1008 → client reconnects with replay.
+
+### Permission Timeout
+
+`permission_request` unanswered for `timeout_sec` (default 300s) → `permission_response {decision: "deny", reason: "timeout"}` → agent continues without the tool. No session termination.
+
+---
+
+## 10. Security
+
+| Concern | Mitigation |
+|---------|-----------|
+| Arbitrary endpoint connection | `api_base_url` validated against allowlist in multi-user mode |
+| Event flooding | Bus enforces per-second rate limit (default 1000/s), adapter disconnected if exceeded |
+| Payload injection | Consumers treat payload as untrusted. WSBroadcaster sanitizes. AuditLogger parameterizes DB writes. |
+| Sandbox escape via adapter | Adapters receive structured events only, no shell access. Sandbox enforces network policy independently. |
+| Cross-user leakage | Bus is per-session, sessions are per-user. Auth checked at WS connect and REST endpoints. |
+| API key leakage | Adapters strip secrets from tool_call arguments. Audit logger redacts known secret patterns. |
+
+---
+
+## 11. Testing Strategy
+
+### Unit Tests
+
+| Component | Focus |
+|-----------|-------|
+| `AgentEvent` | Serialization, all 13 payload shapes, sequence ordering, heartbeat/lifecycle |
+| `StdioAdapter` | Message framing, event translation, disconnect, heartbeat emission |
+| `MCPAdapter` | All 3 transports, tool discovery, event mapping, agent-as-MCP-server model |
+| `OpenAIToolUseAdapter` | Streaming chunks, multi-turn tool call loop, errors, long-running `send_prompt()` |
+| `SessionEventBus` | Fan-out, ordering, replay, backpressure, inject, configurable buffer size |
+| `GovernanceFilter` | Pipeline stage behavior: hold/release tool_calls, all permission tiers, timeout, policy, denied tool result emission |
+| `ToolExecutor` | Server-side tool execution, tool registry, error handling |
+| `WSBroadcaster` | All 3 verbosity levels, reconnect replay, eviction, audit DB fallback for old sequences |
+| `SandboxBridge` | Provision/teardown, trust mapping, snapshot/restore |
+| `AdapterFactory` | Protocol resolution, plugin registration, tool_execution_mode wiring |
+
+### Integration Tests
+
+| Scenario | Coverage |
+|----------|----------|
+| Stdio end-to-end | Mock agent binary → StdioAdapter → GovernanceFilter → bus → WS |
+| MCP end-to-end | Mock MCP server → MCPAdapter → GovernanceFilter → bus → WS |
+| OpenAI end-to-end | Mock OpenAI server → OpenAIToolUseAdapter → ToolExecutor → bus → completion loop |
+| Permission flow (agent_side) | tool_call → GovernanceFilter holds → approval → release → agent executes |
+| Permission flow (server_side) | tool_call → GovernanceFilter holds → approval → ToolExecutor executes → result back to adapter |
+| Sandbox provisioning | SandboxBridge → Docker → adapter connects inside container → events flow out |
+| Reconnect replay (fast) | Connect → events → disconnect → reconnect with recent sequence → bus buffer replay |
+| Reconnect replay (slow) | Connect → many events → buffer rotates → disconnect → reconnect with old sequence → audit DB fallback |
+| Heartbeat liveness | Long tool execution → adapter emits heartbeats → UI receives them → no false disconnect |
+| Lifecycle events | Session create → sandbox_provisioned → agent_started → agent_ready → work → agent_exited |
+
+### Existing Tests Preserved
+
+- All 133 ACP tests pass through Phase A (StdioAdapter wraps existing client)
+- All 100 Sandbox tests untouched (SandboxBridge uses public SandboxService API)
+
+---
+
+## Appendix: Design Review Changes
+
+The following issues were identified during design review and incorporated into this document:
+
+| # | Issue | Severity | Resolution |
+|---|-------|----------|------------|
+| 1 | GovernanceFilter as bus subscriber can't block event delivery | High | Restructured as pipeline stage between adapter and bus (Section 4) |
+| 2 | Tool execution ownership undefined (who runs tools?) | High | Added `ToolExecutor` interface + `tool_execution_mode` registry field (Section 3) |
+| 3 | MCP adapter role ambiguity (client vs server?) | Medium | Explicitly documented agent-as-MCP-server model (Section 3) |
+| 4 | OpenAI adapter multi-turn loop not reflected in interface | Low | Documented `send_prompt()` long-running contract (Section 3) |
+| 5 | No heartbeat for long-running silent agents | Medium | Added `heartbeat` event kind (Section 2) |
+| 6 | Bus buffer exhaustion on long sessions breaks replay | Medium | Added audit DB fallback as slow-path replay (Section 4) |
+| 7 | Flat `AdapterConfig` optional fields won't scale to N protocols | Low | Replaced with `protocol_config: dict` validated per-adapter (Section 3) |
+| 8 | No lifecycle events for agent/sandbox state transitions | Medium | Added `lifecycle` event kind (Section 2) |

--- a/Docs/Plans/2026-03-16-acp-agent-workspace-harness-plan.md
+++ b/Docs/Plans/2026-03-16-acp-agent-workspace-harness-plan.md
@@ -1,0 +1,2301 @@
+# ACP Agent Workspace Harness Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a multi-protocol agent harness (stdio/MCP/OpenAI tool-use) with event bus architecture, accessible from WebUI/extension via ACP.
+
+**Architecture:** Protocol adapters translate agent wire formats into a uniform `AgentEvent` stream. A `GovernanceFilter` pipeline stage gates tool execution. A `SessionEventBus` fans events out to consumers (WebSocket broadcaster, audit logger, metrics, orchestrator). The existing Sandbox module handles container/VM isolation.
+
+**Tech Stack:** Python 3.11+, FastAPI, asyncio, Pydantic, pytest, SQLite (ACP_Audit_DB), existing ACP + Sandbox modules.
+
+**Design Doc:** `Docs/Plans/2026-03-16-acp-agent-workspace-harness-design.md`
+
+---
+
+## Phase A: AgentEvent Schema + ProtocolAdapter Interface + StdioAdapter
+
+Goal: Introduce the new abstractions without breaking any existing behavior. The `StdioAdapter` wraps the existing `ACPStdioClient`, all 133 ACP tests continue to pass.
+
+---
+
+### Task 1: AgentEvent Schema and EventKind Enum
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/events.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
+"""Unit tests for AgentEvent schema."""
+from __future__ import annotations
+
+import pytest
+import json
+from datetime import datetime, timezone
+
+pytestmark = pytest.mark.unit
+
+
+def test_agent_event_kind_enum_has_all_kinds():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+
+    expected = {
+        "thinking", "tool_call", "tool_result", "file_change",
+        "terminal_output", "permission_request", "permission_response",
+        "completion", "error", "status_change", "token_usage",
+        "heartbeat", "lifecycle",
+    }
+    assert {k.value for k in AgentEventKind} == expected
+
+
+def test_agent_event_creation_minimal():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    ev = AgentEvent(
+        session_id="sess-1",
+        kind=AgentEventKind.COMPLETION,
+        payload={"text": "Hello", "stop_reason": "end_turn"},
+    )
+    assert ev.session_id == "sess-1"
+    assert ev.kind == AgentEventKind.COMPLETION
+    assert ev.sequence == 0  # unassigned
+    assert ev.payload["text"] == "Hello"
+    assert isinstance(ev.timestamp, datetime)
+    assert ev.metadata == {}
+
+
+def test_agent_event_to_dict_roundtrip():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    ev = AgentEvent(
+        session_id="sess-2",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}, "permission_tier": "individual"},
+        metadata={"adapter": "stdio"},
+    )
+    d = ev.to_dict()
+    assert d["kind"] == "tool_call"
+    assert d["session_id"] == "sess-2"
+    assert d["payload"]["tool_name"] == "bash"
+    # Verify JSON-serializable
+    json.dumps(d)
+
+
+def test_agent_event_all_payload_shapes():
+    """Verify every event kind can be instantiated with its documented payload."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    payloads = {
+        AgentEventKind.THINKING: {"text": "hmm", "is_partial": False},
+        AgentEventKind.TOOL_CALL: {"tool_id": "t1", "tool_name": "read", "arguments": {}, "permission_tier": "auto"},
+        AgentEventKind.TOOL_RESULT: {"tool_id": "t1", "tool_name": "read", "output": "data", "is_error": False, "duration_ms": 42},
+        AgentEventKind.FILE_CHANGE: {"path": "/a.txt", "action": "create", "diff": None, "content": "hi"},
+        AgentEventKind.TERMINAL_OUTPUT: {"command": "ls", "output": "file.txt", "exit_code": 0, "is_partial": False},
+        AgentEventKind.PERMISSION_REQUEST: {"request_id": "r1", "tool_name": "bash", "arguments": {}, "tier": "individual", "timeout_sec": 300},
+        AgentEventKind.PERMISSION_RESPONSE: {"request_id": "r1", "decision": "approve", "reason": None},
+        AgentEventKind.COMPLETION: {"text": "done", "stop_reason": "end_turn"},
+        AgentEventKind.ERROR: {"code": "adapter_disconnect", "message": "lost", "recoverable": True},
+        AgentEventKind.STATUS_CHANGE: {"from_status": "idle", "to_status": "working"},
+        AgentEventKind.TOKEN_USAGE: {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        AgentEventKind.HEARTBEAT: {"elapsed_sec": 15, "state": "thinking"},
+        AgentEventKind.LIFECYCLE: {"event": "agent_started", "exit_code": None},
+    }
+    for kind, payload in payloads.items():
+        ev = AgentEvent(session_id="s", kind=kind, payload=payload)
+        d = ev.to_dict()
+        json.dumps(d)  # must be serializable
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py -v`
+Expected: FAIL — `ModuleNotFoundError` for `events`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/events.py
+"""AgentEvent schema — the core contract for the agent workspace harness."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class AgentEventKind(str, Enum):
+    """All event types in the agent event stream."""
+
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    FILE_CHANGE = "file_change"
+    TERMINAL_OUTPUT = "terminal_output"
+    PERMISSION_REQUEST = "permission_request"
+    PERMISSION_RESPONSE = "permission_response"
+    COMPLETION = "completion"
+    ERROR = "error"
+    STATUS_CHANGE = "status_change"
+    TOKEN_USAGE = "token_usage"
+    HEARTBEAT = "heartbeat"
+    LIFECYCLE = "lifecycle"
+
+
+@dataclass
+class AgentEvent:
+    """Single event in an agent session's event stream."""
+
+    session_id: str
+    kind: AgentEventKind
+    payload: dict[str, Any]
+    sequence: int = 0  # assigned by SessionEventBus
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable dict representation."""
+        return {
+            "session_id": self.session_id,
+            "sequence": self.sequence,
+            "timestamp": self.timestamp.isoformat(),
+            "kind": self.kind.value,
+            "payload": self.payload,
+            "metadata": self.metadata,
+        }
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py -v`
+Expected: 4 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/events.py tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
+git commit -m "feat(acp): add AgentEvent schema and AgentEventKind enum"
+```
+
+---
+
+### Task 2: ProtocolAdapter ABC + AdapterConfig + AdapterFactory
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py`
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py`
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/adapters/factory.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py
+"""Unit tests for ProtocolAdapter ABC and AdapterFactory."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_protocol_adapter_is_abstract():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import ProtocolAdapter
+
+    with pytest.raises(TypeError, match="abstract"):
+        ProtocolAdapter()
+
+
+def test_adapter_config_creation():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    async def noop(ev):
+        pass
+
+    cfg = AdapterConfig(event_callback=noop, session_id="s1", protocol_config={"key": "val"})
+    assert cfg.session_id == "s1"
+    assert cfg.protocol_config["key"] == "val"
+
+
+def test_adapter_factory_register_and_create():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import ProtocolAdapter, AdapterConfig
+
+    class FakeAdapter(ProtocolAdapter):
+        protocol_name = "fake"
+
+        async def connect(self, config: AdapterConfig) -> None: pass
+        async def disconnect(self) -> None: pass
+        async def send_prompt(self, messages, options=None) -> None: pass
+        async def send_tool_result(self, tool_id, result, is_error) -> None: pass
+        async def cancel(self) -> None: pass
+
+        @property
+        def is_connected(self) -> bool: return False
+
+        @property
+        def supports_streaming(self) -> bool: return True
+
+    factory = AdapterFactory()
+    factory.register("fake", FakeAdapter)
+    adapter = factory.create("fake")
+    assert isinstance(adapter, FakeAdapter)
+    assert adapter.protocol_name == "fake"
+
+
+def test_adapter_factory_unknown_protocol_raises():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+
+    factory = AdapterFactory()
+    with pytest.raises(ValueError, match="Unknown protocol"):
+        factory.create("nonexistent")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
+"""Protocol adapter subsystem for multi-protocol agent support."""
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+    AdapterConfig,
+    PromptOptions,
+    ProtocolAdapter,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+
+__all__ = ["AdapterConfig", "AdapterFactory", "PromptOptions", "ProtocolAdapter"]
+```
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py
+"""ProtocolAdapter ABC and AdapterConfig."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+@dataclass
+class PromptOptions:
+    """Options for send_prompt()."""
+    max_tokens: int | None = None
+    timeout_sec: int | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AdapterConfig:
+    """Configuration passed to ProtocolAdapter.connect()."""
+    event_callback: Callable[[AgentEvent], Awaitable[None]]
+    session_id: str
+    protocol_config: dict[str, Any] = field(default_factory=dict)
+
+
+class ProtocolAdapter(ABC):
+    """Translates between an agent's native protocol and AgentEvent stream."""
+
+    protocol_name: str  # set by subclass
+
+    @abstractmethod
+    async def connect(self, config: AdapterConfig) -> None:
+        """Establish connection to the agent process/endpoint."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Gracefully close the connection."""
+
+    @abstractmethod
+    async def send_prompt(self, messages: list[dict[str, Any]], options: PromptOptions | None = None) -> None:
+        """Send a user prompt. Events flow back via event_callback.
+
+        This method is async and may run for an extended period — the agent's
+        full turn. Events stream via event_callback throughout execution.
+        Returns when the agent's turn is complete or on unrecoverable error.
+        """
+
+    @abstractmethod
+    async def send_tool_result(self, tool_id: str, result: str, is_error: bool) -> None:
+        """Return a tool execution result to the agent."""
+
+    @abstractmethod
+    async def cancel(self) -> None:
+        """Cancel the current in-flight request."""
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool: ...
+
+    @property
+    @abstractmethod
+    def supports_streaming(self) -> bool: ...
+```
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/adapters/factory.py
+"""AdapterFactory — creates the right adapter for a given protocol."""
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import ProtocolAdapter
+
+
+class AdapterFactory:
+    """Creates ProtocolAdapter instances by protocol name."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, type[ProtocolAdapter]] = {}
+
+    def register(self, protocol: str, adapter_cls: type[ProtocolAdapter]) -> None:
+        """Register an adapter class for a protocol name."""
+        self._registry[protocol] = adapter_cls
+
+    def create(self, protocol: str) -> ProtocolAdapter:
+        """Instantiate an adapter for the given protocol."""
+        cls = self._registry.get(protocol)
+        if cls is None:
+            raise ValueError(f"Unknown protocol: {protocol!r}")
+        return cls()
+
+    def available_protocols(self) -> list[str]:
+        """Return registered protocol names."""
+        return list(self._registry.keys())
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py -v`
+Expected: 4 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/adapters/
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py
+git commit -m "feat(acp): add ProtocolAdapter ABC, AdapterConfig, and AdapterFactory"
+```
+
+---
+
+### Task 3: StdioAdapter — Wraps Existing ACPStdioClient
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py`
+
+**Context:** The existing `ACPStdioClient` (in `stdio_client.py`) uses JSON-RPC 2.0 over stdin/stdout. Key methods: `start()`, `close()`, `call(method, params)`, `notify(method, params)`, `set_request_handler()`, `set_notification_handler()`. It spawns a subprocess and reads/writes JSON frames.
+
+The `StdioAdapter` wraps this client, translating JSON-RPC messages into `AgentEvent`s. The existing `runner_client.py` receives JSON-RPC notifications like `{"method": "update", "params": {"type": "tool_use", ...}}` and routes them. The adapter does the same translation.
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
+"""Unit tests for StdioAdapter."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def collected_events():
+    return []
+
+
+@pytest.fixture
+def event_callback(collected_events):
+    async def _cb(event):
+        collected_events.append(event)
+    return _cb
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_protocol_name():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    adapter = StdioAdapter()
+    assert adapter.protocol_name == "stdio"
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_not_connected_initially():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    adapter = StdioAdapter()
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_supports_streaming():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    adapter = StdioAdapter()
+    assert adapter.supports_streaming is True
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_completion_notification(event_callback, collected_events):
+    """Verify that a JSON-RPC notification with method='result' becomes a completion AgentEvent."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from unittest.mock import AsyncMock, MagicMock
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=event_callback,
+        session_id="test-sess",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+    assert adapter.is_connected is True
+
+    # Simulate the notification handler being called with a result notification
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="result",
+        params={"type": "text", "text": "Hello world", "stop_reason": "end_turn"},
+    )
+    await adapter._handle_notification(notification)
+
+    assert len(collected_events) == 1
+    assert collected_events[0].kind == AgentEventKind.COMPLETION
+    assert collected_events[0].payload["text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_tool_use_notification(event_callback, collected_events):
+    """Verify tool_use notification becomes tool_call AgentEvent."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+    from unittest.mock import AsyncMock
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=event_callback,
+        session_id="test-sess",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="update",
+        params={"type": "tool_use", "tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}},
+    )
+    await adapter._handle_notification(notification)
+
+    assert len(collected_events) == 1
+    assert collected_events[0].kind == AgentEventKind.TOOL_CALL
+    assert collected_events[0].payload["tool_name"] == "bash"
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_disconnect(event_callback):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from unittest.mock import AsyncMock
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=event_callback,
+        session_id="test-sess",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+    assert adapter.is_connected is True
+
+    await adapter.disconnect()
+    mock_client.close.assert_awaited_once()
+    assert adapter.is_connected is False
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py -v`
+Expected: FAIL — `ModuleNotFoundError` for `stdio_adapter`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+"""StdioAdapter — wraps ACPStdioClient to produce AgentEvent stream."""
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+    AdapterConfig,
+    PromptOptions,
+    ProtocolAdapter,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+
+class StdioAdapter(ProtocolAdapter):
+    """Wraps ACPStdioClient, translating JSON-RPC messages to AgentEvents."""
+
+    protocol_name = "stdio"
+
+    def __init__(self) -> None:
+        self._client: Any | None = None
+        self._config: AdapterConfig | None = None
+        self._connected = False
+
+    async def connect(self, config: AdapterConfig) -> None:
+        self._config = config
+        self._client = config.protocol_config.get("client")
+        if self._client is None:
+            raise ValueError("StdioAdapter requires 'client' in protocol_config")
+        self._client.set_notification_handler(self._handle_notification)
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await self._client.close()
+        self._connected = False
+
+    async def send_prompt(self, messages: list[dict[str, Any]], options: PromptOptions | None = None) -> None:
+        if self._client is None:
+            raise RuntimeError("Not connected")
+        await self._client.call("prompt", {"messages": messages})
+
+    async def send_tool_result(self, tool_id: str, result: str, is_error: bool) -> None:
+        if self._client is None:
+            raise RuntimeError("Not connected")
+        await self._client.call("tool_result", {
+            "tool_id": tool_id,
+            "result": result,
+            "is_error": is_error,
+        })
+
+    async def cancel(self) -> None:
+        if self._client is None:
+            raise RuntimeError("Not connected")
+        await self._client.notify("cancel", {})
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    # --- Internal notification translation ---
+
+    async def _handle_notification(self, msg: ACPMessage) -> None:
+        """Translate JSON-RPC notifications from the agent into AgentEvents."""
+        if self._config is None:
+            return
+
+        params = msg.params or {}
+        method = msg.method or ""
+        event: AgentEvent | None = None
+
+        if method == "result":
+            event = self._translate_result(params)
+        elif method == "update":
+            event = self._translate_update(params)
+        elif method == "error":
+            event = AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.ERROR,
+                payload={
+                    "code": params.get("code", "agent_error"),
+                    "message": params.get("message", str(params)),
+                    "recoverable": params.get("recoverable", False),
+                },
+            )
+        else:
+            logger.debug(f"StdioAdapter: ignoring unknown notification method={method}")
+            return
+
+        if event is not None:
+            await self._config.event_callback(event)
+
+    def _translate_result(self, params: dict[str, Any]) -> AgentEvent:
+        """Translate a 'result' notification into a completion or tool_result event."""
+        assert self._config is not None
+        result_type = params.get("type", "text")
+
+        if result_type == "tool_result":
+            return AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "output": params.get("output", ""),
+                    "is_error": params.get("is_error", False),
+                    "duration_ms": params.get("duration_ms", 0),
+                },
+            )
+        # Default: completion
+        return AgentEvent(
+            session_id=self._config.session_id,
+            kind=AgentEventKind.COMPLETION,
+            payload={
+                "text": params.get("text", ""),
+                "stop_reason": params.get("stop_reason", "end_turn"),
+            },
+        )
+
+    def _translate_update(self, params: dict[str, Any]) -> AgentEvent | None:
+        """Translate an 'update' notification into the appropriate AgentEvent."""
+        assert self._config is not None
+        update_type = params.get("type", "")
+
+        if update_type == "tool_use":
+            tool_name = params.get("tool_name", "")
+            return AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.TOOL_CALL,
+                payload={
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": tool_name,
+                    "arguments": params.get("arguments", {}),
+                    "permission_tier": determine_permission_tier(tool_name),
+                },
+            )
+        elif update_type == "tool_result":
+            return AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "output": params.get("output", ""),
+                    "is_error": params.get("is_error", False),
+                    "duration_ms": params.get("duration_ms", 0),
+                },
+            )
+        elif update_type == "thinking":
+            return AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.THINKING,
+                payload={
+                    "text": params.get("text", ""),
+                    "is_partial": params.get("is_partial", True),
+                },
+            )
+        elif update_type == "permission_request":
+            return AgentEvent(
+                session_id=self._config.session_id,
+                kind=AgentEventKind.PERMISSION_REQUEST,
+                payload={
+                    "request_id": params.get("request_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "arguments": params.get("arguments", {}),
+                    "tier": params.get("tier", "batch"),
+                    "timeout_sec": params.get("timeout_sec", 300),
+                },
+            )
+        else:
+            logger.debug(f"StdioAdapter: ignoring unknown update type={update_type}")
+            return None
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py -v`
+Expected: 6 PASSED
+
+**Step 5: Register StdioAdapter in factory and update __init__.py**
+
+Add to `adapters/__init__.py`:
+```python
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+```
+
+**Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
+git add tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
+git commit -m "feat(acp): add StdioAdapter wrapping ACPStdioClient"
+```
+
+---
+
+### Task 4: SessionEventBus
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/event_bus.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py
+"""Unit tests for SessionEventBus."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(session_id="s1", kind_str="completion"):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind(kind_str),
+        payload={"text": "test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_bus_assigns_sequence_numbers():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("c1")
+
+    ev1 = _make_event()
+    ev2 = _make_event()
+    await bus.publish(ev1)
+    await bus.publish(ev2)
+
+    r1 = q.get_nowait()
+    r2 = q.get_nowait()
+    assert r1.sequence == 1
+    assert r2.sequence == 2
+
+
+@pytest.mark.asyncio
+async def test_bus_fan_out_to_multiple_subscribers():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1")
+    q1 = bus.subscribe("c1")
+    q2 = bus.subscribe("c2")
+
+    await bus.publish(_make_event())
+
+    assert not q1.empty()
+    assert not q2.empty()
+    assert q1.get_nowait().sequence == q2.get_nowait().sequence == 1
+
+
+@pytest.mark.asyncio
+async def test_bus_unsubscribe_stops_delivery():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("c1")
+    bus.unsubscribe("c1")
+
+    await bus.publish(_make_event())
+    assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_bus_snapshot_returns_history():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1", max_buffer=100)
+    for _ in range(5):
+        await bus.publish(_make_event())
+
+    snap = bus.snapshot(from_sequence=3)
+    assert len(snap) == 3  # sequences 3, 4, 5
+    assert snap[0].sequence == 3
+
+
+@pytest.mark.asyncio
+async def test_bus_snapshot_respects_buffer_limit():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1", max_buffer=3)
+    for _ in range(5):
+        await bus.publish(_make_event())
+
+    # Buffer only holds last 3 (sequences 3, 4, 5)
+    snap = bus.snapshot(from_sequence=1)
+    assert len(snap) == 3
+    assert snap[0].sequence == 3
+
+
+@pytest.mark.asyncio
+async def test_bus_inject_delivers_event():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("c1")
+
+    ev = _make_event(kind_str="permission_response")
+    await bus.inject(ev)
+
+    r = q.get_nowait()
+    assert r.kind.value == "permission_response"
+    assert r.sequence == 1  # inject also gets a sequence number
+
+
+@pytest.mark.asyncio
+async def test_bus_backpressure_drops_to_full_queue():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus("s1", subscriber_queue_size=2)
+    q = bus.subscribe("c1")
+
+    # Fill the queue
+    await bus.publish(_make_event())
+    await bus.publish(_make_event())
+    # Third should not raise but queue is full — event dropped for this subscriber
+    await bus.publish(_make_event())
+
+    assert q.qsize() == 2  # only 2 fit
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/event_bus.py
+"""SessionEventBus — per-session event fan-out with ordering guarantees."""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class SessionEventBus:
+    """Per-session event fan-out with monotonic sequencing and bounded history."""
+
+    def __init__(
+        self,
+        session_id: str,
+        max_buffer: int = 10_000,
+        subscriber_queue_size: int = 1_000,
+    ) -> None:
+        self._session_id = session_id
+        self._sequence = 0
+        self._subscribers: dict[str, asyncio.Queue[AgentEvent]] = {}
+        self._history: deque[AgentEvent] = deque(maxlen=max_buffer)
+        self._subscriber_queue_size = subscriber_queue_size
+
+    async def publish(self, event: AgentEvent) -> None:
+        """Assign sequence number and distribute to all subscribers."""
+        self._sequence += 1
+        event.sequence = self._sequence
+        self._history.append(event)
+        await self._distribute(event)
+
+    async def inject(self, event: AgentEvent) -> None:
+        """Inject an external event (e.g., permission_response). Same as publish."""
+        await self.publish(event)
+
+    def subscribe(
+        self, consumer_id: str, from_sequence: int = 0
+    ) -> asyncio.Queue[AgentEvent]:
+        """Subscribe to events. If from_sequence > 0, replay from history."""
+        q: asyncio.Queue[AgentEvent] = asyncio.Queue(
+            maxsize=self._subscriber_queue_size
+        )
+        self._subscribers[consumer_id] = q
+
+        if from_sequence > 0:
+            for ev in self._history:
+                if ev.sequence >= from_sequence:
+                    try:
+                        q.put_nowait(ev)
+                    except asyncio.QueueFull:
+                        break
+        return q
+
+    def unsubscribe(self, consumer_id: str) -> None:
+        """Remove a subscriber."""
+        self._subscribers.pop(consumer_id, None)
+
+    def snapshot(self, from_sequence: int = 0) -> list[AgentEvent]:
+        """Return event history from a given sequence."""
+        return [ev for ev in self._history if ev.sequence >= from_sequence]
+
+    @property
+    def min_sequence(self) -> int:
+        """Earliest sequence still in the buffer, or 0 if empty."""
+        return self._history[0].sequence if self._history else 0
+
+    @property
+    def current_sequence(self) -> int:
+        """Current (latest) sequence number."""
+        return self._sequence
+
+    async def _distribute(self, event: AgentEvent) -> None:
+        """Send event to all subscriber queues. Drop on full queue."""
+        for consumer_id, q in list(self._subscribers.items()):
+            try:
+                q.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.warning(
+                    f"SessionEventBus: queue full for consumer={consumer_id}, "
+                    f"session={self._session_id}, dropping event seq={event.sequence}"
+                )
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py -v`
+Expected: 7 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/event_bus.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py
+git commit -m "feat(acp): add SessionEventBus with sequencing, fan-out, and replay"
+```
+
+---
+
+### Task 5: GovernanceFilter Pipeline Stage
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
+"""Unit tests for GovernanceFilter pipeline stage."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_tool_call_event(session_id="s1", tool_name="bash"):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.TOOL_CALL,
+        payload={
+            "tool_id": "t1",
+            "tool_name": tool_name,
+            "arguments": {"cmd": "ls"},
+            "permission_tier": "individual",
+        },
+    )
+
+
+def _make_thinking_event(session_id="s1"):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+    return AgentEvent(
+        session_id=session_id,
+        kind=AgentEventKind.THINKING,
+        payload={"text": "hmm", "is_partial": False},
+    )
+
+
+@pytest.mark.asyncio
+async def test_governance_passes_non_tool_events_immediately():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("test")
+    gf = GovernanceFilter(bus=bus)
+
+    ev = _make_thinking_event()
+    await gf.process(ev)
+
+    assert not q.empty()
+    assert q.get_nowait().kind.value == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_governance_auto_tier_passes_through():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("test")
+    gf = GovernanceFilter(bus=bus)
+
+    # "read_file" matches "read" → auto tier
+    ev = _make_tool_call_event(tool_name="read_file")
+    await gf.process(ev)
+
+    assert not q.empty()
+    result = q.get_nowait()
+    assert result.kind.value == "tool_call"
+
+
+@pytest.mark.asyncio
+async def test_governance_individual_tier_holds_and_emits_permission_request():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("test")
+    gf = GovernanceFilter(bus=bus)
+
+    ev = _make_tool_call_event(tool_name="bash")  # "bash" → individual
+    await gf.process(ev)
+
+    # Should emit permission_request, NOT the tool_call
+    result = q.get_nowait()
+    assert result.kind.value == "permission_request"
+    assert result.payload["tool_name"] == "bash"
+    assert q.empty()  # tool_call is held
+
+    # Pending count
+    assert gf.pending_count == 1
+
+
+@pytest.mark.asyncio
+async def test_governance_approve_releases_held_tool_call():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("test")
+    gf = GovernanceFilter(bus=bus)
+
+    ev = _make_tool_call_event(tool_name="bash")
+    await gf.process(ev)
+
+    perm_req = q.get_nowait()
+    request_id = perm_req.payload["request_id"]
+
+    await gf.on_permission_response(request_id, "approve")
+
+    released = q.get_nowait()
+    assert released.kind.value == "tool_call"
+    assert released.payload["tool_name"] == "bash"
+    assert gf.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_governance_deny_emits_error_tool_result():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    bus = SessionEventBus("s1")
+    q = bus.subscribe("test")
+    gf = GovernanceFilter(bus=bus)
+
+    ev = _make_tool_call_event(tool_name="delete_all")  # "delete" → individual
+    await gf.process(ev)
+
+    perm_req = q.get_nowait()
+    request_id = perm_req.payload["request_id"]
+
+    await gf.on_permission_response(request_id, "deny")
+
+    denied = q.get_nowait()
+    assert denied.kind.value == "tool_result"
+    assert denied.payload["is_error"] is True
+    assert "denied" in denied.payload["output"].lower()
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+"""GovernanceFilter — pipeline stage between adapter and bus that gates tool execution."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
+
+
+@dataclass
+class PendingToolCall:
+    """A tool_call event held pending permission approval."""
+
+    event: AgentEvent
+    tier: str
+    request_id: str
+
+
+class GovernanceFilter:
+    """Pipeline stage between adapter and bus. NOT a bus consumer.
+
+    Intercepts tool_call events, checks permission tier, and either:
+    - Forwards immediately (auto tier)
+    - Holds and emits permission_request (batch/individual tiers)
+    """
+
+    def __init__(
+        self,
+        bus: SessionEventBus,
+        default_timeout_sec: int = 300,
+    ) -> None:
+        self._bus = bus
+        self._pending: dict[str, PendingToolCall] = {}
+        self._default_timeout_sec = default_timeout_sec
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    async def process(self, event: AgentEvent) -> None:
+        """Called by adapter's event_callback. Gates tool_calls, forwards everything else."""
+        if event.kind != AgentEventKind.TOOL_CALL:
+            await self._bus.publish(event)
+            return
+
+        tool_name = event.payload.get("tool_name", "")
+        tier = determine_permission_tier(tool_name)
+
+        if tier == "auto":
+            await self._bus.publish(event)
+            return
+
+        # Hold the tool_call and emit a permission_request
+        request_id = str(uuid4())
+        self._pending[request_id] = PendingToolCall(
+            event=event, tier=tier, request_id=request_id,
+        )
+
+        perm_event = AgentEvent(
+            session_id=event.session_id,
+            kind=AgentEventKind.PERMISSION_REQUEST,
+            payload={
+                "request_id": request_id,
+                "tool_name": tool_name,
+                "arguments": event.payload.get("arguments", {}),
+                "tier": tier,
+                "timeout_sec": self._default_timeout_sec,
+            },
+        )
+        await self._bus.publish(perm_event)
+
+    async def on_permission_response(self, request_id: str, decision: str, reason: str | None = None) -> None:
+        """Handle a permission decision. Releases or denies the held tool_call."""
+        pending = self._pending.pop(request_id, None)
+        if pending is None:
+            logger.warning(f"GovernanceFilter: unknown request_id={request_id}")
+            return
+
+        if decision == "approve":
+            await self._bus.publish(pending.event)
+        else:
+            await self._bus.publish(AgentEvent(
+                session_id=pending.event.session_id,
+                kind=AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool_id": pending.event.payload.get("tool_id", ""),
+                    "tool_name": pending.event.payload.get("tool_name", ""),
+                    "output": f"Permission denied: {reason or decision}",
+                    "is_error": True,
+                    "duration_ms": 0,
+                },
+            ))
+
+    async def cancel_all_pending(self) -> None:
+        """Cancel all pending permission requests (e.g., on session close)."""
+        for request_id in list(self._pending.keys()):
+            await self.on_permission_response(request_id, "deny", reason="session_closed")
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py -v`
+Expected: 5 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
+git commit -m "feat(acp): add GovernanceFilter pipeline stage for tool permission gating"
+```
+
+---
+
+### Task 6: EventConsumer ABC + WSBroadcaster Consumer
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py`
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/consumers/base.py`
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+"""Unit tests for WSBroadcaster consumer."""
+from __future__ import annotations
+
+import asyncio
+import json
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(kind_str="completion"):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+    return AgentEvent(session_id="s1", kind=AgentEventKind(kind_str), payload={"text": "test"})
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_delivers_events_full_verbosity():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+
+    bus = SessionEventBus("s1")
+    broadcaster = WSBroadcaster(bus=bus)
+
+    received = []
+    async def mock_send(data):
+        received.append(json.loads(data) if isinstance(data, str) else data)
+
+    broadcaster.add_connection("ws1", mock_send, verbosity="full")
+    await broadcaster.start()
+
+    await bus.publish(_make_event("completion"))
+    await bus.publish(_make_event("thinking"))
+
+    await asyncio.sleep(0.05)  # let consumer loop process
+    await broadcaster.stop()
+
+    assert len(received) == 2
+    assert received[0]["kind"] == "completion"
+    assert received[1]["kind"] == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_summary_filters_thinking():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+
+    bus = SessionEventBus("s1")
+    broadcaster = WSBroadcaster(bus=bus)
+
+    received = []
+    async def mock_send(data):
+        received.append(json.loads(data) if isinstance(data, str) else data)
+
+    broadcaster.add_connection("ws1", mock_send, verbosity="summary")
+    await broadcaster.start()
+
+    await bus.publish(_make_event("thinking"))
+    await bus.publish(_make_event("completion"))
+    await bus.publish(_make_event("tool_call"))
+
+    await asyncio.sleep(0.05)
+    await broadcaster.stop()
+
+    # summary only delivers: completion, error, permission_*, status_change
+    assert len(received) == 1
+    assert received[0]["kind"] == "completion"
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_remove_connection():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+
+    bus = SessionEventBus("s1")
+    broadcaster = WSBroadcaster(bus=bus)
+
+    received = []
+    async def mock_send(data):
+        received.append(data)
+
+    broadcaster.add_connection("ws1", mock_send, verbosity="full")
+    broadcaster.remove_connection("ws1")
+    await broadcaster.start()
+
+    await bus.publish(_make_event("completion"))
+    await asyncio.sleep(0.05)
+    await broadcaster.stop()
+
+    assert len(received) == 0
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_change_verbosity():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+
+    bus = SessionEventBus("s1")
+    broadcaster = WSBroadcaster(bus=bus)
+
+    received = []
+    async def mock_send(data):
+        received.append(json.loads(data) if isinstance(data, str) else data)
+
+    broadcaster.add_connection("ws1", mock_send, verbosity="summary")
+    broadcaster.set_verbosity("ws1", "full")
+    await broadcaster.start()
+
+    await bus.publish(_make_event("thinking"))
+    await asyncio.sleep(0.05)
+    await broadcaster.stop()
+
+    # After switching to full, thinking should come through
+    assert len(received) == 1
+    assert received[0]["kind"] == "thinking"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py
+"""Event bus consumers."""
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+
+__all__ = ["EventConsumer"]
+```
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/consumers/base.py
+"""EventConsumer ABC."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class EventConsumer(ABC):
+    """Base class for bus consumers."""
+
+    consumer_id: str
+
+    @abstractmethod
+    async def on_event(self, event: AgentEvent) -> None:
+        """Process an event."""
+
+    @abstractmethod
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to bus and begin processing loop."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Unsubscribe and clean up."""
+```
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+"""WSBroadcaster — forwards events to WebSocket connections with verbosity filtering."""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+# Events delivered at each verbosity level
+_SUMMARY_KINDS = {"completion", "error", "permission_request", "permission_response", "status_change"}
+_STRUCTURED_KINDS = _SUMMARY_KINDS | {"tool_call", "tool_result", "file_change", "lifecycle"}
+
+
+@dataclass
+class _WSConnection:
+    send: Callable[[str], Awaitable[None]]
+    verbosity: str = "full"
+
+
+class WSBroadcaster(EventConsumer):
+    """Forwards AgentEvents to WebSocket connections with per-connection verbosity filtering."""
+
+    consumer_id = "ws_broadcaster"
+
+    def __init__(self, bus: SessionEventBus) -> None:
+        self._bus = bus
+        self._connections: dict[str, _WSConnection] = {}
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    def add_connection(
+        self,
+        conn_id: str,
+        send_callback: Callable[[str], Awaitable[None]],
+        verbosity: str = "full",
+    ) -> None:
+        self._connections[conn_id] = _WSConnection(send=send_callback, verbosity=verbosity)
+
+    def remove_connection(self, conn_id: str) -> None:
+        self._connections.pop(conn_id, None)
+
+    def set_verbosity(self, conn_id: str, verbosity: str) -> None:
+        conn = self._connections.get(conn_id)
+        if conn:
+            conn.verbosity = verbosity
+
+    async def start(self, bus: SessionEventBus | None = None) -> None:
+        if bus is not None:
+            self._bus = bus
+        self._queue = self._bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        self._running = False
+        self._bus.unsubscribe(self.consumer_id)
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def on_event(self, event: AgentEvent) -> None:
+        await self._broadcast(event)
+
+    async def _consume_loop(self) -> None:
+        assert self._queue is not None
+        while self._running:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+                await self._broadcast(event)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    async def _broadcast(self, event: AgentEvent) -> None:
+        kind_str = event.kind.value
+        data = json.dumps(event.to_dict())
+
+        for conn_id, conn in list(self._connections.items()):
+            if not self._should_deliver(kind_str, conn.verbosity):
+                continue
+            try:
+                await conn.send(data)
+            except Exception:
+                logger.warning(f"WSBroadcaster: failed to send to {conn_id}, removing")
+                self._connections.pop(conn_id, None)
+
+    @staticmethod
+    def _should_deliver(kind: str, verbosity: str) -> bool:
+        if verbosity == "full":
+            return True
+        if verbosity == "summary":
+            return kind in _SUMMARY_KINDS
+        if verbosity == "structured":
+            return kind in _STRUCTURED_KINDS
+        return True  # unknown verbosity → deliver
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py -v`
+Expected: 4 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/consumers/
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+git commit -m "feat(acp): add EventConsumer ABC and WSBroadcaster with verbosity filtering"
+```
+
+---
+
+### Task 7: AuditLogger + MetricsRecorder Consumers
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py`
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py`
+
+These are simpler consumers. AuditLogger batches events and writes to the existing `ACP_Audit_DB`. MetricsRecorder updates the existing Prometheus metrics from `metrics.py`.
+
+**Step 1: Write the failing tests**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+"""Unit tests for AuditLogger and MetricsRecorder consumers."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(kind_str="completion"):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+    return AgentEvent(session_id="s1", kind=AgentEventKind(kind_str), payload={"text": "test"})
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_batches_events():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.audit_logger import AuditLogger
+
+    bus = SessionEventBus("s1")
+    written = []
+
+    async def mock_write_batch(events):
+        written.extend(events)
+
+    logger_consumer = AuditLogger(bus=bus, write_batch_fn=mock_write_batch, flush_interval=0.05, batch_size=3)
+    await logger_consumer.start()
+
+    # Publish 3 events to trigger batch flush
+    for _ in range(3):
+        await bus.publish(_make_event())
+
+    await asyncio.sleep(0.1)
+    await logger_consumer.stop()
+
+    assert len(written) == 3
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_flushes_on_interval():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.audit_logger import AuditLogger
+
+    bus = SessionEventBus("s1")
+    written = []
+
+    async def mock_write_batch(events):
+        written.extend(events)
+
+    logger_consumer = AuditLogger(bus=bus, write_batch_fn=mock_write_batch, flush_interval=0.05, batch_size=100)
+    await logger_consumer.start()
+
+    await bus.publish(_make_event())
+    # Only 1 event, batch_size=100, but flush_interval=0.05s should trigger
+    await asyncio.sleep(0.15)
+    await logger_consumer.stop()
+
+    assert len(written) == 1
+
+
+@pytest.mark.asyncio
+async def test_metrics_recorder_counts_tool_calls():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.metrics_recorder import MetricsRecorder
+
+    bus = SessionEventBus("s1")
+    recorder = MetricsRecorder(bus=bus)
+    await recorder.start()
+
+    await bus.publish(_make_event("tool_call"))
+    await bus.publish(_make_event("tool_call"))
+    await bus.publish(_make_event("completion"))
+
+    await asyncio.sleep(0.05)
+    await recorder.stop()
+
+    assert recorder.counters["tool_call"] == 2
+    assert recorder.counters["completion"] == 1
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementations**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
+"""AuditLogger — persists AgentEvents to durable storage in batches."""
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Awaitable, Callable
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class AuditLogger(EventConsumer):
+    """Batches events and writes to durable storage."""
+
+    consumer_id = "audit_logger"
+
+    def __init__(
+        self,
+        bus: SessionEventBus,
+        write_batch_fn: Callable[[list[AgentEvent]], Awaitable[None]],
+        batch_size: int = 100,
+        flush_interval: float = 5.0,
+    ) -> None:
+        self._bus = bus
+        self._write_batch = write_batch_fn
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval
+        self._buffer: list[AgentEvent] = []
+        self._last_flush = time.monotonic()
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    async def start(self, bus: SessionEventBus | None = None) -> None:
+        if bus is not None:
+            self._bus = bus
+        self._queue = self._bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        self._running = False
+        self._bus.unsubscribe(self.consumer_id)
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        await self._flush()
+
+    async def on_event(self, event: AgentEvent) -> None:
+        self._buffer.append(event)
+        if len(self._buffer) >= self._batch_size:
+            await self._flush()
+
+    async def _consume_loop(self) -> None:
+        assert self._queue is not None
+        while self._running:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=self._flush_interval)
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                if self._buffer:
+                    await self._flush()
+            except asyncio.CancelledError:
+                break
+
+    async def _flush(self) -> None:
+        if not self._buffer:
+            return
+        batch = self._buffer[:]
+        self._buffer.clear()
+        self._last_flush = time.monotonic()
+        try:
+            await self._write_batch(batch)
+        except Exception:
+            logger.exception("AuditLogger: failed to write batch")
+```
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
+"""MetricsRecorder — updates counters from AgentEvents."""
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class MetricsRecorder(EventConsumer):
+    """Counts events by kind. Integrates with Prometheus via existing metrics module."""
+
+    consumer_id = "metrics_recorder"
+
+    def __init__(self, bus: SessionEventBus) -> None:
+        self._bus = bus
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+        self.counters: Counter[str] = Counter()
+
+    async def start(self, bus: SessionEventBus | None = None) -> None:
+        if bus is not None:
+            self._bus = bus
+        self._queue = self._bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        self._running = False
+        self._bus.unsubscribe(self.consumer_id)
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def on_event(self, event: AgentEvent) -> None:
+        self.counters[event.kind.value] += 1
+
+    async def _consume_loop(self) -> None:
+        assert self._queue is not None
+        while self._running:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py -v`
+Expected: 3 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
+git add tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+git commit -m "feat(acp): add AuditLogger and MetricsRecorder event bus consumers"
+```
+
+---
+
+### Task 8: Agent Registry Extension — New Fields
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py
+"""Tests for extended AgentRegistryEntry fields."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_entry_new_fields_have_defaults():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
+
+    entry = AgentRegistryEntry(type="test-agent", name="Test")
+    assert entry.protocol == "stdio"
+    assert entry.tool_execution_mode == "agent_side"
+    assert entry.mcp_transport == "stdio"
+    assert entry.api_base_url is None
+    assert entry.model is None
+    assert entry.tools_from == "auto"
+    assert entry.sandbox == "none"
+    assert entry.trust_level == "standard"
+
+
+def test_registry_entry_with_openai_protocol():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
+
+    entry = AgentRegistryEntry(
+        type="ollama",
+        name="Ollama",
+        protocol="openai_tool_use",
+        tool_execution_mode="server_side",
+        api_base_url="http://localhost:11434/v1",
+        model="llama3.1",
+        sandbox="required",
+        trust_level="untrusted",
+    )
+    assert entry.protocol == "openai_tool_use"
+    assert entry.tool_execution_mode == "server_side"
+    assert entry.api_base_url == "http://localhost:11434/v1"
+
+
+def test_registry_entry_from_yaml_dict_with_new_fields():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
+
+    data = {
+        "type": "mcp-agent",
+        "name": "MCP Agent",
+        "protocol": "mcp",
+        "mcp_transport": "streamable_http",
+        "tool_execution_mode": "server_side",
+        "command": "/usr/bin/agent",
+    }
+    entry = AgentRegistryEntry(**{k: v for k, v in data.items() if k in AgentRegistryEntry.__dataclass_fields__})
+    assert entry.protocol == "mcp"
+    assert entry.mcp_transport == "streamable_http"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py -v`
+Expected: FAIL — `AgentRegistryEntry` doesn't have `protocol` field yet
+
+**Step 3: Add new fields to `AgentRegistryEntry`**
+
+Add the following fields to the existing `AgentRegistryEntry` dataclass in `agent_registry.py` (after the existing fields):
+
+```python
+    # Protocol adapter fields (new for agent workspace harness)
+    protocol: str = "stdio"  # stdio | mcp | openai_tool_use
+    tool_execution_mode: str = "agent_side"  # agent_side | server_side | hybrid
+    mcp_transport: str = "stdio"  # stdio | sse | streamable_http
+    api_base_url: str | None = None
+    model: str | None = None
+    tools_from: str = "auto"  # auto | static | none
+    sandbox: str = "none"  # required | optional | none
+    trust_level: str = "standard"  # untrusted | standard | trusted
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py -v`
+Expected: 3 PASSED
+
+**Step 5: Verify existing tests still pass**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/ -v --timeout=60`
+Expected: All existing tests PASS (new fields have defaults, backward compatible)
+
+**Step 6: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py
+git commit -m "feat(acp): extend AgentRegistryEntry with protocol and sandbox fields"
+```
+
+---
+
+### Task 9: ToolExecutor Interface + Default Implementation
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py
+"""Unit tests for ToolExecutor."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_tool_executor_is_abstract():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.tool_executor import ToolExecutor
+    with pytest.raises(TypeError):
+        ToolExecutor()
+
+
+@pytest.mark.asyncio
+async def test_default_tool_executor_unknown_tool_returns_error():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.tool_executor import DefaultToolExecutor
+
+    executor = DefaultToolExecutor()
+    result = await executor.execute("nonexistent_tool", {})
+    assert result.is_error is True
+    assert "unknown" in result.output.lower() or "not found" in result.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_default_tool_executor_register_and_execute():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.tool_executor import DefaultToolExecutor, ToolResult
+
+    executor = DefaultToolExecutor()
+
+    async def echo_tool(arguments: dict) -> ToolResult:
+        return ToolResult(output=f"echo: {arguments.get('text', '')}", is_error=False)
+
+    executor.register_tool("echo", echo_tool)
+    result = await executor.execute("echo", {"text": "hello"})
+    assert result.output == "echo: hello"
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio
+async def test_default_tool_executor_list_tools():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.tool_executor import DefaultToolExecutor, ToolResult
+
+    executor = DefaultToolExecutor()
+
+    async def noop(args: dict) -> ToolResult:
+        return ToolResult(output="", is_error=False)
+
+    executor.register_tool("tool_a", noop)
+    executor.register_tool("tool_b", noop)
+
+    tools = await executor.list_tools()
+    names = {t["name"] for t in tools}
+    assert names == {"tool_a", "tool_b"}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
+"""ToolExecutor — executes tools on behalf of agents in server_side/hybrid mode."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from loguru import logger
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool execution."""
+    output: str
+    is_error: bool
+    duration_ms: int = 0
+
+
+class ToolExecutor(ABC):
+    """Executes tools on behalf of agents in server_side/hybrid mode."""
+
+    @abstractmethod
+    async def execute(self, tool_name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Run a tool and return its result."""
+
+    @abstractmethod
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return available server-side tools."""
+
+
+ToolHandler = Callable[[dict[str, Any]], Awaitable[ToolResult]]
+
+
+class DefaultToolExecutor(ToolExecutor):
+    """Default implementation with a registry of tool handlers."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolHandler] = {}
+
+    def register_tool(self, name: str, handler: ToolHandler) -> None:
+        """Register a tool handler."""
+        self._tools[name] = handler
+
+    async def execute(self, tool_name: str, arguments: dict[str, Any]) -> ToolResult:
+        handler = self._tools.get(tool_name)
+        if handler is None:
+            return ToolResult(
+                output=f"Tool not found: {tool_name}",
+                is_error=True,
+            )
+        try:
+            return await handler(arguments)
+        except Exception as e:
+            logger.exception(f"ToolExecutor: error executing {tool_name}")
+            return ToolResult(output=str(e), is_error=True)
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return [{"name": name} for name in self._tools]
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py -v`
+Expected: 4 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py
+git commit -m "feat(acp): add ToolExecutor interface and DefaultToolExecutor"
+```
+
+---
+
+### Task 10: SandboxBridge
+
+**Files:**
+- Create: `tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py`
+- Test: `tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py`
+
+**Step 1: Write the failing test**
+
+```python
+# tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
+"""Unit tests for SandboxBridge."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from dataclasses import dataclass
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_sandbox_bridge_provision_returns_handle():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_bridge import (
+        SandboxBridge,
+        SandboxProvisionRequest,
+        SandboxHandle,
+    )
+
+    mock_service = AsyncMock()
+    mock_service.create_session = AsyncMock(return_value=MagicMock(
+        id="sandbox-sess-1",
+        host="127.0.0.1",
+        port=8080,
+        ssh_endpoint="ssh://127.0.0.1:2222",
+    ))
+    mock_service.start_run = AsyncMock(return_value=MagicMock(
+        id="run-1",
+        stdin=None,
+        stdout=None,
+    ))
+
+    bridge = SandboxBridge(sandbox_service=mock_service)
+    handle = await bridge.provision(SandboxProvisionRequest(
+        user_id=1,
+        agent_command="claude",
+        agent_args=["--chat"],
+    ))
+
+    assert isinstance(handle, SandboxHandle)
+    assert handle.sandbox_session_id == "sandbox-sess-1"
+    assert handle.run_id == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_bridge_teardown():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_bridge import (
+        SandboxBridge,
+        SandboxHandle,
+    )
+
+    mock_service = AsyncMock()
+    bridge = SandboxBridge(sandbox_service=mock_service)
+
+    handle = SandboxHandle(
+        sandbox_session_id="s1",
+        run_id="r1",
+    )
+    await bridge.teardown(handle)
+
+    mock_service.cancel_run.assert_awaited_once_with("r1")
+    mock_service.delete_session.assert_awaited_once_with("s1")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py -v`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```python
+# tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
+"""SandboxBridge — integration seam between ACP and the Sandbox module."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+
+@dataclass
+class SandboxProvisionRequest:
+    """What ACP needs to provision a sandbox environment."""
+    user_id: int
+    agent_command: str
+    agent_args: list[str] = field(default_factory=list)
+    agent_env: dict[str, str] = field(default_factory=dict)
+    runtime: str | None = None  # None = use default
+    trust_level: str = "standard"
+    ttl_sec: int = 86400
+    network_policy: str = "deny_all"
+    workspace_files: list[str] | None = None
+
+
+@dataclass
+class SandboxHandle:
+    """Opaque handle to a provisioned sandbox environment."""
+    sandbox_session_id: str
+    run_id: str
+    process_stdin: Any | None = None
+    process_stdout: Any | None = None
+    endpoint: str | None = None
+    ssh_endpoint: str | None = None
+
+
+class SandboxBridge:
+    """Translates between ACP session needs and Sandbox module capabilities."""
+
+    def __init__(self, sandbox_service: Any) -> None:
+        self._sandbox = sandbox_service
+
+    async def provision(self, request: SandboxProvisionRequest) -> SandboxHandle:
+        """Request an execution environment for an agent session."""
+        session = await self._sandbox.create_session(
+            runtime=request.runtime,
+            trust_level=request.trust_level,
+            ttl_sec=request.ttl_sec,
+            user_id=request.user_id,
+            network_policy=request.network_policy,
+        )
+
+        run = await self._sandbox.start_run(
+            session_id=session.id,
+            command=request.agent_command,
+            args=request.agent_args,
+            env=request.agent_env,
+        )
+
+        return SandboxHandle(
+            sandbox_session_id=session.id,
+            run_id=run.id,
+            process_stdin=getattr(run, "stdin", None),
+            process_stdout=getattr(run, "stdout", None),
+            endpoint=f"http://{getattr(session, 'host', '127.0.0.1')}:{getattr(session, 'port', 8080)}",
+            ssh_endpoint=getattr(session, "ssh_endpoint", None),
+        )
+
+    async def teardown(self, handle: SandboxHandle) -> None:
+        """Destroy the sandbox environment."""
+        try:
+            await self._sandbox.cancel_run(handle.run_id)
+        except Exception:
+            logger.debug(f"SandboxBridge: cancel_run failed for {handle.run_id}")
+        await self._sandbox.delete_session(handle.sandbox_session_id)
+
+    async def snapshot(self, handle: SandboxHandle) -> str:
+        """Snapshot current workspace state. Returns snapshot_id."""
+        return await self._sandbox.create_snapshot(handle.sandbox_session_id)
+
+    async def restore(self, handle: SandboxHandle, snapshot_id: str) -> None:
+        """Restore workspace to a previous snapshot."""
+        await self._sandbox.restore_snapshot(handle.sandbox_session_id, snapshot_id)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py -v`
+Expected: 2 PASSED
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
+git commit -m "feat(acp): add SandboxBridge integration seam"
+```
+
+---
+
+### Task 11: Verify All Existing ACP Tests Still Pass
+
+**Step 1: Run the full existing ACP test suite**
+
+Run: `python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/ -v --timeout=60`
+Expected: All tests PASS (new code is additive, no existing code modified except adding default fields to `AgentRegistryEntry`)
+
+**Step 2: Commit if any fixups needed**
+
+If any tests fail due to the registry field additions, fix by ensuring defaults are backward-compatible.
+
+---
+
+## Phase B: MCP Adapter (Future)
+
+> Tasks for Phase B will be planned after Phase A is complete and validated. The `MCPAdapter` will follow the same TDD pattern: test → implement → commit. It will leverage the existing `MCP_unified` module's client patterns for stdio/SSE/streamable_http transports.
+
+## Phase C: OpenAI Tool-Use Adapter (Future)
+
+> The `OpenAIToolUseAdapter` will implement the multi-turn tool call loop, using `httpx` for streaming HTTP. It drives the loop internally: send prompt → get tool calls → execute via `ToolExecutor` → send results → repeat.
+
+## Phase D: ACPRunnerClient Refactor (Future)
+
+> Incrementally refactor `runner_client.py` to use the adapter + bus + consumer architecture. The existing `ACPStdioClient` is wrapped by `StdioAdapter`. Governance, WebSocket routing, audit, and metrics are migrated to their respective consumers. The runner becomes a thin coordinator.
+
+---
+
+## File Map
+
+| New File | Purpose |
+|----------|---------|
+| `app/core/Agent_Client_Protocol/events.py` | AgentEvent + AgentEventKind |
+| `app/core/Agent_Client_Protocol/event_bus.py` | SessionEventBus |
+| `app/core/Agent_Client_Protocol/governance_filter.py` | GovernanceFilter pipeline stage |
+| `app/core/Agent_Client_Protocol/tool_executor.py` | ToolExecutor ABC + DefaultToolExecutor |
+| `app/core/Agent_Client_Protocol/sandbox_bridge.py` | SandboxBridge integration seam |
+| `app/core/Agent_Client_Protocol/adapters/__init__.py` | Adapter package exports |
+| `app/core/Agent_Client_Protocol/adapters/base.py` | ProtocolAdapter ABC + AdapterConfig |
+| `app/core/Agent_Client_Protocol/adapters/factory.py` | AdapterFactory |
+| `app/core/Agent_Client_Protocol/adapters/stdio_adapter.py` | StdioAdapter |
+| `app/core/Agent_Client_Protocol/consumers/__init__.py` | Consumer package exports |
+| `app/core/Agent_Client_Protocol/consumers/base.py` | EventConsumer ABC |
+| `app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py` | WSBroadcaster |
+| `app/core/Agent_Client_Protocol/consumers/audit_logger.py` | AuditLogger |
+| `app/core/Agent_Client_Protocol/consumers/metrics_recorder.py` | MetricsRecorder |
+
+| Modified File | Change |
+|---------------|--------|
+| `app/core/Agent_Client_Protocol/agent_registry.py` | 8 new fields on AgentRegistryEntry |

--- a/Docs/Plans/2026-03-16-model-router-auto-selection-design.md
+++ b/Docs/Plans/2026-03-16-model-router-auto-selection-design.md
@@ -1,0 +1,384 @@
+# Model Router Auto Selection Design
+
+**Date:** 2026-03-16
+
+**Status:** Approved for planning
+
+**Goal:** Add first-class model router support so requests using `model="auto"` are resolved to a concrete provider/model pair server-side, with provider-constrained routing by default, optional cross-provider routing, LLM-based routing as the default strategy, deterministic fallback, and reuse across chat-adjacent LLM surfaces.
+
+## Problem
+
+The current stack already normalizes provider/model selections and infers providers from model IDs, but it does not perform semantic routing. The frontend persists a concrete `selectedModel`, the shared UI client resolves an explicit `api_provider`, and the backend normalizes/validates provider-model pairs before execution. That is sufficient for explicit model selection, but it does not support "choose the best model for this request" behavior.
+
+Treating `auto` as a missing model is not viable because several current surfaces assume a concrete model ID must exist before submission. Routing therefore needs to become a first-class cross-stack mode with a clear sentinel and a dedicated backend decision step that runs before existing provider/model normalization for execution.
+
+## Approved Product Decisions
+
+- `auto` is a first-class model sentinel in the UI and API.
+- Provider-constrained routing is the primary default.
+- Cross-provider routing is optional, not the default.
+- LLM-based routing is the default strategy.
+- Deterministic rules routing is the default fallback.
+- Requests may optionally fail instead of falling back after router failure.
+- Re-evaluate every turn by default.
+- Sticky routing is optional and supported only where a stable scope key exists.
+- The default routing objective is `highest_quality`.
+- The router should be reusable across chat, character chat, writing playground, RAG answer generation, media analysis, and other LLM surfaces over time.
+
+## Routing Contract
+
+### `auto` Is Explicit
+
+`auto` is a real selectable model value across the stack. It is not equivalent to "no model selected". The frontend must preserve it, allow it through validation, and send it to the server intentionally. The backend must recognize it before normal provider/model normalization and availability checks.
+
+### Routing Boundary Modes
+
+Routing boundary is explicit and has three modes:
+
+1. `server_default_provider`
+   The user did not pin a provider. Keep routing inside the server default provider unless cross-provider routing is enabled.
+
+2. `pinned_provider`
+   The user or caller pinned a provider explicitly. Keep routing inside that provider unless cross-provider routing is enabled.
+
+3. `cross_provider`
+   The router is allowed to choose across all eligible providers.
+
+### Canonical Router Output
+
+The router returns an internal `RoutingDecision` with concrete `provider`, `model`, and `canonical=true`.
+
+Once a canonical routing decision exists:
+
+- downstream code must not run additional provider inference on it
+- downstream code must not strip or reinterpret namespaced model IDs
+- availability checks operate on the canonical provider/model pair as-is
+
+This prevents misrouting namespaced models like OpenRouter catalog IDs after the router has already made a valid decision.
+
+### Sticky Routing Scope
+
+Sticky routing is supported only when the caller provides a stable scope key, such as a conversation ID, chat session ID, or writing session ID. If a stable key does not exist, sticky mode degrades to per-turn routing.
+
+Sticky decisions are bypassed automatically when a later request introduces a hard capability mismatch, including:
+
+- tools become required
+- vision/image input appears
+- JSON mode becomes required
+- context requirements increase beyond the previously selected model
+
+## Routing Pipeline
+
+The routing pipeline is:
+
+`candidate prefilter -> sticky reuse check -> llm router -> rules fallback -> canonical decision -> existing execution path`
+
+### 1. Candidate Prefilter
+
+Build the candidate set from configured and enabled chat-capable models, then filter by:
+
+- routing boundary mode
+- enabled/configured provider inventory
+- admin provider overrides and allowed-model constraints
+- BYOK/provider credential availability
+- provider health and circuit state
+- hard capability requirements
+- any per-surface allowlists or exclusions
+
+If only one eligible candidate remains and `skip_when_single_candidate` is enabled, routing short-circuits and returns that model directly.
+
+### 2. Sticky Reuse Check
+
+Sticky reuse in v1 is deterministic, not semantic. Reuse is allowed only when this fingerprint matches:
+
+`surface + objective + boundary_mode + pinned_provider + hard_capabilities + modality_flags + sticky_scope`
+
+This avoids ambiguous "task class" heuristics in the first implementation.
+
+### 3. LLM Router Strategy
+
+The default router strategy uses a small dedicated concrete router model.
+
+Input is minimized:
+
+- latest user turn or a short surface-specific summary
+- compact task features only
+- no full history by default
+- no raw tool schemas
+- no file contents
+- no image bytes
+
+The router is only allowed to choose from the candidate set passed to it. Its structured output must be validated against the candidate pool before use.
+
+The router model must:
+
+- always be configured as a concrete provider/model pair
+- never be `auto`
+- be excluded from the routed candidate pool
+
+This prevents recursive routing.
+
+### 4. Rules Fallback Strategy
+
+Rules fallback is deterministic and boring by design.
+
+Order:
+
+1. hard capability filtering
+2. objective-based ranking using routing metadata
+3. provider/surface preferred-model tie-breaking
+4. admin-curated per-provider ordered fallback list when metadata is incomplete
+
+If no candidate survives and failure mode is configured to error, the request returns a clear structured error to the caller.
+
+### 5. Existing Execution Path
+
+After routing, the existing provider execution path remains responsible for:
+
+- actual provider invocation
+- any execution-time provider fallback behavior
+- normal response construction
+
+Execution fallback and routing fallback are separate concerns and must remain separate in code and logs.
+
+## Components
+
+Create a shared server-side routing module under a path like:
+
+`tldw_Server_API/app/core/LLM_Calls/routing/`
+
+### `ModelRouterService`
+
+Single public entry point. Accepts a routing request, returns a canonical `RoutingDecision`, and encapsulates the entire routing pipeline.
+
+### `RoutingPolicyResolver`
+
+Merges:
+
+- global defaults
+- per-surface defaults
+- per-request overrides
+
+Request overrides should live under one server extension object:
+
+```json
+{
+  "routing": {
+    "strategy": "llm_router",
+    "objective": "highest_quality",
+    "mode": "per_turn",
+    "cross_provider": false,
+    "failure_mode": "fallback_then_error"
+  }
+}
+```
+
+This keeps server extensions grouped instead of scattering many new top-level OpenAI-like fields.
+
+### `CandidatePoolBuilder`
+
+Builds and filters the candidate set using inventory, policy, auth/credentials, health, capabilities, and overrides.
+
+### `LLMRouterStrategy`
+
+Invokes the dedicated router model with minimal structured context and validates that the selected provider/model exists in the provided candidate set.
+
+### `RulesRouterStrategy`
+
+Deterministic fallback. Requires ranking metadata where available and admin-curated fallback ordering where metadata is incomplete.
+
+### `RoutingDecisionStore`
+
+Stores sticky decisions with:
+
+- scope key
+- objective
+- provider boundary mode
+- selected provider/model
+- routing fingerprint
+- policy/config fingerprint
+- last updated timestamp
+
+This allows invalidation when policy or inventory changes.
+
+### `RoutingTelemetry`
+
+Emits structured routing data for logs and diagnostics, including:
+
+- `decision_source`
+- `fallback_used`
+- `routing_scope`
+- `router_selected_provider`
+- `router_selected_model`
+- `execution_provider`
+- `execution_model`
+
+## Candidate Metadata And Ranking
+
+Rules fallback and policy shortcuts need metadata beyond the current basic catalog:
+
+- `context_window`
+- `tool_support`
+- `vision_support`
+- `reasoning_support`
+- `json_mode_support`
+- `quality_rank`
+- `latency_rank`
+- `cost_rank`
+- optional `preferred_for_surfaces`
+
+If ranking metadata is partial or missing, the router falls back to admin-curated ordered model lists per provider rather than inventing cross-model quality judgments dynamically.
+
+## Frontend Behavior
+
+### Selection UX
+
+The UI should allow `selectedModel = "auto"` explicitly instead of treating it as "no model". Provider selection remains separate. If provider selection is also `auto`, the backend interprets that as `server_default_provider` boundary mode unless cross-provider routing is enabled.
+
+### Validation
+
+Any validation logic that currently assumes a concrete model ID must bypass or special-case `auto`. In particular:
+
+- chat composer validation
+- playground validation
+- any availability checks that compare the selected model directly to server catalog IDs
+
+### Client Request Shape
+
+Shared client request types should add an optional `routing` object rather than proliferating additional top-level request fields.
+
+### Debugging
+
+Routing debug output should be opt-in, via a server extension flag or debug header. OpenAI-compatible default responses should remain unchanged unless debug mode is requested.
+
+## Backend Integration Rules
+
+### Early Interception
+
+Routing must run before existing chat provider/model normalization and explicit availability checks. This is necessary because those code paths assume the request already references a concrete provider/model pair.
+
+### Do Not Renormalize Routed Decisions
+
+Once a canonical `RoutingDecision` has been produced, downstream execution logic must use that decision directly and skip additional provider/model normalization.
+
+### Surface Rollout
+
+The first integration target is `/api/v1/chat/completions`. After that:
+
+1. character chat completion endpoint
+2. writing playground generation flows
+3. RAG answer generation and media analysis
+
+The routing module itself should be surface-agnostic even if initial rollout is incremental.
+
+## Accounting, Budgets, And Logging
+
+Router invocations are real LLM calls and must be budgeted and logged separately from execution calls.
+
+Requirements:
+
+- separate budget accounting for router calls
+- separate usage rows for router vs. execution calls
+- separate operation names in usage tracking
+- clear correlation between a routed request and the router call that selected it
+
+Use the existing `llm_usage_log` path instead of inventing a parallel telemetry store. Extend it only if necessary. The existing migration groundwork for router analytics columns is the preferred base.
+
+## Failure Handling
+
+### Default Failure Behavior
+
+- LLM router timeout or invalid output -> run rules fallback
+- rules fallback produces valid candidate -> continue
+- rules fallback produces no valid candidate -> clear structured error if failure mode demands it
+
+### Sticky Invalidations
+
+Sticky decisions are invalidated when:
+
+- selected model is no longer in the candidate set
+- provider health/policy removes eligibility
+- sticky fingerprint no longer matches
+- capability requirements increase beyond the prior model
+
+### User-Facing Errors
+
+Failure responses should explain why no eligible candidate exists, not just that routing failed. For example:
+
+- provider boundary too restrictive
+- no models with required tool support
+- no vision-capable models enabled
+- no provider credentials available
+
+## Configuration Shape
+
+Conceptual configuration:
+
+```text
+model_routing.enabled = true
+model_routing.router_model.provider = "openai"
+model_routing.router_model.model = "gpt-4.1-mini"
+model_routing.router_model.exclude_from_candidates = true
+model_routing.default_strategy = "llm_router"
+model_routing.default_fallback_strategy = "rules_router"
+model_routing.default_objective = "highest_quality"
+model_routing.default_mode = "per_turn"
+model_routing.default_cross_provider = false
+model_routing.default_failure_mode = "fallback_then_error"
+model_routing.skip_when_single_candidate = true
+model_routing.surfaces.chat.enabled = true
+model_routing.surfaces.character_chat.enabled = true
+model_routing.surfaces.writing.enabled = true
+model_routing.surfaces.rag.enabled = true
+```
+
+The exact persistence mechanism can be implemented via existing config parsing and env overrides rather than introducing a new bespoke configuration system.
+
+## Testing Strategy
+
+### Unit Tests
+
+- policy resolution
+- candidate filtering
+- deterministic reuse fingerprint matching
+- rules fallback ranking and fallback ordering
+- router output validation
+- recursion prevention for router model configuration
+
+### Integration Tests
+
+- `/api/v1/chat/completions` resolves `model="auto"` to a concrete canonical provider/model
+- invalid router output falls back to rules routing
+- failure mode `error` surfaces a clear structured error
+- character chat and writing flows accept `auto` without frontend/client breakage
+
+### UI Tests
+
+- `auto` is allowed in selection and validation
+- shared request typing includes nested `routing`
+- client requests preserve `model="auto"` and routing overrides
+
+## Rollout Plan
+
+1. Shared routing module and config/policy support
+2. Candidate metadata and deterministic fallback
+3. Router usage accounting and telemetry
+4. `/api/v1/chat/completions` integration
+5. Frontend `auto` sentinel support
+6. character chat and writing playground integration
+7. later adoption by RAG answer generation and media analysis
+
+## Risks To Watch
+
+- accidental recursion if router model is not excluded
+- double normalization of namespaced model IDs
+- budget/accounting drift if router calls are not logged separately
+- UI validation silently rejecting `auto`
+- metadata gaps causing deterministic fallback to behave unpredictably
+
+## Out Of Scope For V1
+
+- semantic task-class reuse heuristics
+- full-history router prompting
+- cross-provider routing as the default behavior
+- broad response-shape changes to default OpenAI-compatible payloads

--- a/Docs/Plans/2026-03-16-model-router-auto-selection-implementation-plan.md
+++ b/Docs/Plans/2026-03-16-model-router-auto-selection-implementation-plan.md
@@ -1,0 +1,563 @@
+# Model Router Auto Selection Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add first-class `model="auto"` routing that resolves to a canonical provider/model pair server-side, uses an LLM router with deterministic fallback, and rolls out first to chat completions before expanding to character chat and writing flows.
+
+**Architecture:** Build a shared routing package under `tldw_Server_API/app/core/LLM_Calls/routing/` and intercept `auto` requests before existing provider/model normalization. Keep the frontend and shared UI client aware of `auto` as an explicit sentinel, add a nested `routing` request object, and reuse the existing usage/budget infrastructure to account for router calls separately from execution calls.
+
+**Tech Stack:** FastAPI, Pydantic, existing config parser (`config.py`), shared UI package (`apps/packages/ui/src`), Vitest, pytest, Loguru, existing AuthNZ usage tracking.
+
+---
+
+### Task 1: Add Routing Request/Policy Types And Config Loading
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/__init__.py`
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/models.py`
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/policy.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py`
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_policy.py`
+- Test: `apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_policy_defaults_to_server_default_provider_boundary():
+    policy = resolve_routing_policy(request_model="auto", explicit_provider=None)
+    assert policy.boundary_mode == "server_default_provider"
+    assert policy.objective == "highest_quality"
+```
+
+```ts
+it("accepts nested routing overrides on chat completion requests", async () => {
+  const request: ChatCompletionRequest = {
+    model: "auto",
+    messages: [{ role: "user", content: "hello" }],
+    routing: { mode: "per_turn", cross_provider: false }
+  }
+  expect(request.routing?.mode).toBe("per_turn")
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_policy.py -v`
+Expected: FAIL because routing policy types do not exist yet.
+
+Run: `bunx vitest run apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts`
+Expected: FAIL because `ChatCompletionRequest` does not expose `routing`.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- `RoutingOverride`, `RoutingPolicy`, `RoutingBoundaryMode`, and `RoutingDecision` dataclasses/Pydantic models in `models.py`
+- `resolve_routing_policy(...)` in `policy.py`
+- `routing: Optional[RoutingOverride]` in `ChatCompletionRequest`
+- matching `routing?: { ... }` typing in `TldwApiClient.ts`
+
+Keep `routing` optional and server-extension-only.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_policy.py -v`
+Expected: PASS
+
+Run: `bunx vitest run apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/routing/__init__.py tldw_Server_API/app/core/LLM_Calls/routing/models.py tldw_Server_API/app/core/LLM_Calls/routing/policy.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py apps/packages/ui/src/services/tldw/TldwApiClient.ts tldw_Server_API/tests/Chat/unit/test_model_router_policy.py apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts
+git commit -m "feat: add model routing policy and request types"
+```
+
+### Task 2: Build Candidate Pool Filtering And Ranking Metadata
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/candidate_pool.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/llm_providers.py`
+- Modify: `tldw_Server_API/app/core/AuthNZ/llm_provider_overrides.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_candidates.py`
+- Test: `tldw_Server_API/tests/AuthNZ_Unit/test_llm_provider_overrides.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_candidate_pool_filters_models_outside_pinned_provider():
+    candidates = build_candidate_pool(
+        boundary_mode="pinned_provider",
+        pinned_provider="openai",
+        requested_capabilities={"tools": True},
+        catalog=[
+            {"provider": "openai", "model": "gpt-4.1", "tool_support": True},
+            {"provider": "anthropic", "model": "claude-sonnet-4.5", "tool_support": True},
+        ],
+    )
+    assert [(c.provider, c.model) for c in candidates] == [("openai", "gpt-4.1")]
+```
+
+```python
+def test_candidate_pool_uses_admin_order_when_quality_rank_missing():
+    chosen = choose_ranked_candidate(
+        [
+            {"provider": "openai", "model": "gpt-4.1-mini"},
+            {"provider": "openai", "model": "gpt-4.1"},
+        ],
+        provider_order={"openai": ["gpt-4.1", "gpt-4.1-mini"]},
+    )
+    assert chosen["model"] == "gpt-4.1"
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_candidates.py -v`
+Expected: FAIL because the candidate pool module does not exist.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- candidate record model with canonical provider/model fields
+- provider-boundary filtering
+- capability filtering (`tools`, `vision`, `json_mode`, `reasoning`, context)
+- admin override enforcement
+- ranking metadata support in `llm_providers.py`
+- fallback ordered-list support when `quality_rank` is absent
+
+Do not add cross-provider ranking heuristics beyond explicit metadata and admin order.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_candidates.py -v`
+Expected: PASS
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ_Unit/test_llm_provider_overrides.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/routing/candidate_pool.py tldw_Server_API/app/api/v1/endpoints/llm_providers.py tldw_Server_API/app/core/AuthNZ/llm_provider_overrides.py tldw_Server_API/tests/Chat/unit/test_model_router_candidates.py tldw_Server_API/tests/AuthNZ_Unit/test_llm_provider_overrides.py
+git commit -m "feat: add model router candidate filtering"
+```
+
+### Task 3: Implement Deterministic Rules Router And Sticky Decision Store
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/rules_router.py`
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/decision_store.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_rules.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_sticky.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_rules_router_prefers_highest_quality_candidate_for_default_objective():
+    decision = route_with_rules(
+        objective="highest_quality",
+        candidates=[
+            candidate("openai", "gpt-4.1-mini", quality_rank=20),
+            candidate("openai", "gpt-4.1", quality_rank=10),
+        ],
+    )
+    assert decision.model == "gpt-4.1"
+```
+
+```python
+def test_sticky_decision_is_bypassed_when_tools_become_required():
+    store = InMemoryRoutingDecisionStore()
+    store.save(scope="conv-1", fingerprint="chat|no-tools", provider="openai", model="gpt-4.1-mini")
+    reused = maybe_reuse_sticky_decision(
+        store=store,
+        scope="conv-1",
+        fingerprint="chat|tools-required",
+    )
+    assert reused is None
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_rules.py tldw_Server_API/tests/Chat/unit/test_model_router_sticky.py -v`
+Expected: FAIL because rules router and decision store do not exist.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- `route_with_rules(...)`
+- deterministic fingerprint computation
+- scope-aware sticky save/load helpers
+- automatic sticky bypass for hard capability changes
+
+Start with in-memory storage and keep the persistence seam explicit for later expansion.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_rules.py tldw_Server_API/tests/Chat/unit/test_model_router_sticky.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/routing/rules_router.py tldw_Server_API/app/core/LLM_Calls/routing/decision_store.py tldw_Server_API/tests/Chat/unit/test_model_router_rules.py tldw_Server_API/tests/Chat/unit/test_model_router_sticky.py
+git commit -m "feat: add deterministic model router fallback"
+```
+
+### Task 4: Implement LLM Router Strategy And Canonical Routing Service
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/llm_router.py`
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/service.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_llm_strategy.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_service.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_llm_router_rejects_choice_outside_candidate_set():
+    result = validate_llm_router_choice(
+        raw_choice={"provider": "anthropic", "model": "claude-opus-4.1"},
+        candidates=[candidate("openai", "gpt-4.1")],
+    )
+    assert result is None
+```
+
+```python
+def test_model_router_service_marks_routed_decision_as_canonical():
+    decision = route_model(
+        request=router_request(model="auto", surface="chat"),
+        policy=default_policy(),
+        candidates=[candidate("openai", "gpt-4.1")],
+    )
+    assert decision.canonical is True
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_llm_strategy.py tldw_Server_API/tests/Chat/unit/test_model_router_service.py -v`
+Expected: FAIL because the LLM router and service do not exist.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- compact router prompt builder
+- structured output parsing and validation
+- router-model exclusion from candidates
+- service orchestration: candidate pool -> sticky reuse -> LLM router -> rules router
+- canonical decision output that downstream code can trust
+
+Do not pass full message history, raw tool schemas, file contents, or image bytes to the router prompt.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_llm_strategy.py tldw_Server_API/tests/Chat/unit/test_model_router_service.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/routing/llm_router.py tldw_Server_API/app/core/LLM_Calls/routing/service.py tldw_Server_API/tests/Chat/unit/test_model_router_llm_strategy.py tldw_Server_API/tests/Chat/unit/test_model_router_service.py
+git commit -m "feat: add llm-backed model routing service"
+```
+
+### Task 5: Add Router Accounting And Telemetry
+
+**Files:**
+- Create: `tldw_Server_API/app/core/LLM_Calls/routing/telemetry.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Modify: `tldw_Server_API/app/core/Usage/usage_tracker.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_model_router_usage_logging.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_router_and_execution_calls_are_logged_as_separate_operations():
+    rows = capture_usage_rows_for_auto_routed_request()
+    assert [row["operation"] for row in rows] == ["model_router", "chat.completions"]
+```
+
+```python
+def test_chat_endpoint_includes_no_routing_debug_without_opt_in():
+    response = client.post("/api/v1/chat/completions", json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]})
+    assert "routing" not in response.json()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_usage_logging.py tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py -v`
+Expected: FAIL because router usage logging and endpoint routing are not wired.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- router telemetry helper
+- separate operation names for router vs. execution usage rows
+- explicit correlation data between a routed request and its router call
+- opt-in debug payload/header handling
+
+Re-use the existing `llm_usage_log` path instead of creating a new telemetry store.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/unit/test_model_router_usage_logging.py tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/LLM_Calls/routing/telemetry.py tldw_Server_API/app/api/v1/endpoints/chat.py tldw_Server_API/app/core/Usage/usage_tracker.py tldw_Server_API/tests/Chat/unit/test_model_router_usage_logging.py tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py
+git commit -m "feat: log model router usage separately"
+```
+
+### Task 6: Integrate Auto Routing Into Chat Completions
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/chat.py`
+- Modify: `tldw_Server_API/app/core/Chat/chat_service.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py`
+- Test: `tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py`
+- Test: `tldw_Server_API/tests/Chat/unit/test_chat_default_provider.py`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_chat_endpoint_routes_auto_before_provider_normalization(client):
+    response = client.post(
+        "/api/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "summarize this"}]},
+    )
+    assert response.status_code == 200
+    assert response.json()["model"] != "auto"
+```
+
+```python
+def test_canonical_routing_decision_skips_follow_up_provider_inference():
+    decision = make_canonical_decision(provider="openrouter", model="anthropic/claude-4.5-sonnet")
+    provider, model = apply_execution_resolution(decision)
+    assert (provider, model) == ("openrouter", "anthropic/claude-4.5-sonnet")
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py tldw_Server_API/tests/Chat/unit/test_chat_default_provider.py -v`
+Expected: FAIL because the chat endpoint does not route `auto` yet.
+
+**Step 3: Write the minimal implementation**
+
+Add an early `model == "auto"` interception point in `chat.py` before the current provider/model normalization path. Feed the resulting canonical decision into downstream execution without renormalizing it in `chat_service.py`.
+
+Keep explicit-model behavior unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py tldw_Server_API/tests/Chat/unit/test_chat_default_provider.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/chat.py tldw_Server_API/app/core/Chat/chat_service.py tldw_Server_API/app/api/v1/schemas/chat_request_schemas.py tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py tldw_Server_API/tests/Chat/unit/test_chat_default_provider.py
+git commit -m "feat: route auto model selections in chat completions"
+```
+
+### Task 7: Make The Shared UI Treat `auto` As A Valid Model Sentinel
+
+**Files:**
+- Modify: `apps/packages/ui/src/components/Option/Models/index.tsx`
+- Modify: `apps/packages/ui/src/utils/chat-model-availability.ts`
+- Modify: `apps/packages/ui/src/utils/resolve-api-provider.ts`
+- Modify: `apps/packages/ui/src/services/tldw/TldwChat.ts`
+- Modify: `apps/packages/ui/src/models/ChatTldw.ts`
+- Modify: `apps/packages/ui/src/hooks/useMessage.tsx`
+- Test: `apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts`
+- Test: `apps/packages/ui/src/utils/__tests__/resolve-api-provider.test.ts`
+- Test: `apps/packages/ui/src/hooks/__tests__/useMessage.auto-routing.test.tsx`
+
+**Step 1: Write the failing tests**
+
+```ts
+it("treats auto as a valid selected model during availability checks", () => {
+  expect(normalizeChatModelId("auto")).toBe("auto")
+  expect(findUnavailableChatModel(["auto"], ["gpt-4.1"])).toBeNull()
+})
+```
+
+```ts
+it("does not force a concrete provider inference for auto selections", async () => {
+  await expect(resolveApiProviderForModel({ modelId: "auto" })).resolves.toBeUndefined()
+})
+```
+
+```ts
+it("submits auto through the shared message hook without inline validation failure", async () => {
+  // render/use hook, set selectedModel=auto, submit, expect no "no model" error
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts apps/packages/ui/src/utils/__tests__/resolve-api-provider.test.ts apps/packages/ui/src/hooks/__tests__/useMessage.auto-routing.test.tsx`
+Expected: FAIL because `auto` is currently treated like a non-catalog model or missing selection.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- explicit `auto` option in model settings UI
+- `auto` special-casing in availability and validation helpers
+- no forced provider inference when `modelId === "auto"`
+- nested `routing` object pass-through in shared request builders
+
+Keep concrete model behavior unchanged.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `bunx vitest run apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts apps/packages/ui/src/utils/__tests__/resolve-api-provider.test.ts apps/packages/ui/src/hooks/__tests__/useMessage.auto-routing.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/packages/ui/src/components/Option/Models/index.tsx apps/packages/ui/src/utils/chat-model-availability.ts apps/packages/ui/src/utils/resolve-api-provider.ts apps/packages/ui/src/services/tldw/TldwChat.ts apps/packages/ui/src/models/ChatTldw.ts apps/packages/ui/src/hooks/useMessage.tsx apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts apps/packages/ui/src/utils/__tests__/resolve-api-provider.test.ts apps/packages/ui/src/hooks/__tests__/useMessage.auto-routing.test.tsx
+git commit -m "feat: support auto model sentinel in shared ui"
+```
+
+### Task 8: Integrate Character Chat And Writing Playground With Canonical Routing
+
+**Files:**
+- Modify: `tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py`
+- Modify: `apps/packages/ui/src/components/Option/WritingPlayground/index.tsx`
+- Modify: `apps/packages/ui/src/services/tldw/TldwApiClient.ts`
+- Test: `tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_auto_routing.py`
+- Test: `tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py`
+- Test: `apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx`
+
+**Step 1: Write the failing tests**
+
+```python
+def test_character_chat_routes_auto_before_shared_resolution():
+    response = post_character_completion(model="auto")
+    assert response.status_code == 200
+```
+
+```ts
+it("writing playground keeps auto selection and submits routing overrides", async () => {
+  render(<WritingPlayground />)
+  // select auto, trigger generation, assert request body includes model=auto
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_auto_routing.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -v`
+Expected: FAIL because character chat has no auto-routing interception.
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx`
+Expected: FAIL because writing playground does not preserve `auto` end-to-end.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- early `auto` routing interception in `character_chat_sessions.py`
+- canonical routing pass-through for character chat execution
+- writing playground request-builder support for `model="auto"` and nested `routing`
+
+Do not implement RAG/media integration in this task.
+
+**Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_auto_routing.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py -v`
+Expected: PASS
+
+Run: `bunx vitest run apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py apps/packages/ui/src/components/Option/WritingPlayground/index.tsx apps/packages/ui/src/services/tldw/TldwApiClient.ts tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_auto_routing.py tldw_Server_API/tests/Character_Chat_NEW/integration/test_character_chat_stream_and_persist.py apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+git commit -m "feat: extend auto model routing to character and writing flows"
+```
+
+### Task 9: Verification, Security Check, And Final Docs Pass
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-16-model-router-auto-selection-design.md`
+- Modify: `Docs/Plans/2026-03-16-model-router-auto-selection-implementation-plan.md`
+
+**Step 1: Run the targeted backend tests**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m pytest \
+  tldw_Server_API/tests/Chat/unit/test_model_router_policy.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_candidates.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_rules.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_sticky.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_llm_strategy.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_service.py \
+  tldw_Server_API/tests/Chat/unit/test_model_router_usage_logging.py \
+  tldw_Server_API/tests/Chat/integration/test_chat_endpoint_auto_routing.py \
+  tldw_Server_API/tests/Character_Chat_NEW/unit/test_character_chat_auto_routing.py -v
+```
+
+Expected: PASS
+
+**Step 2: Run the targeted frontend tests**
+
+Run:
+
+```bash
+bunx vitest run \
+  apps/packages/ui/src/services/__tests__/tldw-api-client.chat-mutations.test.ts \
+  apps/packages/ui/src/utils/__tests__/chat-model-availability.test.ts \
+  apps/packages/ui/src/utils/__tests__/resolve-api-provider.test.ts \
+  apps/packages/ui/src/hooks/__tests__/useMessage.auto-routing.test.tsx \
+  apps/packages/ui/src/components/Option/WritingPlayground/__tests__/WritingPlayground.phase1-baseline.test.tsx
+```
+
+Expected: PASS
+
+**Step 3: Run Bandit on touched backend paths**
+
+Run:
+
+```bash
+source .venv/bin/activate && python -m bandit -r \
+  tldw_Server_API/app/core/LLM_Calls/routing \
+  tldw_Server_API/app/api/v1/endpoints/chat.py \
+  tldw_Server_API/app/api/v1/endpoints/character_chat_sessions.py \
+  tldw_Server_API/app/core/Chat/chat_service.py \
+  tldw_Server_API/app/core/Usage/usage_tracker.py \
+  -f json -o /tmp/bandit_model_router_auto.json
+```
+
+Expected: no new findings in changed code
+
+**Step 4: Update docs if verification exposed drift**
+
+Update the design and plan docs only if test names, file paths, or rollout sequencing changed during implementation.
+
+**Step 5: Commit**
+
+```bash
+git add Docs/Plans/2026-03-16-model-router-auto-selection-design.md Docs/Plans/2026-03-16-model-router-auto-selection-implementation-plan.md
+git commit -m "docs: finalize model router auto selection plan"
+```
+
+Plan complete and saved to `Docs/Plans/2026-03-16-model-router-auto-selection-implementation-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch a fresh subagent per task, review between tasks, and implement here.
+
+**2. Parallel Session (separate)** - Open a new session with `superpowers:executing-plans` and execute the plan task-by-task in a separate flow.
+
+Which approach?

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Protocol adapters for the ACP agent harness."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
@@ -1,1 +1,16 @@
 """Protocol adapters for the ACP agent harness."""
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+    AdapterConfig,
+    PromptOptions,
+    ProtocolAdapter,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+
+__all__ = [
+    "AdapterConfig",
+    "AdapterFactory",
+    "PromptOptions",
+    "ProtocolAdapter",
+    "StdioAdapter",
+]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py
@@ -1,0 +1,72 @@
+"""ProtocolAdapter ABC, AdapterConfig, and PromptOptions."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Awaitable
+
+
+@dataclass
+class PromptOptions:
+    """Options passed alongside a prompt to the adapter."""
+
+    max_tokens: int | None = None
+    timeout_sec: float | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AdapterConfig:
+    """Configuration handed to an adapter on connect()."""
+
+    event_callback: Callable[..., Awaitable[None]]
+    session_id: str
+    protocol_config: dict[str, Any] = field(default_factory=dict)
+
+
+class ProtocolAdapter(ABC):
+    """Abstract base class for all protocol adapters.
+
+    Subclasses must set ``protocol_name`` and implement every abstract method.
+    """
+
+    protocol_name: str = ""
+
+    @abstractmethod
+    async def connect(self, config: AdapterConfig) -> None:
+        """Establish connection using the given configuration."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Tear down the connection."""
+
+    @abstractmethod
+    async def send_prompt(
+        self,
+        messages: list[dict],
+        options: PromptOptions | None = None,
+    ) -> None:
+        """Send a prompt (list of message dicts) to the agent."""
+
+    @abstractmethod
+    async def send_tool_result(
+        self,
+        tool_id: str,
+        output: str,
+        is_error: bool = False,
+    ) -> None:
+        """Return a tool execution result to the agent."""
+
+    @abstractmethod
+    async def cancel(self) -> None:
+        """Request cancellation of the current operation."""
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Whether the adapter currently has an active connection."""
+
+    @property
+    @abstractmethod
+    def supports_streaming(self) -> bool:
+        """Whether the adapter streams events or returns them in bulk."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/base.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Callable, Awaitable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
 
 
 @dataclass
@@ -19,7 +22,7 @@ class PromptOptions:
 class AdapterConfig:
     """Configuration handed to an adapter on connect()."""
 
-    event_callback: Callable[..., Awaitable[None]]
+    event_callback: Callable[["AgentEvent"], Awaitable[None]]
     session_id: str
     protocol_config: dict[str, Any] = field(default_factory=dict)
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/factory.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/factory.py
@@ -1,0 +1,34 @@
+"""AdapterFactory -- registry and instantiation of protocol adapters."""
+from __future__ import annotations
+
+from typing import Type
+
+from .base import ProtocolAdapter
+
+
+class AdapterFactory:
+    """Simple registry that maps protocol names to adapter classes."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, Type[ProtocolAdapter]] = {}
+
+    def register(self, protocol: str, cls: Type[ProtocolAdapter]) -> None:
+        """Register an adapter class under the given protocol name."""
+        self._registry[protocol] = cls
+
+    def create(self, protocol: str) -> ProtocolAdapter:
+        """Instantiate and return an adapter for *protocol*.
+
+        Raises ``ValueError`` if the protocol is not registered.
+        """
+        cls = self._registry.get(protocol)
+        if cls is None:
+            raise ValueError(
+                f"Unknown protocol '{protocol}'. "
+                f"Available: {sorted(self._registry)}"
+            )
+        return cls()
+
+    def available_protocols(self) -> list[str]:
+        """Return a sorted list of registered protocol names."""
+        return sorted(self._registry)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
@@ -71,7 +71,9 @@ class StdioAdapter(ProtocolAdapter):
 
     @property
     def is_connected(self) -> bool:
-        return self._connected
+        if not self._connected or self._client is None:
+            return False
+        return getattr(self._client, "is_running", False)
 
     @property
     def supports_streaming(self) -> bool:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
@@ -47,7 +47,8 @@ class StdioAdapter(ProtocolAdapter):
         messages: list[dict],
         options: PromptOptions | None = None,
     ) -> None:
-        assert self._client is not None, "Not connected"
+        if self._client is None:
+            raise RuntimeError("Not connected")
         await self._client.call("prompt", {"messages": messages})
 
     async def send_tool_result(
@@ -56,14 +57,16 @@ class StdioAdapter(ProtocolAdapter):
         output: str,
         is_error: bool = False,
     ) -> None:
-        assert self._client is not None, "Not connected"
+        if self._client is None:
+            raise RuntimeError("Not connected")
         await self._client.call(
             "tool_result",
             {"tool_id": tool_id, "output": output, "is_error": is_error},
         )
 
     async def cancel(self) -> None:
-        assert self._client is not None, "Not connected"
+        if self._client is None:
+            raise RuntimeError("Not connected")
         await self._client.notify("cancel", {})
 
     @property
@@ -78,7 +81,8 @@ class StdioAdapter(ProtocolAdapter):
 
     async def _handle_notification(self, msg: ACPMessage) -> None:
         """Translate a JSON-RPC notification from the agent into an AgentEvent."""
-        assert self._config is not None
+        if self._config is None:
+            return
         params: dict[str, Any] = msg.params if isinstance(msg.params, dict) else {}
         method = msg.method or ""
         msg_type = params.get("type", "")

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
@@ -29,6 +29,11 @@ class StdioAdapter(ProtocolAdapter):
 
     async def connect(self, config: AdapterConfig) -> None:
         client: ACPStdioClient = config.protocol_config["client"]
+        if not getattr(client, "is_running", False):
+            raise RuntimeError(
+                "ACPStdioClient process is not running — call client.start() "
+                "before passing it to StdioAdapter.connect()"
+            )
         self._client = client
         self._config = config
         self._connected = True

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
@@ -1,0 +1,148 @@
+"""StdioAdapter -- wraps ACPStdioClient as a ProtocolAdapter."""
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+from .base import AdapterConfig, PromptOptions, ProtocolAdapter
+from ..events import AgentEvent, AgentEventKind
+from ..permission_tiers import determine_permission_tier
+from ..stdio_client import ACPMessage, ACPStdioClient
+
+
+class StdioAdapter(ProtocolAdapter):
+    """Protocol adapter that communicates with an agent over stdio JSON-RPC.
+
+    Expects ``config.protocol_config["client"]`` to be an :class:`ACPStdioClient`
+    instance (already started or ready to use).
+    """
+
+    protocol_name = "stdio"
+
+    def __init__(self) -> None:
+        self._client: ACPStdioClient | None = None
+        self._config: AdapterConfig | None = None
+        self._connected: bool = False
+
+    # -- ProtocolAdapter interface ------------------------------------------
+
+    async def connect(self, config: AdapterConfig) -> None:
+        client: ACPStdioClient = config.protocol_config["client"]
+        self._client = client
+        self._config = config
+        self._connected = True
+
+        # Wire up notification translation
+        client.set_notification_handler(self._handle_notification)
+
+    async def disconnect(self) -> None:
+        if self._client is not None:
+            await self._client.close()
+        self._connected = False
+        self._client = None
+
+    async def send_prompt(
+        self,
+        messages: list[dict],
+        options: PromptOptions | None = None,
+    ) -> None:
+        assert self._client is not None, "Not connected"
+        await self._client.call("prompt", {"messages": messages})
+
+    async def send_tool_result(
+        self,
+        tool_id: str,
+        output: str,
+        is_error: bool = False,
+    ) -> None:
+        assert self._client is not None, "Not connected"
+        await self._client.call(
+            "tool_result",
+            {"tool_id": tool_id, "output": output, "is_error": is_error},
+        )
+
+    async def cancel(self) -> None:
+        assert self._client is not None, "Not connected"
+        await self._client.notify("cancel", {})
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    @property
+    def supports_streaming(self) -> bool:
+        return True
+
+    # -- Internal -----------------------------------------------------------
+
+    async def _handle_notification(self, msg: ACPMessage) -> None:
+        """Translate a JSON-RPC notification from the agent into an AgentEvent."""
+        assert self._config is not None
+        params: dict[str, Any] = msg.params if isinstance(msg.params, dict) else {}
+        method = msg.method or ""
+        msg_type = params.get("type", "")
+
+        kind: AgentEventKind | None = None
+        payload: dict[str, Any] = {}
+
+        if method == "result":
+            if msg_type == "text":
+                kind = AgentEventKind.COMPLETION
+                payload = {
+                    "text": params.get("text", ""),
+                    "stop_reason": params.get("stop_reason"),
+                }
+            elif msg_type == "tool_result":
+                kind = AgentEventKind.TOOL_RESULT
+                payload = {
+                    k: v for k, v in params.items() if k != "type"
+                }
+        elif method == "update":
+            if msg_type == "tool_use":
+                tool_name = params.get("tool_name", "")
+                kind = AgentEventKind.TOOL_CALL
+                payload = {
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": tool_name,
+                    "arguments": params.get("arguments", {}),
+                    "permission_tier": determine_permission_tier(tool_name),
+                }
+            elif msg_type == "tool_result":
+                kind = AgentEventKind.TOOL_RESULT
+                payload = {
+                    k: v for k, v in params.items() if k != "type"
+                }
+            elif msg_type == "thinking":
+                kind = AgentEventKind.THINKING
+                payload = {
+                    "text": params.get("text", ""),
+                    "is_partial": params.get("is_partial", False),
+                }
+            elif msg_type == "permission_request":
+                kind = AgentEventKind.PERMISSION_REQUEST
+                payload = {
+                    k: v for k, v in params.items() if k != "type"
+                }
+        elif method == "error":
+            kind = AgentEventKind.ERROR
+            payload = {
+                "code": params.get("code", "agent_error"),
+                "message": params.get("message", "Unknown error"),
+                "recoverable": params.get("recoverable", False),
+            }
+
+        if kind is None:
+            logger.warning(
+                "StdioAdapter: unhandled notification method={} type={}",
+                method,
+                msg_type,
+            )
+            return
+
+        event = AgentEvent(
+            session_id=self._config.session_id,
+            kind=kind,
+            payload=payload,
+        )
+        await self._config.event_callback(event)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/stdio_adapter.py
@@ -100,7 +100,11 @@ class StdioAdapter(ProtocolAdapter):
             elif msg_type == "tool_result":
                 kind = AgentEventKind.TOOL_RESULT
                 payload = {
-                    k: v for k, v in params.items() if k != "type"
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "output": params.get("output", ""),
+                    "is_error": params.get("is_error", False),
+                    "duration_ms": params.get("duration_ms", 0),
                 }
         elif method == "update":
             if msg_type == "tool_use":
@@ -115,7 +119,11 @@ class StdioAdapter(ProtocolAdapter):
             elif msg_type == "tool_result":
                 kind = AgentEventKind.TOOL_RESULT
                 payload = {
-                    k: v for k, v in params.items() if k != "type"
+                    "tool_id": params.get("tool_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "output": params.get("output", ""),
+                    "is_error": params.get("is_error", False),
+                    "duration_ms": params.get("duration_ms", 0),
                 }
             elif msg_type == "thinking":
                 kind = AgentEventKind.THINKING
@@ -126,7 +134,11 @@ class StdioAdapter(ProtocolAdapter):
             elif msg_type == "permission_request":
                 kind = AgentEventKind.PERMISSION_REQUEST
                 payload = {
-                    k: v for k, v in params.items() if k != "type"
+                    "request_id": params.get("request_id", ""),
+                    "tool_name": params.get("tool_name", ""),
+                    "arguments": params.get("arguments", {}),
+                    "tier": params.get("tier", "batch"),
+                    "timeout_sec": params.get("timeout_sec", 300),
                 }
         elif method == "error":
             kind = AgentEventKind.ERROR

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -36,6 +36,16 @@ class AgentRegistryEntry:
     install_instructions: list[str] = field(default_factory=list)
     docs_url: str | None = None
 
+    # Protocol adapter fields (new for agent workspace harness)
+    protocol: str = "stdio"  # stdio | mcp | openai_tool_use
+    tool_execution_mode: str = "agent_side"  # agent_side | server_side | hybrid
+    mcp_transport: str = "stdio"  # stdio | sse | streamable_http
+    api_base_url: str | None = None
+    model: str | None = None
+    tools_from: str = "auto"  # auto | static | none
+    sandbox: str = "none"  # required | optional | none
+    trust_level: str = "standard"  # untrusted | standard | trusted
+
     def check_availability(self) -> dict[str, Any]:
         """Check runtime availability of this agent."""
         result: dict[str, Any] = {

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -12,7 +12,7 @@ import shutil
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 from loguru import logger
 
@@ -37,14 +37,14 @@ class AgentRegistryEntry:
     docs_url: str | None = None
 
     # Protocol adapter fields (new for agent workspace harness)
-    protocol: str = "stdio"  # stdio | mcp | openai_tool_use
-    tool_execution_mode: str = "agent_side"  # agent_side | server_side | hybrid
-    mcp_transport: str = "stdio"  # stdio | sse | streamable_http
+    protocol: Literal["stdio", "mcp", "openai_tool_use"] = "stdio"
+    tool_execution_mode: Literal["agent_side", "server_side", "hybrid"] = "agent_side"
+    mcp_transport: Literal["stdio", "sse", "streamable_http"] = "stdio"
     api_base_url: str | None = None
     model: str | None = None
-    tools_from: str = "auto"  # auto | static | none
-    sandbox: str = "none"  # required | optional | none
-    trust_level: str = "standard"  # untrusted | standard | trusted
+    tools_from: Literal["auto", "static", "none"] = "auto"
+    sandbox: Literal["required", "optional", "none"] = "none"
+    trust_level: Literal["untrusted", "standard", "trusted"] = "standard"
 
     def check_availability(self) -> dict[str, Any]:
         """Check runtime availability of this agent."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/__init__.py
@@ -1,0 +1,7 @@
+"""Event consumers for the Agent Client Protocol event bus."""
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import WSBroadcaster
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.audit_logger import AuditLogger
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.metrics_recorder import MetricsRecorder
+
+__all__ = ["EventConsumer", "WSBroadcaster", "AuditLogger", "MetricsRecorder"]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
@@ -25,7 +25,6 @@ class AuditLogger(EventConsumer):
 
     def __init__(
         self,
-        bus: SessionEventBus,
         write_batch_fn: WriteBatchFn,
         batch_size: int = 100,
         flush_interval: float = 5.0,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
@@ -1,0 +1,110 @@
+"""AuditLogger -- batching event consumer that flushes to a persistence callback."""
+from __future__ import annotations
+
+import asyncio
+from typing import Awaitable, Callable
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+WriteBatchFn = Callable[[list[AgentEvent]], Awaitable[None]]
+
+
+class AuditLogger(EventConsumer):
+    """Buffers events and flushes them in batches to a persistence callback.
+
+    Flushing occurs when either *batch_size* events have accumulated **or**
+    *flush_interval* seconds have elapsed since the last flush, whichever
+    comes first.  Any remaining events are flushed during :meth:`stop`.
+    """
+
+    consumer_id: str = "audit_logger"
+
+    def __init__(
+        self,
+        bus: SessionEventBus,
+        write_batch_fn: WriteBatchFn,
+        batch_size: int = 100,
+        flush_interval: float = 5.0,
+    ) -> None:
+        self._write_batch_fn = write_batch_fn
+        self._batch_size = batch_size
+        self._flush_interval = flush_interval
+        self._buffer: list[AgentEvent] = []
+        self._bus: SessionEventBus | None = None
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    # ------------------------------------------------------------------ #
+    # EventConsumer interface
+    # ------------------------------------------------------------------ #
+
+    async def on_event(self, event: AgentEvent) -> None:
+        """Buffer the event and flush if batch_size is reached."""
+        self._buffer.append(event)
+        if len(self._buffer) >= self._batch_size:
+            await self._flush()
+
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus* and spawn the consume-loop task."""
+        self._bus = bus
+        self._queue = bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        """Cancel the consume loop, flush remaining buffer, and unsubscribe."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+        # Flush any remaining buffered events
+        if self._buffer:
+            await self._flush()
+
+        if self._bus is not None:
+            self._bus.unsubscribe(self.consumer_id)
+            self._bus = None
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    async def _flush(self) -> None:
+        """Write the current buffer via write_batch_fn and clear it."""
+        if not self._buffer:
+            return
+        batch = list(self._buffer)
+        self._buffer.clear()
+        try:
+            await self._write_batch_fn(batch)
+        except Exception:
+            logger.exception(
+                "AuditLogger: write_batch_fn failed for batch of {} events",
+                len(batch),
+            )
+
+    async def _consume_loop(self) -> None:
+        """Read events from the queue, dispatching and flushing on interval."""
+        assert self._queue is not None  # noqa: S101
+        while self._running:
+            try:
+                event = await asyncio.wait_for(
+                    self._queue.get(),
+                    timeout=self._flush_interval,
+                )
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                # Interval elapsed -- flush partial buffer
+                await self._flush()
+            except asyncio.CancelledError:
+                break

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/audit_logger.py
@@ -94,7 +94,8 @@ class AuditLogger(EventConsumer):
 
     async def _consume_loop(self) -> None:
         """Read events from the queue, dispatching and flushing on interval."""
-        assert self._queue is not None  # noqa: S101
+        if self._queue is None:
+            return
         while self._running:
             try:
                 event = await asyncio.wait_for(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/base.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/base.py
@@ -1,0 +1,29 @@
+"""EventConsumer ABC -- base class for all event bus consumers."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class EventConsumer(ABC):
+    """Abstract base class for event bus consumers.
+
+    Each consumer subscribes to a :class:`SessionEventBus`, receives events
+    through its queue, and processes them according to its purpose.
+    """
+
+    consumer_id: str
+
+    @abstractmethod
+    async def on_event(self, event: AgentEvent) -> None:
+        """Handle a single event. Subclasses must implement this."""
+
+    @abstractmethod
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus* and begin consuming events."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Cancel the consume loop and unsubscribe from the bus."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
@@ -1,0 +1,70 @@
+"""MetricsRecorder -- lightweight event counter by kind."""
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class MetricsRecorder(EventConsumer):
+    """Counts events by :attr:`AgentEvent.kind` for lightweight metrics.
+
+    Access :attr:`counters` to inspect counts (keyed by kind *value* string).
+    """
+
+    consumer_id: str = "metrics_recorder"
+
+    def __init__(self) -> None:
+        self.counters: Counter[str] = Counter()
+        self._bus: SessionEventBus | None = None
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    # ------------------------------------------------------------------ #
+    # EventConsumer interface
+    # ------------------------------------------------------------------ #
+
+    async def on_event(self, event: AgentEvent) -> None:
+        """Increment the counter for the event's kind."""
+        self.counters[event.kind.value] += 1
+
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus* and spawn the consume-loop task."""
+        self._bus = bus
+        self._queue = bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        """Cancel the consume loop and unsubscribe."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._bus is not None:
+            self._bus.unsubscribe(self.consumer_id)
+            self._bus = None
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    async def _consume_loop(self) -> None:
+        """Read events from the queue and count them."""
+        assert self._queue is not None  # noqa: S101
+        while self._running:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/metrics_recorder.py
@@ -23,6 +23,7 @@ class MetricsRecorder(EventConsumer):
         self._queue: asyncio.Queue[AgentEvent] | None = None
         self._task: asyncio.Task[None] | None = None
         self._running: bool = False
+        self._stop_event: asyncio.Event = asyncio.Event()
 
     # ------------------------------------------------------------------ #
     # EventConsumer interface
@@ -37,11 +38,13 @@ class MetricsRecorder(EventConsumer):
         self._bus = bus
         self._queue = bus.subscribe(self.consumer_id)
         self._running = True
+        self._stop_event.clear()
         self._task = asyncio.create_task(self._consume_loop())
 
     async def stop(self) -> None:
-        """Cancel the consume loop and unsubscribe."""
+        """Signal the consume loop to exit and unsubscribe."""
         self._running = False
+        self._stop_event.set()
         if self._task is not None:
             self._task.cancel()
             try:
@@ -59,12 +62,20 @@ class MetricsRecorder(EventConsumer):
 
     async def _consume_loop(self) -> None:
         """Read events from the queue and count them."""
-        assert self._queue is not None  # noqa: S101
-        while self._running:
-            try:
-                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
-                await self.on_event(event)
-            except asyncio.TimeoutError:
-                continue
-            except asyncio.CancelledError:
-                break
+        if self._queue is None:
+            return
+        stop_task = asyncio.create_task(self._stop_event.wait())
+        try:
+            while self._running:
+                get_task = asyncio.create_task(self._queue.get())
+                done, _ = await asyncio.wait(
+                    {get_task, stop_task}, return_when=asyncio.FIRST_COMPLETED,
+                )
+                if stop_task in done:
+                    get_task.cancel()
+                    break
+                await self.on_event(get_task.result())
+        except asyncio.CancelledError:
+            pass
+        finally:
+            stop_task.cancel()

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -61,6 +61,7 @@ class WSBroadcaster(EventConsumer):
         self._queue: asyncio.Queue[AgentEvent] | None = None
         self._task: asyncio.Task[None] | None = None
         self._running: bool = False
+        self._stop_event: asyncio.Event = asyncio.Event()
 
     # ------------------------------------------------------------------ #
     # Connection management
@@ -115,11 +116,13 @@ class WSBroadcaster(EventConsumer):
         self._bus = bus
         self._queue = bus.subscribe(self.consumer_id)
         self._running = True
+        self._stop_event.clear()
         self._task = asyncio.create_task(self._consume_loop())
 
     async def stop(self) -> None:
-        """Cancel the consume loop and unsubscribe."""
+        """Signal the consume loop to exit and unsubscribe."""
         self._running = False
+        self._stop_event.set()
         if self._task is not None:
             self._task.cancel()
             try:
@@ -137,15 +140,23 @@ class WSBroadcaster(EventConsumer):
 
     async def _consume_loop(self) -> None:
         """Read events from the queue and dispatch to connections."""
-        assert self._queue is not None  # noqa: S101
-        while self._running:
-            try:
-                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
-                await self.on_event(event)
-            except asyncio.TimeoutError:
-                continue
-            except asyncio.CancelledError:
-                break
+        if self._queue is None:
+            return
+        stop_task = asyncio.create_task(self._stop_event.wait())
+        try:
+            while self._running:
+                get_task = asyncio.create_task(self._queue.get())
+                done, _ = await asyncio.wait(
+                    {get_task, stop_task}, return_when=asyncio.FIRST_COMPLETED,
+                )
+                if stop_task in done:
+                    get_task.cancel()
+                    break
+                await self.on_event(get_task.result())
+        except asyncio.CancelledError:
+            pass
+        finally:
+            stop_task.cancel()
 
 
 def _passes_filter(kind: AgentEventKind, verbosity: str) -> bool:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -112,6 +112,7 @@ class WSBroadcaster(EventConsumer):
                 logger.warning(
                     "WSBroadcaster: send failed for conn {}, removing",
                     info.conn_id,
+                    exc_info=True,
                 )
                 self.remove_connection(info.conn_id)
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 from loguru import logger
 
@@ -91,17 +91,21 @@ class WSBroadcaster(EventConsumer):
     # ------------------------------------------------------------------ #
 
     async def on_event(self, event: AgentEvent) -> None:
-        """Fan-out *event* to all connections that pass verbosity filter."""
-        msg: str | None = None  # lazily serialized
+        """Fan-out *event* to all connections that pass verbosity filter.
 
-        # Iterate over a snapshot so removals during iteration are safe
-        for info in list(self._connections.values()):
-            if not _passes_filter(event.kind, info.verbosity):
-                continue
+        Sends are dispatched concurrently so one slow connection does not
+        block delivery to others.
+        """
+        targets = [
+            info for info in self._connections.values()
+            if _passes_filter(event.kind, info.verbosity)
+        ]
+        if not targets:
+            return
 
-            if msg is None:
-                msg = json.dumps(event.to_dict())
+        msg = json.dumps(event.to_dict())
 
+        async def _safe_send(info: _ConnectionInfo) -> None:
             try:
                 await info.send_callback(msg)
             except Exception:
@@ -110,6 +114,8 @@ class WSBroadcaster(EventConsumer):
                     info.conn_id,
                 )
                 self.remove_connection(info.conn_id)
+
+        await asyncio.gather(*(_safe_send(info) for info in targets))
 
     async def start(self, bus: SessionEventBus) -> None:
         """Subscribe to *bus* and spawn the consume-loop task."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/consumers/ws_broadcaster.py
@@ -1,0 +1,160 @@
+"""WSBroadcaster -- fan-out events to WebSocket connections with verbosity filtering."""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Awaitable, Callable
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.base import EventConsumer
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+# Verbosity level -> set of event kinds that pass the filter
+_SUMMARY_KINDS: frozenset[AgentEventKind] = frozenset({
+    AgentEventKind.COMPLETION,
+    AgentEventKind.ERROR,
+    AgentEventKind.PERMISSION_REQUEST,
+    AgentEventKind.PERMISSION_RESPONSE,
+    AgentEventKind.STATUS_CHANGE,
+})
+
+_STRUCTURED_KINDS: frozenset[AgentEventKind] = _SUMMARY_KINDS | frozenset({
+    AgentEventKind.TOOL_CALL,
+    AgentEventKind.TOOL_RESULT,
+    AgentEventKind.FILE_CHANGE,
+    AgentEventKind.LIFECYCLE,
+})
+
+SendCallback = Callable[[str], Awaitable[None]]
+
+
+class _ConnectionInfo:
+    """Internal bookkeeping for a single WebSocket connection."""
+
+    __slots__ = ("conn_id", "send_callback", "verbosity")
+
+    def __init__(self, conn_id: str, send_callback: SendCallback, verbosity: str) -> None:
+        self.conn_id = conn_id
+        self.send_callback = send_callback
+        self.verbosity = verbosity
+
+
+class WSBroadcaster(EventConsumer):
+    """Broadcasts agent events to multiple WebSocket connections.
+
+    Each connection has an independent verbosity level that controls which
+    event kinds it receives.  Supported levels:
+
+    - ``"full"``: all events
+    - ``"summary"``: completion, error, permission_request, permission_response,
+      status_change
+    - ``"structured"``: summary + tool_call, tool_result, file_change, lifecycle
+    """
+
+    consumer_id: str = "ws_broadcaster"
+
+    def __init__(self) -> None:
+        self._connections: dict[str, _ConnectionInfo] = {}
+        self._bus: SessionEventBus | None = None
+        self._queue: asyncio.Queue[AgentEvent] | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._running: bool = False
+
+    # ------------------------------------------------------------------ #
+    # Connection management
+    # ------------------------------------------------------------------ #
+
+    def add_connection(
+        self,
+        conn_id: str,
+        send_callback: SendCallback,
+        verbosity: str = "full",
+    ) -> None:
+        """Register a WebSocket connection for event delivery."""
+        self._connections[conn_id] = _ConnectionInfo(conn_id, send_callback, verbosity)
+
+    def remove_connection(self, conn_id: str) -> None:
+        """Unregister a WebSocket connection."""
+        self._connections.pop(conn_id, None)
+
+    def set_verbosity(self, conn_id: str, verbosity: str) -> None:
+        """Change the verbosity level for an existing connection."""
+        info = self._connections.get(conn_id)
+        if info is not None:
+            info.verbosity = verbosity
+
+    # ------------------------------------------------------------------ #
+    # EventConsumer interface
+    # ------------------------------------------------------------------ #
+
+    async def on_event(self, event: AgentEvent) -> None:
+        """Fan-out *event* to all connections that pass verbosity filter."""
+        msg: str | None = None  # lazily serialized
+
+        # Iterate over a snapshot so removals during iteration are safe
+        for info in list(self._connections.values()):
+            if not _passes_filter(event.kind, info.verbosity):
+                continue
+
+            if msg is None:
+                msg = json.dumps(event.to_dict())
+
+            try:
+                await info.send_callback(msg)
+            except Exception:
+                logger.warning(
+                    "WSBroadcaster: send failed for conn {}, removing",
+                    info.conn_id,
+                )
+                self.remove_connection(info.conn_id)
+
+    async def start(self, bus: SessionEventBus) -> None:
+        """Subscribe to *bus* and spawn the consume-loop task."""
+        self._bus = bus
+        self._queue = bus.subscribe(self.consumer_id)
+        self._running = True
+        self._task = asyncio.create_task(self._consume_loop())
+
+    async def stop(self) -> None:
+        """Cancel the consume loop and unsubscribe."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._bus is not None:
+            self._bus.unsubscribe(self.consumer_id)
+            self._bus = None
+
+    # ------------------------------------------------------------------ #
+    # Internal
+    # ------------------------------------------------------------------ #
+
+    async def _consume_loop(self) -> None:
+        """Read events from the queue and dispatch to connections."""
+        assert self._queue is not None  # noqa: S101
+        while self._running:
+            try:
+                event = await asyncio.wait_for(self._queue.get(), timeout=1.0)
+                await self.on_event(event)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+
+def _passes_filter(kind: AgentEventKind, verbosity: str) -> bool:
+    """Return True if *kind* should be sent at *verbosity* level."""
+    if verbosity == "full":
+        return True
+    if verbosity == "structured":
+        return kind in _STRUCTURED_KINDS
+    if verbosity == "summary":
+        return kind in _SUMMARY_KINDS
+    # Unknown verbosity -- default to full
+    return True

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/event_bus.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/event_bus.py
@@ -1,0 +1,133 @@
+"""SessionEventBus -- per-session async event fan-out with monotonic sequencing."""
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent
+
+
+class SessionEventBus:
+    """Fan-out event bus scoped to a single agent session.
+
+    Events are assigned monotonically increasing sequence numbers and kept in a
+    bounded ring buffer for snapshot/replay.  Subscribers receive events via
+    individual ``asyncio.Queue`` instances.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        max_buffer: int = 10_000,
+        subscriber_queue_size: int = 1_000,
+    ) -> None:
+        self._session_id = session_id
+        self._subscriber_queue_size = subscriber_queue_size
+        self._sequence: int = 0
+        self._buffer: deque[AgentEvent] = deque(maxlen=max_buffer)
+        self._subscribers: dict[str, asyncio.Queue[AgentEvent]] = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def current_sequence(self) -> int:
+        """Last assigned sequence number (0 if nothing published yet)."""
+        return self._sequence
+
+    @property
+    def min_sequence(self) -> int:
+        """Lowest sequence number still available in the buffer."""
+        if self._buffer:
+            return self._buffer[0].sequence
+        return 0
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish(self, event: AgentEvent) -> None:
+        """Assign a sequence number and distribute *event* to all subscribers."""
+        self._sequence += 1
+        event.sequence = self._sequence
+        self._buffer.append(event)
+        self._distribute(event)
+
+    async def inject(self, event: AgentEvent) -> None:
+        """Alias for :meth:`publish` -- used for externally-sourced events."""
+        await self.publish(event)
+
+    # ------------------------------------------------------------------
+    # Subscription
+    # ------------------------------------------------------------------
+
+    def subscribe(
+        self,
+        consumer_id: str,
+        from_sequence: int = 0,
+    ) -> asyncio.Queue[AgentEvent]:
+        """Create a bounded queue for *consumer_id* and optionally replay history.
+
+        Parameters
+        ----------
+        consumer_id:
+            Unique identifier for the subscriber.
+        from_sequence:
+            If > 0, replay buffered events starting at this sequence number.
+
+        Returns
+        -------
+        asyncio.Queue that will receive future (and replayed) events.
+        """
+        queue: asyncio.Queue[AgentEvent] = asyncio.Queue(
+            maxsize=self._subscriber_queue_size,
+        )
+        self._subscribers[consumer_id] = queue
+
+        if from_sequence > 0:
+            for ev in self._buffer:
+                if ev.sequence >= from_sequence:
+                    try:
+                        queue.put_nowait(ev)
+                    except asyncio.QueueFull:
+                        logger.warning(
+                            "Replay overflow for subscriber {} at seq {}",
+                            consumer_id,
+                            ev.sequence,
+                        )
+                        break
+
+        return queue
+
+    def unsubscribe(self, consumer_id: str) -> None:
+        """Remove *consumer_id* so it no longer receives events."""
+        self._subscribers.pop(consumer_id, None)
+
+    # ------------------------------------------------------------------
+    # Snapshot / replay
+    # ------------------------------------------------------------------
+
+    def snapshot(self, from_sequence: int = 0) -> list[AgentEvent]:
+        """Return buffered events, optionally filtered by *from_sequence*."""
+        if from_sequence <= 0:
+            return list(self._buffer)
+        return [ev for ev in self._buffer if ev.sequence >= from_sequence]
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _distribute(self, event: AgentEvent) -> None:
+        """Push *event* to every subscriber queue (non-blocking)."""
+        for consumer_id, queue in self._subscribers.items():
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Event bus dropping event seq {} for subscriber {} (queue full)",
+                    event.sequence,
+                    consumer_id,
+                )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
@@ -1,0 +1,48 @@
+"""AgentEvent schema -- the core contract for the agent workspace harness."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class AgentEventKind(str, Enum):
+    """All event types in the agent event stream."""
+
+    THINKING = "thinking"
+    TOOL_CALL = "tool_call"
+    TOOL_RESULT = "tool_result"
+    FILE_CHANGE = "file_change"
+    TERMINAL_OUTPUT = "terminal_output"
+    PERMISSION_REQUEST = "permission_request"
+    PERMISSION_RESPONSE = "permission_response"
+    COMPLETION = "completion"
+    ERROR = "error"
+    STATUS_CHANGE = "status_change"
+    TOKEN_USAGE = "token_usage"
+    HEARTBEAT = "heartbeat"
+    LIFECYCLE = "lifecycle"
+
+
+@dataclass
+class AgentEvent:
+    """Single event in an agent session's event stream."""
+
+    session_id: str
+    kind: AgentEventKind
+    payload: dict[str, Any]
+    sequence: int = 0
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable dict representation."""
+        return {
+            "session_id": self.session_id,
+            "sequence": self.sequence,
+            "timestamp": self.timestamp.isoformat(),
+            "kind": self.kind.value,
+            "payload": self.payload,
+            "metadata": self.metadata,
+        }

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
@@ -46,3 +46,20 @@ class AgentEvent:
             "payload": self.payload,
             "metadata": self.metadata,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AgentEvent":
+        """Reconstruct an AgentEvent from a dict (e.g., from audit DB replay)."""
+        ts = data.get("timestamp")
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        elif not isinstance(ts, datetime):
+            ts = datetime.now(timezone.utc)
+        return cls(
+            session_id=data["session_id"],
+            kind=AgentEventKind(data["kind"]),
+            payload=data.get("payload", {}),
+            sequence=data.get("sequence", 0),
+            timestamp=ts,
+            metadata=data.get("metadata", {}),
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/events.py
@@ -50,9 +50,15 @@ class AgentEvent:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "AgentEvent":
         """Reconstruct an AgentEvent from a dict (e.g., from audit DB replay)."""
+        for key in ("session_id", "kind"):
+            if key not in data:
+                raise ValueError(f"AgentEvent.from_dict: missing required key {key!r}")
         ts = data.get("timestamp")
         if isinstance(ts, str):
-            ts = datetime.fromisoformat(ts)
+            # Python 3.10 fromisoformat doesn't handle +00:00; strip it
+            if ts.endswith("+00:00"):
+                ts = ts[:-6]
+            ts = datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
         elif not isinstance(ts, datetime):
             ts = datetime.now(timezone.utc)
         return cls(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -1,0 +1,159 @@
+"""GovernanceFilter -- pipeline stage between adapter and event bus.
+
+Intercepts TOOL_CALL events and applies permission tier logic:
+- ``auto`` tier tools pass through immediately.
+- ``batch`` / ``individual`` tier tools are held pending human approval.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
+
+
+class GovernanceFilter:
+    """Pipeline stage that gates tool calls based on permission tiers.
+
+    The adapter's ``event_callback`` should point at :meth:`process`.  Non-tool
+    events are forwarded to the bus immediately.  Tool calls are classified via
+    :func:`determine_permission_tier` and either forwarded (``auto``) or held
+    until a human decision arrives via :meth:`on_permission_response`.
+    """
+
+    def __init__(
+        self,
+        bus: SessionEventBus,
+        default_timeout_sec: int = 300,
+    ) -> None:
+        self._bus = bus
+        self._default_timeout_sec = default_timeout_sec
+        # request_id -> held AgentEvent
+        self._pending: dict[str, AgentEvent] = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def pending_count(self) -> int:
+        """Number of tool calls awaiting a permission decision."""
+        return len(self._pending)
+
+    # ------------------------------------------------------------------
+    # Pipeline entry point
+    # ------------------------------------------------------------------
+
+    async def process(self, event: AgentEvent) -> None:
+        """Route *event* through governance logic.
+
+        Non-TOOL_CALL events are forwarded to the bus immediately.
+        TOOL_CALL events are classified by permission tier.
+        """
+        if event.kind != AgentEventKind.TOOL_CALL:
+            await self._bus.publish(event)
+            return
+
+        tool_name: str = event.payload.get("tool_name", "")
+        tier = determine_permission_tier(tool_name)
+
+        if tier == "auto":
+            await self._bus.publish(event)
+            return
+
+        # Hold the event and publish a permission request
+        request_id = str(uuid.uuid4())
+        self._pending[request_id] = event
+
+        perm_request = AgentEvent(
+            session_id=event.session_id,
+            kind=AgentEventKind.PERMISSION_REQUEST,
+            payload={
+                "request_id": request_id,
+                "tool_name": tool_name,
+                "arguments": event.payload.get("arguments", {}),
+                "tier": tier,
+                "timeout_sec": self._default_timeout_sec,
+            },
+        )
+        await self._bus.publish(perm_request)
+        logger.info(
+            "Governance: held tool_call '{}' (tier={}) as request_id={}",
+            tool_name,
+            tier,
+            request_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Permission responses
+    # ------------------------------------------------------------------
+
+    async def on_permission_response(
+        self,
+        request_id: str,
+        decision: str,
+        reason: str | None = None,
+    ) -> None:
+        """Handle a human decision for a held tool call.
+
+        Parameters
+        ----------
+        request_id:
+            The id from the PERMISSION_REQUEST payload.
+        decision:
+            ``"approve"`` or ``"deny"``.
+        reason:
+            Optional human-supplied reason (used in deny error message).
+        """
+        held_event = self._pending.pop(request_id, None)
+        if held_event is None:
+            logger.warning(
+                "Governance: permission response for unknown request_id={}",
+                request_id,
+            )
+            return
+
+        if decision == "approve":
+            await self._bus.publish(held_event)
+            logger.info("Governance: approved request_id={}", request_id)
+        else:
+            # Emit an error TOOL_RESULT so the agent knows the call was denied
+            tool_name = held_event.payload.get("tool_name", "unknown")
+            error_msg = f"Permission denied for tool '{tool_name}'"
+            if reason:
+                error_msg += f": {reason}"
+
+            error_event = AgentEvent(
+                session_id=held_event.session_id,
+                kind=AgentEventKind.TOOL_RESULT,
+                payload={
+                    "tool_id": held_event.payload.get("tool_id", ""),
+                    "tool_name": tool_name,
+                    "output": error_msg,
+                    "is_error": True,
+                    "duration_ms": 0,
+                },
+            )
+            await self._bus.publish(error_event)
+            logger.info(
+                "Governance: denied request_id={} reason={}",
+                request_id,
+                reason,
+            )
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    async def cancel_all_pending(self) -> None:
+        """Cancel all pending permission requests (e.g. on session teardown)."""
+        for request_id in list(self._pending):
+            await self.on_permission_response(
+                request_id,
+                decision="deny",
+                reason="session cancelled",
+            )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -3,9 +3,14 @@
 Intercepts TOOL_CALL events and applies permission tier logic:
 - ``auto`` tier tools pass through immediately.
 - ``batch`` / ``individual`` tier tools are held pending human approval.
+
+Unanswered permission requests are automatically denied after
+``default_timeout_sec`` seconds.
 """
 from __future__ import annotations
 
+import asyncio
+import time
 import uuid
 
 from loguru import logger
@@ -15,6 +20,17 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, Ag
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
 
 
+class _PendingEntry:
+    """A held tool_call with its creation time for timeout enforcement."""
+
+    __slots__ = ("event", "created_at", "timeout_task")
+
+    def __init__(self, event: AgentEvent, timeout_task: asyncio.Task[None] | None = None) -> None:
+        self.event = event
+        self.created_at = time.monotonic()
+        self.timeout_task = timeout_task
+
+
 class GovernanceFilter:
     """Pipeline stage that gates tool calls based on permission tiers.
 
@@ -22,6 +38,9 @@ class GovernanceFilter:
     events are forwarded to the bus immediately.  Tool calls are classified via
     :func:`determine_permission_tier` and either forwarded (``auto``) or held
     until a human decision arrives via :meth:`on_permission_response`.
+
+    If no response arrives within ``default_timeout_sec``, the held tool call
+    is automatically denied.
     """
 
     def __init__(
@@ -31,8 +50,7 @@ class GovernanceFilter:
     ) -> None:
         self._bus = bus
         self._default_timeout_sec = default_timeout_sec
-        # request_id -> held AgentEvent
-        self._pending: dict[str, AgentEvent] = {}
+        self._pending: dict[str, _PendingEntry] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -67,7 +85,8 @@ class GovernanceFilter:
 
         # Hold the event and publish a permission request
         request_id = str(uuid.uuid4())
-        self._pending[request_id] = event
+        timeout_task = asyncio.create_task(self._timeout_pending(request_id, self._default_timeout_sec))
+        self._pending[request_id] = _PendingEntry(event=event, timeout_task=timeout_task)
 
         perm_request = AgentEvent(
             session_id=event.session_id,
@@ -109,13 +128,19 @@ class GovernanceFilter:
         reason:
             Optional human-supplied reason (used in deny error message).
         """
-        held_event = self._pending.pop(request_id, None)
-        if held_event is None:
+        entry = self._pending.pop(request_id, None)
+        if entry is None:
             logger.warning(
                 "Governance: permission response for unknown request_id={}",
                 request_id,
             )
             return
+
+        # Cancel the timeout task since a decision arrived
+        if entry.timeout_task is not None:
+            entry.timeout_task.cancel()
+
+        held_event = entry.event
 
         if decision == "approve":
             await self._bus.publish(held_event)
@@ -144,6 +169,24 @@ class GovernanceFilter:
                 request_id,
                 reason,
             )
+
+    # ------------------------------------------------------------------
+    # Timeout enforcement
+    # ------------------------------------------------------------------
+
+    async def _timeout_pending(self, request_id: str, timeout_sec: int) -> None:
+        """Auto-deny a held tool call after *timeout_sec* seconds."""
+        try:
+            await asyncio.sleep(timeout_sec)
+        except asyncio.CancelledError:
+            return  # decision arrived before timeout
+        if request_id in self._pending:
+            logger.info(
+                "Governance: permission timeout for request_id={} after {}s",
+                request_id,
+                timeout_sec,
+            )
+            await self.on_permission_response(request_id, "deny", reason="timeout")
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -7,7 +7,6 @@ Intercepts TOOL_CALL events and applies permission tier logic:
 from __future__ import annotations
 
 import uuid
-from typing import Any
 
 from loguru import logger
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -59,7 +59,8 @@ class GovernanceFilter:
             return
 
         tool_name: str = event.payload.get("tool_name", "")
-        tier = determine_permission_tier(tool_name)
+        # Use the adapter-provided tier if present; fall back to re-resolving
+        tier = event.payload.get("permission_tier") or determine_permission_tier(tool_name)
 
         if tier == "auto":
             await self._bus.publish(event)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
@@ -1,0 +1,78 @@
+"""SandboxBridge for provisioning and managing sandboxed agent environments.
+
+Delegates to an injected sandbox_service for actual container/VM lifecycle.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SandboxProvisionRequest:
+    """Request to provision a sandbox for an agent."""
+    user_id: int
+    agent_command: str
+    agent_args: list[str] = field(default_factory=list)
+    agent_env: dict[str, str] = field(default_factory=dict)
+    runtime: str | None = None
+    trust_level: str = "standard"
+    ttl_sec: int = 86400
+    network_policy: str = "deny_all"
+    workspace_files: list[str] | None = None
+
+
+@dataclass
+class SandboxHandle:
+    """Handle to a running sandbox session."""
+    sandbox_session_id: str
+    run_id: str
+    process_stdin: Any | None = None
+    process_stdout: Any | None = None
+    endpoint: str | None = None
+    ssh_endpoint: str | None = None
+
+
+class SandboxBridge:
+    """Bridge between ACP agent harness and sandbox service."""
+
+    def __init__(self, sandbox_service: Any) -> None:
+        self._service = sandbox_service
+
+    async def provision(self, request: SandboxProvisionRequest) -> SandboxHandle:
+        """Provision a sandbox session and start a run."""
+        session = await self._service.create_session(
+            user_id=request.user_id,
+            agent_command=request.agent_command,
+            agent_args=request.agent_args,
+            agent_env=request.agent_env,
+            runtime=request.runtime,
+            trust_level=request.trust_level,
+            ttl_sec=request.ttl_sec,
+            network_policy=request.network_policy,
+            workspace_files=request.workspace_files,
+        )
+        run = await self._service.start_run(
+            session_id=session["session_id"],
+        )
+        return SandboxHandle(
+            sandbox_session_id=session["session_id"],
+            run_id=run["run_id"],
+            process_stdin=run.get("process_stdin"),
+            process_stdout=run.get("process_stdout"),
+            endpoint=session.get("endpoint"),
+            ssh_endpoint=session.get("ssh_endpoint"),
+        )
+
+    async def teardown(self, handle: SandboxHandle) -> None:
+        """Tear down a sandbox: cancel the run, then delete the session."""
+        await self._service.cancel_run(handle.run_id)
+        await self._service.delete_session(handle.sandbox_session_id)
+
+    async def snapshot(self, handle: SandboxHandle) -> str:
+        """Create a snapshot of the sandbox state. Returns snapshot ID."""
+        return await self._service.snapshot(handle.sandbox_session_id)
+
+    async def restore(self, handle: SandboxHandle, snapshot_id: str) -> None:
+        """Restore a sandbox from a snapshot."""
+        await self._service.restore(handle.sandbox_session_id, snapshot_id)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/sandbox_bridge.py
@@ -1,19 +1,23 @@
 """SandboxBridge for provisioning and managing sandboxed agent environments.
 
 Delegates to an injected sandbox_service for actual container/VM lifecycle.
+The bridge translates between ACP session concepts and the Sandbox module's
+``SandboxService`` / ``SandboxOrchestrator`` API (``create_session``,
+``start_run_scaffold``, ``destroy_session``).
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
 
+from loguru import logger
+
 
 @dataclass
 class SandboxProvisionRequest:
     """Request to provision a sandbox for an agent."""
     user_id: int
-    agent_command: str
-    agent_args: list[str] = field(default_factory=list)
+    agent_command: list[str]
     agent_env: dict[str, str] = field(default_factory=dict)
     runtime: str | None = None
     trust_level: str = "standard"
@@ -34,40 +38,68 @@ class SandboxHandle:
 
 
 class SandboxBridge:
-    """Bridge between ACP agent harness and sandbox service."""
+    """Bridge between ACP agent harness and sandbox service.
+
+    The injected *sandbox_service* is expected to expose the same contract as
+    ``tldw_Server_API.app.core.Sandbox.service.SandboxService``:
+
+    - ``create_session(user_id, spec, spec_version, idem_key, raw_body) -> Session``
+    - ``start_run_scaffold(run_id, spec, ...) -> RunStatus``
+    - ``destroy_session(session_id) -> bool``
+
+    Where ``Session.id`` and ``RunStatus.run_id`` are the identifiers.
+    """
 
     def __init__(self, sandbox_service: Any) -> None:
         self._service = sandbox_service
 
     async def provision(self, request: SandboxProvisionRequest) -> SandboxHandle:
-        """Provision a sandbox session and start a run."""
+        """Provision a sandbox session and start a run inside it."""
+        # 1. Create the sandbox session (environment only, no process yet)
         session = await self._service.create_session(
             user_id=request.user_id,
-            agent_command=request.agent_command,
-            agent_args=request.agent_args,
-            agent_env=request.agent_env,
-            runtime=request.runtime,
-            trust_level=request.trust_level,
-            ttl_sec=request.ttl_sec,
-            network_policy=request.network_policy,
-            workspace_files=request.workspace_files,
+            spec={
+                "runtime": request.runtime,
+                "timeout_sec": request.ttl_sec,
+            },
+            spec_version="1",
+            idem_key=None,
+            raw_body={
+                "trust_level": request.trust_level,
+                "network_policy": request.network_policy,
+            },
         )
-        run = await self._service.start_run(
-            session_id=session["session_id"],
+        session_id = getattr(session, "id", None) or session.get("id", "")
+
+        # 2. Start the agent process inside the session
+        run = await self._service.start_run_scaffold(
+            run_id=None,
+            spec={
+                "session_id": session_id,
+                "command": request.agent_command,
+                "env": request.agent_env,
+            },
         )
+        run_id = getattr(run, "run_id", None) or getattr(run, "id", None) or run.get("run_id", "")
+
         return SandboxHandle(
-            sandbox_session_id=session["session_id"],
-            run_id=run["run_id"],
-            process_stdin=run.get("process_stdin"),
-            process_stdout=run.get("process_stdout"),
-            endpoint=session.get("endpoint"),
-            ssh_endpoint=session.get("ssh_endpoint"),
+            sandbox_session_id=session_id,
+            run_id=run_id,
+            process_stdin=getattr(run, "stdin", None),
+            process_stdout=getattr(run, "stdout", None),
+            endpoint=getattr(session, "endpoint", None),
+            ssh_endpoint=getattr(session, "ssh_endpoint", None),
         )
 
     async def teardown(self, handle: SandboxHandle) -> None:
-        """Tear down a sandbox: cancel the run, then delete the session."""
-        await self._service.cancel_run(handle.run_id)
-        await self._service.delete_session(handle.sandbox_session_id)
+        """Tear down a sandbox: destroy the session (which cleans up runs)."""
+        try:
+            await self._service.destroy_session(handle.sandbox_session_id)
+        except Exception:
+            logger.warning(
+                "SandboxBridge: destroy_session failed for {}",
+                handle.sandbox_session_id,
+            )
 
     async def snapshot(self, handle: SandboxHandle) -> str:
         """Create a snapshot of the sandbox state. Returns snapshot ID."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
@@ -1,0 +1,66 @@
+"""ToolExecutor interface and DefaultToolExecutor implementation.
+
+Provides an abstract base for executing tools by name, plus a default
+in-memory registry-based implementation.
+"""
+from __future__ import annotations
+
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+
+@dataclass
+class ToolResult:
+    """Result of a tool execution."""
+    output: str
+    is_error: bool
+    duration_ms: int = 0
+
+
+# Type alias for tool handler callables
+ToolHandler = Callable[[dict[str, Any]], Awaitable[ToolResult]]
+
+
+class ToolExecutor(ABC):
+    """Abstract base class for tool executors."""
+
+    @abstractmethod
+    async def execute(self, tool_name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Execute a tool by name with the given arguments."""
+        ...
+
+    @abstractmethod
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """List all available tools."""
+        ...
+
+
+class DefaultToolExecutor(ToolExecutor):
+    """Default in-memory tool executor with a simple handler registry."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolHandler] = {}
+
+    def register_tool(self, name: str, handler: ToolHandler) -> None:
+        """Register a tool handler by name."""
+        self._tools[name] = handler
+
+    async def execute(self, tool_name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Execute a registered tool. Returns error ToolResult if not found."""
+        handler = self._tools.get(tool_name)
+        if handler is None:
+            return ToolResult(
+                output=f"Tool not found: {tool_name}",
+                is_error=True,
+            )
+        start = time.monotonic()
+        result = await handler(arguments)
+        elapsed_ms = int((time.monotonic() - start) * 1000)
+        result.duration_ms = elapsed_ms
+        return result
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return list of registered tool descriptors."""
+        return [{"name": name} for name in self._tools]

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/tool_executor.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_adapter_base.py
@@ -1,0 +1,148 @@
+"""Unit tests for ProtocolAdapter ABC, AdapterConfig, and AdapterFactory."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Task 2 tests
+# ---------------------------------------------------------------------------
+
+def test_protocol_adapter_is_abstract():
+    """Instantiating ProtocolAdapter directly must raise TypeError."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import ProtocolAdapter
+
+    with pytest.raises(TypeError):
+        ProtocolAdapter()  # type: ignore[abstract]
+
+
+def test_adapter_config_creation():
+    """AdapterConfig holds event_callback, session_id, and protocol_config."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    async def _cb(ev):
+        pass
+
+    cfg = AdapterConfig(
+        event_callback=_cb,
+        session_id="sess-42",
+        protocol_config={"foo": "bar"},
+    )
+    assert cfg.event_callback is _cb
+    assert cfg.session_id == "sess-42"
+    assert cfg.protocol_config == {"foo": "bar"}
+
+
+def test_adapter_config_defaults():
+    """AdapterConfig protocol_config defaults to empty dict."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    async def _cb(ev):
+        pass
+
+    cfg = AdapterConfig(event_callback=_cb, session_id="s1")
+    assert cfg.protocol_config == {}
+
+
+def test_prompt_options_defaults():
+    """PromptOptions has sensible defaults."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import PromptOptions
+
+    opts = PromptOptions()
+    assert opts.max_tokens is None
+    assert opts.timeout_sec is None
+    assert opts.extra == {}
+
+
+def test_adapter_factory_register_and_create():
+    """Register a FakeAdapter, create it, verify type."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+        AdapterConfig,
+        ProtocolAdapter,
+        PromptOptions,
+    )
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+
+    class FakeAdapter(ProtocolAdapter):
+        protocol_name = "fake"
+
+        async def connect(self, config: AdapterConfig) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_prompt(self, messages: list[dict], options: PromptOptions | None = None) -> None:
+            pass
+
+        async def send_tool_result(self, tool_id: str, output: str, is_error: bool = False) -> None:
+            pass
+
+        async def cancel(self) -> None:
+            pass
+
+        @property
+        def is_connected(self) -> bool:
+            return False
+
+        @property
+        def supports_streaming(self) -> bool:
+            return False
+
+    factory = AdapterFactory()
+    factory.register("fake", FakeAdapter)
+    adapter = factory.create("fake")
+    assert isinstance(adapter, FakeAdapter)
+    assert adapter.protocol_name == "fake"
+
+
+def test_adapter_factory_unknown_protocol_raises():
+    """Creating an unknown protocol raises ValueError."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+
+    factory = AdapterFactory()
+    with pytest.raises(ValueError, match="Unknown protocol"):
+        factory.create("nonexistent")
+
+
+def test_adapter_factory_available_protocols():
+    """available_protocols returns registered names."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+        AdapterConfig,
+        ProtocolAdapter,
+        PromptOptions,
+    )
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+
+    class Dummy(ProtocolAdapter):
+        protocol_name = "dummy"
+
+        async def connect(self, config: AdapterConfig) -> None:
+            pass
+
+        async def disconnect(self) -> None:
+            pass
+
+        async def send_prompt(self, messages: list[dict], options: PromptOptions | None = None) -> None:
+            pass
+
+        async def send_tool_result(self, tool_id: str, output: str, is_error: bool = False) -> None:
+            pass
+
+        async def cancel(self) -> None:
+            pass
+
+        @property
+        def is_connected(self) -> bool:
+            return False
+
+        @property
+        def supports_streaming(self) -> bool:
+            return False
+
+    factory = AdapterFactory()
+    assert factory.available_protocols() == []
+    factory.register("dummy", Dummy)
+    assert "dummy" in factory.available_protocols()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
@@ -1,0 +1,77 @@
+"""Unit tests for AgentEvent schema."""
+from __future__ import annotations
+
+import pytest
+import json
+from datetime import datetime, timezone
+
+pytestmark = pytest.mark.unit
+
+
+def test_agent_event_kind_enum_has_all_kinds():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+
+    expected = {
+        "thinking", "tool_call", "tool_result", "file_change",
+        "terminal_output", "permission_request", "permission_response",
+        "completion", "error", "status_change", "token_usage",
+        "heartbeat", "lifecycle",
+    }
+    assert {k.value for k in AgentEventKind} == expected
+
+
+def test_agent_event_creation_minimal():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    ev = AgentEvent(
+        session_id="sess-1",
+        kind=AgentEventKind.COMPLETION,
+        payload={"text": "Hello", "stop_reason": "end_turn"},
+    )
+    assert ev.session_id == "sess-1"
+    assert ev.kind == AgentEventKind.COMPLETION
+    assert ev.sequence == 0
+    assert ev.payload["text"] == "Hello"
+    assert isinstance(ev.timestamp, datetime)
+    assert ev.metadata == {}
+
+
+def test_agent_event_to_dict_roundtrip():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    ev = AgentEvent(
+        session_id="sess-2",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}, "permission_tier": "individual"},
+        metadata={"adapter": "stdio"},
+    )
+    d = ev.to_dict()
+    assert d["kind"] == "tool_call"
+    assert d["session_id"] == "sess-2"
+    assert d["payload"]["tool_name"] == "bash"
+    json.dumps(d)
+
+
+def test_agent_event_all_payload_shapes():
+    """Verify every event kind can be instantiated with its documented payload."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    payloads = {
+        AgentEventKind.THINKING: {"text": "hmm", "is_partial": False},
+        AgentEventKind.TOOL_CALL: {"tool_id": "t1", "tool_name": "read", "arguments": {}, "permission_tier": "auto"},
+        AgentEventKind.TOOL_RESULT: {"tool_id": "t1", "tool_name": "read", "output": "data", "is_error": False, "duration_ms": 42},
+        AgentEventKind.FILE_CHANGE: {"path": "/a.txt", "action": "create", "diff": None, "content": "hi"},
+        AgentEventKind.TERMINAL_OUTPUT: {"command": "ls", "output": "file.txt", "exit_code": 0, "is_partial": False},
+        AgentEventKind.PERMISSION_REQUEST: {"request_id": "r1", "tool_name": "bash", "arguments": {}, "tier": "individual", "timeout_sec": 300},
+        AgentEventKind.PERMISSION_RESPONSE: {"request_id": "r1", "decision": "approve", "reason": None},
+        AgentEventKind.COMPLETION: {"text": "done", "stop_reason": "end_turn"},
+        AgentEventKind.ERROR: {"code": "adapter_disconnect", "message": "lost", "recoverable": True},
+        AgentEventKind.STATUS_CHANGE: {"from_status": "idle", "to_status": "working"},
+        AgentEventKind.TOKEN_USAGE: {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        AgentEventKind.HEARTBEAT: {"elapsed_sec": 15, "state": "thinking"},
+        AgentEventKind.LIFECYCLE: {"event": "agent_started", "exit_code": None},
+    }
+    for kind, payload in payloads.items():
+        ev = AgentEvent(session_id="s", kind=kind, payload=payload)
+        d = ev.to_dict()
+        json.dumps(d)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_agent_events.py
@@ -75,3 +75,26 @@ def test_agent_event_all_payload_shapes():
         ev = AgentEvent(session_id="s", kind=kind, payload=payload)
         d = ev.to_dict()
         json.dumps(d)
+
+
+def test_agent_event_from_dict_roundtrip():
+    """to_dict -> from_dict should produce an equivalent event."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+    original = AgentEvent(
+        session_id="sess-rt",
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {}},
+        sequence=42,
+        metadata={"adapter": "stdio"},
+    )
+    d = original.to_dict()
+    restored = AgentEvent.from_dict(d)
+
+    assert restored.session_id == original.session_id
+    assert restored.kind == original.kind
+    assert restored.payload == original.payload
+    assert restored.sequence == original.sequence
+    assert restored.metadata == original.metadata
+    # Timestamps should match (ISO roundtrip)
+    assert restored.timestamp.isoformat() == original.timestamp.isoformat()

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
@@ -25,6 +25,16 @@ def _make_event(
     return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
 
 
+async def _wait_for(predicate, *, timeout: float = 2.0, interval: float = 0.02):
+    """Poll *predicate* until it returns True or *timeout* elapses."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError(f"Timed out waiting for predicate after {timeout}s")
+
+
 # --------------------------------------------------------------------------- #
 # AuditLogger
 # --------------------------------------------------------------------------- #
@@ -39,20 +49,19 @@ async def test_audit_logger_batches_events():
     async def fake_write(batch: list[AgentEvent]) -> None:
         written_batches.append(list(batch))
 
-    logger = AuditLogger(
+    audit = AuditLogger(
         write_batch_fn=fake_write,
         batch_size=3,
         flush_interval=10.0,  # long interval so only batch_size triggers
     )
-    await logger.start(bus)
+    await audit.start(bus)
 
     for _ in range(3):
         await bus.publish(_make_event())
 
-    await asyncio.sleep(0.15)
-    await logger.stop()
+    await _wait_for(lambda: len(written_batches) >= 1)
+    await audit.stop()
 
-    # Should have flushed exactly one batch of 3
     assert len(written_batches) == 1
     assert len(written_batches[0]) == 3
 
@@ -66,20 +75,18 @@ async def test_audit_logger_flushes_on_interval():
     async def fake_write(batch: list[AgentEvent]) -> None:
         written_batches.append(list(batch))
 
-    logger = AuditLogger(
+    audit = AuditLogger(
         write_batch_fn=fake_write,
         batch_size=100,  # high batch size so it never triggers
-        flush_interval=0.15,
+        flush_interval=0.1,
     )
-    await logger.start(bus)
+    await audit.start(bus)
 
     await bus.publish(_make_event())
 
-    # Wait longer than flush_interval
-    await asyncio.sleep(0.35)
-    await logger.stop()
+    await _wait_for(lambda: sum(len(b) for b in written_batches) >= 1)
+    await audit.stop()
 
-    assert len(written_batches) >= 1
     total_events = sum(len(b) for b in written_batches)
     assert total_events == 1
 
@@ -100,7 +107,7 @@ async def test_metrics_recorder_counts_tool_calls():
     await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
     await bus.publish(_make_event(AgentEventKind.COMPLETION))
 
-    await asyncio.sleep(0.1)
+    await _wait_for(lambda: sum(recorder.counters.values()) >= 3)
     await recorder.stop()
 
     assert recorder.counters["tool_call"] == 2

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
@@ -40,7 +40,6 @@ async def test_audit_logger_batches_events():
         written_batches.append(list(batch))
 
     logger = AuditLogger(
-        bus=bus,
         write_batch_fn=fake_write,
         batch_size=3,
         flush_interval=10.0,  # long interval so only batch_size triggers
@@ -68,7 +67,6 @@ async def test_audit_logger_flushes_on_interval():
         written_batches.append(list(batch))
 
     logger = AuditLogger(
-        bus=bus,
         write_batch_fn=fake_write,
         batch_size=100,  # high batch size so it never triggers
         flush_interval=0.15,

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
@@ -1,0 +1,109 @@
+"""Tests for AuditLogger and MetricsRecorder event consumers."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.audit_logger import (
+    AuditLogger,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.metrics_recorder import (
+    MetricsRecorder,
+)
+
+
+def _make_event(
+    kind: AgentEventKind = AgentEventKind.TOOL_CALL,
+    session_id: str = "sess-1",
+) -> AgentEvent:
+    return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
+
+
+# --------------------------------------------------------------------------- #
+# AuditLogger
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_batches_events():
+    """When batch_size events are buffered, write_batch_fn should be called."""
+    bus = SessionEventBus(session_id="sess-1")
+    written_batches: list[list[AgentEvent]] = []
+
+    async def fake_write(batch: list[AgentEvent]) -> None:
+        written_batches.append(list(batch))
+
+    logger = AuditLogger(
+        bus=bus,
+        write_batch_fn=fake_write,
+        batch_size=3,
+        flush_interval=10.0,  # long interval so only batch_size triggers
+    )
+    await logger.start(bus)
+
+    for _ in range(3):
+        await bus.publish(_make_event())
+
+    await asyncio.sleep(0.15)
+    await logger.stop()
+
+    # Should have flushed exactly one batch of 3
+    assert len(written_batches) == 1
+    assert len(written_batches[0]) == 3
+
+
+@pytest.mark.asyncio
+async def test_audit_logger_flushes_on_interval():
+    """A partially-full buffer should flush after flush_interval elapses."""
+    bus = SessionEventBus(session_id="sess-1")
+    written_batches: list[list[AgentEvent]] = []
+
+    async def fake_write(batch: list[AgentEvent]) -> None:
+        written_batches.append(list(batch))
+
+    logger = AuditLogger(
+        bus=bus,
+        write_batch_fn=fake_write,
+        batch_size=100,  # high batch size so it never triggers
+        flush_interval=0.15,
+    )
+    await logger.start(bus)
+
+    await bus.publish(_make_event())
+
+    # Wait longer than flush_interval
+    await asyncio.sleep(0.35)
+    await logger.stop()
+
+    assert len(written_batches) >= 1
+    total_events = sum(len(b) for b in written_batches)
+    assert total_events == 1
+
+
+# --------------------------------------------------------------------------- #
+# MetricsRecorder
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_metrics_recorder_counts_tool_calls():
+    """MetricsRecorder should count events by kind."""
+    bus = SessionEventBus(session_id="sess-1")
+    recorder = MetricsRecorder()
+    await recorder.start(bus)
+
+    await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
+    await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
+    await bus.publish(_make_event(AgentEventKind.COMPLETION))
+
+    await asyncio.sleep(0.1)
+    await recorder.stop()
+
+    assert recorder.counters["tool_call"] == 2
+    assert recorder.counters["completion"] == 1

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_consumers.py
@@ -27,8 +27,8 @@ def _make_event(
 
 async def _wait_for(predicate, *, timeout: float = 2.0, interval: float = 0.02):
     """Poll *predicate* until it returns True or *timeout* elapses."""
-    deadline = asyncio.get_event_loop().time() + timeout
-    while asyncio.get_event_loop().time() < deadline:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
         if predicate():
             return
         await asyncio.sleep(interval)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_event_bus.py
@@ -1,0 +1,133 @@
+"""Unit tests for SessionEventBus."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(session_id: str = "s1", kind: AgentEventKind = AgentEventKind.THINKING) -> AgentEvent:
+    return AgentEvent(session_id=session_id, kind=kind, payload={"text": "hi"})
+
+
+@pytest.mark.asyncio
+async def test_bus_assigns_sequence_numbers():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1")
+    e1 = _make_event()
+    e2 = _make_event()
+    e3 = _make_event()
+    await bus.publish(e1)
+    await bus.publish(e2)
+    await bus.publish(e3)
+    assert e1.sequence == 1
+    assert e2.sequence == 2
+    assert e3.sequence == 3
+    assert bus.current_sequence == 3
+
+
+@pytest.mark.asyncio
+async def test_bus_fan_out_to_multiple_subscribers():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1")
+    q1 = bus.subscribe("consumer-a")
+    q2 = bus.subscribe("consumer-b")
+    ev = _make_event()
+    await bus.publish(ev)
+
+    got1 = await asyncio.wait_for(q1.get(), timeout=1.0)
+    got2 = await asyncio.wait_for(q2.get(), timeout=1.0)
+    assert got1 is ev
+    assert got2 is ev
+    assert got1.sequence == 1
+
+
+@pytest.mark.asyncio
+async def test_bus_unsubscribe_stops_delivery():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1")
+    q = bus.subscribe("consumer-a")
+    await bus.publish(_make_event())
+    bus.unsubscribe("consumer-a")
+    await bus.publish(_make_event())
+
+    # Only one event should be in the queue
+    got = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert got.sequence == 1
+    assert q.empty()
+
+
+@pytest.mark.asyncio
+async def test_bus_snapshot_returns_history():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1")
+    for _ in range(5):
+        await bus.publish(_make_event())
+
+    # All history
+    snap = bus.snapshot()
+    assert len(snap) == 5
+    assert [e.sequence for e in snap] == [1, 2, 3, 4, 5]
+
+    # From sequence 3 onwards
+    snap_from_3 = bus.snapshot(from_sequence=3)
+    assert len(snap_from_3) == 3
+    assert [e.sequence for e in snap_from_3] == [3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_bus_snapshot_respects_buffer_limit():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1", max_buffer=3)
+    for _ in range(5):
+        await bus.publish(_make_event())
+
+    snap = bus.snapshot()
+    # Only last 3 events kept due to deque maxlen
+    assert len(snap) == 3
+    assert [e.sequence for e in snap] == [3, 4, 5]
+    assert bus.min_sequence == 3
+
+
+@pytest.mark.asyncio
+async def test_bus_inject_delivers_event():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1")
+    q = bus.subscribe("consumer-a")
+    ev = _make_event()
+    await bus.inject(ev)
+
+    got = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert got is ev
+    assert got.sequence == 1
+
+
+@pytest.mark.asyncio
+async def test_bus_backpressure_drops_to_full_queue():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+
+    bus = SessionEventBus(session_id="s1", subscriber_queue_size=2)
+    q = bus.subscribe("consumer-a")
+
+    # Publish 5 events without consuming -- queue holds only 2
+    for _ in range(5):
+        await bus.publish(_make_event())
+
+    # Queue should contain exactly 2 events (the first 2 that fit)
+    items = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    assert len(items) == 2
+    # First two were accepted, rest dropped
+    assert items[0].sequence == 1
+    assert items[1].sequence == 2

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
@@ -124,3 +124,29 @@ async def test_governance_deny_emits_error_tool_result(bus, gov):
     assert "too dangerous" in error_result.payload["output"]
     assert error_result.payload["tool_name"] == "bash"
     assert gov.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_governance_timeout_auto_denies(bus):
+    """Unanswered permission requests are auto-denied after timeout_sec."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+
+    gov = GovernanceFilter(bus=bus, default_timeout_sec=0.1)  # 100ms timeout
+    q = bus.subscribe("test")
+
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {}},
+    )
+    await gov.process(ev)
+
+    # Consume the permission_request
+    perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+
+    # Wait for the timeout to fire (100ms + margin)
+    error_result = await asyncio.wait_for(q.get(), timeout=2.0)
+    assert error_result.kind == AgentEventKind.TOOL_RESULT
+    assert error_result.payload["is_error"] is True
+    assert "timeout" in error_result.payload["output"].lower()
+    assert gov.pending_count == 0

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
@@ -1,0 +1,126 @@
+"""Unit tests for GovernanceFilter pipeline stage."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+
+def _make_event(
+    kind: AgentEventKind = AgentEventKind.THINKING,
+    payload: dict | None = None,
+    session_id: str = "s1",
+) -> AgentEvent:
+    return AgentEvent(
+        session_id=session_id,
+        kind=kind,
+        payload=payload or {"text": "hi"},
+    )
+
+
+@pytest.fixture
+def bus():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    return SessionEventBus(session_id="s1")
+
+
+@pytest.fixture
+def gov(bus):
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import GovernanceFilter
+    return GovernanceFilter(bus=bus)
+
+
+@pytest.mark.asyncio
+async def test_governance_passes_non_tool_events_immediately(bus, gov):
+    q = bus.subscribe("test")
+    ev = _make_event(kind=AgentEventKind.THINKING, payload={"text": "hmm"})
+    await gov.process(ev)
+
+    got = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert got is ev
+    assert got.kind == AgentEventKind.THINKING
+
+
+@pytest.mark.asyncio
+async def test_governance_auto_tier_passes_through(bus, gov):
+    """Tool with auto tier (e.g. read_file) goes straight to bus."""
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "read_file", "arguments": {}},
+    )
+    await gov.process(ev)
+
+    got = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert got is ev
+    assert got.kind == AgentEventKind.TOOL_CALL
+
+
+@pytest.mark.asyncio
+async def test_governance_individual_tier_holds_and_emits_permission_request(bus, gov):
+    """Tool with individual tier (e.g. bash) is held; a PERMISSION_REQUEST is emitted."""
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "rm -rf /"}},
+    )
+    await gov.process(ev)
+
+    # The bus should have received a PERMISSION_REQUEST, not the original tool_call
+    perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+    assert "request_id" in perm_req.payload
+    assert perm_req.payload["tool_name"] == "bash"
+    assert perm_req.payload["tier"] == "individual"
+
+    # Original event should NOT be on bus yet
+    assert q.empty()
+    assert gov.pending_count == 1
+
+
+@pytest.mark.asyncio
+async def test_governance_approve_releases_held_tool_call(bus, gov):
+    """Approving a held tool_call publishes it to the bus."""
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}},
+    )
+    await gov.process(ev)
+
+    perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+    request_id = perm_req.payload["request_id"]
+
+    await gov.on_permission_response(request_id, decision="approve")
+
+    released = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert released is ev
+    assert released.kind == AgentEventKind.TOOL_CALL
+    assert gov.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_governance_deny_emits_error_tool_result(bus, gov):
+    """Denying a held tool_call publishes a TOOL_RESULT with is_error=True."""
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "rm -rf /"}},
+    )
+    await gov.process(ev)
+
+    perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+    request_id = perm_req.payload["request_id"]
+
+    await gov.on_permission_response(request_id, decision="deny", reason="too dangerous")
+
+    error_result = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert error_result.kind == AgentEventKind.TOOL_RESULT
+    assert error_result.payload["is_error"] is True
+    assert "too dangerous" in error_result.payload["output"]
+    assert error_result.payload["tool_name"] == "bash"
+    assert gov.pending_count == 0

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_extension.py
@@ -1,0 +1,102 @@
+"""Tests for AgentRegistryEntry new fields (Task 8)."""
+from __future__ import annotations
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import (
+    AgentRegistryEntry,
+)
+
+
+class TestRegistryEntryNewFieldsHaveDefaults:
+    """Creating an entry with only type+name should populate all new field defaults."""
+
+    def test_registry_entry_new_fields_have_defaults(self) -> None:
+        entry = AgentRegistryEntry(type="test_agent", name="Test Agent")
+
+        # Original defaults still hold
+        assert entry.description == ""
+        assert entry.command == ""
+        assert entry.args == []
+        assert entry.env == {}
+        assert entry.requires_api_key is None
+        assert entry.default is False
+        assert entry.install_instructions == []
+        assert entry.docs_url is None
+
+        # New field defaults
+        assert entry.protocol == "stdio"
+        assert entry.tool_execution_mode == "agent_side"
+        assert entry.mcp_transport == "stdio"
+        assert entry.api_base_url is None
+        assert entry.model is None
+        assert entry.tools_from == "auto"
+        assert entry.sandbox == "none"
+        assert entry.trust_level == "standard"
+
+
+class TestRegistryEntryWithOpenaiProtocol:
+    """Creating an entry with openai_tool_use protocol and related fields."""
+
+    def test_registry_entry_with_openai_protocol(self) -> None:
+        entry = AgentRegistryEntry(
+            type="openai_agent",
+            name="OpenAI Agent",
+            protocol="openai_tool_use",
+            api_base_url="https://api.openai.com/v1",
+            model="gpt-4o",
+            tool_execution_mode="server_side",
+            trust_level="trusted",
+        )
+
+        assert entry.protocol == "openai_tool_use"
+        assert entry.api_base_url == "https://api.openai.com/v1"
+        assert entry.model == "gpt-4o"
+        assert entry.tool_execution_mode == "server_side"
+        assert entry.trust_level == "trusted"
+        # Other new fields still at defaults
+        assert entry.mcp_transport == "stdio"
+        assert entry.tools_from == "auto"
+        assert entry.sandbox == "none"
+
+
+class TestRegistryEntryFromYamlDictWithNewFields:
+    """Simulate YAML parsing by constructing from a dict (as load() does)."""
+
+    def test_registry_entry_from_yaml_dict_with_new_fields(self) -> None:
+        yaml_dict = {
+            "type": "mcp_agent",
+            "name": "MCP Agent",
+            "description": "An MCP-based agent",
+            "command": "mcp-server",
+            "args": ["--port", "8080"],
+            "protocol": "mcp",
+            "mcp_transport": "sse",
+            "tool_execution_mode": "hybrid",
+            "sandbox": "required",
+            "trust_level": "untrusted",
+            "tools_from": "static",
+        }
+
+        entry = AgentRegistryEntry(
+            type=str(yaml_dict["type"]),
+            name=str(yaml_dict["name"]),
+            description=str(yaml_dict.get("description", "")),
+            command=str(yaml_dict.get("command", "")),
+            args=list(yaml_dict.get("args", [])),
+            protocol=str(yaml_dict.get("protocol", "stdio")),
+            mcp_transport=str(yaml_dict.get("mcp_transport", "stdio")),
+            tool_execution_mode=str(yaml_dict.get("tool_execution_mode", "agent_side")),
+            sandbox=str(yaml_dict.get("sandbox", "none")),
+            trust_level=str(yaml_dict.get("trust_level", "standard")),
+            tools_from=str(yaml_dict.get("tools_from", "auto")),
+        )
+
+        assert entry.type == "mcp_agent"
+        assert entry.name == "MCP Agent"
+        assert entry.protocol == "mcp"
+        assert entry.mcp_transport == "sse"
+        assert entry.tool_execution_mode == "hybrid"
+        assert entry.sandbox == "required"
+        assert entry.trust_level == "untrusted"
+        assert entry.tools_from == "static"
+        assert entry.api_base_url is None
+        assert entry.model is None

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
@@ -1,8 +1,9 @@
-"""Tests for SandboxBridge (Task 10)."""
+"""Tests for SandboxBridge."""
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_bridge import (
     SandboxBridge,
@@ -10,29 +11,32 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_bridge import (
     SandboxProvisionRequest,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestSandboxBridgeProvisionReturnsHandle:
-    """provision() should call create_session + start_run and return a SandboxHandle."""
+    """provision() should call create_session + start_run_scaffold and return a SandboxHandle."""
 
     @pytest.mark.asyncio
     async def test_sandbox_bridge_provision_returns_handle(self) -> None:
+        mock_session = MagicMock()
+        mock_session.id = "sess-123"
+        mock_session.endpoint = "http://localhost:9000"
+        mock_session.ssh_endpoint = "ssh://localhost:2222"
+
+        mock_run = MagicMock()
+        mock_run.run_id = "run-456"
+        mock_run.stdin = "stdin_mock"
+        mock_run.stdout = "stdout_mock"
+
         mock_service = MagicMock()
-        mock_service.create_session = AsyncMock(return_value={
-            "session_id": "sess-123",
-            "endpoint": "http://localhost:9000",
-            "ssh_endpoint": "ssh://localhost:2222",
-        })
-        mock_service.start_run = AsyncMock(return_value={
-            "run_id": "run-456",
-            "process_stdin": "stdin_mock",
-            "process_stdout": "stdout_mock",
-        })
+        mock_service.create_session = AsyncMock(return_value=mock_session)
+        mock_service.start_run_scaffold = AsyncMock(return_value=mock_run)
 
         bridge = SandboxBridge(sandbox_service=mock_service)
         request = SandboxProvisionRequest(
             user_id=1,
-            agent_command="python",
-            agent_args=["-m", "agent"],
+            agent_command=["python", "-m", "agent"],
             trust_level="untrusted",
         )
         handle = await bridge.provision(request)
@@ -46,17 +50,16 @@ class TestSandboxBridgeProvisionReturnsHandle:
         assert handle.process_stdout == "stdout_mock"
 
         mock_service.create_session.assert_awaited_once()
-        mock_service.start_run.assert_awaited_once()
+        mock_service.start_run_scaffold.assert_awaited_once()
 
 
 class TestSandboxBridgeTeardown:
-    """teardown() should call cancel_run + delete_session."""
+    """teardown() should call destroy_session."""
 
     @pytest.mark.asyncio
     async def test_sandbox_bridge_teardown(self) -> None:
         mock_service = MagicMock()
-        mock_service.cancel_run = AsyncMock()
-        mock_service.delete_session = AsyncMock()
+        mock_service.destroy_session = AsyncMock()
 
         bridge = SandboxBridge(sandbox_service=mock_service)
         handle = SandboxHandle(
@@ -66,5 +69,4 @@ class TestSandboxBridgeTeardown:
 
         await bridge.teardown(handle)
 
-        mock_service.cancel_run.assert_awaited_once_with("run-456")
-        mock_service.delete_session.assert_awaited_once_with("sess-123")
+        mock_service.destroy_session.assert_awaited_once_with("sess-123")

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_sandbox_bridge.py
@@ -1,0 +1,70 @@
+"""Tests for SandboxBridge (Task 10)."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.sandbox_bridge import (
+    SandboxBridge,
+    SandboxHandle,
+    SandboxProvisionRequest,
+)
+
+
+class TestSandboxBridgeProvisionReturnsHandle:
+    """provision() should call create_session + start_run and return a SandboxHandle."""
+
+    @pytest.mark.asyncio
+    async def test_sandbox_bridge_provision_returns_handle(self) -> None:
+        mock_service = MagicMock()
+        mock_service.create_session = AsyncMock(return_value={
+            "session_id": "sess-123",
+            "endpoint": "http://localhost:9000",
+            "ssh_endpoint": "ssh://localhost:2222",
+        })
+        mock_service.start_run = AsyncMock(return_value={
+            "run_id": "run-456",
+            "process_stdin": "stdin_mock",
+            "process_stdout": "stdout_mock",
+        })
+
+        bridge = SandboxBridge(sandbox_service=mock_service)
+        request = SandboxProvisionRequest(
+            user_id=1,
+            agent_command="python",
+            agent_args=["-m", "agent"],
+            trust_level="untrusted",
+        )
+        handle = await bridge.provision(request)
+
+        assert isinstance(handle, SandboxHandle)
+        assert handle.sandbox_session_id == "sess-123"
+        assert handle.run_id == "run-456"
+        assert handle.endpoint == "http://localhost:9000"
+        assert handle.ssh_endpoint == "ssh://localhost:2222"
+        assert handle.process_stdin == "stdin_mock"
+        assert handle.process_stdout == "stdout_mock"
+
+        mock_service.create_session.assert_awaited_once()
+        mock_service.start_run.assert_awaited_once()
+
+
+class TestSandboxBridgeTeardown:
+    """teardown() should call cancel_run + delete_session."""
+
+    @pytest.mark.asyncio
+    async def test_sandbox_bridge_teardown(self) -> None:
+        mock_service = MagicMock()
+        mock_service.cancel_run = AsyncMock()
+        mock_service.delete_session = AsyncMock()
+
+        bridge = SandboxBridge(sandbox_service=mock_service)
+        handle = SandboxHandle(
+            sandbox_session_id="sess-123",
+            run_id="run-456",
+        )
+
+        await bridge.teardown(handle)
+
+        mock_service.cancel_run.assert_awaited_once_with("run-456")
+        mock_service.delete_session.assert_awaited_once_with("sess-123")

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
@@ -1,0 +1,379 @@
+"""Unit tests for StdioAdapter wrapping ACPStdioClient."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_stdio_adapter_protocol_name():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+
+    adapter = StdioAdapter()
+    assert adapter.protocol_name == "stdio"
+
+
+def test_stdio_adapter_not_connected_initially():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+
+    adapter = StdioAdapter()
+    assert adapter.is_connected is False
+
+
+def test_stdio_adapter_supports_streaming():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+
+    adapter = StdioAdapter()
+    assert adapter.supports_streaming is True
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_connect_sets_connected():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-1",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+    assert adapter.is_connected is True
+    mock_client.set_notification_handler.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_completion_notification():
+    """Simulate a result notification with type=text and verify COMPLETION event."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-1",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    # Extract the notification handler that was set on the client
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    # Simulate a completion notification
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="result",
+        params={"type": "text", "text": "Hello world", "stop_reason": "end_turn"},
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    ev = received_events[0]
+    assert ev.kind == AgentEventKind.COMPLETION
+    assert ev.session_id == "sess-1"
+    assert ev.payload["text"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_tool_use_notification():
+    """Simulate an update notification with type=tool_use and verify TOOL_CALL event."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-2",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="update",
+        params={
+            "type": "tool_use",
+            "tool_id": "t1",
+            "tool_name": "bash",
+            "arguments": {"cmd": "ls"},
+        },
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    ev = received_events[0]
+    assert ev.kind == AgentEventKind.TOOL_CALL
+    assert ev.payload["tool_name"] == "bash"
+    assert ev.payload["tool_id"] == "t1"
+    assert "permission_tier" in ev.payload
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_thinking_notification():
+    """Simulate an update notification with type=thinking."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-3",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="update",
+        params={"type": "thinking", "text": "Let me think..."},
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    assert received_events[0].kind == AgentEventKind.THINKING
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_error_notification():
+    """Simulate an error notification."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-4",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="error",
+        params={"message": "something broke"},
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    assert received_events[0].kind == AgentEventKind.ERROR
+    assert received_events[0].payload["message"] == "something broke"
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_tool_result_from_update():
+    """Simulate an update notification with type=tool_result."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-5",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="update",
+        params={"type": "tool_result", "tool_id": "t1", "output": "file.txt"},
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    assert received_events[0].kind == AgentEventKind.TOOL_RESULT
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_translates_permission_request():
+    """Simulate an update notification with type=permission_request."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+    from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+    from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+
+    received_events = []
+
+    async def capture(event):
+        received_events.append(event)
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=capture,
+        session_id="sess-6",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    handler = mock_client.set_notification_handler.call_args[0][0]
+
+    notification = ACPMessage(
+        jsonrpc="2.0",
+        method="update",
+        params={"type": "permission_request", "request_id": "r1", "tool_name": "bash"},
+    )
+    await handler(notification)
+
+    assert len(received_events) == 1
+    assert received_events[0].kind == AgentEventKind.PERMISSION_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_disconnect():
+    """Verify disconnect calls client.close()."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-7",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+    assert adapter.is_connected is True
+
+    await adapter.disconnect()
+    mock_client.close.assert_awaited_once()
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_send_prompt():
+    """Verify send_prompt calls client.call with correct args."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-8",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    messages = [{"role": "user", "content": "Hello"}]
+    await adapter.send_prompt(messages)
+
+    mock_client.call.assert_awaited_once_with("prompt", {"messages": messages})
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_send_tool_result():
+    """Verify send_tool_result calls client.call with correct args."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-9",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    await adapter.send_tool_result("t1", "output data", is_error=True)
+
+    mock_client.call.assert_awaited_once_with(
+        "tool_result",
+        {"tool_id": "t1", "output": "output data", "is_error": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_cancel():
+    """Verify cancel calls client.notify."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = True
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-10",
+        protocol_config={"client": mock_client},
+    )
+    await adapter.connect(config)
+
+    await adapter.cancel()
+
+    mock_client.notify.assert_awaited_once_with("cancel", {})

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_stdio_adapter.py
@@ -50,6 +50,26 @@ async def test_stdio_adapter_connect_sets_connected():
 
 
 @pytest.mark.asyncio
+async def test_stdio_adapter_connect_rejects_unstarted_client():
+    """connect() should raise RuntimeError if the client process is not running."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import AdapterConfig
+
+    mock_client = AsyncMock()
+    mock_client.is_running = False  # process not started
+
+    adapter = StdioAdapter()
+    config = AdapterConfig(
+        event_callback=AsyncMock(),
+        session_id="sess-1",
+        protocol_config={"client": mock_client},
+    )
+    with pytest.raises(RuntimeError, match="not running"):
+        await adapter.connect(config)
+    assert adapter.is_connected is False
+
+
+@pytest.mark.asyncio
 async def test_stdio_adapter_translates_completion_notification():
     """Simulate a result notification with type=text and verify COMPLETION event."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_executor.py
@@ -1,0 +1,72 @@
+"""Tests for ToolExecutor interface and DefaultToolExecutor (Task 9)."""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.tool_executor import (
+    DefaultToolExecutor,
+    ToolExecutor,
+    ToolResult,
+)
+
+
+class TestToolExecutorIsAbstract:
+    """ToolExecutor cannot be instantiated directly."""
+
+    def test_tool_executor_is_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            ToolExecutor()  # type: ignore[abstract]
+
+
+class TestDefaultToolExecutorUnknownToolReturnsError:
+    """Executing an unknown tool returns an error ToolResult."""
+
+    @pytest.mark.asyncio
+    async def test_default_tool_executor_unknown_tool_returns_error(self) -> None:
+        executor = DefaultToolExecutor()
+        result = await executor.execute("nonexistent_tool", {})
+        assert isinstance(result, ToolResult)
+        assert result.is_error is True
+        assert "nonexistent_tool" in result.output
+
+
+class TestDefaultToolExecutorRegisterAndExecute:
+    """Registering a tool handler and executing it returns expected output."""
+
+    @pytest.mark.asyncio
+    async def test_default_tool_executor_register_and_execute(self) -> None:
+        executor = DefaultToolExecutor()
+
+        async def echo_handler(arguments: dict) -> ToolResult:
+            return ToolResult(output=f"echo: {arguments.get('msg', '')}", is_error=False)
+
+        executor.register_tool("echo", echo_handler)
+        result = await executor.execute("echo", {"msg": "hello"})
+
+        assert isinstance(result, ToolResult)
+        assert result.is_error is False
+        assert result.output == "echo: hello"
+        assert result.duration_ms >= 0
+
+
+class TestDefaultToolExecutorListTools:
+    """list_tools returns registered tool names."""
+
+    @pytest.mark.asyncio
+    async def test_default_tool_executor_list_tools(self) -> None:
+        executor = DefaultToolExecutor()
+
+        # Empty initially
+        tools = await executor.list_tools()
+        assert tools == []
+
+        async def noop_handler(arguments: dict) -> ToolResult:
+            return ToolResult(output="ok", is_error=False)
+
+        executor.register_tool("tool_a", noop_handler)
+        executor.register_tool("tool_b", noop_handler)
+
+        tools = await executor.list_tools()
+        names = {t["name"] for t in tools}
+        assert names == {"tool_a", "tool_b"}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
@@ -1,0 +1,135 @@
+"""Tests for WSBroadcaster event consumer."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import (
+    AgentEvent,
+    AgentEventKind,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.consumers.ws_broadcaster import (
+    WSBroadcaster,
+)
+
+
+def _make_event(kind: AgentEventKind, session_id: str = "sess-1") -> AgentEvent:
+    return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_delivers_events_full_verbosity():
+    """All events should be delivered when verbosity is 'full'."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+
+    received: list[dict] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(json.loads(msg))
+
+    await broadcaster.start(bus)
+    broadcaster.add_connection("conn-1", fake_send, verbosity="full")
+
+    # Publish several event kinds
+    for kind in (AgentEventKind.THINKING, AgentEventKind.TOOL_CALL, AgentEventKind.COMPLETION):
+        await bus.publish(_make_event(kind))
+
+    # Give the consume loop time to process
+    await asyncio.sleep(0.1)
+    await broadcaster.stop()
+
+    assert len(received) == 3
+    assert received[0]["kind"] == "thinking"
+    assert received[1]["kind"] == "tool_call"
+    assert received[2]["kind"] == "completion"
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_summary_filters_thinking():
+    """Summary verbosity should drop thinking/tool_call/etc., keep completion."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+
+    received: list[dict] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(json.loads(msg))
+
+    await broadcaster.start(bus)
+    broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
+
+    await bus.publish(_make_event(AgentEventKind.THINKING))
+    await bus.publish(_make_event(AgentEventKind.TOOL_CALL))
+    await bus.publish(_make_event(AgentEventKind.COMPLETION))
+    await bus.publish(_make_event(AgentEventKind.ERROR))
+
+    await asyncio.sleep(0.1)
+    await broadcaster.stop()
+
+    # Only completion and error should pass through summary filter
+    kinds = [e["kind"] for e in received]
+    assert "thinking" not in kinds
+    assert "tool_call" not in kinds
+    assert "completion" in kinds
+    assert "error" in kinds
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_remove_connection():
+    """After removing a connection, it should no longer receive events."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+
+    received: list[dict] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(json.loads(msg))
+
+    await broadcaster.start(bus)
+    broadcaster.add_connection("conn-1", fake_send, verbosity="full")
+
+    await bus.publish(_make_event(AgentEventKind.THINKING))
+    await asyncio.sleep(0.05)
+
+    broadcaster.remove_connection("conn-1")
+
+    await bus.publish(_make_event(AgentEventKind.COMPLETION))
+    await asyncio.sleep(0.05)
+    await broadcaster.stop()
+
+    assert len(received) == 1
+    assert received[0]["kind"] == "thinking"
+
+
+@pytest.mark.asyncio
+async def test_ws_broadcaster_change_verbosity():
+    """Changing verbosity mid-stream should affect subsequent filtering."""
+    bus = SessionEventBus(session_id="sess-1")
+    broadcaster = WSBroadcaster()
+
+    received: list[dict] = []
+
+    async def fake_send(msg: str) -> None:
+        received.append(json.loads(msg))
+
+    await broadcaster.start(bus)
+    broadcaster.add_connection("conn-1", fake_send, verbosity="summary")
+
+    # Thinking should be filtered at summary level
+    await bus.publish(_make_event(AgentEventKind.THINKING))
+    await asyncio.sleep(0.05)
+
+    # Switch to full verbosity
+    broadcaster.set_verbosity("conn-1", "full")
+
+    await bus.publish(_make_event(AgentEventKind.THINKING))
+    await asyncio.sleep(0.05)
+    await broadcaster.stop()
+
+    # Only the second thinking event (after switching to full) should be received
+    assert len(received) == 1
+    assert received[0]["kind"] == "thinking"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_ws_broadcaster.py
@@ -20,6 +20,16 @@ def _make_event(kind: AgentEventKind, session_id: str = "sess-1") -> AgentEvent:
     return AgentEvent(session_id=session_id, kind=kind, payload={"data": kind.value})
 
 
+async def _wait_for(predicate, *, timeout: float = 2.0, interval: float = 0.02):
+    """Poll *predicate* until it returns True or *timeout* elapses."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError(f"Timed out waiting for predicate after {timeout}s")
+
+
 @pytest.mark.asyncio
 async def test_ws_broadcaster_delivers_events_full_verbosity():
     """All events should be delivered when verbosity is 'full'."""
@@ -34,12 +44,10 @@ async def test_ws_broadcaster_delivers_events_full_verbosity():
     await broadcaster.start(bus)
     broadcaster.add_connection("conn-1", fake_send, verbosity="full")
 
-    # Publish several event kinds
     for kind in (AgentEventKind.THINKING, AgentEventKind.TOOL_CALL, AgentEventKind.COMPLETION):
         await bus.publish(_make_event(kind))
 
-    # Give the consume loop time to process
-    await asyncio.sleep(0.1)
+    await _wait_for(lambda: len(received) >= 3)
     await broadcaster.stop()
 
     assert len(received) == 3
@@ -67,10 +75,10 @@ async def test_ws_broadcaster_summary_filters_thinking():
     await bus.publish(_make_event(AgentEventKind.COMPLETION))
     await bus.publish(_make_event(AgentEventKind.ERROR))
 
-    await asyncio.sleep(0.1)
+    # Wait for the 2 events that should pass (completion + error)
+    await _wait_for(lambda: len(received) >= 2)
     await broadcaster.stop()
 
-    # Only completion and error should pass through summary filter
     kinds = [e["kind"] for e in received]
     assert "thinking" not in kinds
     assert "tool_call" not in kinds
@@ -93,11 +101,12 @@ async def test_ws_broadcaster_remove_connection():
     broadcaster.add_connection("conn-1", fake_send, verbosity="full")
 
     await bus.publish(_make_event(AgentEventKind.THINKING))
-    await asyncio.sleep(0.05)
+    await _wait_for(lambda: len(received) >= 1)
 
     broadcaster.remove_connection("conn-1")
 
     await bus.publish(_make_event(AgentEventKind.COMPLETION))
+    # Give a brief window to confirm no more events arrive
     await asyncio.sleep(0.05)
     await broadcaster.stop()
 
@@ -121,15 +130,18 @@ async def test_ws_broadcaster_change_verbosity():
 
     # Thinking should be filtered at summary level
     await bus.publish(_make_event(AgentEventKind.THINKING))
-    await asyncio.sleep(0.05)
+    # Publish a summary-visible event to confirm the bus is processing
+    await bus.publish(_make_event(AgentEventKind.COMPLETION))
+    await _wait_for(lambda: len(received) >= 1)
 
     # Switch to full verbosity
     broadcaster.set_verbosity("conn-1", "full")
 
     await bus.publish(_make_event(AgentEventKind.THINKING))
-    await asyncio.sleep(0.05)
+    await _wait_for(lambda: len(received) >= 2)
     await broadcaster.stop()
 
-    # Only the second thinking event (after switching to full) should be received
-    assert len(received) == 1
-    assert received[0]["kind"] == "thinking"
+    # First received should be completion (thinking was filtered at summary)
+    # Second should be thinking (after switching to full)
+    assert received[0]["kind"] == "completion"
+    assert received[1]["kind"] == "thinking"


### PR DESCRIPTION
## Summary

- Introduces the **AgentEvent** schema (13 event kinds) as the core contract for the agent workspace harness
- Adds **ProtocolAdapter** ABC with **StdioAdapter** wrapping the existing `ACPStdioClient` (JSON-RPC → AgentEvent translation)
- Adds **SessionEventBus** for per-session async event fan-out with monotonic sequencing, bounded history buffer, and replay
- Adds **GovernanceFilter** pipeline stage that intercepts tool calls, gates by permission tier, and manages approval flow
- Adds **WSBroadcaster**, **AuditLogger**, and **MetricsRecorder** event bus consumers with configurable verbosity filtering
- Adds **ToolExecutor** interface for server-side tool execution in hybrid agent modes
- Adds **SandboxBridge** integration seam between ACP and the Sandbox module
- Extends **AgentRegistryEntry** with 8 new fields (protocol, tool_execution_mode, mcp_transport, sandbox, trust_level, etc.)

## Architecture

This is Phase A of the [ACP Agent Workspace Harness design](Docs/Plans/2026-03-16-acp-agent-workspace-harness-design.md). It establishes the adapter + event bus + consumer foundation without modifying any existing code paths. All new code is additive — the existing `ACPRunnerClient` and 267 pre-existing tests are untouched.

```
ProtocolAdapter → GovernanceFilter → SessionEventBus → Consumers (WS, Audit, Metrics)
```

## Test plan

- [x] 46 new unit tests covering all new components
- [x] All 313 ACP tests pass (46 new + 267 existing)
- [x] Zero regressions — no existing files modified except `AgentRegistryEntry` (backward-compatible defaults)
- [x] TDD followed for all tasks (tests written first, verified red, then green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)