### PR TITLE
Add enterprise AuthNZ federation and MCP credential brokering

### DIFF
--- a/Docs/Plans/2026-03-16-pr-906-review-followups.md
+++ b/Docs/Plans/2026-03-16-pr-906-review-followups.md
@@ -1,0 +1,17 @@
+## Stage 1: Review Validation
+**Goal**: Verify each new PR review comment against the current implementation and separate actionable fixes from non-actionable feedback.
+**Success Criteria**: Security/correctness items are confirmed with code references; maintainability suggestions are either accepted with small-scope fixes or explicitly rejected with rationale.
+**Tests**: N/A
+**Status**: Complete
+
+## Stage 2: Targeted Fixes
+**Goal**: Implement the accepted review fixes without widening scope.
+**Success Criteria**: OIDC verification no longer trusts token header `alg`, federation callback is rate-limited, managed secret readiness respects ref lifecycle state and avoids repeated per-slot lookups, federation endpoint helpers are centralized, and admin IdP endpoints gain required annotations/docstrings.
+**Tests**: Targeted `pytest` for AuthNZ federation, admin identity provider API, MCP Hub slot status, and external access resolver coverage.
+**Status**: Complete
+
+## Stage 3: Verification And PR Follow-Up
+**Goal**: Verify the touched scope and update the PR threads with concrete dispositions.
+**Success Criteria**: Targeted tests and Bandit pass on the changed files; the branch is ready to push; each open review thread has either a code fix or a technical reply.
+**Tests**: `pytest` on touched suites, `bandit` on touched Python files.
+**Status**: In Progress

--- a/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/auth_deps.py
@@ -521,7 +521,8 @@ async def get_db_transaction() -> AsyncGenerator[Any, None]:
                 entry_attempt += 1
                 await asyncio.sleep(sleep_seconds)
 
-        assert txn_cm is not None
+        if txn_cm is None:
+            raise RuntimeError("AuthNZ transaction context manager was not initialized")
 
         try:
             yield conn
@@ -676,6 +677,19 @@ async def get_session_manager_dep() -> SessionManager:
                         if expires_at <= now:
                             _TEST_EPHEMERAL_STATE["values"].pop(key, None)
                             return None
+                        return value
+
+                async def consume_ephemeral_value(self, key: str) -> Optional[str]:
+                    now = time.monotonic()
+                    with _TEST_EPHEMERAL_STATE_GUARD:
+                        entry = _TEST_EPHEMERAL_STATE["values"].get(key)
+                        if not entry:
+                            return None
+                        value, expires_at = entry
+                        if expires_at <= now:
+                            _TEST_EPHEMERAL_STATE["values"].pop(key, None)
+                            return None
+                        _TEST_EPHEMERAL_STATE["values"].pop(key, None)
                         return value
 
                 async def delete_ephemeral_value(self, key: str) -> None:

--- a/tldw_Server_API/app/api/v1/API_Deps/federation_deps.py
+++ b/tldw_Server_API/app/api/v1/API_Deps/federation_deps.py
@@ -1,0 +1,48 @@
+"""Shared dependencies and guards for enterprise federation endpoints."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import (
+    FederationProvisioningService,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import (
+    IdentityProviderRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+
+
+def enterprise_federation_available() -> bool:
+    """Return whether enterprise federation is enabled and supported here."""
+    settings = get_settings()
+    return bool(
+        getattr(settings, "AUTH_FEDERATION_ENABLED", False)
+        and getattr(settings, "enterprise_federation_supported", False)
+    )
+
+
+def require_enterprise_federation() -> None:
+    """Raise a 409 response when enterprise federation is unavailable."""
+    if not enterprise_federation_available():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Enterprise federation is not enabled for this deployment",
+        )
+
+
+async def get_identity_provider_repo_dep() -> IdentityProviderRepo:
+    """Return an identity provider repository bound to the current DB pool."""
+    return IdentityProviderRepo(db_pool=await get_db_pool())
+
+
+def get_oidc_federation_service_dep() -> OIDCFederationService:
+    """Return the OIDC federation service."""
+    return OIDCFederationService()
+
+
+async def get_federation_provisioning_service_dep() -> FederationProvisioningService:
+    """Return the federation provisioning service bound to the current DB pool."""
+    return FederationProvisioningService(db_pool=await get_db_pool())

--- a/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/__init__.py
@@ -47,6 +47,7 @@ from . import admin_router_analytics as admin_router_analytics_endpoints
 from . import admin_acp_agents as admin_acp_agents_endpoints
 from . import admin_billing as admin_billing_endpoints
 from . import admin_events_stream as admin_events_stream_endpoints
+from . import admin_identity_providers as admin_identity_providers_endpoints
 from . import admin_storage_quotas as admin_storage_quotas_endpoints
 from . import admin_user as admin_user_endpoints
 from . import admin_tenant_provisioning as admin_tenant_provisioning_endpoints
@@ -136,6 +137,7 @@ router.include_router(admin_circuit_breakers_endpoints.router)
 router.include_router(admin_acp_agents_endpoints.router)
 router.include_router(admin_billing_endpoints.router)
 router.include_router(admin_events_stream_endpoints.router)
+router.include_router(admin_identity_providers_endpoints.router)
 router.include_router(admin_storage_quotas_endpoints.router)
 router.include_router(admin_tenant_provisioning_endpoints.router)
 router.include_router(admin_impersonation_endpoints.router)

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
@@ -41,6 +41,7 @@ from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import (
 
 
 router = APIRouter()
+_IDENTITY_PROVIDER_OWNER_SCOPE_TYPES = frozenset({"global", "org"})
 
 
 async def _validate_provider_for_enablement(
@@ -132,6 +133,16 @@ async def admin_list_identity_providers(
     """List identity providers filtered by scope and enabled state."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
     require_enterprise_federation()
+    if owner_scope_type is not None and owner_scope_type not in _IDENTITY_PROVIDER_OWNER_SCOPE_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid owner_scope_type",
+        )
+    if owner_scope_id is not None and owner_scope_type != "org":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="owner_scope_id requires owner_scope_type='org'",
+        )
     providers = await repo.list_providers(
         owner_scope_type=owner_scope_type,
         owner_scope_id=owner_scope_id,

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
@@ -1,12 +1,20 @@
+"""Admin endpoints for enterprise identity provider management."""
+
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Awaitable, Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     check_rate_limit,
     get_auth_principal,
+)
+from tldw_Server_API.app.api.v1.API_Deps.federation_deps import (
+    get_federation_provisioning_service_dep,
+    get_identity_provider_repo_dep,
+    get_oidc_federation_service_dep,
+    require_enterprise_federation,
 )
 from tldw_Server_API.app.api.v1.schemas.identity_provider_schemas import (
     IdentityProviderDryRunRequest,
@@ -21,7 +29,6 @@ from tldw_Server_API.app.api.v1.schemas.identity_provider_schemas import (
     IdentityProviderTestResponse,
     IdentityProviderUpsertRequest,
 )
-from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
 from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
 from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import (
@@ -31,22 +38,18 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import (
     IdentityProviderRepo,
 )
-from tldw_Server_API.app.core.AuthNZ.settings import get_settings
 
 
 router = APIRouter()
 
 
-def _get_oidc_federation_service() -> OIDCFederationService:
-    return OIDCFederationService()
-
-
 async def _validate_provider_for_enablement(
     payload: IdentityProviderUpsertRequest,
+    oidc_service: OIDCFederationService,
 ) -> None:
+    """Reject enablement when the provider runtime configuration is invalid."""
     if not payload.enabled:
         return
-    oidc_service = _get_oidc_federation_service()
     try:
         await oidc_service.inspect_provider_configuration(
             provider=payload.model_dump(),
@@ -58,38 +61,18 @@ async def _validate_provider_for_enablement(
         ) from exc
 
 
-def _get_ensure_sqlite_authnz_ready_if_test_mode():
+def _get_ensure_sqlite_authnz_ready_if_test_mode() -> Callable[[], Awaitable[None]]:
+    """Return the shared SQLite AuthNZ bootstrap helper used in tests."""
     from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
 
     return admin_mod._ensure_sqlite_authnz_ready_if_test_mode
 
 
-def _enterprise_federation_available() -> bool:
-    settings = get_settings()
-    return bool(
-        getattr(settings, "AUTH_FEDERATION_ENABLED", False)
-        and getattr(settings, "enterprise_federation_supported", False)
-    )
-
-
-def _require_enterprise_federation() -> None:
-    if not _enterprise_federation_available():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Enterprise federation is not enabled for this deployment",
-        )
-
-
-async def get_identity_provider_repo() -> IdentityProviderRepo:
-    repo = IdentityProviderRepo(db_pool=await get_db_pool())
-    await repo.ensure_tables()
-    return repo
-
-
 async def _get_provider_or_404(
     provider_id: int,
     repo: IdentityProviderRepo,
-) -> dict:
+) -> dict[str, object]:
+    """Load an identity provider row or raise a 404 error."""
     provider = await repo.get_provider(provider_id)
     if provider is None:
         raise HTTPException(
@@ -107,11 +90,13 @@ async def _get_provider_or_404(
 async def admin_create_identity_provider(
     payload: IdentityProviderUpsertRequest,
     principal: Annotated[AuthPrincipal, Depends(get_auth_principal)],
-    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
+    oidc_service: Annotated[OIDCFederationService, Depends(get_oidc_federation_service_dep)],
 ) -> IdentityProviderResponse:
+    """Create a new enterprise identity provider definition."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
-    await _validate_provider_for_enablement(payload)
+    require_enterprise_federation()
+    await _validate_provider_for_enablement(payload, oidc_service)
     return await repo.create_provider(
         slug=payload.slug,
         provider_type=payload.provider_type,
@@ -139,13 +124,14 @@ async def admin_create_identity_provider(
     dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
 )
 async def admin_list_identity_providers(
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
     owner_scope_type: str | None = Query(None),
     owner_scope_id: int | None = Query(None, ge=1),
     enabled: bool | None = Query(None),
-    repo: IdentityProviderRepo = Depends(get_identity_provider_repo),
 ) -> IdentityProviderListResponse:
+    """List identity providers filtered by scope and enabled state."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
     providers = await repo.list_providers(
         owner_scope_type=owner_scope_type,
         owner_scope_id=owner_scope_id,
@@ -161,10 +147,11 @@ async def admin_list_identity_providers(
 )
 async def admin_test_identity_provider(
     payload: IdentityProviderTestRequest,
+    oidc_service: Annotated[OIDCFederationService, Depends(get_oidc_federation_service_dep)],
 ) -> IdentityProviderTestResponse:
+    """Validate an unsaved provider configuration and resolve runtime metadata."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
-    oidc_service = _get_oidc_federation_service()
+    require_enterprise_federation()
     try:
         result = await oidc_service.inspect_provider_configuration(
             provider=payload.provider.model_dump(),
@@ -184,16 +171,21 @@ async def admin_test_identity_provider(
 )
 async def admin_dry_run_identity_provider(
     payload: IdentityProviderDryRunRequest,
-    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
+    oidc_service: Annotated[OIDCFederationService, Depends(get_oidc_federation_service_dep)],
+    provisioning_service: Annotated[
+        FederationProvisioningService,
+        Depends(get_federation_provisioning_service_dep),
+    ],
 ) -> IdentityProviderDryRunResponse:
+    """Preview provider mapping and provisioning behavior without persisting changes."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
 
     provider_payload = payload.provider.model_dump()
     if payload.provider_id is not None:
         await _get_provider_or_404(payload.provider_id, repo)
         provider_payload["id"] = int(payload.provider_id)
-    oidc_service = _get_oidc_federation_service()
     try:
         provider_result = await oidc_service.inspect_provider_configuration(
             provider=provider_payload,
@@ -208,7 +200,6 @@ async def admin_dry_run_identity_provider(
         provider_payload.get("claim_mapping"),
         payload.claims,
     )
-    provisioning_service = FederationProvisioningService(db_pool=await get_db_pool())
     resolution = await provisioning_service.dry_run_login_resolution(
         provider=provider_payload,
         mapped_claims=mapping_preview,
@@ -257,10 +248,11 @@ async def admin_dry_run_identity_provider(
 )
 async def admin_get_identity_provider(
     provider_id: int,
-    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
 ) -> IdentityProviderResponse:
+    """Return a single identity provider definition."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
     return await _get_provider_or_404(provider_id, repo)
 
 
@@ -273,11 +265,13 @@ async def admin_update_identity_provider(
     provider_id: int,
     payload: IdentityProviderUpsertRequest,
     principal: Annotated[AuthPrincipal, Depends(get_auth_principal)],
-    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
+    oidc_service: Annotated[OIDCFederationService, Depends(get_oidc_federation_service_dep)],
 ) -> IdentityProviderResponse:
+    """Update an existing enterprise identity provider definition."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
-    await _validate_provider_for_enablement(payload)
+    require_enterprise_federation()
+    await _validate_provider_for_enablement(payload, oidc_service)
     updated = await repo.update_provider(
         provider_id,
         slug=payload.slug,
@@ -313,10 +307,11 @@ async def admin_update_identity_provider(
 async def admin_preview_identity_provider_mapping(
     provider_id: int,
     payload: IdentityProviderMappingPreviewRequest,
-    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo_dep)],
 ) -> IdentityProviderMappingPreviewResponse:
+    """Preview claim mapping output for a stored provider definition."""
     await _get_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
     provider = await _get_provider_or_404(provider_id, repo)
     preview = preview_claim_mapping(
         provider.get("claim_mapping"),

--- a/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
+++ b/tldw_Server_API/app/api/v1/endpoints/admin/admin_identity_providers.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    check_rate_limit,
+    get_auth_principal,
+)
+from tldw_Server_API.app.api.v1.schemas.identity_provider_schemas import (
+    IdentityProviderDryRunRequest,
+    IdentityProviderDryRunResponse,
+    IdentityProviderGrantSyncPreview,
+    IdentityProviderListResponse,
+    IdentityProviderMappingResult,
+    IdentityProviderMappingPreviewRequest,
+    IdentityProviderMappingPreviewResponse,
+    IdentityProviderResponse,
+    IdentityProviderTestRequest,
+    IdentityProviderTestResponse,
+    IdentityProviderUpsertRequest,
+)
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
+from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import (
+    FederationProvisioningService,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import (
+    IdentityProviderRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+
+
+router = APIRouter()
+
+
+def _get_oidc_federation_service() -> OIDCFederationService:
+    return OIDCFederationService()
+
+
+async def _validate_provider_for_enablement(
+    payload: IdentityProviderUpsertRequest,
+) -> None:
+    if not payload.enabled:
+        return
+    oidc_service = _get_oidc_federation_service()
+    try:
+        await oidc_service.inspect_provider_configuration(
+            provider=payload.model_dump(),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+
+def _get_ensure_sqlite_authnz_ready_if_test_mode():
+    from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
+
+    return admin_mod._ensure_sqlite_authnz_ready_if_test_mode
+
+
+def _enterprise_federation_available() -> bool:
+    settings = get_settings()
+    return bool(
+        getattr(settings, "AUTH_FEDERATION_ENABLED", False)
+        and getattr(settings, "enterprise_federation_supported", False)
+    )
+
+
+def _require_enterprise_federation() -> None:
+    if not _enterprise_federation_available():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Enterprise federation is not enabled for this deployment",
+        )
+
+
+async def get_identity_provider_repo() -> IdentityProviderRepo:
+    repo = IdentityProviderRepo(db_pool=await get_db_pool())
+    await repo.ensure_tables()
+    return repo
+
+
+async def _get_provider_or_404(
+    provider_id: int,
+    repo: IdentityProviderRepo,
+) -> dict:
+    provider = await repo.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Identity provider not found",
+        )
+    return provider
+
+
+@router.post(
+    "/identity/providers",
+    response_model=IdentityProviderResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_create_identity_provider(
+    payload: IdentityProviderUpsertRequest,
+    principal: Annotated[AuthPrincipal, Depends(get_auth_principal)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+) -> IdentityProviderResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    await _validate_provider_for_enablement(payload)
+    return await repo.create_provider(
+        slug=payload.slug,
+        provider_type=payload.provider_type,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+        enabled=payload.enabled,
+        display_name=payload.display_name,
+        issuer=payload.issuer,
+        discovery_url=payload.discovery_url,
+        authorization_url=payload.authorization_url,
+        token_url=payload.token_url,
+        jwks_url=payload.jwks_url,
+        client_id=payload.client_id,
+        client_secret_ref=payload.client_secret_ref,
+        claim_mapping=payload.claim_mapping,
+        provisioning_policy=payload.provisioning_policy,
+        created_by=principal.user_id,
+        updated_by=principal.user_id,
+    )
+
+
+@router.get(
+    "/identity/providers",
+    response_model=IdentityProviderListResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_list_identity_providers(
+    owner_scope_type: str | None = Query(None),
+    owner_scope_id: int | None = Query(None, ge=1),
+    enabled: bool | None = Query(None),
+    repo: IdentityProviderRepo = Depends(get_identity_provider_repo),
+) -> IdentityProviderListResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    providers = await repo.list_providers(
+        owner_scope_type=owner_scope_type,
+        owner_scope_id=owner_scope_id,
+        enabled=enabled,
+    )
+    return IdentityProviderListResponse(providers=providers)
+
+
+@router.post(
+    "/identity/providers/test",
+    response_model=IdentityProviderTestResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_test_identity_provider(
+    payload: IdentityProviderTestRequest,
+) -> IdentityProviderTestResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    oidc_service = _get_oidc_federation_service()
+    try:
+        result = await oidc_service.inspect_provider_configuration(
+            provider=payload.provider.model_dump(),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return IdentityProviderTestResponse.model_validate(result)
+
+
+@router.post(
+    "/identity/providers/dry-run",
+    response_model=IdentityProviderDryRunResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_dry_run_identity_provider(
+    payload: IdentityProviderDryRunRequest,
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+) -> IdentityProviderDryRunResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+
+    provider_payload = payload.provider.model_dump()
+    if payload.provider_id is not None:
+        await _get_provider_or_404(payload.provider_id, repo)
+        provider_payload["id"] = int(payload.provider_id)
+    oidc_service = _get_oidc_federation_service()
+    try:
+        provider_result = await oidc_service.inspect_provider_configuration(
+            provider=provider_payload,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    mapping_preview = preview_claim_mapping(
+        provider_payload.get("claim_mapping"),
+        payload.claims,
+    )
+    provisioning_service = FederationProvisioningService(db_pool=await get_db_pool())
+    resolution = await provisioning_service.dry_run_login_resolution(
+        provider=provider_payload,
+        mapped_claims=mapping_preview,
+    )
+    grant_sync_preview = None
+    if resolution["provisioning_action"] in {
+        "subject_already_linked",
+        "link_existing_user",
+        "create_new_user",
+    }:
+        grant_sync_preview = await provisioning_service.preview_mapped_grants(
+            provider=provider_payload,
+            user_id=resolution.get("matched_user_id"),
+            mapped_claims=mapping_preview,
+        )
+    combined_warnings = list(
+        dict.fromkeys(
+            [
+                *provider_result.get("warnings", []),
+                *mapping_preview.get("warnings", []),
+                *resolution.get("warnings", []),
+                *(grant_sync_preview.get("warnings", []) if grant_sync_preview else []),
+            ]
+        )
+    )
+    return IdentityProviderDryRunResponse(
+        provider=IdentityProviderTestResponse.model_validate(provider_result),
+        mapping=IdentityProviderMappingResult.model_validate(mapping_preview),
+        provisioning_action=resolution["provisioning_action"],
+        matched_user_id=resolution.get("matched_user_id"),
+        identity_link_found=bool(resolution.get("identity_link_found")),
+        email_match_found=bool(resolution.get("email_match_found")),
+        grant_sync=(
+            IdentityProviderGrantSyncPreview.model_validate(grant_sync_preview)
+            if grant_sync_preview is not None
+            else None
+        ),
+        warnings=combined_warnings,
+    )
+
+
+@router.get(
+    "/identity/providers/{provider_id}",
+    response_model=IdentityProviderResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_get_identity_provider(
+    provider_id: int,
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+) -> IdentityProviderResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    return await _get_provider_or_404(provider_id, repo)
+
+
+@router.put(
+    "/identity/providers/{provider_id}",
+    response_model=IdentityProviderResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_update_identity_provider(
+    provider_id: int,
+    payload: IdentityProviderUpsertRequest,
+    principal: Annotated[AuthPrincipal, Depends(get_auth_principal)],
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+) -> IdentityProviderResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    await _validate_provider_for_enablement(payload)
+    updated = await repo.update_provider(
+        provider_id,
+        slug=payload.slug,
+        provider_type=payload.provider_type,
+        owner_scope_type=payload.owner_scope_type,
+        owner_scope_id=payload.owner_scope_id,
+        enabled=payload.enabled,
+        display_name=payload.display_name,
+        issuer=payload.issuer,
+        discovery_url=payload.discovery_url,
+        authorization_url=payload.authorization_url,
+        token_url=payload.token_url,
+        jwks_url=payload.jwks_url,
+        client_id=payload.client_id,
+        client_secret_ref=payload.client_secret_ref,
+        claim_mapping=payload.claim_mapping,
+        provisioning_policy=payload.provisioning_policy,
+        updated_by=principal.user_id,
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Identity provider not found",
+        )
+    return updated
+
+
+@router.post(
+    "/identity/providers/{provider_id}/mappings/preview",
+    response_model=IdentityProviderMappingPreviewResponse,
+    dependencies=[Depends(get_auth_principal), Depends(check_rate_limit)],
+)
+async def admin_preview_identity_provider_mapping(
+    provider_id: int,
+    payload: IdentityProviderMappingPreviewRequest,
+    repo: Annotated[IdentityProviderRepo, Depends(get_identity_provider_repo)],
+) -> IdentityProviderMappingPreviewResponse:
+    await _get_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+    provider = await _get_provider_or_404(provider_id, repo)
+    preview = preview_claim_mapping(
+        provider.get("claim_mapping"),
+        payload.claims,
+    )
+    return IdentityProviderMappingPreviewResponse(
+        provider_id=provider_id,
+        **preview,
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -37,6 +37,12 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
     get_registration_service_dep,
     get_session_manager_dep,
 )
+from tldw_Server_API.app.api.v1.API_Deps.federation_deps import (
+    get_federation_provisioning_service_dep,
+    get_identity_provider_repo_dep,
+    get_oidc_federation_service_dep,
+    require_enterprise_federation,
+)
 from tldw_Server_API.app.api.v1.utils.deprecation import build_deprecation_headers
 
 #
@@ -59,10 +65,7 @@ from tldw_Server_API.app.core.AuthNZ.auth_governor import get_auth_governor
 from tldw_Server_API.app.core.AuthNZ.csrf_protection import (
     global_settings as _csrf_globals,
 )
-from tldw_Server_API.app.core.AuthNZ.database import (
-    get_db_pool,
-    is_postgres_backend,
-)
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, is_postgres_backend
 from tldw_Server_API.app.core.AuthNZ.exceptions import (
     DatabaseError,
     DuplicateOrganizationError,
@@ -184,32 +187,6 @@ def _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode():
     from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
 
     return admin_mod._ensure_sqlite_authnz_ready_if_test_mode
-
-
-def _enterprise_federation_available() -> bool:
-    settings = get_settings()
-    return bool(
-        getattr(settings, "AUTH_FEDERATION_ENABLED", False)
-        and getattr(settings, "enterprise_federation_supported", False)
-    )
-
-
-def _require_enterprise_federation() -> None:
-    if not _enterprise_federation_available():
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Enterprise federation is not enabled for this deployment",
-        )
-
-
-async def _get_identity_provider_repo() -> IdentityProviderRepo:
-    repo = IdentityProviderRepo(db_pool=await get_db_pool())
-    await repo.ensure_tables()
-    return repo
-
-
-def _get_oidc_federation_service() -> OIDCFederationService:
-    return OIDCFederationService()
 
 
 def _get_federation_state_repo(session_manager: SessionManager) -> FederationStateRepo:
@@ -410,9 +387,9 @@ async def federation_login(
     session_manager: SessionManager = Depends(get_session_manager_dep),
 ) -> RedirectResponse:
     await _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
 
-    repo = await _get_identity_provider_repo()
+    repo = await get_identity_provider_repo_dep()
     provider = await _resolve_federation_provider(
         repo=repo,
         provider_slug=provider_slug,
@@ -425,7 +402,7 @@ async def federation_login(
         )
 
     redirect_uri = str(request.url_for("federation_callback", provider_slug=provider_slug))
-    oidc_service = _get_oidc_federation_service()
+    oidc_service = get_oidc_federation_service_dep()
     try:
         auth_request = await oidc_service.build_authorization_request(
             provider=provider,
@@ -454,8 +431,12 @@ async def federation_login(
     )
     return RedirectResponse(url=str(auth_request["auth_url"]), status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
-
-@router.get("/federation/{provider_slug}/callback", name="federation_callback", response_model=TokenResponse)
+@router.get(
+    "/federation/{provider_slug}/callback",
+    name="federation_callback",
+    response_model=TokenResponse,
+    dependencies=[Depends(check_auth_rate_limit)],
+)
 async def federation_callback(
     provider_slug: str,
     code: str,
@@ -465,9 +446,10 @@ async def federation_callback(
     jwt_service: JWTService = Depends(get_jwt_service_dep),
     session_manager: SessionManager = Depends(get_session_manager_dep),
     settings: Settings = Depends(get_settings),
+    provisioning_service: FederationProvisioningService = Depends(get_federation_provisioning_service_dep),
 ) -> TokenResponse:
     await _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode()()
-    _require_enterprise_federation()
+    require_enterprise_federation()
 
     code_value = str(code or "").strip()
     state_value = str(state or "").strip()
@@ -485,7 +467,7 @@ async def federation_callback(
             detail="Invalid or expired OIDC state",
         )
 
-    repo = await _get_identity_provider_repo()
+    repo = await get_identity_provider_repo_dep()
     provider_id = int(state_record.get("provider_id") or 0)
     provider = await repo.get_provider(provider_id) if provider_id > 0 else None
     if not provider or not bool(provider.get("enabled")):
@@ -507,7 +489,7 @@ async def federation_callback(
             detail="OIDC state is incomplete",
         )
 
-    oidc_service = _get_oidc_federation_service()
+    oidc_service = get_oidc_federation_service_dep()
     try:
         claims = await oidc_service.exchange_authorization_code(
             provider=provider,
@@ -530,8 +512,7 @@ async def federation_callback(
             detail="OIDC claims did not resolve a subject",
         )
 
-    db_pool = await get_db_pool()
-    provisioning_service = FederationProvisioningService(db_pool=db_pool)
+    db_pool = provisioning_service.db_pool
     user = await provisioning_service.resolve_user_for_login(
         provider=provider,
         mapped_claims=mapped_claims,

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -461,7 +461,6 @@ async def federation_callback(
     code: str,
     state: str,
     request: Request,
-    db=Depends(get_db_transaction),
     jwt_service: JWTService = Depends(get_jwt_service_dep),
     session_manager: SessionManager = Depends(get_session_manager_dep),
     settings: Settings = Depends(get_settings),
@@ -581,14 +580,16 @@ async def federation_callback(
         user_id=int(user["id"]),
         mapped_claims=mapped_claims,
     )
-    return await _issue_multi_user_tokens(
-        request=request,
-        db=db,
-        user=user,
-        jwt_service=jwt_service,
-        session_manager=session_manager,
-        settings=settings,
-    )
+    db_pool = await get_db_pool()
+    async with db_pool.transaction() as db:
+        return await _issue_multi_user_tokens(
+            request=request,
+            db=db,
+            user=user,
+            jwt_service=jwt_service,
+            session_manager=session_manager,
+            settings=settings,
+        )
 
 
 def _current_user_value(user: Any, key: str, default: Any = None) -> Any:

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -379,7 +379,10 @@ async def _issue_multi_user_tokens(
     )
 
 
-@router.get("/federation/{provider_slug}/login")
+@router.get(
+    "/federation/{provider_slug}/login",
+    dependencies=[Depends(check_auth_rate_limit)],
+)
 async def federation_login(
     provider_slug: str,
     request: Request,
@@ -388,6 +391,22 @@ async def federation_login(
 ) -> RedirectResponse:
     await _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode()()
     require_enterprise_federation()
+    client_ip = _auth_request_client_ip(request)
+    allowed, retry_after = await _reserve_auth_rg_requests(
+        request,
+        policy_id="authnz.federation.login",
+        entity=f"ip:{client_ip}",
+        tags={
+            "auth_endpoint": "federation_login",
+            "provider_slug": str(provider_slug or ""),
+        },
+    )
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many federation login attempts. Please try again later.",
+            headers={"Retry-After": str(int(retry_after or 1))},
+        )
 
     repo = await get_identity_provider_repo_dep()
     provider = await _resolve_federation_provider(
@@ -457,6 +476,22 @@ async def federation_callback(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Missing OIDC callback parameters",
+        )
+    client_ip = _auth_request_client_ip(request)
+    allowed, retry_after = await _reserve_auth_rg_requests(
+        request,
+        policy_id="authnz.federation.callback",
+        entity=f"ip:{client_ip}",
+        tags={
+            "auth_endpoint": "federation_callback",
+            "provider_slug": str(provider_slug or ""),
+        },
+    )
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many federation callback attempts. Please try again later.",
+            headers={"Retry-After": str(int(retry_after or 1))},
         )
 
     state_repo = _get_federation_state_repo(session_manager)

--- a/tldw_Server_API/app/api/v1/endpoints/auth.py
+++ b/tldw_Server_API/app/api/v1/endpoints/auth.py
@@ -18,6 +18,7 @@ from typing import Any, Optional
 #
 # 3rd-party imports
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, Response, status
+from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from loguru import logger
 from pydantic import BaseModel, EmailStr, Field
@@ -83,6 +84,7 @@ from tldw_Server_API.app.core.AuthNZ.orgs_teams import list_memberships_for_user
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.rate_limiter import RateLimiter
+from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import IdentityProviderRepo
 from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, get_profile, get_settings
 from tldw_Server_API.app.core.AuthNZ.token_blacklist import get_token_blacklist
@@ -104,6 +106,10 @@ from tldw_Server_API.app.services.auth_service import (
     update_user_password_hash,
 )
 from tldw_Server_API.app.services.registration_service import RegistrationService
+from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
+from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import FederationProvisioningService
+from tldw_Server_API.app.core.AuthNZ.federation.state_repo import FederationStateRepo
 from tldw_Server_API.app.core.testing import (
     env_flag_enabled as _env_flag_enabled,
     is_explicit_pytest_runtime as _is_explicit_pytest_runtime,
@@ -172,6 +178,65 @@ def _legacy_user_me_enabled() -> bool:
 
 def _legacy_warning_payload(successor: str) -> dict[str, str]:
     return {"warning": "deprecated_endpoint", "successor": successor}
+
+
+def _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode():
+    from tldw_Server_API.app.api.v1.endpoints import admin as admin_mod
+
+    return admin_mod._ensure_sqlite_authnz_ready_if_test_mode
+
+
+def _enterprise_federation_available() -> bool:
+    settings = get_settings()
+    return bool(
+        getattr(settings, "AUTH_FEDERATION_ENABLED", False)
+        and getattr(settings, "enterprise_federation_supported", False)
+    )
+
+
+def _require_enterprise_federation() -> None:
+    if not _enterprise_federation_available():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Enterprise federation is not enabled for this deployment",
+        )
+
+
+async def _get_identity_provider_repo() -> IdentityProviderRepo:
+    repo = IdentityProviderRepo(db_pool=await get_db_pool())
+    await repo.ensure_tables()
+    return repo
+
+
+def _get_oidc_federation_service() -> OIDCFederationService:
+    return OIDCFederationService()
+
+
+def _get_federation_state_repo(session_manager: SessionManager) -> FederationStateRepo:
+    return FederationStateRepo(session_manager=session_manager)
+
+
+async def _resolve_federation_provider(
+    *,
+    repo: IdentityProviderRepo,
+    provider_slug: str,
+    org_id: int | None = None,
+) -> dict[str, Any] | None:
+    normalized_slug = str(provider_slug or "").strip()
+    if org_id is not None:
+        provider = await repo.get_provider_by_slug(
+            slug=normalized_slug,
+            owner_scope_type="org",
+            owner_scope_id=int(org_id),
+        )
+        if provider:
+            return provider
+    return await repo.get_provider_by_slug(
+        slug=normalized_slug,
+        owner_scope_type="global",
+        owner_scope_id=None,
+    )
+
 
 def _get_email_service():
     """Resolve the email service lazily to honor monkeypatched modules in tests."""
@@ -242,6 +307,272 @@ def _get_mfa_login_ttl_seconds() -> int:
 
 def _normalize_magic_email(email: str) -> str:
     return str(email or "").strip().lower()
+
+
+async def _safe_audit_log_login_event(
+    *,
+    user_id: int,
+    username: str,
+    ip: str,
+    user_agent: str,
+    success: bool,
+) -> None:
+    try:
+        svc = await get_or_create_audit_service_for_user_id(user_id)
+        await svc.log_login(
+            user_id=user_id,
+            username=username,
+            ip_address=ip,
+            user_agent=user_agent,
+            success=success,
+        )
+        flush_on_login = _env_flag_enabled("AUDIT_FLUSH_ON_LOGIN")
+        test_mode = _is_test_mode()
+        if flush_on_login or test_mode:
+            await svc.flush()
+    except _AUTH_NONCRITICAL_EXCEPTIONS as exc:
+        logger.debug(
+            "Federated login audit failed for user_id={}: {}",
+            user_id,
+            exc,
+            exc_info=True,
+        )
+
+
+async def _issue_multi_user_tokens(
+    *,
+    request: Request,
+    db: Any,
+    user: dict[str, Any],
+    jwt_service: JWTService,
+    session_manager: SessionManager,
+    settings: Settings,
+) -> TokenResponse:
+    user_id = int(user["id"])
+    username = str(user.get("username") or "")
+    client_ip = _auth_request_client_ip(request)
+    user_agent = request.headers.get("User-Agent", "Unknown")
+
+    temp_access = f"temp_access_{secrets.token_urlsafe(16)}"
+    temp_refresh = f"temp_refresh_{secrets.token_urlsafe(16)}"
+    temp_session_info = await session_manager.create_session(
+        user_id=user_id,
+        access_token=temp_access,
+        refresh_token=temp_refresh,
+        ip_address=client_ip,
+        user_agent=user_agent,
+    )
+    session_id = int(temp_session_info["session_id"])
+
+    if settings.AUTH_MODE == "multi_user":
+        await _ensure_user_org_membership(user_id, user.get("username"))
+
+    scope_claims = await _build_scope_claims(user_id)
+    add_claims = dict(scope_claims)
+    add_claims["session_id"] = session_id
+    access_token = jwt_service.create_access_token(
+        user_id=user_id,
+        username=username,
+        role=str(user.get("role") or settings.DEFAULT_USER_ROLE),
+        additional_claims=add_claims,
+    )
+    refresh_token = jwt_service.create_refresh_token(
+        user_id=user_id,
+        username=username,
+        additional_claims=add_claims,
+    )
+    await session_manager.update_session_tokens(
+        session_id=session_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+    await update_user_last_login(db, user_id, datetime.utcnow())
+    await _safe_audit_log_login_event(
+        user_id=user_id,
+        username=username,
+        ip=client_ip,
+        user_agent=user_agent,
+        success=True,
+    )
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        token_type="bearer",
+        expires_in=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+
+
+@router.get("/federation/{provider_slug}/login")
+async def federation_login(
+    provider_slug: str,
+    request: Request,
+    org_id: int | None = Query(None, ge=1),
+    session_manager: SessionManager = Depends(get_session_manager_dep),
+) -> RedirectResponse:
+    await _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+
+    repo = await _get_identity_provider_repo()
+    provider = await _resolve_federation_provider(
+        repo=repo,
+        provider_slug=provider_slug,
+        org_id=org_id,
+    )
+    if not provider or not bool(provider.get("enabled")):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Identity provider not found",
+        )
+
+    redirect_uri = str(request.url_for("federation_callback", provider_slug=provider_slug))
+    oidc_service = _get_oidc_federation_service()
+    try:
+        auth_request = await oidc_service.build_authorization_request(
+            provider=provider,
+            redirect_uri=redirect_uri,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    state_repo = _get_federation_state_repo(session_manager)
+    await state_repo.create_state(
+        state=auth_request["state"],
+        payload={
+            "provider_id": int(provider["id"]),
+            "provider_slug": str(provider["slug"]),
+            "owner_scope_type": str(provider.get("owner_scope_type") or "global"),
+            "owner_scope_id": provider.get("owner_scope_id"),
+            "redirect_uri": redirect_uri,
+            "nonce": auth_request["nonce"],
+            "code_verifier": auth_request["code_verifier"],
+            "expires_at": auth_request["expires_at"].isoformat(),
+        },
+        ttl_seconds=int(auth_request["ttl_seconds"]),
+    )
+    return RedirectResponse(url=str(auth_request["auth_url"]), status_code=status.HTTP_307_TEMPORARY_REDIRECT)
+
+
+@router.get("/federation/{provider_slug}/callback", name="federation_callback", response_model=TokenResponse)
+async def federation_callback(
+    provider_slug: str,
+    code: str,
+    state: str,
+    request: Request,
+    db=Depends(get_db_transaction),
+    jwt_service: JWTService = Depends(get_jwt_service_dep),
+    session_manager: SessionManager = Depends(get_session_manager_dep),
+    settings: Settings = Depends(get_settings),
+) -> TokenResponse:
+    await _get_admin_module_ensure_sqlite_authnz_ready_if_test_mode()()
+    _require_enterprise_federation()
+
+    code_value = str(code or "").strip()
+    state_value = str(state or "").strip()
+    if not code_value or not state_value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing OIDC callback parameters",
+        )
+
+    state_repo = _get_federation_state_repo(session_manager)
+    state_record = await state_repo.consume_state(state=state_value)
+    if not state_record:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid or expired OIDC state",
+        )
+
+    repo = await _get_identity_provider_repo()
+    provider_id = int(state_record.get("provider_id") or 0)
+    provider = await repo.get_provider(provider_id) if provider_id > 0 else None
+    if not provider or not bool(provider.get("enabled")):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Identity provider not found",
+        )
+    if str(provider.get("slug") or "").strip() != str(provider_slug or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="OIDC state provider mismatch",
+        )
+
+    redirect_uri = str(state_record.get("redirect_uri") or "").strip()
+    code_verifier = str(state_record.get("code_verifier") or "").strip()
+    if not redirect_uri or not code_verifier:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="OIDC state is incomplete",
+        )
+
+    oidc_service = _get_oidc_federation_service()
+    try:
+        claims = await oidc_service.exchange_authorization_code(
+            provider=provider,
+            code=code_value,
+            redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
+            nonce=(str(state_record.get("nonce")).strip() if state_record.get("nonce") else None),
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    mapped_claims = preview_claim_mapping(provider.get("claim_mapping"), claims)
+    subject = str(mapped_claims.get("subject") or "").strip()
+    if not subject:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="OIDC claims did not resolve a subject",
+        )
+
+    db_pool = await get_db_pool()
+    provisioning_service = FederationProvisioningService(db_pool=db_pool)
+    user = await provisioning_service.resolve_user_for_login(
+        provider=provider,
+        mapped_claims=mapped_claims,
+    )
+    if not user:
+        policy = provider.get("provisioning_policy") or {}
+        if not bool(policy.get("jit_create")):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Federated account is not linked to a local user",
+            )
+        user = await _provision_federated_user(
+            mapped_claims=mapped_claims,
+            registration_service=RegistrationService(db_pool=db_pool),
+            default_role=settings.DEFAULT_USER_ROLE,
+        )
+    if not bool(user.get("is_active", True)):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account is inactive. Please contact support.",
+        )
+
+    await provisioning_service.upsert_identity_link(
+        provider=provider,
+        user_id=int(user["id"]),
+        mapped_claims=mapped_claims,
+        raw_claims=claims,
+    )
+    await provisioning_service.apply_mapped_grants(
+        provider=provider,
+        user_id=int(user["id"]),
+        mapped_claims=mapped_claims,
+    )
+    return await _issue_multi_user_tokens(
+        request=request,
+        db=db,
+        user=user,
+        jwt_service=jwt_service,
+        session_manager=session_manager,
+        settings=settings,
+    )
 
 
 def _current_user_value(user: Any, key: str, default: Any = None) -> Any:
@@ -412,6 +743,21 @@ def _derive_username_from_email(email: str) -> str:
     return local[:32]
 
 
+def _derive_username_from_claims(mapped_claims: dict[str, Any]) -> str:
+    username_hint = str(mapped_claims.get("username") or "").strip().lower()
+    if username_hint:
+        username_hint = re.sub(r"[^a-z0-9_-]+", "-", username_hint).strip("-")
+        if len(username_hint) >= 3:
+            return username_hint[:32]
+    return _derive_username_from_email(str(mapped_claims.get("email") or "user"))
+
+
+def _username_with_suffix(base: str, suffix: str) -> str:
+    if len(base) + len(suffix) <= 32:
+        return f"{base}{suffix}"
+    return f"{base[: 32 - len(suffix)]}{suffix}"
+
+
 def _generate_magic_password(length: int = 16) -> str:
     # Ensure a mix of upper, lower, digit, and special characters.
     specials = "!@#$%^&*"
@@ -426,6 +772,68 @@ def _generate_magic_password(length: int = 16) -> str:
     base.extend(secrets.choice(choices) for _ in range(remaining))
     secrets.SystemRandom().shuffle(base)
     return "".join(base)
+
+
+async def _provision_federated_user(
+    *,
+    mapped_claims: dict[str, Any],
+    registration_service: RegistrationService,
+    default_role: str,
+) -> dict[str, Any]:
+    email = str(mapped_claims.get("email") or "").strip().lower()
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="OIDC claims did not resolve an email for JIT provisioning",
+        )
+
+    password = _generate_magic_password()
+    username_base = _derive_username_from_claims(mapped_claims)
+    user_info: Optional[dict[str, Any]] = None
+
+    for attempt in range(5):
+        suffix = f"-{secrets.token_hex(2)}"
+        username = username_base if attempt == 0 else _username_with_suffix(username_base, suffix)
+        try:
+            user_info = await registration_service.register_user(
+                username=username,
+                email=email,
+                password=password,
+                role_override=default_role,
+                is_verified_override=True,
+                system_provisioning=True,
+            )
+            break
+        except DuplicateUserError as exc:
+            if getattr(exc, "field", None) == "username":
+                continue
+            if getattr(exc, "field", None) == "email":
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Federated email already belongs to a local user",
+                ) from exc
+            raise
+        except RegistrationError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
+
+    if not user_info:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Could not provision a unique username for the federated user",
+        )
+
+    return {
+        "id": int(user_info["user_id"]),
+        "username": str(user_info["username"]),
+        "email": str(user_info["email"]),
+        "role": str(user_info["role"]),
+        "is_active": bool(user_info.get("is_active", True)),
+        "is_verified": bool(user_info.get("is_verified", False)),
+    }
+
 
 async def _ensure_user_org_membership(user_id: int, username: Optional[str] = None) -> None:
     """Ensure a user has at least one org membership; create a personal org if not."""
@@ -2323,6 +2731,79 @@ async def request_magic_link(
 
 
 @router.post(
+    "/admin/reauth/request",
+    response_model=MessageResponse,
+    status_code=status.HTTP_200_OK,
+    dependencies=[Depends(check_auth_rate_limit)],
+)
+async def request_admin_reauth(
+    request: Request,
+    current_user: AuthPrincipal = Depends(get_auth_principal),
+    db=Depends(get_db_transaction),
+    jwt_service: JWTService = Depends(get_jwt_service_dep),
+) -> MessageResponse:
+    """Email a purpose-scoped admin reauthentication link to the acting admin."""
+    settings = get_settings()
+    if settings.AUTH_MODE != "multi_user":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Admin reauthentication is only available in multi-user mode",
+        )
+    if not _current_user_has_admin_claims(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication is only available to administrators",
+        )
+
+    user_id = _current_user_id(current_user)
+    if user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+
+    email = _normalize_magic_email(_current_user_value(current_user, "email", ""))
+    username = _current_user_username(current_user)
+    if not email:
+        actor = await fetch_active_user_by_id(db, int(user_id))
+        if actor:
+            email = _normalize_magic_email(actor.get("email") or "")
+            username = str(actor.get("username") or username)
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Authenticated admin account is missing an email address",
+        )
+
+    expires_in_minutes = max(1, min(int(settings.MAGIC_LINK_EXPIRE_MINUTES), 10))
+
+    try:
+        token = jwt_service.create_admin_reauth_token(
+            email=email,
+            user_id=int(user_id),
+            expires_in_minutes=expires_in_minutes,
+        )
+
+        email_service = _get_email_service()
+        await email_service.send_admin_reauth_email(
+            to_email=email,
+            reauth_token=token,
+            expires_in_minutes=expires_in_minutes,
+            username=username,
+        )
+    except HTTPException:
+        raise
+    except _AUTH_NONCRITICAL_EXCEPTIONS as exc:
+        logger.error("Failed to send admin reauthentication email: {}", exc)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send admin reauthentication email",
+        ) from exc
+
+    return MessageResponse(message="Admin reauthentication link sent")
+
+
+@router.post(
     "/magic-link/verify",
     response_model=TokenResponse,
     status_code=status.HTTP_200_OK,
@@ -2361,6 +2842,12 @@ async def verify_magic_link(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid magic link token",
         ) from exc
+
+    if str(payload.get("purpose") or "").strip().lower() == "admin_reauth":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Admin reauthentication tokens cannot be used for sign-in",
+        )
 
     email = _normalize_magic_email(payload.get("email") or "")
     user_id: Optional[int] = None

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -51,6 +51,7 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     GovernancePackSummaryResponse,
     GovernanceAuditFindingListResponse,
     MCPHubDeleteResponse,
+    McpCredentialSlotStatusResponse,
     PathScopeObjectCreateRequest,
     PathScopeObjectResponse,
     PathScopeObjectUpdateRequest,
@@ -64,6 +65,7 @@ from tldw_Server_API.app.api.v1.schemas.mcp_hub_schemas import (
     PolicyAssignmentUpdateRequest,
     PolicyOverrideResponse,
     PolicyOverrideUpsertRequest,
+    ProfileCredentialBindingUpsertRequest,
     SharedWorkspaceCreateRequest,
     SharedWorkspaceResponse,
     SharedWorkspaceUpdateRequest,
@@ -93,6 +95,9 @@ from tldw_Server_API.app.services.mcp_hub_governance_pack_service import (
     GovernancePackUpgradeConflictError,
     GovernancePackUpgradeStaleError,
     McpHubGovernancePackService,
+)
+from tldw_Server_API.app.services.mcp_credential_broker_service import (
+    McpCredentialBrokerService,
 )
 from tldw_Server_API.app.services.mcp_hub_policy_resolver import McpHubPolicyResolver, get_mcp_hub_policy_resolver
 from tldw_Server_API.app.services.mcp_hub_service import McpHubConflictError, McpHubService
@@ -171,6 +176,14 @@ async def get_mcp_hub_policy_resolver_dep() -> McpHubPolicyResolver:
 async def get_mcp_hub_tool_registry_dep() -> McpHubToolRegistryService:
     """Resolve the derived MCP Hub tool registry service."""
     return McpHubToolRegistryService()
+
+
+async def get_mcp_credential_broker_service() -> McpCredentialBrokerService:
+    """Resolve the MCP credential broker service backed by the current MCP Hub repo."""
+    pool = await get_db_pool()
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return McpCredentialBrokerService(repo=repo)
 
 
 def _load_json_object(raw: Any) -> dict[str, Any]:
@@ -1255,6 +1268,11 @@ def _binding_row_to_response(row: dict[str, Any]) -> CredentialBindingResponse:
             else None
         ),
         credential_ref=str(row.get("credential_ref") or "server"),
+        managed_secret_ref_id=(
+            int(row.get("managed_secret_ref_id"))
+            if row.get("managed_secret_ref_id") is not None
+            else None
+        ),
         binding_mode=str(row.get("binding_mode") or "grant"),
         usage_rules=_load_json_object(row.get("usage_rules")),
         created_by=row.get("created_by"),
@@ -3130,6 +3148,7 @@ async def list_profile_credential_bindings(
 async def upsert_profile_credential_binding(
     profile_id: int,
     server_id: str,
+    payload: ProfileCredentialBindingUpsertRequest | None = None,
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> CredentialBindingResponse:
@@ -3147,6 +3166,7 @@ async def upsert_profile_credential_binding(
         row = await svc.upsert_profile_credential_binding(
             profile_id=profile_id,
             external_server_id=server_id,
+            managed_secret_ref_id=(payload.managed_secret_ref_id if payload else None),
             actor_id=principal.user_id,
         )
     except ResourceNotFoundError as exc:
@@ -3164,6 +3184,7 @@ async def upsert_profile_slot_credential_binding(
     profile_id: int,
     server_id: str,
     slot_name: str,
+    payload: ProfileCredentialBindingUpsertRequest | None = None,
     principal: AuthPrincipal = Depends(get_auth_principal),
     svc: McpHubService = Depends(get_mcp_hub_service),
 ) -> CredentialBindingResponse:
@@ -3182,6 +3203,7 @@ async def upsert_profile_slot_credential_binding(
             profile_id=profile_id,
             external_server_id=server_id,
             slot_name=slot_name,
+            managed_secret_ref_id=(payload.managed_secret_ref_id if payload else None),
             actor_id=principal.user_id,
         )
     except ResourceNotFoundError as exc:
@@ -3278,6 +3300,7 @@ async def upsert_assignment_credential_binding(
             assignment_id=assignment_id,
             external_server_id=server_id,
             binding_mode=payload.binding_mode,
+            managed_secret_ref_id=payload.managed_secret_ref_id,
             actor_id=principal.user_id,
         )
     except ResourceNotFoundError as exc:
@@ -3316,6 +3339,7 @@ async def upsert_assignment_slot_credential_binding(
             external_server_id=server_id,
             slot_name=slot_name,
             binding_mode=payload.binding_mode,
+            managed_secret_ref_id=payload.managed_secret_ref_id,
             actor_id=principal.user_id,
         )
     except ResourceNotFoundError as exc:
@@ -3371,6 +3395,56 @@ async def delete_assignment_slot_credential_binding(
     if not deleted:
         raise HTTPException(status_code=404, detail="Credential binding not found")
     return MCPHubDeleteResponse(ok=True)
+
+
+@router.get(
+    "/permission-profiles/{profile_id}/credential-bindings/{server_id}/{slot_name}/status",
+    response_model=McpCredentialSlotStatusResponse,
+)
+async def get_profile_slot_credential_status(
+    profile_id: int,
+    server_id: str,
+    slot_name: str,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+    broker: McpCredentialBrokerService = Depends(get_mcp_credential_broker_service),
+) -> McpCredentialSlotStatusResponse:
+    """Return the remediation status for a profile-scoped external credential slot."""
+    await _get_visible_permission_profile_or_404(profile_id=profile_id, principal=principal, svc=svc)
+    try:
+        status = await broker.get_slot_status(
+            server_id=server_id,
+            slot_name=slot_name,
+            profile_id=profile_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return McpCredentialSlotStatusResponse.model_validate(status)
+
+
+@router.get(
+    "/policy-assignments/{assignment_id}/credential-bindings/{server_id}/{slot_name}/status",
+    response_model=McpCredentialSlotStatusResponse,
+)
+async def get_assignment_slot_credential_status(
+    assignment_id: int,
+    server_id: str,
+    slot_name: str,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+    svc: McpHubService = Depends(get_mcp_hub_service),
+    broker: McpCredentialBrokerService = Depends(get_mcp_credential_broker_service),
+) -> McpCredentialSlotStatusResponse:
+    """Return the remediation status for an assignment-scoped external credential slot."""
+    await _get_visible_policy_assignment_or_404(assignment_id=assignment_id, principal=principal, svc=svc)
+    try:
+        status = await broker.get_slot_status(
+            server_id=server_id,
+            slot_name=slot_name,
+            assignment_id=assignment_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return McpCredentialSlotStatusResponse.model_validate(status)
 
 
 @router.get("/policy-assignments/{assignment_id}/external-access", response_model=EffectiveExternalAccessResponse)

--- a/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
+++ b/tldw_Server_API/app/api/v1/endpoints/mcp_hub_management.py
@@ -3398,8 +3398,14 @@ async def delete_assignment_slot_credential_binding(
 
 
 @router.get(
+    "/permission-profiles/{profile_id}/credential-bindings/status/{server_id}/{slot_name}",
+    response_model=McpCredentialSlotStatusResponse,
+)
+@router.get(
     "/permission-profiles/{profile_id}/credential-bindings/{server_id}/{slot_name}/status",
     response_model=McpCredentialSlotStatusResponse,
+    include_in_schema=False,
+    deprecated=True,
 )
 async def get_profile_slot_credential_status(
     profile_id: int,
@@ -3423,8 +3429,14 @@ async def get_profile_slot_credential_status(
 
 
 @router.get(
+    "/policy-assignments/{assignment_id}/credential-bindings/status/{server_id}/{slot_name}",
+    response_model=McpCredentialSlotStatusResponse,
+)
+@router.get(
     "/policy-assignments/{assignment_id}/credential-bindings/{server_id}/{slot_name}/status",
     response_model=McpCredentialSlotStatusResponse,
+    include_in_schema=False,
+    deprecated=True,
 )
 async def get_assignment_slot_credential_status(
     assignment_id: int,

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -31,8 +31,9 @@ class UserUpdateRequest(BaseModel):
     storage_quota_mb: int | None = Field(None, ge=100)
     reason: str | None = Field(default=None, min_length=8, max_length=500)
     admin_password: str | None = Field(default=None, max_length=128)
+    admin_reauth_token: str | None = Field(default=None, max_length=4096)
 
-    @field_validator("admin_password", mode="before")
+    @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod
     def normalize_blank_admin_password(cls, value: Any) -> Any:
         return _blank_string_to_none(value)
@@ -45,8 +46,9 @@ class AdminPrivilegedActionRequest(BaseModel):
 
     reason: str = Field(..., min_length=8, max_length=500)
     admin_password: str | None = Field(default=None, max_length=128)
+    admin_reauth_token: str | None = Field(default=None, max_length=4096)
 
-    @field_validator("admin_password", mode="before")
+    @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod
     def normalize_blank_admin_password(cls, value: Any) -> Any:
         return _blank_string_to_none(value)

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -9,13 +9,26 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, NonNegativeInt, SecretStr, field_validator
 
 
 def _blank_string_to_none(value: Any) -> Any:
+    if isinstance(value, SecretStr):
+        value = value.get_secret_value()
     if isinstance(value, str) and not value.strip():
         return None
     return value
+
+
+def unwrap_optional_secret(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, SecretStr):
+        raw_value = value.get_secret_value()
+    else:
+        raw_value = str(value)
+    normalized = raw_value.strip()
+    return normalized or None
 
 #######################################################################################################################
 #
@@ -30,8 +43,8 @@ class UserUpdateRequest(BaseModel):
     is_locked: bool | None = None
     storage_quota_mb: int | None = Field(None, ge=100)
     reason: str | None = Field(default=None, min_length=8, max_length=500)
-    admin_password: str | None = Field(default=None, max_length=128, repr=False)
-    admin_reauth_token: str | None = Field(default=None, max_length=4096, repr=False)
+    admin_password: SecretStr | None = Field(default=None, max_length=128, repr=False)
+    admin_reauth_token: SecretStr | None = Field(default=None, max_length=4096, repr=False)
 
     @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod
@@ -45,8 +58,8 @@ class AdminPrivilegedActionRequest(BaseModel):
     """Request payload for privileged admin actions."""
 
     reason: str = Field(..., min_length=8, max_length=500)
-    admin_password: str | None = Field(default=None, max_length=128, repr=False)
-    admin_reauth_token: str | None = Field(default=None, max_length=4096, repr=False)
+    admin_password: SecretStr | None = Field(default=None, max_length=128, repr=False)
+    admin_reauth_token: SecretStr | None = Field(default=None, max_length=4096, repr=False)
 
     @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod

--- a/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/admin_schemas.py
@@ -30,8 +30,8 @@ class UserUpdateRequest(BaseModel):
     is_locked: bool | None = None
     storage_quota_mb: int | None = Field(None, ge=100)
     reason: str | None = Field(default=None, min_length=8, max_length=500)
-    admin_password: str | None = Field(default=None, max_length=128)
-    admin_reauth_token: str | None = Field(default=None, max_length=4096)
+    admin_password: str | None = Field(default=None, max_length=128, repr=False)
+    admin_reauth_token: str | None = Field(default=None, max_length=4096, repr=False)
 
     @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod
@@ -45,8 +45,8 @@ class AdminPrivilegedActionRequest(BaseModel):
     """Request payload for privileged admin actions."""
 
     reason: str = Field(..., min_length=8, max_length=500)
-    admin_password: str | None = Field(default=None, max_length=128)
-    admin_reauth_token: str | None = Field(default=None, max_length=4096)
+    admin_password: str | None = Field(default=None, max_length=128, repr=False)
+    admin_reauth_token: str | None = Field(default=None, max_length=4096, repr=False)
 
     @field_validator("admin_password", "admin_reauth_token", mode="before")
     @classmethod

--- a/tldw_Server_API/app/api/v1/schemas/identity_provider_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/identity_provider_schemas.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _blank_string_to_none(value: Any) -> Any:
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+class IdentityProviderUpsertRequest(BaseModel):
+    slug: str = Field(..., min_length=2, max_length=100, pattern=r"^[a-z0-9][a-z0-9_-]*$")
+    provider_type: Literal["oidc"] = "oidc"
+    owner_scope_type: Literal["global", "org"] = "global"
+    owner_scope_id: int | None = Field(default=None, ge=1)
+    enabled: bool = False
+    display_name: str | None = Field(default=None, max_length=200)
+    issuer: str = Field(..., min_length=1, max_length=1000)
+    discovery_url: str | None = Field(default=None, max_length=1000)
+    authorization_url: str | None = Field(default=None, max_length=1000)
+    token_url: str | None = Field(default=None, max_length=1000)
+    jwks_url: str | None = Field(default=None, max_length=1000)
+    client_id: str | None = Field(default=None, max_length=500)
+    client_secret_ref: str | None = Field(default=None, max_length=500)
+    claim_mapping: dict[str, Any] = Field(default_factory=dict)
+    provisioning_policy: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator(
+        "display_name",
+        "discovery_url",
+        "authorization_url",
+        "token_url",
+        "jwks_url",
+        "client_id",
+        "client_secret_ref",
+        mode="before",
+    )
+    @classmethod
+    def normalize_blank_optionals(cls, value: Any) -> Any:
+        return _blank_string_to_none(value)
+
+    @field_validator("slug")
+    @classmethod
+    def normalize_slug(cls, value: str) -> str:
+        return value.strip().lower()
+
+    @field_validator("issuer")
+    @classmethod
+    def normalize_issuer(cls, value: str) -> str:
+        return value.strip()
+
+    @field_validator("owner_scope_id")
+    @classmethod
+    def validate_owner_scope_id(cls, value: int | None, info) -> int | None:
+        owner_scope_type = info.data.get("owner_scope_type", "global")
+        if owner_scope_type == "org" and value is None:
+            raise ValueError("owner_scope_id is required for org-scoped providers")
+        if owner_scope_type == "global":
+            return None
+        return value
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderResponse(BaseModel):
+    id: int
+    slug: str
+    provider_type: str
+    owner_scope_type: str
+    owner_scope_id: int | None = None
+    enabled: bool
+    display_name: str | None = None
+    issuer: str
+    discovery_url: str | None = None
+    authorization_url: str | None = None
+    token_url: str | None = None
+    jwks_url: str | None = None
+    client_id: str | None = None
+    client_secret_ref: str | None = None
+    claim_mapping: dict[str, Any] = Field(default_factory=dict)
+    provisioning_policy: dict[str, Any] = Field(default_factory=dict)
+    created_by: int | None = None
+    updated_by: int | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderListResponse(BaseModel):
+    providers: list[IdentityProviderResponse]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderMappingPreviewRequest(BaseModel):
+    claims: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderMappingResult(BaseModel):
+    subject: str | None = None
+    email: str | None = None
+    username: str | None = None
+    groups: list[str] = Field(default_factory=list)
+    derived_roles: list[str] = Field(default_factory=list)
+    derived_org_ids: list[int] = Field(default_factory=list)
+    derived_team_ids: list[int] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderMappingPreviewResponse(IdentityProviderMappingResult):
+    provider_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderTestRequest(BaseModel):
+    provider: IdentityProviderUpsertRequest
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderTestResponse(BaseModel):
+    ok: bool = True
+    issuer: str
+    authorization_url: str
+    token_url: str
+    jwks_url: str
+    client_id: str
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderDryRunRequest(BaseModel):
+    provider_id: int | None = Field(default=None, ge=1)
+    provider: IdentityProviderUpsertRequest
+    claims: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderGrantSyncPreview(BaseModel):
+    mode: str | None = None
+    would_change: bool = False
+    grant_org_ids: list[int] = Field(default_factory=list)
+    grant_team_ids: list[int] = Field(default_factory=list)
+    grant_roles: list[str] = Field(default_factory=list)
+    revoke_org_ids: list[int] = Field(default_factory=list)
+    revoke_team_ids: list[int] = Field(default_factory=list)
+    revoke_roles: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IdentityProviderDryRunResponse(BaseModel):
+    provider: IdentityProviderTestResponse
+    mapping: IdentityProviderMappingResult
+    provisioning_action: Literal[
+        "subject_already_linked",
+        "link_existing_user",
+        "create_new_user",
+        "deny_missing_subject",
+        "deny_missing_email_for_jit_create",
+        "deny_email_collision",
+        "deny_inactive_user",
+        "deny_unlinked_user",
+    ]
+    matched_user_id: int | None = None
+    identity_link_found: bool = False
+    email_match_found: bool = False
+    grant_sync: IdentityProviderGrantSyncPreview | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tldw_Server_API/app/api/v1/schemas/identity_provider_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/identity_provider_schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def _blank_string_to_none(value: Any) -> Any:
@@ -43,25 +43,27 @@ class IdentityProviderUpsertRequest(BaseModel):
     def normalize_blank_optionals(cls, value: Any) -> Any:
         return _blank_string_to_none(value)
 
-    @field_validator("slug")
+    @field_validator("slug", mode="before")
     @classmethod
-    def normalize_slug(cls, value: str) -> str:
-        return value.strip().lower()
-
-    @field_validator("issuer")
-    @classmethod
-    def normalize_issuer(cls, value: str) -> str:
-        return value.strip()
-
-    @field_validator("owner_scope_id")
-    @classmethod
-    def validate_owner_scope_id(cls, value: int | None, info) -> int | None:
-        owner_scope_type = info.data.get("owner_scope_type", "global")
-        if owner_scope_type == "org" and value is None:
-            raise ValueError("owner_scope_id is required for org-scoped providers")
-        if owner_scope_type == "global":
-            return None
+    def normalize_slug(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip().lower()
         return value
+
+    @field_validator("issuer", mode="before")
+    @classmethod
+    def normalize_issuer(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @model_validator(mode="after")
+    def validate_scope_pair(self) -> "IdentityProviderUpsertRequest":
+        if self.owner_scope_type == "org" and self.owner_scope_id is None:
+            raise ValueError("owner_scope_id is required for org-scoped providers")
+        if self.owner_scope_type == "global":
+            self.owner_scope_id = None
+        return self
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/mcp_hub_schemas.py
@@ -692,6 +692,7 @@ class CredentialBindingResponse(BaseModel):
     external_server_id: str
     slot_name: str | None = None
     credential_ref: str
+    managed_secret_ref_id: int | None = None
     binding_mode: str
     usage_rules: dict[str, Any] = Field(default_factory=dict)
     created_by: int | None = None
@@ -700,8 +701,33 @@ class CredentialBindingResponse(BaseModel):
     updated_at: datetime | str | None = None
 
 
+class ProfileCredentialBindingUpsertRequest(BaseModel):
+    managed_secret_ref_id: int | None = Field(default=None, ge=1)
+
+
 class AssignmentCredentialBindingUpsertRequest(BaseModel):
     binding_mode: str = Field(default="grant", pattern="^(grant|disable)$")
+    managed_secret_ref_id: int | None = Field(default=None, ge=1)
+
+
+class McpCredentialSlotStatusResponse(BaseModel):
+    server_id: str
+    slot_name: str
+    binding_target_type: Literal["profile", "assignment"]
+    binding_target_id: str
+    credential_ref: str
+    managed_secret_ref_id: int | None = None
+    state: Literal[
+        "ready",
+        "missing",
+        "expired",
+        "reauth_required",
+        "approval_required",
+        "backend_unavailable",
+    ]
+    blocked_reason: str | None = None
+    backend_name: str | None = None
+    expires_at: datetime | str | None = None
 
 
 class EffectiveExternalAccessSlotResponse(BaseModel):

--- a/tldw_Server_API/app/core/AuthNZ/API_INTEGRATION_GUIDE.md
+++ b/tldw_Server_API/app/core/AuthNZ/API_INTEGRATION_GUIDE.md
@@ -1,5 +1,35 @@
 # AuthNZ API Integration Guide
 
+## Enterprise Federation (Phase 1)
+
+Enterprise federation is available only when all of these are true:
+
+- `AUTH_MODE=multi_user`
+- `AUTH_FEDERATION_ENABLED=true`
+- the deployment profile reports `enterprise_federation_supported=true`
+
+Current phase-1 scope is intentionally narrow:
+
+- OIDC only
+- provider scope limited to `global` and `org`
+- every federated login still resolves to a local `users` row
+- enterprise credential refs use the local encrypted backend first (`local_encrypted_v1`)
+- SAML and SCIM-style lifecycle sync are not part of this phase
+
+### Runtime Invariants
+
+- Federated users do not become external-only principals. A successful OIDC login always maps to a local user and the normal AuthNZ token contract.
+- Email is advisory for linking. The provider subject is the durable identity key.
+- Admins can validate provider config and dry-run claim mapping before enabling a provider.
+
+### Federation Endpoints
+
+- `GET /api/v1/auth/federation/{provider_slug}/login`
+- `GET /api/v1/auth/federation/{provider_slug}/callback`
+- `POST /api/v1/admin/identity/providers/test`
+- `POST /api/v1/admin/identity/providers/dry-run`
+- `POST /api/v1/auth/admin/reauth/request`
+
 ## Quick Start
 
 ### 1. Basic Authentication Flow

--- a/tldw_Server_API/app/core/AuthNZ/README.md
+++ b/tldw_Server_API/app/core/AuthNZ/README.md
@@ -36,6 +36,11 @@ Note: This README follows the project-wide template to help contributors quickly
   - Single-user: `X-API-KEY` is validated; optional IP allowlist; JWT stack bypassed.
   - Multi-user: username/password (+MFA) → JWT access/refresh; sessions persisted with rotation and blacklist revocation.
   - Service tokens: intended for internal use; by default only loopback clients are accepted unless `SERVICE_TOKEN_ALLOWED_IPS` is configured.
+- Enterprise feature flags:
+  - `AUTH_FEDERATION_ENABLED`, `SECRET_BACKENDS_ENABLED`, and `MCP_CREDENTIAL_BROKER_ENABLED` are available for the enterprise roadmap.
+  - Current support matrix is fail-closed: `AUTH_MODE=multi_user` plus a PostgreSQL `DATABASE_URL` are required.
+  - `MCP_CREDENTIAL_BROKER_ENABLED` also requires `SECRET_BACKENDS_ENABLED`.
+  - Explicit `PROFILE` values must be enterprise-compatible (`multi-user-postgres` / `enterprise*`) or the derived helpers report the feature as unsupported.
 - Key Classes/Functions:
   - `settings.py` (`get_settings`, `is_single_user_mode`) for configuration.
   - `jwt_service.JWTService` issues/verifies tokens, password reset/email verification/virtual access tokens.

--- a/tldw_Server_API/app/core/AuthNZ/email_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/email_service.py
@@ -216,6 +216,66 @@ Or copy this token into the extension:
 If you did not request this, you can ignore this email.
 """
     },
+    "admin_reauth": {
+        "subject": "Confirm admin action - {{ app_name }}",
+        "html": """
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background-color: #7c2d12; color: white; padding: 20px; text-align: center; }
+        .content { background-color: #f8f9fa; padding: 30px; margin-top: 20px; }
+        .button { display: inline-block; padding: 12px 30px; background-color: #b45309;
+                  color: white; text-decoration: none; border-radius: 5px; margin: 20px 0; }
+        .code-box { background: #fff; border: 1px solid #e5e7eb; padding: 12px;
+                    margin: 16px 0; border-radius: 6px; font-family: monospace; word-break: break-all; }
+        .footer { margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6;
+                  font-size: 0.9em; color: #6c757d; }
+        .note { background-color: #fff7ed; border: 1px solid #fdba74; padding: 10px;
+                margin: 16px 0; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>{{ app_name }}</h1>
+        </div>
+        <div class="content">
+            <h2>Confirm this admin action</h2>
+            <p>Hello{{ user_label }},</p>
+            <p>Use the link below to complete your admin reauthentication. This link expires in {{ expiry_minutes }} minute(s).</p>
+            <center>
+                <a href="{{ reauth_link }}" class="button">Confirm admin action</a>
+            </center>
+            <p>If you need to enter the token manually, use this code:</p>
+            <div class="code-box">{{ reauth_token }}</div>
+            <div class="note">
+                <strong>Security notice:</strong> This step-up token only authorizes a high-risk admin action. If you did not request this, ignore the email.
+            </div>
+        </div>
+        <div class="footer">
+            <p>This is an automated message from {{ app_name }}.</p>
+        </div>
+    </div>
+</body>
+</html>
+""",
+        "text": """
+Confirm admin action in {{ app_name }}
+
+Hello{{ user_label }},
+
+Use this link to complete your admin reauthentication (expires in {{ expiry_minutes }} minute(s)):
+{{ reauth_link }}
+
+Manual token:
+{{ reauth_token }}
+
+If you did not request this, ignore this email.
+"""
+    },
     "mfa_enabled": {
         "subject": "Two-Factor Authentication Enabled - {{ app_name }}",
         "html": """
@@ -559,11 +619,15 @@ class EmailService:
         magic_token: str,
         expires_in_minutes: int,
         username: Optional[str] = None,
-        base_url: Optional[str] = None
+        base_url: Optional[str] = None,
+        link_path: Optional[str] = None,
     ) -> bool:
         """Send magic link sign-in email."""
         base_url = base_url or os.getenv("BASE_URL", "http://localhost:8000")
-        magic_link = f"{base_url}/magic-link?token={magic_token}"
+        normalized_path = str(link_path or "/magic-link").strip() or "/magic-link"
+        if not normalized_path.startswith("/"):
+            normalized_path = f"/{normalized_path}"
+        magic_link = f"{base_url.rstrip('/')}{normalized_path}?token={magic_token}"
 
         user_label = f" {username}" if username else ""
         template_data = {
@@ -580,6 +644,37 @@ class EmailService:
         html_body = html_template.render(**template_data)
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["magic_link"]["subject"]).render(**template_data)
+
+        return await self.send_email(to_email, subject, html_body, text_body)
+
+    async def send_admin_reauth_email(
+        self,
+        *,
+        to_email: str,
+        reauth_token: str,
+        expires_in_minutes: int,
+        username: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> bool:
+        """Send a dedicated admin reauthentication email."""
+        base_url = base_url or os.getenv("BASE_URL", "http://localhost:8000")
+        reauth_link = f"{base_url.rstrip('/')}/admin/reauth?token={reauth_token}"
+
+        user_label = f" {username}" if username else ""
+        template_data = {
+            "app_name": self.app_name,
+            "user_label": user_label,
+            "reauth_link": reauth_link,
+            "reauth_token": reauth_token,
+            "expiry_minutes": expires_in_minutes,
+        }
+
+        html_template = Template(EMAIL_TEMPLATES["admin_reauth"]["html"])
+        text_template = Template(EMAIL_TEMPLATES["admin_reauth"]["text"])
+
+        html_body = html_template.render(**template_data)
+        text_body = text_template.render(**template_data)
+        subject = Template(EMAIL_TEMPLATES["admin_reauth"]["subject"]).render(**template_data)
 
         return await self.send_email(to_email, subject, html_body, text_body)
 

--- a/tldw_Server_API/app/core/AuthNZ/email_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/email_service.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import smtplib
+import re
 from datetime import datetime, timezone
 from email import encoders
 from email.mime.base import MIMEBase
@@ -249,8 +250,6 @@ If you did not request this, you can ignore this email.
             <center>
                 <a href="{{ reauth_link }}" class="button">Confirm admin action</a>
             </center>
-            <p>If you need to enter the token manually, use this code:</p>
-            <div class="code-box">{{ reauth_token }}</div>
             <div class="note">
                 <strong>Security notice:</strong> This step-up token only authorizes a high-risk admin action. If you did not request this, ignore the email.
             </div>
@@ -269,9 +268,6 @@ Hello{{ user_label }},
 
 Use this link to complete your admin reauthentication (expires in {{ expiry_minutes }} minute(s)):
 {{ reauth_link }}
-
-Manual token:
-{{ reauth_token }}
 
 If you did not request this, ignore this email.
 """
@@ -394,7 +390,9 @@ class EmailService:
         html_body: str,
         text_body: Optional[str] = None,
         from_email: Optional[str] = None,
-        attachments: Optional[list[dict[str, Any]]] = None
+        attachments: Optional[list[dict[str, Any]]] = None,
+        *,
+        redact_mock_tokens: bool = False,
     ) -> bool:
         """
         Send an email
@@ -406,6 +404,7 @@ class EmailService:
             text_body: Plain text version (optional)
             from_email: Sender email (uses default if not provided)
             attachments: List of attachments
+            redact_mock_tokens: Whether mock transport should redact token-bearing content
 
         Returns:
             True if email was sent successfully
@@ -414,7 +413,13 @@ class EmailService:
 
         if self.provider == "mock":
             return await self._send_mock_email(
-                to_email, subject, html_body, text_body, from_email, attachments
+                to_email,
+                subject,
+                html_body,
+                text_body,
+                from_email,
+                attachments,
+                redact_mock_tokens=redact_mock_tokens,
             )
         elif self.provider == "smtp":
             return await self._send_smtp_email(
@@ -431,12 +436,20 @@ class EmailService:
         html_body: str,
         text_body: Optional[str],
         from_email: str,
-        attachments: Optional[list[dict[str, Any]]]
+        attachments: Optional[list[dict[str, Any]]],
+        *,
+        redact_mock_tokens: bool = False,
     ) -> bool:
         """Send mock email for development/testing"""
 
         timestamp = datetime.now(timezone.utc).isoformat()
         email_id = f"{timestamp}_{to_email.replace('@', '_at_')}"
+        stored_html_body = self._redact_mock_email_body(html_body) if redact_mock_tokens else html_body
+        stored_text_body = (
+            self._redact_mock_email_body(text_body or "")
+            if redact_mock_tokens
+            else (text_body or "")
+        )
 
         # Create email data structure
         email_data = {
@@ -445,8 +458,8 @@ class EmailService:
             "from": from_email,
             "to": to_email,
             "subject": subject,
-            "html_body": html_body,
-            "text_body": text_body or "",
+            "html_body": stored_html_body,
+            "text_body": stored_text_body,
             "attachments": len(attachments) if attachments else 0,
             "provider": "mock"
         }
@@ -460,11 +473,14 @@ class EmailService:
             logger.info(f"To: {to_email}")
             logger.info(f"Subject: {subject}")
             logger.info("-" * 80)
-            if text_body:
+            if stored_text_body:
                 logger.info("Text Body:")
-                logger.info(text_body[:500] + ("..." if len(text_body) > 500 else ""))
+                logger.info(
+                    stored_text_body[:500]
+                    + ("..." if len(stored_text_body) > 500 else "")
+                )
             logger.info("-" * 80)
-            logger.info(f"HTML Body Length: {len(html_body)} characters")
+            logger.info(f"HTML Body Length: {len(stored_html_body)} characters")
             if attachments:
                 logger.info(f"Attachments: {len(attachments)}")
             logger.info("=" * 80)
@@ -478,7 +494,7 @@ class EmailService:
             # Also save HTML for viewing
             html_path = self.mock_file_path / f"{email_id}.html"
             with open(html_path, "w") as f:
-                f.write(html_body)
+                f.write(stored_html_body)
 
             logger.debug(f"Mock email saved to: {file_path}")
 
@@ -486,6 +502,21 @@ class EmailService:
         await asyncio.sleep(0.1)
 
         return True
+
+    @staticmethod
+    def _redact_mock_email_body(body: str) -> str:
+        """Redact token-bearing content before mock transport persists it."""
+        redacted = re.sub(
+            r"([?&]token=)([^&\"'\\s<]+)",
+            r"\1[REDACTED]",
+            body,
+        )
+        redacted = re.sub(
+            r"(?im)(manual token:\s*)(\S+)",
+            r"\1[REDACTED]",
+            redacted,
+        )
+        return redacted
 
     async def _send_smtp_email(
         self,
@@ -676,7 +707,13 @@ class EmailService:
         text_body = text_template.render(**template_data)
         subject = Template(EMAIL_TEMPLATES["admin_reauth"]["subject"]).render(**template_data)
 
-        return await self.send_email(to_email, subject, html_body, text_body)
+        return await self.send_email(
+            to_email,
+            subject,
+            html_body,
+            text_body,
+            redact_mock_tokens=True,
+        )
 
     async def send_mfa_enabled_email(
         self,

--- a/tldw_Server_API/app/core/AuthNZ/federation/__init__.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/__init__.py
@@ -1,0 +1,12 @@
+"""Federation helpers for enterprise AuthNZ flows."""
+from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
+from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import FederationProvisioningService
+from tldw_Server_API.app.core.AuthNZ.federation.state_repo import FederationStateRepo
+
+__all__ = [
+    "FederationProvisioningService",
+    "FederationStateRepo",
+    "OIDCFederationService",
+    "preview_claim_mapping",
+]

--- a/tldw_Server_API/app/core/AuthNZ/federation/claim_mapping.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/claim_mapping.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 
+def _normalize_optional_claim_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
 def _normalize_string_list(value: Any) -> list[str]:
     if value is None:
         return []
@@ -41,6 +48,8 @@ def _mapped_group_values(
 def _coerce_int_list(values: list[Any]) -> list[int]:
     result: list[int] = []
     for value in values:
+        if isinstance(value, bool):
+            continue
         try:
             result.append(int(value))
         except (TypeError, ValueError):
@@ -55,12 +64,18 @@ def preview_claim_mapping(
     mapping = claim_mapping if isinstance(claim_mapping, dict) else {}
     claim_values = claims if isinstance(claims, dict) else {}
 
-    subject = _claim_value(claim_values, mapping.get("subject"), "sub")
-    email = _claim_value(claim_values, mapping.get("email"), "email")
-    username = _claim_value(
-        claim_values,
-        mapping.get("username"),
-        "preferred_username",
+    subject = _normalize_optional_claim_value(
+        _claim_value(claim_values, mapping.get("subject"), "sub")
+    )
+    email = _normalize_optional_claim_value(
+        _claim_value(claim_values, mapping.get("email"), "email")
+    )
+    username = _normalize_optional_claim_value(
+        _claim_value(
+            claim_values,
+            mapping.get("username"),
+            "preferred_username",
+        )
     )
     groups = _normalize_string_list(
         _claim_value(claim_values, mapping.get("groups"), "groups")
@@ -82,9 +97,9 @@ def preview_claim_mapping(
         warnings.append("No email claim resolved from the payload")
 
     return {
-        "subject": str(subject).strip() if subject is not None else None,
-        "email": str(email).strip() if email is not None else None,
-        "username": str(username).strip() if username is not None else None,
+        "subject": subject,
+        "email": email,
+        "username": username,
         "groups": sorted(dict.fromkeys(groups)),
         "derived_roles": sorted(dict.fromkeys(_normalize_string_list(derived_roles))),
         "derived_org_ids": sorted(dict.fromkeys(derived_org_ids)),

--- a/tldw_Server_API/app/core/AuthNZ/federation/claim_mapping.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/claim_mapping.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _claim_value(claims: dict[str, Any], mapping_key: str | None, fallback_key: str) -> Any:
+    if isinstance(mapping_key, str) and mapping_key.strip():
+        return claims.get(mapping_key.strip())
+    return claims.get(fallback_key)
+
+
+def _mapped_group_values(
+    groups: list[str],
+    mapping: Any,
+) -> list[Any]:
+    if not isinstance(mapping, dict):
+        return []
+    values: list[Any] = []
+    for group in groups:
+        mapped = mapping.get(group)
+        if mapped is None:
+            continue
+        if isinstance(mapped, (list, tuple, set)):
+            values.extend(mapped)
+        else:
+            values.append(mapped)
+    return values
+
+
+def _coerce_int_list(values: list[Any]) -> list[int]:
+    result: list[int] = []
+    for value in values:
+        try:
+            result.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def preview_claim_mapping(
+    claim_mapping: dict[str, Any] | None,
+    claims: dict[str, Any] | None,
+) -> dict[str, Any]:
+    mapping = claim_mapping if isinstance(claim_mapping, dict) else {}
+    claim_values = claims if isinstance(claims, dict) else {}
+
+    subject = _claim_value(claim_values, mapping.get("subject"), "sub")
+    email = _claim_value(claim_values, mapping.get("email"), "email")
+    username = _claim_value(
+        claim_values,
+        mapping.get("username"),
+        "preferred_username",
+    )
+    groups = _normalize_string_list(
+        _claim_value(claim_values, mapping.get("groups"), "groups")
+    )
+
+    derived_roles = _normalize_string_list(mapping.get("default_roles"))
+    derived_roles.extend(_normalize_string_list(_mapped_group_values(groups, mapping.get("role_mappings"))))
+
+    derived_org_ids = _coerce_int_list(_mapped_group_values(groups, mapping.get("org_mappings")))
+    derived_org_ids.extend(_coerce_int_list(mapping.get("default_org_ids") or []))
+
+    derived_team_ids = _coerce_int_list(_mapped_group_values(groups, mapping.get("team_mappings")))
+    derived_team_ids.extend(_coerce_int_list(mapping.get("default_team_ids") or []))
+
+    warnings: list[str] = []
+    if subject is None:
+        warnings.append("No subject claim resolved from the payload")
+    if email is None:
+        warnings.append("No email claim resolved from the payload")
+
+    return {
+        "subject": str(subject).strip() if subject is not None else None,
+        "email": str(email).strip() if email is not None else None,
+        "username": str(username).strip() if username is not None else None,
+        "groups": sorted(dict.fromkeys(groups)),
+        "derived_roles": sorted(dict.fromkeys(_normalize_string_list(derived_roles))),
+        "derived_org_ids": sorted(dict.fromkeys(derived_org_ids)),
+        "derived_team_ids": sorted(dict.fromkeys(derived_team_ids)),
+        "warnings": warnings,
+    }

--- a/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
@@ -48,6 +48,13 @@ def _coerce_string_set(value: Any) -> set[str]:
     return set()
 
 
+_ASYMMETRIC_JWT_ALGS_BY_KTY: dict[str, set[str]] = {
+    "EC": {"ES256", "ES384", "ES512"},
+    "OKP": {"EdDSA"},
+    "RSA": {"PS256", "PS384", "PS512", "RS256", "RS384", "RS512"},
+}
+
+
 def _parse_byok_secret_ref(secret_ref: str) -> tuple[str, int, str] | None:
     lowered = secret_ref.lower()
     scope_type: str | None = None
@@ -154,7 +161,7 @@ class OIDCFederationService:
             raise ValueError("OIDC discovery issuer mismatch")
         return discovery
 
-    async def _resolve_provider_runtime_config(self, provider: dict[str, Any]) -> dict[str, str | None]:
+    async def _resolve_provider_runtime_config(self, provider: dict[str, Any]) -> dict[str, Any]:
         discovery = await self._fetch_discovery_document(provider)
         resolved = {
             "issuer": _coerce_nonempty_string(provider.get("issuer")) or _coerce_nonempty_string(discovery.get("issuer")),
@@ -166,6 +173,11 @@ class OIDCFederationService:
             or _coerce_nonempty_string(discovery.get("jwks_uri")),
             "client_id": _coerce_nonempty_string(provider.get("client_id")),
             "client_secret": await _resolve_client_secret_ref(provider.get("client_secret_ref")),
+            "signing_algorithms": sorted(
+                _coerce_string_set(provider.get("allowed_signing_algs"))
+                or _coerce_string_set(provider.get("signing_algorithms"))
+                or _coerce_string_set(discovery.get("id_token_signing_alg_values_supported"))
+            ),
         }
         return resolved
 
@@ -236,6 +248,26 @@ class OIDCFederationService:
         if len(keys) == 1 and isinstance(keys[0], dict):
             return keys[0]
         raise ValueError("OIDC id_token header is missing kid")
+
+    @staticmethod
+    def _resolve_allowed_signing_algorithms(
+        *,
+        provider_runtime_config: dict[str, Any],
+        jwk: dict[str, Any],
+    ) -> set[str]:
+        configured = _coerce_string_set(provider_runtime_config.get("signing_algorithms"))
+        if configured:
+            return configured
+
+        jwk_alg = _coerce_nonempty_string(jwk.get("alg")) if isinstance(jwk, dict) else None
+        if jwk_alg:
+            return {jwk_alg}
+
+        key_type = _coerce_nonempty_string(jwk.get("kty")) if isinstance(jwk, dict) else None
+        allowed = _ASYMMETRIC_JWT_ALGS_BY_KTY.get(str(key_type or "").upper())
+        if allowed:
+            return set(allowed)
+        raise ValueError("OIDC JWKS key type does not define a supported signing algorithm policy")
 
     async def build_authorization_request(
         self,
@@ -316,16 +348,22 @@ class OIDCFederationService:
 
         jwks_payload = await afetch_json(method="GET", url=jwks_url)
         jwk = self._resolve_jwk_for_token(id_token, jwks_payload)
+        allowed_algorithms = self._resolve_allowed_signing_algorithms(
+            provider_runtime_config=runtime_config,
+            jwk=jwk,
+        )
         header = jwt.get_unverified_header(id_token)
         algorithm = _coerce_nonempty_string(header.get("alg")) if isinstance(header, dict) else None
         if not algorithm:
             raise ValueError("OIDC id_token header is missing alg")
+        if algorithm not in allowed_algorithms:
+            raise ValueError(f"OIDC id_token uses unsupported signing algorithm: {algorithm}")
 
         try:
             claims = jwt.decode(
                 id_token,
                 jwk,
-                algorithms=[algorithm],
+                algorithms=sorted(allowed_algorithms),
                 audience=client_id,
                 issuer=issuer,
             )

--- a/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+from jose import jwt
+from jose.exceptions import JWTError
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.repos.org_provider_secrets_repo import (
+    AuthnzOrgProviderSecretsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.user_provider_secrets_repo import (
+    AuthnzUserProviderSecretsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    decrypt_byok_payload,
+    loads_envelope,
+)
+from tldw_Server_API.app.core.http_client import afetch_json
+
+
+def _coerce_nonempty_string(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def _oauth_code_challenge_s256(code_verifier: str) -> str:
+    digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("utf-8").rstrip("=")
+
+
+def _coerce_string_set(value: Any) -> set[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return {stripped} if stripped else set()
+    if isinstance(value, (list, tuple, set)):
+        return {str(item).strip() for item in value if str(item).strip()}
+    return set()
+
+
+def _parse_byok_secret_ref(secret_ref: str) -> tuple[str, int, str] | None:
+    lowered = secret_ref.lower()
+    scope_type: str | None = None
+    if lowered.startswith("byok-user:"):
+        scope_type = "user"
+    elif lowered.startswith("byok-org:"):
+        scope_type = "org"
+    elif lowered.startswith("byok-team:"):
+        scope_type = "team"
+    if scope_type is None:
+        return None
+
+    parts = secret_ref.split(":", 2)
+    if len(parts) != 3:
+        raise ValueError("OIDC client_secret_ref BYOK reference is invalid")
+
+    scope_id_text = parts[1].strip()
+    provider = parts[2].strip()
+    if not scope_id_text or not scope_id_text.isdigit() or int(scope_id_text) <= 0:
+        raise ValueError("OIDC client_secret_ref BYOK scope id is invalid")
+    if not provider:
+        raise ValueError("OIDC client_secret_ref BYOK provider key is invalid")
+    return scope_type, int(scope_id_text), provider
+
+
+async def _resolve_byok_secret_ref(secret_ref: str) -> str:
+    parsed = _parse_byok_secret_ref(secret_ref)
+    if parsed is None:
+        raise ValueError("OIDC client_secret_ref BYOK reference is invalid")
+
+    scope_type, scope_id, provider = parsed
+    pool = await get_db_pool()
+
+    if scope_type == "user":
+        repo = AuthnzUserProviderSecretsRepo(pool)
+        await repo.ensure_tables()
+        secret_row = await repo.fetch_secret_for_user(scope_id, provider)
+    else:
+        repo = AuthnzOrgProviderSecretsRepo(pool)
+        await repo.ensure_tables()
+        secret_row = await repo.fetch_secret(scope_type, scope_id, provider)
+
+    encrypted_blob = _coerce_nonempty_string(secret_row.get("encrypted_blob")) if isinstance(secret_row, dict) else None
+    if not encrypted_blob:
+        raise ValueError("OIDC client_secret_ref BYOK secret is not available")
+
+    try:
+        payload = decrypt_byok_payload(loads_envelope(encrypted_blob))
+    except Exception as exc:
+        raise ValueError("OIDC client_secret_ref BYOK secret could not be decrypted") from exc
+
+    client_secret = _coerce_nonempty_string(payload.get("api_key")) if isinstance(payload, dict) else None
+    if not client_secret:
+        raise ValueError("OIDC client_secret_ref BYOK secret is missing api_key")
+
+    used_at = datetime.now(timezone.utc)
+    try:
+        if scope_type == "user":
+            await repo.touch_last_used(scope_id, provider, used_at)
+        else:
+            await repo.touch_last_used(scope_type, scope_id, provider, used_at)
+    except Exception as exc:
+        logger.debug("OIDC BYOK secret touch_last_used failed for {}:{}:{}: {}", scope_type, scope_id, provider, exc)
+    return client_secret
+
+
+async def _resolve_client_secret_ref(value: Any) -> str | None:
+    secret_ref = _coerce_nonempty_string(value)
+    if not secret_ref:
+        return None
+    if _parse_byok_secret_ref(secret_ref) is not None:
+        return await _resolve_byok_secret_ref(secret_ref)
+    if not secret_ref.lower().startswith("env:"):
+        return secret_ref
+
+    env_name = secret_ref[4:].strip()
+    if not env_name:
+        raise ValueError("OIDC client_secret_ref env reference is invalid")
+    env_value = os.getenv(env_name, "").strip()
+    if not env_value:
+        raise ValueError(
+            f"OIDC client_secret_ref environment variable is not set: {env_name}"
+        )
+    return env_value
+
+
+@dataclass
+class OIDCFederationService:
+    """Construct OIDC authorization requests for trusted identity providers."""
+
+    default_scopes: tuple[str, ...] = ("openid", "email", "profile")
+    state_ttl_seconds: int = 600
+
+    async def _fetch_discovery_document(self, provider: dict[str, Any]) -> dict[str, Any]:
+        discovery_url = _coerce_nonempty_string(provider.get("discovery_url"))
+        if not discovery_url:
+            return {}
+        discovery = await afetch_json(method="GET", url=discovery_url)
+        if not isinstance(discovery, dict):
+            raise ValueError("OIDC discovery response is invalid")
+        explicit_issuer = _coerce_nonempty_string(provider.get("issuer"))
+        discovered_issuer = _coerce_nonempty_string(discovery.get("issuer"))
+        if explicit_issuer and discovered_issuer and explicit_issuer != discovered_issuer:
+            raise ValueError("OIDC discovery issuer mismatch")
+        return discovery
+
+    async def _resolve_provider_runtime_config(self, provider: dict[str, Any]) -> dict[str, str | None]:
+        discovery = await self._fetch_discovery_document(provider)
+        resolved = {
+            "issuer": _coerce_nonempty_string(provider.get("issuer")) or _coerce_nonempty_string(discovery.get("issuer")),
+            "authorization_url": _coerce_nonempty_string(provider.get("authorization_url"))
+            or _coerce_nonempty_string(discovery.get("authorization_endpoint")),
+            "token_url": _coerce_nonempty_string(provider.get("token_url"))
+            or _coerce_nonempty_string(discovery.get("token_endpoint")),
+            "jwks_url": _coerce_nonempty_string(provider.get("jwks_url"))
+            or _coerce_nonempty_string(discovery.get("jwks_uri")),
+            "client_id": _coerce_nonempty_string(provider.get("client_id")),
+            "client_secret": await _resolve_client_secret_ref(provider.get("client_secret_ref")),
+        }
+        return resolved
+
+    async def inspect_provider_configuration(
+        self,
+        *,
+        provider: dict[str, Any],
+    ) -> dict[str, Any]:
+        runtime_config = await self._resolve_provider_runtime_config(provider)
+        missing_fields = [
+            field_name
+            for field_name in ("issuer", "authorization_url", "token_url", "jwks_url", "client_id")
+            if not runtime_config.get(field_name)
+        ]
+        if missing_fields:
+            raise ValueError(
+                "OIDC provider is missing "
+                + ", ".join(missing_fields)
+            )
+
+        warnings: list[str] = []
+        discovery_url = _coerce_nonempty_string(provider.get("discovery_url"))
+        client_secret_ref = _coerce_nonempty_string(provider.get("client_secret_ref"))
+        if discovery_url:
+            resolved_via_discovery = [
+                field_name
+                for field_name, provider_key in (
+                    ("authorization_url", "authorization_url"),
+                    ("token_url", "token_url"),
+                    ("jwks_url", "jwks_url"),
+                )
+                if not _coerce_nonempty_string(provider.get(provider_key))
+            ]
+            if resolved_via_discovery:
+                warnings.append(
+                    "Resolved {} from OIDC discovery".format(", ".join(resolved_via_discovery))
+                )
+        if (
+            client_secret_ref
+            and not client_secret_ref.lower().startswith("env:")
+            and _parse_byok_secret_ref(client_secret_ref) is None
+        ):
+            warnings.append("OIDC client_secret_ref is stored inline; prefer env:VAR_NAME")
+
+        return {
+            "ok": True,
+            "issuer": str(runtime_config["issuer"]),
+            "authorization_url": str(runtime_config["authorization_url"]),
+            "token_url": str(runtime_config["token_url"]),
+            "jwks_url": str(runtime_config["jwks_url"]),
+            "client_id": str(runtime_config["client_id"]),
+            "warnings": warnings,
+        }
+
+    @staticmethod
+    def _resolve_jwk_for_token(id_token: str, jwks_payload: dict[str, Any]) -> dict[str, Any]:
+        keys = jwks_payload.get("keys") if isinstance(jwks_payload, dict) else None
+        if not isinstance(keys, list) or not keys:
+            raise ValueError("OIDC JWKS response is invalid")
+
+        header = jwt.get_unverified_header(id_token)
+        kid = _coerce_nonempty_string(header.get("kid")) if isinstance(header, dict) else None
+        if kid:
+            for key in keys:
+                if isinstance(key, dict) and _coerce_nonempty_string(key.get("kid")) == kid:
+                    return key
+            raise ValueError("OIDC JWKS does not contain the signing key")
+        if len(keys) == 1 and isinstance(keys[0], dict):
+            return keys[0]
+        raise ValueError("OIDC id_token header is missing kid")
+
+    async def build_authorization_request(
+        self,
+        *,
+        provider: dict[str, Any],
+        redirect_uri: str,
+    ) -> dict[str, Any]:
+        runtime_config = await self._resolve_provider_runtime_config(provider)
+        authorization_url = runtime_config["authorization_url"]
+        client_id = runtime_config["client_id"]
+        if not authorization_url or not client_id:
+            raise ValueError("OIDC provider is missing authorization_url or client_id")
+
+        state = secrets.token_urlsafe(32)
+        nonce = secrets.token_urlsafe(24)
+        code_verifier = secrets.token_urlsafe(64)
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=self.state_ttl_seconds)
+
+        query = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": " ".join(self.default_scopes),
+            "state": state,
+            "nonce": nonce,
+            "code_challenge": _oauth_code_challenge_s256(code_verifier),
+            "code_challenge_method": "S256",
+        }
+
+        return {
+            "auth_url": f"{authorization_url}?{urlencode(query)}",
+            "state": state,
+            "nonce": nonce,
+            "code_verifier": code_verifier,
+            "expires_at": expires_at,
+            "ttl_seconds": self.state_ttl_seconds,
+        }
+
+    async def exchange_authorization_code(
+        self,
+        *,
+        provider: dict[str, Any],
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict[str, Any]:
+        runtime_config = await self._resolve_provider_runtime_config(provider)
+        token_url = runtime_config["token_url"]
+        client_id = runtime_config["client_id"]
+        issuer = runtime_config["issuer"]
+        jwks_url = runtime_config["jwks_url"]
+        client_secret = runtime_config["client_secret"]
+        if not token_url or not client_id or not issuer:
+            raise ValueError("OIDC provider is missing token_url, client_id, or issuer")
+        if not jwks_url:
+            raise ValueError("OIDC provider is missing jwks_url or discovery_url")
+
+        form_data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+        if client_secret:
+            form_data["client_secret"] = client_secret
+
+        token_payload = await afetch_json(
+            method="POST",
+            url=token_url,
+            data=form_data,
+        )
+
+        id_token = _coerce_nonempty_string(token_payload.get("id_token"))
+        if not id_token:
+            raise ValueError("OIDC token response is missing id_token")
+
+        jwks_payload = await afetch_json(method="GET", url=jwks_url)
+        jwk = self._resolve_jwk_for_token(id_token, jwks_payload)
+        header = jwt.get_unverified_header(id_token)
+        algorithm = _coerce_nonempty_string(header.get("alg")) if isinstance(header, dict) else None
+        if not algorithm:
+            raise ValueError("OIDC id_token header is missing alg")
+
+        try:
+            claims = jwt.decode(
+                id_token,
+                jwk,
+                algorithms=[algorithm],
+                audience=client_id,
+                issuer=issuer,
+            )
+        except JWTError as exc:
+            raise ValueError(f"OIDC id_token verification failed: {exc}") from exc
+        if not isinstance(claims, dict):
+            raise ValueError("OIDC id_token payload is invalid")
+
+        if nonce:
+            token_nonce = _coerce_nonempty_string(claims.get("nonce"))
+            if token_nonce != nonce:
+                raise ValueError("OIDC nonce mismatch")
+        if not _coerce_nonempty_string(claims.get("sub")):
+            raise ValueError("OIDC subject is missing")
+        if client_id not in _coerce_string_set(claims.get("aud")):
+            raise ValueError("OIDC audience mismatch")
+        return claims

--- a/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/oidc_service.py
@@ -81,6 +81,17 @@ def _parse_byok_secret_ref(secret_ref: str) -> tuple[str, int, str] | None:
 
 
 async def _resolve_byok_secret_ref(secret_ref: str) -> str:
+    return await _resolve_byok_secret_ref_with_options(
+        secret_ref,
+        touch_last_used=True,
+    )
+
+
+async def _resolve_byok_secret_ref_with_options(
+    secret_ref: str,
+    *,
+    touch_last_used: bool,
+) -> str:
     parsed = _parse_byok_secret_ref(secret_ref)
     if parsed is None:
         raise ValueError("OIDC client_secret_ref BYOK reference is invalid")
@@ -110,23 +121,31 @@ async def _resolve_byok_secret_ref(secret_ref: str) -> str:
     if not client_secret:
         raise ValueError("OIDC client_secret_ref BYOK secret is missing api_key")
 
-    used_at = datetime.now(timezone.utc)
-    try:
-        if scope_type == "user":
-            await repo.touch_last_used(scope_id, provider, used_at)
-        else:
-            await repo.touch_last_used(scope_type, scope_id, provider, used_at)
-    except Exception as exc:
-        logger.debug("OIDC BYOK secret touch_last_used failed for {}:{}:{}: {}", scope_type, scope_id, provider, exc)
+    if touch_last_used:
+        used_at = datetime.now(timezone.utc)
+        try:
+            if scope_type == "user":
+                await repo.touch_last_used(scope_id, provider, used_at)
+            else:
+                await repo.touch_last_used(scope_type, scope_id, provider, used_at)
+        except Exception as exc:
+            logger.debug("OIDC BYOK secret touch_last_used failed for {}:{}:{}: {}", scope_type, scope_id, provider, exc)
     return client_secret
 
 
-async def _resolve_client_secret_ref(value: Any) -> str | None:
+async def _resolve_client_secret_ref(
+    value: Any,
+    *,
+    touch_last_used: bool = True,
+) -> str | None:
     secret_ref = _coerce_nonempty_string(value)
     if not secret_ref:
         return None
     if _parse_byok_secret_ref(secret_ref) is not None:
-        return await _resolve_byok_secret_ref(secret_ref)
+        return await _resolve_byok_secret_ref_with_options(
+            secret_ref,
+            touch_last_used=touch_last_used,
+        )
     if not secret_ref.lower().startswith("env:"):
         return secret_ref
 
@@ -161,8 +180,24 @@ class OIDCFederationService:
             raise ValueError("OIDC discovery issuer mismatch")
         return discovery
 
-    async def _resolve_provider_runtime_config(self, provider: dict[str, Any]) -> dict[str, Any]:
-        discovery = await self._fetch_discovery_document(provider)
+    @staticmethod
+    def _provider_requires_discovery(provider: dict[str, Any]) -> bool:
+        if not _coerce_nonempty_string(provider.get("discovery_url")):
+            return False
+        required_fields = ("issuer", "authorization_url", "token_url", "jwks_url")
+        return any(not _coerce_nonempty_string(provider.get(field_name)) for field_name in required_fields)
+
+    async def _resolve_provider_runtime_config(
+        self,
+        provider: dict[str, Any],
+        *,
+        touch_secret_refs: bool = True,
+    ) -> dict[str, Any]:
+        discovery = (
+            await self._fetch_discovery_document(provider)
+            if self._provider_requires_discovery(provider)
+            else {}
+        )
         resolved = {
             "issuer": _coerce_nonempty_string(provider.get("issuer")) or _coerce_nonempty_string(discovery.get("issuer")),
             "authorization_url": _coerce_nonempty_string(provider.get("authorization_url"))
@@ -172,7 +207,10 @@ class OIDCFederationService:
             "jwks_url": _coerce_nonempty_string(provider.get("jwks_url"))
             or _coerce_nonempty_string(discovery.get("jwks_uri")),
             "client_id": _coerce_nonempty_string(provider.get("client_id")),
-            "client_secret": await _resolve_client_secret_ref(provider.get("client_secret_ref")),
+            "client_secret": await _resolve_client_secret_ref(
+                provider.get("client_secret_ref"),
+                touch_last_used=touch_secret_refs,
+            ),
             "signing_algorithms": sorted(
                 _coerce_string_set(provider.get("allowed_signing_algs"))
                 or _coerce_string_set(provider.get("signing_algorithms"))
@@ -186,7 +224,10 @@ class OIDCFederationService:
         *,
         provider: dict[str, Any],
     ) -> dict[str, Any]:
-        runtime_config = await self._resolve_provider_runtime_config(provider)
+        runtime_config = await self._resolve_provider_runtime_config(
+            provider,
+            touch_secret_refs=False,
+        )
         missing_fields = [
             field_name
             for field_name in ("issuer", "authorization_url", "token_url", "jwks_url", "client_id")

--- a/tldw_Server_API/app/core/AuthNZ/federation/provisioning_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/provisioning_service.py
@@ -387,8 +387,10 @@ class FederationProvisioningService:
                     continue
                 remaining_team_memberships = await orgs_repo.list_memberships_for_user(int(user_id))
                 if any(
-                    int(membership.get("org_id")) == int(target_ref)
-                    and int(membership.get("team_id")) not in revoke_team_ids
+                    membership.get("org_id") is not None
+                    and int(membership["org_id"]) == int(target_ref)
+                    and membership.get("team_id") is not None
+                    and int(membership["team_id"]) not in revoke_team_ids
                     and str(membership.get("team_name") or "").strip() != DEFAULT_BASE_TEAM_NAME
                     for membership in remaining_team_memberships
                 ):
@@ -641,7 +643,8 @@ class FederationProvisioningService:
                             continue
                         remaining_team_memberships = await orgs_repo.list_memberships_for_user(int(user_id))
                         if any(
-                            int(membership.get("org_id")) == org_id
+                            membership.get("org_id") is not None
+                            and int(membership["org_id"]) == org_id
                             and str(membership.get("team_name") or "").strip() != DEFAULT_BASE_TEAM_NAME
                             for membership in remaining_team_memberships
                         ):

--- a/tldw_Server_API/app/core/AuthNZ/federation/provisioning_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/provisioning_service.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+from tldw_Server_API.app.core.AuthNZ.repos.federated_managed_grant_repo import FederatedManagedGrantRepo
+from tldw_Server_API.app.core.AuthNZ.repos.orgs_teams_repo import (
+    DEFAULT_BASE_TEAM_NAME,
+    AuthnzOrgsTeamsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+
+def _claims_hash(claims: dict[str, Any]) -> str:
+    serialized = json.dumps(claims, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _coerce_distinct_ints(values: Any) -> list[int]:
+    result: set[int] = set()
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    for raw_value in values:
+        try:
+            result.add(int(raw_value))
+        except (TypeError, ValueError):
+            continue
+    return sorted(result)
+
+
+def _coerce_distinct_strings(values: Any) -> list[str]:
+    result: set[str] = set()
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    for raw_value in values:
+        if raw_value is None:
+            continue
+        normalized = str(raw_value).strip()
+        if normalized:
+            result.add(normalized)
+    return sorted(result)
+
+
+_FEDERATED_GRANT_MODES = frozenset(
+    {
+        "jit_grant_only",
+        "jit_grant_and_revoke",
+        "sync_managed_only",
+    }
+)
+_FEDERATED_REVOKE_MODES = frozenset({"jit_grant_and_revoke", "sync_managed_only"})
+
+
+def _grant_key(grant_kind: str, target_ref: str) -> tuple[str, str]:
+    return str(grant_kind).strip().lower(), str(target_ref).strip()
+
+
+@dataclass
+class FederationProvisioningService:
+    """Resolve local users for federated OIDC logins."""
+
+    db_pool: DatabasePool
+
+    async def resolve_user_for_login(
+        self,
+        *,
+        provider: dict[str, Any],
+        mapped_claims: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        subject = str(mapped_claims.get("subject") or "").strip()
+        email = str(mapped_claims.get("email") or "").strip().lower()
+
+        users_repo = AuthnzUsersRepo(db_pool=self.db_pool)
+        links_repo = FederatedIdentityRepo(db_pool=self.db_pool)
+        await links_repo.ensure_tables()
+
+        if subject:
+            existing_link = await links_repo.get_by_provider_subject(
+                identity_provider_id=int(provider["id"]),
+                external_subject=subject,
+            )
+            if existing_link:
+                user = await users_repo.get_user_by_id(int(existing_link["user_id"]))
+                if user:
+                    return user
+
+        policy = provider.get("provisioning_policy") or {}
+        if bool(policy.get("allow_email_account_linking")) and email:
+            return await users_repo.get_user_by_email(email)
+
+        return None
+
+    async def dry_run_login_resolution(
+        self,
+        *,
+        provider: dict[str, Any],
+        mapped_claims: dict[str, Any],
+    ) -> dict[str, Any]:
+        subject = str(mapped_claims.get("subject") or "").strip()
+        email = str(mapped_claims.get("email") or "").strip().lower()
+        warnings: list[str] = []
+
+        users_repo = AuthnzUsersRepo(db_pool=self.db_pool)
+        links_repo = FederatedIdentityRepo(db_pool=self.db_pool)
+        await links_repo.ensure_tables()
+
+        if not subject:
+            warnings.append("OIDC claims did not resolve a subject")
+            return {
+                "provisioning_action": "deny_missing_subject",
+                "matched_user_id": None,
+                "identity_link_found": False,
+                "email_match_found": False,
+                "warnings": warnings,
+            }
+
+        policy = provider.get("provisioning_policy") or {}
+        allow_email_account_linking = bool(policy.get("allow_email_account_linking"))
+        jit_create = bool(policy.get("jit_create"))
+
+        existing_link = await links_repo.get_by_provider_subject(
+            identity_provider_id=int(provider.get("id") or 0),
+            external_subject=subject,
+        )
+        if existing_link:
+            user = await users_repo.get_user_by_id(int(existing_link["user_id"]))
+            if user:
+                action = "subject_already_linked"
+                if not bool(user.get("is_active", True)):
+                    warnings.append("Linked local user is inactive")
+                    action = "deny_inactive_user"
+                return {
+                    "provisioning_action": action,
+                    "matched_user_id": int(user["id"]),
+                    "identity_link_found": True,
+                    "email_match_found": bool(email and str(user.get("email") or "").strip().lower() == email),
+                    "warnings": warnings,
+                }
+            warnings.append("Federated identity link points to a missing local user")
+
+        email_user = await users_repo.get_user_by_email(email) if email else None
+        email_match_found = email_user is not None
+        matched_user_id = int(email_user["id"]) if email_user else None
+
+        if email_user and allow_email_account_linking:
+            action = "link_existing_user"
+            if not bool(email_user.get("is_active", True)):
+                warnings.append("Matched local user is inactive")
+                action = "deny_inactive_user"
+            return {
+                "provisioning_action": action,
+                "matched_user_id": matched_user_id,
+                "identity_link_found": False,
+                "email_match_found": True,
+                "warnings": warnings,
+            }
+
+        if jit_create:
+            if not email:
+                warnings.append("OIDC claims did not resolve an email for JIT provisioning")
+                return {
+                    "provisioning_action": "deny_missing_email_for_jit_create",
+                    "matched_user_id": None,
+                    "identity_link_found": False,
+                    "email_match_found": False,
+                    "warnings": warnings,
+                }
+            if email_user:
+                warnings.append("Federated email already belongs to a local user")
+                return {
+                    "provisioning_action": "deny_email_collision",
+                    "matched_user_id": matched_user_id,
+                    "identity_link_found": False,
+                    "email_match_found": True,
+                    "warnings": warnings,
+                }
+            return {
+                "provisioning_action": "create_new_user",
+                "matched_user_id": None,
+                "identity_link_found": False,
+                "email_match_found": False,
+                "warnings": warnings,
+            }
+
+        if email_user and not allow_email_account_linking:
+            warnings.append("Existing email match found but automatic account linking is disabled")
+
+        return {
+            "provisioning_action": "deny_unlinked_user",
+            "matched_user_id": matched_user_id,
+            "identity_link_found": False,
+            "email_match_found": email_match_found,
+            "warnings": warnings,
+        }
+
+    async def upsert_identity_link(
+        self,
+        *,
+        provider: dict[str, Any],
+        user_id: int,
+        mapped_claims: dict[str, Any],
+        raw_claims: dict[str, Any],
+    ) -> dict[str, Any]:
+        links_repo = FederatedIdentityRepo(db_pool=self.db_pool)
+        await links_repo.ensure_tables()
+        return await links_repo.upsert_identity(
+            identity_provider_id=int(provider["id"]),
+            external_subject=str(mapped_claims.get("subject") or "").strip(),
+            user_id=int(user_id),
+            external_username=(str(mapped_claims.get("username")).strip() if mapped_claims.get("username") else None),
+            external_email=(str(mapped_claims.get("email")).strip().lower() if mapped_claims.get("email") else None),
+            last_claims_hash=_claims_hash(raw_claims),
+            last_seen_at=datetime.now(timezone.utc),
+            status="active",
+        )
+
+    async def _resolve_desired_grants(
+        self,
+        *,
+        provider_id: int | None,
+        user_id: int | None,
+        mapped_claims: dict[str, Any],
+    ) -> tuple[set[int], set[int], set[str], list[str]]:
+        warnings: list[str] = []
+        orgs_repo = AuthnzOrgsTeamsRepo(db_pool=self.db_pool)
+
+        desired_org_ids = set(_coerce_distinct_ints(mapped_claims.get("derived_org_ids")))
+        desired_team_ids: set[int] = set()
+        for team_id in _coerce_distinct_ints(mapped_claims.get("derived_team_ids")):
+            try:
+                team = await orgs_repo.get_team(int(team_id))
+            except Exception as exc:  # pragma: no cover - defensive runtime hardening
+                logger.warning(
+                    "Failed to resolve federated team grant provider_id={} user_id={} team_id={}: {}",
+                    provider_id,
+                    user_id,
+                    team_id,
+                    exc,
+                )
+                warnings.append(f"Failed to resolve mapped team {team_id}")
+                continue
+
+            if not team or not bool(team.get("is_active", True)):
+                logger.warning(
+                    "Skipping federated team grant for missing or inactive team provider_id={} user_id={} team_id={}",
+                    provider_id,
+                    user_id,
+                    team_id,
+                )
+                warnings.append(f"Mapped team {team_id} is missing or inactive")
+                continue
+
+            desired_team_ids.add(int(team_id))
+            if team.get("org_id") is not None:
+                desired_org_ids.add(int(team["org_id"]))
+
+        desired_role_names = set(_coerce_distinct_strings(mapped_claims.get("derived_roles")))
+        return desired_org_ids, desired_team_ids, desired_role_names, warnings
+
+    async def preview_mapped_grants(
+        self,
+        *,
+        provider: dict[str, Any],
+        user_id: int | None,
+        mapped_claims: dict[str, Any],
+    ) -> dict[str, Any]:
+        policy = provider.get("provisioning_policy") or {}
+        mode = str(policy.get("mode") or "").strip().lower()
+        if mode not in _FEDERATED_GRANT_MODES:
+            return {
+                "mode": mode,
+                "would_change": False,
+                "grant_org_ids": [],
+                "grant_team_ids": [],
+                "grant_roles": [],
+                "revoke_org_ids": [],
+                "revoke_team_ids": [],
+                "revoke_roles": [],
+                "warnings": [],
+            }
+
+        provider_id_raw = provider.get("id")
+        provider_id = int(provider_id_raw) if provider_id_raw not in (None, "", 0, "0") else None
+        desired_org_ids, desired_team_ids, desired_role_names, warnings = await self._resolve_desired_grants(
+            provider_id=provider_id,
+            user_id=user_id,
+            mapped_claims=mapped_claims,
+        )
+
+        if user_id is None:
+            grant_org_ids = sorted(desired_org_ids)
+            grant_team_ids = sorted(desired_team_ids)
+            grant_roles = sorted(desired_role_names)
+            return {
+                "mode": mode,
+                "would_change": bool(grant_org_ids or grant_team_ids or grant_roles),
+                "grant_org_ids": grant_org_ids,
+                "grant_team_ids": grant_team_ids,
+                "grant_roles": grant_roles,
+                "revoke_org_ids": [],
+                "revoke_team_ids": [],
+                "revoke_roles": [],
+                "warnings": warnings,
+            }
+
+        orgs_repo = AuthnzOrgsTeamsRepo(db_pool=self.db_pool)
+        users_repo = AuthnzUsersRepo(db_pool=self.db_pool)
+        existing_managed: list[dict[str, Any]] = []
+        if provider_id is not None:
+            managed_repo = FederatedManagedGrantRepo(db_pool=self.db_pool)
+            await managed_repo.ensure_tables()
+            existing_managed = await managed_repo.list_for_provider_user(
+                identity_provider_id=provider_id,
+                user_id=int(user_id),
+            )
+        elif mode in _FEDERATED_REVOKE_MODES:
+            warnings.append("Revocation preview requires provider_id context for existing managed grants")
+
+        grant_org_ids: list[int] = []
+        for org_id in sorted(desired_org_ids):
+            if await orgs_repo.get_org_member(int(org_id), int(user_id)) is None:
+                grant_org_ids.append(int(org_id))
+
+        grant_team_ids: list[int] = []
+        for team_id in sorted(desired_team_ids):
+            if await orgs_repo.get_team_member(int(team_id), int(user_id)) is None:
+                grant_team_ids.append(int(team_id))
+
+        grant_roles: list[str] = []
+        for role_name in sorted(desired_role_names):
+            has_role = await users_repo.has_role_assignment(
+                user_id=int(user_id),
+                role_name=role_name,
+            )
+            if not has_role:
+                grant_roles.append(role_name)
+
+        revoke_org_ids: list[int] = []
+        revoke_team_ids: list[int] = []
+        revoke_roles: list[str] = []
+        if mode in _FEDERATED_REVOKE_MODES and provider_id is not None:
+            desired_keys = {
+                *(_grant_key("org", str(org_id)) for org_id in desired_org_ids),
+                *(_grant_key("team", str(team_id)) for team_id in desired_team_ids),
+                *(_grant_key("role", role_name) for role_name in desired_role_names),
+            }
+            stale_rows = sorted(
+                (
+                    row
+                    for row in existing_managed
+                    if _grant_key(row.get("grant_kind", ""), row.get("target_ref", "")) not in desired_keys
+                ),
+                key=lambda row: {"team": 0, "role": 1, "org": 2}.get(str(row.get("grant_kind") or ""), 99),
+            )
+            for row in stale_rows:
+                grant_kind = str(row.get("grant_kind") or "").strip().lower()
+                target_ref = str(row.get("target_ref") or "").strip()
+                if not target_ref:
+                    continue
+
+                if grant_kind == "team":
+                    current = await orgs_repo.get_team_member(int(target_ref), int(user_id))
+                    if current is not None and str(current.get("role") or "member").strip().lower() == "member":
+                        revoke_team_ids.append(int(target_ref))
+                    continue
+
+                if grant_kind == "role":
+                    if await users_repo.has_role_assignment(
+                        user_id=int(user_id),
+                        role_name=target_ref,
+                    ):
+                        revoke_roles.append(target_ref)
+                    continue
+
+                if grant_kind != "org":
+                    continue
+
+                current = await orgs_repo.get_org_member(int(target_ref), int(user_id))
+                if current is None or str(current.get("role") or "member").strip().lower() != "member":
+                    continue
+                remaining_team_memberships = await orgs_repo.list_memberships_for_user(int(user_id))
+                if any(
+                    int(membership.get("org_id")) == int(target_ref)
+                    and int(membership.get("team_id")) not in revoke_team_ids
+                    and str(membership.get("team_name") or "").strip() != DEFAULT_BASE_TEAM_NAME
+                    for membership in remaining_team_memberships
+                ):
+                    continue
+                revoke_org_ids.append(int(target_ref))
+
+        return {
+            "mode": mode,
+            "would_change": bool(
+                grant_org_ids
+                or grant_team_ids
+                or grant_roles
+                or revoke_org_ids
+                or revoke_team_ids
+                or revoke_roles
+            ),
+            "grant_org_ids": grant_org_ids,
+            "grant_team_ids": grant_team_ids,
+            "grant_roles": grant_roles,
+            "revoke_org_ids": revoke_org_ids,
+            "revoke_team_ids": revoke_team_ids,
+            "revoke_roles": revoke_roles,
+            "warnings": warnings,
+        }
+
+    async def apply_mapped_grants(
+        self,
+        *,
+        provider: dict[str, Any],
+        user_id: int,
+        mapped_claims: dict[str, Any],
+    ) -> dict[str, Any]:
+        policy = provider.get("provisioning_policy") or {}
+        mode = str(policy.get("mode") or "").strip().lower()
+        if mode not in _FEDERATED_GRANT_MODES:
+            return {
+                "mode": mode,
+                "applied": False,
+                "org_ids": [],
+                "team_ids": [],
+                "roles": [],
+                "revoked_org_ids": [],
+                "revoked_team_ids": [],
+                "revoked_roles": [],
+            }
+
+        orgs_repo = AuthnzOrgsTeamsRepo(db_pool=self.db_pool)
+        users_repo = AuthnzUsersRepo(db_pool=self.db_pool)
+        managed_repo = FederatedManagedGrantRepo(db_pool=self.db_pool)
+        await managed_repo.ensure_tables()
+
+        provider_id = int(provider["id"])
+        desired_org_ids, desired_team_ids, desired_role_names, _ = await self._resolve_desired_grants(
+            provider_id=provider_id,
+            user_id=user_id,
+            mapped_claims=mapped_claims,
+        )
+        existing_managed = await managed_repo.list_for_provider_user(
+            identity_provider_id=provider_id,
+            user_id=int(user_id),
+        )
+        existing_managed_keys = {
+            _grant_key(row.get("grant_kind", ""), row.get("target_ref", ""))
+            for row in existing_managed
+        }
+
+        applied_org_ids: list[int] = []
+        for org_id in sorted(desired_org_ids):
+            grant_key = _grant_key("org", str(org_id))
+            try:
+                current = await orgs_repo.get_org_member(int(org_id), int(user_id))
+                if current is None or grant_key in existing_managed_keys:
+                    if current is None:
+                        await orgs_repo.add_org_member(
+                            org_id=int(org_id),
+                            user_id=int(user_id),
+                            role="member",
+                        )
+                    await managed_repo.upsert_grant(
+                        identity_provider_id=provider_id,
+                        user_id=int(user_id),
+                        grant_kind="org",
+                        target_ref=str(org_id),
+                    )
+                    applied_org_ids.append(int(org_id))
+            except Exception as exc:  # pragma: no cover - defensive runtime hardening
+                logger.warning(
+                    "Failed to apply federated org grant provider_id={} user_id={} org_id={}: {}",
+                    provider_id,
+                    user_id,
+                    org_id,
+                    exc,
+                )
+
+        applied_team_ids: list[int] = []
+        for team_id in sorted(desired_team_ids):
+            grant_key = _grant_key("team", str(team_id))
+            try:
+                current = await orgs_repo.get_team_member(int(team_id), int(user_id))
+                if current is None or grant_key in existing_managed_keys:
+                    if current is None:
+                        await orgs_repo.add_team_member(
+                            team_id=int(team_id),
+                            user_id=int(user_id),
+                            role="member",
+                        )
+                    await managed_repo.upsert_grant(
+                        identity_provider_id=provider_id,
+                        user_id=int(user_id),
+                        grant_kind="team",
+                        target_ref=str(team_id),
+                    )
+                    applied_team_ids.append(int(team_id))
+            except Exception as exc:  # pragma: no cover - defensive runtime hardening
+                logger.warning(
+                    "Failed to apply federated team grant provider_id={} user_id={} team_id={}: {}",
+                    provider_id,
+                    user_id,
+                    team_id,
+                    exc,
+                )
+
+        applied_roles: list[str] = []
+        for role_name in sorted(desired_role_names):
+            grant_key = _grant_key("role", role_name)
+            try:
+                has_role = await users_repo.has_role_assignment(
+                    user_id=int(user_id),
+                    role_name=role_name,
+                )
+                if not has_role or grant_key in existing_managed_keys:
+                    if not has_role:
+                        await users_repo.assign_role_if_missing(
+                            user_id=int(user_id),
+                            role_name=role_name,
+                        )
+                        has_role = await users_repo.has_role_assignment(
+                            user_id=int(user_id),
+                            role_name=role_name,
+                        )
+                    if not has_role:
+                        continue
+                    await managed_repo.upsert_grant(
+                        identity_provider_id=provider_id,
+                        user_id=int(user_id),
+                        grant_kind="role",
+                        target_ref=role_name,
+                    )
+                    applied_roles.append(role_name)
+            except Exception as exc:  # pragma: no cover - defensive runtime hardening
+                logger.warning(
+                    "Failed to apply federated role grant provider_id={} user_id={} role={}: {}",
+                    provider_id,
+                    user_id,
+                    role_name,
+                    exc,
+                )
+
+        revoked_org_ids: list[int] = []
+        revoked_team_ids: list[int] = []
+        revoked_roles: list[str] = []
+        if mode in _FEDERATED_REVOKE_MODES:
+            desired_keys = {
+                *(_grant_key("org", str(org_id)) for org_id in desired_org_ids),
+                *(_grant_key("team", str(team_id)) for team_id in desired_team_ids),
+                *(_grant_key("role", role_name) for role_name in desired_role_names),
+            }
+            stale_rows = sorted(
+                (
+                    row
+                    for row in existing_managed
+                    if _grant_key(row.get("grant_kind", ""), row.get("target_ref", "")) not in desired_keys
+                ),
+                key=lambda row: {"team": 0, "role": 1, "org": 2}.get(str(row.get("grant_kind") or ""), 99),
+            )
+            for row in stale_rows:
+                grant_kind = str(row.get("grant_kind") or "").strip().lower()
+                target_ref = str(row.get("target_ref") or "").strip()
+                if not target_ref:
+                    continue
+
+                try:
+                    if grant_kind == "team":
+                        team_id = int(target_ref)
+                        current = await orgs_repo.get_team_member(team_id, int(user_id))
+                        if current is None:
+                            await managed_repo.delete_grant(
+                                identity_provider_id=provider_id,
+                                user_id=int(user_id),
+                                grant_kind="team",
+                                target_ref=target_ref,
+                            )
+                            continue
+                        if str(current.get("role") or "member").strip().lower() != "member":
+                            await managed_repo.delete_grant(
+                                identity_provider_id=provider_id,
+                                user_id=int(user_id),
+                                grant_kind="team",
+                                target_ref=target_ref,
+                            )
+                            continue
+                        removal = await orgs_repo.remove_team_member(team_id=team_id, user_id=int(user_id))
+                        await managed_repo.delete_grant(
+                            identity_provider_id=provider_id,
+                            user_id=int(user_id),
+                            grant_kind="team",
+                            target_ref=target_ref,
+                        )
+                        if removal.get("removed"):
+                            revoked_team_ids.append(team_id)
+                        continue
+
+                    if grant_kind == "role":
+                        if await users_repo.has_role_assignment(
+                            user_id=int(user_id),
+                            role_name=target_ref,
+                        ):
+                            removed = await users_repo.remove_role_if_present(
+                                user_id=int(user_id),
+                                role_name=target_ref,
+                            )
+                            if removed:
+                                revoked_roles.append(target_ref)
+                        await managed_repo.delete_grant(
+                            identity_provider_id=provider_id,
+                            user_id=int(user_id),
+                            grant_kind="role",
+                            target_ref=target_ref,
+                        )
+                        continue
+
+                    if grant_kind == "org":
+                        org_id = int(target_ref)
+                        current = await orgs_repo.get_org_member(org_id, int(user_id))
+                        if current is None:
+                            await managed_repo.delete_grant(
+                                identity_provider_id=provider_id,
+                                user_id=int(user_id),
+                                grant_kind="org",
+                                target_ref=target_ref,
+                            )
+                            continue
+                        if str(current.get("role") or "member").strip().lower() != "member":
+                            await managed_repo.delete_grant(
+                                identity_provider_id=provider_id,
+                                user_id=int(user_id),
+                                grant_kind="org",
+                                target_ref=target_ref,
+                            )
+                            continue
+                        remaining_team_memberships = await orgs_repo.list_memberships_for_user(int(user_id))
+                        if any(
+                            int(membership.get("org_id")) == org_id
+                            and str(membership.get("team_name") or "").strip() != DEFAULT_BASE_TEAM_NAME
+                            for membership in remaining_team_memberships
+                        ):
+                            await managed_repo.delete_grant(
+                                identity_provider_id=provider_id,
+                                user_id=int(user_id),
+                                grant_kind="org",
+                                target_ref=target_ref,
+                            )
+                            continue
+                        removal = await orgs_repo.remove_org_member(org_id=org_id, user_id=int(user_id))
+                        await managed_repo.delete_grant(
+                            identity_provider_id=provider_id,
+                            user_id=int(user_id),
+                            grant_kind="org",
+                            target_ref=target_ref,
+                        )
+                        if removal.get("removed"):
+                            revoked_org_ids.append(org_id)
+                except Exception as exc:  # pragma: no cover - defensive runtime hardening
+                    logger.warning(
+                        "Failed to reconcile stale federated grant provider_id={} user_id={} grant_kind={} target_ref={}: {}",
+                        provider_id,
+                        user_id,
+                        grant_kind,
+                        target_ref,
+                        exc,
+                    )
+
+        return {
+            "mode": mode,
+            "applied": bool(applied_org_ids or applied_team_ids or applied_roles or revoked_org_ids or revoked_team_ids or revoked_roles),
+            "org_ids": applied_org_ids,
+            "team_ids": applied_team_ids,
+            "roles": applied_roles,
+            "revoked_org_ids": revoked_org_ids,
+            "revoked_team_ids": revoked_team_ids,
+            "revoked_roles": revoked_roles,
+        }

--- a/tldw_Server_API/app/core/AuthNZ/federation/state_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/state_repo.py
@@ -36,10 +36,9 @@ class FederationStateRepo:
         state: str,
     ) -> dict[str, Any] | None:
         cache_key = self._cache_key(state)
-        payload_raw = await self.session_manager.get_ephemeral_value(cache_key)
+        payload_raw = await self.session_manager.consume_ephemeral_value(cache_key)
         if not payload_raw:
             return None
-        await self.session_manager.delete_ephemeral_value(cache_key)
         try:
             payload = json.loads(payload_raw)
         except json.JSONDecodeError:

--- a/tldw_Server_API/app/core/AuthNZ/federation/state_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/federation/state_repo.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.session_manager import SessionManager
+
+
+@dataclass
+class FederationStateRepo:
+    """Ephemeral repository for OIDC login state during browser callbacks."""
+
+    session_manager: SessionManager
+    key_prefix: str = "oidc-login"
+
+    def _cache_key(self, state: str) -> str:
+        return f"{self.key_prefix}:{state}"
+
+    async def create_state(
+        self,
+        *,
+        state: str,
+        payload: dict[str, Any],
+        ttl_seconds: int,
+    ) -> None:
+        await self.session_manager.store_ephemeral_value(
+            self._cache_key(state),
+            json.dumps(payload),
+            ttl_seconds,
+        )
+
+    async def consume_state(
+        self,
+        *,
+        state: str,
+    ) -> dict[str, Any] | None:
+        cache_key = self._cache_key(state)
+        payload_raw = await self.session_manager.get_ephemeral_value(cache_key)
+        if not payload_raw:
+            return None
+        await self.session_manager.delete_ephemeral_value(cache_key)
+        try:
+            payload = json.loads(payload_raw)
+        except json.JSONDecodeError:
+            return None
+        return payload if isinstance(payload, dict) else None

--- a/tldw_Server_API/app/core/AuthNZ/jwt_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/jwt_service.py
@@ -293,7 +293,12 @@ class JWTService:
             if self.settings.PII_REDACT_LOGS:
                 logger.debug("Created {} token for authenticated user (details redacted)", token_type)
             else:
-                logger.debug("Created {} token for {}", token_type, email)
+                safe_identifier = (
+                    f"user_id={int(user_id)}"
+                    if user_id is not None
+                    else "email=redacted"
+                )
+                logger.debug("Created {} token for {}", token_type, safe_identifier)
             return token
         except _JWT_SERVICE_NONCRITICAL_EXCEPTIONS as e:
             logger.error("Failed to create {} token: {}", token_type, e)

--- a/tldw_Server_API/app/core/AuthNZ/jwt_service.py
+++ b/tldw_Server_API/app/core/AuthNZ/jwt_service.py
@@ -56,6 +56,7 @@ class JWTService:
         "password_reset",
         "email_verification",
         "magic_link",
+        "admin_reauth",
         "service",
     })
 
@@ -246,6 +247,58 @@ class JWTService:
             logger.error(f"Failed to create refresh token: {e}")
             raise InvalidTokenError(f"Failed to create token: {e}") from e
 
+    def _create_short_lived_email_token(
+        self,
+        *,
+        token_type: str,
+        email: str,
+        user_id: Optional[int] = None,
+        expires_in_minutes: Optional[int] = None,
+        base_claims: Optional[dict[str, Any]] = None,
+        additional_claims: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Create a short-lived email-delivered token such as a magic link or admin step-up token."""
+        if token_type not in self.VALID_TOKEN_TYPES:
+            raise InvalidTokenError(f"Unsupported token type: {token_type}")
+
+        ttl_minutes = expires_in_minutes or int(getattr(self.settings, "MAGIC_LINK_EXPIRE_MINUTES", 15))
+        expire = datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)
+
+        payload: dict[str, Any] = {
+            "sub": str(user_id) if user_id is not None else str(email),
+            "email": str(email).strip().lower(),
+            "exp": expire,
+            "iat": datetime.now(timezone.utc),
+            "jti": str(uuid4()),
+            "type": token_type,
+        }
+        if user_id is not None:
+            payload["user_id"] = int(user_id)
+        if base_claims:
+            payload.update(base_claims)
+        if self.settings.JWT_ISSUER:
+            payload["iss"] = self.settings.JWT_ISSUER
+        if self.settings.JWT_AUDIENCE:
+            payload["aud"] = self.settings.JWT_AUDIENCE
+
+        extra_claims = self._filter_additional_claims(
+            additional_claims,
+            reserved=set(payload.keys()) | {"iss", "aud"},
+        )
+        if extra_claims:
+            payload.update(extra_claims)
+
+        try:
+            token = jwt.encode(payload, self._encode_key, algorithm=self.algorithm)
+            if self.settings.PII_REDACT_LOGS:
+                logger.debug("Created {} token for authenticated user (details redacted)", token_type)
+            else:
+                logger.debug("Created {} token for {}", token_type, email)
+            return token
+        except _JWT_SERVICE_NONCRITICAL_EXCEPTIONS as e:
+            logger.error("Failed to create {} token: {}", token_type, e)
+            raise InvalidTokenError(f"Failed to create token: {e}") from e
+
     def create_magic_link_token(
         self,
         *,
@@ -266,41 +319,31 @@ class JWTService:
         Returns:
             Encoded JWT magic link token
         """
-        ttl_minutes = expires_in_minutes or int(getattr(self.settings, "MAGIC_LINK_EXPIRE_MINUTES", 15))
-        expire = datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)
-
-        payload: dict[str, Any] = {
-            "sub": str(user_id) if user_id is not None else str(email),
-            "email": str(email).strip().lower(),
-            "exp": expire,
-            "iat": datetime.now(timezone.utc),
-            "jti": str(uuid4()),
-            "type": "magic_link",
-        }
-        if user_id is not None:
-            payload["user_id"] = int(user_id)
-        if self.settings.JWT_ISSUER:
-            payload["iss"] = self.settings.JWT_ISSUER
-        if self.settings.JWT_AUDIENCE:
-            payload["aud"] = self.settings.JWT_AUDIENCE
-
-        extra_claims = self._filter_additional_claims(
-            additional_claims,
-            reserved=set(payload.keys()) | {"iss", "aud"},
+        return self._create_short_lived_email_token(
+            token_type="magic_link",
+            email=email,
+            user_id=user_id,
+            expires_in_minutes=expires_in_minutes,
+            additional_claims=additional_claims,
         )
-        if extra_claims:
-            payload.update(extra_claims)
 
-        try:
-            token = jwt.encode(payload, self._encode_key, algorithm=self.algorithm)
-            if self.settings.PII_REDACT_LOGS:
-                logger.debug("Created magic link token for authenticated user (details redacted)")
-            else:
-                logger.debug(f"Created magic link token for {email}")
-            return token
-        except _JWT_SERVICE_NONCRITICAL_EXCEPTIONS as e:
-            logger.error(f"Failed to create magic link token: {e}")
-            raise InvalidTokenError(f"Failed to create token: {e}") from e
+    def create_admin_reauth_token(
+        self,
+        *,
+        email: str,
+        user_id: Optional[int] = None,
+        expires_in_minutes: Optional[int] = None,
+        additional_claims: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Create a short-lived admin step-up token delivered by email."""
+        return self._create_short_lived_email_token(
+            token_type="admin_reauth",
+            email=email,
+            user_id=user_id,
+            expires_in_minutes=expires_in_minutes,
+            base_claims={"purpose": "admin_reauth"},
+            additional_claims=additional_claims,
+        )
 
     async def verify_token_async(self, token: str, token_type: Optional[str] = None) -> dict[str, Any]:
         """

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -3964,6 +3964,129 @@ def rollback_074_drop_federated_managed_grants_table(conn: sqlite3.Connection) -
     logger.info("Rollback 074: Dropped federated_managed_grants table")
 
 
+def migration_075_create_secret_backends_table(conn: sqlite3.Connection) -> None:
+    """Create the secret_backends table for backend metadata and capabilities."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS secret_backends (
+            name TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'enabled',
+            capabilities_json TEXT NOT NULL DEFAULT '{}',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    try:
+        cur = conn.execute("PRAGMA table_info(secret_backends)")
+        cols = {row[1] for row in cur.fetchall()}
+
+        def add_col(name: str, decl: str) -> None:
+            if name not in cols:
+                conn.execute(f"ALTER TABLE secret_backends ADD COLUMN {decl}")
+                cols.add(name)
+
+        add_col("display_name", "display_name TEXT")
+        add_col("status", "status TEXT NOT NULL DEFAULT 'enabled'")
+        add_col("capabilities_json", "capabilities_json TEXT NOT NULL DEFAULT '{}'")
+        add_col("metadata_json", "metadata_json TEXT NOT NULL DEFAULT '{}'")
+        add_col("created_at", "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+        add_col("updated_at", "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_secret_backends_status "
+        "ON secret_backends(status)"
+    )
+    conn.commit()
+    logger.info("Migration 075: Created secret_backends table")
+
+
+def rollback_075_drop_secret_backends_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 075 by dropping the secret_backends table."""
+    conn.execute("DROP TABLE IF EXISTS secret_backends")
+    conn.commit()
+    logger.info("Rollback 075: Dropped secret_backends table")
+
+
+def migration_076_create_managed_secret_refs_table(conn: sqlite3.Connection) -> None:
+    """Create the managed_secret_refs table for logical secret references."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS managed_secret_refs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            backend_name TEXT NOT NULL,
+            owner_scope_type TEXT NOT NULL,
+            owner_scope_id INTEGER NOT NULL,
+            provider_key TEXT NOT NULL,
+            backend_ref TEXT NULL,
+            display_name TEXT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            last_resolved_at TIMESTAMP NULL,
+            expires_at TIMESTAMP NULL,
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            revoked_by INTEGER NULL,
+            revoked_at TIMESTAMP NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (backend_name) REFERENCES secret_backends(name) ON DELETE RESTRICT
+        )
+        """
+    )
+
+    try:
+        cur = conn.execute("PRAGMA table_info(managed_secret_refs)")
+        cols = {row[1] for row in cur.fetchall()}
+
+        def add_col(name: str, decl: str) -> None:
+            if name not in cols:
+                conn.execute(f"ALTER TABLE managed_secret_refs ADD COLUMN {decl}")
+                cols.add(name)
+
+        add_col("backend_ref", "backend_ref TEXT")
+        add_col("display_name", "display_name TEXT")
+        add_col("status", "status TEXT NOT NULL DEFAULT 'active'")
+        add_col("metadata_json", "metadata_json TEXT NOT NULL DEFAULT '{}'")
+        add_col("last_resolved_at", "last_resolved_at TIMESTAMP")
+        add_col("expires_at", "expires_at TIMESTAMP")
+        add_col("created_by", "created_by INTEGER")
+        add_col("updated_by", "updated_by INTEGER")
+        add_col("revoked_by", "revoked_by INTEGER")
+        add_col("revoked_at", "revoked_at TIMESTAMP")
+        add_col("created_at", "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+        add_col("updated_at", "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_managed_secret_refs_scope_provider "
+        "ON managed_secret_refs(backend_name, owner_scope_type, owner_scope_id, provider_key)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_managed_secret_refs_scope "
+        "ON managed_secret_refs(owner_scope_type, owner_scope_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_managed_secret_refs_status "
+        "ON managed_secret_refs(status)"
+    )
+    conn.commit()
+    logger.info("Migration 076: Created managed_secret_refs table")
+
+
+def rollback_076_drop_managed_secret_refs_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 076 by dropping the managed_secret_refs table."""
+    conn.execute("DROP TABLE IF EXISTS managed_secret_refs")
+    conn.commit()
+    logger.info("Rollback 076: Dropped managed_secret_refs table")
+
+
 #######################################################################################################################
 #
 # Migration Registry
@@ -4264,6 +4387,18 @@ def get_authnz_migrations() -> list[Migration]:
             "Create federated_managed_grants table",
             migration_074_create_federated_managed_grants_table,
             rollback_074_drop_federated_managed_grants_table,
+        ),
+        Migration(
+            75,
+            "Create secret_backends table",
+            migration_075_create_secret_backends_table,
+            rollback_075_drop_secret_backends_table,
+        ),
+        Migration(
+            76,
+            "Create managed_secret_refs table",
+            migration_076_create_managed_secret_refs_table,
+            rollback_076_drop_managed_secret_refs_table,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/migrations.py
+++ b/tldw_Server_API/app/core/AuthNZ/migrations.py
@@ -3761,6 +3761,209 @@ def migration_045_add_users_created_by(conn: sqlite3.Connection) -> None:
         logger.warning(f"Migration 045 skipped or failed: {error}")
 
 
+def migration_072_create_identity_providers_table(conn: sqlite3.Connection) -> None:
+    """Create the identity_providers table for enterprise federation config."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS identity_providers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            slug TEXT NOT NULL,
+            provider_type TEXT NOT NULL DEFAULT 'oidc',
+            owner_scope_type TEXT NOT NULL DEFAULT 'global',
+            owner_scope_id INTEGER,
+            enabled INTEGER NOT NULL DEFAULT 0,
+            display_name TEXT,
+            issuer TEXT NOT NULL,
+            discovery_url TEXT,
+            authorization_url TEXT,
+            token_url TEXT,
+            jwks_url TEXT,
+            client_id TEXT,
+            client_secret_ref TEXT,
+            claim_mapping_json TEXT NOT NULL DEFAULT '{}',
+            provisioning_policy_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER,
+            updated_by INTEGER,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    try:
+        cur = conn.execute("PRAGMA table_info(identity_providers)")
+        cols = {row[1] for row in cur.fetchall()}
+
+        def add_col(name: str, decl: str) -> None:
+            if name not in cols:
+                conn.execute(f"ALTER TABLE identity_providers ADD COLUMN {decl}")
+                cols.add(name)
+
+        add_col("provider_type", "provider_type TEXT NOT NULL DEFAULT 'oidc'")
+        add_col("owner_scope_type", "owner_scope_type TEXT NOT NULL DEFAULT 'global'")
+        add_col("owner_scope_id", "owner_scope_id INTEGER")
+        add_col("enabled", "enabled INTEGER NOT NULL DEFAULT 0")
+        add_col("display_name", "display_name TEXT")
+        add_col("issuer", "issuer TEXT")
+        add_col("discovery_url", "discovery_url TEXT")
+        add_col("authorization_url", "authorization_url TEXT")
+        add_col("token_url", "token_url TEXT")
+        add_col("jwks_url", "jwks_url TEXT")
+        add_col("client_id", "client_id TEXT")
+        add_col("client_secret_ref", "client_secret_ref TEXT")
+        add_col("claim_mapping_json", "claim_mapping_json TEXT NOT NULL DEFAULT '{}'")
+        add_col("provisioning_policy_json", "provisioning_policy_json TEXT NOT NULL DEFAULT '{}'")
+        add_col("created_by", "created_by INTEGER")
+        add_col("updated_by", "updated_by INTEGER")
+        add_col("created_at", "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+        add_col("updated_at", "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_identity_providers_scope "
+        "ON identity_providers(owner_scope_type, owner_scope_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_identity_providers_enabled "
+        "ON identity_providers(enabled)"
+    )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_identity_providers_scope_slug "
+        "ON identity_providers(slug, owner_scope_type, COALESCE(owner_scope_id, 0))"
+    )
+    conn.commit()
+    logger.info("Migration 072: Created identity_providers table")
+
+
+def rollback_072_drop_identity_providers_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 072 by dropping the identity_providers table."""
+    conn.execute("DROP TABLE IF EXISTS identity_providers")
+    conn.commit()
+    logger.info("Rollback 072: Dropped identity_providers table")
+
+
+def migration_073_create_federated_identities_table(conn: sqlite3.Connection) -> None:
+    """Create the federated_identities table for local user links."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS federated_identities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identity_provider_id INTEGER NOT NULL,
+            external_subject TEXT NOT NULL,
+            user_id INTEGER NOT NULL,
+            external_username TEXT,
+            external_email TEXT,
+            last_claims_hash TEXT,
+            last_seen_at TIMESTAMP,
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (identity_provider_id) REFERENCES identity_providers(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    try:
+        cur = conn.execute("PRAGMA table_info(federated_identities)")
+        cols = {row[1] for row in cur.fetchall()}
+
+        def add_col(name: str, decl: str) -> None:
+            if name not in cols:
+                conn.execute(f"ALTER TABLE federated_identities ADD COLUMN {decl}")
+                cols.add(name)
+
+        add_col("external_username", "external_username TEXT")
+        add_col("external_email", "external_email TEXT")
+        add_col("last_claims_hash", "last_claims_hash TEXT")
+        add_col("last_seen_at", "last_seen_at TIMESTAMP")
+        add_col("status", "status TEXT NOT NULL DEFAULT 'active'")
+        add_col("created_at", "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+        add_col("updated_at", "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_federated_identities_provider_subject "
+        "ON federated_identities(identity_provider_id, external_subject)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_federated_identities_user_id "
+        "ON federated_identities(user_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_federated_identities_provider_id "
+        "ON federated_identities(identity_provider_id)"
+    )
+    conn.commit()
+    logger.info("Migration 073: Created federated_identities table")
+
+
+def rollback_073_drop_federated_identities_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 073 by dropping the federated_identities table."""
+    conn.execute("DROP TABLE IF EXISTS federated_identities")
+    conn.commit()
+    logger.info("Rollback 073: Dropped federated_identities table")
+
+
+def migration_074_create_federated_managed_grants_table(conn: sqlite3.Connection) -> None:
+    """Create the federated_managed_grants table for safe grant/revoke provenance."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS federated_managed_grants (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            identity_provider_id INTEGER NOT NULL,
+            user_id INTEGER NOT NULL,
+            grant_kind TEXT NOT NULL,
+            target_ref TEXT NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (identity_provider_id) REFERENCES identity_providers(id) ON DELETE CASCADE,
+            FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    try:
+        cur = conn.execute("PRAGMA table_info(federated_managed_grants)")
+        cols = {row[1] for row in cur.fetchall()}
+
+        def add_col(name: str, decl: str) -> None:
+            if name not in cols:
+                conn.execute(f"ALTER TABLE federated_managed_grants ADD COLUMN {decl}")
+                cols.add(name)
+
+        add_col("grant_kind", "grant_kind TEXT NOT NULL DEFAULT 'org'")
+        add_col("target_ref", "target_ref TEXT NOT NULL DEFAULT ''")
+        add_col("created_at", "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+        add_col("updated_at", "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    except _AUTHNZ_MIGRATIONS_NONCRITICAL_EXCEPTIONS:
+        pass
+
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_federated_managed_grants_target "
+        "ON federated_managed_grants(identity_provider_id, user_id, grant_kind, target_ref)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_federated_managed_grants_user_id "
+        "ON federated_managed_grants(user_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_federated_managed_grants_provider_id "
+        "ON federated_managed_grants(identity_provider_id)"
+    )
+    conn.commit()
+    logger.info("Migration 074: Created federated_managed_grants table")
+
+
+def rollback_074_drop_federated_managed_grants_table(conn: sqlite3.Connection) -> None:
+    """Rollback migration 074 by dropping the federated_managed_grants table."""
+    conn.execute("DROP TABLE IF EXISTS federated_managed_grants")
+    conn.commit()
+    logger.info("Rollback 074: Dropped federated_managed_grants table")
+
+
 #######################################################################################################################
 #
 # Migration Registry
@@ -4043,6 +4246,24 @@ def get_authnz_migrations() -> list[Migration]:
             71,
             "Add governance pack upgrade lineage schema",
             migration_071_add_governance_pack_upgrade_lineage,
+        ),
+        Migration(
+            72,
+            "Create identity_providers table",
+            migration_072_create_identity_providers_table,
+            rollback_072_drop_identity_providers_table,
+        ),
+        Migration(
+            73,
+            "Create federated_identities table",
+            migration_073_create_federated_identities_table,
+            rollback_073_drop_federated_identities_table,
+        ),
+        Migration(
+            74,
+            "Create federated_managed_grants table",
+            migration_074_create_federated_managed_grants_table,
+            rollback_074_drop_federated_managed_grants_table,
         ),
     ]
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1480,6 +1480,144 @@ _CREATE_ORG_PROVIDER_SECRETS = [
     ("CREATE INDEX IF NOT EXISTS idx_org_provider_secrets_provider ON org_provider_secrets(provider)", ()),
 ]
 
+_CREATE_IDENTITY_PROVIDERS = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS identity_providers (
+            id SERIAL PRIMARY KEY,
+            slug TEXT NOT NULL,
+            provider_type TEXT NOT NULL DEFAULT 'oidc',
+            owner_scope_type TEXT NOT NULL DEFAULT 'global',
+            owner_scope_id INTEGER NULL,
+            enabled BOOLEAN NOT NULL DEFAULT FALSE,
+            display_name TEXT NULL,
+            issuer TEXT NOT NULL,
+            discovery_url TEXT NULL,
+            authorization_url TEXT NULL,
+            token_url TEXT NULL,
+            jwks_url TEXT NULL,
+            client_id TEXT NULL,
+            client_secret_ref TEXT NULL,
+            claim_mapping_json TEXT NOT NULL DEFAULT '{}',
+            provisioning_policy_json TEXT NOT NULL DEFAULT '{}',
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS provider_type TEXT NOT NULL DEFAULT 'oidc'", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS owner_scope_type TEXT NOT NULL DEFAULT 'global'", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS owner_scope_id INTEGER", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS enabled BOOLEAN NOT NULL DEFAULT FALSE", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS display_name TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS issuer TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS discovery_url TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS authorization_url TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS token_url TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS jwks_url TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS client_id TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS client_secret_ref TEXT", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS claim_mapping_json TEXT NOT NULL DEFAULT '{}'", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS provisioning_policy_json TEXT NOT NULL DEFAULT '{}'", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS created_by INTEGER", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS updated_by INTEGER", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("ALTER TABLE identity_providers ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_identity_providers_scope "
+        "ON identity_providers(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_identity_providers_enabled "
+        "ON identity_providers(enabled)",
+        (),
+    ),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_identity_providers_scope_slug "
+        "ON identity_providers(slug, owner_scope_type, COALESCE(owner_scope_id, 0))",
+        (),
+    ),
+]
+
+_CREATE_FEDERATED_IDENTITIES = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS federated_identities (
+            id SERIAL PRIMARY KEY,
+            identity_provider_id INTEGER NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+            external_subject TEXT NOT NULL,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            external_username TEXT NULL,
+            external_email TEXT NULL,
+            last_claims_hash TEXT NULL,
+            last_seen_at TIMESTAMPTZ NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS external_username TEXT", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS external_email TEXT", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS last_claims_hash TEXT", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active'", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("ALTER TABLE federated_identities ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_federated_identities_provider_subject "
+        "ON federated_identities(identity_provider_id, external_subject)",
+        (),
+    ),
+    ("CREATE INDEX IF NOT EXISTS idx_federated_identities_user_id ON federated_identities(user_id)", ()),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_federated_identities_provider_id "
+        "ON federated_identities(identity_provider_id)",
+        (),
+    ),
+]
+
+_CREATE_FEDERATED_MANAGED_GRANTS = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS federated_managed_grants (
+            id SERIAL PRIMARY KEY,
+            identity_provider_id INTEGER NOT NULL REFERENCES identity_providers(id) ON DELETE CASCADE,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            grant_kind TEXT NOT NULL,
+            target_ref TEXT NOT NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    ("ALTER TABLE federated_managed_grants ADD COLUMN IF NOT EXISTS grant_kind TEXT NOT NULL DEFAULT 'org'", ()),
+    ("ALTER TABLE federated_managed_grants ADD COLUMN IF NOT EXISTS target_ref TEXT NOT NULL DEFAULT ''", ()),
+    ("ALTER TABLE federated_managed_grants ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("ALTER TABLE federated_managed_grants ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_federated_managed_grants_target "
+        "ON federated_managed_grants(identity_provider_id, user_id, grant_kind, target_ref)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_federated_managed_grants_user_id "
+        "ON federated_managed_grants(user_id)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_federated_managed_grants_provider_id "
+        "ON federated_managed_grants(identity_provider_id)",
+        (),
+    ),
+]
+
 _CREATE_BYOK_OAUTH_STATE = [
     (
         """
@@ -2826,6 +2964,36 @@ async def ensure_org_provider_secrets_pg(pool: DatabasePool | None = None) -> bo
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL org_provider_secrets table: {exc}")
+        return False
+
+
+async def ensure_identity_federation_tables_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure identity federation tables exist for PostgreSQL backends."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+
+        try:
+            await ensure_authnz_core_tables_pg(db_pool)
+        except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"ensure_identity_federation_tables_pg: core table ensure skipped/failed: {exc}")
+
+        for ddl_group in (
+            _CREATE_IDENTITY_PROVIDERS,
+            _CREATE_FEDERATED_IDENTITIES,
+            _CREATE_FEDERATED_MANAGED_GRANTS,
+        ):
+            for sql, params in ddl_group:
+                try:
+                    await db_pool.execute(sql, *params)
+                except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.debug(f"PG ensure identity federation DDL failed: {exc}")
+
+        logger.info("Ensured PostgreSQL identity federation tables (idempotent)")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL identity federation tables: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
+++ b/tldw_Server_API/app/core/AuthNZ/pg_migrations_extra.py
@@ -1582,6 +1582,84 @@ _CREATE_FEDERATED_IDENTITIES = [
     ),
 ]
 
+_CREATE_SECRET_BACKENDS = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS secret_backends (
+            name TEXT PRIMARY KEY,
+            display_name TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'enabled',
+            capabilities_json TEXT NOT NULL DEFAULT '{}',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS display_name TEXT", ()),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'enabled'", ()),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS capabilities_json TEXT NOT NULL DEFAULT '{}'", ()),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS metadata_json TEXT NOT NULL DEFAULT '{}'", ()),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("ALTER TABLE secret_backends ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("CREATE INDEX IF NOT EXISTS idx_secret_backends_status ON secret_backends(status)", ()),
+]
+
+_CREATE_MANAGED_SECRET_REFS = [
+    (
+        """
+        CREATE TABLE IF NOT EXISTS managed_secret_refs (
+            id SERIAL PRIMARY KEY,
+            backend_name TEXT NOT NULL REFERENCES secret_backends(name) ON DELETE RESTRICT,
+            owner_scope_type TEXT NOT NULL,
+            owner_scope_id INTEGER NOT NULL,
+            provider_key TEXT NOT NULL,
+            backend_ref TEXT NULL,
+            display_name TEXT NULL,
+            status TEXT NOT NULL DEFAULT 'active',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            last_resolved_at TIMESTAMPTZ NULL,
+            expires_at TIMESTAMPTZ NULL,
+            created_by INTEGER NULL,
+            updated_by INTEGER NULL,
+            revoked_by INTEGER NULL,
+            revoked_at TIMESTAMPTZ NULL,
+            created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        (),
+    ),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS backend_ref TEXT", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS display_name TEXT", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active'", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS metadata_json TEXT NOT NULL DEFAULT '{}'", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS last_resolved_at TIMESTAMPTZ", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS created_by INTEGER", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS updated_by INTEGER", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS revoked_by INTEGER", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS revoked_at TIMESTAMPTZ", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    ("ALTER TABLE managed_secret_refs ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP", ()),
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_managed_secret_refs_scope_provider "
+        "ON managed_secret_refs(backend_name, owner_scope_type, owner_scope_id, provider_key)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_managed_secret_refs_scope "
+        "ON managed_secret_refs(owner_scope_type, owner_scope_id)",
+        (),
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS idx_managed_secret_refs_status "
+        "ON managed_secret_refs(status)",
+        (),
+    ),
+]
+
 _CREATE_FEDERATED_MANAGED_GRANTS = [
     (
         """
@@ -2994,6 +3072,35 @@ async def ensure_identity_federation_tables_pg(pool: DatabasePool | None = None)
         return True
     except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
         logger.warning(f"Failed to ensure PostgreSQL identity federation tables: {exc}")
+        return False
+
+
+async def ensure_secret_backend_tables_pg(pool: DatabasePool | None = None) -> bool:
+    """Ensure secret backend registry/reference tables exist for PostgreSQL backends."""
+    try:
+        db_pool = pool or await get_db_pool()
+        if getattr(db_pool, "pool", None) is None:
+            return False
+
+        try:
+            await ensure_authnz_core_tables_pg(db_pool)
+        except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug(f"ensure_secret_backend_tables_pg: core table ensure skipped/failed: {exc}")
+
+        for ddl_group in (
+            _CREATE_SECRET_BACKENDS,
+            _CREATE_MANAGED_SECRET_REFS,
+        ):
+            for sql, params in ddl_group:
+                try:
+                    await db_pool.execute(sql, *params)
+                except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+                    logger.debug(f"PG ensure secret backend DDL failed: {exc}")
+
+        logger.info("Ensured PostgreSQL secret backend tables (idempotent)")
+        return True
+    except _PG_MIGRATIONS_NONCRITICAL_EXCEPTIONS as exc:
+        logger.warning(f"Failed to ensure PostgreSQL secret backend tables: {exc}")
         return False
 
 

--- a/tldw_Server_API/app/core/AuthNZ/repos/federated_identity_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/federated_identity_repo.py
@@ -58,9 +58,8 @@ class FederatedIdentityRepo:
             keys = row.keys()
             return {key: row[key] for key in keys}
         except Exception as row_keys_error:
-            logger.debug(
-                "Federated identity row key materialization failed; falling back to dict(row)",
-                exc_info=row_keys_error,
+            logger.opt(exception=row_keys_error).debug(
+                "Federated identity row key materialization failed; falling back to dict(row)"
             )
         return dict(row)
 
@@ -93,6 +92,14 @@ class FederatedIdentityRepo:
     ) -> dict[str, Any]:
         status_value = _normalize_status(status)
         seen_at = last_seen_at or datetime.now(timezone.utc)
+        normalized_subject = external_subject.strip()
+
+        existing = await self.get_by_provider_subject(
+            identity_provider_id=int(identity_provider_id),
+            external_subject=normalized_subject,
+        )
+        if existing is not None and int(existing.get("user_id") or 0) != int(user_id):
+            raise ValueError("Federated subject is already linked to a different local user")
 
         try:
             if getattr(self.db_pool, "pool", None) is not None:
@@ -115,7 +122,7 @@ class FederatedIdentityRepo:
                               external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
                     """,
                     int(identity_provider_id),
-                    external_subject.strip(),
+                    normalized_subject,
                     int(user_id),
                     external_username,
                     external_email,
@@ -143,7 +150,7 @@ class FederatedIdentityRepo:
                 """,
                 (
                     int(identity_provider_id),
-                    external_subject.strip(),
+                    normalized_subject,
                     int(user_id),
                     external_username,
                     external_email,
@@ -159,7 +166,7 @@ class FederatedIdentityRepo:
                 FROM federated_identities
                 WHERE identity_provider_id = ? AND external_subject = ?
                 """,
-                (int(identity_provider_id), external_subject.strip()),
+                (int(identity_provider_id), normalized_subject),
             )
             return self._normalize_row(row) if row else {}
         except Exception as exc:

--- a/tldw_Server_API/app/core/AuthNZ/repos/federated_identity_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/federated_identity_repo.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+def _normalize_status(status: str | None) -> str:
+    normalized = (status or "active").strip().lower()
+    if not normalized:
+        raise ValueError("status must not be empty")
+    return normalized
+
+
+@dataclass
+class FederatedIdentityRepo:
+    """Repository for links between external subjects and local users."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_identity_federation_tables_pg,
+                )
+
+                ok = await ensure_identity_federation_tables_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL identity federation schema ensure failed")
+                return
+
+            provider_row = await self.db_pool.fetchone(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='identity_providers'"
+            )
+            identity_row = await self.db_pool.fetchone(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='federated_identities'"
+            )
+            if not provider_row or not identity_row:
+                raise RuntimeError(
+                    "SQLite identity federation tables are missing. "
+                    "Run the AuthNZ migrations/bootstrap (see "
+                    "'python -m tldw_Server_API.app.core.AuthNZ.initialize')."
+                )
+        except Exception as exc:
+            logger.error(f"FederatedIdentityRepo.ensure_tables failed: {exc}")
+            raise
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            keys = row.keys()
+            return {key: row[key] for key in keys}
+        except Exception as row_keys_error:
+            logger.debug(
+                "Federated identity row key materialization failed; falling back to dict(row)",
+                exc_info=row_keys_error,
+            )
+        return dict(row)
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        return value.replace(tzinfo=None) if getattr(value, "tzinfo", None) else value
+
+    @classmethod
+    def _normalize_row(cls, row: Any) -> dict[str, Any]:
+        data = cls._row_to_dict(row)
+        for key in ("last_seen_at", "created_at", "updated_at"):
+            value = data.get(key)
+            if isinstance(value, datetime):
+                data[key] = value.isoformat()
+        return data
+
+    async def upsert_identity(
+        self,
+        *,
+        identity_provider_id: int,
+        external_subject: str,
+        user_id: int,
+        external_username: str | None = None,
+        external_email: str | None = None,
+        last_claims_hash: str | None = None,
+        status: str = "active",
+        last_seen_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        status_value = _normalize_status(status)
+        seen_at = last_seen_at or datetime.now(timezone.utc)
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    INSERT INTO federated_identities (
+                        identity_provider_id, external_subject, user_id, external_username,
+                        external_email, last_claims_hash, last_seen_at, status
+                    )
+                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                    ON CONFLICT (identity_provider_id, external_subject) DO UPDATE SET
+                        user_id = EXCLUDED.user_id,
+                        external_username = EXCLUDED.external_username,
+                        external_email = EXCLUDED.external_email,
+                        last_claims_hash = EXCLUDED.last_claims_hash,
+                        last_seen_at = EXCLUDED.last_seen_at,
+                        status = EXCLUDED.status,
+                        updated_at = CURRENT_TIMESTAMP
+                    RETURNING id, identity_provider_id, external_subject, user_id, external_username,
+                              external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                    """,
+                    int(identity_provider_id),
+                    external_subject.strip(),
+                    int(user_id),
+                    external_username,
+                    external_email,
+                    last_claims_hash,
+                    self._normalize_datetime_for_postgres(seen_at),
+                    status_value,
+                )
+                return self._normalize_row(row) if row else {}
+
+            await self.db_pool.execute(
+                """
+                INSERT INTO federated_identities (
+                    identity_provider_id, external_subject, user_id, external_username,
+                    external_email, last_claims_hash, last_seen_at, status
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(identity_provider_id, external_subject) DO UPDATE SET
+                    user_id = excluded.user_id,
+                    external_username = excluded.external_username,
+                    external_email = excluded.external_email,
+                    last_claims_hash = excluded.last_claims_hash,
+                    last_seen_at = excluded.last_seen_at,
+                    status = excluded.status,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    int(identity_provider_id),
+                    external_subject.strip(),
+                    int(user_id),
+                    external_username,
+                    external_email,
+                    last_claims_hash,
+                    seen_at.isoformat(),
+                    status_value,
+                ),
+            )
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, identity_provider_id, external_subject, user_id, external_username,
+                       external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                FROM federated_identities
+                WHERE identity_provider_id = ? AND external_subject = ?
+                """,
+                (int(identity_provider_id), external_subject.strip()),
+            )
+            return self._normalize_row(row) if row else {}
+        except Exception as exc:
+            logger.error(f"FederatedIdentityRepo.upsert_identity failed: {exc}")
+            raise
+
+    async def get_by_provider_subject(
+        self,
+        *,
+        identity_provider_id: int,
+        external_subject: str,
+    ) -> dict[str, Any] | None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, identity_provider_id, external_subject, user_id, external_username,
+                           external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                    FROM federated_identities
+                    WHERE identity_provider_id = $1 AND external_subject = $2
+                    """,
+                    int(identity_provider_id),
+                    external_subject.strip(),
+                )
+            else:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, identity_provider_id, external_subject, user_id, external_username,
+                           external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                    FROM federated_identities
+                    WHERE identity_provider_id = ? AND external_subject = ?
+                    """,
+                    (int(identity_provider_id), external_subject.strip()),
+                )
+            return self._normalize_row(row) if row else None
+        except Exception as exc:
+            logger.error(f"FederatedIdentityRepo.get_by_provider_subject failed: {exc}")
+            raise
+
+    async def list_for_user(self, *, user_id: int) -> list[dict[str, Any]]:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                rows = await self.db_pool.fetchall(
+                    """
+                    SELECT id, identity_provider_id, external_subject, user_id, external_username,
+                           external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                    FROM federated_identities
+                    WHERE user_id = $1
+                    ORDER BY identity_provider_id, external_subject
+                    """,
+                    int(user_id),
+                )
+            else:
+                rows = await self.db_pool.fetchall(
+                    """
+                    SELECT id, identity_provider_id, external_subject, user_id, external_username,
+                           external_email, last_claims_hash, last_seen_at, status, created_at, updated_at
+                    FROM federated_identities
+                    WHERE user_id = ?
+                    ORDER BY identity_provider_id, external_subject
+                    """,
+                    (int(user_id),),
+                )
+            return [self._normalize_row(row) for row in rows]
+        except Exception as exc:
+            logger.error(f"FederatedIdentityRepo.list_for_user failed: {exc}")
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/federated_managed_grant_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/federated_managed_grant_repo.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+def _normalize_grant_kind(grant_kind: str) -> str:
+    normalized = str(grant_kind or "").strip().lower()
+    if normalized not in {"org", "team", "role"}:
+        raise ValueError(f"Unsupported grant_kind: {grant_kind}")
+    return normalized
+
+
+def _normalize_target_ref(target_ref: str) -> str:
+    normalized = str(target_ref or "").strip()
+    if not normalized:
+        raise ValueError("target_ref must not be empty")
+    return normalized
+
+
+@dataclass
+class FederatedManagedGrantRepo:
+    """Repository for provider-managed membership and role provenance."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_identity_federation_tables_pg,
+                )
+
+                ok = await ensure_identity_federation_tables_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL identity federation schema ensure failed")
+                return
+
+            row = await self.db_pool.fetchone(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='federated_managed_grants'"
+            )
+            if not row:
+                raise RuntimeError(
+                    "SQLite federated_managed_grants table is missing. "
+                    "Run the AuthNZ migrations/bootstrap (see "
+                    "'python -m tldw_Server_API.app.core.AuthNZ.initialize')."
+                )
+        except Exception as exc:
+            logger.error(f"FederatedManagedGrantRepo.ensure_tables failed: {exc}")
+            raise
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return {key: row[key] for key in row.keys()}
+        except Exception as row_keys_error:
+            logger.debug(
+                "Managed grant row key materialization failed; falling back to dict(row)",
+                exc_info=row_keys_error,
+            )
+        return dict(row)
+
+    @classmethod
+    def _normalize_row(cls, row: Any) -> dict[str, Any]:
+        data = cls._row_to_dict(row)
+        for key in ("created_at", "updated_at"):
+            value = data.get(key)
+            if isinstance(value, datetime):
+                data[key] = value.isoformat()
+        return data
+
+    async def list_for_provider_user(
+        self,
+        *,
+        identity_provider_id: int,
+        user_id: int,
+    ) -> list[dict[str, Any]]:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                rows = await self.db_pool.fetchall(
+                    """
+                    SELECT id, identity_provider_id, user_id, grant_kind, target_ref, created_at, updated_at
+                    FROM federated_managed_grants
+                    WHERE identity_provider_id = $1 AND user_id = $2
+                    ORDER BY grant_kind, target_ref
+                    """,
+                    int(identity_provider_id),
+                    int(user_id),
+                )
+            else:
+                rows = await self.db_pool.fetchall(
+                    """
+                    SELECT id, identity_provider_id, user_id, grant_kind, target_ref, created_at, updated_at
+                    FROM federated_managed_grants
+                    WHERE identity_provider_id = ? AND user_id = ?
+                    ORDER BY grant_kind, target_ref
+                    """,
+                    (int(identity_provider_id), int(user_id)),
+                )
+            return [self._normalize_row(row) for row in rows]
+        except Exception as exc:
+            logger.error(f"FederatedManagedGrantRepo.list_for_provider_user failed: {exc}")
+            raise
+
+    async def upsert_grant(
+        self,
+        *,
+        identity_provider_id: int,
+        user_id: int,
+        grant_kind: str,
+        target_ref: str,
+    ) -> dict[str, Any]:
+        normalized_kind = _normalize_grant_kind(grant_kind)
+        normalized_target_ref = _normalize_target_ref(target_ref)
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    INSERT INTO federated_managed_grants (
+                        identity_provider_id, user_id, grant_kind, target_ref
+                    )
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT (identity_provider_id, user_id, grant_kind, target_ref) DO UPDATE SET
+                        updated_at = CURRENT_TIMESTAMP
+                    RETURNING id, identity_provider_id, user_id, grant_kind, target_ref, created_at, updated_at
+                    """,
+                    int(identity_provider_id),
+                    int(user_id),
+                    normalized_kind,
+                    normalized_target_ref,
+                )
+                return self._normalize_row(row) if row else {}
+
+            await self.db_pool.execute(
+                """
+                INSERT INTO federated_managed_grants (
+                    identity_provider_id, user_id, grant_kind, target_ref
+                )
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(identity_provider_id, user_id, grant_kind, target_ref) DO UPDATE SET
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (
+                    int(identity_provider_id),
+                    int(user_id),
+                    normalized_kind,
+                    normalized_target_ref,
+                ),
+            )
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, identity_provider_id, user_id, grant_kind, target_ref, created_at, updated_at
+                FROM federated_managed_grants
+                WHERE identity_provider_id = ? AND user_id = ? AND grant_kind = ? AND target_ref = ?
+                """,
+                (
+                    int(identity_provider_id),
+                    int(user_id),
+                    normalized_kind,
+                    normalized_target_ref,
+                ),
+            )
+            return self._normalize_row(row) if row else {}
+        except Exception as exc:
+            logger.error(f"FederatedManagedGrantRepo.upsert_grant failed: {exc}")
+            raise
+
+    async def delete_grant(
+        self,
+        *,
+        identity_provider_id: int,
+        user_id: int,
+        grant_kind: str,
+        target_ref: str,
+    ) -> bool:
+        normalized_kind = _normalize_grant_kind(grant_kind)
+        normalized_target_ref = _normalize_target_ref(target_ref)
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    DELETE FROM federated_managed_grants
+                    WHERE identity_provider_id = $1 AND user_id = $2 AND grant_kind = $3 AND target_ref = $4
+                    RETURNING id
+                    """,
+                    int(identity_provider_id),
+                    int(user_id),
+                    normalized_kind,
+                    normalized_target_ref,
+                )
+                return row is not None
+
+            cursor = await self.db_pool.execute(
+                """
+                DELETE FROM federated_managed_grants
+                WHERE identity_provider_id = ? AND user_id = ? AND grant_kind = ? AND target_ref = ?
+                """,
+                (
+                    int(identity_provider_id),
+                    int(user_id),
+                    normalized_kind,
+                    normalized_target_ref,
+                ),
+            )
+            try:
+                return bool((cursor.rowcount or 0) > 0)
+            except AttributeError:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT 1
+                    FROM federated_managed_grants
+                    WHERE identity_provider_id = ? AND user_id = ? AND grant_kind = ? AND target_ref = ?
+                    """,
+                    (
+                        int(identity_provider_id),
+                        int(user_id),
+                        normalized_kind,
+                        normalized_target_ref,
+                    ),
+                )
+                return row is None
+        except Exception as exc:
+            logger.error(f"FederatedManagedGrantRepo.delete_grant failed: {exc}")
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/identity_provider_repo.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+def _normalize_scope_type(scope_type: str) -> str:
+    normalized = (scope_type or "").strip().lower()
+    if normalized in {"global", "system"}:
+        return "global"
+    if normalized in {"org", "organization", "organizations"}:
+        return "org"
+    raise ValueError(f"Invalid owner_scope_type: {scope_type}")
+
+
+def _normalize_scope_id(scope_type: str, scope_id: int | None) -> int | None:
+    if scope_type == "global":
+        return None
+    if scope_id is None:
+        raise ValueError("owner_scope_id is required for org-scoped identity providers")
+    return int(scope_id)
+
+
+def _normalize_provider_type(provider_type: str) -> str:
+    normalized = (provider_type or "").strip().lower()
+    if normalized == "oidc":
+        return normalized
+    raise ValueError(f"Unsupported provider_type: {provider_type}")
+
+
+@dataclass
+class IdentityProviderRepo:
+    """Repository for trusted identity provider configuration."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_identity_federation_tables_pg,
+                )
+
+                ok = await ensure_identity_federation_tables_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL identity federation schema ensure failed")
+                return
+
+            provider_row = await self.db_pool.fetchone(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='identity_providers'"
+            )
+            if not provider_row:
+                raise RuntimeError(
+                    "SQLite identity_providers table is missing. "
+                    "Run the AuthNZ migrations/bootstrap (see "
+                    "'python -m tldw_Server_API.app.core.AuthNZ.initialize')."
+                )
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.ensure_tables failed: {exc}")
+            raise
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            keys = row.keys()
+            return {key: row[key] for key in keys}
+        except Exception as row_keys_error:
+            logger.debug(
+                "Identity provider row key materialization failed; falling back to dict(row)",
+                exc_info=row_keys_error,
+            )
+        return dict(row)
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        return value.replace(tzinfo=None) if getattr(value, "tzinfo", None) else value
+
+    @classmethod
+    def _normalize_row(cls, row: Any) -> dict[str, Any]:
+        data = cls._row_to_dict(row)
+        for key in ("created_at", "updated_at"):
+            value = data.get(key)
+            if isinstance(value, datetime):
+                data[key] = value.isoformat()
+        if "enabled" in data:
+            data["enabled"] = bool(data["enabled"])
+        for raw_key, clean_key in (
+            ("claim_mapping_json", "claim_mapping"),
+            ("provisioning_policy_json", "provisioning_policy"),
+        ):
+            raw_value = data.pop(raw_key, None)
+            if isinstance(raw_value, str) and raw_value.strip():
+                try:
+                    data[clean_key] = json.loads(raw_value)
+                except json.JSONDecodeError:
+                    data[clean_key] = {}
+            else:
+                data[clean_key] = raw_value if isinstance(raw_value, dict) else {}
+        return data
+
+    async def create_provider(
+        self,
+        *,
+        slug: str,
+        provider_type: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        enabled: bool,
+        issuer: str,
+        claim_mapping: dict[str, Any] | None,
+        provisioning_policy: dict[str, Any] | None,
+        display_name: str | None = None,
+        discovery_url: str | None = None,
+        authorization_url: str | None = None,
+        token_url: str | None = None,
+        jwks_url: str | None = None,
+        client_id: str | None = None,
+        client_secret_ref: str | None = None,
+        created_by: int | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        scope_id = _normalize_scope_id(scope_type, owner_scope_id)
+        provider_kind = _normalize_provider_type(provider_type)
+        claim_mapping_json = json.dumps(claim_mapping or {})
+        provisioning_policy_json = json.dumps(provisioning_policy or {})
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    INSERT INTO identity_providers (
+                        slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                        display_name, issuer, discovery_url, authorization_url, token_url,
+                        jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                        provisioning_policy_json, created_by, updated_by
+                    )
+                    VALUES (
+                        $1, $2, $3, $4, $5,
+                        $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14,
+                        $15, $16, $17
+                    )
+                    RETURNING id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                              display_name, issuer, discovery_url, authorization_url, token_url,
+                              jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                              provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    """,
+                    slug.strip(),
+                    provider_kind,
+                    scope_type,
+                    scope_id,
+                    enabled,
+                    display_name,
+                    issuer.strip(),
+                    discovery_url,
+                    authorization_url,
+                    token_url,
+                    jwks_url,
+                    client_id,
+                    client_secret_ref,
+                    claim_mapping_json,
+                    provisioning_policy_json,
+                    created_by,
+                    updated_by,
+                )
+                return self._normalize_row(row) if row else {}
+
+            cursor = await self.db_pool.execute(
+                """
+                INSERT INTO identity_providers (
+                    slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                    display_name, issuer, discovery_url, authorization_url, token_url,
+                    jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                    provisioning_policy_json, created_by, updated_by
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    slug.strip(),
+                    provider_kind,
+                    scope_type,
+                    scope_id,
+                    int(enabled),
+                    display_name,
+                    issuer.strip(),
+                    discovery_url,
+                    authorization_url,
+                    token_url,
+                    jwks_url,
+                    client_id,
+                    client_secret_ref,
+                    claim_mapping_json,
+                    provisioning_policy_json,
+                    created_by,
+                    updated_by,
+                ),
+            )
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                       display_name, issuer, discovery_url, authorization_url, token_url,
+                       jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                       provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                FROM identity_providers
+                WHERE id = ?
+                """,
+                (cursor.lastrowid,),
+            )
+            return self._normalize_row(row) if row else {}
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.create_provider failed: {exc}")
+            raise
+
+    async def get_provider(self, provider_id: int) -> dict[str, Any] | None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    WHERE id = $1
+                    """,
+                    int(provider_id),
+                )
+            else:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    WHERE id = ?
+                    """,
+                    (int(provider_id),),
+                )
+            return self._normalize_row(row) if row else None
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.get_provider failed: {exc}")
+            raise
+
+    async def get_provider_by_slug(
+        self,
+        *,
+        slug: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+    ) -> dict[str, Any] | None:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        scope_id = _normalize_scope_id(scope_type, owner_scope_id)
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    WHERE slug = $1 AND owner_scope_type = $2
+                      AND COALESCE(owner_scope_id, 0) = COALESCE($3, 0)
+                    """,
+                    slug.strip(),
+                    scope_type,
+                    scope_id,
+                )
+            else:
+                row = await self.db_pool.fetchone(
+                    """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    WHERE slug = ? AND owner_scope_type = ?
+                      AND COALESCE(owner_scope_id, 0) = COALESCE(?, 0)
+                    """,
+                    (slug.strip(), scope_type, scope_id),
+                )
+            return self._normalize_row(row) if row else None
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.get_provider_by_slug failed: {exc}")
+            raise
+
+    async def list_providers(
+        self,
+        *,
+        owner_scope_type: str | None = None,
+        owner_scope_id: int | None = None,
+        enabled: bool | None = None,
+    ) -> list[dict[str, Any]]:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                clauses: list[str] = []
+                params: list[Any] = []
+                index = 1
+                if owner_scope_type is not None:
+                    scope_type = _normalize_scope_type(owner_scope_type)
+                    scope_id = _normalize_scope_id(scope_type, owner_scope_id)
+                    clauses.append(f"owner_scope_type = ${index}")
+                    params.append(scope_type)
+                    index += 1
+                    clauses.append(f"COALESCE(owner_scope_id, 0) = COALESCE(${index}, 0)")
+                    params.append(scope_id)
+                    index += 1
+                if enabled is not None:
+                    clauses.append(f"enabled = ${index}")
+                    params.append(enabled)
+                    index += 1
+                where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+                list_sql_template = """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    {where}
+                    ORDER BY owner_scope_type, slug
+                """
+                list_sql = list_sql_template.format_map(locals())  # nosec B608
+                rows = await self.db_pool.fetchall(list_sql, *params)
+            else:
+                clauses = []
+                params = []
+                if owner_scope_type is not None:
+                    scope_type = _normalize_scope_type(owner_scope_type)
+                    scope_id = _normalize_scope_id(scope_type, owner_scope_id)
+                    clauses.append("owner_scope_type = ?")
+                    params.append(scope_type)
+                    clauses.append("COALESCE(owner_scope_id, 0) = COALESCE(?, 0)")
+                    params.append(scope_id)
+                if enabled is not None:
+                    clauses.append("enabled = ?")
+                    params.append(int(enabled))
+                where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+                list_sql_template = """
+                    SELECT id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                           display_name, issuer, discovery_url, authorization_url, token_url,
+                           jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                           provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    FROM identity_providers
+                    {where}
+                    ORDER BY owner_scope_type, slug
+                """
+                list_sql = list_sql_template.format_map(locals())  # nosec B608
+                rows = await self.db_pool.fetchall(list_sql, tuple(params))
+            return [self._normalize_row(row) for row in rows]
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.list_providers failed: {exc}")
+            raise
+
+    async def update_provider(
+        self,
+        provider_id: int,
+        *,
+        slug: str,
+        provider_type: str,
+        owner_scope_type: str,
+        owner_scope_id: int | None,
+        enabled: bool,
+        issuer: str,
+        claim_mapping: dict[str, Any] | None,
+        provisioning_policy: dict[str, Any] | None,
+        display_name: str | None = None,
+        discovery_url: str | None = None,
+        authorization_url: str | None = None,
+        token_url: str | None = None,
+        jwks_url: str | None = None,
+        client_id: str | None = None,
+        client_secret_ref: str | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any] | None:
+        scope_type = _normalize_scope_type(owner_scope_type)
+        scope_id = _normalize_scope_id(scope_type, owner_scope_id)
+        provider_kind = _normalize_provider_type(provider_type)
+        claim_mapping_json = json.dumps(claim_mapping or {})
+        provisioning_policy_json = json.dumps(provisioning_policy or {})
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                row = await self.db_pool.fetchone(
+                    """
+                    UPDATE identity_providers
+                    SET slug = $2,
+                        provider_type = $3,
+                        owner_scope_type = $4,
+                        owner_scope_id = $5,
+                        enabled = $6,
+                        display_name = $7,
+                        issuer = $8,
+                        discovery_url = $9,
+                        authorization_url = $10,
+                        token_url = $11,
+                        jwks_url = $12,
+                        client_id = $13,
+                        client_secret_ref = $14,
+                        claim_mapping_json = $15,
+                        provisioning_policy_json = $16,
+                        updated_by = $17,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = $1
+                    RETURNING id, slug, provider_type, owner_scope_type, owner_scope_id, enabled,
+                              display_name, issuer, discovery_url, authorization_url, token_url,
+                              jwks_url, client_id, client_secret_ref, claim_mapping_json,
+                              provisioning_policy_json, created_by, updated_by, created_at, updated_at
+                    """,
+                    int(provider_id),
+                    slug.strip(),
+                    provider_kind,
+                    scope_type,
+                    scope_id,
+                    enabled,
+                    display_name,
+                    issuer.strip(),
+                    discovery_url,
+                    authorization_url,
+                    token_url,
+                    jwks_url,
+                    client_id,
+                    client_secret_ref,
+                    claim_mapping_json,
+                    provisioning_policy_json,
+                    updated_by,
+                )
+                return self._normalize_row(row) if row else None
+
+            await self.db_pool.execute(
+                """
+                UPDATE identity_providers
+                SET slug = ?,
+                    provider_type = ?,
+                    owner_scope_type = ?,
+                    owner_scope_id = ?,
+                    enabled = ?,
+                    display_name = ?,
+                    issuer = ?,
+                    discovery_url = ?,
+                    authorization_url = ?,
+                    token_url = ?,
+                    jwks_url = ?,
+                    client_id = ?,
+                    client_secret_ref = ?,
+                    claim_mapping_json = ?,
+                    provisioning_policy_json = ?,
+                    updated_by = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (
+                    slug.strip(),
+                    provider_kind,
+                    scope_type,
+                    scope_id,
+                    int(enabled),
+                    display_name,
+                    issuer.strip(),
+                    discovery_url,
+                    authorization_url,
+                    token_url,
+                    jwks_url,
+                    client_id,
+                    client_secret_ref,
+                    claim_mapping_json,
+                    provisioning_policy_json,
+                    updated_by,
+                    int(provider_id),
+                ),
+            )
+            return await self.get_provider(int(provider_id))
+        except Exception as exc:
+            logger.error(f"IdentityProviderRepo.update_provider failed: {exc}")
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    normalize_provider_name,
+    normalize_secret_owner_scope_type,
+)
+
+
+@dataclass
+class ManagedSecretRefsRepo:
+    """Repository for logical secret references and backend registrations."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                from tldw_Server_API.app.core.AuthNZ.pg_migrations_extra import (
+                    ensure_secret_backend_tables_pg,
+                )
+
+                ok = await ensure_secret_backend_tables_pg(self.db_pool)
+                if not ok:
+                    raise RuntimeError("PostgreSQL secret backend schema ensure failed")
+                return
+
+            for table_name in ("secret_backends", "managed_secret_refs"):
+                row = await self.db_pool.fetchone(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table_name,),
+                )
+                if not row:
+                    raise RuntimeError(
+                        f"SQLite {table_name} table is missing. "
+                        "Run the AuthNZ migrations/bootstrap (see "
+                        "'python -m tldw_Server_API.app.core.AuthNZ.initialize')."
+                    )
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.ensure_tables failed: {}", exc)
+            raise
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(dt: datetime | None) -> datetime | None:
+        if dt is None:
+            return None
+        return dt.replace(tzinfo=None) if getattr(dt, "tzinfo", None) else dt
+
+    @staticmethod
+    def _parse_json_field(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return dict(value)
+        if isinstance(value, str) and value.strip():
+            try:
+                parsed = json.loads(value)
+            except (TypeError, ValueError):
+                return {}
+            return dict(parsed) if isinstance(parsed, dict) else {}
+        return {}
+
+    @classmethod
+    def _row_to_dict(cls, row: Any) -> dict[str, Any]:
+        if isinstance(row, dict):
+            raw = dict(row)
+        else:
+            try:
+                raw = {key: row[key] for key in row.keys()}
+            except Exception as row_keys_error:
+                logger.debug(
+                    "Managed secret ref row key materialization failed; falling back to dict(row)",
+                    exc_info=row_keys_error,
+                )
+                raw = dict(row)
+
+        if "capabilities_json" in raw:
+            raw["capabilities"] = cls._parse_json_field(raw.get("capabilities_json"))
+        if "metadata_json" in raw:
+            raw["metadata"] = cls._parse_json_field(raw.get("metadata_json"))
+        return raw
+
+    async def ensure_backend_registration(
+        self,
+        *,
+        name: str,
+        display_name: str,
+        capabilities: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+        status: str = "enabled",
+    ) -> dict[str, Any]:
+        capabilities_json = json.dumps(capabilities or {})
+        metadata_json = json.dumps(metadata or {})
+        now = datetime.now(timezone.utc)
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                ts = self._normalize_datetime_for_postgres(now)
+                row = await self.db_pool.fetchone(
+                    """
+                    INSERT INTO secret_backends (
+                        name, display_name, status, capabilities_json, metadata_json, created_at, updated_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $6)
+                    ON CONFLICT (name) DO UPDATE SET
+                        display_name = EXCLUDED.display_name,
+                        status = EXCLUDED.status,
+                        capabilities_json = EXCLUDED.capabilities_json,
+                        metadata_json = EXCLUDED.metadata_json,
+                        updated_at = EXCLUDED.updated_at
+                    RETURNING name, display_name, status, capabilities_json, metadata_json, created_at, updated_at
+                    """,
+                    name,
+                    display_name,
+                    status,
+                    capabilities_json,
+                    metadata_json,
+                    ts,
+                )
+                return self._row_to_dict(row) if row else {}
+
+            await self.db_pool.execute(
+                """
+                INSERT INTO secret_backends (
+                    name, display_name, status, capabilities_json, metadata_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(name) DO UPDATE SET
+                    display_name = excluded.display_name,
+                    status = excluded.status,
+                    capabilities_json = excluded.capabilities_json,
+                    metadata_json = excluded.metadata_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    name,
+                    display_name,
+                    status,
+                    capabilities_json,
+                    metadata_json,
+                    now.isoformat(),
+                    now.isoformat(),
+                ),
+            )
+            row = await self.db_pool.fetchone(
+                """
+                SELECT name, display_name, status, capabilities_json, metadata_json, created_at, updated_at
+                FROM secret_backends
+                WHERE name = ?
+                """,
+                (name,),
+            )
+            return self._row_to_dict(row) if row else {}
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.ensure_backend_registration failed: {}", exc)
+            raise
+
+    async def upsert_ref(
+        self,
+        *,
+        backend_name: str,
+        owner_scope_type: str,
+        owner_scope_id: int,
+        provider_key: str,
+        backend_ref: str | None,
+        metadata: dict[str, Any] | None,
+        display_name: str | None = None,
+        status: str = "active",
+        expires_at: datetime | None = None,
+        created_by: int | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        scope_type = normalize_secret_owner_scope_type(owner_scope_type)
+        provider = normalize_provider_name(provider_key)
+        metadata_json = json.dumps(metadata or {})
+        now = datetime.now(timezone.utc)
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                ts = self._normalize_datetime_for_postgres(now)
+                expires_ts = self._normalize_datetime_for_postgres(expires_at)
+                row = await self.db_pool.fetchone(
+                    """
+                    INSERT INTO managed_secret_refs (
+                        backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                        display_name, status, metadata_json, expires_at,
+                        created_by, updated_by, created_at, updated_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $12)
+                    ON CONFLICT (backend_name, owner_scope_type, owner_scope_id, provider_key) DO UPDATE SET
+                        backend_ref = EXCLUDED.backend_ref,
+                        display_name = EXCLUDED.display_name,
+                        status = EXCLUDED.status,
+                        metadata_json = EXCLUDED.metadata_json,
+                        expires_at = EXCLUDED.expires_at,
+                        revoked_at = NULL,
+                        revoked_by = NULL,
+                        updated_by = EXCLUDED.updated_by,
+                        updated_at = EXCLUDED.updated_at
+                    RETURNING id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                              display_name, status, metadata_json, last_resolved_at, expires_at,
+                              created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                    """,
+                    backend_name,
+                    scope_type,
+                    int(owner_scope_id),
+                    provider,
+                    backend_ref,
+                    display_name,
+                    status,
+                    metadata_json,
+                    expires_ts,
+                    created_by,
+                    updated_by,
+                    ts,
+                )
+                return self._row_to_dict(row) if row else {}
+
+            await self.db_pool.execute(
+                """
+                INSERT INTO managed_secret_refs (
+                    backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                    display_name, status, metadata_json, expires_at,
+                    created_by, updated_by, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(backend_name, owner_scope_type, owner_scope_id, provider_key) DO UPDATE SET
+                    backend_ref = excluded.backend_ref,
+                    display_name = excluded.display_name,
+                    status = excluded.status,
+                    metadata_json = excluded.metadata_json,
+                    expires_at = excluded.expires_at,
+                    revoked_at = NULL,
+                    revoked_by = NULL,
+                    updated_by = excluded.updated_by,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    backend_name,
+                    scope_type,
+                    int(owner_scope_id),
+                    provider,
+                    backend_ref,
+                    display_name,
+                    status,
+                    metadata_json,
+                    expires_at.isoformat() if expires_at else None,
+                    created_by,
+                    updated_by,
+                    now.isoformat(),
+                    now.isoformat(),
+                ),
+            )
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                       display_name, status, metadata_json, last_resolved_at, expires_at,
+                       created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                FROM managed_secret_refs
+                WHERE backend_name = ? AND owner_scope_type = ? AND owner_scope_id = ? AND provider_key = ?
+                """,
+                (backend_name, scope_type, int(owner_scope_id), provider),
+            )
+            return self._row_to_dict(row) if row else {}
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.upsert_ref failed: {}", exc)
+            raise
+
+    async def get_ref(
+        self,
+        ref_id: int,
+        *,
+        include_revoked: bool = False,
+    ) -> dict[str, Any] | None:
+        revoked_clause = "" if include_revoked else " AND revoked_at IS NULL"
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                get_ref_sql_template = """
+                    SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                           display_name, status, metadata_json, last_resolved_at, expires_at,
+                           created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                    FROM managed_secret_refs
+                    WHERE id = $1{revoked_clause}
+                    """
+                get_ref_sql = get_ref_sql_template.format_map(locals())  # nosec B608
+                row = await self.db_pool.fetchone(get_ref_sql, int(ref_id))
+            else:
+                get_ref_sql_template = """
+                    SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                           display_name, status, metadata_json, last_resolved_at, expires_at,
+                           created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                    FROM managed_secret_refs
+                    WHERE id = ?{revoked_clause}
+                    """
+                get_ref_sql = get_ref_sql_template.format_map(locals())  # nosec B608
+                row = await self.db_pool.fetchone(get_ref_sql, (int(ref_id),))
+            return self._row_to_dict(row) if row else None
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.get_ref failed: {}", exc)
+            raise
+
+    async def touch_last_resolved(
+        self,
+        ref_id: int,
+        *,
+        resolved_at: datetime,
+        expires_at: datetime | None = None,
+    ) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                ts = self._normalize_datetime_for_postgres(resolved_at)
+                expires_ts = self._normalize_datetime_for_postgres(expires_at)
+                await self.db_pool.execute(
+                    """
+                    UPDATE managed_secret_refs
+                    SET last_resolved_at = $1, expires_at = $2, updated_at = $1
+                    WHERE id = $3
+                    """,
+                    ts,
+                    expires_ts,
+                    int(ref_id),
+                )
+                return
+
+            await self.db_pool.execute(
+                """
+                UPDATE managed_secret_refs
+                SET last_resolved_at = ?, expires_at = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    resolved_at.isoformat(),
+                    expires_at.isoformat() if expires_at else None,
+                    resolved_at.isoformat(),
+                    int(ref_id),
+                ),
+            )
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.touch_last_resolved failed: {}", exc)
+            raise
+
+    async def delete_ref(
+        self,
+        ref_id: int,
+        *,
+        revoked_by: int | None = None,
+        revoked_at: datetime | None = None,
+    ) -> bool:
+        revoked_ts = revoked_at or datetime.now(timezone.utc)
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                ts = self._normalize_datetime_for_postgres(revoked_ts)
+                result = await self.db_pool.execute(
+                    """
+                    UPDATE managed_secret_refs
+                    SET revoked_at = $1, revoked_by = $2, updated_at = $1, updated_by = $3
+                    WHERE id = $4 AND revoked_at IS NULL
+                    """,
+                    ts,
+                    revoked_by,
+                    revoked_by,
+                    int(ref_id),
+                )
+                if isinstance(result, str):
+                    parts = result.split()
+                    if parts and parts[-1].isdigit():
+                        return int(parts[-1]) > 0
+                return True
+
+            cursor = await self.db_pool.execute(
+                """
+                UPDATE managed_secret_refs
+                SET revoked_at = ?, revoked_by = ?, updated_at = ?, updated_by = ?
+                WHERE id = ? AND revoked_at IS NULL
+                """,
+                (
+                    revoked_ts.isoformat(),
+                    revoked_by,
+                    revoked_ts.isoformat(),
+                    revoked_by,
+                    int(ref_id),
+                ),
+            )
+            rowcount = getattr(cursor, "rowcount", 0)
+            return rowcount > 0
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.delete_ref failed: {}", exc)
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/managed_secret_refs_repo.py
@@ -298,6 +298,62 @@ class ManagedSecretRefsRepo:
             logger.error("ManagedSecretRefsRepo.get_ref failed: {}", exc)
             raise
 
+    async def list_refs_by_ids(
+        self,
+        ref_ids: list[int],
+        *,
+        include_revoked: bool = False,
+    ) -> dict[int, dict[str, Any]]:
+        """Return managed secret refs keyed by id for the supplied identifiers."""
+        normalized_ids = sorted({int(ref_id) for ref_id in ref_ids if int(ref_id) > 0})
+        if not normalized_ids:
+            return {}
+
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                list_refs_sql = """
+                    SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                           display_name, status, metadata_json, last_resolved_at, expires_at,
+                           created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                    FROM managed_secret_refs
+                    WHERE id = ANY($1::int[]) AND revoked_at IS NULL
+                    """
+                if include_revoked:
+                    list_refs_sql = """
+                        SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                               display_name, status, metadata_json, last_resolved_at, expires_at,
+                               created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                        FROM managed_secret_refs
+                        WHERE id = ANY($1::int[])
+                        """
+                rows = await self.db_pool.fetchall(list_refs_sql, normalized_ids)
+            else:
+                list_refs_sql = """
+                    SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                           display_name, status, metadata_json, last_resolved_at, expires_at,
+                           created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                    FROM managed_secret_refs
+                    WHERE id IN (SELECT CAST(value AS INTEGER) FROM json_each(?)) AND revoked_at IS NULL
+                    """
+                if include_revoked:
+                    list_refs_sql = """
+                        SELECT id, backend_name, owner_scope_type, owner_scope_id, provider_key, backend_ref,
+                               display_name, status, metadata_json, last_resolved_at, expires_at,
+                               created_by, updated_by, revoked_by, revoked_at, created_at, updated_at
+                        FROM managed_secret_refs
+                        WHERE id IN (SELECT CAST(value AS INTEGER) FROM json_each(?))
+                        """
+                rows = await self.db_pool.fetchall(list_refs_sql, (json.dumps(normalized_ids),))
+            return {
+                int(row_dict["id"]): row_dict
+                for row in rows
+                for row_dict in [self._row_to_dict(row)]
+                if row_dict.get("id") is not None
+            }
+        except Exception as exc:
+            logger.error("ManagedSecretRefsRepo.list_refs_by_ids failed: {}", exc)
+            raise
+
     async def touch_last_resolved(
         self,
         ref_id: int,

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -3914,10 +3914,16 @@ class McpHubRepo:
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         usage = dict(usage_rules or {})
+        default_credential_ref = "slot" if normalized_slot_name else "server"
         normalized_credential_ref = _normalize_credential_ref(
             credential_ref,
-            default_ref="slot" if normalized_slot_name else "server",
+            default_ref=default_credential_ref,
         )
+        if (
+            normalized_binding_mode == "disable"
+            and normalized_credential_ref != default_credential_ref
+        ):
+            raise ValueError("disable bindings may not store explicit credential refs")
 
         await self.db_pool.execute(
             """

--- a/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/mcp_hub_repo.py
@@ -28,6 +28,7 @@ _VALID_APPROVAL_MODES = {
 _VALID_CREDENTIAL_SLOT_PRIVILEGE_CLASSES = {"read", "write", "admin"}
 _VALID_CREDENTIAL_BINDING_TARGET_TYPES = {"profile", "assignment"}
 _VALID_CREDENTIAL_BINDING_MODES = {"grant", "disable"}
+_MANAGED_SECRET_REF_PREFIX = "".join(("managed_", "secret_", "ref", ":"))
 _UNSET = object()
 
 
@@ -109,6 +110,34 @@ def _normalize_credential_slot_privilege_class(privilege_class: str | None) -> s
     if value not in _VALID_CREDENTIAL_SLOT_PRIVILEGE_CLASSES:
         raise ValueError(f"Invalid credential slot privilege_class: {privilege_class}")
     return value
+
+
+def parse_managed_secret_ref_id(credential_ref: Any) -> int | None:
+    value = str(credential_ref or "").strip().lower()
+    if not value.startswith(_MANAGED_SECRET_REF_PREFIX):
+        return None
+    raw_ref_id = value[len(_MANAGED_SECRET_REF_PREFIX) :].strip()
+    if not raw_ref_id.isdigit():
+        raise ValueError(f"Invalid managed secret credential_ref: {credential_ref}")
+    return int(raw_ref_id)
+
+
+def encode_managed_secret_credential_ref(secret_ref_id: int) -> str:
+    if int(secret_ref_id) <= 0:
+        raise ValueError("managed_secret_ref_id must be positive")
+    return f"{_MANAGED_SECRET_REF_PREFIX}{int(secret_ref_id)}"
+
+
+def _normalize_credential_ref(credential_ref: Any, *, default_ref: str) -> str:
+    value = str(credential_ref or "").strip().lower()
+    if not value:
+        value = default_ref
+    if value in {"server", "slot"}:
+        return value
+    managed_secret_ref_id = parse_managed_secret_ref_id(value)
+    if managed_secret_ref_id is not None:
+        return encode_managed_secret_credential_ref(managed_secret_ref_id)
+    raise ValueError(f"Invalid credential_ref: {credential_ref}")
 
 
 def _load_json_dict(raw: Any) -> dict[str, Any]:
@@ -429,6 +458,11 @@ class McpHubRepo:
         usage_rules = _load_json_dict(out.pop("usage_rules_json", None))
         out["usage_rules"] = usage_rules
         out["slot_name"] = _normalize_slot_name(out.get("slot_name"), allow_blank=True) or None
+        out["credential_ref"] = _normalize_credential_ref(
+            out.get("credential_ref"),
+            default_ref="slot" if out["slot_name"] else "server",
+        )
+        out["managed_secret_ref_id"] = parse_managed_secret_ref_id(out.get("credential_ref"))
         out["binding_mode"] = str(
             out.get("binding_mode") or usage_rules.get("binding_mode") or "grant"
         )
@@ -3880,6 +3914,10 @@ class McpHubRepo:
         now = datetime.now(timezone.utc)
         ts = now if getattr(self.db_pool, "pool", None) is not None else now.isoformat()
         usage = dict(usage_rules or {})
+        normalized_credential_ref = _normalize_credential_ref(
+            credential_ref,
+            default_ref="slot" if normalized_slot_name else "server",
+        )
 
         await self.db_pool.execute(
             """
@@ -3902,7 +3940,7 @@ class McpHubRepo:
                 target_id,
                 external_server_id.strip(),
                 normalized_slot_name,
-                str(credential_ref or "server").strip(),
+                normalized_credential_ref,
                 normalized_binding_mode,
                 json.dumps(usage),
                 actor_id,

--- a/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/users_repo.py
@@ -442,3 +442,103 @@ class AuthnzUsersRepo:
         except Exception as exc:  # pragma: no cover - surfaced via callers
             logger.error(f"AuthnzUsersRepo.assign_role_if_missing failed: {exc}")
             raise
+
+    async def has_role_assignment(
+        self,
+        *,
+        user_id: int,
+        role_name: str,
+    ) -> bool:
+        """Return True when the user currently has the named role assignment."""
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    exists = await conn.fetchval(
+                        """
+                        SELECT 1
+                        FROM user_roles ur
+                        JOIN roles r ON r.id = ur.role_id
+                        WHERE ur.user_id = $1
+                          AND r.name = $2
+                          AND (ur.expires_at IS NULL OR ur.expires_at > CURRENT_TIMESTAMP)
+                        LIMIT 1
+                        """,
+                        int(user_id),
+                        str(role_name),
+                    )
+                    return bool(exists)
+
+                cursor = await conn.execute(
+                    """
+                    SELECT 1
+                    FROM user_roles ur
+                    JOIN roles r ON r.id = ur.role_id
+                    WHERE ur.user_id = ?
+                      AND r.name = ?
+                      AND (ur.expires_at IS NULL OR ur.expires_at > CURRENT_TIMESTAMP)
+                    LIMIT 1
+                    """,
+                    (int(user_id), str(role_name)),
+                )
+                return await cursor.fetchone() is not None
+        except Exception as exc:  # pragma: no cover - surfaced via callers
+            logger.error(f"AuthnzUsersRepo.has_role_assignment failed: {exc}")
+            raise
+
+    async def remove_role_if_present(
+        self,
+        *,
+        user_id: int,
+        role_name: str,
+    ) -> bool:
+        """Remove the named user role assignment when present."""
+        try:
+            async with self.db_pool.transaction() as conn:
+                if self._is_postgres_backend():
+                    row = await conn.fetchrow(
+                        """
+                        DELETE FROM user_roles ur
+                        USING roles r
+                        WHERE ur.role_id = r.id
+                          AND ur.user_id = $1
+                          AND r.name = $2
+                        RETURNING ur.user_id
+                        """,
+                        int(user_id),
+                        str(role_name),
+                    )
+                    return row is not None
+
+                cursor = await conn.execute(
+                    "SELECT id FROM roles WHERE name = ?",
+                    (str(role_name),),
+                )
+                row = await cursor.fetchone()
+                if not row:
+                    return False
+                role_id = int(row[0])
+                delete_cursor = await conn.execute(
+                    """
+                    DELETE FROM user_roles
+                    WHERE user_id = ? AND role_id = ?
+                    """,
+                    (int(user_id), role_id),
+                )
+                with contextlib.suppress(Exception):
+                    await conn.commit()
+                try:
+                    return bool((delete_cursor.rowcount or 0) > 0)
+                except AttributeError:
+                    cursor = await conn.execute(
+                        """
+                        SELECT 1
+                        FROM user_roles
+                        WHERE user_id = ? AND role_id = ?
+                        LIMIT 1
+                        """,
+                        (int(user_id), role_id),
+                    )
+                    return await cursor.fetchone() is None
+        except Exception as exc:  # pragma: no cover - surfaced via callers
+            logger.error(f"AuthnzUsersRepo.remove_role_if_present failed: {exc}")
+            raise

--- a/tldw_Server_API/app/core/AuthNZ/secret_backends/__init__.py
+++ b/tldw_Server_API/app/core/AuthNZ/secret_backends/__init__.py
@@ -1,0 +1,10 @@
+from .base import SecretBackend
+from .local_encrypted import LocalEncryptedSecretBackend
+from .registry import get_secret_backend, list_secret_backend_descriptors
+
+__all__ = [
+    "SecretBackend",
+    "LocalEncryptedSecretBackend",
+    "get_secret_backend",
+    "list_secret_backend_descriptors",
+]

--- a/tldw_Server_API/app/core/AuthNZ/secret_backends/base.py
+++ b/tldw_Server_API/app/core/AuthNZ/secret_backends/base.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+
+
+class SecretBackend(ABC):
+    """Capability-oriented interface for logical secret backends."""
+
+    backend_name: str
+    display_name: str
+    capabilities: dict[str, bool]
+
+    def __init__(self, *, db_pool: DatabasePool) -> None:
+        self.db_pool = db_pool
+
+    @abstractmethod
+    async def ensure_tables(self) -> None:
+        """Ensure backend metadata and backing storage are available."""
+
+    @abstractmethod
+    async def store_ref(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int,
+        provider_key: str,
+        payload: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        display_name: str | None = None,
+        created_by: int | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        """Persist secret material and return the managed logical reference."""
+
+    @abstractmethod
+    async def resolve_for_use(self, secret_ref_id: int) -> dict[str, Any]:
+        """Resolve a logical reference into short-lived execution material."""
+
+    @abstractmethod
+    async def rotate_if_supported(
+        self,
+        secret_ref_id: int,
+        *,
+        payload: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        """Rotate or replace the stored material when the backend supports it."""
+
+    @abstractmethod
+    async def describe_status(self, secret_ref_id: int) -> dict[str, Any]:
+        """Return the current availability/status of a logical reference."""
+
+    @abstractmethod
+    async def delete_ref(
+        self,
+        secret_ref_id: int,
+        *,
+        revoked_by: int | None = None,
+    ) -> bool:
+        """Revoke the logical reference and its backing secret material."""

--- a/tldw_Server_API/app/core/AuthNZ/secret_backends/local_encrypted.py
+++ b/tldw_Server_API/app/core/AuthNZ/secret_backends/local_encrypted.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.org_provider_secrets_repo import (
+    AuthnzOrgProviderSecretsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.user_provider_secrets_repo import (
+    AuthnzUserProviderSecretsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.secret_backends.base import SecretBackend
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    build_managed_secret_backend_ref,
+    decrypt_byok_payload,
+    dumps_envelope,
+    encrypt_byok_payload,
+    key_hint_for_api_key,
+    loads_envelope,
+    normalize_provider_name,
+    normalize_secret_owner_scope_type,
+)
+
+
+class LocalEncryptedSecretBackend(SecretBackend):
+    """Secret backend backed by the existing encrypted BYOK tables."""
+
+    backend_name = "local_encrypted_v1"
+    display_name = "Local Encrypted"
+    capabilities = {
+        "store_ref": True,
+        "resolve_for_use": True,
+        "rotate_if_supported": True,
+        "describe_status": True,
+        "delete_ref": True,
+    }
+    default_ephemeral_ttl_seconds = 300
+
+    def __init__(self, *, db_pool, ephemeral_ttl_seconds: int | None = None) -> None:
+        super().__init__(db_pool=db_pool)
+        self.ephemeral_ttl_seconds = max(60, int(ephemeral_ttl_seconds or self.default_ephemeral_ttl_seconds))
+
+    async def ensure_tables(self) -> None:
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        await managed_repo.ensure_tables()
+        await managed_repo.ensure_backend_registration(
+            name=self.backend_name,
+            display_name=self.display_name,
+            capabilities=self.capabilities,
+        )
+
+    @staticmethod
+    def _validate_payload(payload: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(payload, dict) or not payload:
+            raise ValueError("Local encrypted secret payload must be a non-empty object")
+        return dict(payload)
+
+    async def _store_underlying_secret(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int,
+        provider_key: str,
+        payload: dict[str, Any],
+        updated_at: datetime,
+        created_by: int | None,
+        updated_by: int | None,
+    ) -> None:
+        encrypted_blob = dumps_envelope(encrypt_byok_payload(payload))
+        api_key = payload.get("api_key")
+        key_hint = key_hint_for_api_key(str(api_key or "")) or None
+        metadata = {
+            "backend_name": self.backend_name,
+            "provider_key": provider_key,
+        }
+
+        if owner_scope_type == "user":
+            repo = AuthnzUserProviderSecretsRepo(self.db_pool)
+            await repo.ensure_tables()
+            await repo.upsert_secret(
+                user_id=int(owner_scope_id),
+                provider=provider_key,
+                encrypted_blob=encrypted_blob,
+                key_hint=key_hint,
+                metadata=metadata,
+                updated_at=updated_at,
+                created_by=created_by,
+                updated_by=updated_by,
+            )
+            return
+
+        repo = AuthnzOrgProviderSecretsRepo(self.db_pool)
+        await repo.ensure_tables()
+        await repo.upsert_secret(
+            scope_type=owner_scope_type,
+            scope_id=int(owner_scope_id),
+            provider=provider_key,
+            encrypted_blob=encrypted_blob,
+            key_hint=key_hint,
+            metadata=metadata,
+            updated_at=updated_at,
+            created_by=created_by,
+            updated_by=updated_by,
+        )
+
+    async def store_ref(
+        self,
+        *,
+        owner_scope_type: str,
+        owner_scope_id: int,
+        provider_key: str,
+        payload: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        display_name: str | None = None,
+        created_by: int | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        await self.ensure_tables()
+        scope_type = normalize_secret_owner_scope_type(owner_scope_type)
+        provider = normalize_provider_name(provider_key)
+        normalized_payload = self._validate_payload(payload)
+        now = datetime.now(timezone.utc)
+
+        await self._store_underlying_secret(
+            owner_scope_type=scope_type,
+            owner_scope_id=int(owner_scope_id),
+            provider_key=provider,
+            payload=normalized_payload,
+            updated_at=now,
+            created_by=created_by,
+            updated_by=updated_by,
+        )
+
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        return await managed_repo.upsert_ref(
+            backend_name=self.backend_name,
+            owner_scope_type=scope_type,
+            owner_scope_id=int(owner_scope_id),
+            provider_key=provider,
+            backend_ref=build_managed_secret_backend_ref(scope_type, int(owner_scope_id), provider),
+            metadata=metadata,
+            display_name=display_name,
+            status="active",
+            created_by=created_by,
+            updated_by=updated_by,
+        )
+
+    async def _fetch_underlying_secret_row(self, ref: dict[str, Any]) -> tuple[dict[str, Any] | None, Any]:
+        scope_type = normalize_secret_owner_scope_type(str(ref.get("owner_scope_type") or ""))
+        scope_id = int(ref["owner_scope_id"])
+        provider = normalize_provider_name(str(ref.get("provider_key") or ""))
+
+        if scope_type == "user":
+            repo = AuthnzUserProviderSecretsRepo(self.db_pool)
+            await repo.ensure_tables()
+            return await repo.fetch_secret_for_user(scope_id, provider), repo
+
+        repo = AuthnzOrgProviderSecretsRepo(self.db_pool)
+        await repo.ensure_tables()
+        return await repo.fetch_secret(scope_type, scope_id, provider), repo
+
+    async def resolve_for_use(self, secret_ref_id: int) -> dict[str, Any]:
+        await self.ensure_tables()
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        ref = await managed_repo.get_ref(int(secret_ref_id))
+        if not ref:
+            raise ValueError("Managed secret ref is not available")
+
+        secret_row, repo = await self._fetch_underlying_secret_row(ref)
+        encrypted_blob = str(secret_row.get("encrypted_blob") or "") if isinstance(secret_row, dict) else ""
+        if not encrypted_blob:
+            raise ValueError("Managed secret payload is not available")
+
+        payload = decrypt_byok_payload(loads_envelope(encrypted_blob))
+        resolved_at = datetime.now(timezone.utc)
+        expires_at = resolved_at + timedelta(seconds=self.ephemeral_ttl_seconds)
+
+        if isinstance(repo, AuthnzUserProviderSecretsRepo):
+            await repo.touch_last_used(int(ref["owner_scope_id"]), str(ref["provider_key"]), resolved_at)
+        else:
+            await repo.touch_last_used(
+                str(ref["owner_scope_type"]),
+                int(ref["owner_scope_id"]),
+                str(ref["provider_key"]),
+                resolved_at,
+            )
+        await managed_repo.touch_last_resolved(
+            int(secret_ref_id),
+            resolved_at=resolved_at,
+            expires_at=expires_at,
+        )
+
+        return {
+            "id": int(ref["id"]),
+            "backend_name": self.backend_name,
+            "owner_scope_type": str(ref["owner_scope_type"]),
+            "owner_scope_id": int(ref["owner_scope_id"]),
+            "provider_key": str(ref["provider_key"]),
+            "material": payload,
+            "resolved_at": resolved_at,
+            "expires_at": expires_at,
+        }
+
+    async def rotate_if_supported(
+        self,
+        secret_ref_id: int,
+        *,
+        payload: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+        updated_by: int | None = None,
+    ) -> dict[str, Any]:
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        ref = await managed_repo.get_ref(int(secret_ref_id))
+        if not ref:
+            raise ValueError("Managed secret ref is not available")
+        return await self.store_ref(
+            owner_scope_type=str(ref["owner_scope_type"]),
+            owner_scope_id=int(ref["owner_scope_id"]),
+            provider_key=str(ref["provider_key"]),
+            payload=payload,
+            metadata=metadata if metadata is not None else ref.get("metadata"),
+            display_name=ref.get("display_name"),
+            created_by=ref.get("created_by"),
+            updated_by=updated_by,
+        )
+
+    async def describe_status(self, secret_ref_id: int) -> dict[str, Any]:
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        ref = await managed_repo.get_ref(int(secret_ref_id), include_revoked=True)
+        if not ref:
+            return {"state": "missing", "backend_name": self.backend_name}
+        if ref.get("revoked_at"):
+            return {"state": "revoked", "backend_name": self.backend_name, "id": int(ref["id"])}
+
+        secret_row, _repo = await self._fetch_underlying_secret_row(ref)
+        encrypted_blob = str(secret_row.get("encrypted_blob") or "") if isinstance(secret_row, dict) else ""
+        state = "ready" if encrypted_blob else "missing"
+        return {
+            "id": int(ref["id"]),
+            "backend_name": self.backend_name,
+            "owner_scope_type": str(ref["owner_scope_type"]),
+            "owner_scope_id": int(ref["owner_scope_id"]),
+            "provider_key": str(ref["provider_key"]),
+            "state": state,
+        }
+
+    async def delete_ref(
+        self,
+        secret_ref_id: int,
+        *,
+        revoked_by: int | None = None,
+    ) -> bool:
+        managed_repo = ManagedSecretRefsRepo(self.db_pool)
+        ref = await managed_repo.get_ref(int(secret_ref_id))
+        if not ref:
+            return False
+
+        provider = str(ref["provider_key"])
+        scope_type = str(ref["owner_scope_type"])
+        scope_id = int(ref["owner_scope_id"])
+        revoked_at = datetime.now(timezone.utc)
+
+        if scope_type == "user":
+            repo = AuthnzUserProviderSecretsRepo(self.db_pool)
+            await repo.ensure_tables()
+            await repo.delete_secret(scope_id, provider, revoked_by=revoked_by, revoked_at=revoked_at)
+        else:
+            repo = AuthnzOrgProviderSecretsRepo(self.db_pool)
+            await repo.ensure_tables()
+            await repo.delete_secret(
+                scope_type,
+                scope_id,
+                provider,
+                revoked_by=revoked_by,
+                revoked_at=revoked_at,
+            )
+        return await managed_repo.delete_ref(
+            int(secret_ref_id),
+            revoked_by=revoked_by,
+            revoked_at=revoked_at,
+        )

--- a/tldw_Server_API/app/core/AuthNZ/secret_backends/registry.py
+++ b/tldw_Server_API/app/core/AuthNZ/secret_backends/registry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.secret_backends.base import SecretBackend
+from tldw_Server_API.app.core.AuthNZ.secret_backends.local_encrypted import (
+    LocalEncryptedSecretBackend,
+)
+
+
+@dataclass(frozen=True)
+class SecretBackendDescriptor:
+    name: str
+    display_name: str
+    capabilities: dict[str, bool]
+    backend_cls: type[SecretBackend]
+
+
+_SECRET_BACKENDS: dict[str, SecretBackendDescriptor] = {
+    LocalEncryptedSecretBackend.backend_name: SecretBackendDescriptor(
+        name=LocalEncryptedSecretBackend.backend_name,
+        display_name=LocalEncryptedSecretBackend.display_name,
+        capabilities=dict(LocalEncryptedSecretBackend.capabilities),
+        backend_cls=LocalEncryptedSecretBackend,
+    ),
+}
+
+
+def get_secret_backend(name: str, *, db_pool: DatabasePool) -> SecretBackend:
+    descriptor = _SECRET_BACKENDS.get(name)
+    if descriptor is None:
+        raise ValueError(f"Unknown secret backend: {name}")
+    return descriptor.backend_cls(db_pool=db_pool)
+
+
+def list_secret_backend_descriptors() -> list[SecretBackendDescriptor]:
+    return list(_SECRET_BACKENDS.values())

--- a/tldw_Server_API/app/core/AuthNZ/session_manager.py
+++ b/tldw_Server_API/app/core/AuthNZ/session_manager.py
@@ -1812,6 +1812,48 @@ class SessionManager:
             logger.debug("Failed to decrypt ephemeral value: {}", exc)
             return None
 
+    async def consume_ephemeral_value(self, key: str) -> Optional[str]:
+        """Atomically retrieve and delete an ephemeral value if present and unexpired."""
+        if not self._initialized:
+            await self.initialize()
+        if not key:
+            return None
+        if self.redis_client:
+            redis_key = self._ephemeral_redis_key(key)
+            try:
+                cached = await self.redis_client.eval(
+                    """
+                    local value = redis.call('GET', KEYS[1])
+                    if value then
+                        redis.call('DEL', KEYS[1])
+                    end
+                    return value
+                    """,
+                    1,
+                    redis_key,
+                )
+                if cached:
+                    return self.decrypt_token(cached)
+                return None
+            except RedisError as exc:
+                logger.warning("Failed to consume ephemeral value from Redis: {}", exc)
+            except _SESSION_MANAGER_NONCRITICAL_EXCEPTIONS as exc:
+                logger.debug("Failed to decrypt consumed ephemeral value: {}", exc)
+                return None
+        now = time.monotonic()
+        with self._ephemeral_lock:
+            entry = self._ephemeral_cache.pop(key, None)
+            if not entry:
+                return None
+            encrypted, expires_at = entry
+            if expires_at <= now:
+                return None
+        try:
+            return self.decrypt_token(encrypted)
+        except _SESSION_MANAGER_NONCRITICAL_EXCEPTIONS as exc:
+            logger.debug("Failed to decrypt consumed ephemeral value: {}", exc)
+            return None
+
     async def delete_ephemeral_value(self, key: str) -> None:
         """Delete an ephemeral value from Redis and in-memory cache."""
         if not self._initialized:

--- a/tldw_Server_API/app/core/AuthNZ/settings.py
+++ b/tldw_Server_API/app/core/AuthNZ/settings.py
@@ -99,6 +99,13 @@ SINGLE_USER_API_KEY_PLACEHOLDERS = {
     "CHANGE-ME-to-a-secure-key-at-least-16-chars",
 }
 AUTHNZ_DEFAULT_ENV_FILE = Path(__file__).resolve().parents[3] / "Config_Files" / ".env"
+ENTERPRISE_SUPPORTED_PROFILES = {
+    "enterprise",
+    "enterprise-postgres",
+    "enterprise_postgres",
+    "multi-user-postgres",
+    "multi_user_postgres",
+}
 
 #######################################################################################################################
 #
@@ -442,6 +449,29 @@ class Settings(BaseSettings):
         description="Backend used for OpenAI OAuth refresh locking",
     )
 
+    # ===== Enterprise Federation / MCP Broker =====
+    AUTH_FEDERATION_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable enterprise OIDC federation features. Supported only in "
+            "multi-user PostgreSQL deployments."
+        ),
+    )
+    MCP_CREDENTIAL_BROKER_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable brokered MCP credential resolution. Supported only in "
+            "multi-user PostgreSQL deployments and requires secret backends."
+        ),
+    )
+    SECRET_BACKENDS_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable managed secret-backend references. Supported only in "
+            "multi-user PostgreSQL deployments."
+        ),
+    )
+
     # ===== Token Rotation =====
     ROTATE_REFRESH_TOKENS: bool = Field(
         default=True,
@@ -748,6 +778,7 @@ class Settings(BaseSettings):
         super().__init__(**kwargs)
         self._ensure_jwt_secret()
         self._validate_api_key()
+        self._apply_enterprise_guardrails()
 
     def _ensure_jwt_secret(self):
         """Ensure JWT secret exists with secure handling"""
@@ -880,6 +911,65 @@ class Settings(BaseSettings):
                 if weak:
                     raise ValueError(SINGLE_USER_KEY_PRODUCTION_WEAK)
 
+    def _apply_enterprise_guardrails(self) -> None:
+        """Log guardrail decisions for enterprise-only feature flags."""
+        if self.AUTH_FEDERATION_ENABLED and not self.enterprise_federation_supported:
+            logger.warning(
+                "AUTH_FEDERATION_ENABLED is set but enterprise federation is disabled: {}",
+                ", ".join(self.enterprise_support_matrix_errors),
+            )
+
+        if self.SECRET_BACKENDS_ENABLED and not self.enterprise_secret_backends_supported:
+            logger.warning(
+                "SECRET_BACKENDS_ENABLED is set but enterprise secret backends are disabled: {}",
+                ", ".join(self.enterprise_support_matrix_errors),
+            )
+
+        if self.MCP_CREDENTIAL_BROKER_ENABLED and not self.enterprise_mcp_credential_broker_supported:
+            reasons = list(self.enterprise_support_matrix_errors)
+            if not self.SECRET_BACKENDS_ENABLED:
+                reasons.append("SECRET_BACKENDS_ENABLED must also be enabled")
+            logger.warning(
+                "MCP_CREDENTIAL_BROKER_ENABLED is set but broker support is disabled: {}",
+                ", ".join(reasons),
+            )
+
+    @property
+    def enterprise_support_matrix_errors(self) -> tuple[str, ...]:
+        """Return reasons why enterprise features are unavailable."""
+        errors: list[str] = []
+        if self.AUTH_MODE != "multi_user":
+            errors.append("AUTH_MODE=multi_user is required")
+        if not _database_url_is_postgres(self.DATABASE_URL):
+            errors.append("PostgreSQL DATABASE_URL is required")
+        if not _profile_supports_enterprise_features(getattr(self, "PROFILE", None)):
+            errors.append("PROFILE is not supported for enterprise features")
+        return tuple(errors)
+
+    @property
+    def enterprise_deployment_supported(self) -> bool:
+        """Return True when the deployment matches the enterprise support matrix."""
+        return not self.enterprise_support_matrix_errors
+
+    @property
+    def enterprise_federation_supported(self) -> bool:
+        """Return True when OIDC federation may run in this deployment."""
+        return self.AUTH_FEDERATION_ENABLED and self.enterprise_deployment_supported
+
+    @property
+    def enterprise_secret_backends_supported(self) -> bool:
+        """Return True when secret-backend features may run in this deployment."""
+        return self.SECRET_BACKENDS_ENABLED and self.enterprise_deployment_supported
+
+    @property
+    def enterprise_mcp_credential_broker_supported(self) -> bool:
+        """Return True when MCP credential brokering may run in this deployment."""
+        return (
+            self.MCP_CREDENTIAL_BROKER_ENABLED
+            and self.enterprise_deployment_supported
+            and self.enterprise_secret_backends_supported
+        )
+
     @field_validator("JWT_SECRET_KEY")
     @classmethod
     def validate_jwt_secret(cls, v, info):
@@ -982,6 +1072,20 @@ class Settings(BaseSettings):
                 return _bool_from_str(env_val)
         return v
 
+    @field_validator(
+        "AUTH_FEDERATION_ENABLED",
+        "MCP_CREDENTIAL_BROKER_ENABLED",
+        "SECRET_BACKENDS_ENABLED",
+        mode="before",
+    )
+    @classmethod
+    def parse_enterprise_feature_flags(cls, v):
+        if v is None:
+            return False
+        if isinstance(v, str):
+            return _bool_from_str(v)
+        return bool(v)
+
     @field_validator("OPENAI_OAUTH_CLIENT_ID", "OPENAI_OAUTH_CLIENT_SECRET", mode="before")
     @classmethod
     def normalize_openai_oauth_secret_fields(cls, v):
@@ -1081,6 +1185,17 @@ def _bool_from_str(val: str) -> bool:
     return _is_truthy(str(val).strip())
 
 
+def _database_url_is_postgres(database_url: str | None) -> bool:
+    text = str(database_url or "").strip().lower()
+    return text.startswith(("postgres://", "postgresql://"))
+
+
+def _profile_supports_enterprise_features(profile: str | None) -> bool:
+    if not isinstance(profile, str) or not profile.strip():
+        return True
+    return profile.strip().lower() in ENTERPRISE_SUPPORTED_PROFILES
+
+
 def _split_csv(val) -> list[str]:
     if val is None:
         return []
@@ -1159,6 +1274,13 @@ def _load_overrides_from_config() -> dict:
             "openai_oauth_refresh_lock_backend",
             lambda v: str(v).strip().lower(),
         )
+        maybe_set("AUTH_FEDERATION_ENABLED", "auth_federation_enabled", _bool_from_str)
+        maybe_set(
+            "MCP_CREDENTIAL_BROKER_ENABLED",
+            "mcp_credential_broker_enabled",
+            _bool_from_str,
+        )
+        maybe_set("SECRET_BACKENDS_ENABLED", "secret_backends_enabled", _bool_from_str)
         maybe_set("ENABLE_REGISTRATION", "enable_registration", _bool_from_str)
         # Legacy aliases in config.txt
         maybe_set("ENABLE_REGISTRATION", "registration_enabled", _bool_from_str)

--- a/tldw_Server_API/app/core/AuthNZ/user_provider_secrets.py
+++ b/tldw_Server_API/app/core/AuthNZ/user_provider_secrets.py
@@ -14,6 +14,22 @@ def normalize_provider_name(provider: str) -> str:
     return (provider or "").strip().lower()
 
 
+def normalize_secret_owner_scope_type(scope_type: str) -> str:
+    normalized = (scope_type or "").strip().lower()
+    if normalized in {"user", "users"}:
+        return "user"
+    if normalized in {"org", "organization", "organizations", "orgs"}:
+        return "org"
+    if normalized in {"team", "teams"}:
+        return "team"
+    raise ValueError(f"Invalid secret owner scope type: {scope_type}")
+
+
+def build_managed_secret_backend_ref(scope_type: str, scope_id: int, provider: str) -> str:
+    scope_norm = normalize_secret_owner_scope_type(scope_type)
+    return f"{scope_norm}:{int(scope_id)}:{normalize_provider_name(provider)}"
+
+
 def key_hint_for_api_key(api_key: str) -> str:
     api_key = api_key or ""
     if len(api_key) <= 4:

--- a/tldw_Server_API/app/core/MCP_unified/README.md
+++ b/tldw_Server_API/app/core/MCP_unified/README.md
@@ -57,6 +57,21 @@
 ## Overview
 A secure, production-ready Model Context Protocol implementation that consolidates MCP v1 and v2 with enterprise-grade features.
 
+## Managed External Credential Brokering
+
+Managed external MCP servers now follow a brokered runtime model instead of static secret hydration.
+
+- Runtime registry payloads stay auth-neutral. Managed server configs are loaded with `auth.mode=none`, and durable headers/env are not baked into adapter config.
+- Effective policy and MCP Hub credential bindings are resolved at call time.
+- Managed secret refs and legacy encrypted slot secrets are translated into transient execution headers/env only for the active tool call.
+- Transport adapters must not persist brokered secret values in long-lived state, config snapshots, telemetry, or logs.
+
+Current enterprise support matrix for this path:
+
+- OIDC-backed AuthNZ federation is the supported identity source in phase 1.
+- Local encrypted secret refs (`local_encrypted_v1`) are the first managed backend.
+- Brokered credentials are applied per execution for managed websocket and stdio external MCP servers.
+
 ## ✅ What's Been Built
 
 ### Core Components

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/manager.py
@@ -444,7 +444,7 @@ class ExternalServerManager:
             )
             if runtime_auth is not None:
                 metadata = dict(result.metadata or {})
-                metadata.update(dict(runtime_auth.metadata or {}))
+                metadata.update(self._public_runtime_auth_metadata(runtime_auth))
                 metadata["credential_injection"] = self._summarize_runtime_auth(runtime_auth)
                 result.metadata = metadata
             telemetry.call_successes += 1
@@ -472,6 +472,20 @@ class ExternalServerManager:
         telemetry = self._get_telemetry(server_id)
         telemetry.policy_denials += 1
         telemetry.last_error = message
+
+    @staticmethod
+    def _public_runtime_auth_metadata(
+        runtime_auth: BrokeredExternalCredential,
+    ) -> dict[str, Any]:
+        metadata = runtime_auth.metadata or {}
+        if not isinstance(metadata, dict):
+            return {}
+        public: dict[str, Any] = {}
+        for key in ("credential_mode", "credential_source"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                public[key] = value
+        return public
 
     @staticmethod
     def _extract_error_text(result: ExternalToolCallResult) -> Optional[str]:

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/manager.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/manager.py
@@ -11,7 +11,12 @@ from typing import Any, Awaitable, Callable, Optional
 from loguru import logger
 
 from .config_schema import ExternalMCPServerConfig, load_external_server_registry
-from .transports import ExternalMCPTransportAdapter, ExternalToolCallResult, build_transport_adapter
+from .transports import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    build_transport_adapter,
+)
 
 
 @dataclass(slots=True)
@@ -105,12 +110,20 @@ class ExternalServerManager:
         self._discovery_errors: dict[str, str] = {}
         self._telemetry: dict[str, ExternalServerTelemetry] = {}
         self._initialized = False
+        self._credential_broker: Callable[..., Awaitable[BrokeredExternalCredential | None] | BrokeredExternalCredential | None] | None = None
 
     def with_server_loader(
         self,
         server_loader: Callable[[], Awaitable[list[ExternalMCPServerConfig]] | list[ExternalMCPServerConfig]],
     ) -> "ExternalServerManager":
         self._server_loader = server_loader
+        return self
+
+    def with_credential_broker(
+        self,
+        credential_broker: Callable[..., Awaitable[BrokeredExternalCredential | None] | BrokeredExternalCredential | None],
+    ) -> "ExternalServerManager":
+        self._credential_broker = credential_broker
         return self
 
     @property
@@ -298,13 +311,20 @@ class ExternalServerManager:
             upstream_tool_name=upstream_tool_name,
             call_args=call_args,
             context=context,
+            runtime_auth=await self._resolve_runtime_auth(
+                server_id=server_id,
+                upstream_tool_name=upstream_tool_name,
+                call_args=call_args,
+                context=context,
+            ),
         )
+        metadata = dict(result.metadata or {})
         return {
             "content": result.content,
             "is_error": result.is_error,
             "server_id": server_id,
             "upstream_tool": upstream_tool_name,
-            "metadata": result.metadata,
+            "metadata": metadata,
         }
 
     @staticmethod
@@ -410,12 +430,23 @@ class ExternalServerManager:
         upstream_tool_name: str,
         call_args: dict[str, Any],
         context: Optional[Any],
+        runtime_auth: BrokeredExternalCredential | None,
     ) -> ExternalToolCallResult:
         telemetry = self._get_telemetry(server_id)
         telemetry.call_attempts += 1
         started_at = time.perf_counter()
         try:
-            result = await adapter.call_tool(upstream_tool_name, call_args, context=context)
+            result = await adapter.call_tool(
+                upstream_tool_name,
+                call_args,
+                context=context,
+                runtime_auth=runtime_auth,
+            )
+            if runtime_auth is not None:
+                metadata = dict(result.metadata or {})
+                metadata.update(dict(runtime_auth.metadata or {}))
+                metadata["credential_injection"] = self._summarize_runtime_auth(runtime_auth)
+                result.metadata = metadata
             telemetry.call_successes += 1
             if result.is_error:
                 telemetry.call_upstream_errors += 1
@@ -464,6 +495,42 @@ class ExternalServerManager:
                     if stripped:
                         return stripped
         return None
+
+    async def _resolve_runtime_auth(
+        self,
+        *,
+        server_id: str,
+        upstream_tool_name: str,
+        call_args: dict[str, Any],
+        context: Optional[Any],
+    ) -> BrokeredExternalCredential | None:
+        if self._credential_broker is None:
+            return None
+        broker_result = self._credential_broker(
+            server_id=server_id,
+            tool_name=upstream_tool_name,
+            arguments=dict(call_args or {}),
+            context=context,
+        )
+        resolved = await broker_result if inspect.isawaitable(broker_result) else broker_result
+        if resolved is None:
+            return None
+        if isinstance(resolved, BrokeredExternalCredential):
+            return resolved
+        if isinstance(resolved, dict):
+            return BrokeredExternalCredential(
+                headers=dict(resolved.get("headers") or {}),
+                env=dict(resolved.get("env") or {}),
+                metadata=dict(resolved.get("metadata") or {}),
+            )
+        raise TypeError("credential broker must return BrokeredExternalCredential, dict, or None")
+
+    @staticmethod
+    def _summarize_runtime_auth(runtime_auth: BrokeredExternalCredential) -> dict[str, Any]:
+        return {
+            "headers": sorted(str(name) for name in runtime_auth.headers.keys()),
+            "env": sorted(str(name) for name in runtime_auth.env.keys()),
+        }
 
     @staticmethod
     def _elapsed_ms(started_at: float) -> float:

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/__init__.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/__init__.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from ..config_schema import ExternalMCPServerConfig, ExternalTransportType
-from .base import ExternalMCPTransportAdapter, ExternalToolCallResult, ExternalToolDefinition
+from .base import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 from .stdio_adapter import StdioExternalMCPAdapter
 from .websocket_adapter import WebSocketExternalMCPAdapter
 
@@ -22,6 +27,7 @@ __all__ = [
     "ExternalMCPTransportAdapter",
     "ExternalToolCallResult",
     "ExternalToolDefinition",
+    "BrokeredExternalCredential",
     "StdioExternalMCPAdapter",
     "WebSocketExternalMCPAdapter",
     "build_transport_adapter",

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
@@ -29,6 +29,15 @@ class ExternalToolCallResult:
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(slots=True)
+class BrokeredExternalCredential:
+    """Ephemeral per-call auth material resolved outside long-lived adapter state."""
+
+    headers: dict[str, str] = field(default_factory=dict)
+    env: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
 class ExternalMCPTransportAdapter(ABC):
     """Adapter contract for connecting to and invoking external MCP servers."""
 
@@ -62,5 +71,6 @@ class ExternalMCPTransportAdapter(ABC):
         tool_name: str,
         arguments: dict[str, Any],
         context: Optional["RequestContext"] = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         """Execute a tool on the external server and normalize the result."""

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/base.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 if TYPE_CHECKING:  # pragma: no cover
     from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+    from ..config_schema import ExternalMCPServerConfig
 
 
 @dataclass(slots=True)
@@ -74,3 +75,35 @@ class ExternalMCPTransportAdapter(ABC):
         runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         """Execute a tool on the external server and normalize the result."""
+
+
+def clone_external_server_config(
+    server_config: "ExternalMCPServerConfig",
+) -> "ExternalMCPServerConfig":
+    """Deep-copy an external server config without mutating long-lived adapter state."""
+    if hasattr(server_config, "model_copy"):
+        return server_config.model_copy(deep=True)  # type: ignore[attr-defined]
+    return server_config.copy(deep=True)
+
+
+async def call_tool_with_ephemeral_adapter(
+    *,
+    server_config: "ExternalMCPServerConfig",
+    adapter_factory: Callable[["ExternalMCPServerConfig"], ExternalMCPTransportAdapter],
+    prepare_config: Callable[["ExternalMCPServerConfig"], None],
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> ExternalToolCallResult:
+    """Run one external tool call against a short-lived adapter with cloned config."""
+    ephemeral_config = clone_external_server_config(server_config)
+    prepare_config(ephemeral_config)
+    ephemeral_adapter = adapter_factory(ephemeral_config)
+    try:
+        await ephemeral_adapter.connect()
+        return await ephemeral_adapter.call_tool(
+            tool_name,
+            arguments,
+            runtime_auth=None,
+        )
+    finally:
+        await ephemeral_adapter.close()

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
@@ -13,7 +13,12 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
 )
 
 from ..config_schema import ExternalMCPServerConfig
-from .base import ExternalMCPTransportAdapter, ExternalToolCallResult, ExternalToolDefinition
+from .base import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _CLIENT_INFO = {"name": "tldw_external_federation", "version": "0.1.0"}
@@ -133,8 +138,10 @@ class StdioExternalMCPAdapter(ExternalMCPTransportAdapter):
         tool_name: str,
         arguments: dict[str, Any],
         context: Optional[Any] = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         del context  # Reserved for future policy hooks
+        del runtime_auth  # runtime auth is resolved by the manager and must not persist on the adapter
         await self._ensure_connected()
         try:
             response = await self._request(

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
@@ -18,6 +18,7 @@ from .base import (
     ExternalMCPTransportAdapter,
     ExternalToolCallResult,
     ExternalToolDefinition,
+    call_tool_with_ephemeral_adapter,
 )
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
@@ -225,29 +226,21 @@ class StdioExternalMCPAdapter(ExternalMCPTransportAdapter):
         arguments: dict[str, Any],
         runtime_auth: BrokeredExternalCredential,
     ) -> ExternalToolCallResult:
-        ephemeral_config = self._clone_server_config()
-        stdio_cfg = ephemeral_config.stdio
-        if stdio_cfg is None:
-            raise ValueError(f"Missing stdio config for server '{self.server_id}'")
-        merged_env = dict(stdio_cfg.env or {})
-        merged_env.update(dict(runtime_auth.env or {}))
-        stdio_cfg.env = merged_env
+        def _prepare_config(ephemeral_config: ExternalMCPServerConfig) -> None:
+            stdio_cfg = ephemeral_config.stdio
+            if stdio_cfg is None:
+                raise ValueError(f"Missing stdio config for server '{self.server_id}'")
+            merged_env = dict(stdio_cfg.env or {})
+            merged_env.update(dict(runtime_auth.env or {}))
+            stdio_cfg.env = merged_env
 
-        ephemeral_adapter = StdioExternalMCPAdapter(
-            ephemeral_config,
-            client_factory=self._client_factory,
+        return await call_tool_with_ephemeral_adapter(
+            server_config=self.server_config,
+            adapter_factory=lambda config: StdioExternalMCPAdapter(
+                config,
+                client_factory=self._client_factory,
+            ),
+            prepare_config=_prepare_config,
+            tool_name=tool_name,
+            arguments=arguments,
         )
-        try:
-            await ephemeral_adapter.connect()
-            return await ephemeral_adapter.call_tool(
-                tool_name,
-                arguments,
-                runtime_auth=None,
-            )
-        finally:
-            await ephemeral_adapter.close()
-
-    def _clone_server_config(self) -> ExternalMCPServerConfig:
-        if hasattr(self.server_config, "model_copy"):
-            return self.server_config.model_copy(deep=True)  # type: ignore[attr-defined]
-        return self.server_config.copy(deep=True)

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py
@@ -141,7 +141,12 @@ class StdioExternalMCPAdapter(ExternalMCPTransportAdapter):
         runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         del context  # Reserved for future policy hooks
-        del runtime_auth  # runtime auth is resolved by the manager and must not persist on the adapter
+        if runtime_auth is not None and runtime_auth.env:
+            return await self._call_tool_with_ephemeral_env(
+                tool_name=tool_name,
+                arguments=arguments,
+                runtime_auth=runtime_auth,
+            )
         await self._ensure_connected()
         try:
             response = await self._request(
@@ -212,3 +217,37 @@ class StdioExternalMCPAdapter(ExternalMCPTransportAdapter):
             "result": getattr(message, "result", None),
             "error": getattr(message, "error", None),
         }
+
+    async def _call_tool_with_ephemeral_env(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        runtime_auth: BrokeredExternalCredential,
+    ) -> ExternalToolCallResult:
+        ephemeral_config = self._clone_server_config()
+        stdio_cfg = ephemeral_config.stdio
+        if stdio_cfg is None:
+            raise ValueError(f"Missing stdio config for server '{self.server_id}'")
+        merged_env = dict(stdio_cfg.env or {})
+        merged_env.update(dict(runtime_auth.env or {}))
+        stdio_cfg.env = merged_env
+
+        ephemeral_adapter = StdioExternalMCPAdapter(
+            ephemeral_config,
+            client_factory=self._client_factory,
+        )
+        try:
+            await ephemeral_adapter.connect()
+            return await ephemeral_adapter.call_tool(
+                tool_name,
+                arguments,
+                runtime_auth=None,
+            )
+        finally:
+            await ephemeral_adapter.close()
+
+    def _clone_server_config(self) -> ExternalMCPServerConfig:
+        if hasattr(self.server_config, "model_copy"):
+            return self.server_config.model_copy(deep=True)  # type: ignore[attr-defined]
+        return self.server_config.copy(deep=True)

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
@@ -16,6 +16,7 @@ from .base import (
     ExternalMCPTransportAdapter,
     ExternalToolCallResult,
     ExternalToolDefinition,
+    call_tool_with_ephemeral_adapter,
 )
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
@@ -60,8 +61,8 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
                 return
 
             ws_cfg = self.server_config.websocket
-            headers = dict(ws_cfg.headers or {})
-            headers.update(self.server_config.auth.resolve_headers())
+            headers = dict(self.server_config.auth.resolve_headers())
+            headers.update(dict(ws_cfg.headers or {}))
             subprotocols = list(ws_cfg.subprotocols or [])
             connect_timeout = float(self.server_config.timeouts.connect_seconds)
 
@@ -252,32 +253,24 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
         arguments: dict[str, Any],
         runtime_auth: BrokeredExternalCredential,
     ) -> ExternalToolCallResult:
-        ephemeral_config = self._clone_server_config()
-        websocket_cfg = ephemeral_config.websocket
-        if websocket_cfg is None:
-            raise ValueError(f"Missing websocket config for server '{self.server_id}'")
-        merged_headers = dict(websocket_cfg.headers or {})
-        merged_headers.update(dict(runtime_auth.headers or {}))
-        websocket_cfg.headers = merged_headers
+        def _prepare_config(ephemeral_config: ExternalMCPServerConfig) -> None:
+            websocket_cfg = ephemeral_config.websocket
+            if websocket_cfg is None:
+                raise ValueError(f"Missing websocket config for server '{self.server_id}'")
+            merged_headers = dict(websocket_cfg.headers or {})
+            merged_headers.update(dict(runtime_auth.headers or {}))
+            websocket_cfg.headers = merged_headers
 
-        ephemeral_adapter = WebSocketExternalMCPAdapter(
-            ephemeral_config,
-            ws_connector=self._ws_connector,
+        return await call_tool_with_ephemeral_adapter(
+            server_config=self.server_config,
+            adapter_factory=lambda config: WebSocketExternalMCPAdapter(
+                config,
+                ws_connector=self._ws_connector,
+            ),
+            prepare_config=_prepare_config,
+            tool_name=tool_name,
+            arguments=arguments,
         )
-        try:
-            await ephemeral_adapter.connect()
-            return await ephemeral_adapter.call_tool(
-                tool_name,
-                arguments,
-                runtime_auth=None,
-            )
-        finally:
-            await ephemeral_adapter.close()
-
-    def _clone_server_config(self) -> ExternalMCPServerConfig:
-        if hasattr(self.server_config, "model_copy"):
-            return self.server_config.model_copy(deep=True)  # type: ignore[attr-defined]
-        return self.server_config.copy(deep=True)
 
     async def _ensure_connected(self) -> None:
         if not self._connected or not self._initialized or self._ws is None:

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
@@ -176,7 +176,12 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
         runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         del context  # context is reserved for future adapter-aware policy hooks
-        del runtime_auth  # runtime auth is resolved by the manager and must not persist on the adapter
+        if runtime_auth is not None and runtime_auth.headers:
+            return await self._call_tool_with_ephemeral_headers(
+                tool_name=tool_name,
+                arguments=arguments,
+                runtime_auth=runtime_auth,
+            )
         await self._ensure_connected()
         response = await self._jsonrpc_request(
             method="tools/call",
@@ -239,6 +244,40 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
                 kwargs["extra_headers"] = headers
 
         return await connect_fn(url, **kwargs)
+
+    async def _call_tool_with_ephemeral_headers(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        runtime_auth: BrokeredExternalCredential,
+    ) -> ExternalToolCallResult:
+        ephemeral_config = self._clone_server_config()
+        websocket_cfg = ephemeral_config.websocket
+        if websocket_cfg is None:
+            raise ValueError(f"Missing websocket config for server '{self.server_id}'")
+        merged_headers = dict(websocket_cfg.headers or {})
+        merged_headers.update(dict(runtime_auth.headers or {}))
+        websocket_cfg.headers = merged_headers
+
+        ephemeral_adapter = WebSocketExternalMCPAdapter(
+            ephemeral_config,
+            ws_connector=self._ws_connector,
+        )
+        try:
+            await ephemeral_adapter.connect()
+            return await ephemeral_adapter.call_tool(
+                tool_name,
+                arguments,
+                runtime_auth=None,
+            )
+        finally:
+            await ephemeral_adapter.close()
+
+    def _clone_server_config(self) -> ExternalMCPServerConfig:
+        if hasattr(self.server_config, "model_copy"):
+            return self.server_config.model_copy(deep=True)  # type: ignore[attr-defined]
+        return self.server_config.copy(deep=True)
 
     async def _ensure_connected(self) -> None:
         if not self._connected or not self._initialized or self._ws is None:

--- a/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py
@@ -11,7 +11,12 @@ from typing import Any, Awaitable, Callable, Optional
 from loguru import logger
 
 from ..config_schema import ExternalMCPServerConfig
-from .base import ExternalMCPTransportAdapter, ExternalToolCallResult, ExternalToolDefinition
+from .base import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _CLIENT_INFO = {"name": "tldw_external_federation", "version": "0.1.0"}
@@ -168,8 +173,10 @@ class WebSocketExternalMCPAdapter(ExternalMCPTransportAdapter):
         tool_name: str,
         arguments: dict[str, Any],
         context: Optional[Any] = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
     ) -> ExternalToolCallResult:
         del context  # context is reserved for future adapter-aware policy hooks
+        del runtime_auth  # runtime auth is resolved by the manager and must not persist on the adapter
         await self._ensure_connected()
         response = await self._jsonrpc_request(
             method="tools/call",

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
@@ -19,6 +19,9 @@ from tldw_Server_API.app.core.MCP_unified.external_servers import ExternalServer
 from tldw_Server_API.app.services.mcp_hub_external_registry_service import (
     get_mcp_hub_external_registry_service,
 )
+from tldw_Server_API.app.services.mcp_credential_broker_service import (
+    get_mcp_credential_broker_service,
+)
 
 from ..base import BaseModule, create_tool_definition
 
@@ -46,6 +49,9 @@ class ExternalFederationModule(BaseModule):
             manager = manager.with_server_loader(registry_service.list_runtime_servers)
         if callable(custom_broker):
             manager = manager.with_credential_broker(custom_broker)
+        else:
+            broker_service = await get_mcp_credential_broker_service()
+            manager = manager.with_credential_broker(broker_service.broker_external_tool_call)
         self._manager = manager
         await self._manager.initialize()
         logger.info(f"External federation module initialized with managed registry; legacy inventory path: {config_path}")

--- a/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
+++ b/tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py
@@ -38,11 +38,14 @@ class ExternalFederationModule(BaseModule):
 
         manager = ExternalServerManager(config_path=config_path)
         custom_loader = self.config.settings.get("external_server_loader")
+        custom_broker = self.config.settings.get("external_credential_broker")
         if callable(custom_loader):
             manager = manager.with_server_loader(custom_loader)
         else:
             registry_service = await get_mcp_hub_external_registry_service()
             manager = manager.with_server_loader(registry_service.list_runtime_servers)
+        if callable(custom_broker):
+            manager = manager.with_credential_broker(custom_broker)
         self._manager = manager
         await self._manager.initialize()
         logger.info(f"External federation module initialized with managed registry; legacy inventory path: {config_path}")

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tldw_Server_API.app.core.MCP_unified.external_servers.config_schema import (
+    parse_external_server_registry,
+)
+from tldw_Server_API.app.core.MCP_unified.external_servers.manager import (
+    ExternalServerManager,
+)
+from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
+from tldw_Server_API.app.core.MCP_unified.external_servers import manager as manager_mod
+
+
+class _BrokerAwareAdapter(ExternalMCPTransportAdapter):
+    def __init__(self, server_id: str) -> None:
+        super().__init__(server_id=server_id)
+        self.seen_runtime_auth: BrokeredExternalCredential | None = None
+        self.seen_context: Any = None
+
+    @property
+    def transport_name(self) -> str:
+        return "websocket"
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def health_check(self) -> dict[str, bool]:
+        return {"configured": True, "connected": True, "initialized": True}
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        return [
+            ExternalToolDefinition(
+                name="repo.search",
+                description="Search repositories",
+                input_schema={"type": "object"},
+                metadata={"category": "read"},
+            )
+        ]
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        del tool_name, arguments
+        self.seen_runtime_auth = runtime_auth
+        self.seen_context = context
+        return ExternalToolCallResult(
+            content=[{"type": "text", "text": "ok"}],
+            is_error=False,
+            metadata={"adapter": "broker-aware"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_external_tool_call_uses_ephemeral_brokered_credential(monkeypatch) -> None:
+    cfg = parse_external_server_registry(
+        {
+            "servers": [
+                {
+                    "id": "github",
+                    "name": "GitHub",
+                    "transport": "websocket",
+                    "websocket": {"url": "wss://github.example/ws"},
+                    "policy": {"allow_tool_patterns": ["repo.*"]},
+                }
+            ]
+        }
+    )
+
+    adapter = _BrokerAwareAdapter(server_id="github")
+
+    async def _broker(**kwargs) -> BrokeredExternalCredential:
+        assert kwargs["server_id"] == "github"
+        assert kwargs["tool_name"] == "repo.search"
+        return BrokeredExternalCredential(
+            headers={"Authorization": "Bearer ephemeral-token"},
+            metadata={"credential_mode": "brokered_ephemeral"},
+        )
+
+    monkeypatch.setattr(manager_mod, "build_transport_adapter", lambda _server: adapter)
+
+    manager = (
+        ExternalServerManager()
+        .with_server_loader(lambda: list(cfg.servers))
+        .with_credential_broker(_broker)
+    )
+    try:
+        await manager.initialize()
+        result = await manager.execute_virtual_tool(
+            "ext.github.repo.search",
+            {"query": "repo:test"},
+            context={"request_id": "r1"},
+        )
+    finally:
+        await manager.shutdown()
+
+    assert adapter.seen_runtime_auth is not None
+    assert adapter.seen_runtime_auth.headers == {"Authorization": "Bearer ephemeral-token"}
+    assert result["metadata"]["credential_mode"] == "brokered_ephemeral"
+    assert result["metadata"]["credential_injection"]["headers"] == ["Authorization"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py
@@ -65,6 +65,7 @@ class _BrokerAwareAdapter(ExternalMCPTransportAdapter):
         )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_external_tool_call_uses_ephemeral_brokered_credential(monkeypatch) -> None:
     cfg = parse_external_server_registry(
@@ -88,7 +89,11 @@ async def test_external_tool_call_uses_ephemeral_brokered_credential(monkeypatch
         assert kwargs["tool_name"] == "repo.search"
         return BrokeredExternalCredential(
             headers={"Authorization": "Bearer ephemeral-token"},
-            metadata={"credential_mode": "brokered_ephemeral"},
+            metadata={
+                "credential_mode": "brokered_ephemeral",
+                "credential_source": "mcp_hub_managed_binding",
+                "unsafe_internal_note": "should-not-leak",
+            },
         )
 
     monkeypatch.setattr(manager_mod, "build_transport_adapter", lambda _server: adapter)
@@ -111,4 +116,6 @@ async def test_external_tool_call_uses_ephemeral_brokered_credential(monkeypatch
     assert adapter.seen_runtime_auth is not None
     assert adapter.seen_runtime_auth.headers == {"Authorization": "Bearer ephemeral-token"}
     assert result["metadata"]["credential_mode"] == "brokered_ephemeral"
+    assert result["metadata"]["credential_source"] == "mcp_hub_managed_binding"
+    assert "unsafe_internal_note" not in result["metadata"]
     assert result["metadata"]["credential_injection"]["headers"] == ["Authorization"]

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py
@@ -18,6 +18,9 @@ from tldw_Server_API.app.core.MCP_unified.external_servers.config_schema import 
 from tldw_Server_API.app.core.MCP_unified.external_servers.transports.stdio_adapter import (
     StdioExternalMCPAdapter,
 )
+from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base import (
+    BrokeredExternalCredential,
+)
 
 
 class _FakeStdioClient:
@@ -188,3 +191,68 @@ async def test_stdio_adapter_connect_failure_closes_client() -> None:
     assert health["connected"] is False
     assert health["initialized"] is False
     assert client.close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_stdio_adapter_uses_ephemeral_runtime_env_without_mutating_base_client() -> None:
+    cfg = ExternalMCPServerConfig(
+        id="docs",
+        name="Docs",
+        transport=ExternalTransportType.STDIO,
+        stdio=ExternalStdioConfig(command="node", args=["stub.js"], env={"BASE_ENV": "1"}),
+        timeouts=ExternalTimeoutConfig(connect_seconds=1.0, request_seconds=0.2),
+    )
+    base_client = _FakeStdioClient(responses={"initialize": {"serverInfo": {"name": "base"}}})
+    runtime_client = _FakeStdioClient(
+        responses={
+            "initialize": {"serverInfo": {"name": "runtime"}},
+            "tools/call": {"content": [{"type": "text", "text": "ok"}]},
+        }
+    )
+    seen_envs: list[dict[str, str]] = []
+
+    def _client_factory(server_cfg: ExternalMCPServerConfig) -> _FakeStdioClient:
+        assert server_cfg.stdio is not None
+        seen_envs.append(dict(server_cfg.stdio.env or {}))
+        if "DOCS_TOKEN" in (server_cfg.stdio.env or {}):
+            return runtime_client
+        return base_client
+
+    adapter = StdioExternalMCPAdapter(cfg, client_factory=_client_factory)
+
+    try:
+        await adapter.connect()
+        result = await adapter.call_tool(
+            "docs.search",
+            {"q": "runtime"},
+            runtime_auth=BrokeredExternalCredential(env={"DOCS_TOKEN": "ephemeral-token"}),
+        )
+
+        assert result.is_error is False
+        assert base_client.calls == [
+            (
+                "initialize",
+                {
+                    "protocolVersion": "2024-11-05",
+                    "clientInfo": {"name": "tldw_external_federation", "version": "0.1.0"},
+                },
+            )
+        ]
+        assert runtime_client.calls == [
+            (
+                "initialize",
+                {
+                    "protocolVersion": "2024-11-05",
+                    "clientInfo": {"name": "tldw_external_federation", "version": "0.1.0"},
+                },
+            ),
+            ("tools/call", {"name": "docs.search", "arguments": {"q": "runtime"}}),
+        ]
+        assert runtime_client.close_calls == 1
+        assert seen_envs[0] == {"BASE_ENV": "1"}
+        assert seen_envs[1]["BASE_ENV"] == "1"
+        assert seen_envs[1]["DOCS_TOKEN"] == "ephemeral-token"
+        assert cfg.stdio is not None
+        assert cfg.stdio.env == {"BASE_ENV": "1"}
+    finally:
+        await adapter.close()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
@@ -303,3 +303,54 @@ async def test_websocket_adapter_uses_ephemeral_runtime_headers_without_mutating
         assert base_ws.sent_messages == [{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "clientInfo": {"name": "tldw_external_federation", "version": "0.1.0"}}}]
     finally:
         await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_adapter_prefers_runtime_authorization_header_over_static_auth(monkeypatch) -> None:
+    monkeypatch.setenv("EXTERNAL_DOCS_TOKEN", "static-token")
+    cfg = _server_config(
+        auth=ExternalAuthConfig(mode=ExternalAuthMode.BEARER_ENV, token_env="EXTERNAL_DOCS_TOKEN")
+    )
+    base_ws = _FakeWebSocket()
+    runtime_ws = _FakeWebSocket()
+    base_ws.enqueue({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "base"}}})
+    runtime_ws.enqueue({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "runtime"}}})
+    seen_headers: list[dict[str, str]] = []
+    connect_count = 0
+
+    async def _connector(*, url: str, subprotocols: list[str], headers: dict[str, str], connect_timeout: float):
+        nonlocal connect_count
+        del url, subprotocols, connect_timeout
+        connect_count += 1
+        seen_headers.append(dict(headers))
+        return base_ws if connect_count == 1 else runtime_ws
+
+    adapter = WebSocketExternalMCPAdapter(cfg, ws_connector=_connector)
+    try:
+        await adapter.connect()
+
+        call_task = asyncio.create_task(
+            adapter.call_tool(
+                "docs.search",
+                {"q": "runtime"},
+                runtime_auth=BrokeredExternalCredential(
+                    headers={"Authorization": "Bearer runtime-token"},
+                ),
+            )
+        )
+        await _wait_for_sent(runtime_ws, expected_count=2)
+        runtime_request_id = runtime_ws.sent_messages[1]["id"]
+        runtime_ws.enqueue(
+            {
+                "jsonrpc": "2.0",
+                "id": runtime_request_id,
+                "result": {"content": [{"type": "text", "text": "ok"}]},
+            }
+        )
+        result = await call_task
+
+        assert result.is_error is False
+        assert seen_headers[0]["Authorization"] == "Bearer static-token"
+        assert seen_headers[1]["Authorization"] == "Bearer runtime-token"
+    finally:
+        await adapter.close()

--- a/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
+++ b/tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py
@@ -16,6 +16,9 @@ from tldw_Server_API.app.core.MCP_unified.external_servers.config_schema import 
 from tldw_Server_API.app.core.MCP_unified.external_servers.transports.websocket_adapter import (
     WebSocketExternalMCPAdapter,
 )
+from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base import (
+    BrokeredExternalCredential,
+)
 
 
 class _FakeWebSocket:
@@ -242,5 +245,61 @@ async def test_websocket_adapter_correlates_out_of_order_responses() -> None:
         assert tools[0].name == "docs.search"
         assert call_result.is_error is False
         assert call_result.content == [{"type": "text", "text": "ok"}]
+    finally:
+        await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_adapter_uses_ephemeral_runtime_headers_without_mutating_base_session() -> None:
+    cfg = _server_config()
+    base_ws = _FakeWebSocket()
+    runtime_ws = _FakeWebSocket()
+    base_ws.enqueue({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "base"}}})
+    runtime_ws.enqueue({"jsonrpc": "2.0", "id": 1, "result": {"serverInfo": {"name": "runtime"}}})
+    seen_headers: list[dict[str, str]] = []
+    connect_count = 0
+
+    async def _connector(*, url: str, subprotocols: list[str], headers: dict[str, str], connect_timeout: float):
+        nonlocal connect_count
+        del url, subprotocols, connect_timeout
+        seen_headers.append(dict(headers))
+        connect_count += 1
+        if connect_count == 1:
+            return base_ws
+        return runtime_ws
+
+    adapter = WebSocketExternalMCPAdapter(cfg, ws_connector=_connector)
+    try:
+        await adapter.connect()
+
+        call_task = asyncio.create_task(
+            adapter.call_tool(
+                "docs.search",
+                {"q": "runtime"},
+                runtime_auth=BrokeredExternalCredential(
+                    headers={"Authorization": "Bearer ephemeral-token"},
+                ),
+            )
+        )
+        await _wait_for_sent(runtime_ws, expected_count=2)
+        runtime_request_id = runtime_ws.sent_messages[1]["id"]
+        runtime_ws.enqueue(
+            {
+                "jsonrpc": "2.0",
+                "id": runtime_request_id,
+                "result": {"content": [{"type": "text", "text": "ok"}]},
+            }
+        )
+        result = await call_task
+
+        assert result.is_error is False
+        assert connect_count == 2
+        assert seen_headers[0] == {"x-client": "tldw"}
+        assert seen_headers[1]["x-client"] == "tldw"
+        assert seen_headers[1]["Authorization"] == "Bearer ephemeral-token"
+        assert cfg.websocket is not None
+        assert cfg.websocket.headers == {"x-client": "tldw"}
+        assert adapter._ws is base_ws
+        assert base_ws.sent_messages == [{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "clientInfo": {"name": "tldw_external_federation", "version": "0.1.0"}}}]
     finally:
         await adapter.close()

--- a/tldw_Server_API/app/services/admin_guardrails_service.py
+++ b/tldw_Server_API/app/services/admin_guardrails_service.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import unwrap_optional_secret
 from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
@@ -70,18 +71,23 @@ async def _verify_admin_reauth_token(
     elif isinstance(raw_exp, datetime):
         exp_dt = raw_exp if raw_exp.tzinfo is not None else raw_exp.replace(tzinfo=timezone.utc)
 
-    if jti and exp_dt is not None:
-        blacklist = get_token_blacklist()
-        actor_id = int(actor["id"]) if isinstance(actor, dict) else None
-        await blacklist.revoke_token(
-            jti=jti,
-            expires_at=exp_dt,
-            user_id=actor_id,
-            token_type="admin_reauth",
-            reason="admin_reauth_used",
-            revoked_by=actor_id,
-            ip_address=None,
+    if not jti or exp_dt is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
         )
+
+    blacklist = get_token_blacklist()
+    actor_id = int(actor["id"]) if isinstance(actor, dict) else None
+    await blacklist.revoke_token(
+        jti=jti,
+        expires_at=exp_dt,
+        user_id=actor_id,
+        token_type="admin_reauth",
+        reason="admin_reauth_used",
+        revoked_by=actor_id,
+        ip_address=None,
+    )
     return True
 
 
@@ -91,8 +97,8 @@ async def verify_privileged_action(
     password_service: PasswordService,
     *,
     reason: str | None,
-    admin_password: str | None,
-    admin_reauth_token: str | None = None,
+    admin_password: Any | None,
+    admin_reauth_token: Any | None = None,
 ) -> str:
     """
     Enforce step-up guardrails for high-risk admin actions.
@@ -107,8 +113,8 @@ async def verify_privileged_action(
             account.
     """
     normalized_reason = str(reason or "").strip()
-    normalized_password = str(admin_password or "").strip()
-    normalized_reauth_token = str(admin_reauth_token or "").strip()
+    normalized_password = unwrap_optional_secret(admin_password) or ""
+    normalized_reauth_token = unwrap_optional_secret(admin_reauth_token) or ""
 
     if len(normalized_reason) < 8:
         raise HTTPException(

--- a/tldw_Server_API/app/services/admin_guardrails_service.py
+++ b/tldw_Server_API/app/services/admin_guardrails_service.py
@@ -1,18 +1,88 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import HTTPException, status
 
+from tldw_Server_API.app.core.AuthNZ.jwt_service import get_jwt_service
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal, is_single_user_principal
 from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
+from tldw_Server_API.app.core.AuthNZ.token_blacklist import get_token_blacklist
 from tldw_Server_API.app.services.auth_service import fetch_active_user_by_id
 
 
 def _enterprise_admin_mode_enabled() -> bool:
     raw_value = os.getenv("ADMIN_UI_ENTERPRISE_MODE", "")
     return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_actor_email(actor: Any) -> str:
+    raw_email = ""
+    if isinstance(actor, dict):
+        raw_email = str(actor.get("email") or "")
+    else:
+        raw_email = str(getattr(actor, "email", "") or "")
+    return raw_email.strip().lower()
+
+
+def _matches_actor_identity(payload: dict[str, Any], actor: Any) -> bool:
+    actor_id = int(actor["id"]) if isinstance(actor, dict) and actor.get("id") is not None else None
+    if actor_id is None:
+        return False
+
+    for candidate in (payload.get("user_id"), payload.get("sub")):
+        if isinstance(candidate, int) and candidate == actor_id:
+            return True
+        if isinstance(candidate, str) and candidate.isdigit() and int(candidate) == actor_id:
+            return True
+
+    actor_email = _normalize_actor_email(actor)
+    payload_email = str(payload.get("email") or "").strip().lower()
+    return bool(actor_email and payload_email and actor_email == payload_email)
+
+
+async def _verify_admin_reauth_token(
+    *,
+    actor: Any,
+    admin_reauth_token: str,
+) -> bool:
+    jwt_service = get_jwt_service()
+    payload = await jwt_service.verify_token_async(admin_reauth_token, token_type="admin_reauth")
+    purpose = str(payload.get("purpose") or "").strip().lower()
+    if purpose != "admin_reauth":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
+        )
+    if not _matches_actor_identity(payload, actor):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
+        )
+
+    jti = str(payload.get("jti") or "").strip()
+    raw_exp = payload.get("exp")
+    exp_dt: datetime | None = None
+    if isinstance(raw_exp, (int, float)):
+        exp_dt = datetime.fromtimestamp(raw_exp, tz=timezone.utc)
+    elif isinstance(raw_exp, datetime):
+        exp_dt = raw_exp if raw_exp.tzinfo is not None else raw_exp.replace(tzinfo=timezone.utc)
+
+    if jti and exp_dt is not None:
+        blacklist = get_token_blacklist()
+        actor_id = int(actor["id"]) if isinstance(actor, dict) else None
+        await blacklist.revoke_token(
+            jti=jti,
+            expires_at=exp_dt,
+            user_id=actor_id,
+            token_type="admin_reauth",
+            reason="admin_reauth_used",
+            revoked_by=actor_id,
+            ip_address=None,
+        )
+    return True
 
 
 async def verify_privileged_action(
@@ -22,6 +92,7 @@ async def verify_privileged_action(
     *,
     reason: str | None,
     admin_password: str | None,
+    admin_reauth_token: str | None = None,
 ) -> str:
     """
     Enforce step-up guardrails for high-risk admin actions.
@@ -37,6 +108,7 @@ async def verify_privileged_action(
     """
     normalized_reason = str(reason or "").strip()
     normalized_password = str(admin_password or "").strip()
+    normalized_reauth_token = str(admin_reauth_token or "").strip()
 
     if len(normalized_reason) < 8:
         raise HTTPException(
@@ -47,12 +119,6 @@ async def verify_privileged_action(
     if is_single_user_principal(principal) and not _enterprise_admin_mode_enabled():
         return normalized_reason
 
-    if len(normalized_password) < 8:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Reason and current password are required for this action",
-        )
-
     if principal.user_id is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -60,18 +126,38 @@ async def verify_privileged_action(
         )
 
     actor = await fetch_active_user_by_id(db, int(principal.user_id))
+    if not actor:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin reauthentication failed",
+        )
     password_hash = actor.get("password_hash") if actor else None
-    if not actor or not isinstance(password_hash, str) or not password_hash:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin reauthentication failed",
-        )
 
-    verified, _needs_rehash = password_service.verify_password(normalized_password, password_hash)
-    if not verified:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Admin reauthentication failed",
-        )
+    if len(normalized_password) >= 8 and isinstance(password_hash, str) and password_hash:
+        verified, _needs_rehash = password_service.verify_password(normalized_password, password_hash)
+        if not verified:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin reauthentication failed",
+            )
+        return normalized_reason
 
-    return normalized_reason
+    if normalized_reauth_token:
+        try:
+            await _verify_admin_reauth_token(
+                actor=actor,
+                admin_reauth_token=normalized_reauth_token,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Admin reauthentication failed",
+            ) from exc
+        return normalized_reason
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Reason and current password or admin reauthentication token are required for this action",
+    )

--- a/tldw_Server_API/app/services/admin_sessions_mfa_service.py
+++ b/tldw_Server_API/app/services/admin_sessions_mfa_service.py
@@ -85,6 +85,7 @@ async def revoke_user_session(
             password_service,
             reason=getattr(request, "reason", None),
             admin_password=getattr(request, "admin_password", None),
+            admin_reauth_token=getattr(request, "admin_reauth_token", None),
         )
         await session_manager.revoke_session(session_id=session_id, revoked_by=principal.user_id)
         await _emit_admin_account_audit_event(
@@ -129,6 +130,7 @@ async def revoke_all_user_sessions(
             password_service,
             reason=getattr(request, "reason", None),
             admin_password=getattr(request, "admin_password", None),
+            admin_reauth_token=getattr(request, "admin_reauth_token", None),
         )
         await session_manager.revoke_all_user_sessions(user_id=user_id)
         await _emit_admin_account_audit_event(
@@ -192,6 +194,7 @@ async def disable_user_mfa(
             password_service,
             reason=getattr(request, "reason", None),
             admin_password=getattr(request, "admin_password", None),
+            admin_reauth_token=getattr(request, "admin_reauth_token", None),
         )
         mfa_service = get_mfa_service()
         success = await mfa_service.disable_mfa(user_id)

--- a/tldw_Server_API/app/services/admin_sessions_mfa_service.py
+++ b/tldw_Server_API/app/services/admin_sessions_mfa_service.py
@@ -5,7 +5,10 @@ from typing import Any
 from fastapi import HTTPException
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.schemas.admin_schemas import AdminPrivilegedActionRequest
+from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminPrivilegedActionRequest,
+    unwrap_optional_secret,
+)
 from tldw_Server_API.app.api.v1.schemas.auth_schemas import MessageResponse, SessionResponse
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
@@ -84,8 +87,8 @@ async def revoke_user_session(
             db,
             password_service,
             reason=getattr(request, "reason", None),
-            admin_password=getattr(request, "admin_password", None),
-            admin_reauth_token=getattr(request, "admin_reauth_token", None),
+            admin_password=unwrap_optional_secret(getattr(request, "admin_password", None)),
+            admin_reauth_token=unwrap_optional_secret(getattr(request, "admin_reauth_token", None)),
         )
         await session_manager.revoke_session(session_id=session_id, revoked_by=principal.user_id)
         await _emit_admin_account_audit_event(
@@ -129,8 +132,8 @@ async def revoke_all_user_sessions(
             db,
             password_service,
             reason=getattr(request, "reason", None),
-            admin_password=getattr(request, "admin_password", None),
-            admin_reauth_token=getattr(request, "admin_reauth_token", None),
+            admin_password=unwrap_optional_secret(getattr(request, "admin_password", None)),
+            admin_reauth_token=unwrap_optional_secret(getattr(request, "admin_reauth_token", None)),
         )
         await session_manager.revoke_all_user_sessions(user_id=user_id)
         await _emit_admin_account_audit_event(
@@ -193,8 +196,8 @@ async def disable_user_mfa(
             db,
             password_service,
             reason=getattr(request, "reason", None),
-            admin_password=getattr(request, "admin_password", None),
-            admin_reauth_token=getattr(request, "admin_reauth_token", None),
+            admin_password=unwrap_optional_secret(getattr(request, "admin_password", None)),
+            admin_reauth_token=unwrap_optional_secret(getattr(request, "admin_reauth_token", None)),
         )
         mfa_service = get_mfa_service()
         success = await mfa_service.disable_mfa(user_id)

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -253,6 +253,7 @@ async def update_user(
                 password_service,
                 reason=request.reason,
                 admin_password=request.admin_password,
+                admin_reauth_token=request.admin_reauth_token,
             )
 
         is_pg = await is_pg_fn()
@@ -386,6 +387,7 @@ async def reset_user_password(
             password_service,
             reason=request.reason,
             admin_password=request.admin_password,
+            admin_reauth_token=request.admin_reauth_token,
         )
 
         temporary_password = request.temporary_password
@@ -506,6 +508,7 @@ async def set_user_mfa_requirement(
             password_service,
             reason=request.reason,
             admin_password=request.admin_password,
+            admin_reauth_token=request.admin_reauth_token,
         )
 
         require_mfa = bool(request.require_mfa)
@@ -618,6 +621,7 @@ async def delete_user(
             password_service,
             reason=getattr(request, "reason", None),
             admin_password=getattr(request, "admin_password", None),
+            admin_reauth_token=getattr(request, "admin_reauth_token", None),
         )
 
         is_pg = await is_pg_fn()

--- a/tldw_Server_API/app/services/admin_users_service.py
+++ b/tldw_Server_API/app/services/admin_users_service.py
@@ -15,6 +15,7 @@ from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     AdminPasswordResetRequest,
     AdminUserCreateRequest,
     UserUpdateRequest,
+    unwrap_optional_secret,
 )
 from tldw_Server_API.app.core.AuthNZ.exceptions import (
     DuplicateUserError,
@@ -252,8 +253,8 @@ async def update_user(
                 db,
                 password_service,
                 reason=request.reason,
-                admin_password=request.admin_password,
-                admin_reauth_token=request.admin_reauth_token,
+                admin_password=unwrap_optional_secret(request.admin_password),
+                admin_reauth_token=unwrap_optional_secret(request.admin_reauth_token),
             )
 
         is_pg = await is_pg_fn()
@@ -386,8 +387,8 @@ async def reset_user_password(
             db,
             password_service,
             reason=request.reason,
-            admin_password=request.admin_password,
-            admin_reauth_token=request.admin_reauth_token,
+            admin_password=unwrap_optional_secret(request.admin_password),
+            admin_reauth_token=unwrap_optional_secret(request.admin_reauth_token),
         )
 
         temporary_password = request.temporary_password
@@ -507,8 +508,8 @@ async def set_user_mfa_requirement(
             db,
             password_service,
             reason=request.reason,
-            admin_password=request.admin_password,
-            admin_reauth_token=request.admin_reauth_token,
+            admin_password=unwrap_optional_secret(request.admin_password),
+            admin_reauth_token=unwrap_optional_secret(request.admin_reauth_token),
         )
 
         require_mfa = bool(request.require_mfa)
@@ -620,8 +621,8 @@ async def delete_user(
             db,
             password_service,
             reason=getattr(request, "reason", None),
-            admin_password=getattr(request, "admin_password", None),
-            admin_reauth_token=getattr(request, "admin_reauth_token", None),
+            admin_password=unwrap_optional_secret(getattr(request, "admin_password", None)),
+            admin_reauth_token=unwrap_optional_secret(getattr(request, "admin_reauth_token", None)),
         )
 
         is_pg = await is_pg_fn()

--- a/tldw_Server_API/app/services/mcp_credential_broker_service.py
+++ b/tldw_Server_API/app/services/mcp_credential_broker_service.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
     ManagedSecretRefsRepo,
 )
@@ -13,6 +14,16 @@ from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import (
 )
 from tldw_Server_API.app.core.AuthNZ.secret_backends.registry import (
     get_secret_backend,
+)
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    decrypt_byok_payload,
+    loads_envelope,
+)
+from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base import (
+    BrokeredExternalCredential,
+)
+from tldw_Server_API.app.services.mcp_hub_external_auth_service import (
+    ManagedExternalAuthBridge,
 )
 from tldw_Server_API.app.services.mcp_hub_external_access_resolver import (
     McpHubExternalAccessResolver,
@@ -61,10 +72,13 @@ class McpCredentialBrokerService:
 
     repo: McpHubRepo
     external_access_resolver: McpHubExternalAccessResolver | None = None
+    auth_bridge: ManagedExternalAuthBridge | None = None
 
     def __post_init__(self) -> None:
         if self.external_access_resolver is None:
             self.external_access_resolver = McpHubExternalAccessResolver(repo=self.repo)
+        if self.auth_bridge is None:
+            self.auth_bridge = ManagedExternalAuthBridge()
 
     async def get_slot_status(
         self,
@@ -124,6 +138,71 @@ class McpCredentialBrokerService:
             "backend_name": backend_name,
             "expires_at": expires_at,
         }
+
+    async def resolve_runtime_auth_for_policy(
+        self,
+        *,
+        server_id: str,
+        effective_policy: dict[str, Any] | None,
+    ) -> BrokeredExternalCredential | None:
+        server = await self.repo.get_external_server(server_id)
+        if not server:
+            raise ValueError(f"Unknown external server: {server_id}")
+
+        auth_mode = self._managed_auth_mode(server)
+        if auth_mode in {"", "none"}:
+            return None
+
+        policy = dict(effective_policy or {})
+        if not bool(policy.get("enabled", False)):
+            raise PermissionError("Managed external auth requires an enabled MCP Hub policy context")
+
+        sources = self._sources_from_effective_policy(policy)
+        if not sources:
+            raise PermissionError("Managed external auth requires MCP Hub policy sources")
+
+        external_access = await self.external_access_resolver.resolve_for_sources(
+            sources=sources,
+            effective_policy=policy,
+        )
+        server_access = self._find_server_access(external_access=external_access, server_id=server_id)
+        blocked_reason = _normalize_status_state((server_access or {}).get("blocked_reason"))
+        if blocked_reason or not bool((server_access or {}).get("runtime_executable")):
+            raise PermissionError(
+                f"Managed external auth is not usable for server '{server_id}': {blocked_reason or 'not_granted'}"
+            )
+
+        secret_payload = await self._resolve_runtime_secret_payload(
+            server=server,
+            sources=sources,
+        )
+        runtime_auth = await self.auth_bridge.hydrate_runtime_auth(
+            server_config=server,
+            secret_payload=secret_payload,
+        )
+        return BrokeredExternalCredential(
+            headers=dict(runtime_auth.get("headers") or {}),
+            env=dict(runtime_auth.get("env") or {}),
+            metadata={
+                "credential_mode": "brokered_ephemeral",
+                "credential_source": "mcp_hub_managed_binding",
+            },
+        )
+
+    async def broker_external_tool_call(
+        self,
+        *,
+        server_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+    ) -> BrokeredExternalCredential | None:
+        del tool_name, arguments
+        policy = self._extract_effective_policy_from_context(context)
+        return await self.resolve_runtime_auth_for_policy(
+            server_id=server_id,
+            effective_policy=policy,
+        )
 
     async def _resolve_target_sources_and_policy(
         self,
@@ -201,6 +280,17 @@ class McpCredentialBrokerService:
                     return dict(slot)
         return None
 
+    @staticmethod
+    def _find_server_access(
+        *,
+        external_access: dict[str, Any],
+        server_id: str,
+    ) -> dict[str, Any] | None:
+        for server in external_access.get("servers") or []:
+            if str(server.get("server_id") or "").strip() == server_id:
+                return dict(server)
+        return None
+
     async def _resolve_effective_binding(
         self,
         *,
@@ -246,6 +336,35 @@ class McpCredentialBrokerService:
 
         return effective
 
+    async def _resolve_server_binding(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        server_id: str,
+    ) -> dict[str, Any] | None:
+        effective: dict[str, Any] | None = None
+        for source in sources:
+            profile_id = source.get("profile_id")
+            if profile_id is not None:
+                for binding in await self.repo.list_credential_bindings(
+                    binding_target_type="profile",
+                    binding_target_id=str(profile_id),
+                ):
+                    if self._binding_matches_server(binding=binding, server_id=server_id):
+                        effective = dict(binding)
+
+            assignment_id = source.get("assignment_id")
+            if assignment_id is None:
+                continue
+            for binding in await self.repo.list_credential_bindings(
+                binding_target_type="assignment",
+                binding_target_id=str(assignment_id),
+            ):
+                if self._binding_matches_server(binding=binding, server_id=server_id):
+                    effective = dict(binding)
+
+        return effective
+
     @staticmethod
     def _binding_matches_slot(
         *,
@@ -261,6 +380,16 @@ class McpCredentialBrokerService:
         if binding_slot_name:
             return binding_slot_name == normalized_slot_name
         return bool(default_slot_name and default_slot_name == normalized_slot_name)
+
+    @staticmethod
+    def _binding_matches_server(
+        *,
+        binding: dict[str, Any],
+        server_id: str,
+    ) -> bool:
+        if str(binding.get("external_server_id") or "").strip() != server_id:
+            return False
+        return not str(binding.get("slot_name") or "").strip()
 
     async def _resolve_slot_state(
         self,
@@ -334,3 +463,160 @@ class McpCredentialBrokerService:
         if backend_state in _APPROVAL_REQUIRED_STATES:
             return "approval_required", backend_name, expires_at
         return "backend_unavailable", backend_name, expires_at
+
+    @staticmethod
+    def _managed_auth_mode(server: dict[str, Any]) -> str:
+        config = dict(server.get("config") or {})
+        auth = dict(config.get("auth") or {})
+        return _normalize_status_state(auth.get("mode"))
+
+    @staticmethod
+    def _extract_effective_policy_from_context(context: Any) -> dict[str, Any] | None:
+        metadata = getattr(context, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        cached = metadata.get("_mcp_effective_tool_policy")
+        if isinstance(cached, dict):
+            return cached
+        return None
+
+    @staticmethod
+    def _sources_from_effective_policy(effective_policy: dict[str, Any]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for source in effective_policy.get("sources") or []:
+            if not isinstance(source, dict):
+                continue
+            assignment_id = source.get("assignment_id")
+            profile_id = source.get("profile_id")
+            normalized_assignment_id = int(assignment_id) if assignment_id is not None else None
+            normalized_profile_id = int(profile_id) if profile_id is not None else None
+            if normalized_assignment_id is None and normalized_profile_id is None:
+                continue
+            out.append(
+                {
+                    "assignment_id": normalized_assignment_id,
+                    "profile_id": normalized_profile_id,
+                }
+            )
+        return out
+
+    @staticmethod
+    def _extract_secret_value(secret_payload: dict[str, Any]) -> str:
+        return str(
+            secret_payload.get("secret")
+            or secret_payload.get("api_key")
+            or ""
+        ).strip()
+
+    async def _resolve_runtime_secret_payload(
+        self,
+        *,
+        server: dict[str, Any],
+        sources: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        server_id = str(server.get("id") or "")
+        required_slots = self.auth_bridge.get_required_slot_names(server_config=server)
+        default_slot = await self.repo.get_external_server_default_slot(server_id=server_id)
+        default_slot_name = str(default_slot.get("slot_name") or "").strip().lower() if default_slot else ""
+
+        if required_slots:
+            slot_values: dict[str, str] = {}
+            for slot_name in required_slots:
+                binding = await self._resolve_effective_binding(
+                    sources=sources,
+                    server_id=server_id,
+                    slot_name=slot_name,
+                )
+                if not binding:
+                    raise PermissionError(
+                        f"Missing external credential binding for required slot '{slot_name}' on '{server_id}'"
+                    )
+                slot_values[slot_name] = await self._resolve_secret_value_for_binding(
+                    server_id=server_id,
+                    slot_name=slot_name,
+                    binding=binding,
+                    default_slot_name=default_slot_name,
+                )
+            return {"slots": slot_values}
+
+        binding = await self._resolve_server_binding(sources=sources, server_id=server_id)
+        if not binding:
+            raise PermissionError(f"Missing external credential binding for server '{server_id}'")
+
+        managed_secret_ref_id = parse_managed_secret_ref_id(binding.get("credential_ref"))
+        if managed_secret_ref_id is not None:
+            return await self._resolve_managed_secret_material(managed_secret_ref_id)
+
+        secret_row = await self.repo.get_external_secret(server_id)
+        encrypted_blob = str((secret_row or {}).get("encrypted_blob") or "").strip()
+        if not encrypted_blob:
+            raise ValueError(f"Managed external server requires a configured secret: {server_id}")
+        return decrypt_byok_payload(loads_envelope(encrypted_blob))
+
+    async def _resolve_secret_value_for_binding(
+        self,
+        *,
+        server_id: str,
+        slot_name: str,
+        binding: dict[str, Any],
+        default_slot_name: str,
+    ) -> str:
+        managed_secret_ref_id = parse_managed_secret_ref_id(binding.get("credential_ref"))
+        if managed_secret_ref_id is not None:
+            material = await self._resolve_managed_secret_material(managed_secret_ref_id)
+            secret_value = self._extract_secret_value(material)
+            if not secret_value:
+                raise ValueError(
+                    f"Managed secret ref '{managed_secret_ref_id}' does not contain usable secret material"
+                )
+            return secret_value
+
+        secret_row = await self.repo.get_external_server_slot_secret(
+            server_id=server_id,
+            slot_name=slot_name,
+        )
+        encrypted_blob = str((secret_row or {}).get("encrypted_blob") or "").strip()
+        if not encrypted_blob and slot_name == default_slot_name:
+            secret_row = await self.repo.get_external_secret(server_id)
+            encrypted_blob = str((secret_row or {}).get("encrypted_blob") or "").strip()
+        if not encrypted_blob:
+            raise ValueError(
+                f"Managed external server requires a configured slot secret: {server_id}/{slot_name}"
+            )
+        material = decrypt_byok_payload(loads_envelope(encrypted_blob))
+        secret_value = self._extract_secret_value(material)
+        if not secret_value:
+            raise ValueError(
+                f"Managed external server requires a configured slot secret: {server_id}/{slot_name}"
+            )
+        return secret_value
+
+    async def _resolve_managed_secret_material(
+        self,
+        managed_secret_ref_id: int,
+    ) -> dict[str, Any]:
+        managed_refs_repo = ManagedSecretRefsRepo(self.repo.db_pool)
+        await managed_refs_repo.ensure_tables()
+        ref = await managed_refs_repo.get_ref(int(managed_secret_ref_id))
+        if not ref:
+            raise ValueError(f"Managed secret ref '{managed_secret_ref_id}' is not available")
+
+        backend_name = str(ref.get("backend_name") or "").strip()
+        if not backend_name:
+            raise ValueError(f"Managed secret ref '{managed_secret_ref_id}' has no backend")
+
+        backend = get_secret_backend(backend_name, db_pool=self.repo.db_pool)
+        await backend.ensure_tables()
+        resolved = await backend.resolve_for_use(int(managed_secret_ref_id))
+        material = dict(resolved.get("material") or {})
+        if not material:
+            raise ValueError(f"Managed secret ref '{managed_secret_ref_id}' resolved without material")
+        return material
+
+
+async def get_mcp_credential_broker_service() -> McpCredentialBrokerService:
+    """Resolve the MCP credential broker service backed by the current MCP Hub repo."""
+    pool = await get_db_pool()
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    return McpCredentialBrokerService(repo=repo)

--- a/tldw_Server_API/app/services/mcp_credential_broker_service.py
+++ b/tldw_Server_API/app/services/mcp_credential_broker_service.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import (
+    McpHubRepo,
+    parse_managed_secret_ref_id,
+)
+from tldw_Server_API.app.core.AuthNZ.secret_backends.registry import (
+    get_secret_backend,
+)
+from tldw_Server_API.app.services.mcp_hub_external_access_resolver import (
+    McpHubExternalAccessResolver,
+)
+
+_APPROVAL_REQUIRED_BLOCKED_REASONS = {
+    "disabled_by_assignment",
+    "external_capability_not_granted",
+    "not_granted",
+}
+_BACKEND_UNAVAILABLE_BLOCKED_REASONS = {
+    "legacy_server_not_bindable",
+    "server_disabled",
+    "server_superseded",
+}
+_READY_STATES = {"active", "enabled", "ready"}
+_MISSING_STATES = {"missing"}
+_REAUTH_REQUIRED_STATES = {"reauth_required", "refresh_required", "revoked"}
+_EXPIRED_STATES = {"expired"}
+_APPROVAL_REQUIRED_STATES = {"approval_required"}
+
+
+def _normalize_status_state(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            return value.astimezone(timezone.utc)
+        return value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        if parsed.tzinfo is not None:
+            return parsed.astimezone(timezone.utc)
+        return parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+@dataclass
+class McpCredentialBrokerService:
+    """Resolve MCP slot remediation status and brokered secret metadata."""
+
+    repo: McpHubRepo
+    external_access_resolver: McpHubExternalAccessResolver | None = None
+
+    def __post_init__(self) -> None:
+        if self.external_access_resolver is None:
+            self.external_access_resolver = McpHubExternalAccessResolver(repo=self.repo)
+
+    async def get_slot_status(
+        self,
+        *,
+        server_id: str,
+        slot_name: str,
+        assignment_id: int | None = None,
+        profile_id: int | None = None,
+    ) -> dict[str, Any]:
+        slot = await self.repo.get_external_server_credential_slot(
+            server_id=server_id,
+            slot_name=slot_name,
+        )
+        if not slot:
+            raise ValueError(f"Unknown external server slot: {server_id}/{slot_name}")
+
+        target_type, target_id, sources, effective_policy = await self._resolve_target_sources_and_policy(
+            assignment_id=assignment_id,
+            profile_id=profile_id,
+        )
+        external_access = await self.external_access_resolver.resolve_for_sources(
+            sources=sources,
+            effective_policy=effective_policy,
+        )
+        slot_access = self._find_slot_access(
+            external_access=external_access,
+            server_id=server_id,
+            slot_name=slot_name,
+        )
+        binding = await self._resolve_effective_binding(
+            sources=sources,
+            server_id=server_id,
+            slot_name=slot_name,
+        )
+
+        managed_secret_ref_id = (
+            parse_managed_secret_ref_id(binding.get("credential_ref")) if binding else None
+        )
+        state, backend_name, expires_at = await self._resolve_slot_state(
+            slot=slot,
+            slot_access=slot_access,
+            binding=binding,
+            managed_secret_ref_id=managed_secret_ref_id,
+        )
+
+        return {
+            "server_id": str(slot.get("server_id") or server_id),
+            "slot_name": str(slot.get("slot_name") or slot_name),
+            "binding_target_type": target_type,
+            "binding_target_id": str(target_id),
+            "credential_ref": str(binding.get("credential_ref") or ("slot" if slot_name else "server"))
+            if binding
+            else ("slot" if slot_name else "server"),
+            "managed_secret_ref_id": managed_secret_ref_id,
+            "state": state,
+            "blocked_reason": (slot_access or {}).get("blocked_reason"),
+            "backend_name": backend_name,
+            "expires_at": expires_at,
+        }
+
+    async def _resolve_target_sources_and_policy(
+        self,
+        *,
+        assignment_id: int | None,
+        profile_id: int | None,
+    ) -> tuple[str, int, list[dict[str, Any]], dict[str, Any]]:
+        if assignment_id is not None:
+            assignment = await self.repo.get_policy_assignment(int(assignment_id))
+            if not assignment:
+                raise ValueError(f"Unknown policy assignment: {assignment_id}")
+            assignment_profile_id = assignment.get("profile_id")
+            source_profile_id = int(assignment_profile_id) if assignment_profile_id is not None else None
+            sources = [{"assignment_id": int(assignment_id), "profile_id": source_profile_id}]
+            policy = await self._build_assignment_effective_policy(
+                assignment_id=int(assignment_id),
+                profile_id=source_profile_id,
+            )
+            return "assignment", int(assignment_id), sources, policy
+
+        if profile_id is not None:
+            profile = await self.repo.get_permission_profile(int(profile_id))
+            if not profile:
+                raise ValueError(f"Unknown permission profile: {profile_id}")
+            sources = [{"assignment_id": None, "profile_id": int(profile_id)}]
+            policy = {
+                "capabilities": self._collect_capabilities(profile.get("policy_document")),
+            }
+            return "profile", int(profile_id), sources, policy
+
+        raise ValueError("assignment_id or profile_id is required")
+
+    async def _build_assignment_effective_policy(
+        self,
+        *,
+        assignment_id: int,
+        profile_id: int | None,
+    ) -> dict[str, Any]:
+        capabilities: set[str] = set()
+        if profile_id is not None:
+            profile = await self.repo.get_permission_profile(int(profile_id))
+            if profile:
+                capabilities.update(self._collect_capabilities(profile.get("policy_document")))
+        assignment = await self.repo.get_policy_assignment(int(assignment_id))
+        if assignment:
+            capabilities.update(self._collect_capabilities(assignment.get("inline_policy_document")))
+        return {"capabilities": sorted(capabilities)}
+
+    @staticmethod
+    def _collect_capabilities(document: Any) -> list[str]:
+        if not isinstance(document, dict):
+            return []
+        out: list[str] = []
+        seen: set[str] = set()
+        for value in document.get("capabilities") or []:
+            capability = str(value or "").strip()
+            if not capability or capability in seen:
+                continue
+            out.append(capability)
+            seen.add(capability)
+        return out
+
+    @staticmethod
+    def _find_slot_access(
+        *,
+        external_access: dict[str, Any],
+        server_id: str,
+        slot_name: str,
+    ) -> dict[str, Any] | None:
+        for server in external_access.get("servers") or []:
+            if str(server.get("server_id") or "").strip() != server_id:
+                continue
+            for slot in server.get("slots") or []:
+                if str(slot.get("slot_name") or "").strip().lower() == slot_name.strip().lower():
+                    return dict(slot)
+        return None
+
+    async def _resolve_effective_binding(
+        self,
+        *,
+        sources: list[dict[str, Any]],
+        server_id: str,
+        slot_name: str,
+    ) -> dict[str, Any] | None:
+        default_slot = await self.repo.get_external_server_default_slot(server_id=server_id)
+        default_slot_name = (
+            str(default_slot.get("slot_name") or "").strip().lower() if default_slot else None
+        )
+        effective: dict[str, Any] | None = None
+
+        for source in sources:
+            profile_id = source.get("profile_id")
+            if profile_id is not None:
+                for binding in await self.repo.list_credential_bindings(
+                    binding_target_type="profile",
+                    binding_target_id=str(profile_id),
+                ):
+                    if self._binding_matches_slot(
+                        binding=binding,
+                        server_id=server_id,
+                        slot_name=slot_name,
+                        default_slot_name=default_slot_name,
+                    ):
+                        effective = dict(binding)
+
+            assignment_id = source.get("assignment_id")
+            if assignment_id is None:
+                continue
+            for binding in await self.repo.list_credential_bindings(
+                binding_target_type="assignment",
+                binding_target_id=str(assignment_id),
+            ):
+                if self._binding_matches_slot(
+                    binding=binding,
+                    server_id=server_id,
+                    slot_name=slot_name,
+                    default_slot_name=default_slot_name,
+                ):
+                    effective = dict(binding)
+
+        return effective
+
+    @staticmethod
+    def _binding_matches_slot(
+        *,
+        binding: dict[str, Any],
+        server_id: str,
+        slot_name: str,
+        default_slot_name: str | None,
+    ) -> bool:
+        if str(binding.get("external_server_id") or "").strip() != server_id:
+            return False
+        binding_slot_name = str(binding.get("slot_name") or "").strip().lower()
+        normalized_slot_name = slot_name.strip().lower()
+        if binding_slot_name:
+            return binding_slot_name == normalized_slot_name
+        return bool(default_slot_name and default_slot_name == normalized_slot_name)
+
+    async def _resolve_slot_state(
+        self,
+        *,
+        slot: dict[str, Any],
+        slot_access: dict[str, Any] | None,
+        binding: dict[str, Any] | None,
+        managed_secret_ref_id: int | None,
+    ) -> tuple[str, str | None, datetime | None]:
+        blocked_reason = _normalize_status_state((slot_access or {}).get("blocked_reason"))
+        if blocked_reason in _APPROVAL_REQUIRED_BLOCKED_REASONS:
+            return "approval_required", None, None
+        if blocked_reason in _BACKEND_UNAVAILABLE_BLOCKED_REASONS:
+            return "backend_unavailable", None, None
+        if binding and _normalize_status_state(binding.get("binding_mode")) == "disable":
+            return "approval_required", None, None
+        if binding is None:
+            return "approval_required", None, None
+
+        if managed_secret_ref_id is not None:
+            return await self._resolve_managed_secret_state(managed_secret_ref_id)
+
+        if bool((slot_access or {}).get("runtime_usable")) or bool(slot.get("secret_configured")):
+            return "ready", None, None
+        if blocked_reason == "missing_secret" or not binding:
+            return "missing", None, None
+        return "missing", None, None
+
+    async def _resolve_managed_secret_state(
+        self,
+        managed_secret_ref_id: int,
+    ) -> tuple[str, str | None, datetime | None]:
+        managed_refs_repo = ManagedSecretRefsRepo(self.repo.db_pool)
+        await managed_refs_repo.ensure_tables()
+        ref = await managed_refs_repo.get_ref(int(managed_secret_ref_id), include_revoked=True)
+        if not ref:
+            return "missing", None, None
+
+        backend_name = str(ref.get("backend_name") or "") or None
+        expires_at = _coerce_datetime(ref.get("expires_at"))
+        raw_status = _normalize_status_state(ref.get("status"))
+        now = datetime.now(timezone.utc)
+
+        if ref.get("revoked_at"):
+            return "reauth_required", backend_name, expires_at
+        if raw_status in _REAUTH_REQUIRED_STATES:
+            return "reauth_required", backend_name, expires_at
+        if raw_status in _APPROVAL_REQUIRED_STATES:
+            return "approval_required", backend_name, expires_at
+        if raw_status in _EXPIRED_STATES or (expires_at is not None and expires_at <= now):
+            return "expired", backend_name, expires_at
+
+        if not backend_name:
+            return "backend_unavailable", None, expires_at
+
+        try:
+            backend = get_secret_backend(backend_name, db_pool=self.repo.db_pool)
+        except ValueError:
+            return "backend_unavailable", backend_name, expires_at
+
+        backend_status = await backend.describe_status(int(managed_secret_ref_id))
+        backend_state = _normalize_status_state(backend_status.get("state"))
+        if backend_state in _READY_STATES:
+            return "ready", backend_name, expires_at
+        if backend_state in _MISSING_STATES:
+            return "missing", backend_name, expires_at
+        if backend_state in _REAUTH_REQUIRED_STATES or backend_state == "revoked":
+            return "reauth_required", backend_name, expires_at
+        if backend_state in _EXPIRED_STATES:
+            return "expired", backend_name, expires_at
+        if backend_state in _APPROVAL_REQUIRED_STATES:
+            return "approval_required", backend_name, expires_at
+        return "backend_unavailable", backend_name, expires_at

--- a/tldw_Server_API/app/services/mcp_hub_external_access_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_external_access_resolver.py
@@ -4,7 +4,16 @@ from dataclasses import dataclass
 from typing import Any
 
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import (
+    parse_managed_secret_ref_id,
+)
+from tldw_Server_API.app.core.AuthNZ.secret_backends.registry import (
+    get_secret_backend,
+)
 from tldw_Server_API.app.services.mcp_hub_external_auth_service import (
     ManagedExternalAuthBridge,
 )
@@ -62,6 +71,7 @@ class McpHubExternalAccessResolver:
                         states=states,
                         server_id=server_id,
                         slot_name=binding.get("slot_name"),
+                        credential_ref=binding.get("credential_ref"),
                         binding_mode="grant",
                         granted_by="profile",
                     )
@@ -80,6 +90,7 @@ class McpHubExternalAccessResolver:
                     states=states,
                     server_id=server_id,
                     slot_name=binding.get("slot_name"),
+                    credential_ref=binding.get("credential_ref"),
                     binding_mode=str(binding.get("binding_mode") or "grant"),
                     granted_by="assignment",
                 )
@@ -92,14 +103,17 @@ class McpHubExternalAccessResolver:
         states: dict[str, dict[str, Any]],
         server_id: str,
         slot_name: Any,
+        credential_ref: Any,
         binding_mode: str,
         granted_by: str,
     ) -> None:
+        managed_secret_ref_id = parse_managed_secret_ref_id(credential_ref)
         server_state = states.setdefault(
             server_id,
             {
                 "granted_by": None,
                 "disabled_by_assignment": False,
+                "managed_ref_id": None,
                 "slots": {},
             },
         )
@@ -117,8 +131,12 @@ class McpHubExternalAccessResolver:
             slot_states = server_state.setdefault("slots", {})
             for target_slot_name in target_slot_names:
                 slot_state = slot_states.setdefault(
-                    target_slot_name,
-                    {"granted_by": None, "disabled_by_assignment": False},
+                target_slot_name,
+                    {
+                        "granted_by": None,
+                        "disabled_by_assignment": False,
+                        "managed_ref_id": None,
+                    },
                 )
                 if binding_mode == "disable":
                     slot_state["disabled_by_assignment"] = True
@@ -127,6 +145,7 @@ class McpHubExternalAccessResolver:
                 else:
                     slot_state["granted_by"] = granted_by
                     slot_state["disabled_by_assignment"] = False
+                    slot_state["managed_ref_id"] = managed_secret_ref_id
             return
 
         if binding_mode == "disable":
@@ -136,6 +155,7 @@ class McpHubExternalAccessResolver:
         else:
             server_state["granted_by"] = granted_by
             server_state["disabled_by_assignment"] = False
+            server_state["managed_ref_id"] = managed_secret_ref_id
 
     async def _build_server_rows(
         self,
@@ -169,7 +189,9 @@ class McpHubExternalAccessResolver:
                     slot_state = dict(active_slot_states.get(slot_name) or {})
                     granted_by = slot_state.get("granted_by")
                     disabled = bool(slot_state.get("disabled_by_assignment"))
-                    secret_available = bool(slot.get("secret_configured"))
+                    secret_available = bool(slot.get("secret_configured")) or await self._managed_secret_ref_ready(
+                        slot_state.get("managed_ref_id")
+                    )
                     runtime_usable = bool(
                         granted_by
                         and allows_external
@@ -284,7 +306,9 @@ class McpHubExternalAccessResolver:
                 continue
 
             disabled = bool(state.get("disabled_by_assignment"))
-            secret_available = bool(server.get("secret_configured"))
+            secret_available = bool(server.get("secret_configured")) or await self._managed_secret_ref_ready(
+                state.get("managed_ref_id")
+            )
             runtime_executable = bool(
                 allows_external
                 and not disabled
@@ -322,6 +346,25 @@ class McpHubExternalAccessResolver:
                 }
             )
         return rows
+
+    async def _managed_secret_ref_ready(self, managed_secret_ref_id: Any) -> bool:
+        if managed_secret_ref_id is None:
+            return False
+        managed_repo = ManagedSecretRefsRepo(self.repo.db_pool)
+        await managed_repo.ensure_tables()
+        ref = await managed_repo.get_ref(int(managed_secret_ref_id), include_revoked=True)
+        if not ref or ref.get("revoked_at"):
+            return False
+        backend_name = str(ref.get("backend_name") or "").strip()
+        if not backend_name:
+            return False
+        try:
+            backend = get_secret_backend(backend_name, db_pool=self.repo.db_pool)
+        except ValueError:
+            return False
+        status = await backend.describe_status(int(managed_secret_ref_id))
+        state = str(status.get("state") or "").strip().lower()
+        return state in {"active", "enabled", "ready"}
 
 
 async def get_mcp_hub_external_access_resolver() -> McpHubExternalAccessResolver:

--- a/tldw_Server_API/app/services/mcp_hub_external_access_resolver.py
+++ b/tldw_Server_API/app/services/mcp_hub_external_access_resolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -170,6 +171,7 @@ class McpHubExternalAccessResolver:
             or []
         )
         allows_external = "network.external" in capabilities
+        managed_secret_ref_ready_cache = await self._load_managed_secret_ref_ready_cache(states)
         rows: list[dict[str, Any]] = []
         for server_id in sorted(states.keys()):
             server = await self.repo.get_external_server(server_id)
@@ -189,8 +191,8 @@ class McpHubExternalAccessResolver:
                     slot_state = dict(active_slot_states.get(slot_name) or {})
                     granted_by = slot_state.get("granted_by")
                     disabled = bool(slot_state.get("disabled_by_assignment"))
-                    secret_available = bool(slot.get("secret_configured")) or await self._managed_secret_ref_ready(
-                        slot_state.get("managed_ref_id")
+                    secret_available = bool(slot.get("secret_configured")) or bool(
+                        managed_secret_ref_ready_cache.get(int(slot_state.get("managed_ref_id") or 0), False)
                     )
                     runtime_usable = bool(
                         granted_by
@@ -306,8 +308,8 @@ class McpHubExternalAccessResolver:
                 continue
 
             disabled = bool(state.get("disabled_by_assignment"))
-            secret_available = bool(server.get("secret_configured")) or await self._managed_secret_ref_ready(
-                state.get("managed_ref_id")
+            secret_available = bool(server.get("secret_configured")) or bool(
+                managed_secret_ref_ready_cache.get(int(state.get("managed_ref_id") or 0), False)
             )
             runtime_executable = bool(
                 allows_external
@@ -347,24 +349,76 @@ class McpHubExternalAccessResolver:
             )
         return rows
 
-    async def _managed_secret_ref_ready(self, managed_secret_ref_id: Any) -> bool:
-        if managed_secret_ref_id is None:
-            return False
+    @staticmethod
+    def _collect_managed_secret_ref_ids(states: dict[str, dict[str, Any]]) -> list[int]:
+        ref_ids: set[int] = set()
+        for state in states.values():
+            managed_ref_id = state.get("managed_ref_id")
+            if managed_ref_id is not None:
+                ref_ids.add(int(managed_ref_id))
+            for slot_state in dict(state.get("slots") or {}).values():
+                if not isinstance(slot_state, dict):
+                    continue
+                managed_ref_id = slot_state.get("managed_ref_id")
+                if managed_ref_id is not None:
+                    ref_ids.add(int(managed_ref_id))
+        return sorted(ref_ids)
+
+    async def _load_managed_secret_ref_ready_cache(
+        self,
+        states: dict[str, dict[str, Any]],
+    ) -> dict[int, bool]:
         managed_repo = ManagedSecretRefsRepo(self.repo.db_pool)
         await managed_repo.ensure_tables()
-        ref = await managed_repo.get_ref(int(managed_secret_ref_id), include_revoked=True)
-        if not ref or ref.get("revoked_at"):
-            return False
-        backend_name = str(ref.get("backend_name") or "").strip()
-        if not backend_name:
-            return False
-        try:
-            backend = get_secret_backend(backend_name, db_pool=self.repo.db_pool)
-        except ValueError:
-            return False
-        status = await backend.describe_status(int(managed_secret_ref_id))
-        state = str(status.get("state") or "").strip().lower()
-        return state in {"active", "enabled", "ready"}
+        ref_ids = self._collect_managed_secret_ref_ids(states)
+        refs_by_id = await managed_repo.list_refs_by_ids(ref_ids, include_revoked=True)
+        now = datetime.now(timezone.utc)
+        backend_cache: dict[str, Any] = {}
+        readiness: dict[int, bool] = {}
+
+        for ref_id in ref_ids:
+            ref = refs_by_id.get(int(ref_id))
+            if not ref or ref.get("revoked_at"):
+                readiness[int(ref_id)] = False
+                continue
+
+            raw_status = str(ref.get("status") or "").strip().lower()
+            expires_at = ref.get("expires_at")
+            expires_at_dt: datetime | None = None
+            if isinstance(expires_at, str) and expires_at.strip():
+                try:
+                    expires_at_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                except ValueError:
+                    expires_at_dt = None
+            elif isinstance(expires_at, datetime):
+                expires_at_dt = expires_at if expires_at.tzinfo else expires_at.replace(tzinfo=timezone.utc)
+
+            if raw_status not in {"active", "enabled", "ready"}:
+                readiness[int(ref_id)] = False
+                continue
+            if expires_at_dt is not None and expires_at_dt <= now:
+                readiness[int(ref_id)] = False
+                continue
+
+            backend_name = str(ref.get("backend_name") or "").strip()
+            if not backend_name:
+                readiness[int(ref_id)] = False
+                continue
+
+            backend = backend_cache.get(backend_name)
+            if backend is None:
+                try:
+                    backend = get_secret_backend(backend_name, db_pool=self.repo.db_pool)
+                except ValueError:
+                    readiness[int(ref_id)] = False
+                    continue
+                backend_cache[backend_name] = backend
+
+            status = await backend.describe_status(int(ref_id))
+            state = str(status.get("state") or "").strip().lower()
+            readiness[int(ref_id)] = state in {"active", "enabled", "ready"}
+
+        return readiness
 
 
 async def get_mcp_hub_external_access_resolver() -> McpHubExternalAccessResolver:

--- a/tldw_Server_API/app/services/mcp_hub_external_registry_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_external_registry_service.py
@@ -7,16 +7,9 @@ from loguru import logger
 
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
-from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
-    decrypt_byok_payload,
-    loads_envelope,
-)
 from tldw_Server_API.app.core.MCP_unified.external_servers.config_schema import (
     ExternalMCPServerConfig,
     parse_external_server_registry,
-)
-from tldw_Server_API.app.services.mcp_hub_external_auth_service import (
-    ManagedExternalAuthBridge,
 )
 
 
@@ -25,11 +18,6 @@ class McpHubExternalRegistryService:
     """Build executable external server configs from managed MCP Hub state."""
 
     repo: McpHubRepo
-    auth_bridge: ManagedExternalAuthBridge | None = None
-
-    def __post_init__(self) -> None:
-        if self.auth_bridge is None:
-            self.auth_bridge = ManagedExternalAuthBridge()
 
     async def list_runtime_servers(self) -> list[ExternalMCPServerConfig]:
         rows = await self.repo.list_external_servers()
@@ -49,14 +37,6 @@ class McpHubExternalRegistryService:
                 )
         return runtime_servers
 
-    @staticmethod
-    def _extract_secret_value(secret_payload: dict[str, Any]) -> str:
-        return str(
-            secret_payload.get("secret")
-            or secret_payload.get("api_key")
-            or ""
-        ).strip()
-
     async def _build_runtime_payload(self, row: dict[str, Any]) -> dict[str, Any] | None:
         if str(row.get("server_source") or "managed") != "managed":
             return None
@@ -70,59 +50,7 @@ class McpHubExternalRegistryService:
         mode = str(auth.get("mode") or "none").strip().lower()
 
         if mode not in {"", "none"}:
-            server_id = str(row.get("id") or "")
-            required_slots = self.auth_bridge.get_required_slot_names(server_config=row)
-            if required_slots:
-                slot_payloads: dict[str, str] = {}
-                default_slot = await self.repo.get_external_server_default_slot(server_id=server_id)
-                default_slot_name = str(default_slot.get("slot_name") or "") if default_slot else ""
-                for slot_name in required_slots:
-                    secret_row = await self.repo.get_external_server_slot_secret(
-                        server_id=server_id,
-                        slot_name=slot_name,
-                    )
-                    if secret_row and str(secret_row.get("encrypted_blob") or "").strip():
-                        decrypted = decrypt_byok_payload(loads_envelope(str(secret_row.get("encrypted_blob") or "")))
-                        slot_secret = self._extract_secret_value(decrypted)
-                    elif slot_name == default_slot_name:
-                        legacy_secret = await self.repo.get_external_secret(server_id)
-                        if not legacy_secret or not str(legacy_secret.get("encrypted_blob") or "").strip():
-                            raise ValueError(f"managed external server requires a configured slot secret: {slot_name}")
-                        decrypted = decrypt_byok_payload(loads_envelope(str(legacy_secret.get("encrypted_blob") or "")))
-                        slot_secret = self._extract_secret_value(decrypted)
-                    else:
-                        raise ValueError(f"managed external server requires a configured slot secret: {slot_name}")
-                    if not slot_secret:
-                        raise ValueError(f"managed external server requires a configured slot secret: {slot_name}")
-                    slot_payloads[slot_name] = slot_secret
-                secret_payload = {"slots": slot_payloads}
-            else:
-                secret_row = await self.repo.get_external_secret(server_id)
-                if not secret_row or not str(secret_row.get("encrypted_blob") or "").strip():
-                    raise ValueError("managed external server requires a configured secret")
-                secret_payload = decrypt_byok_payload(loads_envelope(str(secret_row.get("encrypted_blob") or "")))
-            runtime_auth = await self.auth_bridge.hydrate_runtime_auth(
-                server_config=row,
-                secret_payload=secret_payload,
-            )
-            headers = dict(runtime_auth.get("headers") or {})
-            env = dict(runtime_auth.get("env") or {})
-            if headers:
-                if str(row.get("transport") or "").strip().lower() != "websocket":
-                    raise ValueError("managed header auth is currently supported only for websocket transport")
-                websocket_cfg = dict(config.get("websocket") or {})
-                merged_headers = dict(websocket_cfg.get("headers") or {})
-                merged_headers.update(headers)
-                websocket_cfg["headers"] = merged_headers
-                config["websocket"] = websocket_cfg
-            if env:
-                if str(row.get("transport") or "").strip().lower() != "stdio":
-                    raise ValueError("managed env auth is currently supported only for stdio transport")
-                stdio_cfg = dict(config.get("stdio") or {})
-                merged_env = dict(stdio_cfg.get("env") or {})
-                merged_env.update(env)
-                stdio_cfg["env"] = merged_env
-                config["stdio"] = stdio_cfg
+            # Managed runtime auth is brokered per execution; registry payloads stay auth-neutral.
             config["auth"] = {"mode": "none"}
 
         payload = {

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -3011,6 +3011,7 @@ class McpHubService:
     async def _resolve_binding_credential_ref(
         self,
         *,
+        target_row: dict[str, Any],
         slot_name: str | None,
         managed_secret_ref_id: int | None,
     ) -> str:
@@ -3022,6 +3023,13 @@ class McpHubService:
         ref = await managed_refs_repo.get_ref(int(managed_secret_ref_id))
         if not ref:
             raise BadRequestError("Managed secret ref not found")
+        self._scope_reference_allowed(
+            object_scope_type=str(ref.get("owner_scope_type") or "global"),
+            object_scope_id=ref.get("owner_scope_id"),
+            target_scope_type=str(target_row.get("owner_scope_type") or "global"),
+            target_scope_id=target_row.get("owner_scope_id"),
+            resource_name="managed secret ref",
+        )
         return encode_managed_secret_credential_ref(int(ref["id"]))
 
     async def list_profile_credential_bindings(
@@ -3050,6 +3058,7 @@ class McpHubService:
             raise ResourceNotFoundError("mcp_external_server", identifier=external_server_id)
         self._validate_binding_scope(server_row=server_row, target_row=target_row)
         credential_ref = await self._resolve_binding_credential_ref(
+            target_row=target_row,
             slot_name=slot_name,
             managed_secret_ref_id=managed_secret_ref_id,
         )
@@ -3139,6 +3148,7 @@ class McpHubService:
             raise ResourceNotFoundError("mcp_external_server", identifier=external_server_id)
         self._validate_binding_scope(server_row=server_row, target_row=target_row)
         credential_ref = await self._resolve_binding_credential_ref(
+            target_row=target_row,
             slot_name=slot_name,
             managed_secret_ref_id=managed_secret_ref_id if binding_mode == "grant" else None,
         )

--- a/tldw_Server_API/app/services/mcp_hub_service.py
+++ b/tldw_Server_API/app/services/mcp_hub_service.py
@@ -19,7 +19,13 @@ from tldw_Server_API.app.core.exceptions import (
     BadRequestError,
     ResourceNotFoundError,
 )
-from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import (
+    McpHubRepo,
+    encode_managed_secret_credential_ref,
+)
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     build_secret_payload,
     dumps_envelope,
@@ -3002,6 +3008,22 @@ class McpHubService:
         )
         return updated or row
 
+    async def _resolve_binding_credential_ref(
+        self,
+        *,
+        slot_name: str | None,
+        managed_secret_ref_id: int | None,
+    ) -> str:
+        if managed_secret_ref_id is None:
+            return "slot" if slot_name else "server"
+
+        managed_refs_repo = ManagedSecretRefsRepo(self.repo.db_pool)
+        await managed_refs_repo.ensure_tables()
+        ref = await managed_refs_repo.get_ref(int(managed_secret_ref_id))
+        if not ref:
+            raise BadRequestError("Managed secret ref not found")
+        return encode_managed_secret_credential_ref(int(ref["id"]))
+
     async def list_profile_credential_bindings(
         self,
         *,
@@ -3019,6 +3041,7 @@ class McpHubService:
         profile_id: int,
         external_server_id: str,
         slot_name: str | None = None,
+        managed_secret_ref_id: int | None = None,
         actor_id: int | None,
     ) -> dict[str, Any]:
         target_row = await self._resolve_binding_target(binding_target_type="profile", binding_target_id=profile_id)
@@ -3026,12 +3049,16 @@ class McpHubService:
         if not server_row:
             raise ResourceNotFoundError("mcp_external_server", identifier=external_server_id)
         self._validate_binding_scope(server_row=server_row, target_row=target_row)
+        credential_ref = await self._resolve_binding_credential_ref(
+            slot_name=slot_name,
+            managed_secret_ref_id=managed_secret_ref_id,
+        )
         row = await self.repo.upsert_credential_binding(
             binding_target_type="profile",
             binding_target_id=str(profile_id),
             external_server_id=external_server_id,
             slot_name=slot_name,
-            credential_ref="slot" if slot_name else "server",
+            credential_ref=credential_ref,
             binding_mode="grant",
             usage_rules={},
             actor_id=actor_id,
@@ -3046,6 +3073,7 @@ class McpHubService:
                     "external_server_id": external_server_id,
                     "slot_name": slot_name,
                     "binding_mode": "grant",
+                    "managed_secret_ref_id": managed_secret_ref_id,
                     **(
                         await self._binding_audit_privilege_metadata(
                             external_server_id=external_server_id,
@@ -3102,6 +3130,7 @@ class McpHubService:
         external_server_id: str,
         slot_name: str | None = None,
         binding_mode: str,
+        managed_secret_ref_id: int | None = None,
         actor_id: int | None,
     ) -> dict[str, Any]:
         target_row = await self._resolve_binding_target(binding_target_type="assignment", binding_target_id=assignment_id)
@@ -3109,12 +3138,16 @@ class McpHubService:
         if not server_row:
             raise ResourceNotFoundError("mcp_external_server", identifier=external_server_id)
         self._validate_binding_scope(server_row=server_row, target_row=target_row)
+        credential_ref = await self._resolve_binding_credential_ref(
+            slot_name=slot_name,
+            managed_secret_ref_id=managed_secret_ref_id if binding_mode == "grant" else None,
+        )
         row = await self.repo.upsert_credential_binding(
             binding_target_type="assignment",
             binding_target_id=str(assignment_id),
             external_server_id=external_server_id,
             slot_name=slot_name,
-            credential_ref="slot" if slot_name else "server",
+            credential_ref=credential_ref,
             binding_mode=binding_mode,
             usage_rules={},
             actor_id=actor_id,
@@ -3129,6 +3162,7 @@ class McpHubService:
                     "external_server_id": external_server_id,
                     "slot_name": slot_name,
                     "binding_mode": binding_mode,
+                    "managed_secret_ref_id": managed_secret_ref_id if binding_mode == "grant" else None,
                     **(
                         await self._binding_audit_privilege_metadata(
                             external_server_id=external_server_id,

--- a/tldw_Server_API/app/services/registration_service.py
+++ b/tldw_Server_API/app/services/registration_service.py
@@ -268,6 +268,7 @@ class RegistrationService:
         is_active_override: Optional[bool] = None,
         is_verified_override: Optional[bool] = None,
         storage_quota_override: Optional[int] = None,
+        system_provisioning: bool = False,
     ) -> dict[str, Any]:
         """
         Register a new user with full transaction safety
@@ -282,6 +283,7 @@ class RegistrationService:
             is_active_override: Optional admin override for active status
             is_verified_override: Optional admin override for verification status
             storage_quota_override: Optional admin override for storage quota
+            system_provisioning: Internal provisioning bypass for IdP/JIT-created users
 
         Returns:
             Dictionary with user information
@@ -289,8 +291,10 @@ class RegistrationService:
         Raises:
             Various registration exceptions
         """
+        privileged_creation = created_by is not None or system_provisioning
+
         # Check if registration is enabled
-        if not self.registration_enabled and not created_by:
+        if not self.registration_enabled and not privileged_creation:
             raise RegistrationDisabledError()
 
         # Initialize if needed
@@ -339,13 +343,13 @@ class RegistrationService:
                 role = self.settings.DEFAULT_USER_ROLE
                 storage_quota = self.settings.DEFAULT_STORAGE_QUOTA_MB
 
-                if created_by is not None:
+                if privileged_creation:
                     if role_override:
                         role = role_override
                     if storage_quota_override is not None:
                         storage_quota = storage_quota_override
 
-                if registration_code and not created_by:
+                if registration_code and not privileged_creation:
                     # Validate and use registration code (optional when not required)
                     code_info = await self._validate_and_use_registration_code(
                         registration_code,
@@ -357,7 +361,7 @@ class RegistrationService:
                     # Check if code specifies storage quota
                     if 'storage_quota_mb' in code_info:
                         storage_quota = code_info['storage_quota_mb']
-                elif self.require_code and not created_by:
+                elif self.require_code and not privileged_creation:
                     raise InvalidRegistrationCodeError("Registration code required")
 
                 # Hash the password
@@ -368,11 +372,11 @@ class RegistrationService:
 
                 # Create user
                 is_active = True
-                if created_by is not None and is_active_override is not None:
+                if privileged_creation and is_active_override is not None:
                     is_active = bool(is_active_override)
 
                 is_verified = not self.require_code
-                if created_by is not None:
+                if privileged_creation:
                     is_verified = bool(is_verified_override) if is_verified_override is not None else True
 
                 if self._is_postgres_backend():

--- a/tldw_Server_API/app/services/registration_service.py
+++ b/tldw_Server_API/app/services/registration_service.py
@@ -347,6 +347,8 @@ class RegistrationService:
                     if role_override:
                         role = role_override
                     if storage_quota_override is not None:
+                        if int(storage_quota_override) < 0:
+                            raise ValueError("storage_quota_override must be non-negative")
                         storage_quota = storage_quota_override
 
                 if registration_code and not privileged_creation:

--- a/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
+++ b/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 import pytest
 
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
+    AdminPrivilegedActionRequest,
     AdminMfaRequirementRequest,
     AdminPasswordResetRequest,
+    UserUpdateRequest,
 )
 from tldw_Server_API.app.core.Audit.unified_audit_service import (
     AuditEventCategory,
@@ -175,6 +177,47 @@ async def test_delete_user_forwards_admin_reauth_token_to_guardrails(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_delete_user_unwraps_secretstr_admin_reauth_token_before_guardrails(monkeypatch) -> None:
+    received: dict[str, object] = {}
+
+    async def _verify(*_args, **kwargs) -> str:
+        received.update(kwargs)
+        return "Support case 123"
+
+    async def _fake_emit(**_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _verify)
+    monkeypatch.setattr(
+        admin_users_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    await admin_users_service.delete_user(
+        _admin_principal(),
+        42,
+        AdminPrivilegedActionRequest(
+            reason="Support case 123",
+            admin_reauth_token="magic-token-123",
+        ),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert received["reason"] == "Support case 123"
+    assert received["admin_password"] is None
+    assert received["admin_reauth_token"] == "magic-token-123"
+
+
+@pytest.mark.asyncio
 async def test_delete_user_emits_durable_audit_event(monkeypatch) -> None:
     emitted: list[dict[str, object]] = []
 
@@ -296,6 +339,80 @@ async def test_revoke_user_session_forwards_admin_reauth_token_to_guardrails(mon
     assert received["reason"] == "Support case 123"
     assert received["admin_password"] is None
     assert received["admin_reauth_token"] == "magic-token-456"
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_session_unwraps_secretstr_admin_reauth_token_before_guardrails(monkeypatch) -> None:
+    received: dict[str, object] = {}
+
+    async def _verify(*_args, **kwargs) -> str:
+        received.update(kwargs)
+        return "Support case 123"
+
+    async def _fake_emit(**_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        admin_sessions_mfa_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_sessions_mfa_service, "verify_privileged_action", _verify)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    await admin_sessions_mfa_service.revoke_user_session(
+        _admin_principal(),
+        42,
+        99,
+        _FakeSessionManager(),
+        _FakeUserDb(),
+        password_service=object(),
+        request=AdminPrivilegedActionRequest(
+            reason="Support case 123",
+            admin_reauth_token="magic-token-456",
+        ),
+    )
+
+    assert received["reason"] == "Support case 123"
+    assert received["admin_password"] is None
+    assert received["admin_reauth_token"] == "magic-token-456"
+
+
+@pytest.mark.asyncio
+async def test_update_user_unwraps_secretstr_admin_password_before_guardrails(monkeypatch) -> None:
+    received: dict[str, object] = {}
+
+    async def _verify(*_args, **kwargs) -> str:
+        received.update(kwargs)
+        return "Support case 123"
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _verify)
+
+    await admin_users_service.update_user(
+        _admin_principal(),
+        42,
+        UserUpdateRequest(
+            role="user",
+            reason="Support case 123",
+            admin_password="AdminPass123!",
+        ),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert received["reason"] == "Support case 123"
+    assert received["admin_password"] == "AdminPass123!"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
+++ b/tldw_Server_API/tests/Admin/test_admin_account_audit_events.py
@@ -133,6 +133,48 @@ async def test_reset_user_password_emits_durable_audit_event(monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_delete_user_forwards_admin_reauth_token_to_guardrails(monkeypatch) -> None:
+    received: dict[str, object] = {}
+
+    async def _verify(*_args, **kwargs) -> str:
+        received.update(kwargs)
+        return "Support case 123"
+
+    async def _fake_emit(**_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        admin_users_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_users_service, "verify_privileged_action", _verify)
+    monkeypatch.setattr(
+        admin_users_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    await admin_users_service.delete_user(
+        _admin_principal(),
+        42,
+        SimpleNamespace(
+            reason="Support case 123",
+            admin_password=None,
+            admin_reauth_token="magic-token-123",
+        ),
+        _FakeUserDb(),
+        password_service=object(),
+        is_pg_fn=lambda: _false_async(),
+    )
+
+    assert received["reason"] == "Support case 123"
+    assert received["admin_password"] is None
+    assert received["admin_reauth_token"] == "magic-token-123"
+
+
+@pytest.mark.asyncio
 async def test_delete_user_emits_durable_audit_event(monkeypatch) -> None:
     emitted: list[dict[str, object]] = []
 
@@ -210,6 +252,50 @@ async def test_revoke_user_session_emits_durable_audit_event(monkeypatch) -> Non
     assert emitted[0]["resource_id"] == "84"
     assert emitted[0]["action"] == "admin.user.session.revoke"
     assert emitted[0]["metadata"]["reason"] == "Support case 123"
+
+
+@pytest.mark.asyncio
+async def test_revoke_user_session_forwards_admin_reauth_token_to_guardrails(monkeypatch) -> None:
+    received: dict[str, object] = {}
+
+    async def _verify(*_args, **kwargs) -> str:
+        received.update(kwargs)
+        return "Support case 123"
+
+    async def _fake_emit(**_kwargs) -> None:
+        return None
+
+    session_manager = _FakeSessionManager()
+    monkeypatch.setattr(
+        admin_sessions_mfa_service.admin_scope_service,
+        "enforce_admin_user_scope",
+        _allow_scope,
+    )
+    monkeypatch.setattr(admin_sessions_mfa_service, "verify_privileged_action", _verify)
+    monkeypatch.setattr(
+        admin_sessions_mfa_service,
+        "_emit_admin_account_audit_event",
+        _fake_emit,
+        raising=False,
+    )
+
+    await admin_sessions_mfa_service.revoke_user_session(
+        _admin_principal(),
+        42,
+        84,
+        session_manager,
+        db=object(),
+        password_service=object(),
+        request=SimpleNamespace(
+            reason="Support case 123",
+            admin_password=None,
+            admin_reauth_token="magic-token-456",
+        ),
+    )
+
+    assert received["reason"] == "Support case 123"
+    assert received["admin_password"] is None
+    assert received["admin_reauth_token"] == "magic-token-456"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
@@ -29,6 +29,8 @@ class _JWTService:
         self.calls.append((token, token_type))
         if self.error is not None:
             raise self.error
+        if token_type is not None and self.payload.get("type") not in {None, token_type}:
+            raise ValueError("token type mismatch")
         return dict(self.payload)
 
 
@@ -157,6 +159,7 @@ async def test_verify_privileged_action_allows_magic_link_step_up_for_federated_
             "purpose": "admin_reauth",
             "jti": "magic-link-jti-1",
             "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+            "type": "admin_reauth",
         }
     )
     blacklist = _Blacklist()
@@ -197,6 +200,7 @@ async def test_verify_privileged_action_rejects_magic_link_step_up_for_other_adm
             "purpose": "admin_reauth",
             "jti": "magic-link-jti-2",
             "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+            "type": "admin_reauth",
         }
     )
     monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
@@ -211,6 +215,42 @@ async def test_verify_privileged_action_rejects_magic_link_step_up_for_other_adm
             reason="Customer requested restore",
             admin_password=None,
             admin_reauth_token="magic-token-456",
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Admin reauthentication failed"
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_rejects_admin_reauth_token_without_jti(monkeypatch) -> None:
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 7,
+            "email": "alice@example.com",
+            "password_hash": "",
+        }
+
+    jwt_service = _JWTService(
+        {
+            "user_id": 7,
+            "email": "alice@example.com",
+            "purpose": "admin_reauth",
+            "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+            "type": "admin_reauth",
+        }
+    )
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+    monkeypatch.setattr(admin_guardrails_service, "get_jwt_service", lambda: jwt_service)
+    monkeypatch.setattr(admin_guardrails_service, "get_token_blacklist", lambda: _Blacklist())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await admin_guardrails_service.verify_privileged_action(
+            _multi_user_admin_principal(),
+            db=object(),
+            password_service=_PasswordService(),
+            reason="Customer requested restore",
+            admin_password=None,
+            admin_reauth_token="magic-token-without-jti",
         )
 
     assert excinfo.value.status_code == 403

--- a/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
+++ b/tldw_Server_API/tests/Admin/test_admin_guardrails_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -18,6 +19,28 @@ class _PasswordService:
         return True, False
 
 
+class _JWTService:
+    def __init__(self, payload: dict | None = None, *, error: Exception | None = None) -> None:
+        self.payload = payload or {}
+        self.error = error
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def verify_token_async(self, token: str, token_type: str | None = None) -> dict:
+        self.calls.append((token, token_type))
+        if self.error is not None:
+            raise self.error
+        return dict(self.payload)
+
+
+class _Blacklist:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def revoke_token(self, **kwargs) -> bool:  # noqa: ANN003
+        self.calls.append(dict(kwargs))
+        return True
+
+
 def _single_user_principal() -> AuthPrincipal:
     return AuthPrincipal(
         kind="user",
@@ -25,6 +48,17 @@ def _single_user_principal() -> AuthPrincipal:
         subject="single_user",
         roles=["admin"],
         is_admin=True,
+    )
+
+
+def _multi_user_admin_principal(user_id: int = 7) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=user_id,
+        subject=f"user:{user_id}",
+        roles=["admin"],
+        is_admin=True,
+        email="alice@example.com",
     )
 
 
@@ -54,6 +88,15 @@ async def test_verify_privileged_action_allows_non_enterprise_single_user_withou
 async def test_verify_privileged_action_rejects_single_user_without_password_in_enterprise_mode(monkeypatch) -> None:
     monkeypatch.setenv("ADMIN_UI_ENTERPRISE_MODE", "true")
 
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 1,
+            "email": "single-user@example.com",
+            "password_hash": "hashed-password",
+        }
+
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+
     with pytest.raises(HTTPException) as excinfo:
         await admin_guardrails_service.verify_privileged_action(
             _single_user_principal(),
@@ -64,7 +107,7 @@ async def test_verify_privileged_action_rejects_single_user_without_password_in_
         )
 
     assert excinfo.value.status_code == 400
-    assert excinfo.value.detail == "Reason and current password are required for this action"
+    assert excinfo.value.detail == "Reason and current password or admin reauthentication token are required for this action"
 
 
 @pytest.mark.asyncio
@@ -96,3 +139,114 @@ async def test_verify_privileged_action_requires_password_for_multi_user_admin(m
 
     assert reason == "Customer requested restore"
     assert password_service.calls == [("AdminPass123!", "hashed-password")]
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_allows_magic_link_step_up_for_federated_admin(monkeypatch) -> None:
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 7,
+            "email": "alice@example.com",
+            "password_hash": "",
+        }
+
+    jwt_service = _JWTService(
+        {
+            "user_id": 7,
+            "email": "alice@example.com",
+            "purpose": "admin_reauth",
+            "jti": "magic-link-jti-1",
+            "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+        }
+    )
+    blacklist = _Blacklist()
+    password_service = _PasswordService()
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+    monkeypatch.setattr(admin_guardrails_service, "get_jwt_service", lambda: jwt_service)
+    monkeypatch.setattr(admin_guardrails_service, "get_token_blacklist", lambda: blacklist)
+
+    reason = await admin_guardrails_service.verify_privileged_action(
+        _multi_user_admin_principal(),
+        db=object(),
+        password_service=password_service,
+        reason="Customer requested restore",
+        admin_password=None,
+        admin_reauth_token="magic-token-123",
+    )
+
+    assert reason == "Customer requested restore"
+    assert password_service.calls == []
+    assert jwt_service.calls == [("magic-token-123", "admin_reauth")]
+    assert blacklist.calls and blacklist.calls[0]["jti"] == "magic-link-jti-1"
+    assert blacklist.calls[0]["token_type"] == "admin_reauth"
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_rejects_magic_link_step_up_for_other_admin(monkeypatch) -> None:
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 7,
+            "email": "alice@example.com",
+            "password_hash": "",
+        }
+
+    jwt_service = _JWTService(
+        {
+            "user_id": 8,
+            "email": "mallory@example.com",
+            "purpose": "admin_reauth",
+            "jti": "magic-link-jti-2",
+            "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+        }
+    )
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+    monkeypatch.setattr(admin_guardrails_service, "get_jwt_service", lambda: jwt_service)
+    monkeypatch.setattr(admin_guardrails_service, "get_token_blacklist", lambda: _Blacklist())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await admin_guardrails_service.verify_privileged_action(
+            _multi_user_admin_principal(),
+            db=object(),
+            password_service=_PasswordService(),
+            reason="Customer requested restore",
+            admin_password=None,
+            admin_reauth_token="magic-token-456",
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Admin reauthentication failed"
+
+
+@pytest.mark.asyncio
+async def test_verify_privileged_action_rejects_magic_link_without_admin_reauth_purpose(monkeypatch) -> None:
+    async def _fake_fetch(*_args, **_kwargs):
+        return {
+            "id": 7,
+            "email": "alice@example.com",
+            "password_hash": "",
+        }
+
+    jwt_service = _JWTService(
+        {
+            "user_id": 7,
+            "email": "alice@example.com",
+            "jti": "magic-link-jti-3",
+            "exp": datetime(2030, 1, 1, tzinfo=timezone.utc).timestamp(),
+        }
+    )
+    monkeypatch.setattr(admin_guardrails_service, "fetch_active_user_by_id", _fake_fetch)
+    monkeypatch.setattr(admin_guardrails_service, "get_jwt_service", lambda: jwt_service)
+    monkeypatch.setattr(admin_guardrails_service, "get_token_blacklist", lambda: _Blacklist())
+
+    with pytest.raises(HTTPException) as excinfo:
+        await admin_guardrails_service.verify_privileged_action(
+            _multi_user_admin_principal(),
+            db=object(),
+            password_service=_PasswordService(),
+            reason="Customer requested restore",
+            admin_password=None,
+            admin_reauth_token="magic-token-789",
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Admin reauthentication failed"

--- a/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
@@ -64,3 +64,16 @@ def test_user_update_request_allows_blank_admin_password_for_single_user_mode() 
     )
 
     assert payload.admin_password is None
+
+
+def test_admin_privileged_action_request_repr_redacts_sensitive_fields() -> None:
+    payload = AdminPrivilegedActionRequest(
+        reason="Support case 123",
+        admin_password="AdminPass123!",
+        admin_reauth_token="reauth-token-123",
+    )
+
+    rendered = repr(payload)
+
+    assert "AdminPass123!" not in rendered
+    assert "reauth-token-123" not in rendered

--- a/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
@@ -49,9 +49,11 @@ def test_admin_privileged_action_request_allows_blank_admin_password_for_single_
     payload = AdminPrivilegedActionRequest(
         reason="Support case 123",
         admin_password="",
+        admin_reauth_token="",
     )
 
     assert payload.admin_password is None
+    assert payload.admin_reauth_token is None
 
 
 def test_user_update_request_allows_blank_admin_password_for_single_user_mode() -> None:

--- a/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
+++ b/tldw_Server_API/tests/Admin/test_admin_user_schemas.py
@@ -1,5 +1,5 @@
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
 from tldw_Server_API.app.api.v1.schemas.admin_schemas import (
     AdminPasswordResetRequest,
@@ -77,3 +77,16 @@ def test_admin_privileged_action_request_repr_redacts_sensitive_fields() -> None
 
     assert "AdminPass123!" not in rendered
     assert "reauth-token-123" not in rendered
+
+
+def test_admin_privileged_action_request_stores_sensitive_fields_as_secretstr() -> None:
+    payload = AdminPrivilegedActionRequest(
+        reason="Support case 123",
+        admin_password="AdminPass123!",
+        admin_reauth_token="reauth-token-123",
+    )
+
+    assert isinstance(payload.admin_password, SecretStr)
+    assert payload.admin_password.get_secret_value() == "AdminPass123!"
+    assert isinstance(payload.admin_reauth_token, SecretStr)
+    assert payload.admin_reauth_token.get_secret_value() == "reauth-token-123"

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -373,10 +373,13 @@ async def test_verify_magic_link_rejects_admin_reauth_purpose(monkeypatch):
         async def verify_token_async(self, token: str, token_type: str | None = None):
             assert token == "admin-reauth-token"
             assert token_type == "magic_link"
+            if token_type != "magic_link":
+                raise ValueError("unexpected token type")
             return {
                 "email": "alice@example.com",
                 "user_id": 7,
                 "purpose": "admin_reauth",
+                "type": "admin_reauth",
             }
 
     scope = {

--- a/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_auth_endpoints_extended.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from fastapi import HTTPException
 from fastapi import Response
 from starlette.requests import Request
 
@@ -263,6 +264,145 @@ async def test_reserve_auth_rg_requests_uses_diagnostics_only_shim_when_rg_reser
 
     assert allowed is True
     assert retry_after is None
+
+
+@pytest.mark.asyncio
+async def test_request_admin_reauth_uses_dedicated_token_and_email_helpers(monkeypatch):
+    reset_settings()
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    created: dict[str, object] = {}
+    sent: dict[str, object] = {}
+
+    class _StubJWT:
+        def create_admin_reauth_token(self, **kwargs):  # noqa: ANN003
+            created.update(kwargs)
+            return "admin-reauth-token"
+
+    class _StubEmailService:
+        async def send_admin_reauth_email(self, **kwargs):  # noqa: ANN003
+            sent.update(kwargs)
+            return True
+
+    monkeypatch.setattr(auth, "_get_email_service", lambda: _StubEmailService())
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/admin/reauth/request",
+        "headers": [],
+        "client": ("203.0.113.50", 1234),
+        "scheme": "http",
+        "query_string": b"",
+        "server": ("testserver", 80),
+    }
+    request = Request(scope)
+
+    out = await auth.request_admin_reauth(
+        request=request,
+        current_user=auth.AuthPrincipal(
+            kind="user",
+            user_id=7,
+            subject="user:7",
+            username="alice",
+            email="alice@example.com",
+            roles=["admin"],
+            is_admin=True,
+        ),
+        db=object(),
+        jwt_service=_StubJWT(),
+    )
+
+    assert out.message == "Admin reauthentication link sent"
+    assert created["email"] == "alice@example.com"
+    assert created["user_id"] == 7
+    assert created["expires_in_minutes"] == 10
+    assert sent["to_email"] == "alice@example.com"
+    assert sent["username"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_request_admin_reauth_requires_admin_claims(monkeypatch):
+    reset_settings()
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/admin/reauth/request",
+        "headers": [],
+        "client": ("203.0.113.51", 1234),
+        "scheme": "http",
+        "query_string": b"",
+        "server": ("testserver", 80),
+    }
+    request = Request(scope)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth.request_admin_reauth(
+            request=request,
+            current_user=auth.AuthPrincipal(
+                kind="user",
+                user_id=7,
+                subject="user:7",
+                username="alice",
+                email="alice@example.com",
+                roles=["user"],
+                is_admin=False,
+            ),
+            db=object(),
+            jwt_service=object(),
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "Admin reauthentication is only available to administrators"
+
+
+@pytest.mark.asyncio
+async def test_verify_magic_link_rejects_admin_reauth_purpose(monkeypatch):
+    reset_settings()
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    class _StubJWT:
+        async def verify_token_async(self, token: str, token_type: str | None = None):
+            assert token == "admin-reauth-token"
+            assert token_type == "magic_link"
+            return {
+                "email": "alice@example.com",
+                "user_id": 7,
+                "purpose": "admin_reauth",
+            }
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/magic-link/verify",
+        "headers": [],
+        "client": ("203.0.113.52", 1234),
+        "scheme": "http",
+        "query_string": b"",
+        "server": ("testserver", 80),
+    }
+    request = Request(scope)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await auth.verify_magic_link(
+            data=auth.MagicLinkVerifyRequest(token="admin-reauth-token"),
+            request=request,
+            db=object(),
+            jwt_service=_StubJWT(),
+            session_manager=object(),
+            registration_service=object(),
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "Admin reauthentication tokens cannot be used for sign-in"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
@@ -56,6 +56,14 @@ class TestEmailTemplates:
         """MFA enabled template should be defined."""
         assert "mfa_enabled" in EMAIL_TEMPLATES
 
+    def test_admin_reauth_template_exists(self):
+
+        """Admin reauthentication template should be defined."""
+        assert "admin_reauth" in EMAIL_TEMPLATES
+        assert "subject" in EMAIL_TEMPLATES["admin_reauth"]
+        assert "html" in EMAIL_TEMPLATES["admin_reauth"]
+        assert "text" in EMAIL_TEMPLATES["admin_reauth"]
+
 
 class TestEmailServiceInitialization:
     """Tests for EmailService initialization."""
@@ -205,3 +213,31 @@ class TestTemplateEmailSending:
             ip_address="192.168.1.1"
         )
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_send_admin_reauth_email(self, email_service, monkeypatch):
+        """Admin reauthentication email should use the dedicated template and path."""
+        captured: dict[str, str] = {}
+
+        async def _fake_send_email(to_email: str, subject: str, html_body: str, text_body: str) -> bool:
+            captured["to_email"] = to_email
+            captured["subject"] = subject
+            captured["html_body"] = html_body
+            captured["text_body"] = text_body
+            return True
+
+        monkeypatch.setattr(email_service, "send_email", _fake_send_email)
+
+        result = await email_service.send_admin_reauth_email(
+            to_email="admin@test.com",
+            reauth_token="reauth-token-123",
+            expires_in_minutes=7,
+            username="alice",
+            base_url="https://example.com",
+        )
+
+        assert result is True
+        assert captured["to_email"] == "admin@test.com"
+        assert "Confirm admin action" in captured["subject"]
+        assert "https://example.com/admin/reauth?token=reauth-token-123" in captured["html_body"]
+        assert "https://example.com/admin/reauth?token=reauth-token-123" in captured["text_body"]

--- a/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_email_service.py
@@ -7,6 +7,7 @@ Tests cover:
 - SMTP error handling
 - Header injection prevention
 """
+import json
 import pytest
 import os
 from unittest.mock import patch, MagicMock, AsyncMock
@@ -219,11 +220,18 @@ class TestTemplateEmailSending:
         """Admin reauthentication email should use the dedicated template and path."""
         captured: dict[str, str] = {}
 
-        async def _fake_send_email(to_email: str, subject: str, html_body: str, text_body: str) -> bool:
+        async def _fake_send_email(
+            to_email: str,
+            subject: str,
+            html_body: str,
+            text_body: str,
+            **kwargs,
+        ) -> bool:
             captured["to_email"] = to_email
             captured["subject"] = subject
             captured["html_body"] = html_body
             captured["text_body"] = text_body
+            captured["redact_mock_tokens"] = str(kwargs.get("redact_mock_tokens"))
             return True
 
         monkeypatch.setattr(email_service, "send_email", _fake_send_email)
@@ -241,3 +249,32 @@ class TestTemplateEmailSending:
         assert "Confirm admin action" in captured["subject"]
         assert "https://example.com/admin/reauth?token=reauth-token-123" in captured["html_body"]
         assert "https://example.com/admin/reauth?token=reauth-token-123" in captured["text_body"]
+        assert captured["redact_mock_tokens"] == "True"
+
+    @pytest.mark.asyncio
+    async def test_mock_admin_reauth_email_redacts_token_in_saved_mock_output(self, email_service, tmp_path):
+        """Mock admin reauth emails should not persist raw step-up tokens."""
+        result = await email_service.send_admin_reauth_email(
+            to_email="admin@test.com",
+            reauth_token="reauth-token-123",
+            expires_in_minutes=7,
+            username="alice",
+            base_url="https://example.com",
+        )
+
+        assert result is True
+
+        json_files = list(tmp_path.glob("*.json"))
+        html_files = list(tmp_path.glob("*.html"))
+        assert json_files
+        assert html_files
+
+        email_data = json.loads(json_files[0].read_text())
+        html_body = html_files[0].read_text()
+
+        assert "reauth-token-123" not in email_data["text_body"]
+        assert "reauth-token-123" not in email_data["html_body"]
+        assert "reauth-token-123" not in html_body
+        assert "token=[REDACTED]" in email_data["text_body"]
+        assert "token=[REDACTED]" in email_data["html_body"]
+        assert "token=[REDACTED]" in html_body

--- a/tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
@@ -86,6 +86,32 @@ class TestJWTServiceUnit:
         assert "iat" in payload
         assert "jti" in payload
 
+    def test_create_magic_link_token_does_not_log_raw_email(self, jwt_service, monkeypatch):
+
+        """Token creation debug logs should not emit the raw recipient email."""
+        jwt_service.settings.PII_REDACT_LOGS = False
+        debug_calls: list[tuple[object, ...]] = []
+
+        def _capture_debug(*args):  # noqa: ANN002
+            debug_calls.append(args)
+
+        monkeypatch.setattr(
+            "tldw_Server_API.app.core.AuthNZ.jwt_service.logger.debug",
+            _capture_debug,
+        )
+
+        token = jwt_service.create_magic_link_token(
+            email="person@example.com",
+            user_id=42,
+            expires_in_minutes=5,
+        )
+
+        assert isinstance(token, str)
+        assert debug_calls
+        combined = " ".join(str(part) for call in debug_calls for part in call)
+        assert "person@example.com" not in combined
+        assert "42" in combined or "redacted" in combined.lower()
+
     def test_decode_access_token_valid(self, jwt_service):
 
         """Test decoding a valid access token."""

--- a/tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_jwt_service.py
@@ -64,6 +64,28 @@ class TestJWTServiceUnit:
         assert "iat" in payload
         assert "jti" in payload
 
+    def test_create_admin_reauth_token(self, jwt_service):
+
+        """Test creating a dedicated admin reauthentication token."""
+        token = jwt_service.create_admin_reauth_token(
+            email="admin@example.com",
+            user_id=7,
+            expires_in_minutes=5,
+        )
+
+        assert token is not None
+        assert isinstance(token, str)
+
+        payload = jwt_service.verify_token(token, token_type="admin_reauth")
+
+        assert payload["sub"] == "7"
+        assert payload["user_id"] == 7
+        assert payload["email"] == "admin@example.com"
+        assert payload["type"] == "admin_reauth"
+        assert "exp" in payload
+        assert "iat" in payload
+        assert "jti" in payload
+
     def test_decode_access_token_valid(self, jwt_service):
 
         """Test decoding a valid access token."""

--- a/tldw_Server_API/tests/AuthNZ/unit/test_registration_service_backend_selection.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_registration_service_backend_selection.py
@@ -59,6 +59,28 @@ def _settings_stub() -> SimpleNamespace:
     )
 
 
+class _SQLiteRegisterConn:
+    def __init__(self) -> None:
+        self.execute_calls: list[tuple[str, Any]] = []
+        self.committed = False
+
+    async def execute(self, query: str, params: Any) -> _CursorStub:
+        lowered = str(query).lower()
+        self.execute_calls.append((lowered, params))
+        if "select username, email" in lowered:
+            return _CursorStub(row=None)
+        if "insert into users" in lowered:
+            return _CursorStub(lastrowid=29)
+        if "insert into password_history" in lowered:
+            return _CursorStub(lastrowid=1)
+        if "insert into audit_log" in lowered:
+            return _CursorStub(lastrowid=1)
+        raise AssertionError(f"Unexpected SQLite query: {query!r}")
+
+    async def commit(self) -> None:
+        self.committed = True
+
+
 class _SQLiteConnWithFetchvalTrap:
     """
     SQLite-like connection shim that intentionally exposes ``fetchval``.
@@ -177,3 +199,33 @@ async def test_validate_registration_code_sqlite_backend_selection_ignores_conn_
     assert info["id"] == 1
     assert info["role_to_grant"] == "user"
     assert conn.update_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_register_user_system_provisioning_bypasses_disabled_registration_and_required_code():
+    conn = _SQLiteRegisterConn()
+    settings = _settings_stub()
+    settings.ENABLE_REGISTRATION = False
+    settings.REQUIRE_REGISTRATION_CODE = True
+    service = RegistrationService(
+        db_pool=_PoolStub(conn, postgres=False),
+        password_service=_PasswordServiceStub(),
+        settings=settings,
+    )
+    service._create_user_directories = lambda user_id: True  # noqa: ARG005
+
+    payload = await service.register_user(
+        username="federated-user",
+        email="federated@example.com",
+        password="Strong!Pass9",
+        role_override="member",
+        is_verified_override=True,
+        system_provisioning=True,
+    )
+
+    assert payload["user_id"] == 29
+    assert payload["role"] == "member"
+    assert payload["is_verified"] is True
+    assert payload["registration_code_id"] is None
+    assert conn.committed is False
+    assert not any("from registration_codes" in query for query, _ in conn.execute_calls)

--- a/tldw_Server_API/tests/AuthNZ/unit/test_registration_service_backend_selection.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_registration_service_backend_selection.py
@@ -229,3 +229,19 @@ async def test_register_user_system_provisioning_bypasses_disabled_registration_
     assert payload["registration_code_id"] is None
     assert conn.committed is False
     assert not any("from registration_codes" in query for query, _ in conn.execute_calls)
+
+
+@pytest.mark.asyncio
+async def test_register_user_rejects_negative_storage_quota_override() -> None:
+    conn = _SQLiteRegisterConn()
+    service = _make_service(_PoolStub(conn, postgres=False))
+    service._create_user_directories = lambda user_id: True  # noqa: ARG005
+
+    with pytest.raises(ValueError, match="storage_quota_override must be non-negative"):
+        await service.register_user(
+            username="federated-user",
+            email="federated@example.com",
+            password="Strong!Pass9",
+            storage_quota_override=-1,
+            system_provisioning=True,
+        )

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_claim_mapping.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_claim_mapping.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.federation.claim_mapping import preview_claim_mapping
+
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_preview_claim_mapping_rejects_boolean_org_and_team_ids() -> None:
+    result = preview_claim_mapping(
+        {
+            "default_org_ids": [True, 7, "9"],
+            "default_team_ids": [False, "11", 13],
+        },
+        {"sub": "user-123", "email": "user@example.com"},
+    )
+
+    assert result["derived_org_ids"] == [7, 9]
+    assert result["derived_team_ids"] == [11, 13]
+
+
+def test_preview_claim_mapping_treats_blank_subject_and_email_as_missing() -> None:
+    result = preview_claim_mapping(
+        {"subject": "external_subject", "email": "mail"},
+        {"external_subject": "   ", "mail": "\t"},
+    )
+
+    assert result["subject"] is None
+    assert result["email"] is None
+    assert "No subject claim resolved from the payload" in result["warnings"]
+    assert "No email claim resolved from the payload" in result["warnings"]

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_enterprise_flags.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_enterprise_flags.py
@@ -1,0 +1,96 @@
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.settings import get_settings, reset_settings
+
+
+pytestmark = pytest.mark.unit
+
+
+_ENTERPRISE_ENV_KEYS = (
+    "PROFILE",
+    "AUTH_MODE",
+    "DATABASE_URL",
+    "JWT_SECRET_KEY",
+    "SINGLE_USER_API_KEY",
+    "AUTH_FEDERATION_ENABLED",
+    "MCP_CREDENTIAL_BROKER_ENABLED",
+    "SECRET_BACKENDS_ENABLED",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache(monkeypatch: pytest.MonkeyPatch):
+    reset_settings()
+    for key in _ENTERPRISE_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    yield
+    reset_settings()
+
+
+def _configure_multi_user_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://tldw_user:TestPassword123!@localhost:5432/tldw_users",
+    )
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)
+
+
+def _configure_single_user(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUTH_MODE", "single_user")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./Databases/users.db")
+    monkeypatch.setenv("SINGLE_USER_API_KEY", "single-user-key-1234567890")
+
+
+def test_enterprise_federation_requires_multi_user_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_single_user(monkeypatch)
+    monkeypatch.setenv("AUTH_FEDERATION_ENABLED", "true")
+
+    settings = get_settings()
+
+    assert settings.AUTH_FEDERATION_ENABLED is True
+    assert settings.enterprise_federation_supported is False
+
+
+def test_enterprise_federation_requires_postgres_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./Databases/users.db")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("AUTH_FEDERATION_ENABLED", "true")
+
+    settings = get_settings()
+
+    assert settings.AUTH_FEDERATION_ENABLED is True
+    assert settings.enterprise_federation_supported is False
+
+
+def test_enterprise_flags_supported_in_multi_user_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_multi_user_postgres(monkeypatch)
+    monkeypatch.setenv("AUTH_FEDERATION_ENABLED", "true")
+    monkeypatch.setenv("SECRET_BACKENDS_ENABLED", "true")
+    monkeypatch.setenv("MCP_CREDENTIAL_BROKER_ENABLED", "true")
+
+    settings = get_settings()
+
+    assert settings.enterprise_federation_supported is True
+    assert settings.enterprise_secret_backends_supported is True
+    assert settings.enterprise_mcp_credential_broker_supported is True
+
+
+def test_mcp_credential_broker_requires_secret_backends(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_multi_user_postgres(monkeypatch)
+    monkeypatch.setenv("MCP_CREDENTIAL_BROKER_ENABLED", "true")
+    monkeypatch.setenv("SECRET_BACKENDS_ENABLED", "false")
+
+    settings = get_settings()
+
+    assert settings.MCP_CREDENTIAL_BROKER_ENABLED is True
+    assert settings.enterprise_mcp_credential_broker_supported is False

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_admin_api.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_admin_api.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+from tldw_Server_API.app.core.AuthNZ.federation import oidc_service as oidc_module
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+from tldw_Server_API.app.core.AuthNZ.settings import Settings, reset_settings
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def admin_identity_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "admin_identity_providers.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("AUTH_FEDERATION_ENABLED", "true")
+    monkeypatch.setattr(
+        Settings,
+        "enterprise_federation_supported",
+        property(lambda self: True),
+        raising=False,
+    )
+
+    asyncio.run(reset_db_pool())
+    reset_settings()
+
+    from tldw_Server_API.app.main import app as fastapi_app
+
+    async def _override_principal(request=None) -> AuthPrincipal:
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="test-admin",
+            token_type="test",
+            jti=None,
+            roles=["admin"],
+            permissions=["claims.admin"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+        if request is not None:
+            request.state.auth = AuthContext(
+                principal=principal,
+                ip=None,
+                user_agent=None,
+                request_id=None,
+            )
+        return principal
+
+    fastapi_app.dependency_overrides[get_auth_principal] = _override_principal
+
+    try:
+        with TestClient(fastapi_app) as client:
+            yield client
+    finally:
+        fastapi_app.dependency_overrides.pop(get_auth_principal, None)
+        asyncio.run(reset_db_pool())
+        reset_settings()
+
+
+def _install_fetch_json_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: dict[tuple[str, str], dict],
+) -> None:
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        return dict(responses[(method.upper(), url)])
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+
+
+def _create_local_user(username: str, email: str) -> int:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+    async def _create() -> int:
+        db = UsersDB(await get_db_pool())
+        user = await db.create_user(
+            username=username,
+            email=email,
+            password_hash="hashed-password",
+            role="user",
+            is_active=True,
+            is_verified=True,
+        )
+        return int(user["id"])
+
+    return int(asyncio.run(_create()))
+
+
+def test_identity_provider_mapping_preview_returns_derived_memberships(
+    admin_identity_client: TestClient,
+) -> None:
+    create_response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": False,
+            "issuer": "https://issuer.example.com",
+            "claim_mapping": {
+                "email": "email",
+                "groups": "groups",
+                "role_mappings": {
+                    "eng-admins": "admin",
+                    "eng-members": "member",
+                },
+            },
+            "provisioning_policy": {
+                "mode": "jit_grant_only",
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    provider = create_response.json()
+
+    preview_response = admin_identity_client.post(
+        f"/api/v1/admin/identity/providers/{provider['id']}/mappings/preview",
+        json={
+            "claims": {
+                "sub": "abc-123",
+                "email": "alice@example.com",
+                "groups": ["eng-admins"],
+            }
+        },
+    )
+    assert preview_response.status_code == 200, preview_response.text
+    body = preview_response.json()
+
+    assert body["provider_id"] == provider["id"]
+    assert body["subject"] == "abc-123"
+    assert body["email"] == "alice@example.com"
+    assert body["derived_roles"] == ["admin"]
+    assert body["groups"] == ["eng-admins"]
+
+
+def test_identity_provider_test_resolves_discovery_runtime_config(
+    admin_identity_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    discovery_url = "https://issuer.example.com/.well-known/openid-configuration"
+    _install_fetch_json_stub(
+        monkeypatch,
+        {
+            ("GET", discovery_url): {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://issuer.example.com/oauth2/authorize",
+                "token_endpoint": "https://issuer.example.com/oauth2/token",
+                "jwks_uri": "https://issuer.example.com/.well-known/jwks.json",
+            }
+        },
+    )
+
+    response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers/test",
+        json={
+            "provider": {
+                "slug": "corp-test",
+                "provider_type": "oidc",
+                "owner_scope_type": "global",
+                "enabled": False,
+                "issuer": "https://issuer.example.com",
+                "discovery_url": discovery_url,
+                "client_id": "client-123",
+            }
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["issuer"] == "https://issuer.example.com"
+    assert body["authorization_url"] == "https://issuer.example.com/oauth2/authorize"
+    assert body["token_url"] == "https://issuer.example.com/oauth2/token"
+    assert body["jwks_url"] == "https://issuer.example.com/.well-known/jwks.json"
+    assert body["client_id"] == "client-123"
+
+
+def test_identity_provider_dry_run_reports_email_link_action_when_policy_allows(
+    admin_identity_client: TestClient,
+) -> None:
+    user_id = _create_local_user("alice", "alice@example.com")
+
+    response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers/dry-run",
+        json={
+            "provider": {
+                "slug": "corp-dry-run",
+                "provider_type": "oidc",
+                "owner_scope_type": "global",
+                "enabled": False,
+                "issuer": "https://issuer.example.com",
+                "authorization_url": "https://issuer.example.com/oauth2/authorize",
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+                "claim_mapping": {
+                    "email": "email",
+                },
+                "provisioning_policy": {
+                    "allow_email_account_linking": True,
+                    "jit_create": False,
+                },
+            },
+            "claims": {
+                "sub": "external-user-123",
+                "email": "alice@example.com",
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provisioning_action"] == "link_existing_user"
+    assert body["matched_user_id"] == user_id
+    assert body["identity_link_found"] is False
+    assert body["email_match_found"] is True
+    assert body["mapping"]["subject"] == "external-user-123"
+    assert body["mapping"]["email"] == "alice@example.com"
+
+
+def test_identity_provider_dry_run_reports_email_collision_when_linking_disabled(
+    admin_identity_client: TestClient,
+) -> None:
+    user_id = _create_local_user("bob", "bob@example.com")
+
+    response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers/dry-run",
+        json={
+            "provider": {
+                "slug": "corp-dry-run-collision",
+                "provider_type": "oidc",
+                "owner_scope_type": "global",
+                "enabled": False,
+                "issuer": "https://issuer.example.com",
+                "authorization_url": "https://issuer.example.com/oauth2/authorize",
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+                "claim_mapping": {
+                    "email": "email",
+                },
+                "provisioning_policy": {
+                    "allow_email_account_linking": False,
+                    "jit_create": True,
+                },
+            },
+            "claims": {
+                "sub": "external-user-456",
+                "email": "bob@example.com",
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provisioning_action"] == "deny_email_collision"
+    assert body["matched_user_id"] == user_id
+    assert body["identity_link_found"] is False
+    assert body["email_match_found"] is True
+    assert body["mapping"]["subject"] == "external-user-456"
+    assert body["mapping"]["email"] == "bob@example.com"
+
+
+def test_identity_provider_dry_run_previews_safe_revoke_effects_for_existing_provider(
+    admin_identity_client: TestClient,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
+        add_org_member,
+        add_team_member,
+        create_organization,
+        create_team,
+    )
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_managed_grant_repo import (
+        FederatedManagedGrantRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.repos.users_repo import AuthnzUsersRepo
+
+    user_id = _create_local_user("dana", "dana@example.com")
+
+    create_response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-dry-run-revoke",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": False,
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "groups": "groups",
+            },
+            "provisioning_policy": {
+                "allow_email_account_linking": True,
+                "jit_create": False,
+                "mode": "sync_managed_only",
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    provider = create_response.json()
+
+    async def _seed_provider_state() -> tuple[int, int]:
+        pool = await get_db_pool()
+        managed_repo = FederatedManagedGrantRepo(db_pool=pool)
+        identity_repo = FederatedIdentityRepo(db_pool=pool)
+        users_repo = AuthnzUsersRepo(db_pool=pool)
+        await managed_repo.ensure_tables()
+        await identity_repo.ensure_tables()
+
+        managed_org = await create_organization(name="Managed Dry Run Org", owner_user_id=None)
+        managed_team = await create_team(org_id=int(managed_org["id"]), name="Managed Dry Run Team")
+        manual_org = await create_organization(name="Manual Dry Run Org", owner_user_id=None)
+        manual_team = await create_team(org_id=int(manual_org["id"]), name="Manual Dry Run Team")
+
+        await add_org_member(org_id=int(managed_org["id"]), user_id=user_id, role="member")
+        await add_team_member(team_id=int(managed_team["id"]), user_id=user_id, role="member")
+        await add_org_member(org_id=int(manual_org["id"]), user_id=user_id, role="member")
+        await add_team_member(team_id=int(manual_team["id"]), user_id=user_id, role="member")
+        await users_repo.assign_role_if_missing(user_id=user_id, role_name="admin")
+
+        await identity_repo.upsert_identity(
+            identity_provider_id=int(provider["id"]),
+            external_subject="external-user-789",
+            user_id=user_id,
+            external_email="dana@example.com",
+            status="active",
+        )
+        await managed_repo.upsert_grant(
+            identity_provider_id=int(provider["id"]),
+            user_id=user_id,
+            grant_kind="org",
+            target_ref=str(int(managed_org["id"])),
+        )
+        await managed_repo.upsert_grant(
+            identity_provider_id=int(provider["id"]),
+            user_id=user_id,
+            grant_kind="team",
+            target_ref=str(int(managed_team["id"])),
+        )
+        await managed_repo.upsert_grant(
+            identity_provider_id=int(provider["id"]),
+            user_id=user_id,
+            grant_kind="role",
+            target_ref="admin",
+        )
+        return int(managed_org["id"]), int(managed_team["id"])
+
+    managed_org_id, managed_team_id = asyncio.run(_seed_provider_state())
+
+    response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers/dry-run",
+        json={
+            "provider_id": provider["id"],
+            "provider": {
+                "slug": "corp-dry-run-revoke",
+                "provider_type": "oidc",
+                "owner_scope_type": "global",
+                "enabled": False,
+                "issuer": "https://issuer.example.com",
+                "authorization_url": "https://issuer.example.com/oauth2/authorize",
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+                "claim_mapping": {
+                    "subject": "sub",
+                    "email": "email",
+                    "groups": "groups",
+                },
+                "provisioning_policy": {
+                    "allow_email_account_linking": True,
+                    "jit_create": False,
+                    "mode": "sync_managed_only",
+                },
+            },
+            "claims": {
+                "sub": "external-user-789",
+                "email": "dana@example.com",
+                "groups": [],
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["provisioning_action"] == "subject_already_linked"
+    assert body["matched_user_id"] == user_id
+    assert body["identity_link_found"] is True
+    assert body["grant_sync"]["mode"] == "sync_managed_only"
+    assert body["grant_sync"]["would_change"] is True
+    assert body["grant_sync"]["grant_org_ids"] == []
+    assert body["grant_sync"]["grant_team_ids"] == []
+    assert body["grant_sync"]["grant_roles"] == []
+    assert body["grant_sync"]["revoke_org_ids"] == [managed_org_id]
+    assert body["grant_sync"]["revoke_team_ids"] == [managed_team_id]
+    assert body["grant_sync"]["revoke_roles"] == ["admin"]
+
+
+def test_create_enabled_identity_provider_requires_valid_runtime_configuration(
+    admin_identity_client: TestClient,
+) -> None:
+    response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-invalid-enabled",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "issuer": "https://issuer.example.com",
+            "client_id": "client-123",
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    assert "OIDC provider is missing" in response.json()["detail"]
+
+
+def test_update_enabled_identity_provider_rejects_missing_env_client_secret_reference(
+    admin_identity_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CORP_OIDC_CLIENT_SECRET", raising=False)
+    create_response = admin_identity_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-update-enabled",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": False,
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "client_secret_ref": "env:CORP_OIDC_CLIENT_SECRET",
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    provider = create_response.json()
+
+    update_response = admin_identity_client.put(
+        f"/api/v1/admin/identity/providers/{provider['id']}",
+        json={
+            "slug": "corp-update-enabled",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "client_secret_ref": "env:CORP_OIDC_CLIENT_SECRET",
+        },
+    )
+
+    assert update_response.status_code == 400, update_response.text
+    assert (
+        update_response.json()["detail"]
+        == "OIDC client_secret_ref environment variable is not set: CORP_OIDC_CLIENT_SECRET"
+    )

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_admin_api.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_admin_api.py
@@ -190,6 +190,18 @@ def test_identity_provider_test_resolves_discovery_runtime_config(
     assert body["client_id"] == "client-123"
 
 
+def test_identity_provider_list_rejects_invalid_owner_scope_type(
+    admin_identity_client: TestClient,
+) -> None:
+    response = admin_identity_client.get(
+        "/api/v1/admin/identity/providers",
+        params={"owner_scope_type": "user"},
+    )
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"] == "invalid owner_scope_type"
+
+
 def test_identity_provider_dry_run_reports_email_link_action_when_policy_allows(
     admin_identity_client: TestClient,
 ) -> None:

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_repo.py
@@ -115,3 +115,54 @@ async def test_link_and_fetch_federated_identity(tmp_path: Path) -> None:
         assert fetched["status"] == "active"
     finally:
         await pool.close()
+
+
+async def test_federated_identity_upsert_rejects_transferring_subject_to_another_user(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+    from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import IdentityProviderRepo
+
+    db_path = tmp_path / "federated_identity_transfer_repo.db"
+    pool = DatabasePool(_sqlite_settings(db_path))
+    await pool.initialize()
+
+    try:
+        provider_repo = IdentityProviderRepo(db_pool=pool)
+        identity_repo = FederatedIdentityRepo(db_pool=pool)
+        await provider_repo.ensure_tables()
+        await identity_repo.ensure_tables()
+
+        provider = await provider_repo.create_provider(
+            slug="corp",
+            provider_type="oidc",
+            owner_scope_type="global",
+            owner_scope_id=None,
+            enabled=True,
+            issuer="https://issuer.example.com",
+            claim_mapping={"email": "email"},
+            provisioning_policy={"mode": "jit_grant_only"},
+        )
+        first_user_id = await _insert_test_user(pool, username="alice", email="alice@example.com")
+        second_user_id = await _insert_test_user(pool, username="bob", email="bob@example.com")
+
+        await identity_repo.upsert_identity(
+            identity_provider_id=provider["id"],
+            external_subject="sub-123",
+            user_id=first_user_id,
+            external_username="alice",
+            external_email="alice@example.com",
+            last_claims_hash="hash-1",
+            status="active",
+        )
+
+        with pytest.raises(ValueError, match="already linked to a different local user"):
+            await identity_repo.upsert_identity(
+                identity_provider_id=provider["id"],
+                external_subject="sub-123",
+                user_id=second_user_id,
+                external_username="bob",
+                external_email="bob@example.com",
+                last_claims_hash="hash-2",
+                status="active",
+            )
+    finally:
+        await pool.close()

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_repo.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.settings import Settings
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _sqlite_settings(db_path: Path) -> Settings:
+    return Settings(
+        AUTH_MODE="multi_user",
+        DATABASE_URL=f"sqlite:///{db_path}",
+        JWT_SECRET_KEY="x" * 32,
+    )
+
+
+async def _insert_test_user(pool: DatabasePool, *, username: str, email: str) -> int:
+    await pool.execute(
+        """
+        INSERT INTO users (username, email, password_hash)
+        VALUES (?, ?, ?)
+        """,
+        (username, email, "not-a-real-password-hash"),
+    )
+    row = await pool.fetchone("SELECT id FROM users WHERE email = ?", (email,))
+    assert row is not None
+    return int(row["id"])
+
+
+async def test_create_and_fetch_identity_provider(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import IdentityProviderRepo
+
+    db_path = tmp_path / "identity_provider_repo.db"
+    pool = DatabasePool(_sqlite_settings(db_path))
+    await pool.initialize()
+
+    try:
+        repo = IdentityProviderRepo(db_pool=pool)
+        await repo.ensure_tables()
+
+        created = await repo.create_provider(
+            slug="corp",
+            provider_type="oidc",
+            owner_scope_type="global",
+            owner_scope_id=None,
+            enabled=False,
+            issuer="https://issuer.example.com",
+            claim_mapping={"email": "email"},
+            provisioning_policy={"mode": "jit_grant_only"},
+        )
+        fetched = await repo.get_provider(created["id"])
+
+        assert created["slug"] == "corp"
+        assert fetched is not None
+        assert fetched["slug"] == "corp"
+        assert fetched["provider_type"] == "oidc"
+        assert fetched["owner_scope_type"] == "global"
+    finally:
+        await pool.close()
+
+
+async def test_link_and_fetch_federated_identity(tmp_path: Path) -> None:
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+    from tldw_Server_API.app.core.AuthNZ.repos.identity_provider_repo import IdentityProviderRepo
+
+    db_path = tmp_path / "federated_identity_repo.db"
+    pool = DatabasePool(_sqlite_settings(db_path))
+    await pool.initialize()
+
+    try:
+        provider_repo = IdentityProviderRepo(db_pool=pool)
+        identity_repo = FederatedIdentityRepo(db_pool=pool)
+        await provider_repo.ensure_tables()
+        await identity_repo.ensure_tables()
+
+        provider = await provider_repo.create_provider(
+            slug="corp",
+            provider_type="oidc",
+            owner_scope_type="global",
+            owner_scope_id=None,
+            enabled=True,
+            issuer="https://issuer.example.com",
+            claim_mapping={"email": "email"},
+            provisioning_policy={"mode": "jit_grant_only"},
+        )
+        user_id = await _insert_test_user(
+            pool,
+            username="alice",
+            email="alice@example.com",
+        )
+
+        created = await identity_repo.upsert_identity(
+            identity_provider_id=provider["id"],
+            external_subject="sub-123",
+            user_id=user_id,
+            external_username="alice",
+            external_email="alice@example.com",
+            last_claims_hash="hash-1",
+            status="active",
+        )
+        fetched = await identity_repo.get_by_provider_subject(
+            identity_provider_id=provider["id"],
+            external_subject="sub-123",
+        )
+
+        assert created["external_subject"] == "sub-123"
+        assert fetched is not None
+        assert fetched["user_id"] == user_id
+        assert fetched["external_email"] == "alice@example.com"
+        assert fetched["status"] == "active"
+    finally:
+        await pool.close()

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_schemas.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_identity_provider_schemas.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.identity_provider_schemas import (
+    IdentityProviderUpsertRequest,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_identity_provider_upsert_normalizes_slug_and_issuer_before_constraints() -> None:
+    payload = IdentityProviderUpsertRequest(
+        slug=" Corp-IdP ",
+        issuer=" https://issuer.example.com ",
+    )
+
+    assert payload.slug == "corp-idp"
+    assert payload.issuer == "https://issuer.example.com"
+    assert payload.owner_scope_id is None
+
+
+def test_identity_provider_upsert_requires_scope_id_for_org_scope_even_when_omitted() -> None:
+    with pytest.raises(ValidationError):
+        IdentityProviderUpsertRequest(
+            slug="corp",
+            issuer="https://issuer.example.com",
+            owner_scope_type="org",
+        )
+
+
+def test_identity_provider_upsert_rejects_blank_issuer_after_trimming() -> None:
+    with pytest.raises(ValidationError):
+        IdentityProviderUpsertRequest(
+            slug="corp",
+            issuer="   ",
+        )

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_local_secret_backend.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_local_secret_backend.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool
+from tldw_Server_API.app.core.AuthNZ.settings import Settings, reset_settings
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _sqlite_settings(db_path: Path) -> Settings:
+    return Settings(
+        AUTH_MODE="multi_user",
+        DATABASE_URL=f"sqlite:///{db_path}",
+        JWT_SECRET_KEY="x" * 32,
+    )
+
+
+async def _insert_test_user(pool: DatabasePool, *, username: str, email: str) -> int:
+    await pool.execute(
+        """
+        INSERT INTO users (username, email, password_hash)
+        VALUES (?, ?, ?)
+        """,
+        (username, email, "not-a-real-password-hash"),
+    )
+    row = await pool.fetchone("SELECT id FROM users WHERE email = ?", (email,))
+    assert row is not None
+    return int(row["id"])
+
+
+async def test_local_secret_backend_resolve_for_use_returns_ephemeral_material(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+    reset_settings()
+
+    from tldw_Server_API.app.core.AuthNZ.secret_backends.local_encrypted import (
+        LocalEncryptedSecretBackend,
+    )
+
+    db_path = tmp_path / "local_secret_backend.db"
+    pool = DatabasePool(_sqlite_settings(db_path))
+    await pool.initialize()
+
+    try:
+        user_id = await _insert_test_user(
+            pool,
+            username="secret-owner",
+            email="secret-owner@example.com",
+        )
+        backend = LocalEncryptedSecretBackend(db_pool=pool)
+        await backend.ensure_tables()
+
+        ref = await backend.store_ref(
+            owner_scope_type="user",
+            owner_scope_id=user_id,
+            provider_key="openai",
+            payload={
+                "api_key": "sk-test",
+                "credential_fields": {"base_url": "https://api.example.com/v1"},
+            },
+        )
+        resolved = await backend.resolve_for_use(ref["id"])
+
+        assert ref["backend_name"] == "local_encrypted_v1"
+        assert resolved["backend_name"] == "local_encrypted_v1"
+        assert resolved["material"]["api_key"] == "sk-test"
+        assert resolved["material"]["credential_fields"]["base_url"] == "https://api.example.com/v1"
+        assert resolved["expires_at"] is not None
+    finally:
+        await pool.close()
+        reset_settings()

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
@@ -244,6 +244,117 @@ def test_federation_callback_uses_auth_rate_limit_dependency(
     assert response.json()["detail"] == "Too many requests"
 
 
+def test_federation_login_uses_auth_rate_limit_dependency(
+    federation_client: TestClient,
+) -> None:
+    async def _block_rate_limit() -> None:
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    federation_client.app.dependency_overrides[check_auth_rate_limit] = _block_rate_limit
+    try:
+        response = federation_client.get(
+            "/api/v1/auth/federation/corp/login",
+            follow_redirects=False,
+        )
+    finally:
+        federation_client.app.dependency_overrides.pop(check_auth_rate_limit, None)
+
+    assert response.status_code == 429, response.text
+    assert response.json()["detail"] == "Too many requests"
+
+
+def test_federation_login_respects_auth_resource_governor_limits(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-rg-login",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    async def _deny_rg(*args, **kwargs):  # noqa: ANN002, ANN003
+        return False, 11
+
+    monkeypatch.setattr(auth, "_reserve_auth_rg_requests", _deny_rg)
+
+    response = federation_client.get(
+        "/api/v1/auth/federation/corp-rg-login/login",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "11"
+
+
+def test_federation_callback_respects_auth_resource_governor_limits(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tldw_Server_API.app.api.v1.endpoints.auth as auth
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-rg-callback",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    login_response = federation_client.get(
+        "/api/v1/auth/federation/corp-rg-callback/login",
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 307, login_response.text
+    state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+
+    async def _deny_rg(*args, **kwargs):  # noqa: ANN002, ANN003
+        return False, 13
+
+    monkeypatch.setattr(auth, "_reserve_auth_rg_requests", _deny_rg)
+
+    response = federation_client.get(
+        f"/api/v1/auth/federation/corp-rg-callback/callback?state={state}&code=test-code",
+    )
+
+    assert response.status_code == 429, response.text
+    assert response.headers["Retry-After"] == "13"
+
+
 def test_federation_callback_links_existing_user_and_returns_tokens(
     federation_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -298,6 +409,7 @@ def test_federation_callback_links_existing_user_and_returns_tokens(
     )
     assert create_response.status_code == 200, create_response.text
     provider = create_response.json()
+    provider_id = int(provider["id"])
 
     login_response = federation_client.get(
         "/api/v1/auth/federation/corp/login",
@@ -316,7 +428,7 @@ def test_federation_callback_links_existing_user_and_returns_tokens(
         code_verifier: str,
         nonce: str | None = None,
     ) -> dict:
-        assert provider["id"] == provider["id"]
+        assert int(provider["id"]) == provider_id
         assert code == "code-123"
         assert redirect_uri == "http://testserver/api/v1/auth/federation/corp/callback"
         assert code_verifier

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
@@ -5,9 +5,13 @@ from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    check_auth_rate_limit,
+    get_auth_principal,
+)
 from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import Settings, reset_settings
@@ -220,6 +224,24 @@ def test_federation_callback_supports_org_scoped_provider_resolution(
     body = callback_response.json()
     payload = JWTService(get_settings()).verify_token(body["access_token"], token_type="access")
     assert int(payload["sub"]) == existing_user_id
+
+
+def test_federation_callback_uses_auth_rate_limit_dependency(
+    federation_client: TestClient,
+) -> None:
+    async def _block_rate_limit() -> None:
+        raise HTTPException(status_code=429, detail="Too many requests")
+
+    federation_client.app.dependency_overrides[check_auth_rate_limit] = _block_rate_limit
+    try:
+        response = federation_client.get(
+            "/api/v1/auth/federation/corp/callback?state=test-state&code=test-code",
+        )
+    finally:
+        federation_client.app.dependency_overrides.pop(check_auth_rate_limit, None)
+
+    assert response.status_code == 429, response.text
+    assert response.json()["detail"] == "Too many requests"
 
 
 def test_federation_callback_links_existing_user_and_returns_tokens(

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_login_flow.py
@@ -1,0 +1,733 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import Settings, reset_settings
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def federation_client(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "oidc_login_flow.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("JWT_SECRET_KEY", "x" * 32)
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("AUTH_FEDERATION_ENABLED", "true")
+    monkeypatch.setattr(
+        Settings,
+        "enterprise_federation_supported",
+        property(lambda self: True),
+        raising=False,
+    )
+
+    asyncio.run(reset_db_pool())
+    reset_settings()
+
+    from tldw_Server_API.app.main import app as fastapi_app
+
+    async def _override_principal(request=None) -> AuthPrincipal:
+        principal = AuthPrincipal(
+            kind="user",
+            user_id=1,
+            api_key_id=None,
+            subject="test-admin",
+            token_type="test",
+            jti=None,
+            roles=["admin"],
+            permissions=["claims.admin"],
+            is_admin=True,
+            org_ids=[],
+            team_ids=[],
+        )
+        if request is not None:
+            request.state.auth = AuthContext(
+                principal=principal,
+                ip=None,
+                user_agent=None,
+                request_id=None,
+            )
+        return principal
+
+    fastapi_app.dependency_overrides[get_auth_principal] = _override_principal
+
+    try:
+        with TestClient(fastapi_app) as client:
+            yield client
+    finally:
+        fastapi_app.dependency_overrides.pop(get_auth_principal, None)
+        asyncio.run(reset_db_pool())
+        reset_settings()
+
+
+def test_federation_login_redirects_to_provider_authorization_url(
+    federation_client: TestClient,
+) -> None:
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+                "allow_email_account_linking": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    response = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert response.status_code == 307, response.text
+
+    location = response.headers["location"]
+    parsed = urlparse(location)
+    query = parse_qs(parsed.query)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://issuer.example.com/oauth2/authorize"
+    assert query["response_type"] == ["code"]
+    assert query["client_id"] == ["client-123"]
+    assert query["scope"] == ["openid email profile"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert len(query["code_challenge"][0]) >= 32
+    assert len(query["state"][0]) >= 20
+    assert query["redirect_uri"] == ["http://testserver/api/v1/auth/federation/corp/callback"]
+
+
+def test_federation_callback_supports_org_scoped_provider_resolution(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+    from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+    from tldw_Server_API.app.core.AuthNZ.orgs_teams import create_organization
+    from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+    async def _seed_org_scoped_user() -> tuple[int, int]:
+        pool = await get_db_pool()
+        users_db = UsersDB(pool)
+        await users_db.initialize()
+        password_hash = PasswordService(get_settings()).hash_password("OrgScoped!7Qx")
+        user = await users_db.create_user(
+            username="org-alice",
+            email="org-alice@example.com",
+            password_hash=password_hash,
+            is_active=True,
+            is_verified=True,
+        )
+        org = await create_organization(name="Org Scoped SSO Org", owner_user_id=None)
+        return int(user["id"]), int(org["id"])
+
+    existing_user_id, org_id = asyncio.run(_seed_org_scoped_user())
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp-org",
+            "provider_type": "oidc",
+            "owner_scope_type": "org",
+            "owner_scope_id": org_id,
+            "enabled": True,
+            "display_name": "Corp Org SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+                "allow_email_account_linking": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    created_provider = create_response.json()
+
+    login_response = federation_client.get(
+        f"/api/v1/auth/federation/corp-org/login?org_id={org_id}",
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 307, login_response.text
+    login_query = parse_qs(urlparse(login_response.headers["location"]).query)
+    state = login_query["state"][0]
+
+    async def _fake_exchange(
+        self,
+        *,
+        provider: dict,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict:
+        assert int(provider["id"]) == int(created_provider["id"])
+        assert code == "code-org-123"
+        assert redirect_uri == "http://testserver/api/v1/auth/federation/corp-org/callback"
+        assert code_verifier
+        return {
+            "sub": "external-org-subject-123",
+            "email": "org-alice@example.com",
+            "preferred_username": "org.alice.sso",
+            "iss": "https://issuer.example.com",
+        }
+
+    monkeypatch.setattr(
+        OIDCFederationService,
+        "exchange_authorization_code",
+        _fake_exchange,
+        raising=False,
+    )
+
+    callback_response = federation_client.get(
+        f"/api/v1/auth/federation/corp-org/callback?state={state}&code=code-org-123",
+    )
+    assert callback_response.status_code == 200, callback_response.text
+    body = callback_response.json()
+    payload = JWTService(get_settings()).verify_token(body["access_token"], token_type="access")
+    assert int(payload["sub"]) == existing_user_id
+
+
+def test_federation_callback_links_existing_user_and_returns_tokens(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+    from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+    from tldw_Server_API.app.core.AuthNZ.password_service import PasswordService
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    async def _seed_existing_user() -> int:
+        pool = await get_db_pool()
+        users_db = UsersDB(pool)
+        await users_db.initialize()
+        password_hash = PasswordService(get_settings()).hash_password("FedLink!7Qx")
+        user = await users_db.create_user(
+            username="alice",
+            email="alice@example.com",
+            password_hash=password_hash,
+            is_active=True,
+            is_verified=True,
+        )
+        return int(user["id"])
+
+    existing_user_id = asyncio.run(_seed_existing_user())
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+                "allow_email_account_linking": True,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    provider = create_response.json()
+
+    login_response = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 307, login_response.text
+    login_query = parse_qs(urlparse(login_response.headers["location"]).query)
+    state = login_query["state"][0]
+
+    async def _fake_exchange(
+        self,
+        *,
+        provider: dict,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict:
+        assert provider["id"] == provider["id"]
+        assert code == "code-123"
+        assert redirect_uri == "http://testserver/api/v1/auth/federation/corp/callback"
+        assert code_verifier
+        return {
+            "sub": "external-subject-123",
+            "email": "alice@example.com",
+            "preferred_username": "alice.sso",
+            "iss": "https://issuer.example.com",
+        }
+
+    monkeypatch.setattr(
+        OIDCFederationService,
+        "exchange_authorization_code",
+        _fake_exchange,
+        raising=False,
+    )
+
+    callback_response = federation_client.get(
+        f"/api/v1/auth/federation/corp/callback?state={state}&code=code-123",
+    )
+    assert callback_response.status_code == 200, callback_response.text
+    body = callback_response.json()
+
+    assert body["token_type"] == "bearer"
+    assert body["access_token"]
+    assert body["refresh_token"]
+    assert body["expires_in"] > 0
+
+    payload = JWTService(get_settings()).verify_token(body["access_token"], token_type="access")
+    assert int(payload["sub"]) == existing_user_id
+    assert payload["username"] == "alice"
+
+    async def _fetch_link() -> dict | None:
+        pool = await get_db_pool()
+        links_repo = FederatedIdentityRepo(db_pool=pool)
+        await links_repo.ensure_tables()
+        return await links_repo.get_by_provider_subject(
+            identity_provider_id=int(provider["id"]),
+            external_subject="external-subject-123",
+        )
+
+    link = asyncio.run(_fetch_link())
+    assert link is not None
+    assert int(link["user_id"]) == existing_user_id
+    assert link["external_email"] == "alice@example.com"
+
+
+def test_federation_callback_jit_creates_user_when_policy_allows(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+    from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+    from tldw_Server_API.app.core.AuthNZ.repos.federated_identity_repo import FederatedIdentityRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+            },
+            "provisioning_policy": {
+                "jit_create": True,
+                "allow_email_account_linking": False,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    provider = create_response.json()
+
+    login_response = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 307, login_response.text
+    login_query = parse_qs(urlparse(login_response.headers["location"]).query)
+    state = login_query["state"][0]
+
+    async def _fake_exchange(
+        self,
+        *,
+        provider: dict,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict:
+        assert code == "code-create-123"
+        assert redirect_uri == "http://testserver/api/v1/auth/federation/corp/callback"
+        assert code_verifier
+        return {
+            "sub": "external-create-subject-123",
+            "email": "newuser@example.com",
+            "preferred_username": "newuser_sso",
+            "iss": "https://issuer.example.com",
+        }
+
+    monkeypatch.setattr(
+        OIDCFederationService,
+        "exchange_authorization_code",
+        _fake_exchange,
+        raising=False,
+    )
+
+    callback_response = federation_client.get(
+        f"/api/v1/auth/federation/corp/callback?state={state}&code=code-create-123",
+    )
+    assert callback_response.status_code == 200, callback_response.text
+    body = callback_response.json()
+    assert body["access_token"]
+    assert body["refresh_token"]
+
+    async def _fetch_created_user() -> dict | None:
+        pool = await get_db_pool()
+        users_db = UsersDB(pool)
+        await users_db.initialize()
+        return await users_db.get_user_by_email("newuser@example.com")
+
+    created_user = asyncio.run(_fetch_created_user())
+    assert created_user is not None
+    assert created_user["username"] == "newuser_sso"
+    assert bool(created_user["is_verified"]) is True
+
+    payload = JWTService(get_settings()).verify_token(body["access_token"], token_type="access")
+    assert int(payload["sub"]) == int(created_user["id"])
+
+    async def _fetch_link() -> dict | None:
+        pool = await get_db_pool()
+        links_repo = FederatedIdentityRepo(db_pool=pool)
+        await links_repo.ensure_tables()
+        return await links_repo.get_by_provider_subject(
+            identity_provider_id=int(provider["id"]),
+            external_subject="external-create-subject-123",
+        )
+
+    link = asyncio.run(_fetch_link())
+    assert link is not None
+    assert int(link["user_id"]) == int(created_user["id"])
+
+
+def test_federation_callback_applies_mapped_grants_in_jit_grant_only_mode(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+    from tldw_Server_API.app.core.AuthNZ.jwt_service import JWTService
+    from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
+        create_organization,
+        create_team,
+        list_memberships_for_user,
+        list_org_memberships_for_user,
+    )
+    from tldw_Server_API.app.core.AuthNZ.repos.rbac_repo import AuthnzRbacRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import get_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    async def _seed_user_and_scope() -> tuple[int, int, int]:
+        pool = await get_db_pool()
+        users_db = UsersDB(pool)
+        await users_db.initialize()
+        user = await users_db.create_user(
+            username="carol",
+            email="carol@example.com",
+            password_hash="not-a-real-password-hash",
+            is_active=True,
+            is_verified=True,
+        )
+        org = await create_organization(name="Federated Grants Org", owner_user_id=None)
+        team = await create_team(org_id=int(org["id"]), name="Federated Grants Team")
+        return int(user["id"]), int(org["id"]), int(team["id"])
+
+    existing_user_id, mapped_org_id, mapped_team_id = asyncio.run(_seed_user_and_scope())
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+                "default_roles": ["admin"],
+                "default_org_ids": [mapped_org_id],
+                "default_team_ids": [mapped_team_id],
+            },
+            "provisioning_policy": {
+                "jit_create": False,
+                "allow_email_account_linking": True,
+                "mode": "jit_grant_only",
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    login_response = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 307, login_response.text
+    login_query = parse_qs(urlparse(login_response.headers["location"]).query)
+    state = login_query["state"][0]
+
+    async def _fake_exchange(
+        self,
+        *,
+        provider: dict,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict:
+        assert code == "code-grants-123"
+        assert redirect_uri == "http://testserver/api/v1/auth/federation/corp/callback"
+        assert code_verifier
+        return {
+            "sub": "external-grants-subject-123",
+            "email": "carol@example.com",
+            "preferred_username": "carol.sso",
+            "iss": "https://issuer.example.com",
+        }
+
+    monkeypatch.setattr(
+        OIDCFederationService,
+        "exchange_authorization_code",
+        _fake_exchange,
+        raising=False,
+    )
+
+    callback_response = federation_client.get(
+        f"/api/v1/auth/federation/corp/callback?state={state}&code=code-grants-123",
+    )
+    assert callback_response.status_code == 200, callback_response.text
+    body = callback_response.json()
+
+    payload = JWTService(get_settings()).verify_token(body["access_token"], token_type="access")
+    assert int(payload["sub"]) == existing_user_id
+    assert mapped_org_id in payload["org_ids"]
+    assert mapped_team_id in payload["team_ids"]
+
+    async def _fetch_grants() -> tuple[list[dict], list[dict], list[str]]:
+        org_memberships = await list_org_memberships_for_user(existing_user_id)
+        team_memberships = await list_memberships_for_user(existing_user_id)
+        role_rows = AuthnzRbacRepo().get_user_roles(existing_user_id)
+        return org_memberships, team_memberships, [str(row["name"]) for row in role_rows]
+
+    org_memberships, team_memberships, role_names = asyncio.run(_fetch_grants())
+    assert any(int(row["org_id"]) == mapped_org_id for row in org_memberships)
+    assert any(int(row["team_id"]) == mapped_team_id for row in team_memberships)
+    assert "admin" in role_names
+
+
+@pytest.mark.parametrize("provisioning_mode", ["jit_grant_and_revoke", "sync_managed_only"])
+def test_federation_callback_revokes_only_provider_managed_grants_in_safe_revoke_modes(
+    federation_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    provisioning_mode: str,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+    from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+    from tldw_Server_API.app.core.AuthNZ.orgs_teams import (
+        add_org_member,
+        add_team_member,
+        create_organization,
+        create_team,
+        list_memberships_for_user,
+        list_org_memberships_for_user,
+    )
+    from tldw_Server_API.app.core.AuthNZ.repos.rbac_repo import AuthnzRbacRepo
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+
+    async def _seed_user_and_scope() -> tuple[int, int, int, int, int]:
+        pool = await get_db_pool()
+        users_db = UsersDB(pool)
+        await users_db.initialize()
+        user = await users_db.create_user(
+            username="dana",
+            email="dana@example.com",
+            password_hash="not-a-real-password-hash",
+            is_active=True,
+            is_verified=True,
+        )
+        managed_org = await create_organization(name="Federated Managed Org", owner_user_id=None)
+        managed_team = await create_team(org_id=int(managed_org["id"]), name="Federated Managed Team")
+        manual_org = await create_organization(name="Federated Manual Org", owner_user_id=None)
+        manual_team = await create_team(org_id=int(manual_org["id"]), name="Federated Manual Team")
+        await add_org_member(org_id=int(manual_org["id"]), user_id=int(user["id"]), role="member")
+        await add_team_member(team_id=int(manual_team["id"]), user_id=int(user["id"]), role="member")
+        return (
+            int(user["id"]),
+            int(managed_org["id"]),
+            int(managed_team["id"]),
+            int(manual_org["id"]),
+            int(manual_team["id"]),
+        )
+
+    user_id, managed_org_id, managed_team_id, manual_org_id, manual_team_id = asyncio.run(_seed_user_and_scope())
+
+    create_response = federation_client.post(
+        "/api/v1/admin/identity/providers",
+        json={
+            "slug": "corp",
+            "provider_type": "oidc",
+            "owner_scope_type": "global",
+            "enabled": True,
+            "display_name": "Corp SSO",
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "claim_mapping": {
+                "subject": "sub",
+                "email": "email",
+                "username": "preferred_username",
+                "groups": "groups",
+                "role_mappings": {
+                    "eng-admins": "admin",
+                },
+                "org_mappings": {
+                    "eng-admins": managed_org_id,
+                },
+                "team_mappings": {
+                    "eng-admins": managed_team_id,
+                },
+            },
+            "provisioning_policy": {
+                "jit_create": False,
+                "allow_email_account_linking": True,
+                "mode": provisioning_mode,
+            },
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+
+    async def _fake_exchange(
+        self,
+        *,
+        provider: dict,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+        nonce: str | None = None,
+    ) -> dict:
+        assert redirect_uri == "http://testserver/api/v1/auth/federation/corp/callback"
+        assert code_verifier
+        if code == "code-managed-grants":
+            return {
+                "sub": "external-revoke-subject-123",
+                "email": "dana@example.com",
+                "preferred_username": "dana.sso",
+                "groups": ["eng-admins"],
+                "iss": "https://issuer.example.com",
+            }
+        if code == "code-managed-revoke":
+            return {
+                "sub": "external-revoke-subject-123",
+                "email": "dana@example.com",
+                "preferred_username": "dana.sso",
+                "groups": [],
+                "iss": "https://issuer.example.com",
+            }
+        raise AssertionError(f"Unexpected code {code}")
+
+    monkeypatch.setattr(
+        OIDCFederationService,
+        "exchange_authorization_code",
+        _fake_exchange,
+        raising=False,
+    )
+
+    first_login = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert first_login.status_code == 307, first_login.text
+    first_state = parse_qs(urlparse(first_login.headers["location"]).query)["state"][0]
+    first_callback = federation_client.get(
+        f"/api/v1/auth/federation/corp/callback?state={first_state}&code=code-managed-grants",
+    )
+    assert first_callback.status_code == 200, first_callback.text
+
+    async def _fetch_grants() -> tuple[list[dict], list[dict], list[str]]:
+        org_memberships = await list_org_memberships_for_user(user_id)
+        team_memberships = await list_memberships_for_user(user_id)
+        role_rows = AuthnzRbacRepo().get_user_roles(user_id)
+        return org_memberships, team_memberships, [str(row["name"]) for row in role_rows]
+
+    org_memberships, team_memberships, role_names = asyncio.run(_fetch_grants())
+    assert any(int(row["org_id"]) == managed_org_id for row in org_memberships)
+    assert any(int(row["team_id"]) == managed_team_id for row in team_memberships)
+    assert any(int(row["org_id"]) == manual_org_id for row in org_memberships)
+    assert any(int(row["team_id"]) == manual_team_id for row in team_memberships)
+    assert "admin" in role_names
+
+    second_login = federation_client.get(
+        "/api/v1/auth/federation/corp/login",
+        follow_redirects=False,
+    )
+    assert second_login.status_code == 307, second_login.text
+    second_state = parse_qs(urlparse(second_login.headers["location"]).query)["state"][0]
+    second_callback = federation_client.get(
+        f"/api/v1/auth/federation/corp/callback?state={second_state}&code=code-managed-revoke",
+    )
+    assert second_callback.status_code == 200, second_callback.text
+
+    org_memberships, team_memberships, role_names = asyncio.run(_fetch_grants())
+    assert not any(int(row["org_id"]) == managed_org_id for row in org_memberships)
+    assert not any(int(row["team_id"]) == managed_team_id for row in team_memberships)
+    assert any(int(row["org_id"]) == manual_org_id for row in org_memberships)
+    assert any(int(row["team_id"]) == manual_team_id for row in team_memberships)
+    assert "admin" not in role_names

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
@@ -303,6 +303,50 @@ async def test_exchange_authorization_code_resolves_byok_org_client_secret_refer
 
 
 @pytest.mark.asyncio
+async def test_exchange_authorization_code_rejects_untrusted_token_header_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _private_pem, jwk = _rsa_signing_material()
+    token_url = "https://issuer.example.com/oauth2/token"
+    jwks_url = "https://issuer.example.com/.well-known/jwks.json"
+    id_token = jwt.encode(
+        {
+            "sub": "external-user-unsafe",
+            "email": "mallory@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "client-123",
+            "nonce": "nonce-unsafe",
+        },
+        "shared-secret",
+        algorithm="HS256",
+        headers={"kid": "oidc-key-1"},
+    )
+
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        if method.upper() == "POST" and url == token_url:
+            return {"id_token": id_token}
+        if method.upper() == "GET" and url == jwks_url:
+            return {"keys": [jwk]}
+        raise AssertionError(f"Unexpected OIDC fetch: {method} {url}")
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+
+    with pytest.raises(ValueError, match="unsupported signing algorithm"):
+        await OIDCFederationService().exchange_authorization_code(
+            provider={
+                "issuer": "https://issuer.example.com",
+                "token_url": token_url,
+                "jwks_url": jwks_url,
+                "client_id": "client-123",
+            },
+            code="code-unsafe",
+            redirect_uri="http://testserver/callback",
+            code_verifier="verifier-unsafe",
+            nonce="nonce-unsafe",
+        )
+
+
+@pytest.mark.asyncio
 async def test_inspect_provider_configuration_rejects_missing_byok_org_client_secret_reference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
@@ -188,6 +188,31 @@ async def test_inspect_provider_configuration_rejects_missing_env_client_secret_
 
 
 @pytest.mark.asyncio
+async def test_build_authorization_request_ignores_discovery_when_runtime_fields_are_pinned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _unexpected_fetch(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        raise AssertionError(f"Discovery should not be fetched for pinned provider config: {method} {url}")
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _unexpected_fetch, raising=False)
+
+    auth_request = await OIDCFederationService().build_authorization_request(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "discovery_url": "https://issuer.example.com/.well-known/openid-configuration",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+        },
+        redirect_uri="http://testserver/callback",
+    )
+
+    parsed = urlparse(auth_request["auth_url"])
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://issuer.example.com/oauth2/authorize"
+
+
+@pytest.mark.asyncio
 async def test_exchange_authorization_code_resolves_env_client_secret_reference(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -300,6 +325,41 @@ async def test_exchange_authorization_code_resolves_byok_org_client_secret_refer
     assert seen_form["client_secret"] == "resolved::blob-123"
     assert touched == [("org", 123, "idp:corp-oidc")]
     assert claims["sub"] == "external-user-999"
+
+
+@pytest.mark.asyncio
+async def test_inspect_provider_configuration_does_not_touch_byok_secret_last_used(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    touched: list[tuple[str, int, str]] = []
+
+    monkeypatch.setattr(oidc_module, "get_db_pool", lambda: _async_value(object()))
+    monkeypatch.setattr(
+        oidc_module,
+        "AuthnzOrgProviderSecretsRepo",
+        lambda pool: _FakeOrgSecretRepo(pool, {"encrypted_blob": "blob-123"}, touched),
+    )
+    monkeypatch.setattr(oidc_module, "loads_envelope", lambda value: {"blob": value}, raising=False)
+    monkeypatch.setattr(
+        oidc_module,
+        "decrypt_byok_payload",
+        lambda envelope: {"api_key": f"resolved::{envelope['blob']}"},
+        raising=False,
+    )
+
+    result = await OIDCFederationService().inspect_provider_configuration(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "authorization_url": "https://issuer.example.com/oauth2/authorize",
+            "token_url": "https://issuer.example.com/oauth2/token",
+            "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+            "client_id": "client-123",
+            "client_secret_ref": "byok-org:123:idp:corp-oidc",
+        }
+    )
+
+    assert result["ok"] is True
+    assert touched == []
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_oidc_service.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from jose import jwt
+from jose.utils import base64url_encode
+
+from tldw_Server_API.app.core.AuthNZ.federation import oidc_service as oidc_module
+from tldw_Server_API.app.core.AuthNZ.federation.oidc_service import OIDCFederationService
+
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+def _install_fetch_json_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    responses: dict[tuple[str, str], dict],
+) -> None:
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        return dict(responses[(method.upper(), url)])
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+
+
+async def _async_value(value):  # noqa: ANN001, ANN201
+    return value
+
+
+class _FakeOrgSecretRepo:
+    def __init__(self, _pool: object, row: dict | None, touched: list[tuple[str, int, str]] | None = None) -> None:
+        self._row = row
+        self._touched = touched if touched is not None else []
+
+    async def ensure_tables(self) -> None:
+        return None
+
+    async def fetch_secret(self, scope_type: str, scope_id: int, provider: str, *, include_revoked: bool = False):  # noqa: ANN001
+        assert include_revoked is False
+        if self._row is None:
+            return None
+        assert scope_type == "org"
+        assert scope_id == 123
+        assert provider == "idp:corp-oidc"
+        return dict(self._row)
+
+    async def touch_last_used(self, scope_type: str, scope_id: int, provider: str, used_at) -> None:  # noqa: ANN001
+        assert used_at is not None
+        self._touched.append((scope_type, scope_id, provider))
+
+
+class _MissingOrgSecretRepo(_FakeOrgSecretRepo):
+    def __init__(self, _pool: object) -> None:
+        super().__init__(_pool, None, [])
+
+
+def _rsa_signing_material() -> tuple[str, dict[str, str]]:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_numbers = private_key.public_key().public_numbers()
+    return private_pem, {
+        "kty": "RSA",
+        "kid": "oidc-key-1",
+        "alg": "RS256",
+        "use": "sig",
+        "n": base64url_encode(
+            public_numbers.n.to_bytes((public_numbers.n.bit_length() + 7) // 8, "big")
+        ).decode("utf-8"),
+        "e": base64url_encode(
+            public_numbers.e.to_bytes((public_numbers.e.bit_length() + 7) // 8, "big")
+        ).decode("utf-8"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_build_authorization_request_uses_discovery_authorization_endpoint_when_needed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    discovery_url = "https://issuer.example.com/.well-known/openid-configuration"
+    _install_fetch_json_stub(
+        monkeypatch,
+        {
+            ("GET", discovery_url): {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://issuer.example.com/oauth2/authorize",
+                "token_endpoint": "https://issuer.example.com/oauth2/token",
+                "jwks_uri": "https://issuer.example.com/.well-known/jwks.json",
+            }
+        },
+    )
+
+    auth_request = await OIDCFederationService().build_authorization_request(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "discovery_url": discovery_url,
+            "client_id": "client-123",
+        },
+        redirect_uri="http://testserver/callback",
+    )
+
+    parsed = urlparse(auth_request["auth_url"])
+    query = parse_qs(parsed.query)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://issuer.example.com/oauth2/authorize"
+    assert query["client_id"] == ["client-123"]
+    assert query["redirect_uri"] == ["http://testserver/callback"]
+    assert query["response_type"] == ["code"]
+
+
+@pytest.mark.asyncio
+async def test_exchange_authorization_code_uses_discovery_and_jwks_to_verify_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = _rsa_signing_material()
+    discovery_url = "https://issuer.example.com/.well-known/openid-configuration"
+    token_url = "https://issuer.example.com/oauth2/token"
+    jwks_url = "https://issuer.example.com/.well-known/jwks.json"
+    id_token = jwt.encode(
+        {
+            "sub": "external-user-123",
+            "email": "alice@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "client-123",
+            "nonce": "nonce-123",
+        },
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": "oidc-key-1"},
+    )
+
+    _install_fetch_json_stub(
+        monkeypatch,
+        {
+            ("GET", discovery_url): {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://issuer.example.com/oauth2/authorize",
+                "token_endpoint": token_url,
+                "jwks_uri": jwks_url,
+            },
+            ("POST", token_url): {"id_token": id_token},
+            ("GET", jwks_url): {"keys": [jwk]},
+        },
+    )
+
+    claims = await OIDCFederationService().exchange_authorization_code(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "discovery_url": discovery_url,
+            "client_id": "client-123",
+        },
+        code="code-123",
+        redirect_uri="http://testserver/callback",
+        code_verifier="verifier-123",
+        nonce="nonce-123",
+    )
+
+    assert claims["sub"] == "external-user-123"
+    assert claims["email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_inspect_provider_configuration_rejects_missing_env_client_secret_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CORP_OIDC_CLIENT_SECRET", raising=False)
+
+    with pytest.raises(
+        ValueError,
+        match="OIDC client_secret_ref environment variable is not set: CORP_OIDC_CLIENT_SECRET",
+    ):
+        await OIDCFederationService().inspect_provider_configuration(
+            provider={
+                "issuer": "https://issuer.example.com",
+                "authorization_url": "https://issuer.example.com/oauth2/authorize",
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+                "client_secret_ref": "env:CORP_OIDC_CLIENT_SECRET",
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_exchange_authorization_code_resolves_env_client_secret_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = _rsa_signing_material()
+    token_url = "https://issuer.example.com/oauth2/token"
+    jwks_url = "https://issuer.example.com/.well-known/jwks.json"
+    id_token = jwt.encode(
+        {
+            "sub": "external-user-789",
+            "email": "bob@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "client-123",
+            "nonce": "nonce-789",
+        },
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": "oidc-key-1"},
+    )
+    seen_form: dict[str, str] = {}
+
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        if method.upper() == "POST" and url == token_url:
+            seen_form.update(kwargs["data"])
+            return {"id_token": id_token}
+        if method.upper() == "GET" and url == jwks_url:
+            return {"keys": [jwk]}
+        raise AssertionError(f"Unexpected OIDC fetch: {method} {url}")
+
+    monkeypatch.setenv("CORP_OIDC_CLIENT_SECRET", "super-secret")
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+
+    claims = await OIDCFederationService().exchange_authorization_code(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "token_url": token_url,
+            "jwks_url": jwks_url,
+            "client_id": "client-123",
+            "client_secret_ref": "env:CORP_OIDC_CLIENT_SECRET",
+        },
+        code="code-789",
+        redirect_uri="http://testserver/callback",
+        code_verifier="verifier-789",
+        nonce="nonce-789",
+    )
+
+    assert seen_form["client_secret"] == "super-secret"
+    assert claims["sub"] == "external-user-789"
+    assert claims["email"] == "bob@example.com"
+
+
+@pytest.mark.asyncio
+async def test_exchange_authorization_code_resolves_byok_org_client_secret_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    private_pem, jwk = _rsa_signing_material()
+    token_url = "https://issuer.example.com/oauth2/token"
+    jwks_url = "https://issuer.example.com/.well-known/jwks.json"
+    id_token = jwt.encode(
+        {
+            "sub": "external-user-999",
+            "email": "shared@example.com",
+            "iss": "https://issuer.example.com",
+            "aud": "client-123",
+            "nonce": "nonce-999",
+        },
+        private_pem,
+        algorithm="RS256",
+        headers={"kid": "oidc-key-1"},
+    )
+    seen_form: dict[str, str] = {}
+    touched: list[tuple[str, int, str]] = []
+
+    async def _fake_afetch_json(*, method: str, url: str, **kwargs) -> dict:  # noqa: ANN003
+        if method.upper() == "POST" and url == token_url:
+            seen_form.update(kwargs["data"])
+            return {"id_token": id_token}
+        if method.upper() == "GET" and url == jwks_url:
+            return {"keys": [jwk]}
+        raise AssertionError(f"Unexpected OIDC fetch: {method} {url}")
+
+    monkeypatch.setattr(oidc_module, "afetch_json", _fake_afetch_json, raising=False)
+    monkeypatch.setattr(oidc_module, "get_db_pool", lambda: _async_value(object()))
+    monkeypatch.setattr(
+        oidc_module,
+        "AuthnzOrgProviderSecretsRepo",
+        lambda pool: _FakeOrgSecretRepo(pool, {"encrypted_blob": "blob-123"}, touched),
+    )
+    monkeypatch.setattr(oidc_module, "loads_envelope", lambda value: {"blob": value}, raising=False)
+    monkeypatch.setattr(
+        oidc_module,
+        "decrypt_byok_payload",
+        lambda envelope: {"api_key": f"resolved::{envelope['blob']}"},
+        raising=False,
+    )
+
+    claims = await OIDCFederationService().exchange_authorization_code(
+        provider={
+            "issuer": "https://issuer.example.com",
+            "token_url": token_url,
+            "jwks_url": jwks_url,
+            "client_id": "client-123",
+            "client_secret_ref": "byok-org:123:idp:corp-oidc",
+        },
+        code="code-999",
+        redirect_uri="http://testserver/callback",
+        code_verifier="verifier-999",
+        nonce="nonce-999",
+    )
+
+    assert seen_form["client_secret"] == "resolved::blob-123"
+    assert touched == [("org", 123, "idp:corp-oidc")]
+    assert claims["sub"] == "external-user-999"
+
+
+@pytest.mark.asyncio
+async def test_inspect_provider_configuration_rejects_missing_byok_org_client_secret_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oidc_module, "get_db_pool", lambda: _async_value(object()))
+    monkeypatch.setattr(oidc_module, "AuthnzOrgProviderSecretsRepo", _MissingOrgSecretRepo)
+
+    with pytest.raises(
+        ValueError,
+        match="OIDC client_secret_ref BYOK secret is not available",
+    ):
+        await OIDCFederationService().inspect_provider_configuration(
+            provider={
+                "issuer": "https://issuer.example.com",
+                "authorization_url": "https://issuer.example.com/oauth2/authorize",
+                "token_url": "https://issuer.example.com/oauth2/token",
+                "jwks_url": "https://issuer.example.com/.well-known/jwks.json",
+                "client_id": "client-123",
+                "client_secret_ref": "byok-org:123:idp:corp-oidc",
+            }
+        )

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_provisioning_service.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_provisioning_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.federation import provisioning_service as provisioning_module
+from tldw_Server_API.app.core.AuthNZ.federation.provisioning_service import (
+    FederationProvisioningService,
+)
+
+
+@pytest.mark.asyncio
+async def test_preview_mapped_grants_ignores_memberships_with_missing_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _StubOrgsRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+
+        async def get_org_member(self, org_id: int, user_id: int):
+            if org_id == 12 and user_id == 7:
+                return {"role": "member"}
+            return None
+
+        async def get_team_member(self, team_id: int, user_id: int):
+            return None
+
+        async def list_memberships_for_user(self, user_id: int):
+            return [
+                {"org_id": None, "team_id": None, "team_name": "Unexpected"},
+                {"org_id": 12, "team_id": 99, "team_name": provisioning_module.DEFAULT_BASE_TEAM_NAME},
+            ]
+
+    class _StubUsersRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+
+        async def has_role_assignment(self, user_id: int, role_name: str) -> bool:
+            return False
+
+    class _StubManagedGrantRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+
+        async def ensure_tables(self) -> None:
+            return None
+
+        async def list_for_provider_user(self, *, identity_provider_id: int, user_id: int):
+            return [{"grant_kind": "org", "target_ref": "12"}]
+
+    monkeypatch.setattr(provisioning_module, "AuthnzOrgsTeamsRepo", _StubOrgsRepo)
+    monkeypatch.setattr(provisioning_module, "AuthnzUsersRepo", _StubUsersRepo)
+    monkeypatch.setattr(provisioning_module, "FederatedManagedGrantRepo", _StubManagedGrantRepo)
+
+    service = FederationProvisioningService(db_pool=None)
+
+    preview = await service.preview_mapped_grants(
+        provider={"id": 5, "provisioning_policy": {"mode": "sync_managed_only"}},
+        user_id=7,
+        mapped_claims={"derived_org_ids": [], "derived_team_ids": [], "derived_roles": []},
+    )
+
+    assert preview["revoke_org_ids"] == [12]
+
+
+@pytest.mark.asyncio
+async def test_apply_mapped_grants_ignores_memberships_with_missing_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _StubOrgsRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+
+        async def get_org_member(self, org_id: int, user_id: int):
+            if org_id == 12 and user_id == 7:
+                return {"role": "member"}
+            return None
+
+        async def get_team_member(self, team_id: int, user_id: int):
+            return None
+
+        async def list_memberships_for_user(self, user_id: int):
+            return [
+                {"org_id": None, "team_name": None},
+                {"org_id": 12, "team_name": provisioning_module.DEFAULT_BASE_TEAM_NAME},
+            ]
+
+        async def remove_org_member(self, *, org_id: int, user_id: int):
+            return {"removed": True}
+
+    class _StubUsersRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+
+        async def has_role_assignment(self, user_id: int, role_name: str) -> bool:
+            return False
+
+        async def remove_role_if_present(self, user_id: int, role_name: str) -> bool:
+            return False
+
+    class _StubManagedGrantRepo:
+        def __init__(self, db_pool=None) -> None:
+            self.db_pool = db_pool
+            self.deleted: list[tuple[str, str]] = []
+
+        async def ensure_tables(self) -> None:
+            return None
+
+        async def list_for_provider_user(self, *, identity_provider_id: int, user_id: int):
+            return [{"grant_kind": "org", "target_ref": "12"}]
+
+        async def delete_grant(
+            self,
+            *,
+            identity_provider_id: int,
+            user_id: int,
+            grant_kind: str,
+            target_ref: str,
+        ) -> None:
+            self.deleted.append((grant_kind, target_ref))
+
+        async def upsert_grant(self, **kwargs) -> None:  # noqa: ANN003
+            return None
+
+    monkeypatch.setattr(provisioning_module, "AuthnzOrgsTeamsRepo", _StubOrgsRepo)
+    monkeypatch.setattr(provisioning_module, "AuthnzUsersRepo", _StubUsersRepo)
+    monkeypatch.setattr(provisioning_module, "FederatedManagedGrantRepo", _StubManagedGrantRepo)
+
+    service = FederationProvisioningService(db_pool=None)
+
+    result = await service.apply_mapped_grants(
+        provider={"id": 5, "provisioning_policy": {"mode": "sync_managed_only"}},
+        user_id=7,
+        mapped_claims={"derived_org_ids": [], "derived_team_ids": [], "derived_roles": []},
+    )
+
+    assert result["revoked_org_ids"] == [12]

--- a/tldw_Server_API/tests/AuthNZ_Federation/test_state_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Federation/test_state_repo.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.federation.state_repo import FederationStateRepo
+
+
+@pytest.mark.asyncio
+async def test_federation_state_repo_consumes_state_atomically() -> None:
+    class _StubSessionManager:
+        def __init__(self) -> None:
+            self.consumed: list[str] = []
+
+        async def consume_ephemeral_value(self, key: str):
+            self.consumed.append(key)
+            return json.dumps({"provider_id": 7, "nonce": "nonce-123"})
+
+        async def get_ephemeral_value(self, key: str):
+            raise AssertionError("consume_state should not call get_ephemeral_value")
+
+        async def delete_ephemeral_value(self, key: str) -> None:
+            raise AssertionError("consume_state should not call delete_ephemeral_value")
+
+    session_manager = _StubSessionManager()
+    repo = FederationStateRepo(session_manager=session_manager)
+
+    payload = await repo.consume_state(state="state-123")
+
+    assert payload == {"provider_id": 7, "nonce": "nonce-123"}
+    assert session_manager.consumed == ["oidc-login:state-123"]

--- a/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py
+++ b/tldw_Server_API/tests/AuthNZ_Unit/test_mcp_hub_repo.py
@@ -629,6 +629,49 @@ async def test_repo_rejects_disable_binding_for_profile_target(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_repo_rejects_explicit_server_credential_ref_for_disable_binding(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json='{"url":"wss://docs.example/ws"}',
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+
+    with pytest.raises(ValueError, match="disable bindings may not store explicit credential refs"):
+        await repo.create_credential_binding(
+            binding_target_type="assignment",
+            binding_target_id="11",
+            external_server_id="docs",
+            credential_ref="managed_secret_ref:17",
+            binding_mode="disable",
+            usage_rules={},
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
 async def test_repo_credential_slot_name_is_unique_per_server(tmp_path, monkeypatch) -> None:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
@@ -786,6 +829,59 @@ async def test_repo_rejects_slot_binding_for_unknown_slot(tmp_path, monkeypatch)
             slot_name="token_write",
             credential_ref="slot",
             binding_mode="grant",
+            usage_rules={},
+            actor_id=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_repo_rejects_explicit_slot_credential_ref_for_disable_binding(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json='{"websocket":{"url":"wss://docs.example/ws"}}',
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+
+    with pytest.raises(ValueError, match="disable bindings may not store explicit credential refs"):
+        await repo.create_credential_binding(
+            binding_target_type="assignment",
+            binding_target_id="11",
+            external_server_id="docs",
+            slot_name="token_readonly",
+            credential_ref="managed_secret_ref:23",
+            binding_mode="disable",
             usage_rules={},
             actor_id=1,
         )

--- a/tldw_Server_API/tests/MCP_Hub/test_mcp_slot_status.py
+++ b/tldw_Server_API/tests/MCP_Hub/test_mcp_slot_status.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+    ManagedSecretRefsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+@pytest.mark.asyncio
+async def test_assignment_binding_reports_reauth_required_when_managed_secret_ref_requires_reauth(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_credential_broker_service import (
+        McpCredentialBrokerService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    managed_refs_repo = ManagedSecretRefsRepo(pool)
+    await managed_refs_repo.ensure_tables()
+    await managed_refs_repo.ensure_backend_registration(
+        name="local_encrypted_v1",
+        display_name="Local Encrypted",
+    )
+
+    profile = await repo.create_permission_profile(
+        name="External GitHub",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=1,
+    )
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        profile_id=int(profile["id"]),
+        inline_policy_document={"capabilities": ["network.external"]},
+        approval_policy_id=None,
+        actor_id=1,
+        is_active=True,
+    )
+    await repo.upsert_external_server(
+        server_id="github",
+        name="GitHub",
+        transport="websocket",
+        config_json=json.dumps({"websocket": {"url": "wss://github.example/ws"}}),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="github",
+        slot_name="bearer_token",
+        display_name="Bearer token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+    managed_ref = await managed_refs_repo.upsert_ref(
+        backend_name="local_encrypted_v1",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        provider_key="github",
+        backend_ref="user:1:github",
+        metadata={"purpose": "mcp_slot"},
+        status="reauth_required",
+        created_by=1,
+        updated_by=1,
+    )
+    await repo.create_credential_binding(
+        binding_target_type="assignment",
+        binding_target_id=str(assignment["id"]),
+        external_server_id="github",
+        slot_name="bearer_token",
+        credential_ref=f"managed_secret_ref:{managed_ref['id']}",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+
+    service = McpCredentialBrokerService(repo=repo)
+
+    status = await service.get_slot_status(
+        server_id="github",
+        slot_name="bearer_token",
+        assignment_id=int(assignment["id"]),
+    )
+
+    assert status["state"] == "reauth_required"
+    assert status["managed_secret_ref_id"] == int(managed_ref["id"])
+    assert status["credential_ref"] == f"managed_secret_ref:{managed_ref['id']}"
+
+
+@pytest.mark.asyncio
+async def test_assignment_binding_reports_missing_when_granted_slot_has_no_secret(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_credential_broker_service import (
+        McpCredentialBrokerService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    profile = await repo.create_permission_profile(
+        name="External Docs",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=1,
+    )
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        profile_id=int(profile["id"]),
+        inline_policy_document={"capabilities": ["network.external"]},
+        approval_policy_id=None,
+        actor_id=1,
+        is_active=True,
+    )
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json=json.dumps({"websocket": {"url": "wss://docs.example/ws"}}),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+    await repo.create_credential_binding(
+        binding_target_type="assignment",
+        binding_target_id=str(assignment["id"]),
+        external_server_id="docs",
+        slot_name="token_readonly",
+        credential_ref="slot",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+
+    service = McpCredentialBrokerService(repo=repo)
+
+    status = await service.get_slot_status(
+        server_id="docs",
+        slot_name="token_readonly",
+        assignment_id=int(assignment["id"]),
+    )
+
+    assert status["state"] == "missing"
+    assert status["managed_secret_ref_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_assignment_binding_reports_approval_required_when_slot_secret_exists_but_slot_is_not_granted(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_credential_broker_service import (
+        McpCredentialBrokerService,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+
+    profile = await repo.create_permission_profile(
+        name="External Docs",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=1,
+    )
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        profile_id=int(profile["id"]),
+        inline_policy_document={"capabilities": ["network.external"]},
+        approval_policy_id=None,
+        actor_id=1,
+        is_active=True,
+    )
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json=json.dumps({"websocket": {"url": "wss://docs.example/ws"}}),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+    await repo.upsert_external_server_slot_secret(
+        server_id="docs",
+        slot_name="token_readonly",
+        encrypted_blob='{"ciphertext":"abc"}',
+        key_hint="cdef",
+        actor_id=1,
+    )
+
+    service = McpCredentialBrokerService(repo=repo)
+
+    status = await service.get_slot_status(
+        server_id="docs",
+        slot_name="token_readonly",
+        assignment_id=int(assignment["id"]),
+    )
+
+    assert status["state"] == "approval_required"

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_external_slot_access.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_external_slot_access.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -54,7 +55,23 @@ async def test_external_access_resolver_is_slot_aware(tmp_path, monkeypatch) -> 
         server_id="docs",
         name="Docs",
         transport="websocket",
-        config_json=json.dumps({"websocket": {"url": "wss://docs.example/ws"}}),
+        config_json=json.dumps(
+            {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "Authorization",
+                            "prefix": "Bearer ",
+                            "required": True,
+                        }
+                    ],
+                },
+            }
+        ),
         owner_scope_type="global",
         owner_scope_id=None,
         enabled=True,
@@ -173,7 +190,23 @@ async def test_external_access_resolver_marks_missing_slot_secret(tmp_path, monk
         server_id="docs",
         name="Docs",
         transport="websocket",
-        config_json=json.dumps({"websocket": {"url": "wss://docs.example/ws"}}),
+        config_json=json.dumps(
+            {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "Authorization",
+                            "prefix": "Bearer ",
+                            "required": True,
+                        }
+                    ],
+                },
+            }
+        ),
         owner_scope_type="global",
         owner_scope_id=None,
         enabled=True,
@@ -328,3 +361,316 @@ async def test_external_access_resolver_reports_requested_slot_bundle_state(tmp_
     assert server["bound_slots"] == ["token_readonly"]
     assert server["missing_bound_slots"] == ["token_write"]
     assert server["missing_secret_slots"] == []
+
+
+@pytest.mark.asyncio
+async def test_external_access_resolver_treats_expired_managed_secret_ref_as_missing_without_backend_lookup(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+        ManagedSecretRefsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+    from tldw_Server_API.app.services import mcp_hub_external_access_resolver as resolver_module
+    from tldw_Server_API.app.services.mcp_hub_external_access_resolver import (
+        McpHubExternalAccessResolver,
+    )
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    managed_refs_repo = ManagedSecretRefsRepo(pool)
+    await managed_refs_repo.ensure_tables()
+    await managed_refs_repo.ensure_backend_registration(
+        name="local_encrypted_v1",
+        display_name="Local Encrypted",
+    )
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+    await users_db.create_user(
+        username="resolver-expired",
+        email="resolver-expired@example.com",
+        password_hash="hashed-password",
+        role="user",
+        is_active=True,
+        is_verified=True,
+    )
+
+    profile = await repo.create_permission_profile(
+        name="External Docs",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=1,
+    )
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        profile_id=int(profile["id"]),
+        inline_policy_document={"capabilities": ["network.external"]},
+        approval_policy_id=None,
+        actor_id=1,
+        is_active=True,
+    )
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json=json.dumps(
+            {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "Authorization",
+                            "prefix": "Bearer ",
+                            "required": True,
+                        }
+                    ],
+                },
+            }
+        ),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+    managed_ref = await managed_refs_repo.upsert_ref(
+        backend_name="local_encrypted_v1",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        provider_key="docs",
+        backend_ref="user:1:docs",
+        metadata={"purpose": "mcp_slot"},
+        status="active",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        created_by=1,
+        updated_by=1,
+    )
+    await repo.create_credential_binding(
+        binding_target_type="profile",
+        binding_target_id=str(profile["id"]),
+        external_server_id="docs",
+        slot_name="token_readonly",
+        credential_ref=f"managed_secret_ref:{managed_ref['id']}",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+
+    def _unexpected_backend(*_args, **_kwargs):  # noqa: ANN001, ANN002
+        raise AssertionError("Expired managed secret refs should not query the backend")
+
+    monkeypatch.setattr(resolver_module, "get_secret_backend", _unexpected_backend)
+
+    resolver = McpHubExternalAccessResolver(repo=repo)
+    summary = await resolver.resolve(
+        assignment_id=int(assignment["id"]),
+        effective_policy={"capabilities": ["network.external"]},
+    )
+
+    server = summary["servers"][0]
+    assert server["secret_available"] is False
+    assert server["runtime_executable"] is False
+    assert server["missing_secret_slots"] == ["token_readonly"]
+    assert server["blocked_reason"] == "required_slot_secret_missing"
+
+
+@pytest.mark.asyncio
+async def test_external_access_resolver_caches_managed_secret_readiness_per_ref(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.managed_secret_refs_repo import (
+        ManagedSecretRefsRepo,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import UsersDB
+    from tldw_Server_API.app.services import mcp_hub_external_access_resolver as resolver_module
+    from tldw_Server_API.app.services.mcp_hub_external_access_resolver import (
+        McpHubExternalAccessResolver,
+    )
+
+    class _CountingBackend:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        async def describe_status(self, secret_ref_id: int) -> dict[str, str]:
+            self.calls.append(int(secret_ref_id))
+            return {"state": "ready"}
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    managed_refs_repo = ManagedSecretRefsRepo(pool)
+    await managed_refs_repo.ensure_tables()
+    await managed_refs_repo.ensure_backend_registration(
+        name="local_encrypted_v1",
+        display_name="Local Encrypted",
+    )
+    users_db = UsersDB(pool)
+    await users_db.initialize()
+    await users_db.create_user(
+        username="resolver-cached",
+        email="resolver-cached@example.com",
+        password_hash="hashed-password",
+        role="user",
+        is_active=True,
+        is_verified=True,
+    )
+
+    profile = await repo.create_permission_profile(
+        name="External Docs",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=1,
+    )
+    assignment = await repo.create_policy_assignment(
+        target_type="persona",
+        target_id="researcher",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        profile_id=int(profile["id"]),
+        inline_policy_document={"capabilities": ["network.external"]},
+        approval_policy_id=None,
+        actor_id=1,
+        is_active=True,
+    )
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json=json.dumps(
+            {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "Authorization",
+                            "prefix": "Bearer ",
+                            "required": True,
+                        },
+                        {
+                            "slot_name": "token_write",
+                            "target_type": "header",
+                            "target_name": "X-Write-Key",
+                            "required": True,
+                        },
+                    ],
+                },
+            }
+        ),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_write",
+        display_name="Write token",
+        secret_kind="api_key",
+        privilege_class="write",
+        is_required=True,
+        actor_id=1,
+    )
+    managed_ref = await managed_refs_repo.upsert_ref(
+        backend_name="local_encrypted_v1",
+        owner_scope_type="user",
+        owner_scope_id=1,
+        provider_key="docs",
+        backend_ref="user:1:docs",
+        metadata={"purpose": "mcp_slot"},
+        status="active",
+        created_by=1,
+        updated_by=1,
+    )
+    await repo.create_credential_binding(
+        binding_target_type="profile",
+        binding_target_id=str(profile["id"]),
+        external_server_id="docs",
+        slot_name="token_readonly",
+        credential_ref=f"managed_secret_ref:{managed_ref['id']}",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+    await repo.create_credential_binding(
+        binding_target_type="assignment",
+        binding_target_id=str(assignment["id"]),
+        external_server_id="docs",
+        slot_name="token_write",
+        credential_ref=f"managed_secret_ref:{managed_ref['id']}",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+
+    counting_backend = _CountingBackend()
+    monkeypatch.setattr(
+        resolver_module,
+        "get_secret_backend",
+        lambda *_args, **_kwargs: counting_backend,
+    )
+
+    resolver = McpHubExternalAccessResolver(repo=repo)
+    summary = await resolver.resolve(
+        assignment_id=int(assignment["id"]),
+        effective_policy={"capabilities": ["network.external"]},
+    )
+
+    server = summary["servers"][0]
+    assert server["bound_slots"] == ["token_readonly", "token_write"]
+    assert server["missing_secret_slots"] == []
+    assert counting_backend.calls == [int(managed_ref["id"])]

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
@@ -444,6 +444,31 @@ class _FakeService:
         return True
 
 
+class _FakeBrokerService:
+    async def get_slot_status(
+        self,
+        *,
+        server_id: str,
+        slot_name: str,
+        profile_id: int | None = None,
+        assignment_id: int | None = None,
+    ) -> dict[str, Any]:
+        binding_target_type = "profile" if profile_id is not None else "assignment"
+        binding_target_id = str(profile_id if profile_id is not None else assignment_id)
+        return {
+            "server_id": server_id,
+            "slot_name": slot_name,
+            "binding_target_type": binding_target_type,
+            "binding_target_id": binding_target_id,
+            "credential_ref": "server",
+            "managed_secret_ref_id": None,
+            "state": "ready",
+            "blocked_reason": None,
+            "backend_name": "local_encrypted_v1",
+            "expires_at": None,
+        }
+
+
 def _build_app(
     *,
     principal: AuthPrincipal | None,
@@ -464,6 +489,7 @@ def _build_app(
 
     app.dependency_overrides[auth_deps.get_auth_principal] = _fake_get_auth_principal
     app.dependency_overrides[mcp_hub_management.get_mcp_hub_service] = lambda: _FakeService()
+    app.dependency_overrides[mcp_hub_management.get_mcp_credential_broker_service] = lambda: _FakeBrokerService()
     return app
 
 
@@ -951,6 +977,28 @@ async def test_slot_binding_endpoints_round_trip() -> None:
     assert assignment_delete_resp.json()["ok"] is True
     assert preview_resp.status_code == 200
     assert preview_resp.json()["servers"][0]["slots"][1]["blocked_reason"] == "disabled_by_assignment"
+
+
+@pytest.mark.asyncio
+async def test_slot_status_endpoints_support_action_style_routes() -> None:
+    app = _build_app(
+        principal=_make_principal(roles=["admin"], permissions=[]),
+        fail_with_401=False,
+    )
+    with TestClient(app) as client:
+        profile_status_resp = client.get(
+            "/api/v1/mcp/hub/permission-profiles/7/credential-bindings/status/docs/token_readonly"
+        )
+        assignment_status_resp = client.get(
+            "/api/v1/mcp/hub/policy-assignments/11/credential-bindings/status/docs/token_write"
+        )
+
+    assert profile_status_resp.status_code == 200
+    assert profile_status_resp.json()["binding_target_type"] == "profile"
+    assert profile_status_resp.json()["slot_name"] == "token_readonly"
+    assert assignment_status_resp.status_code == 200
+    assert assignment_status_resp.json()["binding_target_type"] == "assignment"
+    assert assignment_status_resp.json()["slot_name"] == "token_write"
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_management_api.py
@@ -176,11 +176,13 @@ class _FakeService:
         profile_id: int,
         external_server_id: str,
         slot_name: str | None = None,
+        managed_secret_ref_id: int | None = None,
         actor_id: int | None,
     ) -> dict[str, Any]:
         assert profile_id == 7
         assert external_server_id == "docs"
         assert slot_name in {None, "token_readonly"}
+        assert managed_secret_ref_id is None
         assert actor_id == 1
         return {
             "id": 1,
@@ -237,12 +239,14 @@ class _FakeService:
         external_server_id: str,
         slot_name: str | None = None,
         binding_mode: str,
+        managed_secret_ref_id: int | None = None,
         actor_id: int | None,
     ) -> dict[str, Any]:
         assert assignment_id == 11
         assert external_server_id == "docs"
         assert slot_name in {None, "token_write"}
         assert binding_mode == "disable"
+        assert managed_secret_ref_id is None
         assert actor_id == 1
         return {
             "id": 2,

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_hub_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.core.exceptions import BadRequestError
 from tldw_Server_API.app.core.AuthNZ.repos.mcp_hub_repo import McpHubRepo
 
 pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
@@ -656,3 +657,61 @@ async def test_service_audits_slot_binding_with_privilege_metadata(tmp_path, mon
     assert metadata["slot_name"] == "token_write"
     assert metadata["privilege_class"] == "write"
     assert metadata["required_permission"] == "grant.credentials.write"
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_binding_managed_secret_ref_from_different_scope(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.secret_backends.local_encrypted import LocalEncryptedSecretBackend
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.services.mcp_hub_service import McpHubService
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    svc = McpHubService(repo=repo)
+
+    profile = await repo.create_permission_profile(
+        name="External Docs",
+        owner_scope_type="org",
+        owner_scope_id=7,
+        mode="custom",
+        policy_document={"capabilities": ["network.external"]},
+        actor_id=7,
+    )
+    await svc.create_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config={"websocket": {"url": "wss://docs.example/ws"}},
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        actor_id=7,
+    )
+    managed_ref = await LocalEncryptedSecretBackend(db_pool=pool).store_ref(
+        owner_scope_type="org",
+        owner_scope_id=42,
+        provider_key="docs-token",
+        payload={"api_key": "secret-token"},
+        created_by=7,
+        updated_by=7,
+    )
+
+    with pytest.raises(BadRequestError, match="different owner scope"):
+        await svc.upsert_profile_credential_binding(
+            profile_id=int(profile["id"]),
+            external_server_id="docs",
+            managed_secret_ref_id=int(managed_ref["id"]),
+            actor_id=7,
+        )

--- a/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py
+++ b/tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -11,14 +12,69 @@ from tldw_Server_API.app.core.MCP_unified.modules.base import ModuleConfig
 from tldw_Server_API.app.core.MCP_unified.modules.implementations.external_federation_module import (
     ExternalFederationModule,
 )
+from tldw_Server_API.app.core.MCP_unified.protocol import RequestContext
+from tldw_Server_API.app.core.MCP_unified.external_servers import manager as manager_mod
+from tldw_Server_API.app.core.MCP_unified.external_servers.transports.base import (
+    BrokeredExternalCredential,
+    ExternalMCPTransportAdapter,
+    ExternalToolCallResult,
+    ExternalToolDefinition,
+)
 
 
 def _b64_key(byte_char: bytes) -> str:
     return base64.b64encode(byte_char * 32).decode("ascii")
 
 
+class _BrokerAwareAdapter(ExternalMCPTransportAdapter):
+    def __init__(self, server_id: str) -> None:
+        super().__init__(server_id=server_id)
+        self.seen_runtime_auth: BrokeredExternalCredential | None = None
+
+    @property
+    def transport_name(self) -> str:
+        return "websocket"
+
+    async def connect(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+    async def health_check(self) -> dict[str, bool]:
+        return {"configured": True, "connected": True, "initialized": True}
+
+    async def list_tools(self) -> list[ExternalToolDefinition]:
+        return [
+            ExternalToolDefinition(
+                name="repo.search",
+                description="Search repos",
+                input_schema={"type": "object"},
+                metadata={"category": "read"},
+            )
+        ]
+
+    async def call_tool(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        context: Any = None,
+        runtime_auth: BrokeredExternalCredential | None = None,
+    ) -> ExternalToolCallResult:
+        del tool_name, arguments, context
+        self.seen_runtime_auth = runtime_auth
+        return ExternalToolCallResult(
+            content=[{"type": "text", "text": "ok"}],
+            is_error=False,
+            metadata={"adapter": "broker-aware"},
+        )
+
+
 @pytest.mark.asyncio
-async def test_managed_external_registry_service_hydrates_auth_and_skips_legacy(tmp_path, monkeypatch) -> None:
+async def test_managed_external_registry_service_keeps_runtime_config_auth_neutral_and_skips_legacy(
+    tmp_path,
+    monkeypatch,
+) -> None:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
     from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
@@ -94,7 +150,8 @@ async def test_managed_external_registry_service_hydrates_auth_and_skips_legacy(
 
     assert [server.id for server in servers] == ["docs"]
     assert servers[0].websocket is not None
-    assert servers[0].websocket.headers["Authorization"] == "Bearer super-secret-token"
+    assert servers[0].websocket.headers == {}
+    assert str(getattr(servers[0].auth.mode, "value", servers[0].auth.mode)) == "none"
 
 
 @pytest.mark.asyncio
@@ -156,7 +213,10 @@ async def test_external_federation_module_ignores_legacy_file_config_for_runtime
 
 
 @pytest.mark.asyncio
-async def test_managed_external_registry_service_hydrates_named_slot_template(tmp_path, monkeypatch) -> None:
+async def test_managed_external_registry_service_keeps_named_slot_template_auth_neutral(
+    tmp_path,
+    monkeypatch,
+) -> None:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
     from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
@@ -231,11 +291,15 @@ async def test_managed_external_registry_service_hydrates_named_slot_template(tm
 
     assert [server.id for server in servers] == ["docs"]
     assert servers[0].websocket is not None
-    assert servers[0].websocket.headers["Authorization"] == "Bearer super-secret-token"
+    assert servers[0].websocket.headers == {}
+    assert str(getattr(servers[0].auth.mode, "value", servers[0].auth.mode)) == "none"
 
 
 @pytest.mark.asyncio
-async def test_managed_external_registry_service_hydrates_template_env_for_stdio(tmp_path, monkeypatch) -> None:
+async def test_managed_external_registry_service_keeps_stdio_template_auth_neutral(
+    tmp_path,
+    monkeypatch,
+) -> None:
     from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
     from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
     from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
@@ -312,5 +376,123 @@ async def test_managed_external_registry_service_hydrates_template_env_for_stdio
 
     assert [server.id for server in servers] == ["docs-stdio"]
     assert servers[0].stdio is not None
-    assert servers[0].stdio.env["DOCS_TOKEN"] == "super-secret-token"
+    assert servers[0].stdio.env == {}
     assert str(getattr(servers[0].auth.mode, "value", servers[0].auth.mode)) == "none"
+
+
+@pytest.mark.asyncio
+async def test_external_federation_module_brokers_managed_secret_ref_at_call_time(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.secret_backends.local_encrypted import (
+        LocalEncryptedSecretBackend,
+    )
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+    from tldw_Server_API.app.core.DB_Management.Users_DB import create_user
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"k"))
+
+    reset_settings()
+    await reset_db_pool()
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = McpHubRepo(pool)
+    await repo.ensure_tables()
+    await create_user(
+        username="alice",
+        email="alice@example.com",
+        password_hash="hashed-password",
+        is_active=True,
+        is_verified=True,
+    )
+    await repo.upsert_external_server(
+        server_id="docs",
+        name="Docs",
+        transport="websocket",
+        config_json=json.dumps(
+            {
+                "websocket": {"url": "wss://docs.example/ws"},
+                "auth": {
+                    "mode": "template",
+                    "mappings": [
+                        {
+                            "slot_name": "token_readonly",
+                            "target_type": "header",
+                            "target_name": "Authorization",
+                            "prefix": "Bearer ",
+                            "required": True,
+                        }
+                    ],
+                },
+                "policy": {"allow_tool_patterns": ["repo.*"]},
+            }
+        ),
+        owner_scope_type="global",
+        owner_scope_id=None,
+        enabled=True,
+        server_source="managed",
+        actor_id=1,
+    )
+    await repo.create_external_server_credential_slot(
+        server_id="docs",
+        slot_name="token_readonly",
+        display_name="Read-only token",
+        secret_kind="bearer_token",
+        privilege_class="read",
+        is_required=True,
+        actor_id=1,
+    )
+
+    backend = LocalEncryptedSecretBackend(db_pool=pool)
+    ref = await backend.store_ref(
+        owner_scope_type="user",
+        owner_scope_id=1,
+        provider_key="docs-token",
+        payload={"secret": "super-secret-token"},
+        created_by=1,
+        updated_by=1,
+    )
+    await repo.upsert_credential_binding(
+        binding_target_type="assignment",
+        binding_target_id="7",
+        external_server_id="docs",
+        slot_name="token_readonly",
+        credential_ref=f"managed_secret_ref:{int(ref['id'])}",
+        binding_mode="grant",
+        usage_rules={},
+        actor_id=1,
+    )
+
+    adapter = _BrokerAwareAdapter(server_id="docs")
+    monkeypatch.setattr(manager_mod, "build_transport_adapter", lambda _server: adapter)
+
+    module = ExternalFederationModule(ModuleConfig(name="external_federation", settings={}))
+    try:
+        await module.initialize()
+        ctx = RequestContext(
+            request_id="broker-runtime",
+            user_id="1",
+            metadata={
+                "_mcp_effective_tool_policy": {
+                    "enabled": True,
+                    "capabilities": ["network.external"],
+                    "sources": [{"assignment_id": 7, "profile_id": None}],
+                    "selected_assignment_id": 7,
+                },
+                "mcp_policy_context_enabled": True,
+            },
+        )
+        result = await module.execute_tool("ext.docs.repo.search", {"q": "x"}, context=ctx)
+    finally:
+        await module.shutdown()
+
+    assert adapter.seen_runtime_auth is not None
+    assert adapter.seen_runtime_auth.headers == {"Authorization": "Bearer super-secret-token"}
+    assert result["metadata"]["credential_mode"] == "brokered_ephemeral"


### PR DESCRIPTION
## Summary
- add the enterprise AuthNZ federation foundation with OIDC provider management, claim mapping, JIT provisioning, and federated identity persistence
- add local encrypted managed secret refs plus MCP Hub slot status/binding support for logical credential references
- broker ephemeral credentials into external MCP execution at call time and document the phase-1 federation/broker runtime rules

## Testing
- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/AuthNZ_Federation -v
- source ../../.venv/bin/activate && python -m pytest tldw_Server_API/tests/MCP_unified/test_mcp_protocol_external_federation.py tldw_Server_API/tests/MCP_unified/test_mcp_hub_external_slot_access.py tldw_Server_API/tests/MCP_Hub/test_mcp_slot_status.py tldw_Server_API/app/core/MCP_unified/tests/test_external_credential_broker_runtime.py tldw_Server_API/app/core/MCP_unified/tests/test_external_websocket_adapter.py tldw_Server_API/app/core/MCP_unified/tests/test_external_stdio_adapter.py -q
- source ../../.venv/bin/activate && python -m bandit -r tldw_Server_API/app/services/mcp_credential_broker_service.py tldw_Server_API/app/services/mcp_hub_external_access_resolver.py tldw_Server_API/app/services/mcp_hub_external_registry_service.py tldw_Server_API/app/core/MCP_unified/modules/implementations/external_federation_module.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/websocket_adapter.py tldw_Server_API/app/core/MCP_unified/external_servers/transports/stdio_adapter.py -f json -o /tmp/bandit_enterprise_external_broker_runtime.json