### PR TITLE
docs: default onboarding to docker webui

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,7 @@ apps/extension/.wxt/
 
 # Runtime/local data (never bake into images)
 Databases/
+docker-data/
 cache/
 dlq/
 models/

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ cython_debug/
 *.m4a
 *.mp4
 *.mp3
+
+# Optional Docker host-storage bind mounts
+docker-data/
 *.ogg
 *.opus
 *.wav

--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -18,6 +18,19 @@ This folder contains the base Compose stack for tldw_server, optional overlays, 
   - `docker compose -f Dockerfiles/docker-compose.yml ps`
   - `docker compose -f Dockerfiles/docker-compose.yml logs -f app`
 
+## Persistence and Backups
+
+- Default quickstart persistence uses Docker named volumes, not repo-local folders.
+- `app-data` backs `/app/Databases`, which includes the default SQLite AuthNZ DB, first-run marker files, and filesystem-backed uploads such as `Databases/user_files`.
+- `chroma-data` backs `/app/Databases/user_databases`, which is the full per-user data tree used by `USER_DB_BASE_DIR`, not just Chroma embeddings.
+- `postgres_data` and `redis_data` back the bundled Postgres and Redis services.
+- Startup configuration is also persisted in `tldw_Server_API/Config_Files/.env`; keep that file with your volume backups.
+- `docker compose down` keeps named volumes. `docker compose down -v` deletes them and will remove the persisted databases, user files, and vector stores.
+- If you want host-visible storage for easier inspection or external backups, use `Dockerfiles/docker-compose.host-storage.yml` instead of the default compose file:
+  - `docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.host-storage.yml up -d --build`
+  - Optional WebUI: `docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.host-storage.yml -f Dockerfiles/docker-compose.webui.yml up -d --build`
+- The host-storage variant writes under `docker-data/` in the repo root and is optional; the default named-volume quickstart remains unchanged for backwards compatibility.
+
 ## Overlays & Profiles
 
 - Production overrides: `Dockerfiles/docker-compose.override.yml`
@@ -44,6 +57,10 @@ This folder contains the base Compose stack for tldw_server, optional overlays, 
 - Dev overlay (unified streaming pilot): `Dockerfiles/docker-compose.dev.yml`
   - `docker compose -f Dockerfiles/docker-compose.yml -f Dockerfiles/docker-compose.dev.yml up -d --build`
   - Sets `STREAMS_UNIFIED=1` (keep off in production until validated).
+
+- Host-visible storage variant: `Dockerfiles/docker-compose.host-storage.yml`
+  - `docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.host-storage.yml up -d --build`
+  - Use this instead of the default base compose file when you want bind mounts under `docker-data/`.
 
 - WebUI overlay: `Dockerfiles/docker-compose.webui.yml`
   - `docker compose -f Dockerfiles/docker-compose.yml -f Dockerfiles/docker-compose.webui.yml up -d --build`

