### PR TITLE
feat(acp): MCP adapter with multi-transport + configurable orchestration (Phase B)

### DIFF
--- a/Docs/Plans/2026-03-17-pr907-coderabbit-followups.md
+++ b/Docs/Plans/2026-03-17-pr907-coderabbit-followups.md
@@ -1,0 +1,175 @@
+# PR 907 CodeRabbit Followups Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Address the verified new PR #907 review findings around ACP/MCP adapter robustness, transport cleanup, runner validation, registry MCP-field persistence, and remaining test hygiene.
+
+**Architecture:** Tighten failure handling at adapter and transport boundaries so partial MCP connections cannot leak live clients or stale state, fail fast on invalid protocol/orchestration configuration, and make structured/LLM runner paths validate malformed inputs instead of crashing. Extend the agent registry and ACP session persistence path so MCP orchestration fields survive YAML/API/DB round-trips, then lock the behavior in with targeted unit tests before touching production code.
+
+**Tech Stack:** Python 3.11+, FastAPI/Pydantic, asyncio, SQLite, pytest, loguru, Bandit, pre-commit.
+
+---
+
+### Task 1: Add failing adapter and runner regression tests
+**Status:** Complete
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py`
+
+**Step 1: Write the failing tests**
+
+- Add adapter tests for:
+  - `connect()` cleaning up transport/config/tools/connected state when lifecycle emit or `list_tools()` fails.
+  - `send_prompt()` rejecting an unknown `mcp_orchestration` value.
+- Add runner tests for:
+  - structured responses with missing required fields emitting `ERROR` instead of `KeyError`.
+  - LLM multi-tool responses stopping before approving/executing later tools once cancellation is set during the tool loop.
+
+**Step 2: Run the targeted tests to verify they fail**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py -q
+```
+
+**Step 3: Write the minimal production changes**
+
+- Update `mcp_adapter.py` to:
+  - clean up transport/config/tools on failed connect.
+  - reject unknown orchestration modes with a deterministic config validation error.
+- Update `mcp_runners.py` to:
+  - validate structured step payloads per step type and emit `ERROR` for malformed steps.
+  - re-check cancellation inside the per-tool loop.
+  - convert the `%r` Loguru warning format to `{!r}`.
+
+**Step 4: Re-run the targeted tests**
+
+Run the same pytest command and confirm green.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+git commit -m "fix(acp): harden adapter and runner review followups"
+```
+
+### Task 2: Add failing transport factory and transport cleanup tests
+**Status:** Complete
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py`
+
+**Step 1: Write the failing tests**
+
+- Add transport-factory tests for missing required keys (`command`, `sse_url`, `endpoint`).
+- Add stdio tests for handshake failure cleanup, `close()` clearing `_client`, and list/call methods refusing disconnected clients.
+- Add SSE tests for:
+  - handshake failure cleanup.
+  - parser support for multi-line `data:` frames and default `"message"` event type.
+  - pending RPC futures being failed on reader-loop shutdown.
+- Add streamable HTTP tests for handshake failure cleanup.
+
+**Step 2: Run the targeted tests to verify they fail**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py -q
+```
+
+**Step 3: Write the minimal production changes**
+
+- Update `mcp_transport.py` to validate required config keys with a project exception.
+- Update `stdio.py`, `sse.py`, and `streamable_http.py` to clean up failed handshakes and stale clients.
+- Add a shared SSE teardown path for disconnect/error handling and improve the SSE parser for multiline/default-event frames.
+
+**Step 4: Re-run the targeted tests**
+
+Run the same pytest command and confirm green.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
+git commit -m "fix(acp): harden MCP transport lifecycle handling"
+```
+
+### Task 3: Add failing registry persistence and API-shape tests
+**Status:** Complete
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py`
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py`
+- Modify: `tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py`
+- Modify: `tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py`
+
+**Step 1: Write the failing tests**
+
+- Add YAML-loading tests proving MCP fields are populated into `AgentRegistryEntry`.
+- Add dynamic-registration / reload tests proving MCP fields survive DB persistence and `update_agent()`.
+- Add request-model tests, if needed, to prove API register/update payloads accept the MCP field set.
+
+**Step 2: Run the targeted tests to verify they fail**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py -q
+```
+
+**Step 3: Write the minimal production changes**
+
+- Extend `AgentRegistry.load()`, `_load_api_entries()`, `register_agent()`, `update_agent()`, and DB save/load paths to include the MCP field set.
+- Add the necessary `agent_registry` schema columns/migrations in `ACP_Sessions_DB.py`.
+- Extend ACP register/update request schemas and endpoint wiring to accept and pass through the MCP fields.
+
+**Step 4: Re-run the targeted tests**
+
+Run the same pytest command and confirm green.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
+git commit -m "fix(acp): persist MCP registry configuration"
+```
+
+### Task 4: Clean up remaining test-only review comments and verify
+**Status:** Complete
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py`
+
+**Step 1: Write/adjust tests**
+
+- Remove unused fixture arguments in `test_mcp_adapter.py`.
+- Use raw regex strings where regex metacharacters are intended.
+- Rename intentionally unused unpacked helper returns with underscore-prefixed names.
+- Rename helper parameters shadowing builtins in streamable HTTP tests.
+- Replace the `"/tmp"` literal in `test_tool_gate.py` with a neutral placeholder.
+
+**Step 2: Run the targeted tests and local hygiene gates**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py -q
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && pre-commit run --files tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_integration_persistence.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py -f json -o /tmp/bandit_pr907_coderabbit_followups.json
+```
+
+**Step 3: Commit**
+
+```bash
+git add tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+git commit -m "test(acp): clean up remaining PR 907 review warnings"
+```