--- a/Dockerfiles/docker-compose.host-storage.yml
+++ b/Dockerfiles/docker-compose.host-storage.yml
@@ -1,0 +1,76 @@
+# docker-compose.host-storage.yml for tldw_server using repo-visible bind mounts
+#
+# This file is a drop-in alternative to Dockerfiles/docker-compose.yml when you
+# want Docker-managed data to live under ../docker-data instead of named volumes.
+# It intentionally preserves the same service names and mount targets so the
+# runtime behavior stays aligned with the default quickstart.
+
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfiles/Dockerfile.prod
+    image: tldw-server:prod
+    container_name: tldw-app
+    ports:
+      - "8000:8000"
+    environment:
+      - AUTH_MODE=${AUTH_MODE:-single_user}
+      - SINGLE_USER_API_KEY=${SINGLE_USER_API_KEY:-change-me}
+      - tldw_production=${tldw_production:-false}
+      - DATABASE_URL=${DATABASE_URL:-sqlite:///./Databases/users.db}
+      - JOBS_DB_URL=${JOBS_DB_URL:-}
+      - UVICORN_WORKERS=${UVICORN_WORKERS:-4}
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+    volumes:
+      - ../docker-data/app:/app/Databases
+      - ../docker-data/user_data:/app/Databases/user_databases
+    depends_on:
+      - postgres
+      - redis
+    healthcheck:
+      test: ["CMD", "python", "-c", "import sys, urllib.request; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/ready', timeout=3).status == 200 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+
+  postgres:
+    image: postgres:18-bookworm
+    container_name: tldw-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-tldw_users}
+      POSTGRES_USER: ${POSTGRES_USER:-tldw_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-TestPassword123!}
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ../docker-data/postgres:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    container_name: tldw-redis
+    ports:
+      - "6379:6379"
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - ../docker-data/redis:/data
+
+# Usage:
+#   # Single-user with repo-visible storage:
+#   #   docker compose --env-file tldw_Server_API/Config_Files/.env \
+#   #     -f Dockerfiles/docker-compose.host-storage.yml up -d --build
+#   # Optional WebUI:
+#   #   docker compose --env-file tldw_Server_API/Config_Files/.env \
+#   #     -f Dockerfiles/docker-compose.host-storage.yml \
+#   #     -f Dockerfiles/docker-compose.webui.yml up -d --build

--- a/Docs/Getting_Started/Profile_Docker_Single_User.md
+++ b/Docs/Getting_Started/Profile_Docker_Single_User.md
@@ -29,6 +29,24 @@ SINGLE_USER_API_KEY=replace-with-strong-key
 docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.yml up -d --build
 ```
 
+By default this profile stores application data in Docker named volumes, not in the repo checkout:
+
+- `app-data` backs `/app/Databases`
+- `chroma-data` backs `/app/Databases/user_databases`
+- `postgres_data` and `redis_data` back the bundled Postgres and Redis containers
+
+Keep `tldw_Server_API/Config_Files/.env` with your backups, because it stores the startup auth mode and single-user API key that the quickstart uses.
+
+`docker compose down` keeps the Docker named volumes. `docker compose down -v` deletes them and removes the persisted databases, user files, and vector storage.
+
+If you prefer host-visible storage for manual backups or inspection, use `Dockerfiles/docker-compose.host-storage.yml` instead of the default compose file:
+
+```bash
+docker compose --env-file tldw_Server_API/Config_Files/.env -f Dockerfiles/docker-compose.host-storage.yml up -d --build
+```
+
+That optional variant writes data under `docker-data/` at the repo root and preserves the default quickstart behavior for existing users.
+
 ## Verify
 
 ```bash

--- a/Docs/Getting_Started/Profile_Local_Single_User.md
+++ b/Docs/Getting_Started/Profile_Local_Single_User.md
@@ -1,6 +1,11 @@
 # Local Single-User Setup
 
-Use this profile when you want to run the API directly on your machine with a local Python virtual environment.
+Use this profile for development, local debugging, or contributor workflows where you want to run the API directly on your machine with a local Python virtual environment.
+
+For most self-hosted users:
+- use `make quickstart` for the Docker single-user + WebUI path,
+- use `make quickstart-docker` for the API-only Docker path,
+- use `Docker multi-user + Postgres` for team or public deployments.
 
 ## Prerequisites
 
@@ -26,7 +31,7 @@ make quickstart-install PYTHON=python3.12
 ## Run
 
 ```bash
-make quickstart
+make quickstart-local
 ```
 
 Default API URL: `http://127.0.0.1:8000`

--- a/Docs/Getting_Started/README.md
+++ b/Docs/Getting_Started/README.md
@@ -2,6 +2,12 @@
 
 Choose exactly one base setup profile and follow it end-to-end.
 
+Recommended default:
+- Run `make quickstart` from the repo root for the Docker single-user + WebUI path.
+- Use `make quickstart-docker` if you want the API-only Docker path.
+- Use `Docker multi-user + Postgres` when you need a team or public deployment.
+- Use `Local single-user` for development, debugging, or contributor workflows.
+
 Canonical base profiles:
 
 1. [Local single-user](./Profile_Local_Single_User.md)
@@ -15,6 +21,7 @@ Optional add-ons:
 ## How To Use These Guides
 
 - Pick the profile that matches your target environment.
+- For most users, start with the `quickstart-docker-webui` path via `make quickstart`.
 - Complete the guide sections in order: prerequisites, install, run, verify, troubleshoot.
 - Do not mix setup commands from other docs unless the guide explicitly links to them.
 - Apply add-ons only after your chosen base profile is healthy.

--- a/Docs/Getting_Started/onboarding_manifest.yaml
+++ b/Docs/Getting_Started/onboarding_manifest.yaml
@@ -1,3 +1,5 @@
+default_profile: docker_single_user
+default_entrypoint: quickstart-docker-webui
 profiles:
   local_single_user:
     title: "Local single-user"

--- a/Docs/Published/Getting_Started/README.md
+++ b/Docs/Published/Getting_Started/README.md
@@ -2,6 +2,12 @@
 
 Choose exactly one base setup profile and follow it end-to-end.
 
+Recommended default:
+- Run `make quickstart` from the repo root for the Docker single-user + WebUI path.
+- Use `make quickstart-docker` if you want the API-only Docker path.
+- Use `Docker multi-user + Postgres` when you need a team or public deployment.
+- Use `Local single-user` for development, debugging, or contributor workflows.
+
 Canonical base profiles:
 
 1. [Local single-user](./Profile_Local_Single_User.md)
@@ -15,6 +21,7 @@ Optional add-ons:
 ## How To Use These Guides
 
 - Pick the profile that matches your target environment.
+- For most users, start with the `quickstart-docker-webui` path via `make quickstart`.
 - Complete the guide sections in order: prerequisites, install, run, verify, troubleshoot.
 - Do not mix setup commands from other docs unless the guide explicitly links to them.
 - Apply add-ons only after your chosen base profile is healthy.

--- a/Docs/Website/index.html
+++ b/Docs/Website/index.html
@@ -188,58 +188,56 @@
     <div class="container">
       <div class="reveal">
         <h2 id="cta-title" style="margin:0 0 6px 0;font-size:28px">Quick Start</h2>
-        <p class="muted" style="max-width:60ch;margin-bottom:24px">Get tldw running locally in under a minute. Docker quickstart is recommended; PyPI publishing is still in progress.</p>
+        <p class="muted" style="max-width:60ch;margin-bottom:24px">Get tldw running with the WebUI in under a minute. The default path is the Docker single-user + WebUI setup; local/manual flows are for contributors and debugging.</p>
       </div>
       <div class="reveal">
         <div class="code-block">
           <div class="code-header">
-            <span>Install with pip (coming soon)</span>
-            <button class="copy-btn" data-code="pip install tldw_server&#10;python -m uvicorn tldw_Server_API.app.main:app --reload" aria-label="Copy pip install command">Copy</button>
-          </div>
-          <pre><code>pip install tldw_server
-python -m uvicorn tldw_Server_API.app.main:app --reload</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">Note: <code>pip install tldw_server</code> is currently in progress and not generally available yet. Use the Docker Compose setup below for now.</p>
-        </div>
-        <div class="code-block">
-          <div class="code-header">
-            <span>Manual Setup (No Docker)</span>
-            <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart-install" aria-label="Copy manual setup command">Copy</button>
+            <span>Recommended: Docker + WebUI</span>
+            <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart" aria-label="Copy default Docker and WebUI quickstart command">Copy</button>
           </div>
           <pre><code>git clone https://github.com/rmusser01/tldw_server.git
 cd tldw_server
-make quickstart-install</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">This installs dependencies, initializes auth, and starts the API server. If you already have dependencies installed, run <code>make quickstart</code>.</p>
+make quickstart</code></pre>
+          <p class="muted" style="font-size:13px;margin-top:10px">This launches the Docker single-user setup with the API on <code>http://localhost:8000</code> and WebUI on <code>http://localhost:8080</code>.</p>
         </div>
         <div class="code-block">
           <div class="code-header">
-            <span>Recommended: Docker Quickstart</span>
-            <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart-docker" aria-label="Copy Docker quickstart command">Copy</button>
+            <span>API-Only Docker</span>
+            <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart-docker" aria-label="Copy API-only Docker quickstart command">Copy</button>
           </div>
           <pre><code>git clone https://github.com/rmusser01/tldw_server.git
 cd tldw_server
 make quickstart-docker</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">This first-use flow auto-generates a secure <code>SINGLE_USER_API_KEY</code> (if missing/placeholder) and runs auth initialization once. View your key with <code>grep '^SINGLE_USER_API_KEY=' tldw_Server_API/Config_Files/.env</code>.</p>
+          <p class="muted" style="font-size:13px;margin-top:10px">Use this when you want the production-style API setup without the WebUI.</p>
         </div>
         <div class="code-block">
           <div class="code-header">
-            <span>Run API + WebUI (Docker)</span>
+            <span>Public/Team Deployment</span>
+            <button class="copy-btn" data-code="Open Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md" aria-label="Copy multi-user deployment doc path">Copy</button>
+          </div>
+          <pre><code>Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md</code></pre>
+          <p class="muted" style="font-size:13px;margin-top:10px">For teams or public deployments, use the multi-user + Postgres guide rather than the single-user quickstart.</p>
+        </div>
+        <div class="code-block">
+          <div class="code-header">
+            <span>Explicit Docker + WebUI Command</span>
             <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart-docker-webui" aria-label="Copy Docker API plus WebUI command">Copy</button>
           </div>
           <pre><code>git clone https://github.com/rmusser01/tldw_server.git
 cd tldw_server
 make quickstart-docker-webui</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">Starts API at <code>http://localhost:8000</code> and WebUI at <code>http://localhost:8080</code>.</p>
+          <p class="muted" style="font-size:13px;margin-top:10px">This is the full-stack target that <code>make quickstart</code> now uses by default.</p>
         </div>
         <div class="code-block">
           <div class="code-header">
-            <span>Run WebUI Locally (No Docker)</span>
-            <button class="copy-btn" data-code="cd apps/tldw-frontend&#10;cp .env.local.example .env.local&#10;npm install&#10;npm run dev -- -p 8080" aria-label="Copy local WebUI run command">Copy</button>
+            <span>Manual Setup (Development)</span>
+            <button class="copy-btn" data-code="git clone https://github.com/rmusser01/tldw_server.git&#10;cd tldw_server&#10;make quickstart-install" aria-label="Copy local development setup command">Copy</button>
           </div>
-          <pre><code>cd apps/tldw-frontend
-cp .env.local.example .env.local
-npm install
-npm run dev -- -p 8080</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">Use this with the API running separately (for example via <code>make quickstart</code>).</p>
+          <pre><code>git clone https://github.com/rmusser01/tldw_server.git
+cd tldw_server
+make quickstart-install</code></pre>
+          <p class="muted" style="font-size:13px;margin-top:10px">Keep this path for local API development and contributor workflows. Pair it with local WebUI development only when you need a dev server.</p>
         </div>
         <p class="muted" style="font-size:14px">API docs at <a href="http://127.0.0.1:8000/docs" style="color:var(--brand-2)">localhost:8000/docs</a> · Quickstart wizard at <a href="http://127.0.0.1:8000/api/v1/config/quickstart" style="color:var(--brand-2)">localhost:8000/api/v1/config/quickstart</a></p>
       </div>

--- a/Docs/Website/index.html
+++ b/Docs/Website/index.html
@@ -214,10 +214,8 @@ make quickstart-docker</code></pre>
         <div class="code-block">
           <div class="code-header">
             <span>Public/Team Deployment</span>
-            <button class="copy-btn" data-code="Open Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md" aria-label="Copy multi-user deployment doc path">Copy</button>
           </div>
-          <pre><code>Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md</code></pre>
-          <p class="muted" style="font-size:13px;margin-top:10px">For teams or public deployments, use the multi-user + Postgres guide rather than the single-user quickstart.</p>
+          <p class="muted" style="font-size:13px;margin:14px">For teams or public deployments, use the <a href="https://github.com/rmusser01/tldw_server/blob/main/Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md" style="color:var(--brand-2)">multi-user + Postgres guide</a> rather than the single-user quickstart.</p>
         </div>
         <div class="code-block">
           <div class="code-header">

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # Quickstart targets (first-time setup)
 # -----------------------------------------------------------------------------
-.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke
+.PHONY: quickstart quickstart-install quickstart-prereqs quickstart-local quickstart-docker quickstart-docker-bootstrap quickstart-docker-webui model-cycle verify pypi-build pypi-check tooling-install tooling-smoke
 
 PYTHON ?= python3
 VENV_DIR ?= .venv
@@ -54,18 +54,21 @@ quickstart-install:
 	@if [ "$$(uname -s)" = "Linux" ]; then \
 		echo "[quickstart-install] Linux audio note: if PyAudio build/install fails, install PortAudio headers (e.g., sudo apt install -y portaudio19-dev python3-pyaudio)."; \
 	fi
-	@$(MAKE) quickstart PYTHON=$(VENV_PYTHON)
+	@$(MAKE) quickstart-local PYTHON=$(VENV_PYTHON)
 
-quickstart: quickstart-prereqs
-	@echo "[quickstart] Setting up tldw_server for first-time use..."
+quickstart-local: quickstart-prereqs
+	@echo "[quickstart-local] Setting up local tldw_server development..."
 	@mkdir -p $(dir $(TLDW_ENV_FILE))
-	@test -f $(TLDW_ENV_FILE) || (cp $(TLDW_ENV_TEMPLATE) $(TLDW_ENV_FILE) && echo "[quickstart] Created $(TLDW_ENV_FILE) from template - set SINGLE_USER_API_KEY before exposing beyond localhost.")
-	@echo "[quickstart] Initializing auth (non-interactive)..."
+	@test -f $(TLDW_ENV_FILE) || (cp $(TLDW_ENV_TEMPLATE) $(TLDW_ENV_FILE) && echo "[quickstart-local] Created $(TLDW_ENV_FILE) from template - set SINGLE_USER_API_KEY before exposing beyond localhost.")
+	@echo "[quickstart-local] Initializing auth (non-interactive)..."
 	$(PYTHON) -m tldw_Server_API.app.core.AuthNZ.initialize --non-interactive
-	@echo "[quickstart] Starting server on http://127.0.0.1:8000"
-	@echo "[quickstart] Verify with: curl http://localhost:8000/health"
-	@echo "[quickstart] API docs at: http://127.0.0.1:8000/docs"
+	@echo "[quickstart-local] Starting server on http://127.0.0.1:8000"
+	@echo "[quickstart-local] Verify with: curl http://localhost:8000/health"
+	@echo "[quickstart-local] API docs at: http://127.0.0.1:8000/docs"
 	$(PYTHON) -m uvicorn tldw_Server_API.app.main:app --host 127.0.0.1 --port 8000
+
+quickstart:
+	@$(MAKE) quickstart-docker-webui
 
 tooling-install:
 	@command -v $(PYTHON) >/dev/null 2>&1 || (echo "[tooling-install] $(PYTHON) not found. Install Python 3.10+ and retry." && exit 1)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ Good fit for:
 
 ## Start Here (Self-Hosting Profiles)
 
-Choose one base onboarding path:
+Choose one base onboarding path.
+
+Recommended default:
+- Run `make quickstart` for the Docker single-user + WebUI setup most users want.
+- Use [Docker multi-user + Postgres](Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md) if you are deploying for a team or exposing the app publicly.
+- Keep local setup in [apps/DEVELOPMENT.md](apps/DEVELOPMENT.md) and the local profile docs.
 
 1. [Local single-user](Docs/Getting_Started/Profile_Local_Single_User.md)
 2. [Docker single-user](Docs/Getting_Started/Profile_Docker_Single_User.md)
@@ -220,14 +225,20 @@ Choose one install path:
 ```bash
 git clone https://github.com/rmusser01/tldw_server.git && cd tldw_server
 
-# API only (local Python): installs deps, initializes auth, starts API
-make quickstart-install
+# Recommended default: Docker single-user + WebUI
+make quickstart
+
+# API-only Docker path:
+# make quickstart-docker
+
+# Explicit full-stack Docker path:
+# make quickstart-docker-webui
+
+# Local development path (API only):
+# make quickstart-install
 # If `python3` is older than 3.10 on your machine:
 # make quickstart-install PYTHON=python3.13  # or python3.12 / python3.11 / python3.10
 
-# Docker paths:
-# make quickstart-docker
-# make quickstart-docker-webui
 # Force a full image rebuild when needed:
 # make quickstart-docker DOCKER_BUILD=true
 # make quickstart-docker-webui DOCKER_BUILD=true
@@ -235,7 +246,23 @@ make quickstart-install
 
 If `make` is unavailable, use [No-Make Path (Windows-Friendly)](#no-make-path-windows-friendly).
 
-### No-Docker Path (Makefile)
+### Default Docker Path (Makefile)
+
+```bash
+# from repo root
+make quickstart
+```
+
+This target:
+- Starts the Docker single-user + WebUI setup.
+- Uses the existing `quickstart-docker-webui` flow under the hood.
+- Brings up the API at `http://localhost:8000` and WebUI at `http://localhost:8080`.
+
+Want a more advanced deployment?
+- Team/public deployment: [Docker Multi-User + Postgres Profile](Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md)
+- API-only Docker deployment: `make quickstart-docker`
+
+### No-Docker Path (Makefile, Development)
 
 ```bash
 # from repo root
@@ -248,14 +275,14 @@ This target:
 - Creates `.venv` if missing and installs dependencies.
 - Creates `tldw_Server_API/Config_Files/.env` from `.env.example` if missing.
 - Initializes AuthNZ (non-interactive).
-- Starts the API server at `http://127.0.0.1:8000`.
+- Starts the local API server at `http://127.0.0.1:8000`.
 
 Verify with:
 ```bash
 curl http://localhost:8000/health  # No auth needed!
 ```
 
-Already have dependencies installed and a Python 3.10+ interpreter selected? Use `make quickstart` (or set `PYTHON=python3.13` / `PYTHON=python3.12` / `PYTHON=.venv/bin/python`).
+Already have dependencies installed and a Python 3.10+ interpreter selected? Use `make quickstart-local` (or set `PYTHON=python3.13` / `PYTHON=python3.12` / `PYTHON=.venv/bin/python`).
 
 ### No-Make Path (Windows-Friendly)
 
@@ -395,6 +422,7 @@ See [MCP System Admin Guide](Docs/MCP/Unified/System_Admin_Guide.md) for details
 | I want to... | Guide |
 |--------------|-------|
 | Choose the right onboarding path | [Getting Started Index](Docs/Getting_Started/README.md) |
+| Start the default Docker + WebUI setup | `make quickstart` |
 | Start from local single-user, then launch the WebUI | [Local Profile: Add the WebUI](#local-profile-add-the-webui) |
 | Build apps against the API locally | [Local Single-User Profile](Docs/Getting_Started/Profile_Local_Single_User.md) |
 | Run on my home server with Docker | [Docker Single-User Profile](Docs/Getting_Started/Profile_Docker_Single_User.md) |

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Optional add-on:
 
 ## Current Status
 
-Latest release: 
-- 0.1.26 (2026-03-15) Beta status -  Expect rough edges; 
-  * please report issues. 
+Latest release:
+- 0.1.26 (2026-03-15) Beta status -  Expect rough edges;
+  * please report issues.
 - See `CHANGELOG.md` for release history.
 
 <details>

--- a/apps/DEVELOPMENT.md
+++ b/apps/DEVELOPMENT.md
@@ -7,7 +7,7 @@ This guide helps developers maintain feature parity between the browser extensio
 - Recommended user/self-hosting setup: `make quickstart`
 - API-only Docker setup: `make quickstart-docker`
 - Team/public deployment: `Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md`
-- Local contributor setup: `make quickstart-install` for the API and `bun run --cwd tldw-frontend dev` for the WebUI
+- Local contributor setup: `make quickstart-install` for the API and `bun run --cwd apps/tldw-frontend dev` for the WebUI
 
 Use the Docker paths when you want a stable instance. Use the local paths when you are actively changing code, debugging, or running frontend development workflows.
 

--- a/apps/DEVELOPMENT.md
+++ b/apps/DEVELOPMENT.md
@@ -2,6 +2,49 @@
 
 This guide helps developers maintain feature parity between the browser extension and web UI while allowing platform-specific implementations where necessary.
 
+## Setup Modes
+
+- Recommended user/self-hosting setup: `make quickstart`
+- API-only Docker setup: `make quickstart-docker`
+- Team/public deployment: `Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md`
+- Local contributor setup: `make quickstart-install` for the API and `bun run --cwd tldw-frontend dev` for the WebUI
+
+Use the Docker paths when you want a stable instance. Use the local paths when you are actively changing code, debugging, or running frontend development workflows.
+
+## Local Development Setup
+
+### Local API
+
+```bash
+# from repo root
+make quickstart-install
+
+# already have the venv and deps?
+make quickstart-local
+```
+
+### Local WebUI
+
+```bash
+# from repo root
+cd apps/tldw-frontend
+cp .env.local.example .env.local
+bun install
+bun run dev -- -p 8080
+```
+
+If Turbopack becomes unstable or its cache is corrupted, use:
+
+```bash
+cd apps/tldw-frontend
+bun run dev:webpack
+```
+
+Related setup docs:
+- `Docs/Getting_Started/Profile_Docker_Single_User.md`
+- `Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md`
+- `Docs/Getting_Started/Profile_Local_Single_User.md`
+
 ## Architecture Overview
 
 ### Monorepo Structure

--- a/tldw_Server_API/tests/Docs/test_docker_persistence_docs.py
+++ b/tldw_Server_API/tests/Docs/test_docker_persistence_docs.py
@@ -1,0 +1,47 @@
+"""Regression tests for Docker persistence documentation."""
+
+from pathlib import Path
+
+import pytest
+
+
+def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message."""
+    if not condition:
+        pytest.fail(message)
+
+
+def test_dockerfiles_readme_documents_persistence_contract() -> None:
+    """Dockerfiles README should explain where quickstart data persists."""
+    text = Path("Dockerfiles/README.md").read_text(encoding="utf-8")
+
+    for snippet in (
+        "app-data",
+        "chroma-data",
+        "docker-compose.host-storage.yml",
+        "docker compose down -v",
+        "tldw_Server_API/Config_Files/.env",
+    ):
+        _require(
+            snippet in text,
+            f"Dockerfiles README should mention {snippet}",
+        )
+
+
+def test_docker_single_user_profile_documents_named_volumes_and_overlay() -> None:
+    """Docker single-user setup should document default persistence and the optional overlay."""
+    text = Path("Docs/Getting_Started/Profile_Docker_Single_User.md").read_text(
+        encoding="utf-8"
+    )
+
+    for snippet in (
+        "Docker named volumes",
+        "docker-compose.host-storage.yml",
+        "docker compose down -v",
+        "app-data",
+        "chroma-data",
+    ):
+        _require(
+            snippet in text,
+            f"Docker single-user profile should mention {snippet}",
+        )

--- a/tldw_Server_API/tests/Docs/test_onboarding_default_contract.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_default_contract.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+def test_manifest_declares_default_profile_and_entrypoint() -> None:
+    manifest = yaml.safe_load(Path("Docs/Getting_Started/onboarding_manifest.yaml").read_text())
+    _require(
+        manifest["default_profile"] == "docker_single_user",
+        "Onboarding manifest should declare docker_single_user as the default profile",
+    )
+    _require(
+        manifest["default_entrypoint"] == "quickstart-docker-webui",
+        "Onboarding manifest should declare quickstart-docker-webui as the default entrypoint",
+    )

--- a/tldw_Server_API/tests/Docs/test_onboarding_default_contract.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_default_contract.py
@@ -1,3 +1,5 @@
+"""Contract tests for onboarding manifest defaults."""
+
 from pathlib import Path
 
 import pytest
@@ -5,11 +7,13 @@ import yaml
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message when a contract is broken."""
     if not condition:
         pytest.fail(message)
 
 
 def test_manifest_declares_default_profile_and_entrypoint() -> None:
+    """Manifest should declare the Docker WebUI onboarding default explicitly."""
     manifest = yaml.safe_load(Path("Docs/Getting_Started/onboarding_manifest.yaml").read_text())
     _require(
         manifest["default_profile"] == "docker_single_user",

--- a/tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+import pytest
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+def test_local_single_user_profile_is_marked_for_development() -> None:
+    text = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text()
+    _require("development" in text.lower(), "Local single-user profile should be marked for development")
+    _require("make quickstart-install" in text, "Local single-user profile should keep the install command")
+    _require("make quickstart-local" in text, "Local single-user profile should use make quickstart-local to run")
+    _require("make quickstart" in text, "Local single-user profile should still point typical users to make quickstart")
+
+
+def test_development_guide_links_local_dev_to_prod_paths() -> None:
+    text = Path("apps/DEVELOPMENT.md").read_text()
+    _require("quickstart-install" in text, "Development guide should mention quickstart-install")
+    _require("dev:webpack" in text, "Development guide should mention the webpack fallback")
+    _require(
+        "Docs/Getting_Started/Profile_Docker_Single_User.md" in text,
+        "Development guide should link to the Docker single-user profile",
+    )
+    _require(
+        "Docs/Getting_Started/Profile_Docker_Multi_User_Postgres.md" in text,
+        "Development guide should link to the multi-user + Postgres profile",
+    )
+
+
+def test_website_quick_start_defaults_to_make_quickstart() -> None:
+    text = Path("Docs/Website/index.html").read_text()
+    _require("Recommended: Docker + WebUI" in text, "Website quick start should label the default Docker + WebUI path")
+    _require("make quickstart" in text, "Website quick start should mention make quickstart")
+    _require(
+        text.index("make quickstart") < text.index("make quickstart-install"),
+        "Website quick start should present make quickstart before make quickstart-install",
+    )

--- a/tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py
@@ -1,25 +1,46 @@
+"""Regression tests for the development-focused onboarding docs."""
+
 from pathlib import Path
 
 import pytest
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message when a contract is broken."""
     if not condition:
         pytest.fail(message)
 
 
 def test_local_single_user_profile_is_marked_for_development() -> None:
+    """The local single-user profile should be clearly marked as a dev path."""
     text = Path("Docs/Getting_Started/Profile_Local_Single_User.md").read_text()
-    _require("development" in text.lower(), "Local single-user profile should be marked for development")
-    _require("make quickstart-install" in text, "Local single-user profile should keep the install command")
-    _require("make quickstart-local" in text, "Local single-user profile should use make quickstart-local to run")
-    _require("make quickstart" in text, "Local single-user profile should still point typical users to make quickstart")
+    _require(
+        "development" in text.lower(),
+        "Local single-user profile should be marked for development",
+    )
+    _require(
+        "make quickstart-install" in text,
+        "Local single-user profile should keep the install command",
+    )
+    _require(
+        "make quickstart-local" in text,
+        "Local single-user profile should use make quickstart-local to run",
+    )
+    _require(
+        "make quickstart" in text,
+        "Local single-user profile should still point typical users to make quickstart",
+    )
 
 
 def test_development_guide_links_local_dev_to_prod_paths() -> None:
+    """Development guide should point local contributors to the right paths."""
     text = Path("apps/DEVELOPMENT.md").read_text()
     _require("quickstart-install" in text, "Development guide should mention quickstart-install")
     _require("dev:webpack" in text, "Development guide should mention the webpack fallback")
+    _require(
+        "bun run --cwd apps/tldw-frontend dev" in text,
+        "Development guide should use the correct frontend workspace path",
+    )
     _require(
         "Docs/Getting_Started/Profile_Docker_Single_User.md" in text,
         "Development guide should link to the Docker single-user profile",
@@ -31,9 +52,21 @@ def test_development_guide_links_local_dev_to_prod_paths() -> None:
 
 
 def test_website_quick_start_defaults_to_make_quickstart() -> None:
+    """Website quick start should lead with make quickstart and keep the dev path secondary."""
     text = Path("Docs/Website/index.html").read_text()
-    _require("Recommended: Docker + WebUI" in text, "Website quick start should label the default Docker + WebUI path")
+    _require(
+        "Recommended: Docker + WebUI" in text,
+        "Website quick start should label the default Docker + WebUI path",
+    )
     _require("make quickstart" in text, "Website quick start should mention make quickstart")
+    _require(
+        "make quickstart-install" in text,
+        "Website quick start should still mention the development quickstart-install path",
+    )
+    _require(
+        "Profile_Docker_Multi_User_Postgres.md" in text,
+        "Website quick start should link to the multi-user + Postgres guide",
+    )
     _require(
         text.index("make quickstart") < text.index("make quickstart-install"),
         "Website quick start should present make quickstart before make quickstart-install",

--- a/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
@@ -1,28 +1,55 @@
+"""Contract tests for the top-level onboarding entrypoints."""
+
 from pathlib import Path
 
 import pytest
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message when a contract is broken."""
     if not condition:
         pytest.fail(message)
 
 
 def test_readme_start_here_links_to_profile_index() -> None:
+    """README should keep linking to the canonical onboarding profiles."""
     text = Path("README.md").read_text()
-    _require("Docs/Getting_Started/README.md" in text, "README should link to the Getting Started index")
-    _require("Local single-user" in text, "README should still mention the local single-user profile")
-    _require("Docker single-user" in text, "README should mention the Docker single-user profile")
+    _require(
+        "Docs/Getting_Started/README.md" in text,
+        "README should link to the Getting Started index",
+    )
+    _require(
+        "Local single-user" in text,
+        "README should still mention the local single-user profile",
+    )
+    _require(
+        "Docker single-user" in text,
+        "README should mention the Docker single-user profile",
+    )
     _require("make quickstart" in text, "README should mention make quickstart")
-    _require("make quickstart-docker-webui" in text, "README should mention the explicit WebUI Docker path")
-    _require("apps/DEVELOPMENT.md" in text, "README should link developers to apps/DEVELOPMENT.md")
+    _require(
+        "make quickstart-docker-webui" in text,
+        "README should mention the explicit WebUI Docker path",
+    )
+    _require(
+        "apps/DEVELOPMENT.md" in text,
+        "README should link developers to apps/DEVELOPMENT.md",
+    )
 
 
 def test_readme_quickstart_defaults_to_webui_before_local_dev() -> None:
+    """README quickstart should lead with the Docker WebUI path."""
     text = Path("README.md").read_text()
-    quickstart_section = text.split("## Quickstart", 1)[1]
-    _require("make quickstart" in quickstart_section, "Quickstart section should mention make quickstart")
-    _require("make quickstart-install" in quickstart_section, "Quickstart section should still mention make quickstart-install")
+    _, separator, quickstart_section = text.partition("## Quickstart")
+    _require(separator == "## Quickstart", "README should include a Quickstart section")
+    _require(
+        "make quickstart" in quickstart_section,
+        "Quickstart section should mention make quickstart",
+    )
+    _require(
+        "make quickstart-install" in quickstart_section,
+        "Quickstart section should still mention make quickstart-install",
+    )
     _require(
         quickstart_section.index("make quickstart") < quickstart_section.index("make quickstart-install"),
         "Quickstart section should present make quickstart before make quickstart-install",
@@ -34,9 +61,16 @@ def test_readme_quickstart_defaults_to_webui_before_local_dev() -> None:
 
 
 def test_getting_started_index_lists_all_profiles() -> None:
+    """The Getting Started index should still enumerate every base profile."""
     text = Path("Docs/Getting_Started/README.md").read_text()
-    _require("Choose exactly one base setup profile" in text, "Getting Started index should explain the base-profile model")
-    _require("Canonical base profiles" in text, "Getting Started index should list canonical base profiles")
+    _require(
+        "Choose exactly one base setup profile" in text,
+        "Getting Started index should explain the base-profile model",
+    )
+    _require(
+        "Canonical base profiles" in text,
+        "Getting Started index should list canonical base profiles",
+    )
     _require("Optional add-ons" in text, "Getting Started index should keep the optional add-ons section")
     for label in [
         "Local single-user",
@@ -48,7 +82,14 @@ def test_getting_started_index_lists_all_profiles() -> None:
 
 
 def test_getting_started_index_calls_out_default_webui_path() -> None:
+    """The Getting Started index should call out the WebUI Docker default."""
     text = Path("Docs/Getting_Started/README.md").read_text()
     _require("make quickstart" in text, "Getting Started index should mention make quickstart")
-    _require("quickstart-docker-webui" in text, "Getting Started index should mention the WebUI Docker path")
-    _require("Docker multi-user + Postgres" in text, "Getting Started index should keep the team/public deployment callout")
+    _require(
+        "quickstart-docker-webui" in text,
+        "Getting Started index should mention the WebUI Docker path",
+    )
+    _require(
+        "Docker multi-user + Postgres" in text,
+        "Getting Started index should keep the team/public deployment callout",
+    )

--- a/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
+++ b/tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py
@@ -1,22 +1,54 @@
 from pathlib import Path
 
+import pytest
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
 
 def test_readme_start_here_links_to_profile_index() -> None:
     text = Path("README.md").read_text()
-    assert "Docs/Getting_Started/README.md" in text
-    assert "Local single-user" in text
-    assert "Docker single-user" in text
+    _require("Docs/Getting_Started/README.md" in text, "README should link to the Getting Started index")
+    _require("Local single-user" in text, "README should still mention the local single-user profile")
+    _require("Docker single-user" in text, "README should mention the Docker single-user profile")
+    _require("make quickstart" in text, "README should mention make quickstart")
+    _require("make quickstart-docker-webui" in text, "README should mention the explicit WebUI Docker path")
+    _require("apps/DEVELOPMENT.md" in text, "README should link developers to apps/DEVELOPMENT.md")
+
+
+def test_readme_quickstart_defaults_to_webui_before_local_dev() -> None:
+    text = Path("README.md").read_text()
+    quickstart_section = text.split("## Quickstart", 1)[1]
+    _require("make quickstart" in quickstart_section, "Quickstart section should mention make quickstart")
+    _require("make quickstart-install" in quickstart_section, "Quickstart section should still mention make quickstart-install")
+    _require(
+        quickstart_section.index("make quickstart") < quickstart_section.index("make quickstart-install"),
+        "Quickstart section should present make quickstart before make quickstart-install",
+    )
+    _require(
+        "docker multi-user + postgres" in quickstart_section.lower(),
+        "Quickstart section should mention the multi-user + Postgres deployment path",
+    )
 
 
 def test_getting_started_index_lists_all_profiles() -> None:
     text = Path("Docs/Getting_Started/README.md").read_text()
-    assert "Choose exactly one base setup profile" in text
-    assert "Canonical base profiles" in text
-    assert "Optional add-ons" in text
+    _require("Choose exactly one base setup profile" in text, "Getting Started index should explain the base-profile model")
+    _require("Canonical base profiles" in text, "Getting Started index should list canonical base profiles")
+    _require("Optional add-ons" in text, "Getting Started index should keep the optional add-ons section")
     for label in [
         "Local single-user",
         "Docker single-user",
         "Docker multi-user + Postgres",
         "GPU/STT Add-on",
     ]:
-        assert label in text
+        _require(label in text, f"Getting Started index should include {label}")
+
+
+def test_getting_started_index_calls_out_default_webui_path() -> None:
+    text = Path("Docs/Getting_Started/README.md").read_text()
+    _require("make quickstart" in text, "Getting Started index should mention make quickstart")
+    _require("quickstart-docker-webui" in text, "Getting Started index should mention the WebUI Docker path")
+    _require("Docker multi-user + Postgres" in text, "Getting Started index should keep the team/public deployment callout")

--- a/tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py
+++ b/tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py
@@ -1,32 +1,45 @@
-from pathlib import Path
 import re
+from pathlib import Path
 
 import pytest
+import yaml
 
 
 def _read_text(path: str) -> str:
+    """Return a UTF-8 file body for assertions."""
     return Path(path).read_text(encoding="utf-8")
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message."""
     if not condition:
         pytest.fail(message)
 
 
 def _target_block(makefile_text: str, target: str) -> str:
+    """Return a Makefile target body or fail clearly."""
     pattern = rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)"
     match = re.search(pattern, makefile_text, flags=re.MULTILINE | re.DOTALL)
     _require(match is not None, f"Make target {target} not found")
     return match.group(0)
 
 
+def _load_yaml(path: str) -> dict:
+    """Load a YAML file into a plain dictionary."""
+    loaded = yaml.safe_load(_read_text(path))
+    _require(isinstance(loaded, dict), f"Expected YAML document at {path} to be a mapping")
+    return loaded
+
+
 def test_root_dockerignore_exists_and_excludes_large_local_paths():
+    """The Docker build context should exclude large local-only paths."""
     text = _read_text(".dockerignore")
 
     required_patterns = (
         ".venv/",
         ".git/",
         "Databases/",
+        "docker-data/",
         "apps/tldw-frontend/.next/",
         "apps/extension/tmp-playwright-profile/",
         "**/node_modules/",
@@ -36,7 +49,14 @@ def test_root_dockerignore_exists_and_excludes_large_local_paths():
         _require(pattern in text, f"Expected .dockerignore to contain: {pattern}")
 
 
+def test_root_gitignore_excludes_optional_host_storage_data():
+    """Optional host-storage bind mounts should stay out of git."""
+    text = _read_text(".gitignore")
+    _require("docker-data/" in text, "Expected .gitignore to exclude docker-data/")
+
+
 def test_makefile_quickstart_docker_targets_use_opt_in_build_flag():
+    """Docker quickstart Make targets should keep build opt-in."""
     text = _read_text("Makefile")
 
     _require("DOCKER_BUILD ?= false" in text, "Expected DOCKER_BUILD default to false")
@@ -55,6 +75,7 @@ def test_makefile_quickstart_docker_targets_use_opt_in_build_flag():
 
 
 def test_api_dockerfile_avoids_expensive_copy_and_recursive_chown_layers():
+    """The API Dockerfile should avoid heavyweight copy and chown steps."""
     text = _read_text("Dockerfiles/Dockerfile.prod")
 
     _require("COPY Databases /app/Databases" not in text, "Expected Dockerfile.prod to avoid copying Databases")
@@ -67,6 +88,7 @@ def test_api_dockerfile_avoids_expensive_copy_and_recursive_chown_layers():
 
 
 def test_webui_dockerfile_uses_copy_chown_instead_of_recursive_chown():
+    """The WebUI Dockerfile should use targeted --chown copies."""
     text = _read_text("Dockerfiles/Dockerfile.webui")
 
     _require("chown -R webui:webui /app" not in text, "Expected Dockerfile.webui to avoid recursive chown")
@@ -77,6 +99,7 @@ def test_webui_dockerfile_uses_copy_chown_instead_of_recursive_chown():
 
 
 def test_webui_dockerfile_installs_only_frontend_and_ui_workspaces():
+    """The WebUI Docker build should avoid installing every workspace."""
     text = _read_text("Dockerfiles/Dockerfile.webui")
 
     _require(
@@ -86,4 +109,67 @@ def test_webui_dockerfile_installs_only_frontend_and_ui_workspaces():
     _require(
         "npm install --workspaces --include-workspace-root" not in text,
         "Expected Dockerfile.webui to avoid installing all workspaces",
+    )
+
+
+def test_base_docker_compose_keeps_backward_compatible_named_volumes():
+    """The base compose file should preserve existing named volume identifiers."""
+    compose = _load_yaml("Dockerfiles/docker-compose.yml")
+    volumes = compose.get("volumes", {})
+    _require(isinstance(volumes, dict), "Expected top-level volumes mapping in docker-compose.yml")
+
+    for volume_name in ("app-data", "chroma-data", "postgres_data", "redis_data"):
+        _require(volume_name in volumes, f"Expected docker-compose.yml to declare {volume_name}")
+
+
+def test_app_service_keeps_split_databases_mounts():
+    """The app service should keep the root and user-data mounts split."""
+    compose = _load_yaml("Dockerfiles/docker-compose.yml")
+    services = compose.get("services", {})
+    _require(isinstance(services, dict), "Expected top-level services mapping in docker-compose.yml")
+    app_service = services.get("app", {})
+    _require(isinstance(app_service, dict), "Expected app service mapping in docker-compose.yml")
+    app_volumes = app_service.get("volumes", [])
+    _require(isinstance(app_volumes, list), "Expected app service volumes list in docker-compose.yml")
+
+    _require(
+        "app-data:/app/Databases" in app_volumes,
+        "Expected app-data to back /app/Databases",
+    )
+    _require(
+        "chroma-data:/app/Databases/user_databases" in app_volumes,
+        "Expected chroma-data to back /app/Databases/user_databases",
+    )
+
+
+def test_docker_host_storage_overlay_uses_bind_mounts():
+    """The optional host-storage overlay should bind-mount repo-visible paths."""
+    overlay = _load_yaml("Dockerfiles/docker-compose.host-storage.yml")
+    services = overlay.get("services", {})
+    _require(isinstance(services, dict), "Expected services mapping in host-storage overlay")
+
+    expected_mounts = {
+        "app": "../docker-data/app:/app/Databases",
+        "postgres": "../docker-data/postgres:/var/lib/postgresql/data",
+        "redis": "../docker-data/redis:/data",
+    }
+
+    for service_name, expected_mount in expected_mounts.items():
+        service = services.get(service_name, {})
+        _require(isinstance(service, dict), f"Expected {service_name} service mapping in host-storage overlay")
+        service_volumes = service.get("volumes", [])
+        _require(
+            isinstance(service_volumes, list),
+            f"Expected {service_name} volumes list in host-storage overlay",
+        )
+        _require(
+            expected_mount in service_volumes,
+            f"Expected {service_name} to bind-mount {expected_mount}",
+        )
+
+    app_service = services.get("app", {})
+    app_volumes = app_service.get("volumes", []) if isinstance(app_service, dict) else []
+    _require(
+        "../docker-data/user_data:/app/Databases/user_databases" in app_volumes,
+        "Expected app service to bind-mount repo-visible user_data storage",
     )

--- a/tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py
+++ b/tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py
@@ -1,15 +1,19 @@
-from pathlib import Path
+"""Regression tests for the default Makefile quickstart wiring."""
+
 import re
+from pathlib import Path
 
 import pytest
 
 
 def _require(condition: bool, message: str) -> None:
+    """Fail with a descriptive assertion message when a contract is broken."""
     if not condition:
         pytest.fail(message)
 
 
 def _target_block(makefile_text: str, target: str) -> str:
+    """Return a target block from the Makefile or fail with a clear message."""
     pattern = rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)"
     match = re.search(pattern, makefile_text, flags=re.MULTILINE | re.DOTALL)
     _require(match is not None, f"Make target {target} should exist")
@@ -17,14 +21,22 @@ def _target_block(makefile_text: str, target: str) -> str:
 
 
 def test_quickstart_target_delegates_to_webui_docker_path() -> None:
+    """make quickstart should route to the WebUI Docker target by default."""
     text = Path("Makefile").read_text(encoding="utf-8")
     quickstart = _target_block(text, "quickstart")
-    _require("quickstart-docker-webui" in quickstart, "quickstart should delegate to quickstart-docker-webui")
+    _require(
+        "quickstart-docker-webui" in quickstart,
+        "quickstart should delegate to quickstart-docker-webui",
+    )
 
 
 def test_quickstart_install_stays_on_local_dev_path() -> None:
+    """make quickstart-install should preserve the local development path."""
     text = Path("Makefile").read_text(encoding="utf-8")
     quickstart_install = _target_block(text, "quickstart-install")
     quickstart_local = _target_block(text, "quickstart-local")
-    _require("quickstart-local" in quickstart_install, "quickstart-install should still delegate to quickstart-local")
+    _require(
+        "quickstart-local" in quickstart_install,
+        "quickstart-install should still delegate to quickstart-local",
+    )
     _require("uvicorn" in quickstart_local, "quickstart-local should still start uvicorn")

--- a/tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py
+++ b/tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import re
+
+import pytest
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        pytest.fail(message)
+
+
+def _target_block(makefile_text: str, target: str) -> str:
+    pattern = rf"^{re.escape(target)}:.*?(?=^[A-Za-z0-9_.-]+:|\Z)"
+    match = re.search(pattern, makefile_text, flags=re.MULTILINE | re.DOTALL)
+    _require(match is not None, f"Make target {target} should exist")
+    return match.group(0)
+
+
+def test_quickstart_target_delegates_to_webui_docker_path() -> None:
+    text = Path("Makefile").read_text(encoding="utf-8")
+    quickstart = _target_block(text, "quickstart")
+    _require("quickstart-docker-webui" in quickstart, "quickstart should delegate to quickstart-docker-webui")
+
+
+def test_quickstart_install_stays_on_local_dev_path() -> None:
+    text = Path("Makefile").read_text(encoding="utf-8")
+    quickstart_install = _target_block(text, "quickstart-install")
+    quickstart_local = _target_block(text, "quickstart-local")
+    _require("quickstart-local" in quickstart_install, "quickstart-install should still delegate to quickstart-local")
+    _require("uvicorn" in quickstart_local, "quickstart-local should still start uvicorn")


### PR DESCRIPTION
## Summary
- make quickstart now defaults to the Docker single-user WebUI path while preserving the existing Make targets
- move local API and local WebUI setup into development-focused docs and secondary onboarding sections
- add regression tests for the onboarding manifest, README/website entrypoints, and Makefile wiring

## Test Plan
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest -v tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_manifest.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py tldw_Server_API/tests/Docs/test_published_onboarding_parity.py tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py
- make -n quickstart
- make -n quickstart-install
- source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Docs/test_onboarding_entrypoints.py tldw_Server_API/tests/Docs/test_onboarding_default_contract.py tldw_Server_API/tests/Docs/test_onboarding_dev_docs.py tldw_Server_API/tests/Utils/test_docker_quickstart_hardening.py tldw_Server_API/tests/Utils/test_makefile_quickstart_default.py -f json -o /tmp/bandit_default_prod_onboarding.json