--- a/Docs/Plans/2026-03-17-pr907-coderabbit-followups.md
+++ b/Docs/Plans/2026-03-17-pr907-coderabbit-followups.md
@@ -173,3 +173,41 @@ source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && py
 git add tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
 git commit -m "test(acp): clean up remaining PR 907 review warnings"
 ```
+
+### Task 5: Close remaining governance and runner review gaps
+**Status:** Complete
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py`
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py`
+- Modify: `tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py`
+- Modify: `tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py`
+
+**Step 1: Add failing tests**
+
+- Add runner tests proving LLM caller failures and approval-gate failures emit terminal `ERROR` events instead of bubbling out of the adapter.
+- Add governance-tool-gate coverage proving a pending approval returns promptly when the session cancel event is set.
+
+**Step 2: Re-run the focused failing tests**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py -q
+```
+
+**Step 3: Write the minimal production changes**
+
+- Catch `LLMDrivenRunner` failures from `llm_caller.call()` and `tool_gate.request_approval()` and emit `AgentEventKind.ERROR`.
+- Pass the runner cancel event through the `ToolGate` interface.
+- Make `GovernanceToolGate.request_approval()` race approval futures against cancellation and cancel pending requests for the same session when cancellation wins.
+
+**Step 4: Re-run the ACP verification gates**
+
+Run:
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py -q
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && pre-commit run --files tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py -f json -o /tmp/bandit_pr907_coderabbit_followups_round2.json
+```

--- a/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/endpoints/agent_client_protocol.py
@@ -1569,6 +1569,13 @@ async def acp_register_agent(
         requires_api_key=request.requires_api_key,
         install_instructions=request.install_instructions,
         docs_url=request.docs_url,
+        mcp_orchestration=request.mcp_orchestration,
+        mcp_entry_tool=request.mcp_entry_tool,
+        mcp_structured_response=request.mcp_structured_response,
+        mcp_llm_provider=request.mcp_llm_provider,
+        mcp_llm_model=request.mcp_llm_model,
+        mcp_max_iterations=request.mcp_max_iterations,
+        mcp_refresh_tools=request.mcp_refresh_tools,
     )
     return ACPAgentRegistrationResponse(status="registered", agent_type=entry.type, name=entry.name)
 

--- a/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
+++ b/tldw_Server_API/app/api/v1/schemas/agent_client_protocol.py
@@ -45,6 +45,22 @@ class ACPAgentRegisterRequest(BaseModel):
     requires_api_key: str | None = Field(default=None, description="Required API key env var")
     install_instructions: list[str] = Field(default_factory=list, description="Installation steps")
     docs_url: str | None = Field(default=None, description="Documentation URL")
+    mcp_orchestration: Literal["agent_driven", "llm_driven"] = Field(
+        default="agent_driven",
+        description="MCP orchestration mode when protocol='mcp'",
+    )
+    mcp_entry_tool: str = Field(default="execute", description="Entry tool for agent-driven MCP agents")
+    mcp_structured_response: bool = Field(
+        default=False,
+        description="Whether the entry tool returns structured JSON steps",
+    )
+    mcp_llm_provider: str | None = Field(default=None, description="Provider for llm_driven MCP orchestration")
+    mcp_llm_model: str | None = Field(default=None, description="Model for llm_driven MCP orchestration")
+    mcp_max_iterations: int = Field(default=20, description="Maximum llm_driven MCP iterations")
+    mcp_refresh_tools: bool = Field(
+        default=False,
+        description="Refresh MCP tool inventory before each prompt",
+    )
 
 
 class ACPAgentUpdateRequest(BaseModel):
@@ -57,6 +73,13 @@ class ACPAgentUpdateRequest(BaseModel):
     requires_api_key: str | None = None
     install_instructions: list[str] | None = None
     docs_url: str | None = None
+    mcp_orchestration: Literal["agent_driven", "llm_driven"] | None = None
+    mcp_entry_tool: str | None = None
+    mcp_structured_response: bool | None = None
+    mcp_llm_provider: str | None = None
+    mcp_llm_model: str | None = None
+    mcp_max_iterations: int | None = None
+    mcp_refresh_tools: bool | None = None
 
 
 # -----------------------------------------------------------------------------

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/__init__.py
@@ -5,11 +5,13 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
     ProtocolAdapter,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.factory import AdapterFactory
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.stdio_adapter import StdioAdapter
 
 __all__ = [
     "AdapterConfig",
     "AdapterFactory",
+    "MCPAdapter",
     "PromptOptions",
     "ProtocolAdapter",
     "StdioAdapter",

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 
 from loguru import logger
@@ -20,6 +21,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport impor
     create_transport,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.exceptions import ValidationError
 
 
 class MCPAdapter(ProtocolAdapter):
@@ -42,17 +44,26 @@ class MCPAdapter(ProtocolAdapter):
         pc = config.protocol_config
         self._transport = create_transport(pc)
         self._config = config
+        try:
+            await self._transport.connect()
+            logger.info("MCPAdapter: transport connected (session={})", config.session_id)
 
-        await self._transport.connect()
-        logger.info("MCPAdapter: transport connected (session={})", config.session_id)
+            await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_started", "exit_code": None})
 
-        await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_started", "exit_code": None})
+            self._tools = await self._transport.list_tools()
+            logger.debug("MCPAdapter: discovered {} tools", len(self._tools))
 
-        self._tools = await self._transport.list_tools()
-        logger.debug("MCPAdapter: discovered {} tools", len(self._tools))
-
-        await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_ready", "exit_code": None})
-        self._connected = True
+            await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_ready", "exit_code": None})
+            self._connected = True
+        except Exception:
+            if self._transport is not None:
+                with suppress(Exception):
+                    await self._transport.close()
+            self._transport = None
+            self._config = None
+            self._tools = []
+            self._connected = False
+            raise
 
     async def disconnect(self) -> None:
         """Disconnect from the MCP server and clean up resources."""
@@ -106,7 +117,7 @@ class MCPAdapter(ProtocolAdapter):
                     tools=self._tools,
                     max_iterations=pc.get("mcp_max_iterations", 20),
                 )
-            else:
+            elif orchestration == "agent_driven":
                 runner = AgentDrivenRunner(
                     transport=self._transport,
                     event_callback=self._config.event_callback,
@@ -114,6 +125,11 @@ class MCPAdapter(ProtocolAdapter):
                     cancel_event=self._cancel_event,
                     entry_tool=pc.get("mcp_entry_tool", "execute"),
                     structured_response=pc.get("mcp_structured_response", False),
+                )
+            else:
+                raise ValidationError(
+                    f"Invalid mcp_orchestration value: {orchestration!r}. "
+                    "Supported values are 'agent_driven' and 'llm_driven'."
                 )
             await runner.run(messages)
         finally:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
@@ -158,11 +158,12 @@ class MCPAdapter(ProtocolAdapter):
 
     async def _heartbeat_loop(self) -> None:
         """Emit periodic heartbeat events every 15 seconds."""
-        elapsed = 0
+        import time
+        start = time.monotonic()
         try:
             while True:
                 await asyncio.sleep(15)
-                elapsed += 15
+                elapsed = int(time.monotonic() - start)
                 await self._emit(
                     AgentEventKind.HEARTBEAT,
                     {"elapsed_sec": elapsed, "state": "executing"},

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
@@ -1,0 +1,171 @@
+"""MCPAdapter — main adapter wiring transport + runners + heartbeat + lifecycle events."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+    AdapterConfig,
+    PromptOptions,
+    ProtocolAdapter,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_runners import (
+    AgentDrivenRunner,
+    LLMDrivenRunner,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
+    MCPTransport,
+    create_transport,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+
+class MCPAdapter(ProtocolAdapter):
+    """MCP protocol adapter supporting multiple transports and orchestration modes."""
+
+    protocol_name = "mcp"
+
+    def __init__(self) -> None:
+        self._transport: MCPTransport | None = None
+        self._config: AdapterConfig | None = None
+        self._tools: list[dict[str, Any]] = []
+        self._connected = False
+        self._cancel_event = asyncio.Event()
+        self._heartbeat_task: asyncio.Task | None = None
+
+    # -- ProtocolAdapter interface --
+
+    async def connect(self, config: AdapterConfig) -> None:
+        """Connect to an MCP server via the configured transport."""
+        pc = config.protocol_config
+        self._transport = create_transport(pc)
+        self._config = config
+
+        await self._transport.connect()
+        logger.info("MCPAdapter: transport connected (session={})", config.session_id)
+
+        await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_started", "exit_code": None})
+
+        self._tools = await self._transport.list_tools()
+        logger.debug("MCPAdapter: discovered {} tools", len(self._tools))
+
+        await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_ready", "exit_code": None})
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        """Disconnect from the MCP server and clean up resources."""
+        self._cancel_event.set()
+        self._stop_heartbeat()
+        if self._transport is not None:
+            await self._transport.close()
+        await self._emit(AgentEventKind.LIFECYCLE, {"event": "agent_exited", "exit_code": None})
+        self._connected = False
+        self._transport = None
+
+    async def send_prompt(
+        self,
+        messages: list[dict],
+        options: PromptOptions | None = None,
+    ) -> None:
+        """Send a prompt through the configured orchestration runner."""
+        if not self._connected or self._transport is None or self._config is None:
+            raise RuntimeError("Not connected")
+
+        pc = self._config.protocol_config
+        self._cancel_event.clear()
+
+        # Refresh tools if configured
+        if pc.get("mcp_refresh_tools", False):
+            self._tools = await self._transport.list_tools()
+
+        # Start heartbeat
+        self._start_heartbeat()
+
+        # Emit status change
+        await self._emit(AgentEventKind.STATUS_CHANGE, {"from_status": "idle", "to_status": "working"})
+
+        try:
+            orchestration = pc.get("mcp_orchestration", "agent_driven")
+            if orchestration == "llm_driven":
+                runner = LLMDrivenRunner(
+                    transport=self._transport,
+                    event_callback=self._config.event_callback,
+                    session_id=self._config.session_id,
+                    cancel_event=self._cancel_event,
+                    llm_caller=pc["llm_caller"],
+                    tool_gate=pc["tool_gate"],
+                    tools=self._tools,
+                    max_iterations=pc.get("mcp_max_iterations", 20),
+                )
+            else:
+                runner = AgentDrivenRunner(
+                    transport=self._transport,
+                    event_callback=self._config.event_callback,
+                    session_id=self._config.session_id,
+                    cancel_event=self._cancel_event,
+                    entry_tool=pc.get("mcp_entry_tool", "execute"),
+                    structured_response=pc.get("mcp_structured_response", False),
+                )
+            await runner.run(messages)
+        finally:
+            self._stop_heartbeat()
+            await self._emit(
+                AgentEventKind.STATUS_CHANGE, {"from_status": "working", "to_status": "idle"}
+            )
+
+    async def send_tool_result(self, tool_id: str, output: str, is_error: bool = False) -> None:
+        """No-op for now; future sampling support."""
+
+    async def cancel(self) -> None:
+        """Request cancellation of the current operation."""
+        self._cancel_event.set()
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the adapter currently has an active connection."""
+        return self._connected and self._transport is not None and self._transport.is_connected
+
+    @property
+    def supports_streaming(self) -> bool:
+        """Whether the adapter streams events or returns them in bulk."""
+        return True
+
+    # -- Internal helpers --
+
+    async def _emit(self, kind: AgentEventKind, payload: dict[str, Any]) -> None:
+        """Emit an AgentEvent via the configured callback."""
+        if self._config is None:
+            return
+        event = AgentEvent(
+            session_id=self._config.session_id,
+            kind=kind,
+            payload=payload,
+        )
+        await self._config.event_callback(event)
+
+    def _start_heartbeat(self) -> None:
+        """Start the background heartbeat task."""
+        self._stop_heartbeat()
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+
+    def _stop_heartbeat(self) -> None:
+        """Cancel the background heartbeat task if running."""
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            self._heartbeat_task = None
+
+    async def _heartbeat_loop(self) -> None:
+        """Emit periodic heartbeat events every 15 seconds."""
+        elapsed = 0
+        try:
+            while True:
+                await asyncio.sleep(15)
+                elapsed += 15
+                await self._emit(
+                    AgentEventKind.HEARTBEAT,
+                    {"elapsed_sec": elapsed, "state": "executing"},
+                )
+        except asyncio.CancelledError:
+            pass

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_adapter.py
@@ -89,13 +89,20 @@ class MCPAdapter(ProtocolAdapter):
         try:
             orchestration = pc.get("mcp_orchestration", "agent_driven")
             if orchestration == "llm_driven":
+                llm_caller = pc.get("llm_caller")
+                tool_gate = pc.get("tool_gate")
+                if llm_caller is None or tool_gate is None:
+                    raise ValueError(
+                        "MCP llm_driven orchestration requires protocol_config keys: "
+                        "llm_caller and tool_gate"
+                    )
                 runner = LLMDrivenRunner(
                     transport=self._transport,
                     event_callback=self._config.event_callback,
                     session_id=self._config.session_id,
                     cancel_event=self._cancel_event,
-                    llm_caller=pc["llm_caller"],
-                    tool_gate=pc["tool_gate"],
+                    llm_caller=llm_caller,
+                    tool_gate=tool_gate,
                     tools=self._tools,
                     max_iterations=pc.get("mcp_max_iterations", 20),
                 )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_llm_caller.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_llm_caller.py
@@ -1,0 +1,52 @@
+"""LLMCaller abstraction for the MCP adapter's LLM-driven orchestration."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class LLMToolCall:
+    """A tool call requested by the LLM."""
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+@dataclass
+class LLMResponse:
+    """Response from an LLM call."""
+    text: str | None = None
+    tool_calls: list[LLMToolCall] = field(default_factory=list)
+
+
+class LLMCaller(ABC):
+    """Abstract interface for calling an LLM with tool definitions."""
+
+    @abstractmethod
+    async def call(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+    ) -> LLMResponse:
+        """Send messages + tool definitions to LLM, return response."""
+
+
+def mcp_tools_to_openai_format(mcp_tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert MCP tool definitions to OpenAI function-calling format.
+
+    MCP tools have: name, description, inputSchema (JSON Schema)
+    OpenAI tools have: type="function", function={name, description, parameters}
+    """
+    result = []
+    for tool in mcp_tools:
+        result.append({
+            "type": "function",
+            "function": {
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "parameters": tool.get("inputSchema", {"type": "object"}),
+            },
+        })
+    return result

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
@@ -37,6 +37,23 @@ def _extract_text_content(result: dict[str, Any]) -> str:
         return str(result)
 
 
+async def _emit_malformed_step_error(
+    emit: Callable[[AgentEventKind, dict[str, Any]], Awaitable[None]],
+    *,
+    step_type: str,
+    missing: str,
+) -> None:
+    """Emit a consistent error for malformed structured response steps."""
+    await emit(
+        AgentEventKind.ERROR,
+        {
+            "message": "Malformed structured response step",
+            "step_type": step_type,
+            "missing": missing,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # AgentDrivenRunner
 # ---------------------------------------------------------------------------
@@ -114,10 +131,32 @@ class AgentDrivenRunner:
 
         has_completion = False
         for step in steps:
+            if not isinstance(step, dict):
+                await _emit_malformed_step_error(
+                    self._emit_event,
+                    step_type="",
+                    missing="step mapping",
+                )
+                continue
+
             step_type = step.get("type", "")
             if step_type == "thinking":
+                if "text" not in step:
+                    await _emit_malformed_step_error(
+                        self._emit_event,
+                        step_type=step_type,
+                        missing="text",
+                    )
+                    continue
                 await self._emit_event(AgentEventKind.THINKING, {"text": step["text"]})
             elif step_type == "tool_call":
+                if "tool_name" not in step:
+                    await _emit_malformed_step_error(
+                        self._emit_event,
+                        step_type=step_type,
+                        missing="tool_name",
+                    )
+                    continue
                 await self._emit_event(
                     AgentEventKind.TOOL_CALL,
                     {
@@ -126,6 +165,13 @@ class AgentDrivenRunner:
                     },
                 )
             elif step_type == "tool_result":
+                if "tool_name" not in step:
+                    await _emit_malformed_step_error(
+                        self._emit_event,
+                        step_type=step_type,
+                        missing="tool_name",
+                    )
+                    continue
                 await self._emit_event(
                     AgentEventKind.TOOL_RESULT,
                     {
@@ -134,10 +180,17 @@ class AgentDrivenRunner:
                     },
                 )
             elif step_type == "completion":
+                if "text" not in step:
+                    await _emit_malformed_step_error(
+                        self._emit_event,
+                        step_type=step_type,
+                        missing="text",
+                    )
+                    continue
                 has_completion = True
                 await self._emit_event(AgentEventKind.COMPLETION, {"text": step["text"]})
             else:
-                logger.warning("Unknown step type %r in structured response", step_type)
+                logger.warning("Unknown step type {!r} in structured response", step_type)
 
         if not has_completion:
             await self._emit_event(AgentEventKind.COMPLETION, {"text": raw_text})
@@ -231,6 +284,9 @@ class LLMDrivenRunner:
 
                 # Now process each tool call
                 for tc in response.tool_calls:
+                    if self._cancel.is_set():
+                        break
+
                     gate_result = await self._gate.request_approval(
                         self._session_id, tc.name, tc.arguments
                     )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -19,11 +18,11 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller impo
     LLMToolCall,
     mcp_tools_to_openai_format,
 )
+from loguru import logger
+
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import MCPTransport
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
 from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGate
-
-logger = logging.getLogger(__name__)
 
 
 def _extract_text_content(result: dict[str, Any]) -> str:
@@ -206,10 +205,26 @@ class LLMDrivenRunner:
             response = await self._llm.call(history, openai_tools)
 
             if response.tool_calls:
-                # Build assistant message for history
-                assistant_tool_calls = []
+                # Per OpenAI convention: assistant message with tool_calls
+                # must come BEFORE the corresponding tool result messages.
+                assistant_tool_calls = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                    }
+                    for tc in response.tool_calls
+                ]
+                assistant_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "tool_calls": assistant_tool_calls,
+                }
+                if response.text:
+                    assistant_msg["content"] = response.text
+                history.append(assistant_msg)
+
+                # Now process each tool call
                 for tc in response.tool_calls:
-                    # Ask governance
                     gate_result = await self._gate.request_approval(
                         self._session_id, tc.name, tc.arguments
                     )
@@ -229,20 +244,13 @@ class LLMDrivenRunner:
                             "tool_call_id": tc.id,
                             "content": f"Error: {denied_msg}",
                         })
-                        assistant_tool_calls.append({
-                            "id": tc.id,
-                            "type": "function",
-                            "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
-                        })
                         continue
 
-                    # Emit TOOL_CALL event
                     await self._emit_event(
                         AgentEventKind.TOOL_CALL,
                         {"tool_name": tc.name, "arguments": tc.arguments},
                     )
 
-                    # Execute via transport
                     try:
                         result = await self._transport.call_tool(tc.name, tc.arguments)
                         output = _extract_text_content(result)
@@ -260,20 +268,6 @@ class LLMDrivenRunner:
                         "tool_call_id": tc.id,
                         "content": output,
                     })
-                    assistant_tool_calls.append({
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
-                    })
-
-                # Add assistant message with tool calls to history
-                assistant_msg: dict[str, Any] = {
-                    "role": "assistant",
-                    "tool_calls": assistant_tool_calls,
-                }
-                if response.text:
-                    assistant_msg["content"] = response.text
-                history.append(assistant_msg)
 
             if response.text and not response.tool_calls:
                 await self._emit_event(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
@@ -1,0 +1,289 @@
+"""MCP Runners — AgentDrivenRunner and LLMDrivenRunner for the ACP-MCP adapter.
+
+AgentDrivenRunner: calls the agent's entry tool and translates the response into
+AgentEvent instances.
+
+LLMDrivenRunner: implements a ReAct loop where an LLM decides which tools to call,
+ToolGate approves each call, and transport executes them against the MCP server.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+    LLMCaller,
+    LLMToolCall,
+    mcp_tools_to_openai_format,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import MCPTransport
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGate
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_text_content(result: dict[str, Any]) -> str:
+    """Pull text from an MCP content array.
+
+    MCP convention: ``result["content"][0]["text"]``.
+    Falls back to ``str(result)`` if the structure is unexpected.
+    """
+    try:
+        return result.get("content", [{}])[0].get("text", str(result))
+    except (IndexError, AttributeError):
+        return str(result)
+
+
+# ---------------------------------------------------------------------------
+# AgentDrivenRunner
+# ---------------------------------------------------------------------------
+
+
+class AgentDrivenRunner:
+    """Call an agent's entry tool and translate the response into AgentEvents.
+
+    In *simple mode* (``structured_response=False``), the raw text from the
+    MCP response is emitted as a single ``COMPLETION`` event.
+
+    In *structured mode* (``structured_response=True``), the text is parsed as
+    JSON with a ``{"steps": [...]}`` envelope.  Each step is emitted as an
+    appropriate event type.
+    """
+
+    def __init__(
+        self,
+        transport: MCPTransport,
+        event_callback: Callable[[AgentEvent], Awaitable[None]],
+        session_id: str,
+        cancel_event: asyncio.Event,
+        entry_tool: str = "execute",
+        structured_response: bool = False,
+    ) -> None:
+        self._transport = transport
+        self._emit = event_callback
+        self._session_id = session_id
+        self._cancel = cancel_event
+        self._entry_tool = entry_tool
+        self._structured = structured_response
+        self._seq = 0
+
+    # -- helpers --
+
+    async def _emit_event(self, kind: AgentEventKind, payload: dict[str, Any]) -> None:
+        event = AgentEvent(
+            session_id=self._session_id,
+            kind=kind,
+            payload=payload,
+            sequence=self._seq,
+        )
+        self._seq += 1
+        await self._emit(event)
+
+    # -- public API --
+
+    async def run(self, messages: list[dict]) -> None:
+        """Call entry tool with *messages* and emit events from the response."""
+        if self._cancel.is_set():
+            return
+
+        try:
+            result = await self._transport.call_tool(
+                self._entry_tool, {"messages": messages}
+            )
+        except Exception as exc:
+            await self._emit_event(AgentEventKind.ERROR, {"error": str(exc)})
+            return
+
+        raw_text = _extract_text_content(result)
+
+        if not self._structured:
+            await self._emit_event(AgentEventKind.COMPLETION, {"text": raw_text})
+            return
+
+        # Structured mode: parse JSON steps
+        try:
+            parsed = json.loads(raw_text)
+            steps = parsed.get("steps", [])
+        except (json.JSONDecodeError, AttributeError):
+            # Fallback: emit raw text as completion
+            await self._emit_event(AgentEventKind.COMPLETION, {"text": raw_text})
+            return
+
+        has_completion = False
+        for step in steps:
+            step_type = step.get("type", "")
+            if step_type == "thinking":
+                await self._emit_event(AgentEventKind.THINKING, {"text": step["text"]})
+            elif step_type == "tool_call":
+                await self._emit_event(
+                    AgentEventKind.TOOL_CALL,
+                    {
+                        "tool_name": step["tool_name"],
+                        "arguments": step.get("arguments", {}),
+                    },
+                )
+            elif step_type == "tool_result":
+                await self._emit_event(
+                    AgentEventKind.TOOL_RESULT,
+                    {
+                        "tool_name": step["tool_name"],
+                        "output": step.get("output", ""),
+                    },
+                )
+            elif step_type == "completion":
+                has_completion = True
+                await self._emit_event(AgentEventKind.COMPLETION, {"text": step["text"]})
+            else:
+                logger.warning("Unknown step type %r in structured response", step_type)
+
+        if not has_completion:
+            await self._emit_event(AgentEventKind.COMPLETION, {"text": raw_text})
+
+
+# ---------------------------------------------------------------------------
+# LLMDrivenRunner
+# ---------------------------------------------------------------------------
+
+
+class LLMDrivenRunner:
+    """ReAct loop: LLM decides tools, ToolGate approves, transport executes.
+
+    Each iteration:
+    1. Call the LLM with the conversation history and available tools.
+    2. If the LLM requests tool calls, gate each one and execute approved calls.
+    3. If the LLM produces text without tool calls, emit COMPLETION and stop.
+    4. Stop after ``max_iterations`` with a ``max_iterations`` completion.
+    """
+
+    def __init__(
+        self,
+        transport: MCPTransport,
+        event_callback: Callable[[AgentEvent], Awaitable[None]],
+        session_id: str,
+        cancel_event: asyncio.Event,
+        llm_caller: LLMCaller,
+        tool_gate: ToolGate,
+        tools: list[dict],
+        max_iterations: int = 20,
+    ) -> None:
+        self._transport = transport
+        self._emit = event_callback
+        self._session_id = session_id
+        self._cancel = cancel_event
+        self._llm = llm_caller
+        self._gate = tool_gate
+        self._tools = tools
+        self._max_iterations = max_iterations
+        self._seq = 0
+
+    # -- helpers --
+
+    async def _emit_event(self, kind: AgentEventKind, payload: dict[str, Any]) -> None:
+        event = AgentEvent(
+            session_id=self._session_id,
+            kind=kind,
+            payload=payload,
+            sequence=self._seq,
+        )
+        self._seq += 1
+        await self._emit(event)
+
+    # -- public API --
+
+    async def run(self, messages: list[dict]) -> None:
+        """Run the ReAct loop until completion or max iterations."""
+        history = list(messages)
+        openai_tools = mcp_tools_to_openai_format(self._tools)
+
+        for _i in range(self._max_iterations):
+            if self._cancel.is_set():
+                break
+
+            response = await self._llm.call(history, openai_tools)
+
+            if response.tool_calls:
+                # Build assistant message for history
+                assistant_tool_calls = []
+                for tc in response.tool_calls:
+                    # Ask governance
+                    gate_result = await self._gate.request_approval(
+                        self._session_id, tc.name, tc.arguments
+                    )
+                    if not gate_result.approved:
+                        reason = gate_result.reason or "denied"
+                        denied_msg = f"Permission denied: {reason}"
+                        await self._emit_event(
+                            AgentEventKind.TOOL_RESULT,
+                            {
+                                "tool_name": tc.name,
+                                "output": denied_msg,
+                                "is_error": True,
+                            },
+                        )
+                        history.append({
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": f"Error: {denied_msg}",
+                        })
+                        assistant_tool_calls.append({
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                        })
+                        continue
+
+                    # Emit TOOL_CALL event
+                    await self._emit_event(
+                        AgentEventKind.TOOL_CALL,
+                        {"tool_name": tc.name, "arguments": tc.arguments},
+                    )
+
+                    # Execute via transport
+                    try:
+                        result = await self._transport.call_tool(tc.name, tc.arguments)
+                        output = _extract_text_content(result)
+                        is_error = result.get("isError", False)
+                    except Exception as exc:
+                        output = str(exc)
+                        is_error = True
+
+                    await self._emit_event(
+                        AgentEventKind.TOOL_RESULT,
+                        {"tool_name": tc.name, "output": output, "is_error": is_error},
+                    )
+                    history.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": output,
+                    })
+                    assistant_tool_calls.append({
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.name, "arguments": json.dumps(tc.arguments)},
+                    })
+
+                # Add assistant message with tool calls to history
+                assistant_msg: dict[str, Any] = {
+                    "role": "assistant",
+                    "tool_calls": assistant_tool_calls,
+                }
+                if response.text:
+                    assistant_msg["content"] = response.text
+                history.append(assistant_msg)
+
+            if response.text and not response.tool_calls:
+                await self._emit_event(
+                    AgentEventKind.COMPLETION,
+                    {"text": response.text, "stop_reason": "end_turn"},
+                )
+                return
+        else:
+            # Exhausted max_iterations without returning
+            await self._emit_event(
+                AgentEventKind.COMPLETION,
+                {"text": "Reached maximum iterations", "stop_reason": "max_iterations"},
+            )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
@@ -261,7 +261,11 @@ class LLMDrivenRunner:
             if self._cancel.is_set():
                 break
 
-            response = await self._llm.call(history, openai_tools)
+            try:
+                response = await self._llm.call(history, openai_tools)
+            except Exception as exc:
+                await self._emit_event(AgentEventKind.ERROR, {"error": str(exc)})
+                return
 
             if response.tool_calls:
                 # Per OpenAI convention: assistant message with tool_calls
@@ -287,9 +291,22 @@ class LLMDrivenRunner:
                     if self._cancel.is_set():
                         break
 
-                    gate_result = await self._gate.request_approval(
-                        self._session_id, tc.name, tc.arguments
-                    )
+                    try:
+                        gate_result = await self._gate.request_approval(
+                            self._session_id,
+                            tc.name,
+                            tc.arguments,
+                            cancel_event=self._cancel,
+                        )
+                    except asyncio.CancelledError:
+                        break
+                    except Exception as exc:
+                        await self._emit_event(AgentEventKind.ERROR, {"error": str(exc)})
+                        return
+
+                    if self._cancel.is_set():
+                        break
+
                     if not gate_result.approved:
                         reason = gate_result.reason or "denied"
                         denied_msg = f"Permission denied: {reason}"

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_runners.py
@@ -181,12 +181,18 @@ class LLMDrivenRunner:
 
     # -- helpers --
 
-    async def _emit_event(self, kind: AgentEventKind, payload: dict[str, Any]) -> None:
+    async def _emit_event(
+        self,
+        kind: AgentEventKind,
+        payload: dict[str, Any],
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
         event = AgentEvent(
             session_id=self._session_id,
             kind=kind,
             payload=payload,
             sequence=self._seq,
+            metadata=metadata or {},
         )
         self._seq += 1
         await self._emit(event)
@@ -249,6 +255,7 @@ class LLMDrivenRunner:
                     await self._emit_event(
                         AgentEventKind.TOOL_CALL,
                         {"tool_name": tc.name, "arguments": tc.arguments},
+                        metadata={"_already_approved": True},
                     )
 
                     try:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
@@ -1,0 +1,98 @@
+"""MCPTransport — abstract base for MCP transport implementations."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class MCPTransport(ABC):
+    """Abstract transport layer for communicating with an MCP server.
+
+    Concrete implementations handle the protocol details (stdio, SSE,
+    streamable HTTP) while exposing a uniform async interface to callers.
+    """
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Establish a connection to the MCP server."""
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Close the connection and release resources."""
+
+    @abstractmethod
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return the list of tools advertised by the MCP server."""
+
+    @abstractmethod
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Invoke a tool on the MCP server and return the result."""
+
+    @abstractmethod
+    async def health_check(self) -> bool:
+        """Return True if the transport connection is healthy."""
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Whether the transport is currently connected."""
+
+
+def create_transport(protocol_config: dict[str, Any]) -> MCPTransport:
+    """Factory: build the right MCPTransport from a protocol config dict.
+
+    Parameters
+    ----------
+    protocol_config:
+        Must contain ``"protocol"`` key with one of ``"stdio"``,
+        ``"sse"``, or ``"streamable_http"``.  Remaining keys are
+        forwarded to the concrete transport constructor.
+
+    Returns
+    -------
+    MCPTransport
+        A concrete transport instance (not yet connected).
+
+    Raises
+    ------
+    ValueError
+        If the protocol is not recognised.
+    """
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.sse import (
+        MCPSSETransport,
+    )
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.stdio import (
+        MCPStdioTransport,
+    )
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.streamable_http import (
+        MCPStreamableHTTPTransport,
+    )
+
+    protocol = protocol_config.get("protocol", "")
+
+    if protocol == "stdio":
+        return MCPStdioTransport(
+            command=protocol_config["command"],
+            args=protocol_config.get("args"),
+            env=protocol_config.get("env"),
+        )
+    elif protocol == "sse":
+        return MCPSSETransport(
+            sse_url=protocol_config["sse_url"],
+            post_url=protocol_config.get("post_url"),
+            headers=protocol_config.get("headers"),
+            timeout_sec=protocol_config.get("timeout_sec", 30),
+        )
+    elif protocol == "streamable_http":
+        return MCPStreamableHTTPTransport(
+            endpoint=protocol_config["endpoint"],
+            headers=protocol_config.get("headers"),
+            timeout_sec=protocol_config.get("timeout_sec", 30),
+        )
+    else:
+        raise ValueError(
+            f"Unknown MCP transport protocol: {protocol!r}. "
+            f"Supported: 'stdio', 'sse', 'streamable_http'."
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from tldw_Server_API.app.core.exceptions import ValidationError
+
 
 class MCPTransport(ABC):
     """Abstract transport layer for communicating with an MCP server.
@@ -72,27 +74,34 @@ def create_transport(protocol_config: dict[str, Any]) -> MCPTransport:
 
     protocol = protocol_config.get("mcp_transport", "")
 
+    def _require_key(key: str) -> Any:
+        if key not in protocol_config:
+            raise ValidationError(
+                f"MCP transport {protocol!r} requires protocol_config key: {key}"
+            )
+        return protocol_config[key]
+
     if protocol == "stdio":
         return MCPStdioTransport(
-            command=protocol_config["command"],
+            command=_require_key("command"),
             args=protocol_config.get("args"),
             env=protocol_config.get("env"),
         )
     elif protocol == "sse":
         return MCPSSETransport(
-            sse_url=protocol_config["sse_url"],
+            sse_url=_require_key("sse_url"),
             post_url=protocol_config.get("post_url"),
             headers=protocol_config.get("headers"),
             timeout_sec=protocol_config.get("timeout_sec", 30),
         )
     elif protocol == "streamable_http":
         return MCPStreamableHTTPTransport(
-            endpoint=protocol_config["endpoint"],
+            endpoint=_require_key("endpoint"),
             headers=protocol_config.get("headers"),
             timeout_sec=protocol_config.get("timeout_sec", 30),
         )
     else:
-        raise ValueError(
+        raise ValidationError(
             f"Unknown MCP transport protocol: {protocol!r}. "
             f"Supported: 'stdio', 'sse', 'streamable_http'."
         )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transport.py
@@ -46,7 +46,7 @@ def create_transport(protocol_config: dict[str, Any]) -> MCPTransport:
     Parameters
     ----------
     protocol_config:
-        Must contain ``"protocol"`` key with one of ``"stdio"``,
+        Must contain ``"mcp_transport"`` key with one of ``"stdio"``,
         ``"sse"``, or ``"streamable_http"``.  Remaining keys are
         forwarded to the concrete transport constructor.
 
@@ -70,7 +70,7 @@ def create_transport(protocol_config: dict[str, Any]) -> MCPTransport:
         MCPStreamableHTTPTransport,
     )
 
-    protocol = protocol_config.get("protocol", "")
+    protocol = protocol_config.get("mcp_transport", "")
 
     if protocol == "stdio":
         return MCPStdioTransport(

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/__init__.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/__init__.py
@@ -1,0 +1,2 @@
+"""Concrete MCP transport implementations."""
+from __future__ import annotations

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -254,29 +254,39 @@ class MCPSSETransport(MCPTransport):
 
         if self._http_client is None:
             raise RuntimeError("HTTP client not initialized")
+        if self._post_url is None:
+            raise RuntimeError("post_url must be set before making calls")
 
-        await self._http_client.post(
-            self._post_url,  # type: ignore[arg-type]
-            json={
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "method": method,
-                "params": params,
-            },
-        )
-
-        return await asyncio.wait_for(future, timeout=self._timeout_sec)
+        try:
+            response = await self._http_client.post(
+                self._post_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "method": method,
+                    "params": params,
+                },
+            )
+            response.raise_for_status()
+            return await asyncio.wait_for(future, timeout=self._timeout_sec)
+        finally:
+            pending = self._pending.pop(req_id, None)
+            if pending is not None and not pending.done():
+                pending.cancel()
 
     async def _json_rpc_notify(self, method: str, params: dict[str, Any]) -> None:
         """Send a JSON-RPC notification (no id, no response expected)."""
         if self._http_client is None:
             raise RuntimeError("HTTP client not initialized")
+        if self._post_url is None:
+            raise RuntimeError("post_url must be set before making calls")
 
-        await self._http_client.post(
-            self._post_url,  # type: ignore[arg-type]
+        response = await self._http_client.post(
+            self._post_url,
             json={
                 "jsonrpc": "2.0",
                 "method": method,
                 "params": params,
             },
         )
+        response.raise_for_status()

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -1,7 +1,13 @@
-"""MCPSSETransport — SSE-based MCP transport (stub)."""
+"""MCPSSETransport — SSE-based MCP transport."""
 from __future__ import annotations
 
+import asyncio
+import json
 from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+from loguru import logger
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
     MCPTransport,
@@ -11,7 +17,15 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport impor
 class MCPSSETransport(MCPTransport):
     """MCP transport over Server-Sent Events.
 
-    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    Uses two channels:
+    - **Server -> Client:** SSE stream at ``sse_url`` for JSON-RPC responses/notifications
+    - **Client -> Server:** HTTP POST to ``post_url`` for JSON-RPC requests
+
+    Connection flow:
+    1. Open SSE stream to ``sse_url``
+    2. If ``post_url`` is not provided, discover it from the first SSE ``endpoint`` event
+    3. Start background reader task for SSE stream
+    4. Perform MCP ``initialize`` / ``initialized`` handshake
     """
 
     def __init__(
@@ -25,25 +39,244 @@ class MCPSSETransport(MCPTransport):
         self._post_url = post_url
         self._headers = headers
         self._timeout_sec = timeout_sec
+        self._http_client: httpx.AsyncClient | None = None
+        self._pending: dict[str, asyncio.Future] = {}
+        self._next_id = 1
+        self._reader_task: asyncio.Task | None = None
         self._connected = False
+        # SSE line parser state
+        self._sse_event_type: str | None = None
+        self._sse_data: str | None = None
+
+    # ------------------------------------------------------------------
+    # MCPTransport interface
+    # ------------------------------------------------------------------
 
     @property
     def is_connected(self) -> bool:
         return self._connected
 
     async def connect(self) -> None:
-        raise NotImplementedError("MCPSSETransport.connect not yet implemented")
+        """Open the SSE stream, discover post_url if needed, and perform MCP handshake."""
+        self._http_client = self._create_http_client()
+
+        if not self._post_url:
+            self._post_url = await self._discover_post_url()
+            logger.info("SSE transport discovered post_url: {}", self._post_url)
+
+        self._reader_task = asyncio.create_task(self._sse_reader_loop())
+
+        init_result = await self._json_rpc_call("initialize", {
+            "protocolVersion": "2024-11-05",
+            "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+            "capabilities": {},
+        })
+        logger.debug("MCP initialize response: {}", init_result)
+
+        await self._json_rpc_notify("initialized", {})
+        self._connected = True
+        logger.info("SSE transport connected to {}", self._sse_url)
 
     async def close(self) -> None:
-        raise NotImplementedError("MCPSSETransport.close not yet implemented")
+        """Cancel reader task, close HTTP client, mark disconnected."""
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            self._reader_task = None
+        if self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+        # Cancel any pending futures
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+        self._connected = False
 
     async def list_tools(self) -> list[dict[str, Any]]:
-        raise NotImplementedError("MCPSSETransport.list_tools not yet implemented")
+        """Request the tool list from the MCP server."""
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        result = await self._json_rpc_call("tools/list", {})
+        return result.get("tools", [])
 
     async def call_tool(
-        self, tool_name: str, arguments: dict[str, Any]
+        self, tool_name: str, arguments: dict[str, Any],
     ) -> dict[str, Any]:
-        raise NotImplementedError("MCPSSETransport.call_tool not yet implemented")
+        """Invoke a tool on the MCP server and return the result."""
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        return await self._json_rpc_call(
+            "tools/call", {"name": tool_name, "arguments": arguments},
+        )
 
     async def health_check(self) -> bool:
-        raise NotImplementedError("MCPSSETransport.health_check not yet implemented")
+        """Return True if the transport is connected."""
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # HTTP client factory (patchable in tests)
+    # ------------------------------------------------------------------
+
+    def _create_http_client(self) -> httpx.AsyncClient:
+        """Create an httpx.AsyncClient. Extracted for test patching."""
+        return httpx.AsyncClient(
+            headers=self._headers or {},
+            timeout=httpx.Timeout(self._timeout_sec),
+        )
+
+    # ------------------------------------------------------------------
+    # SSE discovery
+    # ------------------------------------------------------------------
+
+    async def _discover_post_url(self) -> str:
+        """Connect to the SSE stream and read the first ``endpoint`` event.
+
+        The MCP spec says the first event has ``event: endpoint`` with
+        ``data: <relative_url>``.  We resolve this against the ``sse_url``
+        base to get the absolute POST URL.
+        """
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+
+        async with self._http_client.stream("GET", self._sse_url) as response:
+            async for raw_line in response.aiter_lines():
+                event = self._parse_sse_line(raw_line)
+                if event is not None:
+                    event_type, data = event
+                    if event_type == "endpoint":
+                        # Resolve relative URL against sse_url base
+                        base = self._sse_url.rsplit("/", 1)[0] + "/"
+                        return urljoin(base, data)
+
+        raise RuntimeError(
+            f"SSE stream at {self._sse_url} closed without sending an endpoint event"
+        )
+
+    # ------------------------------------------------------------------
+    # SSE reader loop
+    # ------------------------------------------------------------------
+
+    async def _sse_reader_loop(self) -> None:
+        """Long-running task: read SSE stream, parse events, route responses."""
+        if self._http_client is None:
+            return
+        try:
+            async with self._http_client.stream("GET", self._sse_url) as response:
+                async for raw_line in response.aiter_lines():
+                    event = self._parse_sse_line(raw_line)
+                    if event is None:
+                        continue
+                    event_type, data = event
+                    if event_type == "message":
+                        self._route_sse_message(data)
+        except asyncio.CancelledError:
+            logger.debug("SSE reader loop cancelled")
+        except Exception:
+            logger.exception("SSE reader loop error")
+            self._connected = False
+
+    def _route_sse_message(self, data: str) -> None:
+        """Parse a JSON-RPC message from SSE data and resolve the pending future."""
+        try:
+            msg = json.loads(data)
+        except json.JSONDecodeError:
+            logger.warning("SSE: ignoring non-JSON message: {}", data[:200])
+            return
+
+        msg_id = msg.get("id")
+        if msg_id is not None:
+            msg_id = str(msg_id)
+            future = self._pending.pop(msg_id, None)
+            if future is not None and not future.done():
+                if "error" in msg:
+                    future.set_exception(
+                        RuntimeError(f"JSON-RPC error: {msg['error']}")
+                    )
+                else:
+                    future.set_result(msg.get("result", {}))
+            elif future is None:
+                logger.warning("SSE: no pending future for id={}", msg_id)
+        else:
+            # Notification from server (no id) — log for now
+            logger.debug("SSE server notification: {}", msg.get("method", "unknown"))
+
+    # ------------------------------------------------------------------
+    # SSE line parser
+    # ------------------------------------------------------------------
+
+    def _parse_sse_line(self, line: str) -> tuple[str, str] | None:
+        """Parse a single SSE line and return a complete event when ready.
+
+        SSE events are separated by blank lines. Each event consists of
+        ``event:`` and ``data:`` fields.  Returns ``(event_type, data)``
+        when a blank line (event boundary) is encountered and there is a
+        complete event buffered.  Returns ``None`` otherwise.
+        """
+        line = line.rstrip("\r\n")
+
+        if line.startswith("event:"):
+            self._sse_event_type = line[len("event:"):].strip()
+            return None
+        elif line.startswith("data:"):
+            self._sse_data = line[len("data:"):].strip()
+            return None
+        elif line == "":
+            # Blank line = event boundary
+            if self._sse_event_type is not None and self._sse_data is not None:
+                event = (self._sse_event_type, self._sse_data)
+                self._sse_event_type = None
+                self._sse_data = None
+                return event
+            # Reset even if incomplete
+            self._sse_event_type = None
+            self._sse_data = None
+            return None
+        else:
+            # Comment or unknown field — ignore
+            return None
+
+    # ------------------------------------------------------------------
+    # JSON-RPC helpers
+    # ------------------------------------------------------------------
+
+    async def _json_rpc_call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a JSON-RPC request and await the response via the SSE stream.
+
+        Assigns an incrementing id, creates a Future in ``_pending``, POSTs
+        the request, and waits for the SSE reader to resolve the Future.
+        """
+        req_id = str(self._next_id)
+        self._next_id += 1
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending[req_id] = future
+
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+
+        await self._http_client.post(
+            self._post_url,  # type: ignore[arg-type]
+            json={
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "method": method,
+                "params": params,
+            },
+        )
+
+        return await asyncio.wait_for(future, timeout=self._timeout_sec)
+
+    async def _json_rpc_notify(self, method: str, params: dict[str, Any]) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        if self._http_client is None:
+            raise RuntimeError("HTTP client not initialized")
+
+        await self._http_client.post(
+            self._post_url,  # type: ignore[arg-type]
+            json={
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+            },
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -1,0 +1,49 @@
+"""MCPSSETransport — SSE-based MCP transport (stub)."""
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
+    MCPTransport,
+)
+
+
+class MCPSSETransport(MCPTransport):
+    """MCP transport over Server-Sent Events.
+
+    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    """
+
+    def __init__(
+        self,
+        sse_url: str,
+        post_url: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout_sec: int = 30,
+    ) -> None:
+        self._sse_url = sse_url
+        self._post_url = post_url
+        self._headers = headers
+        self._timeout_sec = timeout_sec
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        raise NotImplementedError("MCPSSETransport.connect not yet implemented")
+
+    async def close(self) -> None:
+        raise NotImplementedError("MCPSSETransport.close not yet implemented")
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        raise NotImplementedError("MCPSSETransport.list_tools not yet implemented")
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise NotImplementedError("MCPSSETransport.call_tool not yet implemented")
+
+    async def health_check(self) -> bool:
+        raise NotImplementedError("MCPSSETransport.health_check not yet implemented")

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/sse.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import suppress
 from typing import Any
 from urllib.parse import urljoin
 
@@ -59,38 +60,30 @@ class MCPSSETransport(MCPTransport):
     async def connect(self) -> None:
         """Open the SSE stream, discover post_url if needed, and perform MCP handshake."""
         self._http_client = self._create_http_client()
+        try:
+            if not self._post_url:
+                self._post_url = await self._discover_post_url()
+                logger.info("SSE transport discovered post_url: {}", self._post_url)
 
-        if not self._post_url:
-            self._post_url = await self._discover_post_url()
-            logger.info("SSE transport discovered post_url: {}", self._post_url)
+            self._reader_task = asyncio.create_task(self._sse_reader_loop())
 
-        self._reader_task = asyncio.create_task(self._sse_reader_loop())
+            init_result = await self._json_rpc_call("initialize", {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+                "capabilities": {},
+            })
+            logger.debug("MCP initialize response: {}", init_result)
 
-        init_result = await self._json_rpc_call("initialize", {
-            "protocolVersion": "2024-11-05",
-            "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
-            "capabilities": {},
-        })
-        logger.debug("MCP initialize response: {}", init_result)
-
-        await self._json_rpc_notify("initialized", {})
-        self._connected = True
-        logger.info("SSE transport connected to {}", self._sse_url)
+            await self._json_rpc_notify("initialized", {})
+            self._connected = True
+            logger.info("SSE transport connected to {}", self._sse_url)
+        except Exception as exc:
+            await self._teardown(reason=exc)
+            raise
 
     async def close(self) -> None:
         """Cancel reader task, close HTTP client, mark disconnected."""
-        if self._reader_task is not None:
-            self._reader_task.cancel()
-            self._reader_task = None
-        if self._http_client is not None:
-            await self._http_client.aclose()
-            self._http_client = None
-        # Cancel any pending futures
-        for future in self._pending.values():
-            if not future.done():
-                future.cancel()
-        self._pending.clear()
-        self._connected = False
+        await self._teardown()
 
     async def list_tools(self) -> list[dict[str, Any]]:
         """Request the tool list from the MCP server."""
@@ -169,11 +162,13 @@ class MCPSSETransport(MCPTransport):
                     event_type, data = event
                     if event_type == "message":
                         self._route_sse_message(data)
+            logger.warning("SSE reader loop ended because the stream closed")
+            await self._teardown(reason=RuntimeError("SSE stream closed"))
         except asyncio.CancelledError:
             logger.debug("SSE reader loop cancelled")
         except Exception:
             logger.exception("SSE reader loop error")
-            self._connected = False
+            await self._teardown(reason=RuntimeError("SSE reader loop error"))
 
     def _route_sse_message(self, data: str) -> None:
         """Parse a JSON-RPC message from SSE data and resolve the pending future."""
@@ -218,12 +213,16 @@ class MCPSSETransport(MCPTransport):
             self._sse_event_type = line[len("event:"):].strip()
             return None
         elif line.startswith("data:"):
-            self._sse_data = line[len("data:"):].strip()
+            chunk = line[len("data:"):].strip()
+            if self._sse_data is None:
+                self._sse_data = chunk
+            else:
+                self._sse_data = f"{self._sse_data}\n{chunk}"
             return None
         elif line == "":
             # Blank line = event boundary
-            if self._sse_event_type is not None and self._sse_data is not None:
-                event = (self._sse_event_type, self._sse_data)
+            if self._sse_data is not None:
+                event = (self._sse_event_type or "message", self._sse_data)
                 self._sse_event_type = None
                 self._sse_data = None
                 return event
@@ -269,6 +268,9 @@ class MCPSSETransport(MCPTransport):
             )
             response.raise_for_status()
             return await asyncio.wait_for(future, timeout=self._timeout_sec)
+        except Exception as exc:
+            await self._teardown(reason=exc)
+            raise
         finally:
             pending = self._pending.pop(req_id, None)
             if pending is not None and not pending.done():
@@ -289,4 +291,37 @@ class MCPSSETransport(MCPTransport):
                 "params": params,
             },
         )
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except Exception as exc:
+            await self._teardown(reason=exc)
+            raise
+
+    async def _teardown(self, reason: Exception | None = None) -> None:
+        """Return the transport to a disconnected state and unblock pending RPCs."""
+        self._connected = False
+
+        current_task = asyncio.current_task()
+        reader_task = self._reader_task
+        self._reader_task = None
+        if reader_task is not None and reader_task is not current_task:
+            reader_task.cancel()
+            if isinstance(reader_task, asyncio.Task):
+                with suppress(asyncio.CancelledError):
+                    await reader_task
+
+        client = self._http_client
+        self._http_client = None
+        if client is not None:
+            await client.aclose()
+
+        error_message = str(reason) if reason is not None else "SSE transport disconnected"
+        pending_futures = list(self._pending.values())
+        self._pending.clear()
+        for future in pending_futures:
+            if future.done():
+                continue
+            if reason is None:
+                future.cancel()
+            else:
+                future.set_exception(RuntimeError(error_message))

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
@@ -1,6 +1,7 @@
 """MCPStdioTransport — stdio-based MCP transport using ACPStdioClient."""
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
@@ -47,24 +48,33 @@ class MCPStdioTransport(MCPTransport):
         """Start the subprocess and perform the MCP initialize handshake."""
         if self._client is None:
             self._client = self._create_client()
-        await self._client.start()
-        await self._client.call("initialize", {
-            "protocolVersion": "2024-11-05",
-            "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
-            "capabilities": {},
-        })
-        await self._client.notify("initialized", {})
-        self._connected = True
+        try:
+            await self._client.start()
+            await self._client.call("initialize", {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+                "capabilities": {},
+            })
+            await self._client.notify("initialized", {})
+            self._connected = True
+        except Exception:
+            if self._client is not None:
+                with suppress(Exception):
+                    await self._client.close()
+            self._client = None
+            self._connected = False
+            raise
 
     async def close(self) -> None:
         """Shut down the subprocess and mark as disconnected."""
         if self._client is not None:
             await self._client.close()
+            self._client = None
         self._connected = False
 
     async def list_tools(self) -> list[dict[str, Any]]:
         """Request the tool list from the MCP server."""
-        if self._client is None:
+        if not self._connected or self._client is None:
             raise RuntimeError("Not connected")
         resp = await self._client.call("tools/list", {})
         return resp.result.get("tools", []) if resp.result else []
@@ -73,7 +83,7 @@ class MCPStdioTransport(MCPTransport):
         self, tool_name: str, arguments: dict[str, Any]
     ) -> dict[str, Any]:
         """Invoke a tool on the MCP server."""
-        if self._client is None:
+        if not self._connected or self._client is None:
             raise RuntimeError("Not connected")
         resp = await self._client.call(
             "tools/call", {"name": tool_name, "arguments": arguments}

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
@@ -1,4 +1,4 @@
-"""MCPStdioTransport — stdio-based MCP transport (stub)."""
+"""MCPStdioTransport — stdio-based MCP transport using ACPStdioClient."""
 from __future__ import annotations
 
 from typing import Any
@@ -6,12 +6,16 @@ from typing import Any
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
     MCPTransport,
 )
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import (
+    ACPStdioClient,
+)
 
 
 class MCPStdioTransport(MCPTransport):
     """MCP transport over stdio (JSON-RPC over stdin/stdout).
 
-    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    Wraps :class:`ACPStdioClient` and performs the MCP initialize
+    handshake on :meth:`connect`.
     """
 
     def __init__(
@@ -21,27 +25,61 @@ class MCPStdioTransport(MCPTransport):
         env: dict[str, str] | None = None,
     ) -> None:
         self._command = command
-        self._args = args
-        self._env = env
+        self._args = args or []
+        self._env = env or {}
+        self._client: ACPStdioClient | None = None
         self._connected = False
+
+    def _create_client(self) -> ACPStdioClient:
+        """Create a new :class:`ACPStdioClient` instance.
+
+        Extracted as a method so tests can patch it to inject a mock.
+        """
+        return ACPStdioClient(self._command, self._args, self._env)
 
     @property
     def is_connected(self) -> bool:
-        return self._connected
+        if not self._connected or self._client is None:
+            return False
+        return getattr(self._client, "is_running", False)
 
     async def connect(self) -> None:
-        raise NotImplementedError("MCPStdioTransport.connect not yet implemented")
+        """Start the subprocess and perform the MCP initialize handshake."""
+        if self._client is None:
+            self._client = self._create_client()
+        await self._client.start()
+        await self._client.call("initialize", {
+            "protocolVersion": "2024-11-05",
+            "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+            "capabilities": {},
+        })
+        await self._client.notify("initialized", {})
+        self._connected = True
 
     async def close(self) -> None:
-        raise NotImplementedError("MCPStdioTransport.close not yet implemented")
+        """Shut down the subprocess and mark as disconnected."""
+        if self._client is not None:
+            await self._client.close()
+        self._connected = False
 
     async def list_tools(self) -> list[dict[str, Any]]:
-        raise NotImplementedError("MCPStdioTransport.list_tools not yet implemented")
+        """Request the tool list from the MCP server."""
+        if self._client is None:
+            raise RuntimeError("Not connected")
+        resp = await self._client.call("tools/list", {})
+        return resp.result.get("tools", []) if resp.result else []
 
     async def call_tool(
         self, tool_name: str, arguments: dict[str, Any]
     ) -> dict[str, Any]:
-        raise NotImplementedError("MCPStdioTransport.call_tool not yet implemented")
+        """Invoke a tool on the MCP server."""
+        if self._client is None:
+            raise RuntimeError("Not connected")
+        resp = await self._client.call(
+            "tools/call", {"name": tool_name, "arguments": arguments}
+        )
+        return resp.result if resp.result else {}
 
     async def health_check(self) -> bool:
-        raise NotImplementedError("MCPStdioTransport.health_check not yet implemented")
+        """Return True if the underlying client process is running."""
+        return self._client is not None and getattr(self._client, "is_running", False)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/stdio.py
@@ -1,0 +1,47 @@
+"""MCPStdioTransport — stdio-based MCP transport (stub)."""
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
+    MCPTransport,
+)
+
+
+class MCPStdioTransport(MCPTransport):
+    """MCP transport over stdio (JSON-RPC over stdin/stdout).
+
+    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._command = command
+        self._args = args
+        self._env = env
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        raise NotImplementedError("MCPStdioTransport.connect not yet implemented")
+
+    async def close(self) -> None:
+        raise NotImplementedError("MCPStdioTransport.close not yet implemented")
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        raise NotImplementedError("MCPStdioTransport.list_tools not yet implemented")
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise NotImplementedError("MCPStdioTransport.call_tool not yet implemented")
+
+    async def health_check(self) -> bool:
+        raise NotImplementedError("MCPStdioTransport.health_check not yet implemented")

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -48,22 +48,30 @@ class MCPStreamableHTTPTransport(MCPTransport):
     async def connect(self) -> None:
         """Establish a connection: create HTTP client, run MCP handshake."""
         self._http_client = self._create_http_client()
-        await self._json_rpc_call(
-            "initialize",
-            {
-                "protocolVersion": "2024-11-05",
-                "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
-                "capabilities": {},
-            },
-        )
-        # Send the ``initialized`` notification (no response expected).
-        await self._json_rpc_notify("initialized", {})
-        self._connected = True
+        try:
+            await self._json_rpc_call(
+                "initialize",
+                {
+                    "protocolVersion": "2024-11-05",
+                    "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+                    "capabilities": {},
+                },
+            )
+            # Send the ``initialized`` notification (no response expected).
+            await self._json_rpc_notify("initialized", {})
+            self._connected = True
+        except Exception:
+            if self._http_client is not None:
+                await self._http_client.aclose()
+                self._http_client = None
+            self._connected = False
+            raise
 
     async def close(self) -> None:
         """Close the underlying HTTP client and mark disconnected."""
         if self._http_client is not None:
             await self._http_client.aclose()
+            self._http_client = None
         self._connected = False
 
     async def list_tools(self) -> list[dict[str, Any]]:

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -1,0 +1,57 @@
+"""MCPStreamableHTTPTransport — streamable HTTP MCP transport (stub)."""
+from __future__ import annotations
+
+from typing import Any
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
+    MCPTransport,
+)
+
+
+class MCPStreamableHTTPTransport(MCPTransport):
+    """MCP transport over streamable HTTP (chunked JSON responses).
+
+    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        headers: dict[str, str] | None = None,
+        timeout_sec: int = 30,
+    ) -> None:
+        self._endpoint = endpoint
+        self._headers = headers
+        self._timeout_sec = timeout_sec
+        self._connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        raise NotImplementedError(
+            "MCPStreamableHTTPTransport.connect not yet implemented"
+        )
+
+    async def close(self) -> None:
+        raise NotImplementedError(
+            "MCPStreamableHTTPTransport.close not yet implemented"
+        )
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        raise NotImplementedError(
+            "MCPStreamableHTTPTransport.list_tools not yet implemented"
+        )
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        raise NotImplementedError(
+            "MCPStreamableHTTPTransport.call_tool not yet implemented"
+        )
+
+    async def health_check(self) -> bool:
+        raise NotImplementedError(
+            "MCPStreamableHTTPTransport.health_check not yet implemented"
+        )

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -1,7 +1,15 @@
-"""MCPStreamableHTTPTransport — streamable HTTP MCP transport (stub)."""
+"""MCPStreamableHTTPTransport — streamable HTTP MCP transport.
+
+Single HTTP endpoint.  Client POSTs JSON-RPC requests.  Server responds with
+either ``application/json`` (single response) or ``text/event-stream`` (SSE
+stream of JSON-RPC response events).  This transport handles both transparently.
+"""
 from __future__ import annotations
 
+import json
 from typing import Any
+
+import httpx
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
     MCPTransport,
@@ -9,9 +17,13 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport impor
 
 
 class MCPStreamableHTTPTransport(MCPTransport):
-    """MCP transport over streamable HTTP (chunked JSON responses).
+    """MCP transport over the *Streamable HTTP* protocol.
 
-    This is currently a stub; all I/O methods raise ``NotImplementedError``.
+    Connection flow:
+    1. Create an ``httpx.AsyncClient``.
+    2. Perform the MCP ``initialize`` handshake via POST.
+    3. Send the ``initialized`` notification.
+    4. Mark connected.
     """
 
     def __init__(
@@ -21,37 +33,105 @@ class MCPStreamableHTTPTransport(MCPTransport):
         timeout_sec: int = 30,
     ) -> None:
         self._endpoint = endpoint
-        self._headers = headers
+        self._headers = headers or {}
         self._timeout_sec = timeout_sec
+        self._http_client: httpx.AsyncClient | None = None
+        self._next_id = 1
         self._connected = False
+
+    # -- MCPTransport interface ------------------------------------------------
 
     @property
     def is_connected(self) -> bool:
         return self._connected
 
     async def connect(self) -> None:
-        raise NotImplementedError(
-            "MCPStreamableHTTPTransport.connect not yet implemented"
+        """Establish a connection: create HTTP client, run MCP handshake."""
+        self._http_client = httpx.AsyncClient(
+            headers=self._headers,
+            timeout=self._timeout_sec,
         )
+        await self._json_rpc_call(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "clientInfo": {"name": "tldw_acp_harness", "version": "0.1.0"},
+                "capabilities": {},
+            },
+        )
+        # Send the ``initialized`` notification (no response expected).
+        await self._json_rpc_notify("initialized", {})
+        self._connected = True
 
     async def close(self) -> None:
-        raise NotImplementedError(
-            "MCPStreamableHTTPTransport.close not yet implemented"
-        )
+        """Close the underlying HTTP client and mark disconnected."""
+        if self._http_client is not None:
+            await self._http_client.aclose()
+        self._connected = False
 
     async def list_tools(self) -> list[dict[str, Any]]:
-        raise NotImplementedError(
-            "MCPStreamableHTTPTransport.list_tools not yet implemented"
-        )
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        result = await self._json_rpc_call("tools/list", {})
+        return result.get("tools", [])
 
     async def call_tool(
         self, tool_name: str, arguments: dict[str, Any]
     ) -> dict[str, Any]:
-        raise NotImplementedError(
-            "MCPStreamableHTTPTransport.call_tool not yet implemented"
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        return await self._json_rpc_call(
+            "tools/call", {"name": tool_name, "arguments": arguments}
         )
 
     async def health_check(self) -> bool:
-        raise NotImplementedError(
-            "MCPStreamableHTTPTransport.health_check not yet implemented"
-        )
+        return self._connected
+
+    # -- Internal helpers ------------------------------------------------------
+
+    async def _json_rpc_call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Send a JSON-RPC *request* (has ``id``) and return the result."""
+        request_id = str(self._next_id)
+        self._next_id += 1
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        assert self._http_client is not None
+        resp = await self._http_client.post(self._endpoint, json=payload)
+        resp.raise_for_status()
+
+        content_type = resp.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            return self._parse_sse_response(resp.text, request_id)
+
+        data = resp.json()
+        if "error" in data:
+            raise RuntimeError(data["error"].get("message", "RPC error"))
+        return data.get("result", {})
+
+    async def _json_rpc_notify(self, method: str, params: dict[str, Any]) -> None:
+        """Send a JSON-RPC *notification* (no ``id``, no response expected)."""
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }
+        assert self._http_client is not None
+        resp = await self._http_client.post(self._endpoint, json=payload)
+        resp.raise_for_status()
+
+    def _parse_sse_response(self, text: str, expected_id: str) -> dict[str, Any]:
+        """Parse SSE text body to extract the JSON-RPC response for *expected_id*."""
+        for line in text.split("\n"):
+            if line.startswith("data: "):
+                data = json.loads(line[6:])
+                if str(data.get("id")) == expected_id:
+                    if "error" in data:
+                        raise RuntimeError(
+                            data["error"].get("message", "RPC error")
+                        )
+                    return data.get("result", {})
+        raise RuntimeError("No matching response in SSE stream")

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -99,7 +99,8 @@ class MCPStreamableHTTPTransport(MCPTransport):
             "method": method,
             "params": params,
         }
-        assert self._http_client is not None
+        if self._http_client is None:
+            raise RuntimeError("Not connected")
         resp = await self._http_client.post(self._endpoint, json=payload)
         resp.raise_for_status()
 
@@ -119,7 +120,8 @@ class MCPStreamableHTTPTransport(MCPTransport):
             "method": method,
             "params": params,
         }
-        assert self._http_client is not None
+        if self._http_client is None:
+            raise RuntimeError("Not connected")
         resp = await self._http_client.post(self._endpoint, json=payload)
         resp.raise_for_status()
 

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/adapters/mcp_transports/streamable_http.py
@@ -20,7 +20,7 @@ class MCPStreamableHTTPTransport(MCPTransport):
     """MCP transport over the *Streamable HTTP* protocol.
 
     Connection flow:
-    1. Create an ``httpx.AsyncClient``.
+    1. Create an HTTP client.
     2. Perform the MCP ``initialize`` handshake via POST.
     3. Send the ``initialized`` notification.
     4. Mark connected.
@@ -47,10 +47,7 @@ class MCPStreamableHTTPTransport(MCPTransport):
 
     async def connect(self) -> None:
         """Establish a connection: create HTTP client, run MCP handshake."""
-        self._http_client = httpx.AsyncClient(
-            headers=self._headers,
-            timeout=self._timeout_sec,
-        )
+        self._http_client = self._create_http_client()
         await self._json_rpc_call(
             "initialize",
             {
@@ -88,6 +85,13 @@ class MCPStreamableHTTPTransport(MCPTransport):
         return self._connected
 
     # -- Internal helpers ------------------------------------------------------
+
+    def _create_http_client(self) -> httpx.AsyncClient:
+        """Create the async HTTP client. Extracted so tests can replace it."""
+        return httpx.AsyncClient(
+            headers=self._headers,
+            timeout=self._timeout_sec,
+        )
 
     async def _json_rpc_call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         """Send a JSON-RPC *request* (has ``id``) and return the result."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -46,6 +46,15 @@ class AgentRegistryEntry:
     sandbox: Literal["required", "optional", "none"] = "none"
     trust_level: Literal["untrusted", "standard", "trusted"] = "standard"
 
+    # MCP orchestration fields (Phase B)
+    mcp_orchestration: Literal["agent_driven", "llm_driven"] = "agent_driven"
+    mcp_entry_tool: str = "execute"
+    mcp_structured_response: bool = False
+    mcp_llm_provider: str | None = None
+    mcp_llm_model: str | None = None
+    mcp_max_iterations: int = 20
+    mcp_refresh_tools: bool = False
+
     def check_availability(self) -> dict[str, Any]:
         """Check runtime availability of this agent."""
         result: dict[str, Any] = {

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/agent_registry.py
@@ -159,6 +159,13 @@ class AgentRegistry:
                 default=bool(item.get("default", False)),
                 install_instructions=list(item.get("install_instructions", [])),
                 docs_url=item.get("docs_url"),
+                mcp_orchestration=item.get("mcp_orchestration", "agent_driven"),
+                mcp_entry_tool=str(item.get("mcp_entry_tool", "execute")),
+                mcp_structured_response=bool(item.get("mcp_structured_response", False)),
+                mcp_llm_provider=item.get("mcp_llm_provider"),
+                mcp_llm_model=item.get("mcp_llm_model"),
+                mcp_max_iterations=int(item.get("mcp_max_iterations", 20)),
+                mcp_refresh_tools=bool(item.get("mcp_refresh_tools", False)),
             )
             entries.append(entry)
             if entry.default:
@@ -222,6 +229,13 @@ class AgentRegistry:
                     default=bool(row.get("is_default", 0)),
                     install_instructions=self._load_json(row.get("install_instructions"), []),
                     docs_url=row.get("docs_url"),
+                    mcp_orchestration=row.get("mcp_orchestration", "agent_driven"),
+                    mcp_entry_tool=row.get("mcp_entry_tool", "execute"),
+                    mcp_structured_response=bool(row.get("mcp_structured_response", 0)),
+                    mcp_llm_provider=row.get("mcp_llm_provider"),
+                    mcp_llm_model=row.get("mcp_llm_model"),
+                    mcp_max_iterations=int(row.get("mcp_max_iterations", 20)),
+                    mcp_refresh_tools=bool(row.get("mcp_refresh_tools", 0)),
                 ))
             self._api_entries = entries
 
@@ -273,6 +287,13 @@ class AgentRegistry:
         requires_api_key: str | None = None,
         install_instructions: list[str] | None = None,
         docs_url: str | None = None,
+        mcp_orchestration: Literal["agent_driven", "llm_driven"] = "agent_driven",
+        mcp_entry_tool: str = "execute",
+        mcp_structured_response: bool = False,
+        mcp_llm_provider: str | None = None,
+        mcp_llm_model: str | None = None,
+        mcp_max_iterations: int = 20,
+        mcp_refresh_tools: bool = False,
     ) -> AgentRegistryEntry:
         """Register or update a dynamic agent entry."""
         with self._lock:
@@ -286,6 +307,13 @@ class AgentRegistry:
                 requires_api_key=requires_api_key,
                 install_instructions=install_instructions or [],
                 docs_url=docs_url,
+                mcp_orchestration=mcp_orchestration,
+                mcp_entry_tool=mcp_entry_tool,
+                mcp_structured_response=mcp_structured_response,
+                mcp_llm_provider=mcp_llm_provider,
+                mcp_llm_model=mcp_llm_model,
+                mcp_max_iterations=mcp_max_iterations,
+                mcp_refresh_tools=mcp_refresh_tools,
             )
             if self._db is not None:
                 self._db.save_agent_entry({
@@ -298,6 +326,13 @@ class AgentRegistry:
                     "requires_api_key": requires_api_key,
                     "install_instructions": json.dumps(install_instructions or []),
                     "docs_url": docs_url,
+                    "mcp_orchestration": mcp_orchestration,
+                    "mcp_entry_tool": mcp_entry_tool,
+                    "mcp_structured_response": mcp_structured_response,
+                    "mcp_llm_provider": mcp_llm_provider,
+                    "mcp_llm_model": mcp_llm_model,
+                    "mcp_max_iterations": mcp_max_iterations,
+                    "mcp_refresh_tools": mcp_refresh_tools,
                     "source": "api",
                 })
             self._api_entries = [e for e in self._api_entries if e.type != type]
@@ -317,6 +352,8 @@ class AgentRegistry:
     _UPDATABLE_FIELDS = frozenset({
         "name", "description", "command", "args", "env",
         "requires_api_key", "install_instructions", "docs_url",
+        "mcp_orchestration", "mcp_entry_tool", "mcp_structured_response",
+        "mcp_llm_provider", "mcp_llm_model", "mcp_max_iterations", "mcp_refresh_tools",
     })
 
     # Defaults for fields that must never be None at runtime
@@ -349,6 +386,13 @@ class AgentRegistry:
                     "requires_api_key": existing.requires_api_key,
                     "install_instructions": json.dumps(existing.install_instructions),
                     "docs_url": existing.docs_url,
+                    "mcp_orchestration": existing.mcp_orchestration,
+                    "mcp_entry_tool": existing.mcp_entry_tool,
+                    "mcp_structured_response": existing.mcp_structured_response,
+                    "mcp_llm_provider": existing.mcp_llm_provider,
+                    "mcp_llm_model": existing.mcp_llm_model,
+                    "mcp_max_iterations": existing.mcp_max_iterations,
+                    "mcp_refresh_tools": existing.mcp_refresh_tools,
                     "source": "api",
                 })
             return existing

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -24,18 +24,20 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGate, T
 class _PendingEntry:
     """A held tool_call with its creation time for timeout enforcement."""
 
-    __slots__ = ("event", "created_at", "timeout_task", "approval_future")
+    __slots__ = ("event", "created_at", "timeout_task", "approval_future", "internal_only")
 
     def __init__(
         self,
         event: AgentEvent,
         timeout_task: asyncio.Task[None] | None = None,
         approval_future: asyncio.Future | None = None,
+        internal_only: bool = False,
     ) -> None:
         self.event = event
         self.created_at = time.monotonic()
         self.timeout_task = timeout_task
         self.approval_future = approval_future
+        self.internal_only = internal_only
 
 
 class GovernanceFilter:
@@ -82,23 +84,33 @@ class GovernanceFilter:
             await self._bus.publish(event)
             return
 
+        if event.metadata.get("_already_approved"):
+            await self._bus.publish(event)
+            return
+
         tool_name: str = event.payload.get("tool_name", "")
         # Use the adapter-provided tier if present; fall back to re-resolving
         tier = event.payload.get("permission_tier") or determine_permission_tier(tool_name)
 
         approval_future = event.metadata.get("_approval_future")
+        internal_only = approval_future is not None
 
         if tier == "auto":
-            await self._bus.publish(event)
             if approval_future is not None and not approval_future.done():
                 approval_future.set_result(("approve", None))
+            if internal_only:
+                return
+            await self._bus.publish(event)
             return
 
         # Hold the event and publish a permission request
         request_id = str(uuid.uuid4())
         timeout_task = asyncio.create_task(self._timeout_pending(request_id, self._default_timeout_sec))
         self._pending[request_id] = _PendingEntry(
-            event=event, timeout_task=timeout_task, approval_future=approval_future,
+            event=event,
+            timeout_task=timeout_task,
+            approval_future=approval_future,
+            internal_only=internal_only,
         )
 
         perm_request = AgentEvent(
@@ -158,6 +170,14 @@ class GovernanceFilter:
         # Resolve the approval future if one was attached
         if entry.approval_future is not None and not entry.approval_future.done():
             entry.approval_future.set_result((decision, reason))
+
+        if entry.internal_only:
+            logger.info(
+                "Governance: resolved internal approval request_id={} decision={}",
+                request_id,
+                decision,
+            )
+            return
 
         if decision == "approve":
             await self._bus.publish(held_event)
@@ -226,9 +246,8 @@ class GovernanceToolGate(ToolGate):
     metadata, and awaits the governance decision.
     """
 
-    def __init__(self, governance_filter: GovernanceFilter, session_id: str) -> None:
+    def __init__(self, governance_filter: GovernanceFilter) -> None:
         self._filter = governance_filter
-        self._session_id = session_id
 
     async def request_approval(
         self,

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from contextlib import suppress
 
 from loguru import logger
 
@@ -229,9 +230,11 @@ class GovernanceFilter:
     # Cleanup
     # ------------------------------------------------------------------
 
-    async def cancel_all_pending(self) -> None:
-        """Cancel all pending permission requests (e.g. on session teardown)."""
-        for request_id in list(self._pending):
+    async def cancel_all_pending(self, session_id: str | None = None) -> None:
+        """Cancel pending permission requests, optionally scoped to one session."""
+        for request_id, entry in list(self._pending.items()):
+            if session_id is not None and entry.event.session_id != session_id:
+                continue
             await self.on_permission_response(
                 request_id,
                 decision="deny",
@@ -254,6 +257,8 @@ class GovernanceToolGate(ToolGate):
         session_id: str,
         tool_name: str,
         arguments: dict,
+        *,
+        cancel_event: asyncio.Event | None = None,
     ) -> ToolGateResult:
         future: asyncio.Future = asyncio.get_running_loop().create_future()
         event = AgentEvent(
@@ -268,5 +273,22 @@ class GovernanceToolGate(ToolGate):
             metadata={"_approval_future": future},
         )
         await self._filter.process(event)
-        decision, reason = await future
+        if cancel_event is None:
+            decision, reason = await future
+            return ToolGateResult(approved=(decision == "approve"), reason=reason)
+
+        cancel_task = asyncio.create_task(cancel_event.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {future, cancel_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if cancel_task in done and cancel_event.is_set():
+                await self._filter.cancel_all_pending(session_id=session_id)
+            decision, reason = await future
+        finally:
+            cancel_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await cancel_task
+
         return ToolGateResult(approved=(decision == "approve"), reason=reason)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/governance_filter.py
@@ -18,17 +18,24 @@ from loguru import logger
 from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
 from tldw_Server_API.app.core.Agent_Client_Protocol.permission_tiers import determine_permission_tier
+from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGate, ToolGateResult
 
 
 class _PendingEntry:
     """A held tool_call with its creation time for timeout enforcement."""
 
-    __slots__ = ("event", "created_at", "timeout_task")
+    __slots__ = ("event", "created_at", "timeout_task", "approval_future")
 
-    def __init__(self, event: AgentEvent, timeout_task: asyncio.Task[None] | None = None) -> None:
+    def __init__(
+        self,
+        event: AgentEvent,
+        timeout_task: asyncio.Task[None] | None = None,
+        approval_future: asyncio.Future | None = None,
+    ) -> None:
         self.event = event
         self.created_at = time.monotonic()
         self.timeout_task = timeout_task
+        self.approval_future = approval_future
 
 
 class GovernanceFilter:
@@ -79,14 +86,20 @@ class GovernanceFilter:
         # Use the adapter-provided tier if present; fall back to re-resolving
         tier = event.payload.get("permission_tier") or determine_permission_tier(tool_name)
 
+        approval_future = event.metadata.get("_approval_future")
+
         if tier == "auto":
             await self._bus.publish(event)
+            if approval_future is not None and not approval_future.done():
+                approval_future.set_result(("approve", None))
             return
 
         # Hold the event and publish a permission request
         request_id = str(uuid.uuid4())
         timeout_task = asyncio.create_task(self._timeout_pending(request_id, self._default_timeout_sec))
-        self._pending[request_id] = _PendingEntry(event=event, timeout_task=timeout_task)
+        self._pending[request_id] = _PendingEntry(
+            event=event, timeout_task=timeout_task, approval_future=approval_future,
+        )
 
         perm_request = AgentEvent(
             session_id=event.session_id,
@@ -141,6 +154,10 @@ class GovernanceFilter:
             entry.timeout_task.cancel()
 
         held_event = entry.event
+
+        # Resolve the approval future if one was attached
+        if entry.approval_future is not None and not entry.approval_future.done():
+            entry.approval_future.set_result((decision, reason))
 
         if decision == "approve":
             await self._bus.publish(held_event)
@@ -200,3 +217,37 @@ class GovernanceFilter:
                 decision="deny",
                 reason="session cancelled",
             )
+
+
+class GovernanceToolGate(ToolGate):
+    """Concrete ToolGate that delegates to GovernanceFilter.
+
+    Creates an ``asyncio.Future`` per tool call, attaches it to the event
+    metadata, and awaits the governance decision.
+    """
+
+    def __init__(self, governance_filter: GovernanceFilter, session_id: str) -> None:
+        self._filter = governance_filter
+        self._session_id = session_id
+
+    async def request_approval(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict,
+    ) -> ToolGateResult:
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        event = AgentEvent(
+            session_id=session_id,
+            kind=AgentEventKind.TOOL_CALL,
+            payload={
+                "tool_id": str(uuid.uuid4()),
+                "tool_name": tool_name,
+                "arguments": arguments,
+                "permission_tier": determine_permission_tier(tool_name),
+            },
+            metadata={"_approval_future": future},
+        )
+        await self._filter.process(event)
+        decision, reason = await future
+        return ToolGateResult(approved=(decision == "approve"), reason=reason)

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py
@@ -1,0 +1,32 @@
+"""ToolGate — approval interface between adapter and governance layer."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class ToolGateResult:
+    """Result of a tool approval request."""
+
+    approved: bool
+    reason: str | None = None
+
+
+class ToolGate(ABC):
+    """Abstract approval gate for tool execution.
+
+    Implementations sit between the protocol adapter and the actual tool
+    executor, allowing governance policies (human-in-the-loop, RBAC,
+    budget limits, etc.) to approve or deny each tool call.
+    """
+
+    @abstractmethod
+    async def request_approval(
+        self,
+        session_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> ToolGateResult:
+        """Block until governance decision. Returns approved/denied."""

--- a/tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py
+++ b/tldw_Server_API/app/core/Agent_Client_Protocol/tool_gate.py
@@ -1,6 +1,7 @@
 """ToolGate — approval interface between adapter and governance layer."""
 from __future__ import annotations
 
+import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
@@ -28,5 +29,7 @@ class ToolGate(ABC):
         session_id: str,
         tool_name: str,
         arguments: dict[str, Any],
+        *,
+        cancel_event: asyncio.Event | None = None,
     ) -> ToolGateResult:
         """Block until governance decision. Returns approved/denied."""

--- a/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
+++ b/tldw_Server_API/app/core/DB_Management/ACP_Sessions_DB.py
@@ -17,7 +17,7 @@ from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
 
-_SCHEMA_VERSION = 4
+_SCHEMA_VERSION = 5
 
 _SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS sessions (
@@ -77,6 +77,13 @@ CREATE TABLE IF NOT EXISTS agent_registry (
     is_default INTEGER NOT NULL DEFAULT 0,
     install_instructions TEXT NOT NULL DEFAULT '[]',
     docs_url TEXT,
+    mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven',
+    mcp_entry_tool TEXT NOT NULL DEFAULT 'execute',
+    mcp_structured_response INTEGER NOT NULL DEFAULT 0,
+    mcp_llm_provider TEXT,
+    mcp_llm_model TEXT,
+    mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
+    mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
     source TEXT NOT NULL DEFAULT 'api',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
@@ -95,7 +102,12 @@ CREATE INDEX IF NOT EXISTS idx_health_agent_time
 """
 
 # Columns that are stored as INTEGER 0/1 but should be returned as bool
-_BOOL_FIELDS = frozenset({"bootstrap_ready", "needs_bootstrap"})
+_BOOL_FIELDS = frozenset({
+    "bootstrap_ready",
+    "needs_bootstrap",
+    "mcp_structured_response",
+    "mcp_refresh_tools",
+})
 
 # Columns that are stored as JSON TEXT but should be returned as parsed objects
 _JSON_LIST_FIELDS = frozenset({"tags", "mcp_servers"})
@@ -108,7 +120,16 @@ _ALLOWED_MIGRATION_COLUMNS = {
         "policy_summary": "policy_summary TEXT",
         "policy_provenance_summary": "policy_provenance_summary TEXT",
         "policy_refresh_error": "policy_refresh_error TEXT",
-    }
+    },
+    "agent_registry": {
+        "mcp_orchestration": "mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven'",
+        "mcp_entry_tool": "mcp_entry_tool TEXT NOT NULL DEFAULT 'execute'",
+        "mcp_structured_response": "mcp_structured_response INTEGER NOT NULL DEFAULT 0",
+        "mcp_llm_provider": "mcp_llm_provider TEXT",
+        "mcp_llm_model": "mcp_llm_model TEXT",
+        "mcp_max_iterations": "mcp_max_iterations INTEGER NOT NULL DEFAULT 20",
+        "mcp_refresh_tools": "mcp_refresh_tools INTEGER NOT NULL DEFAULT 0",
+    },
 }
 
 
@@ -190,6 +211,13 @@ class ACPSessionsDB:
                         is_default INTEGER NOT NULL DEFAULT 0,
                         install_instructions TEXT NOT NULL DEFAULT '[]',
                         docs_url TEXT,
+                        mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven',
+                        mcp_entry_tool TEXT NOT NULL DEFAULT 'execute',
+                        mcp_structured_response INTEGER NOT NULL DEFAULT 0,
+                        mcp_llm_provider TEXT,
+                        mcp_llm_model TEXT,
+                        mcp_max_iterations INTEGER NOT NULL DEFAULT 20,
+                        mcp_refresh_tools INTEGER NOT NULL DEFAULT 0,
                         source TEXT NOT NULL DEFAULT 'api',
                         created_at TEXT NOT NULL,
                         updated_at TEXT NOT NULL
@@ -244,6 +272,49 @@ class ACPSessionsDB:
                     "sessions",
                     "policy_refresh_error",
                     "policy_refresh_error TEXT",
+                )
+            if current_version < 5:
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_orchestration",
+                    "mcp_orchestration TEXT NOT NULL DEFAULT 'agent_driven'",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_entry_tool",
+                    "mcp_entry_tool TEXT NOT NULL DEFAULT 'execute'",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_structured_response",
+                    "mcp_structured_response INTEGER NOT NULL DEFAULT 0",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_llm_provider",
+                    "mcp_llm_provider TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_llm_model",
+                    "mcp_llm_model TEXT",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_max_iterations",
+                    "mcp_max_iterations INTEGER NOT NULL DEFAULT 20",
+                )
+                _ensure_column(
+                    conn,
+                    "agent_registry",
+                    "mcp_refresh_tools",
+                    "mcp_refresh_tools INTEGER NOT NULL DEFAULT 0",
                 )
             conn.execute(f"PRAGMA user_version={_SCHEMA_VERSION}")
             conn.commit()
@@ -966,6 +1037,13 @@ class ACPSessionsDB:
         is_default = int(entry_dict.get("is_default", 0))
         install_instructions = entry_dict.get("install_instructions", "[]")
         docs_url = entry_dict.get("docs_url")
+        mcp_orchestration = entry_dict.get("mcp_orchestration", "agent_driven")
+        mcp_entry_tool = entry_dict.get("mcp_entry_tool", "execute")
+        mcp_structured_response = int(bool(entry_dict.get("mcp_structured_response", 0)))
+        mcp_llm_provider = entry_dict.get("mcp_llm_provider")
+        mcp_llm_model = entry_dict.get("mcp_llm_model")
+        mcp_max_iterations = int(entry_dict.get("mcp_max_iterations", 20))
+        mcp_refresh_tools = int(bool(entry_dict.get("mcp_refresh_tools", 0)))
         source = entry_dict.get("source", "api")
 
         conn.execute(
@@ -973,8 +1051,10 @@ class ACPSessionsDB:
             INSERT INTO agent_registry (
                 agent_type, name, description, command, args, env,
                 requires_api_key, is_default, install_instructions, docs_url,
+                mcp_orchestration, mcp_entry_tool, mcp_structured_response,
+                mcp_llm_provider, mcp_llm_model, mcp_max_iterations, mcp_refresh_tools,
                 source, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(agent_type) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -985,12 +1065,21 @@ class ACPSessionsDB:
                 is_default = excluded.is_default,
                 install_instructions = excluded.install_instructions,
                 docs_url = excluded.docs_url,
+                mcp_orchestration = excluded.mcp_orchestration,
+                mcp_entry_tool = excluded.mcp_entry_tool,
+                mcp_structured_response = excluded.mcp_structured_response,
+                mcp_llm_provider = excluded.mcp_llm_provider,
+                mcp_llm_model = excluded.mcp_llm_model,
+                mcp_max_iterations = excluded.mcp_max_iterations,
+                mcp_refresh_tools = excluded.mcp_refresh_tools,
                 source = excluded.source,
                 updated_at = excluded.updated_at
             """,
             (
                 agent_type, name, description, command, args, env,
                 requires_api_key, is_default, install_instructions, docs_url,
+                mcp_orchestration, mcp_entry_tool, mcp_structured_response,
+                mcp_llm_provider, mcp_llm_model, mcp_max_iterations, mcp_refresh_tools,
                 source, now, now,
             ),
         )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_acp_agent_registry.py
@@ -66,6 +66,40 @@ def test_registry_entry_fields(registry_file):
     assert entry.default is True
 
 
+def test_registry_loads_mcp_fields_from_yaml(tmp_path):
+    """YAML-defined MCP fields should populate the registry entry."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
+
+    yaml_content = """
+agents:
+  - type: mcp_agent
+    name: MCP Agent
+    command: python3
+    mcp_orchestration: llm_driven
+    mcp_entry_tool: run
+    mcp_structured_response: true
+    mcp_llm_provider: openai
+    mcp_llm_model: gpt-4o
+    mcp_max_iterations: 7
+    mcp_refresh_tools: true
+"""
+    yaml_file = tmp_path / "agents.yaml"
+    yaml_file.write_text(yaml_content)
+
+    reg = AgentRegistry(yaml_path=str(yaml_file))
+    reg.load()
+
+    entry = reg.get_entry("mcp_agent")
+    assert entry is not None
+    assert entry.mcp_orchestration == "llm_driven"
+    assert entry.mcp_entry_tool == "run"
+    assert entry.mcp_structured_response is True
+    assert entry.mcp_llm_provider == "openai"
+    assert entry.mcp_llm_model == "gpt-4o"
+    assert entry.mcp_max_iterations == 7
+    assert entry.mcp_refresh_tools is True
+
+
 def test_registry_get_entry_none(registry_file):
     """get_entry returns None for unknown type."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistry
@@ -336,3 +370,57 @@ class TestDynamicRegistration:
     def test_cannot_deregister_yaml_only(self, db_registry):
         """Deregistering a YAML-only entry returns False."""
         assert db_registry.deregister_agent("claude_code") is False
+
+    def test_register_agent_persists_mcp_fields_across_reload(self, db_registry):
+        """Dynamic registrations should keep MCP config across DB-backed reloads."""
+        db_registry.register_agent(
+            type="mcp_agent",
+            name="MCP Agent",
+            command="mcp-cli",
+            mcp_orchestration="llm_driven",
+            mcp_entry_tool="run",
+            mcp_structured_response=True,
+            mcp_llm_provider="openai",
+            mcp_llm_model="gpt-4o",
+            mcp_max_iterations=9,
+            mcp_refresh_tools=True,
+        )
+
+        db_registry.load()
+        entry = db_registry.get_entry("mcp_agent")
+        assert entry is not None
+        assert entry.mcp_orchestration == "llm_driven"
+        assert entry.mcp_entry_tool == "run"
+        assert entry.mcp_structured_response is True
+        assert entry.mcp_llm_provider == "openai"
+        assert entry.mcp_llm_model == "gpt-4o"
+        assert entry.mcp_max_iterations == 9
+        assert entry.mcp_refresh_tools is True
+
+    def test_update_agent_persists_mcp_fields_across_reload(self, db_registry):
+        """Dynamic updates should save MCP config changes back to the DB."""
+        db_registry.register_agent(type="mcp_agent", name="MCP Agent", command="mcp-cli")
+
+        updated = db_registry.update_agent(
+            "mcp_agent",
+            mcp_orchestration="llm_driven",
+            mcp_entry_tool="run",
+            mcp_structured_response=True,
+            mcp_llm_provider="openai",
+            mcp_llm_model="gpt-4o-mini",
+            mcp_max_iterations=11,
+            mcp_refresh_tools=True,
+        )
+
+        assert updated is not None
+
+        db_registry.load()
+        entry = db_registry.get_entry("mcp_agent")
+        assert entry is not None
+        assert entry.mcp_orchestration == "llm_driven"
+        assert entry.mcp_entry_tool == "run"
+        assert entry.mcp_structured_response is True
+        assert entry.mcp_llm_provider == "openai"
+        assert entry.mcp_llm_model == "gpt-4o-mini"
+        assert entry.mcp_max_iterations == 11
+        assert entry.mcp_refresh_tools is True

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_filter.py
@@ -150,3 +150,49 @@ async def test_governance_timeout_auto_denies(bus):
     assert error_result.payload["is_error"] is True
     assert "timeout" in error_result.payload["output"].lower()
     assert gov.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_governance_internal_approval_only_resolves_future(bus, gov):
+    """ToolGate approval requests should not publish held tool events on decision."""
+    future = asyncio.get_running_loop().create_future()
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}},
+        session_id="s1",
+    )
+    ev.metadata["_approval_future"] = future
+
+    await gov.process(ev)
+
+    perm_req = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+    request_id = perm_req.payload["request_id"]
+
+    await gov.on_permission_response(request_id, decision="approve")
+    decision, reason = await asyncio.wait_for(future, timeout=1.0)
+
+    assert decision == "approve"
+    assert reason is None
+    assert gov.pending_count == 0
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q.get(), timeout=0.05)
+
+
+@pytest.mark.asyncio
+async def test_governance_already_approved_tool_call_bypasses_reapproval(bus, gov):
+    """Runner-emitted TOOL_CALL events should pass through once already approved."""
+    q = bus.subscribe("test")
+    ev = _make_event(
+        kind=AgentEventKind.TOOL_CALL,
+        payload={"tool_id": "t1", "tool_name": "bash", "arguments": {"cmd": "ls"}},
+    )
+    ev.metadata["_already_approved"] = True
+
+    await gov.process(ev)
+
+    got = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert got is ev
+    assert got.kind == AgentEventKind.TOOL_CALL
+    assert gov.pending_count == 0

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
@@ -87,3 +87,32 @@ async def test_governance_tool_gate_held_then_denied(bus, gov, gate):
 
     assert result.approved is False
     assert result.reason == "too dangerous"
+
+
+@pytest.mark.asyncio
+async def test_governance_tool_gate_cancels_pending_approval_on_session_cancel(bus, gov, gate):
+    """Session cancellation should unblock pending approvals without waiting for timeout."""
+    q = bus.subscribe("test")
+    cancel_event = asyncio.Event()
+
+    request_task = asyncio.create_task(
+        gate.request_approval(
+            session_id="s1",
+            tool_name="bash",
+            arguments={"cmd": "ls"},
+            cancel_event=cancel_event,
+        )
+    )
+
+    perm_req = await asyncio.wait_for(q.get(), timeout=2.0)
+    assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+    assert gov.pending_count == 1
+
+    cancel_event.set()
+    result = await asyncio.wait_for(request_task, timeout=1.0)
+
+    assert result.approved is False
+    assert result.reason == "session cancelled"
+    assert gov.pending_count == 0
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(q.get(), timeout=0.05)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
@@ -27,7 +27,7 @@ def gov(bus):
 
 @pytest.fixture
 def gate(gov):
-    return GovernanceToolGate(governance_filter=gov, session_id="s1")
+    return GovernanceToolGate(governance_filter=gov)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_governance_tool_gate.py
@@ -1,0 +1,89 @@
+"""Tests for GovernanceToolGate -- bridges ToolGate ABC to GovernanceFilter."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import (
+    GovernanceFilter,
+    GovernanceToolGate,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def bus():
+    return SessionEventBus(session_id="s1")
+
+
+@pytest.fixture
+def gov(bus):
+    return GovernanceFilter(bus=bus)
+
+
+@pytest.fixture
+def gate(gov):
+    return GovernanceToolGate(governance_filter=gov, session_id="s1")
+
+
+@pytest.mark.asyncio
+async def test_governance_tool_gate_auto_approved(gate):
+    """Auto-tier tool (read_file) should be approved immediately."""
+    result = await gate.request_approval(
+        session_id="s1",
+        tool_name="read_file",
+        arguments={"path": "/tmp/foo.txt"},
+    )
+    assert result.approved is True
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+async def test_governance_tool_gate_held_then_approved(bus, gov, gate):
+    """Individual-tier tool (bash) held, then approved via on_permission_response."""
+    q = bus.subscribe("test")
+
+    async def _approve_after_hold():
+        # Wait for the PERMISSION_REQUEST to appear on the bus
+        perm_req = await asyncio.wait_for(q.get(), timeout=2.0)
+        assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+        request_id = perm_req.payload["request_id"]
+        await gov.on_permission_response(request_id, decision="approve")
+
+    approve_task = asyncio.create_task(_approve_after_hold())
+
+    result = await asyncio.wait_for(
+        gate.request_approval(session_id="s1", tool_name="bash", arguments={"cmd": "ls"}),
+        timeout=3.0,
+    )
+    await approve_task
+
+    assert result.approved is True
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+async def test_governance_tool_gate_held_then_denied(bus, gov, gate):
+    """Individual-tier tool (bash) held, then denied via on_permission_response."""
+    q = bus.subscribe("test")
+
+    async def _deny_after_hold():
+        perm_req = await asyncio.wait_for(q.get(), timeout=2.0)
+        assert perm_req.kind == AgentEventKind.PERMISSION_REQUEST
+        request_id = perm_req.payload["request_id"]
+        await gov.on_permission_response(request_id, decision="deny", reason="too dangerous")
+
+    deny_task = asyncio.create_task(_deny_after_hold())
+
+    result = await asyncio.wait_for(
+        gate.request_approval(session_id="s1", tool_name="bash", arguments={"cmd": "rm -rf /"}),
+        timeout=3.0,
+    )
+    await deny_task
+
+    assert result.approved is False
+    assert result.reason == "too dangerous"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
@@ -1,0 +1,313 @@
+"""Tests for MCPAdapter — the main adapter wiring transport + runners + heartbeat + lifecycle."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
+    AdapterConfig,
+    PromptOptions,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+SESSION_ID = "adapter-session-001"
+
+
+@pytest.fixture
+def mock_transport():
+    t = AsyncMock()
+    t.is_connected = True
+    t.list_tools.return_value = [{"name": "search", "inputSchema": {"type": "object"}}]
+    t.call_tool.return_value = {"content": [{"type": "text", "text": "result"}]}
+    return t
+
+
+@pytest.fixture
+def collected_events():
+    return []
+
+
+@pytest.fixture
+def event_callback(collected_events):
+    async def cb(event: AgentEvent):
+        collected_events.append(event)
+    return cb
+
+
+def _make_config(event_callback, protocol_config=None):
+    return AdapterConfig(
+        event_callback=event_callback,
+        session_id=SESSION_ID,
+        protocol_config=protocol_config or {"protocol": "stdio", "command": "echo"},
+    )
+
+
+def _events_of_kind(events, kind: AgentEventKind):
+    return [e for e in events if e.kind == kind]
+
+
+# ---------------------------------------------------------------------------
+# Basic properties
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_adapter_protocol_name():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    assert adapter.protocol_name == "mcp"
+
+
+def test_mcp_adapter_not_connected_initially():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    assert adapter.is_connected is False
+
+
+def test_mcp_adapter_supports_streaming():
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    assert adapter.supports_streaming is True
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_connect_lifecycle(mock_transport, event_callback, collected_events):
+    """Connect should: create transport, connect, list_tools, emit agent_started + agent_ready."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback)
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    # Transport interactions
+    mock_transport.connect.assert_awaited_once()
+    mock_transport.list_tools.assert_awaited_once()
+
+    # Lifecycle events
+    lifecycle_events = _events_of_kind(collected_events, AgentEventKind.LIFECYCLE)
+    assert len(lifecycle_events) == 2
+    assert lifecycle_events[0].payload["event"] == "agent_started"
+    assert lifecycle_events[1].payload["event"] == "agent_ready"
+
+    assert adapter.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_disconnect(mock_transport, event_callback, collected_events):
+    """Disconnect should: close transport, emit agent_exited, mark disconnected."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback)
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    collected_events.clear()
+    await adapter.disconnect()
+
+    mock_transport.close.assert_awaited_once()
+
+    lifecycle_events = _events_of_kind(collected_events, AgentEventKind.LIFECYCLE)
+    assert len(lifecycle_events) == 1
+    assert lifecycle_events[0].payload["event"] == "agent_exited"
+
+    assert adapter.is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# send_prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_send_prompt_agent_driven(mock_transport, event_callback, collected_events):
+    """Agent-driven prompt should emit status_change events and use AgentDrivenRunner."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback, protocol_config={
+        "protocol": "stdio",
+        "command": "echo",
+        "mcp_orchestration": "agent_driven",
+    })
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    collected_events.clear()
+    await adapter.send_prompt([{"role": "user", "content": "hello"}])
+
+    # Transport should have been called (agent-driven uses call_tool)
+    mock_transport.call_tool.assert_awaited_once()
+
+    # Status changes: idle -> working, then working -> idle
+    status_events = _events_of_kind(collected_events, AgentEventKind.STATUS_CHANGE)
+    assert len(status_events) == 2
+    assert status_events[0].payload == {"from_status": "idle", "to_status": "working"}
+    assert status_events[1].payload == {"from_status": "working", "to_status": "idle"}
+
+    # Should have a COMPLETION event from the runner
+    completion_events = _events_of_kind(collected_events, AgentEventKind.COMPLETION)
+    assert len(completion_events) == 1
+    assert completion_events[0].payload["text"] == "result"
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_send_prompt_llm_driven(mock_transport, event_callback, collected_events):
+    """LLM-driven prompt should use LLMDrivenRunner with llm_caller and tool_gate."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+
+    # Mock LLM caller that returns text completion (no tool calls)
+    mock_llm_caller = AsyncMock()
+    mock_llm_response = AsyncMock()
+    mock_llm_response.text = "LLM final answer"
+    mock_llm_response.tool_calls = []
+    mock_llm_caller.call = AsyncMock(return_value=mock_llm_response)
+
+    mock_tool_gate = AsyncMock()
+
+    config = _make_config(event_callback, protocol_config={
+        "protocol": "stdio",
+        "command": "echo",
+        "mcp_orchestration": "llm_driven",
+        "llm_caller": mock_llm_caller,
+        "tool_gate": mock_tool_gate,
+    })
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    collected_events.clear()
+    await adapter.send_prompt([{"role": "user", "content": "hello"}])
+
+    # LLM caller should have been invoked
+    mock_llm_caller.call.assert_awaited()
+
+    # Status changes
+    status_events = _events_of_kind(collected_events, AgentEventKind.STATUS_CHANGE)
+    assert len(status_events) == 2
+
+    # COMPLETION from the LLM
+    completion_events = _events_of_kind(collected_events, AgentEventKind.COMPLETION)
+    assert len(completion_events) == 1
+    assert completion_events[0].payload["text"] == "LLM final answer"
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_send_prompt_not_connected():
+    """send_prompt when not connected should raise RuntimeError."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await adapter.send_prompt([{"role": "user", "content": "hello"}])
+
+
+# ---------------------------------------------------------------------------
+# cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_cancel(mock_transport, event_callback, collected_events):
+    """cancel() should set the internal cancel event."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback)
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    await adapter.cancel()
+    # The cancel event should be set (verified indirectly: runner would respect it)
+    assert adapter._cancel_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# is_connected delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_is_connected_delegates(mock_transport, event_callback, collected_events):
+    """is_connected should delegate to transport.is_connected."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback)
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    assert adapter.is_connected is True
+
+    # Simulate transport disconnect
+    mock_transport.is_connected = False
+    assert adapter.is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# tool refresh
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_tool_refresh(mock_transport, event_callback, collected_events):
+    """When mcp_refresh_tools=True, list_tools should be called again on send_prompt."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback, protocol_config={
+        "protocol": "stdio",
+        "command": "echo",
+        "mcp_refresh_tools": True,
+    })
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    # list_tools called once during connect
+    assert mock_transport.list_tools.await_count == 1
+
+    await adapter.send_prompt([{"role": "user", "content": "go"}])
+
+    # list_tools called again during send_prompt
+    assert mock_transport.list_tools.await_count == 2

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
@@ -8,7 +8,6 @@ import pytest
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
     AdapterConfig,
-    PromptOptions,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
 
@@ -219,6 +218,31 @@ async def test_mcp_adapter_send_prompt_llm_driven(mock_transport, event_callback
     completion_events = _events_of_kind(collected_events, AgentEventKind.COMPLETION)
     assert len(completion_events) == 1
     assert completion_events[0].payload["text"] == "LLM final answer"
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_send_prompt_llm_driven_requires_llm_caller_and_tool_gate(
+    mock_transport,
+    event_callback,
+):
+    """LLM-driven mode should fail with a clear error when required config is missing."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback, protocol_config={
+        "mcp_transport": "stdio",
+        "command": "echo",
+        "mcp_orchestration": "llm_driven",
+    })
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    with pytest.raises(ValueError, match="llm_driven.*llm_caller.*tool_gate"):
+        await adapter.send_prompt([{"role": "user", "content": "hello"}])
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
@@ -1,7 +1,6 @@
 """Tests for MCPAdapter — the main adapter wiring transport + runners + heartbeat + lifecycle."""
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -10,6 +9,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.base import (
     AdapterConfig,
 )
 from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.exceptions import ValidationError
 
 pytestmark = pytest.mark.unit
 
@@ -105,6 +105,32 @@ async def test_mcp_adapter_connect_lifecycle(mock_transport, event_callback, col
     assert lifecycle_events[1].payload["event"] == "agent_ready"
 
     assert adapter.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_connect_rolls_back_state_when_list_tools_fails(
+    mock_transport,
+    event_callback,
+):
+    """Connect failures should close the transport and clear partial adapter state."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback)
+    mock_transport.list_tools.side_effect = RuntimeError("tools unavailable")
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        with pytest.raises(RuntimeError, match="tools unavailable"):
+            await adapter.connect(config)
+
+    mock_transport.close.assert_awaited_once()
+    assert adapter.is_connected is False
+    assert adapter._transport is None
+    assert adapter._config is None
+    assert adapter._tools == []
 
 
 @pytest.mark.asyncio
@@ -241,7 +267,32 @@ async def test_mcp_adapter_send_prompt_llm_driven_requires_llm_caller_and_tool_g
     ):
         await adapter.connect(config)
 
-    with pytest.raises(ValueError, match="llm_driven.*llm_caller.*tool_gate"):
+    with pytest.raises(ValueError, match=r"llm_driven.*llm_caller.*tool_gate"):
+        await adapter.send_prompt([{"role": "user", "content": "hello"}])
+
+
+@pytest.mark.asyncio
+async def test_mcp_adapter_send_prompt_rejects_unknown_orchestration(
+    mock_transport,
+    event_callback,
+):
+    """Unknown orchestration modes should fail fast instead of silently falling back."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
+
+    adapter = MCPAdapter()
+    config = _make_config(event_callback, protocol_config={
+        "mcp_transport": "stdio",
+        "command": "echo",
+        "mcp_orchestration": "surprise_mode",
+    })
+
+    with patch(
+        "tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter.create_transport",
+        return_value=mock_transport,
+    ):
+        await adapter.connect(config)
+
+    with pytest.raises(ValidationError, match=r"mcp_orchestration.*surprise_mode"):
         await adapter.send_prompt([{"role": "user", "content": "hello"}])
 
 
@@ -261,7 +312,7 @@ async def test_mcp_adapter_send_prompt_not_connected():
 
 
 @pytest.mark.asyncio
-async def test_mcp_adapter_cancel(mock_transport, event_callback, collected_events):
+async def test_mcp_adapter_cancel(mock_transport, event_callback):
     """cancel() should set the internal cancel event."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
 
@@ -285,7 +336,7 @@ async def test_mcp_adapter_cancel(mock_transport, event_callback, collected_even
 
 
 @pytest.mark.asyncio
-async def test_mcp_adapter_is_connected_delegates(mock_transport, event_callback, collected_events):
+async def test_mcp_adapter_is_connected_delegates(mock_transport, event_callback):
     """is_connected should delegate to transport.is_connected."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
 
@@ -311,7 +362,7 @@ async def test_mcp_adapter_is_connected_delegates(mock_transport, event_callback
 
 
 @pytest.mark.asyncio
-async def test_mcp_adapter_tool_refresh(mock_transport, event_callback, collected_events):
+async def test_mcp_adapter_tool_refresh(mock_transport, event_callback):
     """When mcp_refresh_tools=True, list_tools should be called again on send_prompt."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_adapter import MCPAdapter
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_adapter.py
@@ -42,7 +42,7 @@ def _make_config(event_callback, protocol_config=None):
     return AdapterConfig(
         event_callback=event_callback,
         session_id=SESSION_ID,
-        protocol_config=protocol_config or {"protocol": "stdio", "command": "echo"},
+        protocol_config=protocol_config or {"mcp_transport": "stdio", "command": "echo"},
     )
 
 
@@ -146,7 +146,7 @@ async def test_mcp_adapter_send_prompt_agent_driven(mock_transport, event_callba
 
     adapter = MCPAdapter()
     config = _make_config(event_callback, protocol_config={
-        "protocol": "stdio",
+        "mcp_transport": "stdio",
         "command": "echo",
         "mcp_orchestration": "agent_driven",
     })
@@ -192,7 +192,7 @@ async def test_mcp_adapter_send_prompt_llm_driven(mock_transport, event_callback
     mock_tool_gate = AsyncMock()
 
     config = _make_config(event_callback, protocol_config={
-        "protocol": "stdio",
+        "mcp_transport": "stdio",
         "command": "echo",
         "mcp_orchestration": "llm_driven",
         "llm_caller": mock_llm_caller,
@@ -293,7 +293,7 @@ async def test_mcp_adapter_tool_refresh(mock_transport, event_callback, collecte
 
     adapter = MCPAdapter()
     config = _make_config(event_callback, protocol_config={
-        "protocol": "stdio",
+        "mcp_transport": "stdio",
         "command": "echo",
         "mcp_refresh_tools": True,
     })

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_llm_caller.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_llm_caller.py
@@ -33,9 +33,9 @@ def test_llm_caller_is_abstract():
         LLMCaller()
 
 
-def test_llm_caller_concrete():
+@pytest.mark.asyncio
+async def test_llm_caller_concrete():
     """A concrete subclass of LLMCaller can be instantiated and called."""
-    import asyncio
     from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
         LLMCaller,
         LLMResponse,
@@ -46,9 +46,7 @@ def test_llm_caller_concrete():
             return LLMResponse(text="Hello!")
 
     llm = FakeLLM()
-    resp = asyncio.get_event_loop().run_until_complete(
-        llm.call(messages=[{"role": "user", "content": "hi"}], tools=[])
-    )
+    resp = await llm.call(messages=[{"role": "user", "content": "hi"}], tools=[])
     assert resp.text == "Hello!"
     assert resp.tool_calls == []
 

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_llm_caller.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_llm_caller.py
@@ -1,0 +1,102 @@
+"""Tests for mcp_llm_caller: LLMCaller ABC, LLMResponse, LLMToolCall, mcp_tools_to_openai_format."""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_llm_response_defaults():
+    """LLMResponse() has text=None and tool_calls=[]."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import LLMResponse
+
+    resp = LLMResponse()
+    assert resp.text is None
+    assert resp.tool_calls == []
+
+
+def test_llm_tool_call_fields():
+    """LLMToolCall stores id, name, arguments."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import LLMToolCall
+
+    tc = LLMToolCall(id="tc1", name="search", arguments={"q": "hello"})
+    assert tc.id == "tc1"
+    assert tc.name == "search"
+    assert tc.arguments == {"q": "hello"}
+
+
+def test_llm_caller_is_abstract():
+    """Cannot instantiate LLMCaller directly."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import LLMCaller
+
+    with pytest.raises(TypeError):
+        LLMCaller()
+
+
+def test_llm_caller_concrete():
+    """A concrete subclass of LLMCaller can be instantiated and called."""
+    import asyncio
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+        LLMCaller,
+        LLMResponse,
+    )
+
+    class FakeLLM(LLMCaller):
+        async def call(self, messages, tools):
+            return LLMResponse(text="Hello!")
+
+    llm = FakeLLM()
+    resp = asyncio.get_event_loop().run_until_complete(
+        llm.call(messages=[{"role": "user", "content": "hi"}], tools=[])
+    )
+    assert resp.text == "Hello!"
+    assert resp.tool_calls == []
+
+
+def test_mcp_tools_to_openai_format():
+    """Convert MCP tool with inputSchema to OpenAI function-calling format."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+        mcp_tools_to_openai_format,
+    )
+
+    mcp_tools = [
+        {
+            "name": "search",
+            "description": "Search the web",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        }
+    ]
+    result = mcp_tools_to_openai_format(mcp_tools)
+    assert len(result) == 1
+    assert result[0]["type"] == "function"
+    assert result[0]["function"]["name"] == "search"
+    assert result[0]["function"]["description"] == "Search the web"
+    assert result[0]["function"]["parameters"]["type"] == "object"
+    assert "query" in result[0]["function"]["parameters"]["properties"]
+
+
+def test_mcp_tools_to_openai_format_empty():
+    """Empty list returns empty list."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+        mcp_tools_to_openai_format,
+    )
+
+    assert mcp_tools_to_openai_format([]) == []
+
+
+def test_mcp_tools_to_openai_format_missing_fields():
+    """Tool without description/inputSchema gets defaults."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+        mcp_tools_to_openai_format,
+    )
+
+    result = mcp_tools_to_openai_format([{"name": "bare_tool"}])
+    assert len(result) == 1
+    func = result[0]["function"]
+    assert func["name"] == "bare_tool"
+    assert func["description"] == ""
+    assert func["parameters"] == {"type": "object"}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
@@ -127,6 +127,42 @@ async def test_agent_driven_structured_no_completion_step():
 
 
 @pytest.mark.asyncio
+async def test_agent_driven_structured_malformed_steps_emit_error_and_fallback_completion():
+    """Malformed structured steps should not crash the runner."""
+    steps = {
+        "steps": [
+            {"type": "tool_call", "arguments": {"q": "test"}},
+            {"type": "completion"},
+        ]
+    }
+    raw_text = json.dumps(steps)
+    runner, transport, callback = _make_runner(
+        transport_return={"content": [{"type": "text", "text": raw_text}]},
+        structured_response=True,
+    )
+
+    await runner.run([{"role": "user", "content": "go"}])
+
+    events = [call[0][0] for call in callback.call_args_list]
+    assert [event.kind for event in events] == [
+        AgentEventKind.ERROR,
+        AgentEventKind.ERROR,
+        AgentEventKind.COMPLETION,
+    ]
+    assert events[0].payload == {
+        "message": "Malformed structured response step",
+        "step_type": "tool_call",
+        "missing": "tool_name",
+    }
+    assert events[1].payload == {
+        "message": "Malformed structured response step",
+        "step_type": "completion",
+        "missing": "text",
+    }
+    assert events[-1].payload["text"] == raw_text
+
+
+@pytest.mark.asyncio
 async def test_agent_driven_tool_error():
     """Transport.call_tool raises; verify ERROR event is emitted."""
     runner, transport, callback = _make_runner(

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
@@ -1,0 +1,173 @@
+"""Tests for AgentDrivenRunner — calls agent entry tool, translates response to events."""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+
+pytestmark = pytest.mark.unit
+
+SESSION_ID = "test-session-001"
+
+
+def _make_runner(
+    transport_return=None,
+    transport_side_effect=None,
+    structured_response: bool = False,
+    cancel: bool = False,
+    entry_tool: str = "execute",
+):
+    """Helper to build an AgentDrivenRunner with mocked dependencies."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_runners import (
+        AgentDrivenRunner,
+    )
+
+    transport = AsyncMock()
+    if transport_side_effect:
+        transport.call_tool.side_effect = transport_side_effect
+    else:
+        transport.call_tool.return_value = transport_return or {}
+
+    callback = AsyncMock()
+    cancel_event = asyncio.Event()
+    if cancel:
+        cancel_event.set()
+
+    runner = AgentDrivenRunner(
+        transport=transport,
+        event_callback=callback,
+        session_id=SESSION_ID,
+        cancel_event=cancel_event,
+        entry_tool=entry_tool,
+        structured_response=structured_response,
+    )
+    return runner, transport, callback
+
+
+def test_agent_driven_simple_text():
+    """Transport returns plain text content; verify single COMPLETION event."""
+    runner, transport, callback = _make_runner(
+        transport_return={"content": [{"type": "text", "text": "Answer"}]}
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "hello"}])
+    )
+
+    transport.call_tool.assert_awaited_once_with(
+        "execute", {"messages": [{"role": "user", "content": "hello"}]}
+    )
+    assert callback.await_count == 1
+    event: AgentEvent = callback.call_args_list[0][0][0]
+    assert event.kind == AgentEventKind.COMPLETION
+    assert event.payload["text"] == "Answer"
+    assert event.session_id == SESSION_ID
+
+
+def test_agent_driven_structured_steps():
+    """Transport returns structured JSON steps; verify multiple events in order."""
+    steps = {
+        "steps": [
+            {"type": "thinking", "text": "Let me think..."},
+            {"type": "tool_call", "tool_name": "search", "arguments": {"q": "test"}},
+            {"type": "tool_result", "tool_name": "search", "output": "found it"},
+            {"type": "completion", "text": "Here is the answer"},
+        ]
+    }
+    runner, transport, callback = _make_runner(
+        transport_return={"content": [{"type": "text", "text": json.dumps(steps)}]},
+        structured_response=True,
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "search for test"}])
+    )
+
+    assert callback.await_count == 4
+    events = [call[0][0] for call in callback.call_args_list]
+
+    assert events[0].kind == AgentEventKind.THINKING
+    assert events[0].payload["text"] == "Let me think..."
+
+    assert events[1].kind == AgentEventKind.TOOL_CALL
+    assert events[1].payload["tool_name"] == "search"
+    assert events[1].payload["arguments"] == {"q": "test"}
+
+    assert events[2].kind == AgentEventKind.TOOL_RESULT
+    assert events[2].payload["tool_name"] == "search"
+    assert events[2].payload["output"] == "found it"
+
+    assert events[3].kind == AgentEventKind.COMPLETION
+    assert events[3].payload["text"] == "Here is the answer"
+
+
+def test_agent_driven_structured_no_completion_step():
+    """If structured response has no completion step, emit one with raw text."""
+    steps = {
+        "steps": [
+            {"type": "thinking", "text": "hmm"},
+        ]
+    }
+    raw_text = json.dumps(steps)
+    runner, transport, callback = _make_runner(
+        transport_return={"content": [{"type": "text", "text": raw_text}]},
+        structured_response=True,
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "go"}])
+    )
+
+    events = [call[0][0] for call in callback.call_args_list]
+    assert events[0].kind == AgentEventKind.THINKING
+    # Fallback completion
+    assert events[-1].kind == AgentEventKind.COMPLETION
+    assert events[-1].payload["text"] == raw_text
+
+
+def test_agent_driven_tool_error():
+    """Transport.call_tool raises; verify ERROR event is emitted."""
+    runner, transport, callback = _make_runner(
+        transport_side_effect=RuntimeError("connection lost")
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "hi"}])
+    )
+
+    assert callback.await_count == 1
+    event: AgentEvent = callback.call_args_list[0][0][0]
+    assert event.kind == AgentEventKind.ERROR
+    assert "connection lost" in event.payload["error"]
+
+
+def test_agent_driven_cancel():
+    """Cancel event is set; verify no call_tool and no events."""
+    runner, transport, callback = _make_runner(cancel=True)
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "hi"}])
+    )
+
+    transport.call_tool.assert_not_awaited()
+    callback.assert_not_awaited()
+
+
+def test_agent_driven_custom_entry_tool():
+    """Verify custom entry_tool name is used in call_tool."""
+    runner, transport, callback = _make_runner(
+        transport_return={"content": [{"type": "text", "text": "ok"}]},
+        entry_tool="run_agent",
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "go"}])
+    )
+
+    transport.call_tool.assert_awaited_once_with(
+        "run_agent", {"messages": [{"role": "user", "content": "go"}]}
+    )

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_agent.py
@@ -48,15 +48,14 @@ def _make_runner(
     return runner, transport, callback
 
 
-def test_agent_driven_simple_text():
+@pytest.mark.asyncio
+async def test_agent_driven_simple_text():
     """Transport returns plain text content; verify single COMPLETION event."""
     runner, transport, callback = _make_runner(
         transport_return={"content": [{"type": "text", "text": "Answer"}]}
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "hello"}])
-    )
+    await runner.run([{"role": "user", "content": "hello"}])
 
     transport.call_tool.assert_awaited_once_with(
         "execute", {"messages": [{"role": "user", "content": "hello"}]}
@@ -68,7 +67,8 @@ def test_agent_driven_simple_text():
     assert event.session_id == SESSION_ID
 
 
-def test_agent_driven_structured_steps():
+@pytest.mark.asyncio
+async def test_agent_driven_structured_steps():
     """Transport returns structured JSON steps; verify multiple events in order."""
     steps = {
         "steps": [
@@ -83,9 +83,7 @@ def test_agent_driven_structured_steps():
         structured_response=True,
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "search for test"}])
-    )
+    await runner.run([{"role": "user", "content": "search for test"}])
 
     assert callback.await_count == 4
     events = [call[0][0] for call in callback.call_args_list]
@@ -105,7 +103,8 @@ def test_agent_driven_structured_steps():
     assert events[3].payload["text"] == "Here is the answer"
 
 
-def test_agent_driven_structured_no_completion_step():
+@pytest.mark.asyncio
+async def test_agent_driven_structured_no_completion_step():
     """If structured response has no completion step, emit one with raw text."""
     steps = {
         "steps": [
@@ -118,9 +117,7 @@ def test_agent_driven_structured_no_completion_step():
         structured_response=True,
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "go"}])
-    )
+    await runner.run([{"role": "user", "content": "go"}])
 
     events = [call[0][0] for call in callback.call_args_list]
     assert events[0].kind == AgentEventKind.THINKING
@@ -129,15 +126,14 @@ def test_agent_driven_structured_no_completion_step():
     assert events[-1].payload["text"] == raw_text
 
 
-def test_agent_driven_tool_error():
+@pytest.mark.asyncio
+async def test_agent_driven_tool_error():
     """Transport.call_tool raises; verify ERROR event is emitted."""
     runner, transport, callback = _make_runner(
         transport_side_effect=RuntimeError("connection lost")
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "hi"}])
-    )
+    await runner.run([{"role": "user", "content": "hi"}])
 
     assert callback.await_count == 1
     event: AgentEvent = callback.call_args_list[0][0][0]
@@ -145,28 +141,26 @@ def test_agent_driven_tool_error():
     assert "connection lost" in event.payload["error"]
 
 
-def test_agent_driven_cancel():
+@pytest.mark.asyncio
+async def test_agent_driven_cancel():
     """Cancel event is set; verify no call_tool and no events."""
     runner, transport, callback = _make_runner(cancel=True)
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "hi"}])
-    )
+    await runner.run([{"role": "user", "content": "hi"}])
 
     transport.call_tool.assert_not_awaited()
     callback.assert_not_awaited()
 
 
-def test_agent_driven_custom_entry_tool():
+@pytest.mark.asyncio
+async def test_agent_driven_custom_entry_tool():
     """Verify custom entry_tool name is used in call_tool."""
     runner, transport, callback = _make_runner(
         transport_return={"content": [{"type": "text", "text": "ok"}]},
         entry_tool="run_agent",
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "go"}])
-    )
+    await runner.run([{"role": "user", "content": "go"}])
 
     transport.call_tool.assert_awaited_once_with(
         "run_agent", {"messages": [{"role": "user", "content": "go"}]}

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
@@ -92,15 +92,14 @@ def _make_runner(
     return runner, transport, llm_caller, tool_gate, callback, cancel_event
 
 
-def test_llm_driven_single_turn():
+@pytest.mark.asyncio
+async def test_llm_driven_single_turn():
     """LLM returns text immediately; verify single COMPLETION event."""
     runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
         llm_responses=[LLMResponse(text="The answer is 42")]
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "what is the answer?"}])
-    )
+    await runner.run([{"role": "user", "content": "what is the answer?"}])
 
     assert callback.await_count == 1
     event: AgentEvent = callback.call_args_list[0][0][0]
@@ -110,7 +109,8 @@ def test_llm_driven_single_turn():
     transport.call_tool.assert_not_awaited()
 
 
-def test_llm_driven_multi_turn():
+@pytest.mark.asyncio
+async def test_llm_driven_multi_turn():
     """LLM returns tool_call first, then text. Verify TOOL_CALL -> TOOL_RESULT -> COMPLETION."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "hello"})
     runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
@@ -123,9 +123,7 @@ def test_llm_driven_multi_turn():
         ],
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "search hello"}])
-    )
+    await runner.run([{"role": "user", "content": "search hello"}])
 
     events = [call[0][0] for call in callback.call_args_list]
     assert len(events) == 3
@@ -143,7 +141,8 @@ def test_llm_driven_multi_turn():
     assert events[2].payload["text"] == "Found the answer"
 
 
-def test_llm_driven_max_iterations():
+@pytest.mark.asyncio
+async def test_llm_driven_max_iterations():
     """LLM always returns tool_calls; verify max_iterations COMPLETION."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "loop"})
     # Return tool_calls every time (more than max_iterations)
@@ -153,9 +152,7 @@ def test_llm_driven_max_iterations():
         max_iterations=3,
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "loop"}])
-    )
+    await runner.run([{"role": "user", "content": "loop"}])
 
     events = [call[0][0] for call in callback.call_args_list]
     # Last event should be COMPLETION with max_iterations
@@ -164,7 +161,8 @@ def test_llm_driven_max_iterations():
     assert last.payload["stop_reason"] == "max_iterations"
 
 
-def test_llm_driven_cancel():
+@pytest.mark.asyncio
+async def test_llm_driven_cancel():
     """Cancel event set after first iteration; verify loop stops."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "test"})
     responses = [
@@ -179,15 +177,14 @@ def test_llm_driven_cancel():
         cancel_after=2,
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "test"}])
-    )
+    await runner.run([{"role": "user", "content": "test"}])
 
     # LLM should have been called once (first iteration), then cancel kicks in
     assert llm_caller.call.await_count == 1
 
 
-def test_llm_driven_governance_denial():
+@pytest.mark.asyncio
+async def test_llm_driven_governance_denial():
     """ToolGate returns denied; verify TOOL_RESULT with is_error."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "forbidden"})
     runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
@@ -198,9 +195,7 @@ def test_llm_driven_governance_denial():
         gate_results=[ToolGateResult(approved=False, reason="Not allowed")],
     )
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "do forbidden thing"}])
-    )
+    await runner.run([{"role": "user", "content": "do forbidden thing"}])
 
     events = [call[0][0] for call in callback.call_args_list]
     # Should have: denied TOOL_RESULT, then COMPLETION
@@ -216,7 +211,8 @@ def test_llm_driven_governance_denial():
     assert completion.kind == AgentEventKind.COMPLETION
 
 
-def test_llm_driven_transport_error():
+@pytest.mark.asyncio
+async def test_llm_driven_transport_error():
     """Transport raises during tool execution; verify ERROR event."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "boom"})
     runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
@@ -229,9 +225,7 @@ def test_llm_driven_transport_error():
     # Override: side_effect with exception
     transport.call_tool.side_effect = RuntimeError("transport failed")
 
-    asyncio.get_event_loop().run_until_complete(
-        runner.run([{"role": "user", "content": "boom"}])
-    )
+    await runner.run([{"role": "user", "content": "boom"}])
 
     events = [call[0][0] for call in callback.call_args_list]
     # TOOL_CALL, then TOOL_RESULT with error

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
@@ -1,0 +1,244 @@
+"""Tests for LLMDrivenRunner — ReAct loop: LLM decides tools, ToolGate approves, transport executes."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_llm_caller import (
+    LLMResponse,
+    LLMToolCall,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.events import AgentEvent, AgentEventKind
+from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import ToolGateResult
+
+pytestmark = pytest.mark.unit
+
+SESSION_ID = "test-session-llm"
+
+MCP_TOOLS = [
+    {
+        "name": "search",
+        "description": "Web search",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+        },
+    }
+]
+
+
+def _make_runner(
+    llm_responses: list[LLMResponse] | None = None,
+    gate_results: list[ToolGateResult] | None = None,
+    transport_returns: list[dict] | None = None,
+    cancel_after: int | None = None,
+    max_iterations: int = 20,
+):
+    """Helper to build an LLMDrivenRunner with mocked dependencies."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_runners import (
+        LLMDrivenRunner,
+    )
+
+    transport = AsyncMock()
+    if transport_returns:
+        transport.call_tool.side_effect = transport_returns
+    else:
+        transport.call_tool.return_value = {"content": [{"type": "text", "text": "result"}]}
+
+    llm_caller = AsyncMock()
+    if llm_responses:
+        llm_caller.call.side_effect = llm_responses
+    else:
+        llm_caller.call.return_value = LLMResponse(text="Done")
+
+    tool_gate = AsyncMock()
+    if gate_results:
+        tool_gate.request_approval.side_effect = gate_results
+    else:
+        tool_gate.request_approval.return_value = ToolGateResult(approved=True)
+
+    callback = AsyncMock()
+    cancel_event = asyncio.Event()
+
+    # If cancel_after is set, wrap callback to set cancel after N calls
+    if cancel_after is not None:
+        original_callback = callback
+
+        call_count = 0
+
+        async def cancelling_callback(event):
+            nonlocal call_count
+            call_count += 1
+            await original_callback(event)
+            if call_count >= cancel_after:
+                cancel_event.set()
+
+        callback_fn = cancelling_callback
+    else:
+        callback_fn = callback
+
+    runner = LLMDrivenRunner(
+        transport=transport,
+        event_callback=callback_fn,
+        session_id=SESSION_ID,
+        cancel_event=cancel_event,
+        llm_caller=llm_caller,
+        tool_gate=tool_gate,
+        tools=MCP_TOOLS,
+        max_iterations=max_iterations,
+    )
+    return runner, transport, llm_caller, tool_gate, callback, cancel_event
+
+
+def test_llm_driven_single_turn():
+    """LLM returns text immediately; verify single COMPLETION event."""
+    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+        llm_responses=[LLMResponse(text="The answer is 42")]
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "what is the answer?"}])
+    )
+
+    assert callback.await_count == 1
+    event: AgentEvent = callback.call_args_list[0][0][0]
+    assert event.kind == AgentEventKind.COMPLETION
+    assert event.payload["text"] == "The answer is 42"
+    assert event.payload["stop_reason"] == "end_turn"
+    transport.call_tool.assert_not_awaited()
+
+
+def test_llm_driven_multi_turn():
+    """LLM returns tool_call first, then text. Verify TOOL_CALL -> TOOL_RESULT -> COMPLETION."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "hello"})
+    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+        llm_responses=[
+            LLMResponse(tool_calls=[tc]),
+            LLMResponse(text="Found the answer"),
+        ],
+        transport_returns=[
+            {"content": [{"type": "text", "text": "search result"}]},
+        ],
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "search hello"}])
+    )
+
+    events = [call[0][0] for call in callback.call_args_list]
+    assert len(events) == 3
+
+    assert events[0].kind == AgentEventKind.TOOL_CALL
+    assert events[0].payload["tool_name"] == "search"
+    assert events[0].payload["arguments"] == {"query": "hello"}
+
+    assert events[1].kind == AgentEventKind.TOOL_RESULT
+    assert events[1].payload["tool_name"] == "search"
+    assert events[1].payload["output"] == "search result"
+    assert events[1].payload["is_error"] is False
+
+    assert events[2].kind == AgentEventKind.COMPLETION
+    assert events[2].payload["text"] == "Found the answer"
+
+
+def test_llm_driven_max_iterations():
+    """LLM always returns tool_calls; verify max_iterations COMPLETION."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "loop"})
+    # Return tool_calls every time (more than max_iterations)
+    responses = [LLMResponse(tool_calls=[tc]) for _ in range(5)]
+    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+        llm_responses=responses,
+        max_iterations=3,
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "loop"}])
+    )
+
+    events = [call[0][0] for call in callback.call_args_list]
+    # Last event should be COMPLETION with max_iterations
+    last = events[-1]
+    assert last.kind == AgentEventKind.COMPLETION
+    assert last.payload["stop_reason"] == "max_iterations"
+
+
+def test_llm_driven_cancel():
+    """Cancel event set after first iteration; verify loop stops."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "test"})
+    responses = [
+        LLMResponse(tool_calls=[tc]),
+        LLMResponse(tool_calls=[tc]),
+        LLMResponse(text="done"),
+    ]
+    # Cancel after 2 events (TOOL_CALL + TOOL_RESULT from first iteration)
+    runner, transport, llm_caller, tool_gate, callback, cancel_event = _make_runner(
+        llm_responses=responses,
+        max_iterations=10,
+        cancel_after=2,
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "test"}])
+    )
+
+    # LLM should have been called once (first iteration), then cancel kicks in
+    assert llm_caller.call.await_count == 1
+
+
+def test_llm_driven_governance_denial():
+    """ToolGate returns denied; verify TOOL_RESULT with is_error."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "forbidden"})
+    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+        llm_responses=[
+            LLMResponse(tool_calls=[tc]),
+            LLMResponse(text="Okay, denied"),
+        ],
+        gate_results=[ToolGateResult(approved=False, reason="Not allowed")],
+    )
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "do forbidden thing"}])
+    )
+
+    events = [call[0][0] for call in callback.call_args_list]
+    # Should have: denied TOOL_RESULT, then COMPLETION
+    denied = events[0]
+    assert denied.kind == AgentEventKind.TOOL_RESULT
+    assert denied.payload["is_error"] is True
+    assert "Not allowed" in denied.payload["output"]
+
+    # Transport should NOT have been called (denied)
+    transport.call_tool.assert_not_awaited()
+
+    completion = events[-1]
+    assert completion.kind == AgentEventKind.COMPLETION
+
+
+def test_llm_driven_transport_error():
+    """Transport raises during tool execution; verify ERROR event."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "boom"})
+    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+        llm_responses=[
+            LLMResponse(tool_calls=[tc]),
+            LLMResponse(text="recovered"),
+        ],
+        transport_returns=[RuntimeError("transport failed")],
+    )
+    # Override: side_effect with exception
+    transport.call_tool.side_effect = RuntimeError("transport failed")
+
+    asyncio.get_event_loop().run_until_complete(
+        runner.run([{"role": "user", "content": "boom"}])
+    )
+
+    events = [call[0][0] for call in callback.call_args_list]
+    # TOOL_CALL, then TOOL_RESULT with error
+    tool_call_ev = events[0]
+    assert tool_call_ev.kind == AgentEventKind.TOOL_CALL
+
+    tool_result_ev = events[1]
+    assert tool_result_ev.kind == AgentEventKind.TOOL_RESULT
+    assert tool_result_ev.payload["is_error"] is True
+    assert "transport failed" in tool_result_ev.payload["output"]

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
@@ -236,3 +236,60 @@ async def test_llm_driven_transport_error():
     assert tool_result_ev.kind == AgentEventKind.TOOL_RESULT
     assert tool_result_ev.payload["is_error"] is True
     assert "transport failed" in tool_result_ev.payload["output"]
+
+
+@pytest.mark.asyncio
+async def test_llm_driven_with_governance_filter_emits_single_permission_request():
+    """Governance-backed runs should not re-enter approval for already-approved tool calls."""
+    from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus
+    from tldw_Server_API.app.core.Agent_Client_Protocol.governance_filter import (
+        GovernanceFilter,
+        GovernanceToolGate,
+    )
+    from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_runners import (
+        LLMDrivenRunner,
+    )
+
+    tc = LLMToolCall(id="tc1", name="bash", arguments={"cmd": "ls"})
+    transport = AsyncMock()
+    transport.call_tool.return_value = {"content": [{"type": "text", "text": "ok"}]}
+    llm_caller = AsyncMock()
+    llm_caller.call.side_effect = [
+        LLMResponse(tool_calls=[tc]),
+        LLMResponse(text="done"),
+    ]
+
+    bus = SessionEventBus(session_id=SESSION_ID)
+    gov = GovernanceFilter(bus=bus)
+    gate = GovernanceToolGate(governance_filter=gov)
+    queue = bus.subscribe("test")
+
+    async def approve_once():
+        permission_request = await asyncio.wait_for(queue.get(), timeout=1.0)
+        assert permission_request.kind == AgentEventKind.PERMISSION_REQUEST
+        await gov.on_permission_response(permission_request.payload["request_id"], decision="approve")
+
+    approve_task = asyncio.create_task(approve_once())
+
+    runner = LLMDrivenRunner(
+        transport=transport,
+        event_callback=gov.process,
+        session_id=SESSION_ID,
+        cancel_event=asyncio.Event(),
+        llm_caller=llm_caller,
+        tool_gate=gate,
+        tools=MCP_TOOLS,
+    )
+
+    await runner.run([{"role": "user", "content": "run ls"}])
+    await approve_task
+
+    events = []
+    while not queue.empty():
+        events.append(await queue.get())
+
+    assert [event.kind for event in events] == [
+        AgentEventKind.TOOL_CALL,
+        AgentEventKind.TOOL_RESULT,
+        AgentEventKind.COMPLETION,
+    ]

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
@@ -95,7 +95,7 @@ def _make_runner(
 @pytest.mark.asyncio
 async def test_llm_driven_single_turn():
     """LLM returns text immediately; verify single COMPLETION event."""
-    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+    runner, transport, _llm_caller, _tool_gate, callback, _cancel_event = _make_runner(
         llm_responses=[LLMResponse(text="The answer is 42")]
     )
 
@@ -113,7 +113,7 @@ async def test_llm_driven_single_turn():
 async def test_llm_driven_multi_turn():
     """LLM returns tool_call first, then text. Verify TOOL_CALL -> TOOL_RESULT -> COMPLETION."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "hello"})
-    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+    runner, _transport, _llm_caller, _tool_gate, callback, _cancel_event = _make_runner(
         llm_responses=[
             LLMResponse(tool_calls=[tc]),
             LLMResponse(text="Found the answer"),
@@ -147,7 +147,7 @@ async def test_llm_driven_max_iterations():
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "loop"})
     # Return tool_calls every time (more than max_iterations)
     responses = [LLMResponse(tool_calls=[tc]) for _ in range(5)]
-    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+    runner, _transport, _llm_caller, _tool_gate, callback, _cancel_event = _make_runner(
         llm_responses=responses,
         max_iterations=3,
     )
@@ -171,7 +171,7 @@ async def test_llm_driven_cancel():
         LLMResponse(text="done"),
     ]
     # Cancel after 2 events (TOOL_CALL + TOOL_RESULT from first iteration)
-    runner, transport, llm_caller, tool_gate, callback, cancel_event = _make_runner(
+    runner, _transport, llm_caller, _tool_gate, _callback, cancel_event = _make_runner(
         llm_responses=responses,
         max_iterations=10,
         cancel_after=2,
@@ -184,10 +184,43 @@ async def test_llm_driven_cancel():
 
 
 @pytest.mark.asyncio
+async def test_llm_driven_cancel_stops_remaining_tool_calls_in_same_turn():
+    """Cancellation after one tool result should prevent later tool approvals/executions."""
+    tool_calls = [
+        LLMToolCall(id="tc1", name="search", arguments={"query": "first"}),
+        LLMToolCall(id="tc2", name="search", arguments={"query": "second"}),
+    ]
+    runner, transport, llm_caller, tool_gate, callback, cancel_event = _make_runner(
+        llm_responses=[
+            LLMResponse(tool_calls=tool_calls),
+            LLMResponse(text="done"),
+        ],
+        transport_returns=[
+            {"content": [{"type": "text", "text": "first result"}]},
+            {"content": [{"type": "text", "text": "second result"}]},
+        ],
+        cancel_after=2,
+    )
+
+    await runner.run([{"role": "user", "content": "test"}])
+
+    assert cancel_event.is_set() is True
+    assert llm_caller.call.await_count == 1
+    assert tool_gate.request_approval.await_count == 1
+    assert transport.call_tool.await_count == 1
+
+    events = [call[0][0] for call in callback.call_args_list]
+    assert [event.kind for event in events] == [
+        AgentEventKind.TOOL_CALL,
+        AgentEventKind.TOOL_RESULT,
+    ]
+
+
+@pytest.mark.asyncio
 async def test_llm_driven_governance_denial():
     """ToolGate returns denied; verify TOOL_RESULT with is_error."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "forbidden"})
-    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+    runner, transport, _llm_caller, _tool_gate, callback, _cancel_event = _make_runner(
         llm_responses=[
             LLMResponse(tool_calls=[tc]),
             LLMResponse(text="Okay, denied"),
@@ -215,7 +248,7 @@ async def test_llm_driven_governance_denial():
 async def test_llm_driven_transport_error():
     """Transport raises during tool execution; verify ERROR event."""
     tc = LLMToolCall(id="tc1", name="search", arguments={"query": "boom"})
-    runner, transport, llm_caller, tool_gate, callback, _ = _make_runner(
+    runner, transport, _llm_caller, _tool_gate, callback, _cancel_event = _make_runner(
         llm_responses=[
             LLMResponse(tool_calls=[tc]),
             LLMResponse(text="recovered"),

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_runners_llm.py
@@ -272,6 +272,37 @@ async def test_llm_driven_transport_error():
 
 
 @pytest.mark.asyncio
+async def test_llm_driven_llm_error_emits_error_event():
+    """LLM call failures should be surfaced as terminal ERROR events."""
+    runner, _transport, llm_caller, _tool_gate, callback, _cancel_event = _make_runner()
+    llm_caller.call.side_effect = RuntimeError("llm failed")
+
+    await runner.run([{"role": "user", "content": "boom"}])
+
+    assert callback.await_count == 1
+    event: AgentEvent = callback.call_args_list[0][0][0]
+    assert event.kind == AgentEventKind.ERROR
+    assert "llm failed" in event.payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_llm_driven_gate_error_emits_error_event():
+    """Approval-gate failures should be surfaced as terminal ERROR events."""
+    tc = LLMToolCall(id="tc1", name="search", arguments={"query": "boom"})
+    runner, _transport, _llm_caller, tool_gate, callback, _cancel_event = _make_runner(
+        llm_responses=[LLMResponse(tool_calls=[tc])]
+    )
+    tool_gate.request_approval.side_effect = RuntimeError("gate failed")
+
+    await runner.run([{"role": "user", "content": "boom"}])
+
+    assert callback.await_count == 1
+    event: AgentEvent = callback.call_args_list[0][0][0]
+    assert event.kind == AgentEventKind.ERROR
+    assert "gate failed" in event.payload["error"]
+
+
+@pytest.mark.asyncio
 async def test_llm_driven_with_governance_filter_emits_single_permission_request():
     """Governance-backed runs should not re-enter approval for already-approved tool calls."""
     from tldw_Server_API.app.core.Agent_Client_Protocol.event_bus import SessionEventBus

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
@@ -189,6 +189,49 @@ async def test_sse_transport_json_rpc_call():
     assert posted_json["id"] == "1"
     assert posted_json["method"] == "tools/list"
     assert posted_json["params"] == {}
+    assert "1" not in t._pending
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_call_requires_post_url():
+    """_json_rpc_call should require that post_url has been initialized."""
+    t = _make_transport(post_url=None)
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+    t._http_client = mock_http
+
+    with pytest.raises(RuntimeError, match="post_url must be set"):
+        await t._json_rpc_call("tools/list", {})
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_call_cleans_pending_on_timeout():
+    """Timed-out JSON-RPC calls should not leak pending futures."""
+    t = _make_transport(timeout_sec=0)
+    t._post_url = "http://localhost:8080/messages"
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+    t._http_client = mock_http
+
+    with pytest.raises(asyncio.TimeoutError):
+        await t._json_rpc_call("tools/list", {})
+
+    assert t._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_call_cleans_pending_on_post_error():
+    """POST failures should remove any pending future for the request."""
+    t = _make_transport()
+    t._post_url = "http://localhost:8080/messages"
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(side_effect=RuntimeError("post failed"))
+    t._http_client = mock_http
+
+    with pytest.raises(RuntimeError, match="post failed"):
+        await t._json_rpc_call("tools/list", {})
+
+    assert t._pending == {}
 
 
 @pytest.mark.asyncio
@@ -208,6 +251,18 @@ async def test_sse_transport_json_rpc_notify():
     assert posted_json["method"] == "initialized"
     assert posted_json["params"] == {}
     assert "id" not in posted_json
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_notify_requires_post_url():
+    """_json_rpc_notify should require that post_url has been initialized."""
+    t = _make_transport(post_url=None)
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+    t._http_client = mock_http
+
+    with pytest.raises(RuntimeError, match="post_url must be set"):
+        await t._json_rpc_notify("initialized", {})
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
@@ -1,0 +1,268 @@
+"""Tests for MCPSSETransport — SSE-based MCP transport."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.sse import (
+    MCPSSETransport,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_transport(
+    sse_url: str = "http://localhost:8080/sse",
+    post_url: str | None = "http://localhost:8080/messages",
+    **kwargs,
+) -> MCPSSETransport:
+    return MCPSSETransport(sse_url=sse_url, post_url=post_url, **kwargs)
+
+
+async def _resolve_pending(transport: MCPSSETransport, req_id: str, result: dict):
+    """Simulate an SSE response arriving for a pending request."""
+    # Give the call a moment to register the pending future
+    for _ in range(50):
+        if req_id in transport._pending:
+            break
+        await asyncio.sleep(0.01)
+    future = transport._pending.get(req_id)
+    if future and not future.done():
+        future.set_result(result)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_sse_transport_not_connected_initially():
+    """A freshly created transport should not be connected."""
+    t = _make_transport()
+    assert t.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_connect_with_explicit_post_url():
+    """connect() with explicit post_url skips discovery and performs handshake."""
+    t = _make_transport(post_url="http://localhost:8080/messages")
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+    with patch.object(t, "_create_http_client", return_value=mock_http):
+        # Mock the reader loop so it doesn't actually run
+        with patch.object(t, "_sse_reader_loop", new_callable=AsyncMock):
+            # We need _json_rpc_call to work for the handshake.
+            # Mock it to return a valid initialize response.
+            with patch.object(t, "_json_rpc_call", new_callable=AsyncMock) as mock_call:
+                mock_call.return_value = {
+                    "protocolVersion": "2024-11-05",
+                    "serverInfo": {"name": "test"},
+                    "capabilities": {},
+                }
+                with patch.object(t, "_json_rpc_notify", new_callable=AsyncMock) as mock_notify:
+                    await t.connect()
+
+    # Verify handshake
+    mock_call.assert_awaited_once()
+    call_args = mock_call.call_args
+    assert call_args[0][0] == "initialize"
+    init_params = call_args[0][1]
+    assert init_params["protocolVersion"] == "2024-11-05"
+    assert init_params["clientInfo"]["name"] == "tldw_acp_harness"
+
+    mock_notify.assert_awaited_once_with("initialized", {})
+    assert t.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_list_tools():
+    """list_tools() should call tools/list and return the tools array."""
+    t = _make_transport()
+    t._connected = True
+
+    tools = [
+        {"name": "echo", "description": "echoes input"},
+        {"name": "add", "description": "adds numbers"},
+    ]
+    with patch.object(t, "_json_rpc_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = {"tools": tools}
+        result = await t.list_tools()
+
+    assert result == tools
+    mock_call.assert_awaited_once_with("tools/list", {})
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_call_tool():
+    """call_tool() should forward name and arguments correctly."""
+    t = _make_transport()
+    t._connected = True
+
+    expected = {"content": [{"type": "text", "text": "hello"}]}
+    with patch.object(t, "_json_rpc_call", new_callable=AsyncMock) as mock_call:
+        mock_call.return_value = expected
+        result = await t.call_tool("echo", {"message": "hello"})
+
+    assert result == expected
+    mock_call.assert_awaited_once_with(
+        "tools/call", {"name": "echo", "arguments": {"message": "hello"}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_close():
+    """close() should cancel reader task, close HTTP client, mark disconnected."""
+    t = _make_transport()
+    t._connected = True
+
+    mock_task = MagicMock()
+    t._reader_task = mock_task
+
+    mock_http = AsyncMock()
+    t._http_client = mock_http
+
+    await t.close()
+
+    mock_task.cancel.assert_called_once()
+    mock_http.aclose.assert_awaited_once()
+    assert t.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_health_check():
+    """health_check() returns connection status."""
+    t = _make_transport()
+    assert await t.health_check() is False
+
+    t._connected = True
+    assert await t.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_list_tools_not_connected():
+    """list_tools() raises RuntimeError when not connected."""
+    t = _make_transport()
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await t.list_tools()
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_call_tool_not_connected():
+    """call_tool() raises RuntimeError when not connected."""
+    t = _make_transport()
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await t.call_tool("echo", {})
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_call():
+    """_json_rpc_call posts JSON-RPC and resolves from pending future."""
+    t = _make_transport()
+    t._post_url = "http://localhost:8080/messages"
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+    t._http_client = mock_http
+
+    expected_result = {"tools": []}
+
+    async def resolve_soon():
+        await _resolve_pending(t, "1", expected_result)
+
+    # Run the call and the resolver concurrently
+    resolve_task = asyncio.create_task(resolve_soon())
+    result = await t._json_rpc_call("tools/list", {})
+    await resolve_task
+
+    assert result == expected_result
+    # Verify the POST was made with correct JSON-RPC payload
+    mock_http.post.assert_awaited_once()
+    posted_json = mock_http.post.call_args[1]["json"]
+    assert posted_json["jsonrpc"] == "2.0"
+    assert posted_json["id"] == "1"
+    assert posted_json["method"] == "tools/list"
+    assert posted_json["params"] == {}
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_json_rpc_notify():
+    """_json_rpc_notify posts JSON-RPC notification (no id field)."""
+    t = _make_transport()
+    t._post_url = "http://localhost:8080/messages"
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+    t._http_client = mock_http
+
+    await t._json_rpc_notify("initialized", {})
+
+    mock_http.post.assert_awaited_once()
+    posted_json = mock_http.post.call_args[1]["json"]
+    assert posted_json["jsonrpc"] == "2.0"
+    assert posted_json["method"] == "initialized"
+    assert posted_json["params"] == {}
+    assert "id" not in posted_json
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_parse_sse_events():
+    """_parse_sse_line correctly accumulates and yields SSE events."""
+    t = _make_transport()
+
+    # Simulate SSE lines
+    lines = [
+        "event: endpoint",
+        "data: /messages",
+        "",  # blank = event boundary
+        "event: message",
+        'data: {"jsonrpc": "2.0", "id": "1", "result": {"ok": true}}',
+        "",
+    ]
+
+    events = []
+    for line in lines:
+        evt = t._parse_sse_line(line)
+        if evt is not None:
+            events.append(evt)
+
+    assert len(events) == 2
+    assert events[0] == ("endpoint", "/messages")
+    assert events[1] == ("message", '{"jsonrpc": "2.0", "id": "1", "result": {"ok": true}}')
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_discover_post_url():
+    """_discover_post_url resolves relative URL against sse_url base."""
+    t = MCPSSETransport(sse_url="http://localhost:8080/sse")
+
+    # Mock the HTTP client stream to return an endpoint event
+    async def mock_stream_lines():
+        yield "event: endpoint"
+        yield "data: /messages"
+        yield ""
+
+    mock_response = AsyncMock()
+    mock_response.aiter_lines = mock_stream_lines
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_http = AsyncMock()
+    mock_http.stream = MagicMock(return_value=mock_response)
+    t._http_client = mock_http
+
+    url = await t._discover_post_url()
+    assert url == "http://localhost:8080/messages"
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_close_idempotent():
+    """close() should be safe to call even when nothing is initialized."""
+    t = _make_transport()
+    await t.close()  # Should not raise
+    assert t.is_connected is False

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_sse_transport.py
@@ -83,6 +83,31 @@ async def test_sse_transport_connect_with_explicit_post_url():
 
 
 @pytest.mark.asyncio
+async def test_sse_transport_connect_cleans_up_on_handshake_failure():
+    """Failed connect handshakes should close the client and clear partial state."""
+    t = _make_transport(post_url="http://localhost:8080/messages")
+    mock_http = AsyncMock()
+    mock_http.post = AsyncMock(return_value=MagicMock(status_code=200))
+
+    with patch.object(t, "_create_http_client", return_value=mock_http):
+        with patch.object(t, "_sse_reader_loop", new_callable=AsyncMock):
+            with patch.object(
+                t,
+                "_json_rpc_call",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("initialize failed"),
+            ):
+                with pytest.raises(RuntimeError, match="initialize failed"):
+                    await t.connect()
+
+    mock_http.aclose.assert_awaited_once()
+    assert t.is_connected is False
+    assert t._http_client is None
+    assert t._reader_task is None
+    assert t._pending == {}
+
+
+@pytest.mark.asyncio
 async def test_sse_transport_list_tools():
     """list_tools() should call tools/list and return the tools array."""
     t = _make_transport()
@@ -289,6 +314,44 @@ async def test_sse_transport_parse_sse_events():
     assert len(events) == 2
     assert events[0] == ("endpoint", "/messages")
     assert events[1] == ("message", '{"jsonrpc": "2.0", "id": "1", "result": {"ok": true}}')
+
+
+def test_sse_transport_parse_sse_multiline_data_defaults_to_message():
+    """Data-only SSE frames should default to 'message' and preserve all data lines."""
+    t = _make_transport()
+
+    assert t._parse_sse_line("data: first line") is None
+    assert t._parse_sse_line("data: second line") is None
+    assert t._parse_sse_line("") == ("message", "first line\nsecond line")
+
+
+@pytest.mark.asyncio
+async def test_sse_transport_reader_loop_tears_down_on_stream_end():
+    """Reader loop should mark the transport disconnected and fail pending RPCs on EOF."""
+    t = _make_transport()
+    t._connected = True
+    pending = asyncio.get_running_loop().create_future()
+    t._pending["1"] = pending
+
+    async def empty_lines():
+        if False:
+            yield ""
+
+    mock_response = AsyncMock()
+    mock_response.aiter_lines = empty_lines
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=False)
+
+    mock_http = AsyncMock()
+    mock_http.stream = MagicMock(return_value=mock_response)
+    t._http_client = mock_http
+
+    await t._sse_reader_loop()
+
+    assert t.is_connected is False
+    assert t._pending == {}
+    assert pending.done() is True
+    assert isinstance(pending.exception(), RuntimeError)
 
 
 @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py
@@ -58,6 +58,20 @@ async def test_stdio_transport_connect_performs_handshake(transport, mock_client
 
 
 @pytest.mark.asyncio
+async def test_stdio_transport_connect_cleans_up_client_on_handshake_failure(transport, mock_client):
+    """A failed handshake should close the client and clear the cached reference."""
+    mock_client.call.side_effect = RuntimeError("handshake failed")
+
+    with patch.object(transport, "_create_client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="handshake failed"):
+            await transport.connect()
+
+    mock_client.close.assert_awaited_once()
+    assert transport.is_connected is False
+    assert transport._client is None
+
+
+@pytest.mark.asyncio
 async def test_stdio_transport_list_tools(transport, mock_client):
     """list_tools() should parse the tools from the call response."""
     tools = [
@@ -105,6 +119,7 @@ async def test_stdio_transport_close(transport, mock_client):
 
     mock_client.close.assert_awaited_once()
     assert transport.is_connected is False
+    assert transport._client is None
 
 
 @pytest.mark.asyncio
@@ -127,7 +142,27 @@ async def test_stdio_transport_list_tools_not_connected(transport):
 
 
 @pytest.mark.asyncio
+async def test_stdio_transport_list_tools_rejects_stale_client_when_disconnected(transport, mock_client):
+    """Disconnected transports should not reuse a cached stdio client."""
+    transport._client = mock_client
+    transport._connected = False
+
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.list_tools()
+
+
+@pytest.mark.asyncio
 async def test_stdio_transport_call_tool_not_connected(transport):
     """call_tool() raises RuntimeError when not connected."""
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.call_tool("echo", {})
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_call_tool_rejects_stale_client_when_disconnected(transport, mock_client):
+    """Disconnected transports should not execute tools through a stale client."""
+    transport._client = mock_client
+    transport._connected = False
+
     with pytest.raises(RuntimeError, match="Not connected"):
         await transport.call_tool("echo", {})

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_stdio_transport.py
@@ -1,0 +1,133 @@
+"""Tests for MCPStdioTransport — stdio-based MCP transport."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.stdio_client import ACPMessage
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.stdio import (
+    MCPStdioTransport,
+)
+
+
+@pytest.fixture
+def mock_client():
+    client = AsyncMock()
+    client.is_running = True
+    return client
+
+
+@pytest.fixture
+def transport():
+    return MCPStdioTransport(command="node", args=["server.js"], env={"FOO": "bar"})
+
+
+# ---- Tests ----
+
+
+def test_stdio_transport_not_connected_initially(transport):
+    """A freshly created transport should not be connected."""
+    assert transport.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_connect_performs_handshake(transport, mock_client):
+    """connect() should start the client, send initialize call, then initialized notification."""
+    mock_client.call.return_value = ACPMessage(
+        jsonrpc="2.0",
+        result={
+            "protocolVersion": "2024-11-05",
+            "serverInfo": {"name": "test"},
+            "capabilities": {},
+        },
+    )
+
+    with patch.object(transport, "_create_client", return_value=mock_client):
+        await transport.connect()
+
+    mock_client.start.assert_awaited_once()
+    mock_client.call.assert_awaited_once()
+    call_args = mock_client.call.call_args
+    assert call_args[0][0] == "initialize"
+    init_params = call_args[0][1]
+    assert init_params["protocolVersion"] == "2024-11-05"
+    assert init_params["clientInfo"]["name"] == "tldw_acp_harness"
+
+    mock_client.notify.assert_awaited_once_with("initialized", {})
+    assert transport.is_connected is True
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_list_tools(transport, mock_client):
+    """list_tools() should parse the tools from the call response."""
+    tools = [
+        {"name": "echo", "description": "echoes input"},
+        {"name": "add", "description": "adds numbers"},
+    ]
+    mock_client.call.return_value = ACPMessage(
+        jsonrpc="2.0",
+        result={"tools": tools},
+    )
+    transport._client = mock_client
+    transport._connected = True
+
+    result = await transport.list_tools()
+
+    assert result == tools
+    mock_client.call.assert_awaited_once_with("tools/list", {})
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_call_tool(transport, mock_client):
+    """call_tool() should forward name and arguments correctly."""
+    mock_client.call.return_value = ACPMessage(
+        jsonrpc="2.0",
+        result={"content": [{"type": "text", "text": "hello"}]},
+    )
+    transport._client = mock_client
+    transport._connected = True
+
+    result = await transport.call_tool("echo", {"message": "hello"})
+
+    assert result == {"content": [{"type": "text", "text": "hello"}]}
+    mock_client.call.assert_awaited_once_with(
+        "tools/call", {"name": "echo", "arguments": {"message": "hello"}}
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_close(transport, mock_client):
+    """close() should call client.close() and mark transport as disconnected."""
+    transport._client = mock_client
+    transport._connected = True
+
+    await transport.close()
+
+    mock_client.close.assert_awaited_once()
+    assert transport.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_health_check(transport, mock_client):
+    """health_check() returns True when client is running, False otherwise."""
+    transport._client = mock_client
+    transport._connected = True
+
+    assert await transport.health_check() is True
+
+    mock_client.is_running = False
+    assert await transport.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_list_tools_not_connected(transport):
+    """list_tools() raises RuntimeError when not connected."""
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.list_tools()
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport_call_tool_not_connected(transport):
+    """call_tool() raises RuntimeError when not connected."""
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.call_tool("echo", {})

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
@@ -16,34 +16,39 @@ pytestmark = pytest.mark.unit
 # ---- Helpers ----
 
 
-def make_json_response(result: dict, id: str = "1") -> MagicMock:
+def make_json_response(result: dict, request_id: str = "1") -> MagicMock:
     """Create a fake JSON response object."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "application/json"}
-    resp.json.return_value = {"jsonrpc": "2.0", "id": id, "result": result}
+    resp.json.return_value = {"jsonrpc": "2.0", "id": request_id, "result": result}
     resp.raise_for_status = MagicMock()
     return resp
 
 
-def make_sse_response(result: dict, id: str = "1") -> MagicMock:
+def make_sse_response(result: dict, request_id: str = "1") -> MagicMock:
     """Create a fake SSE response object."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "text/event-stream"}
-    resp.text = f'data: {json.dumps({"jsonrpc": "2.0", "id": id, "result": result})}\n\n'
+    resp.text = (
+        f'data: {json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result})}\n\n'
+    )
     resp.raise_for_status = MagicMock()
     return resp
 
 
-def make_json_error_response(message: str = "Method not found", id: str = "1") -> MagicMock:
+def make_json_error_response(
+    message: str = "Method not found",
+    request_id: str = "1",
+) -> MagicMock:
     """Create a fake JSON-RPC error response."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "application/json"}
     resp.json.return_value = {
         "jsonrpc": "2.0",
-        "id": id,
+        "id": request_id,
         "error": {"code": -32601, "message": message},
     }
     resp.raise_for_status = MagicMock()
@@ -91,7 +96,7 @@ async def test_streamable_http_connect_handshake(transport):
     # Second call: initialized notification (no id)
     mock_post = AsyncMock(
         side_effect=[
-            make_json_response(init_result, id="1"),
+            make_json_response(init_result, request_id="1"),
             make_notify_response(),
         ]
     )
@@ -121,6 +126,27 @@ async def test_streamable_http_connect_handshake(transport):
 
 
 @pytest.mark.asyncio
+async def test_streamable_http_connect_cleans_up_on_handshake_failure(transport):
+    """Handshake failures should close and clear the HTTP client."""
+    mock_client = MagicMock()
+    mock_client.aclose = AsyncMock()
+
+    with patch.object(transport, "_create_http_client", return_value=mock_client):
+        with patch.object(
+            transport,
+            "_json_rpc_call",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("initialize failed"),
+        ):
+            with pytest.raises(RuntimeError, match="initialize failed"):
+                await transport.connect()
+
+    mock_client.aclose.assert_awaited_once()
+    assert transport.is_connected is False
+    assert transport._http_client is None
+
+
+@pytest.mark.asyncio
 async def test_streamable_http_list_tools_json_mode(transport):
     """list_tools() should parse tools from a JSON response."""
     tools = [
@@ -128,7 +154,7 @@ async def test_streamable_http_list_tools_json_mode(transport):
         {"name": "add", "description": "adds numbers"},
     ]
     mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=make_json_response({"tools": tools}, id="1"))
+    mock_client.post = AsyncMock(return_value=make_json_response({"tools": tools}, request_id="1"))
     mock_client.aclose = AsyncMock()
     transport._http_client = mock_client
     transport._connected = True
@@ -145,7 +171,7 @@ async def test_streamable_http_call_tool_sse_mode(transport):
     """call_tool() should parse result from an SSE response."""
     tool_result = {"content": [{"type": "text", "text": "hello"}]}
     mock_client = MagicMock()
-    mock_client.post = AsyncMock(return_value=make_sse_response(tool_result, id="1"))
+    mock_client.post = AsyncMock(return_value=make_sse_response(tool_result, request_id="1"))
     mock_client.aclose = AsyncMock()
     transport._http_client = mock_client
     transport._connected = True
@@ -190,7 +216,7 @@ async def test_streamable_http_error_response(transport):
     """A JSON-RPC error in the response should raise RuntimeError."""
     mock_client = MagicMock()
     mock_client.post = AsyncMock(
-        return_value=make_json_error_response("Method not found", id="1")
+        return_value=make_json_error_response("Method not found", request_id="1")
     )
     mock_client.aclose = AsyncMock()
     transport._http_client = mock_client

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.streamable_http import (
     MCPStreamableHTTPTransport,
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 
 
 def make_json_response(result: dict, id: str = "1") -> MagicMock:
-    """Create a mock httpx response with application/json content-type."""
+    """Create a fake JSON response object."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "application/json"}
@@ -27,7 +27,7 @@ def make_json_response(result: dict, id: str = "1") -> MagicMock:
 
 
 def make_sse_response(result: dict, id: str = "1") -> MagicMock:
-    """Create a mock httpx response with text/event-stream content-type."""
+    """Create a fake SSE response object."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "text/event-stream"}
@@ -37,7 +37,7 @@ def make_sse_response(result: dict, id: str = "1") -> MagicMock:
 
 
 def make_json_error_response(message: str = "Method not found", id: str = "1") -> MagicMock:
-    """Create a mock httpx response with a JSON-RPC error."""
+    """Create a fake JSON-RPC error response."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "application/json"}
@@ -51,7 +51,7 @@ def make_json_error_response(message: str = "Method not found", id: str = "1") -
 
 
 def make_notify_response() -> MagicMock:
-    """Create a mock httpx response for a notification (no body needed)."""
+    """Create a fake notification response."""
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {"content-type": "application/json"}
@@ -96,12 +96,10 @@ async def test_streamable_http_connect_handshake(transport):
         ]
     )
 
-    with patch("httpx.AsyncClient") as MockClient:
-        instance = MagicMock()
-        instance.post = mock_post
-        instance.aclose = AsyncMock()
-        MockClient.return_value = instance
-
+    instance = MagicMock()
+    instance.post = mock_post
+    instance.aclose = AsyncMock()
+    with patch.object(transport, "_create_http_client", return_value=instance):
         await transport.connect()
 
     assert transport.is_connected is True

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_streamable_http_transport.py
@@ -1,0 +1,217 @@
+"""Tests for MCPStreamableHTTPTransport — streamable HTTP MCP transport."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.streamable_http import (
+    MCPStreamableHTTPTransport,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---- Helpers ----
+
+
+def make_json_response(result: dict, id: str = "1") -> MagicMock:
+    """Create a mock httpx response with application/json content-type."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {"jsonrpc": "2.0", "id": id, "result": result}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def make_sse_response(result: dict, id: str = "1") -> MagicMock:
+    """Create a mock httpx response with text/event-stream content-type."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "text/event-stream"}
+    resp.text = f'data: {json.dumps({"jsonrpc": "2.0", "id": id, "result": result})}\n\n'
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def make_json_error_response(message: str = "Method not found", id: str = "1") -> MagicMock:
+    """Create a mock httpx response with a JSON-RPC error."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": -32601, "message": message},
+    }
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def make_notify_response() -> MagicMock:
+    """Create a mock httpx response for a notification (no body needed)."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/json"}
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture
+def transport():
+    return MCPStreamableHTTPTransport(
+        endpoint="http://localhost:8080/mcp",
+        headers={"Authorization": "Bearer test"},
+        timeout_sec=15,
+    )
+
+
+# ---- Tests ----
+
+
+def test_streamable_http_not_connected_initially(transport):
+    """A freshly created transport should not be connected."""
+    assert transport.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_connect_handshake(transport):
+    """connect() should POST initialize then send initialized notification."""
+    init_result = {
+        "protocolVersion": "2024-11-05",
+        "serverInfo": {"name": "test-server"},
+        "capabilities": {},
+    }
+    # First call: initialize (JSON-RPC call with id "1")
+    # Second call: initialized notification (no id)
+    mock_post = AsyncMock(
+        side_effect=[
+            make_json_response(init_result, id="1"),
+            make_notify_response(),
+        ]
+    )
+
+    with patch("httpx.AsyncClient") as MockClient:
+        instance = MagicMock()
+        instance.post = mock_post
+        instance.aclose = AsyncMock()
+        MockClient.return_value = instance
+
+        await transport.connect()
+
+    assert transport.is_connected is True
+    assert mock_post.await_count == 2
+
+    # Verify initialize call
+    first_call = mock_post.call_args_list[0]
+    payload = first_call.kwargs.get("json") or first_call[1].get("json")
+    assert payload["method"] == "initialize"
+    assert payload["params"]["protocolVersion"] == "2024-11-05"
+    assert payload["params"]["clientInfo"]["name"] == "tldw_acp_harness"
+    assert "id" in payload
+
+    # Verify initialized notification
+    second_call = mock_post.call_args_list[1]
+    notify_payload = second_call.kwargs.get("json") or second_call[1].get("json")
+    assert notify_payload["method"] == "initialized"
+    assert "id" not in notify_payload
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_list_tools_json_mode(transport):
+    """list_tools() should parse tools from a JSON response."""
+    tools = [
+        {"name": "echo", "description": "echoes input"},
+        {"name": "add", "description": "adds numbers"},
+    ]
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=make_json_response({"tools": tools}, id="1"))
+    mock_client.aclose = AsyncMock()
+    transport._http_client = mock_client
+    transport._connected = True
+    transport._next_id = 1
+
+    result = await transport.list_tools()
+
+    assert result == tools
+    mock_client.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_call_tool_sse_mode(transport):
+    """call_tool() should parse result from an SSE response."""
+    tool_result = {"content": [{"type": "text", "text": "hello"}]}
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=make_sse_response(tool_result, id="1"))
+    mock_client.aclose = AsyncMock()
+    transport._http_client = mock_client
+    transport._connected = True
+    transport._next_id = 1
+
+    result = await transport.call_tool("echo", {"message": "hello"})
+
+    assert result == tool_result
+    # Verify the POST payload
+    call_args = mock_client.post.call_args
+    payload = call_args.kwargs.get("json") or call_args[1].get("json")
+    assert payload["method"] == "tools/call"
+    assert payload["params"]["name"] == "echo"
+    assert payload["params"]["arguments"] == {"message": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_close(transport):
+    """close() should call aclose on the HTTP client and mark disconnected."""
+    mock_client = MagicMock()
+    mock_client.aclose = AsyncMock()
+    transport._http_client = mock_client
+    transport._connected = True
+
+    await transport.close()
+
+    mock_client.aclose.assert_awaited_once()
+    assert transport.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_health_check(transport):
+    """health_check() returns True when connected, False otherwise."""
+    assert await transport.health_check() is False
+
+    transport._connected = True
+    assert await transport.health_check() is True
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_error_response(transport):
+    """A JSON-RPC error in the response should raise RuntimeError."""
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(
+        return_value=make_json_error_response("Method not found", id="1")
+    )
+    mock_client.aclose = AsyncMock()
+    transport._http_client = mock_client
+    transport._connected = True
+    transport._next_id = 1
+
+    with pytest.raises(RuntimeError, match="Method not found"):
+        await transport.list_tools()
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_list_tools_not_connected(transport):
+    """list_tools() raises RuntimeError when not connected."""
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.list_tools()
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_call_tool_not_connected(transport):
+    """call_tool() raises RuntimeError when not connected."""
+    with pytest.raises(RuntimeError, match="Not connected"):
+        await transport.call_tool("echo", {})

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
@@ -86,8 +86,8 @@ def test_create_transport_stdio_defaults():
         "command": "node",
     })
     assert isinstance(transport, MCPStdioTransport)
-    assert transport._args is None
-    assert transport._env is None
+    assert transport._args == []
+    assert transport._env == {}
 
 
 def test_create_transport_sse_defaults():

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
@@ -29,13 +29,13 @@ def test_mcp_transport_is_abstract():
 def test_create_transport_unknown_raises():
     """create_transport should raise ValueError for unknown protocol."""
     with pytest.raises(ValueError, match="Unknown.*protocol"):
-        create_transport({"protocol": "grpc"})
+        create_transport({"mcp_transport": "grpc"})
 
 
 def test_create_transport_stdio():
     """create_transport('stdio') should return MCPStdioTransport."""
     transport = create_transport({
-        "protocol": "stdio",
+        "mcp_transport": "stdio",
         "command": "python",
         "args": ["-m", "my_server"],
         "env": {"FOO": "bar"},
@@ -50,7 +50,7 @@ def test_create_transport_stdio():
 def test_create_transport_sse():
     """create_transport('sse') should return MCPSSETransport."""
     transport = create_transport({
-        "protocol": "sse",
+        "mcp_transport": "sse",
         "sse_url": "http://localhost:8080/sse",
         "post_url": "http://localhost:8080/messages",
         "headers": {"Authorization": "Bearer tok"},
@@ -67,7 +67,7 @@ def test_create_transport_sse():
 def test_create_transport_streamable_http():
     """create_transport('streamable_http') should return MCPStreamableHTTPTransport."""
     transport = create_transport({
-        "protocol": "streamable_http",
+        "mcp_transport": "streamable_http",
         "endpoint": "http://localhost:9090/mcp",
         "headers": {"X-Key": "val"},
         "timeout_sec": 45,
@@ -82,7 +82,7 @@ def test_create_transport_streamable_http():
 def test_create_transport_stdio_defaults():
     """Stdio transport defaults: args=None, env=None."""
     transport = create_transport({
-        "protocol": "stdio",
+        "mcp_transport": "stdio",
         "command": "node",
     })
     assert isinstance(transport, MCPStdioTransport)
@@ -93,7 +93,7 @@ def test_create_transport_stdio_defaults():
 def test_create_transport_sse_defaults():
     """SSE transport defaults: post_url=None, headers=None, timeout_sec=30."""
     transport = create_transport({
-        "protocol": "sse",
+        "mcp_transport": "sse",
         "sse_url": "http://localhost/sse",
     })
     assert isinstance(transport, MCPSSETransport)

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
@@ -1,0 +1,102 @@
+"""Tests for MCPTransport ABC, create_transport factory, and stub transports."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transport import (
+    MCPTransport,
+    create_transport,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.stdio import (
+    MCPStdioTransport,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.sse import (
+    MCPSSETransport,
+)
+from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.streamable_http import (
+    MCPStreamableHTTPTransport,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_mcp_transport_is_abstract():
+    """Instantiating MCPTransport directly should raise TypeError."""
+    with pytest.raises(TypeError):
+        MCPTransport()
+
+
+def test_create_transport_unknown_raises():
+    """create_transport should raise ValueError for unknown protocol."""
+    with pytest.raises(ValueError, match="Unknown.*protocol"):
+        create_transport({"protocol": "grpc"})
+
+
+def test_create_transport_stdio():
+    """create_transport('stdio') should return MCPStdioTransport."""
+    transport = create_transport({
+        "protocol": "stdio",
+        "command": "python",
+        "args": ["-m", "my_server"],
+        "env": {"FOO": "bar"},
+    })
+    assert isinstance(transport, MCPStdioTransport)
+    assert transport._command == "python"
+    assert transport._args == ["-m", "my_server"]
+    assert transport._env == {"FOO": "bar"}
+    assert transport.is_connected is False
+
+
+def test_create_transport_sse():
+    """create_transport('sse') should return MCPSSETransport."""
+    transport = create_transport({
+        "protocol": "sse",
+        "sse_url": "http://localhost:8080/sse",
+        "post_url": "http://localhost:8080/messages",
+        "headers": {"Authorization": "Bearer tok"},
+        "timeout_sec": 60,
+    })
+    assert isinstance(transport, MCPSSETransport)
+    assert transport._sse_url == "http://localhost:8080/sse"
+    assert transport._post_url == "http://localhost:8080/messages"
+    assert transport._headers == {"Authorization": "Bearer tok"}
+    assert transport._timeout_sec == 60
+    assert transport.is_connected is False
+
+
+def test_create_transport_streamable_http():
+    """create_transport('streamable_http') should return MCPStreamableHTTPTransport."""
+    transport = create_transport({
+        "protocol": "streamable_http",
+        "endpoint": "http://localhost:9090/mcp",
+        "headers": {"X-Key": "val"},
+        "timeout_sec": 45,
+    })
+    assert isinstance(transport, MCPStreamableHTTPTransport)
+    assert transport._endpoint == "http://localhost:9090/mcp"
+    assert transport._headers == {"X-Key": "val"}
+    assert transport._timeout_sec == 45
+    assert transport.is_connected is False
+
+
+def test_create_transport_stdio_defaults():
+    """Stdio transport defaults: args=None, env=None."""
+    transport = create_transport({
+        "protocol": "stdio",
+        "command": "node",
+    })
+    assert isinstance(transport, MCPStdioTransport)
+    assert transport._args is None
+    assert transport._env is None
+
+
+def test_create_transport_sse_defaults():
+    """SSE transport defaults: post_url=None, headers=None, timeout_sec=30."""
+    transport = create_transport({
+        "protocol": "sse",
+        "sse_url": "http://localhost/sse",
+    })
+    assert isinstance(transport, MCPSSETransport)
+    assert transport._post_url is None
+    assert transport._headers is None
+    assert transport._timeout_sec == 30

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_mcp_transport.py
@@ -16,6 +16,7 @@ from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.sse 
 from tldw_Server_API.app.core.Agent_Client_Protocol.adapters.mcp_transports.streamable_http import (
     MCPStreamableHTTPTransport,
 )
+from tldw_Server_API.app.core.exceptions import ValidationError
 
 pytestmark = pytest.mark.unit
 
@@ -27,9 +28,23 @@ def test_mcp_transport_is_abstract():
 
 
 def test_create_transport_unknown_raises():
-    """create_transport should raise ValueError for unknown protocol."""
-    with pytest.raises(ValueError, match="Unknown.*protocol"):
+    """create_transport should raise ValidationError for unknown protocol."""
+    with pytest.raises(ValidationError, match=r"Unknown.*protocol"):
         create_transport({"mcp_transport": "grpc"})
+
+
+@pytest.mark.parametrize(
+    ("protocol_config", "expected_message"),
+    [
+        ({"mcp_transport": "stdio"}, "command"),
+        ({"mcp_transport": "sse"}, "sse_url"),
+        ({"mcp_transport": "streamable_http"}, "endpoint"),
+    ],
+)
+def test_create_transport_missing_required_config_raises(protocol_config, expected_message):
+    """create_transport should fail with a deterministic config error for missing required keys."""
+    with pytest.raises(ValidationError, match=expected_message):
+        create_transport(protocol_config)
 
 
 def test_create_transport_stdio():

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
@@ -1,0 +1,42 @@
+"""Tests for MCP orchestration fields on AgentRegistryEntry (Phase B)."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
+
+pytestmark = pytest.mark.unit
+
+
+def test_registry_mcp_fields_defaults():
+    """Entry with just type+name should have all 7 MCP defaults."""
+    entry = AgentRegistryEntry(type="test_agent", name="Test Agent")
+
+    assert entry.mcp_orchestration == "agent_driven"
+    assert entry.mcp_entry_tool == "execute"
+    assert entry.mcp_structured_response is False
+    assert entry.mcp_llm_provider is None
+    assert entry.mcp_llm_model is None
+    assert entry.mcp_max_iterations == 20
+    assert entry.mcp_refresh_tools is False
+
+
+def test_registry_mcp_llm_driven_config():
+    """Entry with mcp_orchestration='llm_driven' and explicit provider/model/iterations."""
+    entry = AgentRegistryEntry(
+        type="llm_agent",
+        name="LLM Agent",
+        mcp_orchestration="llm_driven",
+        mcp_llm_provider="openai",
+        mcp_llm_model="gpt-4o",
+        mcp_max_iterations=50,
+    )
+
+    assert entry.mcp_orchestration == "llm_driven"
+    assert entry.mcp_llm_provider == "openai"
+    assert entry.mcp_llm_model == "gpt-4o"
+    assert entry.mcp_max_iterations == 50
+    # Other defaults unchanged
+    assert entry.mcp_entry_tool == "execute"
+    assert entry.mcp_structured_response is False
+    assert entry.mcp_refresh_tools is False

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_registry_mcp_fields.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import pytest
 
+from tldw_Server_API.app.api.v1.schemas.agent_client_protocol import (
+    ACPAgentRegisterRequest,
+    ACPAgentUpdateRequest,
+)
 from tldw_Server_API.app.core.Agent_Client_Protocol.agent_registry import AgentRegistryEntry
 
 pytestmark = pytest.mark.unit
@@ -40,3 +44,52 @@ def test_registry_mcp_llm_driven_config():
     assert entry.mcp_entry_tool == "execute"
     assert entry.mcp_structured_response is False
     assert entry.mcp_refresh_tools is False
+
+
+def test_agent_register_request_preserves_mcp_fields():
+    """ACP agent registration payloads should expose MCP orchestration fields."""
+    request = ACPAgentRegisterRequest(
+        agent_type="mcp_agent",
+        name="MCP Agent",
+        command="mcp-cli",
+        mcp_orchestration="llm_driven",
+        mcp_entry_tool="run",
+        mcp_structured_response=True,
+        mcp_llm_provider="openai",
+        mcp_llm_model="gpt-4o",
+        mcp_max_iterations=6,
+        mcp_refresh_tools=True,
+    )
+
+    assert request.mcp_orchestration == "llm_driven"
+    assert request.mcp_entry_tool == "run"
+    assert request.mcp_structured_response is True
+    assert request.mcp_llm_provider == "openai"
+    assert request.mcp_llm_model == "gpt-4o"
+    assert request.mcp_max_iterations == 6
+    assert request.mcp_refresh_tools is True
+
+
+def test_agent_update_request_preserves_mcp_fields():
+    """ACP agent update payloads should serialize MCP orchestration fields."""
+    request = ACPAgentUpdateRequest(
+        mcp_orchestration="llm_driven",
+        mcp_entry_tool="run",
+        mcp_structured_response=True,
+        mcp_llm_provider="openai",
+        mcp_llm_model="gpt-4o-mini",
+        mcp_max_iterations=8,
+        mcp_refresh_tools=True,
+    )
+
+    payload = request.model_dump(exclude_unset=True, exclude_none=True)
+
+    assert payload == {
+        "mcp_orchestration": "llm_driven",
+        "mcp_entry_tool": "run",
+        "mcp_structured_response": True,
+        "mcp_llm_provider": "openai",
+        "mcp_llm_model": "gpt-4o-mini",
+        "mcp_max_iterations": 8,
+        "mcp_refresh_tools": True,
+    }

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
@@ -1,0 +1,45 @@
+"""Tests for ToolGate ABC and ToolGateResult."""
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.core.Agent_Client_Protocol.tool_gate import (
+    ToolGate,
+    ToolGateResult,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_tool_gate_result_defaults():
+    """ToolGateResult(approved=True) should have reason=None by default."""
+    result = ToolGateResult(approved=True)
+    assert result.approved is True
+    assert result.reason is None
+
+
+def test_tool_gate_result_with_reason():
+    """ToolGateResult should store a custom reason string."""
+    result = ToolGateResult(approved=False, reason="policy violation")
+    assert result.approved is False
+    assert result.reason == "policy violation"
+
+
+def test_tool_gate_is_abstract():
+    """Instantiating ToolGate directly should raise TypeError."""
+    with pytest.raises(TypeError):
+        ToolGate()
+
+
+@pytest.mark.asyncio
+async def test_tool_gate_concrete_implementation():
+    """A concrete subclass of ToolGate should work as expected."""
+
+    class AlwaysApprove(ToolGate):
+        async def request_approval(self, session_id, tool_name, arguments):
+            return ToolGateResult(approved=True, reason="auto-approved")
+
+    gate = AlwaysApprove()
+    result = await gate.request_approval("sess-1", "read_file", {"path": "/tmp"})
+    assert result.approved is True
+    assert result.reason == "auto-approved"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
@@ -40,6 +40,10 @@ async def test_tool_gate_concrete_implementation():
             return ToolGateResult(approved=True, reason="auto-approved")
 
     gate = AlwaysApprove()
-    result = await gate.request_approval("sess-1", "read_file", {"path": "/tmp"})
+    result = await gate.request_approval(
+        "sess-1",
+        "read_file",
+        {"path": "/placeholder/path"},
+    )
     assert result.approved is True
     assert result.reason == "auto-approved"

--- a/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
+++ b/tldw_Server_API/tests/Agent_Client_Protocol/test_tool_gate.py
@@ -36,7 +36,7 @@ async def test_tool_gate_concrete_implementation():
     """A concrete subclass of ToolGate should work as expected."""
 
     class AlwaysApprove(ToolGate):
-        async def request_approval(self, session_id, tool_name, arguments):
+        async def request_approval(self, session_id, tool_name, arguments, *, cancel_event=None):
             return ToolGateResult(approved=True, reason="auto-approved")
 
     gate = AlwaysApprove()


### PR DESCRIPTION
## Summary

- Adds **MCPAdapter** implementing `ProtocolAdapter` for MCP-based agents
- Three **MCP transports**: `MCPStdioTransport` (composes ACPStdioClient), `MCPSSETransport` (SSE stream + HTTP POST with auto-discovery), `MCPStreamableHTTPTransport` (dual response modes: JSON + SSE)
- **Configurable orchestration**: `agent_driven` (agent handles its own tool execution) or `llm_driven` (ReAct loop with LLM deciding tool calls)
- **ToolGate** protocol bridging MCPAdapter to GovernanceFilter for tool approval — uses `_approval_future` metadata convention
- **GovernanceToolGate** concrete implementation wired into GovernanceFilter
- **LLMCaller** abstraction for testable LLM integration with `mcp_tools_to_openai_format` converter
- **AgentDrivenRunner** supporting simple text + structured steps response formats
- **LLMDrivenRunner** with ephemeral message history, max iterations, cancellation, and governance denial handling
- **AgentRegistryEntry** extended with 7 MCP orchestration fields
- Heartbeat emission during `send_prompt()`, lifecycle events on connect/disconnect

## Architecture

```
MCPAdapter.send_prompt()
  → AgentDrivenRunner (agent_driven) or LLMDrivenRunner (llm_driven)
    → MCPTransport (stdio/SSE/streamable_http)
      → MCP server agent
```

Design doc: `Docs/Plans/2026-03-16-acp-mcp-adapter-design.md`

## Test plan

- [x] 76 new unit tests across 10 test files
- [x] All 392 ACP tests pass (76 new + 316 existing)
- [x] Zero regressions
- [x] TDD followed for all tasks
- [x] Async test patterns corrected (pytest.mark.asyncio, not run_until_complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)