### PR TITLE
redesign jobs and metering persistence boundaries

### DIFF
--- a/Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md
+++ b/Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md
@@ -1,5 +1,16 @@
 # PR 898 Jobs and Metering Boundary Redesign
 
+## Implementation Status
+
+Completed on `2026-03-17` in worktree `codex-pr898-boundary-redesign`.
+
+Implemented commits:
+
+- `de8569d55` `refactor: add jobs repository boundary`
+- `217722302` `refactor: route fair share through jobs repository`
+- `126e71d31` `refactor: add authnz metering repositories`
+- `71fe7f9a8` `refactor: split stripe metering orchestration from persistence`
+
 ## Context
 
 PR 898 fixed the production correctness issues, but three larger architecture comments remain:
@@ -30,7 +41,9 @@ This follow-up intentionally takes the broader redesign path rather than another
 
 Add a new DB layer under `tldw_Server_API/app/core/DB_Management` that owns Jobs persistence.
 
-Planned pieces:
+This redesign intentionally follows the repository's existing `DB_Management` package and module naming conventions instead of introducing a one-off snake_case subtree just for this boundary.
+
+Implemented pieces:
 
 - `JobsRepository`
   - Public persistence API for job reads/writes needed by `JobManager`.
@@ -48,24 +61,26 @@ Planned pieces:
 - payload hygiene / secret rejection
 - orchestration of repository calls
 
-The key structural change is that `create_job()` will ask the repository for a transactional session, perform the active-job count through that session, compute fair-share priority, and persist the job through the same session. That removes the extra connection and removes the raw SQL from `manager.py`.
+The implemented structural change is that `create_job()` now reuses a repository-backed session for fair-share counting and the non-idempotent insert path. That removes the extra connection for those operations and narrows the raw-SQL footprint in `manager.py` to the remaining idempotent create path.
 
 ### 2. Metering Boundary
 
 Split Stripe metering into orchestration and repository concerns.
 
-Planned pieces:
+Implemented pieces:
 
-- `AuthnzUsageDailyRepository`
+- `AuthNZUsageDailyRepository`
   - Reads `usage_daily` and handles legacy-schema fallback (`bytes_in_total` missing).
-- `AuthnzBillingSubscriptionRepository`
+- `AuthNZBillingSubscriptionRepository`
   - Resolves active Stripe subscriptions through membership and org-owner paths.
-- `AuthnzMeteringSyncLogRepository`
+- `AuthNZMeteringSyncLogRepository`
   - Owns `metering_sync_log` schema/bootstrap, duplicate checks, sync writes, and sync-total reads.
-- `StripeMeteringOrchestrator` or a refactored `StripeMeteringService`
+- Refactored `StripeMeteringService`
   - Keeps Stripe API calls, per-user sync flow, and reconciliation assembly.
+  - Accepts injected repositories and optional pool injection for testing or alternate composition.
 
-The service layer will no longer contain SQL or table DDL. It will depend on injected repository interfaces plus a DB pool provider and Stripe client adapter.
+The service layer no longer owns the metering SQL or DDL. Its persistence helpers are now thin adapters over the repository layer, with a compatibility path that still acquires a shared pool in the default service configuration.
+The three repository types currently live in one metering module because they form a single persistence boundary with shared AuthNZ pool semantics and a small public surface. They can be split later if the boundary grows materially.
 
 ### 3. Schema Ownership
 
@@ -87,7 +102,7 @@ This is intentionally less ambitious than introducing a global migration subsyst
 ### Metering Sync Flow
 
 1. Caller invokes `StripeMeteringService.sync_daily_usage(...)`.
-2. Service acquires/injects AuthNZ DB pool once.
+2. Service either uses injected repositories directly or acquires a shared AuthNZ DB pool for the default repository path.
 3. Sync-log repository ensures schema.
 4. Usage repository reads daily usage rows.
 5. Subscription repository resolves Stripe subscription per user.
@@ -137,11 +152,20 @@ This is intentionally less ambitious than introducing a global migration subsyst
 - Add any new repository unit tests to that verification command.
 - Run Bandit on touched Jobs/DB/metering files before publishing.
 
+## Verification
+
+- `python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v`
+  - Result: `28 passed`
+- `python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `67 passed`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/services/stripe_metering_service.py -f json -o /tmp/bandit_pr898_boundary_redesign.json`
+  - Result: `0` findings, `0` errors
+
 ## Risks
 
 - `JobManager` is used pervasively, so constructor changes must stay backward-compatible or defaultable.
 - Repository/session abstractions can accidentally duplicate existing `JobManager` logic if the split is not kept strict.
-- Stripe metering tests currently patch service internals; they will need careful rewrite to avoid coupling to deleted helpers.
+- The remaining idempotent create branch in `JobManager.create_job()` still uses module-local SQL and can be split further in a later pass if maintainers want the repository boundary to own that path too.
 
 ## Recommended PR Strategy
 

--- a/Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md
+++ b/Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md
@@ -1,0 +1,150 @@
+# PR 898 Jobs and Metering Boundary Redesign
+
+## Context
+
+PR 898 fixed the production correctness issues, but three larger architecture comments remain:
+
+- `JobManager` still owns a fair-share read against the jobs table.
+- `JobManager.create_job()` cannot reuse that read inside its existing create-time DB transaction boundary.
+- `StripeMeteringService` still owns direct persistence for `usage_daily`, subscription lookup, and `metering_sync_log`.
+
+This follow-up intentionally takes the broader redesign path rather than another local extraction pass.
+
+## Goals
+
+- Move Jobs persistence concerns out of `tldw_Server_API/app/core/Jobs/manager.py`.
+- Move Stripe metering persistence concerns out of `tldw_Server_API/app/services/stripe_metering_service.py`.
+- Introduce explicit repository/session boundaries that can be injected and unit-tested independently.
+- Preserve current user-visible behavior while allowing internal interface changes.
+- Make the new boundaries usable from both SQLite and PostgreSQL without leaking backend-specific SQL into orchestration code.
+
+## Non-Goals
+
+- Replacing `JobManager` as the public entry point across the codebase in this pass.
+- Changing queue semantics, fair-share policy semantics, or Stripe API behavior.
+- Introducing a full migration framework beyond the schema/bootstrap needs already owned by these modules.
+
+## Architecture
+
+### 1. Jobs Boundary
+
+Add a new DB layer under `tldw_Server_API/app/core/DB_Management` that owns Jobs persistence.
+
+Planned pieces:
+
+- `JobsRepository`
+  - Public persistence API for job reads/writes needed by `JobManager`.
+  - Owns SQL for both SQLite and PostgreSQL.
+- `JobsSession`
+  - Backend-agnostic wrapper around a live jobs DB connection/transaction.
+  - Lets create-time reads and writes share the same connection.
+- `JobsRepositoryFactory` or constructor helpers
+  - Builds the repository from the existing `JobManager` config (`backend`, `db_path`, `db_url`).
+
+`JobManager` remains the public façade used across the codebase, but its role narrows to:
+
+- queue policy validation
+- fair-share policy application
+- payload hygiene / secret rejection
+- orchestration of repository calls
+
+The key structural change is that `create_job()` will ask the repository for a transactional session, perform the active-job count through that session, compute fair-share priority, and persist the job through the same session. That removes the extra connection and removes the raw SQL from `manager.py`.
+
+### 2. Metering Boundary
+
+Split Stripe metering into orchestration and repository concerns.
+
+Planned pieces:
+
+- `AuthnzUsageDailyRepository`
+  - Reads `usage_daily` and handles legacy-schema fallback (`bytes_in_total` missing).
+- `AuthnzBillingSubscriptionRepository`
+  - Resolves active Stripe subscriptions through membership and org-owner paths.
+- `AuthnzMeteringSyncLogRepository`
+  - Owns `metering_sync_log` schema/bootstrap, duplicate checks, sync writes, and sync-total reads.
+- `StripeMeteringOrchestrator` or a refactored `StripeMeteringService`
+  - Keeps Stripe API calls, per-user sync flow, and reconciliation assembly.
+
+The service layer will no longer contain SQL or table DDL. It will depend on injected repository interfaces plus a DB pool provider and Stripe client adapter.
+
+### 3. Schema Ownership
+
+`metering_sync_log` remains logically owned by metering, but schema bootstrap moves into the repository layer instead of the service layer. The repository exposes an `ensure_schema()` method and encapsulates backend-specific DDL.
+
+This is intentionally less ambitious than introducing a global migration subsystem, but it is enough to move schema ownership out of the service/orchestrator.
+
+## Data Flow
+
+### Jobs Create Flow
+
+1. Caller invokes `JobManager.create_job(...)`.
+2. `JobManager` validates queue/domain and redacts or rejects payload secrets.
+3. `JobManager` opens a repository session.
+4. Repository counts active jobs for `owner_user_id` using the same session that will persist the new row.
+5. `JobManager` applies fair-share policy and computes final priority.
+6. Repository persists the job and returns the created row.
+
+### Metering Sync Flow
+
+1. Caller invokes `StripeMeteringService.sync_daily_usage(...)`.
+2. Service acquires/injects AuthNZ DB pool once.
+3. Sync-log repository ensures schema.
+4. Usage repository reads daily usage rows.
+5. Subscription repository resolves Stripe subscription per user.
+6. Sync-log repository checks idempotency state.
+7. Service reports usage to Stripe.
+8. Sync-log repository records successful sync.
+
+### Reconciliation Flow
+
+1. Usage repository reads local totals.
+2. Sync-log repository reads synced totals.
+3. Service compares the two datasets and builds drift results.
+
+## Error Handling
+
+- Repositories raise backend-specific query failures upward as typed project exceptions or plain exceptions with preserved context.
+- `JobManager` keeps the current behavior of warning and continuing when fair-share evaluation cannot be completed.
+- Stripe metering orchestration keeps its current skip/error semantics, but the repository boundary makes failures attributable to usage reads, subscription resolution, or sync-log access separately.
+- Legacy-schema fallback remains in the usage repository so callers receive normalized row dictionaries.
+
+## Testing Strategy
+
+### Jobs
+
+- Add repository-focused tests for:
+  - active-job counting in SQLite
+  - active-job counting in PostgreSQL fixture paths where available
+  - create-time session reuse / single-transaction behavior
+- Keep the current fair-share integration tests, updated to assert the repository-backed path.
+
+### Metering
+
+- Add repository-focused tests for:
+  - usage query normalization with and without `bytes_in_total`
+  - membership and owner subscription lookup
+  - sync-log ensure/check/write/read behavior
+- Keep the current service/orchestrator tests, but swap their mocks to repository interfaces instead of direct SQL helpers.
+
+### Regression Suite
+
+- Re-run the PR 898 targeted suite:
+  - consent endpoints
+  - audit chain
+  - overage enforcement
+  - fair-share integration
+  - Stripe metering
+- Add any new repository unit tests to that verification command.
+- Run Bandit on touched Jobs/DB/metering files before publishing.
+
+## Risks
+
+- `JobManager` is used pervasively, so constructor changes must stay backward-compatible or defaultable.
+- Repository/session abstractions can accidentally duplicate existing `JobManager` logic if the split is not kept strict.
+- Stripe metering tests currently patch service internals; they will need careful rewrite to avoid coupling to deleted helpers.
+
+## Recommended PR Strategy
+
+- Keep PR 898 limited to the correctness fixes already pushed.
+- Open this follow-up as a stacked draft PR against `feat/production-readiness-gaps`.
+- Land the repository/session scaffolding first, then the `JobManager` refactor, then the Stripe metering split, with verification at each step.

--- a/Docs/Plans/2026-03-17-pr898-boundary-redesign.md
+++ b/Docs/Plans/2026-03-17-pr898-boundary-redesign.md
@@ -1,0 +1,337 @@
+# PR 898 Jobs And Metering Boundary Redesign Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Redesign Jobs and Stripe metering persistence boundaries so `JobManager` and the Stripe metering service become orchestration façades backed by explicit repository/session layers.
+
+**Architecture:** Introduce a dedicated Jobs repository/session layer under `app/core/DB_Management`, plus AuthNZ-backed repositories for metering usage, subscriptions, and sync-log persistence. Refactor `JobManager` and Stripe metering to depend on those layers instead of embedding SQL and schema bootstrap logic directly.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLite, PostgreSQL/asyncpg, psycopg, pytest, loguru, Bandit
+
+---
+
+### Task 1: Add Jobs Repository Scaffolding
+
+**Files:**
+- Create: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+- Test: `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+- Reference: `tldw_Server_API/app/core/Jobs/manager.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that describe the new persistence API:
+
+```python
+def test_count_active_jobs_for_user_sqlite_uses_session_connection():
+    repo = JobsRepository.for_sqlite(db_path)
+    with repo.session() as session:
+        assert repo.count_active_jobs_for_user("42", session=session) == 2
+```
+
+```python
+def test_create_job_session_can_read_and_write_in_one_transaction():
+    repo = JobsRepository.for_sqlite(db_path)
+    with repo.session() as session:
+        active = repo.count_active_jobs_for_user("42", session=session)
+        row = repo.insert_job(..., session=session)
+        assert active == 0
+        assert row["owner_user_id"] == "42"
+```
+
+**Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
+```
+
+Expected: failures because `JobsRepository` and its session API do not exist yet.
+
+**Step 3: Write the minimal implementation**
+
+Add:
+
+- `JobsSession` wrapper for live SQLite/psycopg connections
+- `JobsRepository.session()`
+- `JobsRepository.count_active_jobs_for_user(...)`
+- `JobsRepository.insert_job(...)` only as far as needed by the tests
+
+Keep backend-specific SQL inside this file only.
+
+**Step 4: Run the repository tests again**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/tests/Jobs/test_jobs_repository.py
+git commit -m "refactor: add jobs repository boundary"
+```
+
+### Task 2: Refactor JobManager To Use The Repository Boundary
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Test: `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+
+**Step 1: Write the failing test**
+
+Add a test that proves `create_job()` uses repository-backed counting instead of opening a second connection:
+
+```python
+def test_create_job_reuses_repository_session_for_fair_share(monkeypatch):
+    repo = FakeJobsRepository(...)
+    jm = JobManager(db_path, jobs_repository=repo)
+    jm.create_job(...)
+    assert repo.count_calls == 1
+    assert repo.insert_used_same_session is True
+```
+
+**Step 2: Run the focused tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
+```
+
+Expected: failure because `JobManager` does not accept/use the repository yet.
+
+**Step 3: Write the minimal implementation**
+
+Refactor `JobManager` so that:
+
+- constructor accepts optional `jobs_repository`
+- default construction builds the repository from existing config
+- `_count_active_jobs_for_user()` delegates to repository/session behavior or is removed entirely
+- `create_job()` opens a repository session, performs fair-share counting there, then inserts through the repository
+
+Do not change the public `create_job()` call signature.
+
+**Step 4: Run the Jobs tests again**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py
+git commit -m "refactor: route fair share through jobs repository"
+```
+
+### Task 3: Add Metering Repositories
+
+**Files:**
+- Create: `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
+- Test: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+- Reference: `tldw_Server_API/app/services/stripe_metering_service.py`
+
+**Step 1: Write the failing tests**
+
+Cover the repository contract:
+
+```python
+async def test_usage_repository_normalizes_legacy_rows():
+    repo = AuthNZUsageDailyRepository(pool=fake_pool)
+    rows = await repo.fetch_usage_for_date("2026-03-13")
+    assert rows[0]["bytes_in_total"] == 0
+```
+
+```python
+async def test_subscription_repository_falls_back_to_org_owner():
+    repo = AuthNZBillingSubscriptionRepository(pool=fake_pool)
+    row = await repo.get_active_subscription_for_user(42)
+    assert row["stripe_subscription_id"] == "sub_123"
+```
+
+```python
+async def test_sync_log_repository_ensures_and_records_schema():
+    repo = AuthNZMeteringSyncLogRepository(pool=fake_pool)
+    await repo.ensure_schema()
+    await repo.record_sync(...)
+```
+
+**Step 2: Run the repository tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
+```
+
+Expected: failures because the repositories do not exist yet.
+
+**Step 3: Write the minimal implementation**
+
+Add repository classes for:
+
+- usage reads
+- subscription lookup
+- sync-log schema/bootstrap and sync state
+
+Keep all SQL and DDL in this module. Normalize SQLite/PostgreSQL row shapes before returning.
+
+**Step 4: Run the repository tests again**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
+git commit -m "refactor: add authnz metering repositories"
+```
+
+### Task 4: Refactor Stripe Metering Into Orchestration Plus Repositories
+
+**Files:**
+- Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
+- Modify: `tldw_Server_API/tests/test_stripe_metering.py`
+- Test: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+
+**Step 1: Write the failing service test**
+
+Add a service-level test that injects fake repositories:
+
+```python
+async def test_sync_daily_usage_uses_repositories_and_records_sync():
+    svc = StripeMeteringService(
+        usage_repo=fake_usage_repo,
+        subscription_repo=fake_subscription_repo,
+        sync_log_repo=fake_sync_log_repo,
+        stripe_client=fake_stripe_client,
+    )
+    result = await svc.sync_daily_usage(date="2026-03-13")
+    assert result["synced_users"] == 1
+```
+
+**Step 2: Run the focused metering tests to verify failure**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
+```
+
+Expected: failures because the service still depends on internal SQL helpers.
+
+**Step 3: Write the minimal implementation**
+
+Refactor `StripeMeteringService` so that:
+
+- constructor accepts optional repositories and optional db-pool provider
+- SQL helper methods are deleted or reduced to thin adapter creation
+- `sync_daily_usage()` and `check_reconciliation()` operate through repository interfaces
+- Stripe calls remain in the service layer
+
+Preserve the external return payloads.
+
+**Step 4: Run the metering tests again**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
+```
+
+Expected: pass.
+
+**Step 5: Commit**
+
+```bash
+git add tldw_Server_API/app/services/stripe_metering_service.py tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
+git commit -m "refactor: split stripe metering orchestration from persistence"
+```
+
+### Task 5: Run Full Verification And Update PR Threading
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md`
+- Modify: `Docs/Plans/2026-03-17-pr898-boundary-redesign.md`
+- Review: `tldw_Server_API/app/core/Jobs/manager.py`
+- Review: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+- Review: `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
+- Review: `tldw_Server_API/app/services/stripe_metering_service.py`
+
+**Step 1: Run the expanded regression suite**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py \
+  tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
+  tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py \
+  tldw_Server_API/tests/Billing/test_authnz_metering_repository.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/Jobs/test_jobs_repository.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: all pass.
+
+**Step 2: Run Bandit on touched scope**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/DB_Management/Jobs_Repository.py \
+  tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  -f json -o /tmp/bandit_pr898_boundary_redesign.json
+```
+
+Expected: `0` new findings in touched files.
+
+**Step 3: Update PR materials**
+
+- Refresh the design/plan docs if the final implementation deviated.
+- Update the draft PR body with the final architectural summary and verification output.
+- Reply on the follow-up PR threads with the repository-boundary changes.
+
+**Step 4: Commit**
+
+```bash
+git add Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md Docs/Plans/2026-03-17-pr898-boundary-redesign.md
+git commit -m "docs: finalize boundary redesign execution notes"
+```
+
+Plan complete and saved to `Docs/Plans/2026-03-17-pr898-boundary-redesign.md`. Two execution options:
+
+1. Subagent-Driven (this session) - I dispatch fresh subagent per task, review between tasks, fast iteration
+2. Parallel Session (separate) - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/Docs/Plans/2026-03-17-pr898-boundary-redesign.md
+++ b/Docs/Plans/2026-03-17-pr898-boundary-redesign.md
@@ -2,15 +2,41 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
+**Status:** Complete
+
+## Execution Summary
+
+Completed on `2026-03-17` in worktree `codex-pr898-boundary-redesign`.
+
+Implemented commits:
+
+- `de8569d55` `refactor: add jobs repository boundary`
+- `217722302` `refactor: route fair share through jobs repository`
+- `126e71d31` `refactor: add authnz metering repositories`
+- `71fe7f9a8` `refactor: split stripe metering orchestration from persistence`
+
+Final verification:
+
+- `python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v`
+  - Result: `28 passed`
+- `python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `67 passed`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/services/stripe_metering_service.py -f json -o /tmp/bandit_pr898_boundary_redesign.json`
+  - Result: `0` findings, `0` errors
+
 **Goal:** Redesign Jobs and Stripe metering persistence boundaries so `JobManager` and the Stripe metering service become orchestration façades backed by explicit repository/session layers.
 
 **Architecture:** Introduce a dedicated Jobs repository/session layer under `app/core/DB_Management`, plus AuthNZ-backed repositories for metering usage, subscriptions, and sync-log persistence. Refactor `JobManager` and Stripe metering to depend on those layers instead of embedding SQL and schema bootstrap logic directly.
+
+**Naming note:** This plan keeps the existing repository conventions under `app/core/DB_Management`, including the current package and module naming style already used throughout the codebase, rather than introducing a one-off naming scheme for only this refactor.
 
 **Tech Stack:** Python 3.11, FastAPI, SQLite, PostgreSQL/asyncpg, psycopg, pytest, loguru, Bandit
 
 ---
 
 ### Task 1: Add Jobs Repository Scaffolding
+
+**Status:** Complete
 
 **Files:**
 - Create: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
@@ -43,7 +69,7 @@ def test_create_job_session_can_read_and_write_in_one_transaction():
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
 ```
 
@@ -65,7 +91,7 @@ Keep backend-specific SQL inside this file only.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
 ```
 
@@ -79,6 +105,8 @@ git commit -m "refactor: add jobs repository boundary"
 ```
 
 ### Task 2: Refactor JobManager To Use The Repository Boundary
+
+**Status:** Complete
 
 **Files:**
 - Modify: `tldw_Server_API/app/core/Jobs/manager.py`
@@ -103,7 +131,7 @@ def test_create_job_reuses_repository_session_for_fair_share(monkeypatch):
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
 ```
 
@@ -125,7 +153,7 @@ Do not change the public `create_job()` call signature.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
 ```
 
@@ -139,6 +167,8 @@ git commit -m "refactor: route fair share through jobs repository"
 ```
 
 ### Task 3: Add Metering Repositories
+
+**Status:** Complete
 
 **Files:**
 - Create: `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
@@ -175,7 +205,7 @@ async def test_sync_log_repository_ensures_and_records_schema():
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
 ```
 
@@ -189,14 +219,14 @@ Add repository classes for:
 - subscription lookup
 - sync-log schema/bootstrap and sync state
 
-Keep all SQL and DDL in this module. Normalize SQLite/PostgreSQL row shapes before returning.
+Keep all SQL and DDL in this module. Normalize SQLite/PostgreSQL row shapes before returning. Keeping the three metering repositories in one boundary module is intentional for this pass because they share the same AuthNZ pool semantics and form one cohesive metering persistence surface.
 
 **Step 4: Run the repository tests again**
 
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
 ```
 
@@ -210,6 +240,8 @@ git commit -m "refactor: add authnz metering repositories"
 ```
 
 ### Task 4: Refactor Stripe Metering Into Orchestration Plus Repositories
+
+**Status:** Complete
 
 **Files:**
 - Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
@@ -237,7 +269,7 @@ async def test_sync_daily_usage_uses_repositories_and_records_sync():
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
 ```
 
@@ -259,7 +291,7 @@ Preserve the external return payloads.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest tldw_Server_API/tests/test_stripe_metering.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py -v
 ```
 
@@ -274,6 +306,8 @@ git commit -m "refactor: split stripe metering orchestration from persistence"
 
 ### Task 5: Run Full Verification And Update PR Threading
 
+**Status:** Complete
+
 **Files:**
 - Modify: `Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md`
 - Modify: `Docs/Plans/2026-03-17-pr898-boundary-redesign.md`
@@ -287,7 +321,7 @@ git commit -m "refactor: split stripe metering orchestration from persistence"
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m pytest \
   tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py \
   tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py \
@@ -305,7 +339,7 @@ Expected: all pass.
 Run:
 
 ```bash
-source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+source .venv/bin/activate
 python -m bandit -r \
   tldw_Server_API/app/core/Jobs/manager.py \
   tldw_Server_API/app/core/DB_Management/Jobs_Repository.py \
@@ -329,9 +363,4 @@ git add Docs/Plans/2026-03-17-pr898-boundary-redesign-design.md Docs/Plans/2026-
 git commit -m "docs: finalize boundary redesign execution notes"
 ```
 
-Plan complete and saved to `Docs/Plans/2026-03-17-pr898-boundary-redesign.md`. Two execution options:
-
-1. Subagent-Driven (this session) - I dispatch fresh subagent per task, review between tasks, fast iteration
-2. Parallel Session (separate) - Open new session with executing-plans, batch execution with checkpoints
-
-Which approach?
+Plan complete and execution notes are now finalized in this file.

--- a/Docs/Plans/2026-03-17-pr908-final-review-cleanup-design.md
+++ b/Docs/Plans/2026-03-17-pr908-final-review-cleanup-design.md
@@ -1,0 +1,36 @@
+## Context
+
+PR 908 still has unresolved review threads after the boundary-redesign rebase. The remaining feedback is concentrated in the new metering repositories, the new jobs repository/session layer, and the `JobManager` fair-share admission flow.
+
+## Goals
+
+- Close the remaining correctness gaps without widening the PR beyond the persistence-boundary redesign.
+- Keep `JobManager` as the orchestration entry point while making admission control fail closed on repository errors.
+- Improve the new repositories enough to satisfy the active review threads, including optional pool support, integrity checks, and low-risk hygiene fixes.
+
+## Design
+
+### AuthNZ metering repository
+
+- Add an explicit `DuplicateActiveSubscriptionError` so duplicate active subscription rows fail fast instead of silently selecting one row.
+- Resolve active subscriptions by fetching up to two matches in each query branch and raising on duplicates.
+- Add a secondary `day` index for `metering_sync_log` in both PostgreSQL and SQLite schema creation paths.
+
+### Jobs repository
+
+- Add optional pool injection so `JobsRepository` can reuse caller-managed connections while preserving existing direct-connect behavior.
+- Move session acquisition into a single context-managed helper that works for both pooled and non-pooled connections.
+- Replace silent SQLite policy suppression with diagnostic logging and use SQLite `RETURNING *` on insert to align the SQLite and PostgreSQL insert paths.
+- Clean up the remaining style issues called out by review bots (`collections.abc.Iterator`, unquoted forward references).
+
+### Job manager
+
+- Validate injected repository compatibility at construction time by checking the required interface and backend alignment.
+- Make fair-share admission fail closed: repository/admission errors should raise a retryable request error instead of returning permissive defaults.
+- Run the SQLite fair-share check inside the same transaction as the insert so count and insert share one connection/transaction window.
+
+### Tests
+
+- Extend repository tests to cover pooled sessions and SQLite `RETURNING` behavior.
+- Extend metering repository tests to cover duplicate subscription detection and schema indexing.
+- Extend fair-share tests to cover fail-closed admission and repository validation.

--- a/Docs/Plans/2026-03-17-pr908-final-review-cleanup.md
+++ b/Docs/Plans/2026-03-17-pr908-final-review-cleanup.md
@@ -1,0 +1,29 @@
+## Stage 1: Reconfirm Live Review Scope
+**Goal**: Pull the current unresolved PR 908 review threads and map them to concrete code/test changes.
+**Success Criteria**: Every unresolved thread has an explicit owner file and planned resolution path.
+**Tests**: None.
+**Status**: Complete
+
+## Stage 2: Patch Repository and Manager Boundaries
+**Goal**: Implement the remaining metering, jobs repository, and fair-share fixes.
+**Success Criteria**: Repository integrity checks, optional pooling, constructor validation, and fail-closed admission behavior are all in place.
+**Tests**: Targeted pytest coverage for metering repositories, jobs repository, and fair-share integration.
+**Status**: Complete
+
+## Stage 3: Expand Regression Coverage
+**Goal**: Add or update tests for duplicate subscriptions, sync-log indexing, pooled sessions, SQLite transactional fair-share ordering, and repository validation.
+**Success Criteria**: New tests fail before the changes and pass after them.
+**Tests**: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`, `tldw_Server_API/tests/Jobs/test_jobs_repository.py`, `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+**Status**: Complete
+
+## Stage 4: Verify the Touched Scope
+**Goal**: Prove the cleanup with scoped tests and Bandit.
+**Success Criteria**: Targeted pytest suite passes and Bandit reports no findings in changed files.
+**Tests**: Scoped pytest command plus scoped Bandit run.
+**Status**: Complete
+
+## Stage 5: Push and Resolve Review Threads
+**Goal**: Update the branch on GitHub and close the remaining PR 908 review threads with concrete replies.
+**Success Criteria**: Branch pushed, summary comment posted, and no unresolved review threads remain.
+**Tests**: `gh pr view` / GraphQL review-thread check.
+**Status**: In Progress

--- a/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md
+++ b/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md
@@ -1,0 +1,65 @@
+# PR 908 Merge Conflict Resolution Design
+
+## Context
+
+PR 908 is stacked on `feat/production-readiness-gaps`, and GitHub now reports it as `CONFLICTING`. The local worktree is clean, which means the conflict is not an in-progress local merge. It comes from divergence between:
+
+- the PR 908 boundary-redesign commits on `codex/pr898-boundary-redesign`
+- the later PR 898 fixes that landed on `feat/production-readiness-gaps`
+
+The shared merge base is `1b35062ee4a2fef3c4a27e04e1aa0e418a41f96a`.
+
+## Goals
+
+- Make PR 908 mergeable again against the current head of `feat/production-readiness-gaps`.
+- Preserve the Jobs and metering boundary redesign as the authoritative version in overlapping files.
+- Keep the non-overlapping PR 898 fixes from the base branch intact.
+- Re-run the scoped Jobs and metering verification after conflict resolution.
+
+## Non-Goals
+
+- Reopening the design of PR 908 or pulling new scope into it.
+- Reworking unrelated files that do not participate in the branch divergence.
+- Re-litigating the behavioral choices already accepted in PR 908.
+
+## Root Cause
+
+`codex/pr898-boundary-redesign` was built from `1b35062ee...`, while `feat/production-readiness-gaps` advanced to `8f7a96469` with additional edits in several of the same files:
+
+- `tldw_Server_API/app/core/Jobs/manager.py`
+- `tldw_Server_API/app/services/stripe_metering_service.py`
+- `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- `tldw_Server_API/tests/test_stripe_metering.py`
+
+Because both branches changed those files after the shared base, GitHub cannot auto-merge PR 908.
+
+## Approved Resolution Strategy
+
+### 1. Rebase PR 908 onto the current base branch
+
+Replay `codex/pr898-boundary-redesign` on top of `feat/production-readiness-gaps` rather than merging the base branch in. That keeps the stacked PR history clean and mirrors the conflict set GitHub is reporting.
+
+### 2. Treat PR 908 as authoritative in overlapping files
+
+For files touched by both branches, keep the PR 908 side when behavior differs. This matches the user’s chosen policy that the architecture/redesign branch should win in overlaps. During rebase conflict resolution, that means selecting the rebased commit side for the overlapping files and only reintroducing base-branch content if it is strictly non-conflicting and still needed.
+
+### 3. Keep base-only files untouched
+
+Files changed only on `feat/production-readiness-gaps` stay as provided by the new base. PR 908 should only add its repository-boundary and associated test/doc changes on top.
+
+### 4. Verify the scope that actually overlaps
+
+After the rebase, rerun the focused Jobs and metering suite:
+
+- `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+- `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+- `tldw_Server_API/tests/test_stripe_metering.py`
+
+Then confirm the branch is clean and GitHub reports PR 908 as mergeable.
+
+## Risks
+
+- Using the PR 908 side blindly could drop a base-branch fix if one of the redesign commits predates it and did not already absorb it.
+- Rebase conflict labels (`ours` vs `theirs`) are easy to misuse; for this workflow, the replayed PR 908 commit side is the one that should win in overlapping files.
+- The branch must be force-pushed after rebase, so verification needs to happen before publishing.

--- a/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md
+++ b/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md
@@ -63,3 +63,23 @@ Then confirm the branch is clean and GitHub reports PR 908 as mergeable.
 - Using the PR 908 side blindly could drop a base-branch fix if one of the redesign commits predates it and did not already absorb it.
 - Rebase conflict labels (`ours` vs `theirs`) are easy to misuse; for this workflow, the replayed PR 908 commit side is the one that should win in overlapping files.
 - The branch must be force-pushed after rebase, so verification needs to happen before publishing.
+
+## Implementation Notes
+
+- The rebase onto `feat/production-readiness-gaps` stopped in the expected overlapping files:
+  - `tldw_Server_API/app/core/Jobs/manager.py`
+  - `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+  - `tldw_Server_API/app/services/stripe_metering_service.py`
+- The branch was replayed with the PR 908 side as the authoritative version in those overlaps.
+- After the rebase completed, the Stripe metering suite exposed five carry-forward regressions caused by losing later stacked fixes during the conflict resolution.
+- Those were restored directly by:
+  - adding PostgreSQL `date` coercion in `AuthNZ_Metering_Repository.py`
+  - restoring Stripe runtime gating and non-missing error propagation in `stripe_metering_service.py`
+  - restoring the `_stripe_ok()` test helper in `test_stripe_metering.py`
+
+## Verification
+
+- `python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `46 passed, 5 warnings`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/services/stripe_metering_service.py -f json -o /tmp/bandit_pr908_merge_conflict_resolution.json`
+  - Result: `0` findings, `0` errors

--- a/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution.md
+++ b/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution.md
@@ -2,6 +2,8 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
+**Status:** Complete
+
 **Goal:** Rebase PR 908 onto the current `feat/production-readiness-gaps` head, resolve the overlapping file conflicts in favor of PR 908, and restore GitHub mergeability.
 
 **Architecture:** Keep the current base branch as the foundation, replay the PR 908 boundary-redesign commits on top, and resolve only the true overlapping files by preferring the PR 908 side. Verification stays scoped to the Jobs and metering files that participate in the conflict set.
@@ -139,3 +141,21 @@ gh pr view 908 --repo rmusser01/tldw_server --json mergeStateStatus,mergeable,ur
 ```
 
 Expected: PR 908 is no longer `DIRTY` / `CONFLICTING`.
+
+## Execution Summary
+
+Completed on `2026-03-17` in worktree `codex-pr898-boundary-redesign`.
+
+Implemented steps:
+
+- rebased `codex/pr898-boundary-redesign` onto `feat/production-readiness-gaps`
+- resolved the overlapping Jobs and Stripe files in favor of the PR 908 boundary-redesign versions
+- restored the lost stacked Stripe correctness fixes after the rebase
+- re-ran the scoped Jobs and metering verification suite
+
+Final verification:
+
+- `python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `46 passed, 5 warnings`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/services/stripe_metering_service.py -f json -o /tmp/bandit_pr908_merge_conflict_resolution.json`
+  - Result: `0` findings, `0` errors

--- a/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution.md
+++ b/Docs/Plans/2026-03-17-pr908-merge-conflict-resolution.md
@@ -1,0 +1,141 @@
+# PR 908 Merge Conflict Resolution Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Rebase PR 908 onto the current `feat/production-readiness-gaps` head, resolve the overlapping file conflicts in favor of PR 908, and restore GitHub mergeability.
+
+**Architecture:** Keep the current base branch as the foundation, replay the PR 908 boundary-redesign commits on top, and resolve only the true overlapping files by preferring the PR 908 side. Verification stays scoped to the Jobs and metering files that participate in the conflict set.
+
+**Tech Stack:** Git worktrees, git rebase, Python 3.11, pytest, Bandit, GitHub CLI
+
+---
+
+### Task 1: Start The Rebase And Capture The Conflict Set
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Modify: `tldw_Server_API/tests/test_stripe_metering.py`
+- Reference: `Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md`
+
+**Step 1: Start the rebase**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-pr898-boundary-redesign rebase feat/production-readiness-gaps
+```
+
+Expected: the rebase stops on the overlapping Jobs/metering files.
+
+**Step 2: Record the conflict set**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-pr898-boundary-redesign diff --name-only --diff-filter=U
+```
+
+Expected: only the overlapping files appear.
+
+### Task 2: Resolve Overlaps With PR 908 As Authoritative
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Modify: `tldw_Server_API/app/services/stripe_metering_service.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Modify: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Resolve each overlapping file**
+
+For the overlapping files, keep the rebased PR 908 side and remove conflict markers. During rebase this means selecting the replayed commit side for the files where behavior differs, then reading the result to confirm it matches the intended repository-boundary version.
+
+**Step 2: Stage the resolved files**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-pr898-boundary-redesign add \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/test_stripe_metering.py
+```
+
+**Step 3: Continue the rebase**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-pr898-boundary-redesign rebase --continue
+```
+
+Repeat until the rebase completes cleanly.
+
+### Task 3: Verify The Resolved Boundary Scope
+
+**Files:**
+- Test: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+- Test: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Test: `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+- Test: `tldw_Server_API/tests/test_stripe_metering.py`
+
+**Step 1: Run the focused regression suite**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Billing/test_authnz_metering_repository.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/Jobs/test_jobs_repository.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: pass.
+
+**Step 2: Run Bandit on the touched backend files**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/DB_Management/Jobs_Repository.py \
+  tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py \
+  tldw_Server_API/app/services/stripe_metering_service.py \
+  -f json -o /tmp/bandit_pr908_merge_conflict_resolution.json
+```
+
+Expected: `0` findings and `0` errors in the JSON output.
+
+### Task 4: Publish The Rebasing Result
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-17-pr908-merge-conflict-resolution-design.md`
+- Modify: `Docs/Plans/2026-03-17-pr908-merge-conflict-resolution.md`
+
+**Step 1: Update the plan docs with final results**
+
+Record the exact rebase outcome, final verification output, and any notable conflict-resolution notes.
+
+**Step 2: Force-push the rebased branch**
+
+Run:
+
+```bash
+git -C /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/codex-pr898-boundary-redesign push --force-with-lease origin codex/pr898-boundary-redesign
+```
+
+**Step 3: Confirm mergeability**
+
+Run:
+
+```bash
+gh pr view 908 --repo rmusser01/tldw_server --json mergeStateStatus,mergeable,url
+```
+
+Expected: PR 908 is no longer `DIRTY` / `CONFLICTING`.

--- a/Docs/Plans/2026-03-17-pr908-open-review-cleanup-design.md
+++ b/Docs/Plans/2026-03-17-pr908-open-review-cleanup-design.md
@@ -1,0 +1,103 @@
+# PR 908 Open Review Cleanup Design
+
+## Context
+
+PR 908 already landed the larger Jobs and metering persistence boundary redesign, but four review threads remain open:
+
+- `JobManager.create_job()` performs the Postgres fair-share count before `_pg_cursor()` applies RLS session state.
+- `Jobs_Repository.py` lacks module/class/method docstrings that explain the new transaction boundary.
+- `AuthNZ_Metering_Repository.py` lacks module/class/method docstrings that explain the repository contracts.
+- `TrackingJobsRepository` in the fair-share integration tests omits type hints on new helper methods.
+
+The first item is a correctness bug. The other three are narrow compliance and maintainability gaps.
+
+## Goals
+
+- Preserve the architectural direction already merged into PR 908.
+- Fix the Postgres fair-share bug without broadening the scope of the repository redesign.
+- Close the documentation and typing review threads with minimal churn.
+- Add regression coverage that proves fair-share counting runs after Postgres cursor setup.
+
+## Non-Goals
+
+- Reworking the repository boundaries introduced in PR 908.
+- Expanding the repository API beyond what the current orchestration path needs.
+- Refactoring unrelated `JobManager` create-time branches or metering flows.
+
+## Root Cause
+
+`JobManager.create_job()` currently opens a raw connection, immediately constructs a `JobsSession`, and runs the fair-share count against that session before entering `with self._pg_cursor(conn)`. On PostgreSQL, `_pg_cursor()` is the code path that applies `SET ROLE` and the `app.*` session variables used by RLS. That means the repository count query may execute without the required RLS context. If it fails, `_count_active_jobs_for_user()` catches the database exception and returns `0`, which silently disables fair-share admission control.
+
+SQLite is unaffected because it does not use `_pg_cursor()` for access control.
+
+## Recommended Approach
+
+### 1. Split fair-share timing by backend
+
+Keep the existing early fair-share block for SQLite, but defer the fair-share count for PostgreSQL until after `with self._pg_cursor(conn)` has been entered. This keeps the current repository-backed session reuse while ensuring the Postgres session has the correct RLS state before the repository issues the count query.
+
+### 2. Reuse one repository session for count and insert
+
+Continue to use a single `JobsSession` object for the create path so the fair-share count and repository insert stay on the same live connection. This preserves the boundary redesign’s main benefit without requiring a larger session-factory refactor in this PR.
+
+### 3. Add boundary documentation in place
+
+Add concise module, class, and method docstrings to:
+
+- `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+- `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
+
+The docstrings should describe backend differences, transaction ownership, and the returned row shapes rather than restating obvious implementation details.
+
+### 4. Tighten the regression tests
+
+Extend `tldw_Server_API/tests/Jobs/test_fair_share_integration.py` with:
+
+- explicit type hints on `TrackingJobsRepository`
+- a regression test that proves the Postgres branch performs the fair-share count only after `_pg_cursor()` has been entered
+
+The regression can be implemented with a fake Postgres connection and instrumented `_pg_cursor()` / repository methods rather than a full live Postgres fixture. The point is sequencing, not SQL correctness.
+
+## Data Flow After The Fix
+
+### SQLite create path
+
+1. `create_job()` opens the repository session.
+2. Fair-share count runs immediately using that session.
+3. Priority and admission checks complete.
+4. Existing SQLite insert path runs.
+
+### Postgres create path
+
+1. `create_job()` opens the connection and repository session.
+2. Code enters `with conn: with self._pg_cursor(conn)`.
+3. Fair-share count runs using the same repository session, now with RLS state applied.
+4. Quota, idempotency, and insert logic run on that same connection.
+
+## Testing Strategy
+
+- Add the new Postgres-ordering regression first and confirm it fails against the current code.
+- Keep the existing fair-share integration coverage green for SQLite behavior.
+- Re-run the repository and Stripe metering tests after the docstring changes to make sure the cleanup does not affect behavior.
+- Run Bandit on the touched Jobs and metering files before pushing.
+
+## Risks
+
+- Moving the fair-share block must not change SQLite behavior or create double evaluation on Postgres.
+- The Postgres regression test should be narrow and deterministic; it should assert sequencing rather than replicate the full create flow.
+- Docstring additions must stay concise enough that they do not become stale quickly.
+
+## Implementation Notes
+
+- `JobManager` now centralizes fair-share submission enforcement in `_apply_fair_share_submission_policy(...)`.
+- SQLite still performs fair-share evaluation immediately after the repository session is opened.
+- PostgreSQL now performs the same check only after `_pg_cursor()` has applied RLS session state, while reusing the same `JobsSession` for the active-job count and insert.
+- The fair-share integration tests now include a fake-Postgres regression that proves the repository count happens after `_pg_cursor()` is entered.
+- `Jobs_Repository.py` and `AuthNZ_Metering_Repository.py` now include module/class/method docstrings describing the persistence boundary and normalized return contracts.
+
+## Verification
+
+- `python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `41 passed, 5 warnings`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py -f json -o /tmp/bandit_pr908_open_review_cleanup.json`
+  - Result: `0` findings, `0` errors

--- a/Docs/Plans/2026-03-17-pr908-open-review-cleanup.md
+++ b/Docs/Plans/2026-03-17-pr908-open-review-cleanup.md
@@ -1,0 +1,181 @@
+# PR 908 Open Review Cleanup Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Status:** Complete
+
+**Goal:** Close the remaining PR 908 review threads by fixing the Postgres fair-share/RLS ordering bug and adding the missing repository documentation and test type hints.
+
+**Architecture:** Keep the existing Jobs and metering repository redesign intact. Adjust `JobManager.create_job()` so the Postgres fair-share count runs only after `_pg_cursor()` applies RLS state, and document the new repository boundaries directly in the new modules.
+
+**Tech Stack:** Python 3.11, FastAPI, SQLite, PostgreSQL/psycopg, pytest, loguru, Bandit
+
+---
+
+### Task 1: Add The Failing Fair-Share Ordering Regression
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+- Reference: `tldw_Server_API/app/core/Jobs/manager.py`
+
+**Step 1: Write the failing test**
+
+Add a focused regression test that exercises the Postgres create path and proves fair-share counting does not happen until after `_pg_cursor()` has been entered.
+
+```python
+def test_postgres_fair_share_count_runs_after_pg_cursor_setup(...):
+    events = []
+    repo = TrackingJobsRepository(...)
+    manager = JobManager(..., jobs_repository=repo)
+    ...
+    assert events.index("pg_cursor_enter") < events.index("count_active_jobs")
+```
+
+Also add explicit parameter and return annotations to the `TrackingJobsRepository` helper methods in the same file.
+
+**Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py -k postgres_fair_share_count_runs_after_pg_cursor_setup -v
+```
+
+Expected: the new test fails because the current Postgres branch counts before `_pg_cursor()`.
+
+**Step 3: Commit checkpoint**
+
+Do not commit yet. Keep this red test in place while implementing the fix.
+
+### Task 2: Move Postgres Fair-Share Counting Behind `_pg_cursor()`
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+- Reference: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+
+**Step 1: Write the minimal implementation**
+
+Refactor `create_job()` so that:
+
+- SQLite keeps the current early fair-share block.
+- PostgreSQL skips the early fair-share block.
+- Inside `with conn: with self._pg_cursor(conn) as cur:` the Postgres branch performs the fair-share check before quota, idempotency, and insert logic.
+- The count and insert reuse the same `JobsSession`.
+
+Use `BadRequestError` for the admission-control rejection to match the established narrow-scope cleanup already applied elsewhere in Jobs.
+
+**Step 2: Run the focused Jobs tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py -v
+```
+
+Expected: the new regression and the existing Jobs tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+git commit -m "fix: restore postgres fair-share rls ordering"
+```
+
+### Task 3: Add Repository Boundary Docstrings
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
+
+**Step 1: Add the missing docstrings**
+
+Document:
+
+- module responsibilities
+- class roles
+- backend-specific session/transaction behavior
+- method contracts and normalized return shapes
+
+Keep the wording concise and behavior-focused.
+
+**Step 2: Run the directly affected tests**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: pass.
+
+**Step 3: Commit**
+
+```bash
+git add tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+git commit -m "docs: document repository boundaries"
+```
+
+### Task 4: Full Verification And PR Cleanup
+
+**Files:**
+- Modify: `Docs/Plans/2026-03-17-pr908-open-review-cleanup-design.md`
+- Modify: `Docs/Plans/2026-03-17-pr908-open-review-cleanup.md`
+
+**Step 1: Run the scoped regression suite**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m pytest \
+  tldw_Server_API/tests/Billing/test_authnz_metering_repository.py \
+  tldw_Server_API/tests/Jobs/test_fair_share_integration.py \
+  tldw_Server_API/tests/Jobs/test_jobs_repository.py \
+  tldw_Server_API/tests/test_stripe_metering.py -v
+```
+
+Expected: pass.
+
+**Step 2: Run Bandit on the touched backend files**
+
+Run:
+
+```bash
+source .venv/bin/activate
+python -m bandit -r \
+  tldw_Server_API/app/core/Jobs/manager.py \
+  tldw_Server_API/app/core/DB_Management/Jobs_Repository.py \
+  tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py \
+  -f json -o /tmp/bandit_pr908_open_review_cleanup.json
+```
+
+Expected: `0` findings and `0` errors in the JSON output.
+
+**Step 3: Update plan docs with results**
+
+Record the final verification output and any notable implementation notes in these two plan files.
+
+**Step 4: Push and resolve review threads**
+
+Run the normal git push, then reply in each PR 908 thread with the exact fix location and resolve the thread.
+
+## Execution Summary
+
+Completed on `2026-03-17` in worktree `codex-pr898-boundary-redesign`.
+
+Implemented changes:
+
+- moved Postgres fair-share evaluation behind `_pg_cursor()` while keeping the same `JobsSession`
+- added a deterministic fake-Postgres regression for fair-share/RLS ordering
+- added explicit type hints to `TrackingJobsRepository`
+- documented the Jobs and AuthNZ metering repository boundaries with module/class/method docstrings
+
+Final verification:
+
+- `python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
+  - Result: `41 passed, 5 warnings`
+- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py -f json -o /tmp/bandit_pr908_open_review_cleanup.json`
+  - Result: `0` findings, `0` errors

--- a/Docs/Plans/2026-03-17-pr908-review-followups.md
+++ b/Docs/Plans/2026-03-17-pr908-review-followups.md
@@ -1,0 +1,137 @@
+# PR 908 Review Followups Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the remaining PR 908 review threads without broadening scope beyond the live unresolved comments.
+
+**Architecture:** Keep the existing Jobs and metering repository boundaries intact while hardening their configuration and lifecycle behavior. Preserve the current repository/session split, but move shared exceptions into `app/core/exceptions.py`, stop stale AuthNZ pool caching, validate Jobs repository construction up front, and restore idempotent replay semantics when fair-share admission would otherwise reject a retry.
+
+**Tech Stack:** Python, FastAPI backend modules, SQLite/PostgreSQL repository adapters, pytest, Bandit
+
+---
+
+### Task 1: Document the remaining review scope
+
+**Files:**
+- Create: `Docs/Plans/2026-03-17-pr908-review-followups.md`
+
+**Step 1: Capture the live unresolved review threads**
+
+Run:
+
+```bash
+gh api graphql -f query='query { repository(owner:"rmusser01", name:"tldw_server") { pullRequest(number: 908) { reviewThreads(first: 100) { nodes { id isResolved path line comments(first: 20) { nodes { id url body author { login } } } } } } } }'
+```
+
+Expected: unresolved threads limited to metering repository lifecycle, Jobs repository validation, and fair-share/idempotency behavior.
+
+**Step 2: Record the execution plan**
+
+Expected: this file exists and the remaining tasks below match the live thread set.
+
+### Task 2: Write the failing tests first
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+
+**Step 1: Write the failing metering repository tests**
+
+Add tests that:
+- import `DuplicateActiveSubscriptionError` from `tldw_Server_API.app.core.exceptions`
+- verify `_get_db_pool()` re-reads the global `get_db_pool()` when no pool was injected
+
+**Step 2: Write the failing Jobs repository validation tests**
+
+Add tests that:
+- reject unsupported `backend`
+- reject SQLite repositories without `db_path` when not pooled
+- reject Postgres repositories without `db_url` when not pooled
+- reject connection pools missing `acquire`
+
+**Step 3: Write the failing fair-share/idempotency regression tests**
+
+Add tests that prove:
+- an idempotent retry returns the existing row when the user is already at the fair-share limit
+- this holds for the SQLite create path
+
+**Step 4: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py -q
+```
+
+Expected: failures in the new assertions before production code changes.
+
+### Task 3: Implement the minimal fixes
+
+**Files:**
+- Modify: `tldw_Server_API/app/core/exceptions.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py`
+- Modify: `tldw_Server_API/app/core/DB_Management/Jobs_Repository.py`
+- Modify: `tldw_Server_API/app/core/Jobs/manager.py`
+
+**Step 1: Centralize the shared exceptions**
+
+Move or define:
+- `DuplicateActiveSubscriptionError`
+- a repository configuration exception that subclasses the project exception hierarchy
+
+**Step 2: Fix AuthNZ pool resolution**
+
+Update `_get_db_pool()` so:
+- injected pools are reused
+- globally managed pools are fetched fresh from `get_db_pool()` instead of being cached on the repository instance
+
+**Step 3: Harden `JobsRepository` construction**
+
+Validate in `__init__`:
+- backend is only `sqlite` or `postgres`
+- SQLite requires `db_path` unless a pool is injected
+- Postgres requires `db_url` unless a pool is injected
+- invalid pool objects raise the project repository configuration exception
+
+**Step 4: Restore idempotent retry semantics**
+
+Update `JobManager.create_job()` so:
+- existing idempotent rows are checked before fair-share rejection
+- retries with the same idempotency key return the pre-existing row instead of raising `BadRequestError`
+- the same repository session/transaction is preserved
+
+### Task 4: Verify and close the review threads
+
+**Files:**
+- Modify: `tldw_Server_API/tests/Billing/test_authnz_metering_repository.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_jobs_repository.py`
+- Modify: `tldw_Server_API/tests/Jobs/test_fair_share_integration.py`
+
+**Step 1: Run the scoped regression suite**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/test_stripe_metering.py -q
+```
+
+Expected: all selected tests pass.
+
+**Step 2: Run Bandit on the touched production files**
+
+Run:
+
+```bash
+source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/exceptions.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/Jobs/manager.py -f json -o /tmp/bandit_pr908_review_followups.json
+```
+
+Expected: `results=0` and `errors=0`.
+
+**Step 3: Reply on GitHub and resolve threads**
+
+Reply in-thread for:
+- the five code fixes implemented here
+- the one already-fixed `self._jobs_repository.session()` comment
+
+Expected: PR 908 has zero unresolved review threads.

--- a/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
@@ -8,8 +8,13 @@ shapes before returning dictionaries to the orchestration layer.
 
 from __future__ import annotations
 
+import inspect
 from datetime import date, datetime
 from typing import Any
+
+
+class DuplicateActiveSubscriptionError(RuntimeError):
+    """Raised when a user resolves to more than one active billing subscription."""
 
 
 class _AuthNZMeteringRepositoryBase:
@@ -38,6 +43,24 @@ class _AuthNZMeteringRepositoryBase:
         if isinstance(value, date):
             return value
         return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+    @staticmethod
+    async def _sqlite_fetch_rows(cur: Any) -> list[Any]:
+        """Fetch SQLite cursor rows from adapters that expose fetchall or fetchone."""
+        fetchall = getattr(cur, "fetchall", None)
+        if callable(fetchall):
+            rows = fetchall()
+            if inspect.isawaitable(rows):
+                rows = await rows
+            return list(rows)
+
+        fetchone = getattr(cur, "fetchone", None)
+        if not callable(fetchone):
+            return []
+        row = fetchone()
+        if inspect.isawaitable(row):
+            row = await row
+        return [] if row is None else [row]
 
 
 class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
@@ -129,6 +152,33 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
 class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
     """Resolve the active Stripe subscription that should receive metered usage."""
 
+    @staticmethod
+    def _raise_on_duplicate_matches(
+        rows: list[dict[str, Any]],
+        *,
+        user_id: int,
+        source: str,
+    ) -> None:
+        """Fail fast when a lookup branch returns more than one active subscription."""
+        if len(rows) > 1:
+            raise DuplicateActiveSubscriptionError(
+                f"Found multiple active subscriptions for user {user_id} via {source} lookup"
+            )
+
+    @staticmethod
+    def _coalesce_unique_match(rows: list[dict[str, Any]]) -> dict[str, Any] | None:
+        """Collapse member/owner matches into a single unique subscription row."""
+        unique_rows: dict[tuple[Any, Any], dict[str, Any]] = {}
+        for row in rows:
+            unique_rows[(row.get("org_id"), row.get("stripe_subscription_id"))] = row
+        if not unique_rows:
+            return None
+        if len(unique_rows) > 1:
+            raise DuplicateActiveSubscriptionError(
+                "Found multiple active subscriptions for a single user across membership ownership lookups"
+            )
+        return next(iter(unique_rows.values()))
+
     async def get_active_subscription_for_user(
         self,
         user_id: int,
@@ -137,38 +187,44 @@ class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
-                row = await conn.fetchrow(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN org_members om ON om.org_id = os.org_id
-                    WHERE om.user_id = $1
-                      AND om.status = 'active'
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    user_id,
-                )
-                if row:
-                    return dict(row)
-                row = await conn.fetchrow(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN organizations o ON o.id = os.org_id
-                    WHERE o.owner_user_id = $1
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    user_id,
-                )
-                return dict(row) if row else None
+                member_rows = [
+                    dict(row)
+                    for row in await conn.fetch(
+                        """
+                        SELECT os.stripe_customer_id,
+                               os.stripe_subscription_id,
+                               os.org_id
+                        FROM org_subscriptions os
+                        JOIN org_members om ON om.org_id = os.org_id
+                        WHERE om.user_id = $1
+                          AND om.status = 'active'
+                          AND os.status = 'active'
+                          AND os.stripe_subscription_id IS NOT NULL
+                        LIMIT 2
+                        """,
+                        user_id,
+                    )
+                ]
+                self._raise_on_duplicate_matches(member_rows, user_id=user_id, source="member")
+                owner_rows = [
+                    dict(row)
+                    for row in await conn.fetch(
+                        """
+                        SELECT os.stripe_customer_id,
+                               os.stripe_subscription_id,
+                               os.org_id
+                        FROM org_subscriptions os
+                        JOIN organizations o ON o.id = os.org_id
+                        WHERE o.owner_user_id = $1
+                          AND os.status = 'active'
+                          AND os.stripe_subscription_id IS NOT NULL
+                        LIMIT 2
+                        """,
+                        user_id,
+                    )
+                ]
+                self._raise_on_duplicate_matches(owner_rows, user_id=user_id, source="owner")
+                return self._coalesce_unique_match(member_rows + owner_rows)
 
             cur = await conn.execute(
                 """
@@ -181,14 +237,14 @@ class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
                   AND om.status = 'active'
                   AND os.status = 'active'
                   AND os.stripe_subscription_id IS NOT NULL
-                LIMIT 1
+                LIMIT 2
                 """,
                 (user_id,),
             )
-            row = await cur.fetchone()
-            if row:
-                columns = [col[0] for col in cur.description]
-                return dict(zip(columns, row))
+            member_rows_raw = await self._sqlite_fetch_rows(cur)
+            member_columns = [col[0] for col in cur.description]
+            member_rows = [dict(zip(member_columns, row)) for row in member_rows_raw]
+            self._raise_on_duplicate_matches(member_rows, user_id=user_id, source="member")
 
             cur = await conn.execute(
                 """
@@ -200,15 +256,15 @@ class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
                 WHERE o.owner_user_id = ?
                   AND os.status = 'active'
                   AND os.stripe_subscription_id IS NOT NULL
-                LIMIT 1
+                LIMIT 2
                 """,
                 (user_id,),
             )
-            row = await cur.fetchone()
-            if not row:
-                return None
-            columns = [col[0] for col in cur.description]
-            return dict(zip(columns, row))
+            owner_rows_raw = await self._sqlite_fetch_rows(cur)
+            owner_columns = [col[0] for col in cur.description]
+            owner_rows = [dict(zip(owner_columns, row)) for row in owner_rows_raw]
+            self._raise_on_duplicate_matches(owner_rows, user_id=user_id, source="owner")
+            return self._coalesce_unique_match(member_rows + owner_rows)
 
 
 class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
@@ -232,6 +288,10 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
                     )
                     """
                 )
+                await conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_metering_sync_log_day "
+                    "ON metering_sync_log (day)"
+                )
                 return
 
             await conn.execute(
@@ -246,6 +306,10 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
                     PRIMARY KEY (user_id, day, stripe_subscription_id)
                 )
                 """
+            )
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_metering_sync_log_day "
+                "ON metering_sync_log (day)"
             )
             await conn.commit()
 

--- a/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class _AuthNZMeteringRepositoryBase:
+    def __init__(self, *, db_pool: Any | None = None) -> None:
+        self._db_pool = db_pool
+
+    async def _get_db_pool(self) -> Any:
+        if self._db_pool is None:
+            from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+            self._db_pool = await get_db_pool()
+        return self._db_pool
+
+    @staticmethod
+    def _is_postgres(conn: Any) -> bool:
+        return hasattr(conn, "fetchrow")
+
+
+class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
+    @staticmethod
+    def _is_missing_usage_column_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return "bytes_in_total" in message and (
+            "no such column" in message
+            or "does not exist" in message
+            or "undefined column" in message
+        )
+
+    @staticmethod
+    def _sqlite_rows_to_dicts(
+        raw_rows: list[tuple[Any, ...]],
+        description: list[tuple[Any, ...]] | None,
+        *,
+        include_bytes_in_total: bool,
+    ) -> list[dict[str, Any]]:
+        if not raw_rows:
+            return []
+        columns = [col[0] for col in (description or [])]
+        rows = [dict(zip(columns, row)) for row in raw_rows]
+        if not include_bytes_in_total:
+            for row in rows:
+                row["bytes_in_total"] = 0
+        return rows
+
+    async def fetch_usage_for_date(self, target_date: str) -> list[dict[str, Any]]:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                try:
+                    rows = await conn.fetch(
+                        "SELECT user_id, requests, errors, bytes_total, "
+                        "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = $1",
+                        target_date,
+                    )
+                    return [dict(r) for r in rows]
+                except Exception as exc:
+                    if not self._is_missing_usage_column_error(exc):
+                        raise
+                    rows = await conn.fetch(
+                        "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
+                        "FROM usage_daily WHERE day = $1",
+                        target_date,
+                    )
+                    legacy_rows = [dict(r) for r in rows]
+                    for row in legacy_rows:
+                        row["bytes_in_total"] = 0
+                    return legacy_rows
+
+            try:
+                cur = await conn.execute(
+                    "SELECT user_id, requests, errors, bytes_total, "
+                    "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
+                    "FROM usage_daily WHERE day = ?",
+                    (target_date,),
+                )
+                raw_rows = await cur.fetchall()
+                return self._sqlite_rows_to_dicts(
+                    raw_rows,
+                    cur.description,
+                    include_bytes_in_total=True,
+                )
+            except Exception as exc:
+                if not self._is_missing_usage_column_error(exc):
+                    raise
+                cur = await conn.execute(
+                    "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
+                    "FROM usage_daily WHERE day = ?",
+                    (target_date,),
+                )
+                raw_rows = await cur.fetchall()
+                return self._sqlite_rows_to_dicts(
+                    raw_rows,
+                    cur.description,
+                    include_bytes_in_total=False,
+                )
+
+
+class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
+    async def get_active_subscription_for_user(
+        self,
+        user_id: int,
+    ) -> dict[str, Any] | None:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                row = await conn.fetchrow(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN org_members om ON om.org_id = os.org_id
+                    WHERE om.user_id = $1
+                      AND om.status = 'active'
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    user_id,
+                )
+                if row:
+                    return dict(row)
+                row = await conn.fetchrow(
+                    """
+                    SELECT os.stripe_customer_id,
+                           os.stripe_subscription_id,
+                           os.org_id
+                    FROM org_subscriptions os
+                    JOIN organizations o ON o.id = os.org_id
+                    WHERE o.owner_user_id = $1
+                      AND os.status = 'active'
+                      AND os.stripe_subscription_id IS NOT NULL
+                    LIMIT 1
+                    """,
+                    user_id,
+                )
+                return dict(row) if row else None
+
+            cur = await conn.execute(
+                """
+                SELECT os.stripe_customer_id,
+                       os.stripe_subscription_id,
+                       os.org_id
+                FROM org_subscriptions os
+                JOIN org_members om ON om.org_id = os.org_id
+                WHERE om.user_id = ?
+                  AND om.status = 'active'
+                  AND os.status = 'active'
+                  AND os.stripe_subscription_id IS NOT NULL
+                LIMIT 1
+                """,
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            if row:
+                columns = [col[0] for col in cur.description]
+                return dict(zip(columns, row))
+
+            cur = await conn.execute(
+                """
+                SELECT os.stripe_customer_id,
+                       os.stripe_subscription_id,
+                       os.org_id
+                FROM org_subscriptions os
+                JOIN organizations o ON o.id = os.org_id
+                WHERE o.owner_user_id = ?
+                  AND os.status = 'active'
+                  AND os.stripe_subscription_id IS NOT NULL
+                LIMIT 1
+                """,
+                (user_id,),
+            )
+            row = await cur.fetchone()
+            if not row:
+                return None
+            columns = [col[0] for col in cur.description]
+            return dict(zip(columns, row))
+
+
+class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
+    async def ensure_schema(self) -> None:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                await conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS metering_sync_log (
+                        user_id INTEGER NOT NULL,
+                        day DATE NOT NULL,
+                        stripe_subscription_id TEXT NOT NULL,
+                        requests_synced INTEGER DEFAULT 0,
+                        bytes_synced BIGINT DEFAULT 0,
+                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (user_id, day, stripe_subscription_id)
+                    )
+                    """
+                )
+                return
+
+            await conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS metering_sync_log (
+                    user_id INTEGER NOT NULL,
+                    day DATE NOT NULL,
+                    stripe_subscription_id TEXT NOT NULL,
+                    requests_synced INTEGER DEFAULT 0,
+                    bytes_synced INTEGER DEFAULT 0,
+                    synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (user_id, day, stripe_subscription_id)
+                )
+                """
+            )
+            await conn.commit()
+
+    async def already_synced(
+        self,
+        *,
+        user_id: int,
+        day: str,
+        subscription_id: str,
+    ) -> bool:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                row = await conn.fetchval(
+                    "SELECT 1 FROM metering_sync_log "
+                    "WHERE user_id = $1 AND day = $2 AND stripe_subscription_id = $3",
+                    user_id,
+                    day,
+                    subscription_id,
+                )
+                return row is not None
+
+            cur = await conn.execute(
+                "SELECT 1 FROM metering_sync_log "
+                "WHERE user_id = ? AND day = ? AND stripe_subscription_id = ?",
+                (user_id, day, subscription_id),
+            )
+            return (await cur.fetchone()) is not None
+
+    async def record_sync(
+        self,
+        *,
+        user_id: int,
+        day: str,
+        subscription_id: str,
+        requests: int,
+        bytes_total: int,
+    ) -> None:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                await conn.execute(
+                    "INSERT INTO metering_sync_log "
+                    "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
+                    "VALUES ($1, $2, $3, $4, $5) "
+                    "ON CONFLICT (user_id, day, stripe_subscription_id) DO UPDATE "
+                    "SET requests_synced = EXCLUDED.requests_synced, "
+                    "    bytes_synced = EXCLUDED.bytes_synced, "
+                    "    synced_at = CURRENT_TIMESTAMP",
+                    user_id,
+                    day,
+                    subscription_id,
+                    requests,
+                    bytes_total,
+                )
+                return
+
+            await conn.execute(
+                "INSERT OR REPLACE INTO metering_sync_log "
+                "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (user_id, day, subscription_id, requests, bytes_total),
+            )
+            await conn.commit()
+
+    async def fetch_sync_totals(self, target_date: str) -> list[dict[str, Any]]:
+        pool = await self._get_db_pool()
+        async with pool.acquire() as conn:
+            if self._is_postgres(conn):
+                rows = await conn.fetch(
+                    "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
+                    "FROM metering_sync_log WHERE day = $1",
+                    target_date,
+                )
+                return [dict(r) for r in rows]
+
+            cur = await conn.execute(
+                "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
+                "FROM metering_sync_log WHERE day = ?",
+                (target_date,),
+            )
+            raw = await cur.fetchall()
+            if not raw:
+                return []
+            columns = [col[0] for col in cur.description]
+            return [dict(zip(columns, row)) for row in raw]

--- a/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
@@ -1,13 +1,25 @@
+"""Persistence boundary for AuthNZ metering reads and sync-log writes.
+
+The Stripe metering service delegates all database access in this module so the
+service layer only coordinates usage lookup, subscription resolution, Stripe
+calls, and reconciliation. Each repository normalizes backend-specific row
+shapes before returning dictionaries to the orchestration layer.
+"""
+
 from __future__ import annotations
 
 from typing import Any
 
 
 class _AuthNZMeteringRepositoryBase:
+    """Shared pool-loading helpers for AuthNZ metering repositories."""
+
     def __init__(self, *, db_pool: Any | None = None) -> None:
+        """Store an optional injected pool for tests or alternate composition."""
         self._db_pool = db_pool
 
     async def _get_db_pool(self) -> Any:
+        """Lazily resolve the shared AuthNZ DB pool on first use."""
         if self._db_pool is None:
             from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 
@@ -16,12 +28,16 @@ class _AuthNZMeteringRepositoryBase:
 
     @staticmethod
     def _is_postgres(conn: Any) -> bool:
+        """Detect whether the acquired connection exposes asyncpg-style methods."""
         return hasattr(conn, "fetchrow")
 
 
 class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
+    """Read normalized daily usage rows from the AuthNZ billing database."""
+
     @staticmethod
     def _is_missing_usage_column_error(exc: Exception) -> bool:
+        """Identify legacy-schema errors where `bytes_in_total` is unavailable."""
         message = str(exc).lower()
         return "bytes_in_total" in message and (
             "no such column" in message
@@ -36,6 +52,7 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
         *,
         include_bytes_in_total: bool,
     ) -> list[dict[str, Any]]:
+        """Map SQLite cursor output to normalized usage dictionaries."""
         if not raw_rows:
             return []
         columns = [col[0] for col in (description or [])]
@@ -46,6 +63,7 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
         return rows
 
     async def fetch_usage_for_date(self, target_date: str) -> list[dict[str, Any]]:
+        """Return per-user usage rows for a billing date with legacy fallback."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
@@ -100,10 +118,13 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
 
 
 class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
+    """Resolve the active Stripe subscription that should receive metered usage."""
+
     async def get_active_subscription_for_user(
         self,
         user_id: int,
     ) -> dict[str, Any] | None:
+        """Return the active subscription for a member or org owner, if any."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
@@ -182,7 +203,10 @@ class AuthNZBillingSubscriptionRepository(_AuthNZMeteringRepositoryBase):
 
 
 class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
+    """Own metering sync-log schema management and sync-state persistence."""
+
     async def ensure_schema(self) -> None:
+        """Create the metering sync-log table if it does not already exist."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
@@ -223,6 +247,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
         day: str,
         subscription_id: str,
     ) -> bool:
+        """Check whether a subscription/day pair has already been synced."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
@@ -251,6 +276,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
         requests: int,
         bytes_total: int,
     ) -> None:
+        """Persist the latest synced totals for a user/subscription/day tuple."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
@@ -279,6 +305,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
             await conn.commit()
 
     async def fetch_sync_totals(self, target_date: str) -> list[dict[str, Any]]:
+        """Return previously recorded sync totals for reconciliation output."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):

--- a/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
@@ -8,6 +8,7 @@ shapes before returning dictionaries to the orchestration layer.
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any
 
 
@@ -30,6 +31,13 @@ class _AuthNZMeteringRepositoryBase:
     def _is_postgres(conn: Any) -> bool:
         """Detect whether the acquired connection exposes asyncpg-style methods."""
         return hasattr(conn, "fetchrow")
+
+    @staticmethod
+    def _coerce_day(value: str | date) -> date:
+        """Return a concrete date object for PostgreSQL DATE bindings."""
+        if isinstance(value, date):
+            return value
+        return datetime.strptime(str(value), "%Y-%m-%d").date()
 
 
 class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
@@ -62,17 +70,18 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
                 row["bytes_in_total"] = 0
         return rows
 
-    async def fetch_usage_for_date(self, target_date: str) -> list[dict[str, Any]]:
+    async def fetch_usage_for_date(self, target_date: str | date) -> list[dict[str, Any]]:
         """Return per-user usage rows for a billing date with legacy fallback."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(target_date)
                 try:
                     rows = await conn.fetch(
                         "SELECT user_id, requests, errors, bytes_total, "
                         "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
                         "FROM usage_daily WHERE day = $1",
-                        target_date,
+                        pg_day,
                     )
                     return [dict(r) for r in rows]
                 except Exception as exc:
@@ -81,7 +90,7 @@ class AuthNZUsageDailyRepository(_AuthNZMeteringRepositoryBase):
                     rows = await conn.fetch(
                         "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
                         "FROM usage_daily WHERE day = $1",
-                        target_date,
+                        pg_day,
                     )
                     legacy_rows = [dict(r) for r in rows]
                     for row in legacy_rows:
@@ -244,18 +253,19 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
         self,
         *,
         user_id: int,
-        day: str,
+        day: str | date,
         subscription_id: str,
     ) -> bool:
         """Check whether a subscription/day pair has already been synced."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(day)
                 row = await conn.fetchval(
                     "SELECT 1 FROM metering_sync_log "
                     "WHERE user_id = $1 AND day = $2 AND stripe_subscription_id = $3",
                     user_id,
-                    day,
+                    pg_day,
                     subscription_id,
                 )
                 return row is not None
@@ -271,7 +281,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
         self,
         *,
         user_id: int,
-        day: str,
+        day: str | date,
         subscription_id: str,
         requests: int,
         bytes_total: int,
@@ -280,6 +290,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(day)
                 await conn.execute(
                     "INSERT INTO metering_sync_log "
                     "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
@@ -289,7 +300,7 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
                     "    bytes_synced = EXCLUDED.bytes_synced, "
                     "    synced_at = CURRENT_TIMESTAMP",
                     user_id,
-                    day,
+                    pg_day,
                     subscription_id,
                     requests,
                     bytes_total,
@@ -304,15 +315,16 @@ class AuthNZMeteringSyncLogRepository(_AuthNZMeteringRepositoryBase):
             )
             await conn.commit()
 
-    async def fetch_sync_totals(self, target_date: str) -> list[dict[str, Any]]:
+    async def fetch_sync_totals(self, target_date: str | date) -> list[dict[str, Any]]:
         """Return previously recorded sync totals for reconciliation output."""
         pool = await self._get_db_pool()
         async with pool.acquire() as conn:
             if self._is_postgres(conn):
+                pg_day = self._coerce_day(target_date)
                 rows = await conn.fetch(
                     "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
                     "FROM metering_sync_log WHERE day = $1",
-                    target_date,
+                    pg_day,
                 )
                 return [dict(r) for r in rows]
 

--- a/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py
@@ -12,9 +12,7 @@ import inspect
 from datetime import date, datetime
 from typing import Any
 
-
-class DuplicateActiveSubscriptionError(RuntimeError):
-    """Raised when a user resolves to more than one active billing subscription."""
+from tldw_Server_API.app.core.exceptions import DuplicateActiveSubscriptionError
 
 
 class _AuthNZMeteringRepositoryBase:
@@ -25,12 +23,13 @@ class _AuthNZMeteringRepositoryBase:
         self._db_pool = db_pool
 
     async def _get_db_pool(self) -> Any:
-        """Lazily resolve the shared AuthNZ DB pool on first use."""
-        if self._db_pool is None:
-            from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+        """Resolve the injected pool or the current shared AuthNZ DB pool."""
+        if self._db_pool is not None:
+            return self._db_pool
 
-            self._db_pool = await get_db_pool()
-        return self._db_pool
+        from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+
+        return await get_db_pool()
 
     @staticmethod
     def _is_postgres(conn: Any) -> bool:

--- a/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+import uuid as _uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone as _tz
+from pathlib import Path
+from typing import Any, Iterator
+
+from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
+
+try:
+    import psycopg  # type: ignore
+    from psycopg.rows import dict_row  # type: ignore
+except ImportError:  # pragma: no cover - postgres is optional
+    psycopg = None  # type: ignore[assignment]
+    dict_row = None  # type: ignore[assignment]
+
+
+def _normalize_sqlite_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is not None:
+        value = value.astimezone(_tz.utc).replace(tzinfo=None)
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _normalize_postgres_datetime(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_tz.utc)
+    return value.astimezone(_tz.utc)
+
+
+@dataclass(slots=True)
+class JobsSession:
+    backend: str
+    conn: Any
+
+
+class JobsRepository:
+    def __init__(
+        self,
+        *,
+        backend: str,
+        db_path: Path | None = None,
+        db_url: str | None = None,
+    ) -> None:
+        self.backend = backend
+        self.db_path = Path(db_path) if db_path is not None else None
+        self.db_url = db_url
+
+    @classmethod
+    def for_sqlite(cls, db_path: Path) -> "JobsRepository":
+        return cls(backend="sqlite", db_path=db_path)
+
+    @classmethod
+    def for_postgres(cls, db_url: str) -> "JobsRepository":
+        return cls(backend="postgres", db_url=db_url)
+
+    def _connect(self) -> Any:
+        if self.backend == "postgres":
+            if psycopg is None:  # pragma: no cover - guarded by optional dependency
+                raise RuntimeError("psycopg is required for postgres jobs repositories")
+            return psycopg.connect(self.db_url)
+        conn = sqlite3.connect(self.db_path)
+        with contextlib.suppress(sqlite3.Error):
+            configure_sqlite_connection(conn)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @contextlib.contextmanager
+    def session(self) -> Iterator[JobsSession]:
+        conn = self._connect()
+        session = JobsSession(backend=self.backend, conn=conn)
+        try:
+            yield session
+            conn.commit()
+        except Exception:
+            with contextlib.suppress(Exception):
+                conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def count_active_jobs_for_user(
+        self,
+        user_id: str,
+        *,
+        session: JobsSession | None = None,
+    ) -> int:
+        if session is None:
+            with self.session() as managed_session:
+                return self.count_active_jobs_for_user(user_id, session=managed_session)
+
+        if session.backend == "postgres":
+            with session.conn.cursor(row_factory=dict_row) as cur:
+                cur.execute(
+                    "SELECT COUNT(*) AS c FROM jobs WHERE owner_user_id = %s AND status IN ('queued', 'processing')",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+                return int(row["c"] if row else 0)
+
+        row = session.conn.execute(
+            "SELECT COUNT(*) FROM jobs WHERE owner_user_id = ? AND status IN ('queued', 'processing')",
+            (user_id,),
+        ).fetchone()
+        return int(row[0] if row else 0)
+
+    def insert_job(
+        self,
+        *,
+        domain: str,
+        queue: str,
+        job_type: str,
+        payload_json: str,
+        owner_user_id: str | None,
+        project_id: int | None,
+        batch_group: str | None,
+        idempotency_key: str | None,
+        priority: int,
+        max_retries: int,
+        available_at: datetime | None,
+        request_id: str | None,
+        trace_id: str | None,
+        created_at: datetime,
+        session: JobsSession | None = None,
+    ) -> dict[str, Any]:
+        if session is None:
+            with self.session() as managed_session:
+                return self.insert_job(
+                    domain=domain,
+                    queue=queue,
+                    job_type=job_type,
+                    payload_json=payload_json,
+                    owner_user_id=owner_user_id,
+                    project_id=project_id,
+                    batch_group=batch_group,
+                    idempotency_key=idempotency_key,
+                    priority=priority,
+                    max_retries=max_retries,
+                    available_at=available_at,
+                    request_id=request_id,
+                    trace_id=trace_id,
+                    created_at=created_at,
+                    session=managed_session,
+                )
+
+        uuid_val = str(_uuid.uuid4())
+
+        if session.backend == "postgres":
+            created_at_pg = _normalize_postgres_datetime(created_at)
+            available_at_pg = _normalize_postgres_datetime(available_at)
+            with session.conn.cursor(row_factory=dict_row) as cur:
+                cur.execute(
+                    (
+                        "INSERT INTO jobs (uuid, domain, queue, job_type, owner_user_id, project_id, batch_group, "
+                        "idempotency_key, payload, result, status, priority, max_retries, retry_count, available_at, "
+                        "created_at, updated_at, request_id, trace_id) "
+                        "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, NULL, 'queued', %s, %s, 0, %s, %s, %s, %s, %s) "
+                        "RETURNING *"
+                    ),
+                    (
+                        uuid_val,
+                        domain,
+                        queue,
+                        job_type,
+                        owner_user_id,
+                        project_id,
+                        batch_group,
+                        idempotency_key,
+                        payload_json,
+                        priority,
+                        max_retries,
+                        available_at_pg,
+                        created_at_pg,
+                        created_at_pg,
+                        request_id,
+                        trace_id,
+                    ),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else {}
+
+        created_at_sqlite = _normalize_sqlite_datetime(created_at)
+        available_at_sqlite = _normalize_sqlite_datetime(available_at)
+        session.conn.execute(
+            """
+            INSERT INTO jobs (
+              uuid, domain, queue, job_type, owner_user_id, project_id, batch_group,
+              idempotency_key, payload, result, status, priority, max_retries,
+              retry_count, available_at, created_at, updated_at, request_id, trace_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 'queued', ?, ?, 0, ?, ?, ?, ?, ?)
+            """,
+            (
+                uuid_val,
+                domain,
+                queue,
+                job_type,
+                owner_user_id,
+                project_id,
+                batch_group,
+                idempotency_key,
+                payload_json,
+                priority,
+                max_retries,
+                available_at_sqlite,
+                created_at_sqlite,
+                created_at_sqlite,
+                request_id,
+                trace_id,
+            ),
+        )
+        job_id = session.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        row = session.conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        return dict(row) if row else {}

--- a/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import contextlib
 import sqlite3
 import uuid as _uuid
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone as _tz
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
+
+from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
 
@@ -61,48 +64,95 @@ class JobsRepository:
         backend: str,
         db_path: Path | None = None,
         db_url: str | None = None,
+        connection_pool: Any | None = None,
     ) -> None:
         """Build a repository bound to either a SQLite path or Postgres DSN."""
         self.backend = backend
         self.db_path = Path(db_path) if db_path is not None else None
         self.db_url = db_url
+        self.connection_pool = connection_pool
+        if self.connection_pool is not None and not hasattr(self.connection_pool, "acquire"):
+            raise TypeError("JobsRepository connection_pool must define an acquire() context manager")
 
     @classmethod
-    def for_sqlite(cls, db_path: Path) -> "JobsRepository":
+    def for_sqlite(
+        cls,
+        db_path: Path,
+        *,
+        connection_pool: Any | None = None,
+    ) -> JobsRepository:
         """Create a repository configured for the SQLite jobs database."""
-        return cls(backend="sqlite", db_path=db_path)
+        return cls(backend="sqlite", db_path=db_path, connection_pool=connection_pool)
 
     @classmethod
-    def for_postgres(cls, db_url: str) -> "JobsRepository":
+    def for_postgres(
+        cls,
+        db_url: str,
+        *,
+        connection_pool: Any | None = None,
+    ) -> JobsRepository:
         """Create a repository configured for the PostgreSQL jobs database."""
-        return cls(backend="postgres", db_url=db_url)
+        return cls(backend="postgres", db_url=db_url, connection_pool=connection_pool)
+
+    @staticmethod
+    def _prepare_sqlite_connection(conn: sqlite3.Connection) -> sqlite3.Connection:
+        """Apply local SQLite connection policy and row normalization."""
+        try:
+            configure_sqlite_connection(conn)
+        except sqlite3.Error as exc:
+            logger.debug("SQLite jobs repository policy configuration skipped: {}", exc)
+        conn.row_factory = sqlite3.Row
+        return conn
 
     def _connect(self) -> Any:
         """Open a backend-specific connection with the expected local policy."""
         if self.backend == "postgres":
             if psycopg is None:  # pragma: no cover - guarded by optional dependency
                 raise RuntimeError("psycopg is required for postgres jobs repositories")
-            return psycopg.connect(self.db_url)
+            conn = psycopg.connect(self.db_url)
+            logger.debug("Opened direct postgres jobs repository connection")
+            return conn
+        if self.db_path is None:
+            raise ValueError("SQLite jobs repository requires db_path when no connection pool is provided")
         conn = sqlite3.connect(self.db_path)
-        with contextlib.suppress(sqlite3.Error):
-            configure_sqlite_connection(conn)
-        conn.row_factory = sqlite3.Row
-        return conn
+        logger.debug("Opened direct sqlite jobs repository connection for {}", self.db_path)
+        return self._prepare_sqlite_connection(conn)
+
+    @contextlib.contextmanager
+    def _acquire_connection(self) -> Iterator[Any]:
+        """Yield either a pooled connection or a directly opened backend connection."""
+        if self.connection_pool is None:
+            conn = self._connect()
+            try:
+                yield conn
+            finally:
+                conn.close()
+            return
+
+        with self.connection_pool.acquire() as conn:
+            if self.backend == "sqlite" and isinstance(conn, sqlite3.Connection):
+                self._prepare_sqlite_connection(conn)
+            logger.debug("Acquired {} jobs repository pooled connection", self.backend)
+            yield conn
 
     @contextlib.contextmanager
     def session(self) -> Iterator[JobsSession]:
         """Yield a managed session that commits on success and rolls back on failure."""
-        conn = self._connect()
-        session = JobsSession(backend=self.backend, conn=conn)
-        try:
-            yield session
-            conn.commit()
-        except Exception:
-            with contextlib.suppress(Exception):
-                conn.rollback()
-            raise
-        finally:
-            conn.close()
+        with self._acquire_connection() as conn:
+            session = JobsSession(backend=self.backend, conn=conn)
+            try:
+                yield session
+                conn.commit()
+            except Exception:
+                with contextlib.suppress(Exception):
+                    conn.rollback()
+                raise
+
+    def close_pool(self) -> None:
+        """Close an injected connection pool when the repository owns one."""
+        close_pool = getattr(self.connection_pool, "close", None)
+        if callable(close_pool):
+            close_pool()
 
     def count_active_jobs_for_user(
         self,
@@ -208,6 +258,42 @@ class JobsRepository:
 
         created_at_sqlite = _normalize_sqlite_datetime(created_at)
         available_at_sqlite = _normalize_sqlite_datetime(available_at)
+        params = (
+            uuid_val,
+            domain,
+            queue,
+            job_type,
+            owner_user_id,
+            project_id,
+            batch_group,
+            idempotency_key,
+            payload_json,
+            priority,
+            max_retries,
+            available_at_sqlite,
+            created_at_sqlite,
+            created_at_sqlite,
+            request_id,
+            trace_id,
+        )
+        try:
+            cur = session.conn.execute(
+                """
+                INSERT INTO jobs (
+                  uuid, domain, queue, job_type, owner_user_id, project_id, batch_group,
+                  idempotency_key, payload, result, status, priority, max_retries,
+                  retry_count, available_at, created_at, updated_at, request_id, trace_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 'queued', ?, ?, 0, ?, ?, ?, ?, ?)
+                RETURNING *
+                """,
+                params,
+            )
+            row = cur.fetchone()
+            return dict(row) if row else {}
+        except sqlite3.OperationalError as exc:
+            if "returning" not in str(exc).lower():
+                raise
+
         session.conn.execute(
             """
             INSERT INTO jobs (
@@ -216,24 +302,7 @@ class JobsRepository:
               retry_count, available_at, created_at, updated_at, request_id, trace_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 'queued', ?, ?, 0, ?, ?, ?, ?, ?)
             """,
-            (
-                uuid_val,
-                domain,
-                queue,
-                job_type,
-                owner_user_id,
-                project_id,
-                batch_group,
-                idempotency_key,
-                payload_json,
-                priority,
-                max_retries,
-                available_at_sqlite,
-                created_at_sqlite,
-                created_at_sqlite,
-                request_id,
-                trace_id,
-            ),
+            params,
         )
         job_id = session.conn.execute("SELECT last_insert_rowid()").fetchone()[0]
         row = session.conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()

--- a/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
@@ -1,3 +1,11 @@
+"""Repository boundary for Jobs persistence.
+
+This module keeps backend-specific SQL for create-time job operations in one
+place so `JobManager` can stay focused on policy and orchestration. The public
+API exposes a lightweight `JobsSession` wrapper plus repository methods that
+either manage their own transaction scope or reuse a caller-supplied session.
+"""
+
 from __future__ import annotations
 
 import contextlib
@@ -19,6 +27,7 @@ except ImportError:  # pragma: no cover - postgres is optional
 
 
 def _normalize_sqlite_datetime(value: datetime | None) -> str | None:
+    """Convert datetimes into the naive UTC string format stored in SQLite."""
     if value is None:
         return None
     if value.tzinfo is not None:
@@ -27,6 +36,7 @@ def _normalize_sqlite_datetime(value: datetime | None) -> str | None:
 
 
 def _normalize_postgres_datetime(value: datetime | None) -> datetime | None:
+    """Normalize datetimes into timezone-aware UTC values for PostgreSQL."""
     if value is None:
         return None
     if value.tzinfo is None:
@@ -36,11 +46,15 @@ def _normalize_postgres_datetime(value: datetime | None) -> datetime | None:
 
 @dataclass(slots=True)
 class JobsSession:
+    """Wrap a live Jobs DB connection for a single backend-specific session."""
+
     backend: str
     conn: Any
 
 
 class JobsRepository:
+    """Encapsulate Jobs create-time SQL for SQLite and PostgreSQL backends."""
+
     def __init__(
         self,
         *,
@@ -48,19 +62,23 @@ class JobsRepository:
         db_path: Path | None = None,
         db_url: str | None = None,
     ) -> None:
+        """Build a repository bound to either a SQLite path or Postgres DSN."""
         self.backend = backend
         self.db_path = Path(db_path) if db_path is not None else None
         self.db_url = db_url
 
     @classmethod
     def for_sqlite(cls, db_path: Path) -> "JobsRepository":
+        """Create a repository configured for the SQLite jobs database."""
         return cls(backend="sqlite", db_path=db_path)
 
     @classmethod
     def for_postgres(cls, db_url: str) -> "JobsRepository":
+        """Create a repository configured for the PostgreSQL jobs database."""
         return cls(backend="postgres", db_url=db_url)
 
     def _connect(self) -> Any:
+        """Open a backend-specific connection with the expected local policy."""
         if self.backend == "postgres":
             if psycopg is None:  # pragma: no cover - guarded by optional dependency
                 raise RuntimeError("psycopg is required for postgres jobs repositories")
@@ -73,6 +91,7 @@ class JobsRepository:
 
     @contextlib.contextmanager
     def session(self) -> Iterator[JobsSession]:
+        """Yield a managed session that commits on success and rolls back on failure."""
         conn = self._connect()
         session = JobsSession(backend=self.backend, conn=conn)
         try:
@@ -91,6 +110,7 @@ class JobsRepository:
         *,
         session: JobsSession | None = None,
     ) -> int:
+        """Count queued or processing jobs for a user within an optional session."""
         if session is None:
             with self.session() as managed_session:
                 return self.count_active_jobs_for_user(user_id, session=managed_session)
@@ -129,6 +149,7 @@ class JobsRepository:
         created_at: datetime,
         session: JobsSession | None = None,
     ) -> dict[str, Any]:
+        """Insert a queued job row and return the created record as a dict."""
         if session is None:
             with self.session() as managed_session:
                 return self.insert_job(

--- a/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
+++ b/tldw_Server_API/app/core/DB_Management/Jobs_Repository.py
@@ -20,6 +20,7 @@ from typing import Any
 from loguru import logger
 
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import configure_sqlite_connection
+from tldw_Server_API.app.core.exceptions import BadRequestError
 
 try:
     import psycopg  # type: ignore
@@ -67,12 +68,20 @@ class JobsRepository:
         connection_pool: Any | None = None,
     ) -> None:
         """Build a repository bound to either a SQLite path or Postgres DSN."""
-        self.backend = backend
+        normalized_backend = backend.lower()
+        if normalized_backend not in {"sqlite", "postgres"}:
+            raise BadRequestError(f"Unsupported jobs repository backend: {backend}")
+
+        self.backend = normalized_backend
         self.db_path = Path(db_path) if db_path is not None else None
         self.db_url = db_url
         self.connection_pool = connection_pool
         if self.connection_pool is not None and not hasattr(self.connection_pool, "acquire"):
-            raise TypeError("JobsRepository connection_pool must define an acquire() context manager")
+            raise BadRequestError("JobsRepository connection_pool must define an acquire() context manager")
+        if self.backend == "sqlite" and self.connection_pool is None and self.db_path is None:
+            raise BadRequestError("SQLite jobs repository requires db_path when no connection pool is provided")
+        if self.backend == "postgres" and self.connection_pool is None and not self.db_url:
+            raise BadRequestError("Postgres jobs repository requires db_url when no connection pool is provided")
 
     @classmethod
     def for_sqlite(
@@ -109,11 +118,13 @@ class JobsRepository:
         if self.backend == "postgres":
             if psycopg is None:  # pragma: no cover - guarded by optional dependency
                 raise RuntimeError("psycopg is required for postgres jobs repositories")
+            if not self.db_url:
+                raise BadRequestError("Postgres jobs repository requires db_url when no connection pool is provided")
             conn = psycopg.connect(self.db_url)
             logger.debug("Opened direct postgres jobs repository connection")
             return conn
         if self.db_path is None:
-            raise ValueError("SQLite jobs repository requires db_path when no connection pool is provided")
+            raise BadRequestError("SQLite jobs repository requires db_path when no connection pool is provided")
         conn = sqlite3.connect(self.db_path)
         logger.debug("Opened direct sqlite jobs repository connection for {}", self.db_path)
         return self._prepare_sqlite_connection(conn)

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -7,6 +7,7 @@ import os
 import re
 import secrets
 import sqlite3
+import sys
 import time
 import uuid as _uuid
 from contextvars import ContextVar
@@ -1183,8 +1184,9 @@ class JobManager:
                 raise ValueError(f"Payload too large: {payload_bytes} bytes > limit {max_bytes}")  # noqa: TRY003
 
         # Note: completion_token enforcement applies to finalize paths (complete/fail), not creation.
-        conn = self._connect()
-        repo_session = JobsSession(self.backend, conn)
+        repo_session_context = self._jobs_repository.session()
+        repo_session = repo_session_context.__enter__()
+        conn = repo_session.conn
         try:
             try:
                 with job_span(
@@ -1683,7 +1685,7 @@ class JobManager:
                                 continue
                         raise
         finally:
-            conn.close()
+            repo_session_context.__exit__(*sys.exc_info())
 
     def _get_dependency_uuids(self, job_uuid: str) -> list[str]:
         if not job_uuid:

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -17,6 +17,7 @@ from typing import Any, ClassVar
 
 from loguru import logger
 
+from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository, JobsSession
 from tldw_Server_API.app.core.DB_Management.sqlite_policy import (
     configure_sqlite_connection,
 )
@@ -157,6 +158,7 @@ class JobManager:
         db_url: str | None = None,
         clock: JobManager.Clock | None = None,
         enforce_leases: bool | None = None,
+        jobs_repository: JobsRepository | None = None,
     ):
         """Initialize JobManager.
 
@@ -206,6 +208,11 @@ class JobManager:
                 else:
                     self.db_path = ensure_jobs_tables(db_path)
         self._conn = None  # Lazily opened per operation
+        self._jobs_repository = jobs_repository or (
+            JobsRepository.for_postgres(self.db_url)
+            if self.backend == "postgres"
+            else JobsRepository.for_sqlite(self.db_path)
+        )
 
         self._enforce_override = enforce_leases
         with contextlib.suppress(_JOB_NONCRITICAL_EXCEPTIONS):
@@ -225,36 +232,29 @@ class JobManager:
         """Globally gate new acquisitions during graceful shutdown."""
         cls._ACQUIRE_GATE_ENABLED = bool(enabled)
 
-    def _count_active_jobs_for_user(self, user_id: str) -> int:
+    def _count_active_jobs_for_user(
+        self,
+        user_id: str,
+        *,
+        session: JobsSession | None = None,
+    ) -> int:
         """Count jobs with active status (queued or processing) for a user.
 
         Args:
             user_id: The owner_user_id to count active jobs for.
+            session: Optional repository-backed session to reuse.
 
         Returns:
             Number of active jobs for this user.
         """
-        conn = self._connect()
         try:
-            if self.backend == "postgres":
-                with self._pg_cursor(conn) as cur:
-                    cur.execute(
-                        "SELECT COUNT(*) AS c FROM jobs WHERE owner_user_id = %s AND status IN ('queued', 'processing')",
-                        (user_id,),
-                    )
-                    row = cur.fetchone()
-                    return int(row["c"] if isinstance(row, dict) else (row[0] if row else 0))
-            else:
-                row = conn.execute(
-                    "SELECT COUNT(*) FROM jobs WHERE owner_user_id = ? AND status IN ('queued', 'processing')",
-                    (user_id,),
-                ).fetchone()
-                return int(row[0] if row else 0)
+            return self._jobs_repository.count_active_jobs_for_user(
+                user_id,
+                session=session,
+            )
         except _JOB_NONCRITICAL_EXCEPTIONS as exc:
             logger.debug(f"Failed to count active jobs for user {user_id}: {exc}")
             return 0
-        finally:
-            conn.close()
 
     @staticmethod
     def _map_fair_share_score_to_priority(score: int) -> int:
@@ -1097,24 +1097,6 @@ class JobManager:
         if queue not in allowed_queues:
             raise ValueError(f"Queue '{queue}' not allowed for domain '{domain}'. Allowed: {allowed_queues}")  # noqa: TRY003
 
-        # Fair-share scheduling: enforce per-user concurrency limits and adjust priority
-        if owner_user_id:
-            try:
-                scheduler = _get_fair_share()
-                active_count = self._count_active_jobs_for_user(owner_user_id)
-                if not scheduler.can_submit(owner_user_id, active_count):
-                    raise BadRequestError(
-                        f"User {owner_user_id} has reached the maximum concurrent job limit "
-                        f"({scheduler.max_per_user})"
-                    )
-                fair_priority = scheduler.calculate_priority(owner_user_id, active_count)
-                fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
-                priority = min(priority, fair_priority_mapped)
-            except BadRequestError:
-                raise
-            except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
-                logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
-
         # Secret hygiene (reject/redact)
         try:
             cleaned, found, where = self._scan_and_redact_secrets(payload)
@@ -1142,7 +1124,26 @@ class JobManager:
 
         # Note: completion_token enforcement applies to finalize paths (complete/fail), not creation.
         conn = self._connect()
+        repo_session = JobsSession(self.backend, conn)
         try:
+            # Fair-share scheduling: enforce per-user concurrency limits and adjust priority
+            if owner_user_id:
+                try:
+                    scheduler = _get_fair_share()
+                    active_count = self._count_active_jobs_for_user(owner_user_id, session=repo_session)
+                    if not scheduler.can_submit(int(owner_user_id), active_count):
+                        raise ValueError(  # noqa: TRY003
+                            f"User {owner_user_id} has reached the maximum concurrent job limit "
+                            f"({scheduler.max_per_user})"
+                        )
+                    fair_priority = scheduler.calculate_priority(int(owner_user_id), active_count)
+                    fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
+                    priority = min(priority, fair_priority_mapped)
+                except ValueError:
+                    raise
+                except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
+                    logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
+
             try:
                 with job_span(
                     "job.create",
@@ -1340,30 +1341,23 @@ class JobManager:
                                 )
                             return d
                         # Non-idempotent insert
-                        cur.execute(
-                            (
-                                "INSERT INTO jobs (uuid, domain, queue, job_type, owner_user_id, project_id, batch_group, idempotency_key, payload, result, status, priority, max_retries, retry_count, available_at, created_at, updated_at, request_id, trace_id) "
-                                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, NULL, 'queued', %s, %s, 0, %s, NOW(), NOW(), %s, %s) RETURNING *"
-                            ),
-                            (
-                                uuid_val,
-                                domain,
-                                queue,
-                                job_type,
-                                owner_user_id,
-                                project_id,
-                                batch_group,
-                                idempotency_key,
-                                payload_json,
-                                priority,
-                                max_retries,
-                                avail_param if avail_param else None,
-                                request_id,
-                                trace_id,
-                            ),
+                        d = self._jobs_repository.insert_job(
+                            domain=domain,
+                            queue=queue,
+                            job_type=job_type,
+                            payload_json=payload_json,
+                            owner_user_id=owner_user_id,
+                            project_id=project_id,
+                            batch_group=batch_group,
+                            idempotency_key=idempotency_key,
+                            priority=priority,
+                            max_retries=max_retries,
+                            available_at=avail_param if avail_param else None,
+                            request_id=request_id,
+                            trace_id=trace_id,
+                            created_at=_now_dt,
+                            session=repo_session,
                         )
-                        row = cur.fetchone()
-                        d = dict(row)
                         # SLA check: queue latency (Postgres create path)
                         try:
                             pol = self._get_sla_policy(d.get("domain"), d.get("queue"), d.get("job_type"))
@@ -1536,50 +1530,22 @@ class JobManager:
                                         )
                                     return d
                             # Non-idempotent (or no existing row on IGNORE path): normal insert
-                            conn.execute(
-                                """
-                                INSERT INTO jobs (
-                                  uuid, domain, queue, job_type, owner_user_id, project_id, batch_group,
-                                  idempotency_key, payload, result, status, priority, max_retries,
-                                  retry_count, available_at, created_at, updated_at, request_id, trace_id
-                                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 'queued', ?, ?, 0, ?, ?, ?, ?, ?)
-                                """,
-                                (
-                                    uuid_val,
-                                    domain,
-                                    queue,
-                                    job_type,
-                                    owner_user_id,
-                                    project_id,
-                                    batch_group,
-                                    idempotency_key,
-                                    json.dumps(payload),
-                                    priority,
-                                    max_retries,
-                                    (
-                                        avail_param_sqlite.strftime("%Y-%m-%d %H:%M:%S")
-                                        if avail_param_sqlite
-                                        else None
-                                    ),
-                                    now,
-                                    now,
-                                    request_id,
-                                    trace_id,
-                                ),
-                            )
-                            job_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-                            row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-                            d = (
-                                dict(row)
-                                if row
-                                else {
-                                    "id": job_id,
-                                    "uuid": uuid_val,
-                                    "status": "queued",
-                                    "domain": domain,
-                                    "queue": queue,
-                                    "job_type": job_type,
-                                }
+                            d = self._jobs_repository.insert_job(
+                                domain=domain,
+                                queue=queue,
+                                job_type=job_type,
+                                payload_json=payload_json,
+                                owner_user_id=owner_user_id,
+                                project_id=project_id,
+                                batch_group=batch_group,
+                                idempotency_key=idempotency_key,
+                                priority=priority,
+                                max_retries=max_retries,
+                                available_at=avail_param_sqlite,
+                                request_id=request_id,
+                                trace_id=trace_id,
+                                created_at=_now_dt,
+                                session=repo_session,
                             )
                             try:
                                 self._update_gauges(domain=domain, queue=queue, job_type=job_type)

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -150,6 +150,29 @@ class JobManager:
     def _is_truthy(val: str | None) -> bool:
         return _shared_is_truthy(val)
 
+    @staticmethod
+    def _validate_jobs_repository(
+        jobs_repository: Any,
+        *,
+        backend: str,
+    ) -> JobsRepository:
+        """Validate an injected repository before the manager starts using it."""
+        required_methods = ("session", "count_active_jobs_for_user", "insert_job")
+        missing = [name for name in required_methods if not callable(getattr(jobs_repository, name, None))]
+        if missing:
+            raise TypeError(
+                "jobs_repository must expose backend/session/count_active_jobs_for_user/insert_job; "
+                f"missing {missing}"
+            )
+
+        repo_backend = str(getattr(jobs_repository, "backend", "")).lower()
+        if repo_backend != backend:
+            raise ValueError(  # noqa: TRY003
+                f"Injected JobsRepository backend '{repo_backend or 'unknown'}' "
+                f"does not match manager backend '{backend}'"
+            )
+        return jobs_repository
+
     def __init__(
         self,
         db_path: Path | None = None,
@@ -208,10 +231,15 @@ class JobManager:
                 else:
                     self.db_path = ensure_jobs_tables(db_path)
         self._conn = None  # Lazily opened per operation
-        self._jobs_repository = jobs_repository or (
+        default_jobs_repository = (
             JobsRepository.for_postgres(self.db_url)
             if self.backend == "postgres"
             else JobsRepository.for_sqlite(self.db_path)
+        )
+        self._jobs_repository = (
+            self._validate_jobs_repository(jobs_repository, backend=self.backend)
+            if jobs_repository is not None
+            else default_jobs_repository
         )
 
         self._enforce_override = enforce_leases
@@ -253,8 +281,8 @@ class JobManager:
                 session=session,
             )
         except _JOB_NONCRITICAL_EXCEPTIONS as exc:
-            logger.debug(f"Failed to count active jobs for user {user_id}: {exc}")
-            return 0
+            logger.warning(f"Failed to count active jobs for user {user_id}: {exc}")
+            raise BadRequestError("Unable to evaluate fair-share policy; please retry") from exc
 
     def _apply_fair_share_submission_policy(
         self,
@@ -285,8 +313,8 @@ class JobManager:
         except BadRequestError:
             raise
         except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
-            logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
-            return priority
+            logger.warning(f"Fair-share scheduling check failed: {_fs_exc}")
+            raise BadRequestError("Unable to evaluate fair-share policy; please retry") from _fs_exc
 
     @staticmethod
     def _map_fair_share_score_to_priority(score: int) -> int:
@@ -1158,14 +1186,6 @@ class JobManager:
         conn = self._connect()
         repo_session = JobsSession(self.backend, conn)
         try:
-            # Fair-share scheduling: enforce per-user concurrency limits and adjust priority
-            if owner_user_id and self.backend != "postgres":
-                priority = self._apply_fair_share_submission_policy(
-                    owner_user_id,
-                    priority,
-                    session=repo_session,
-                )
-
             try:
                 with job_span(
                     "job.create",
@@ -1210,7 +1230,7 @@ class JobManager:
             if self.backend == "postgres":
                 with conn:  # noqa: SIM117
                     with self._pg_cursor(conn) as cur:
-                        priority = self._apply_fair_share_submission_policy(
+                        effective_priority = self._apply_fair_share_submission_policy(
                             owner_user_id,
                             priority,
                             session=repo_session,
@@ -1267,7 +1287,7 @@ class JobManager:
                                     batch_group,
                                     idempotency_key,
                                     payload_json,
-                                    priority,
+                                    effective_priority,
                                     max_retries,
                                     avail_param if avail_param else None,
                                     request_id,
@@ -1377,7 +1397,7 @@ class JobManager:
                             project_id=project_id,
                             batch_group=batch_group,
                             idempotency_key=idempotency_key,
-                            priority=priority,
+                            priority=effective_priority,
                             max_retries=max_retries,
                             available_at=avail_param if avail_param else None,
                             request_id=request_id,
@@ -1480,6 +1500,11 @@ class JobManager:
                 for attempt in range(2):
                     try:
                         with conn:
+                            effective_priority = self._apply_fair_share_submission_policy(
+                                owner_user_id,
+                                priority,
+                                session=repo_session,
+                            )
                             # Domain/user quotas (SQLite)
                             try:
                                 max_q = self._quota_get("JOBS_QUOTA_MAX_QUEUED", domain, owner_user_id)
@@ -1521,7 +1546,7 @@ class JobManager:
                                         batch_group,
                                         idempotency_key,
                                         payload_json,
-                                        priority,
+                                        effective_priority,
                                         max_retries,
                                         (
                                             avail_param_sqlite.strftime("%Y-%m-%d %H:%M:%S")
@@ -1566,7 +1591,7 @@ class JobManager:
                                 project_id=project_id,
                                 batch_group=batch_group,
                                 idempotency_key=idempotency_key,
-                                priority=priority,
+                                priority=effective_priority,
                                 max_retries=max_retries,
                                 available_at=avail_param_sqlite,
                                 request_id=request_id,

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -256,6 +256,38 @@ class JobManager:
             logger.debug(f"Failed to count active jobs for user {user_id}: {exc}")
             return 0
 
+    def _apply_fair_share_submission_policy(
+        self,
+        owner_user_id: str | None,
+        priority: int,
+        *,
+        session: JobsSession,
+    ) -> int:
+        """Enforce fair-share admission and priority mapping for a pending job.
+
+        The repository session is supplied by the caller so the active-job count
+        can run inside the same DB transaction/context as the eventual insert.
+        """
+        if not owner_user_id:
+            return priority
+
+        try:
+            scheduler = _get_fair_share()
+            active_count = self._count_active_jobs_for_user(owner_user_id, session=session)
+            if not scheduler.can_submit(owner_user_id, active_count):
+                raise BadRequestError(  # noqa: TRY003
+                    f"User {owner_user_id} has reached the maximum concurrent job limit "
+                    f"({scheduler.max_per_user})"
+                )
+            fair_priority = scheduler.calculate_priority(owner_user_id, active_count)
+            fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
+            return min(priority, fair_priority_mapped)
+        except BadRequestError:
+            raise
+        except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
+            logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
+            return priority
+
     @staticmethod
     def _map_fair_share_score_to_priority(score: int) -> int:
         """Convert a higher fair-share score into a higher queue priority.
@@ -1127,22 +1159,12 @@ class JobManager:
         repo_session = JobsSession(self.backend, conn)
         try:
             # Fair-share scheduling: enforce per-user concurrency limits and adjust priority
-            if owner_user_id:
-                try:
-                    scheduler = _get_fair_share()
-                    active_count = self._count_active_jobs_for_user(owner_user_id, session=repo_session)
-                    if not scheduler.can_submit(int(owner_user_id), active_count):
-                        raise ValueError(  # noqa: TRY003
-                            f"User {owner_user_id} has reached the maximum concurrent job limit "
-                            f"({scheduler.max_per_user})"
-                        )
-                    fair_priority = scheduler.calculate_priority(int(owner_user_id), active_count)
-                    fair_priority_mapped = self._map_fair_share_score_to_priority(fair_priority)
-                    priority = min(priority, fair_priority_mapped)
-                except ValueError:
-                    raise
-                except _JOB_NONCRITICAL_EXCEPTIONS as _fs_exc:
-                    logger.warning(f"Fair-share scheduling check skipped: {_fs_exc}")
+            if owner_user_id and self.backend != "postgres":
+                priority = self._apply_fair_share_submission_policy(
+                    owner_user_id,
+                    priority,
+                    session=repo_session,
+                )
 
             try:
                 with job_span(
@@ -1188,6 +1210,11 @@ class JobManager:
             if self.backend == "postgres":
                 with conn:  # noqa: SIM117
                     with self._pg_cursor(conn) as cur:
+                        priority = self._apply_fair_share_submission_policy(
+                            owner_user_id,
+                            priority,
+                            session=repo_session,
+                        )
                         # Domain/user quotas
                         try:
                             # Max queued

--- a/tldw_Server_API/app/core/Jobs/manager.py
+++ b/tldw_Server_API/app/core/Jobs/manager.py
@@ -326,6 +326,39 @@ class JobManager:
         clamped_score = max(0, min(100, int(score)))
         return max(1, 10 - min(9, clamped_score // 10))
 
+    @staticmethod
+    def _select_existing_idempotent_job_postgres(
+        cur: Any,
+        *,
+        domain: str,
+        queue: str,
+        job_type: str,
+        idempotency_key: str,
+    ) -> dict[str, Any] | None:
+        """Return a pre-existing PostgreSQL job row for an idempotent create."""
+        cur.execute(
+            "SELECT * FROM jobs WHERE domain = %s AND queue = %s AND job_type = %s AND idempotency_key = %s",
+            (domain, queue, job_type, idempotency_key),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+    @staticmethod
+    def _select_existing_idempotent_job_sqlite(
+        conn: sqlite3.Connection,
+        *,
+        domain: str,
+        queue: str,
+        job_type: str,
+        idempotency_key: str,
+    ) -> dict[str, Any] | None:
+        """Return a pre-existing SQLite job row for an idempotent create."""
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE domain = ? AND queue = ? AND job_type = ? AND idempotency_key = ?",
+            (domain, queue, job_type, idempotency_key),
+        ).fetchone()
+        return dict(row) if row else None
+
     def _get_allowed_queues(self, domain: str | None = None) -> list[str]:
         allowed = list(self.STANDARD_QUEUES)
         if domain:
@@ -1232,6 +1265,16 @@ class JobManager:
             if self.backend == "postgres":
                 with conn:  # noqa: SIM117
                     with self._pg_cursor(conn) as cur:
+                        if idempotency_key:
+                            existing = self._select_existing_idempotent_job_postgres(
+                                cur,
+                                domain=domain,
+                                queue=queue,
+                                job_type=job_type,
+                                idempotency_key=idempotency_key,
+                            )
+                            if existing:
+                                return existing
                         effective_priority = self._apply_fair_share_submission_policy(
                             owner_user_id,
                             priority,
@@ -1299,11 +1342,13 @@ class JobManager:
                             row = cur.fetchone()
                             was_insert = row is not None
                             if not row:
-                                cur.execute(
-                                    "SELECT * FROM jobs WHERE domain = %s AND queue = %s AND job_type = %s AND idempotency_key = %s",
-                                    (domain, queue, job_type, idempotency_key),
+                                row = self._select_existing_idempotent_job_postgres(
+                                    cur,
+                                    domain=domain,
+                                    queue=queue,
+                                    job_type=job_type,
+                                    idempotency_key=idempotency_key,
                                 )
-                                row = cur.fetchone()
                             d = (
                                 dict(row)
                                 if row
@@ -1502,6 +1547,16 @@ class JobManager:
                 for attempt in range(2):
                     try:
                         with conn:
+                            if idempotency_key:
+                                existing = self._select_existing_idempotent_job_sqlite(
+                                    conn,
+                                    domain=domain,
+                                    queue=queue,
+                                    job_type=job_type,
+                                    idempotency_key=idempotency_key,
+                                )
+                                if existing:
+                                    return existing
                             effective_priority = self._apply_fair_share_submission_policy(
                                 owner_user_id,
                                 priority,
@@ -1560,10 +1615,13 @@ class JobManager:
                                     ),
                                 )
                                 inserted = bool(getattr(conn, "total_changes", 0))
-                                row = conn.execute(
-                                    "SELECT * FROM jobs WHERE domain = ? AND queue = ? AND job_type = ? AND idempotency_key = ?",
-                                    (domain, queue, job_type, idempotency_key),
-                                ).fetchone()
+                                row = self._select_existing_idempotent_job_sqlite(
+                                    conn,
+                                    domain=domain,
+                                    queue=queue,
+                                    job_type=job_type,
+                                    idempotency_key=idempotency_key,
+                                )
                                 if row:
                                     d = dict(row)
                                     try:

--- a/tldw_Server_API/app/core/exceptions.py
+++ b/tldw_Server_API/app/core/exceptions.py
@@ -38,6 +38,10 @@ class BadRequestError(ValueError):
     """Raised when a caller provides invalid arguments for an operation."""
 
 
+class DuplicateActiveSubscriptionError(RuntimeError):
+    """Raised when a user resolves to more than one active billing subscription."""
+
+
 class ValidationError(BadRequestError):
     """Raised when validation of input parameters fails."""
 

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -123,6 +123,15 @@ class StripeMeteringService:
             return None
         return AuthNZMeteringSyncLogRepository(db_pool=pool)
 
+    @staticmethod
+    def _is_missing_stripe_resource_error(exc: Exception) -> bool:
+        """Return True when Stripe reports a missing subscription/resource."""
+        code = str(getattr(exc, "code", "") or "").lower()
+        if code == "resource_missing":
+            return True
+        message = str(exc).lower()
+        return "no such subscription" in message or "resource missing" in message
+
     async def _query_usage_for_date(
         self,
         pool: Any | None,
@@ -174,12 +183,18 @@ class StripeMeteringService:
             # No metered item found — return None so caller can skip
             return None
         except Exception as exc:
+            if self._is_missing_stripe_resource_error(exc):
+                logger.warning(
+                    "Stripe subscription {} is missing; skipping metering sync",
+                    subscription_id,
+                )
+                return None
             logger.warning(
                 "Failed to retrieve subscription items for {}: {}",
                 subscription_id,
                 exc,
             )
-            return None
+            raise
 
     async def _ensure_metering_sync_table(self, pool: Any | None) -> None:
         """Create the ``metering_sync_log`` tracking table if it does not exist."""
@@ -551,4 +566,4 @@ class StripeMeteringService:
     @property
     def is_enabled(self) -> bool:
         """Whether Stripe metering is enabled."""
-        return self._enabled and bool(self._stripe_key)
+        return self._enabled and bool(self._stripe_key) and STRIPE_AVAILABLE

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -44,6 +44,13 @@ class StripeMeteringService:
         self._stripe_key = os.getenv("STRIPE_API_KEY", "")
         self._meter_event_name = os.getenv("STRIPE_METER_EVENT_NAME", "api_requests")
         self._db_pool = db_pool
+        injected_repo_count = sum(
+            repo is not None for repo in (usage_repo, subscription_repo, sync_log_repo)
+        )
+        if db_pool is None and 0 < injected_repo_count < 3:
+            raise ValueError(  # noqa: TRY003
+                "Inject all metering repositories together or provide db_pool"
+            )
         self._usage_repo = usage_repo or AuthNZUsageDailyRepository(db_pool=db_pool)
         self._subscription_repo = subscription_repo or AuthNZBillingSubscriptionRepository(
             db_pool=db_pool
@@ -51,10 +58,7 @@ class StripeMeteringService:
         self._sync_log_repo = sync_log_repo or AuthNZMeteringSyncLogRepository(
             db_pool=db_pool
         )
-        self._use_repository_owned_pool = any(
-            dependency is not None
-            for dependency in (db_pool, usage_repo, subscription_repo, sync_log_repo)
-        )
+        self._use_repository_owned_pool = db_pool is not None or injected_repo_count == 3
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tldw_Server_API/app/services/stripe_metering_service.py
+++ b/tldw_Server_API/app/services/stripe_metering_service.py
@@ -8,10 +8,15 @@ from __future__ import annotations
 
 import asyncio
 import os
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from loguru import logger
+from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+    AuthNZBillingSubscriptionRepository,
+    AuthNZMeteringSyncLogRepository,
+    AuthNZUsageDailyRepository,
+)
 
 # Stripe import is optional - mirrors stripe_client.py pattern
 try:
@@ -27,10 +32,29 @@ except ImportError:
 class StripeMeteringService:
     """Reconciles local usage tracking with Stripe metering."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        db_pool: Any | None = None,
+        usage_repo: AuthNZUsageDailyRepository | None = None,
+        subscription_repo: AuthNZBillingSubscriptionRepository | None = None,
+        sync_log_repo: AuthNZMeteringSyncLogRepository | None = None,
+    ) -> None:
         self._enabled = os.getenv("BILLING_ENABLED", "false").lower() in ("1", "true")
         self._stripe_key = os.getenv("STRIPE_API_KEY", "")
         self._meter_event_name = os.getenv("STRIPE_METER_EVENT_NAME", "api_requests")
+        self._db_pool = db_pool
+        self._usage_repo = usage_repo or AuthNZUsageDailyRepository(db_pool=db_pool)
+        self._subscription_repo = subscription_repo or AuthNZBillingSubscriptionRepository(
+            db_pool=db_pool
+        )
+        self._sync_log_repo = sync_log_repo or AuthNZMeteringSyncLogRepository(
+            db_pool=db_pool
+        )
+        self._use_repository_owned_pool = any(
+            dependency is not None
+            for dependency in (db_pool, usage_repo, subscription_repo, sync_log_repo)
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -38,9 +62,13 @@ class StripeMeteringService:
 
     async def _get_db_pool(self) -> Any:
         """Lazily acquire the AuthNZ database pool."""
+        if self._db_pool is not None:
+            return self._db_pool
+
         from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 
-        return await get_db_pool()
+        self._db_pool = await get_db_pool()
+        return self._db_pool
 
     @staticmethod
     def _is_postgres(conn: Any) -> bool:
@@ -74,81 +102,44 @@ class StripeMeteringService:
         return rows
 
     @staticmethod
-    def _coerce_day(value: str | date) -> date:
-        """Return a real date object for PostgreSQL DATE bindings."""
-        if isinstance(value, date):
-            return value
-        return datetime.strptime(str(value), "%Y-%m-%d").date()
+    def _pool_bound_usage_repo(pool: Any | None) -> AuthNZUsageDailyRepository | None:
+        if pool is None:
+            return None
+        return AuthNZUsageDailyRepository(db_pool=pool)
 
     @staticmethod
-    def _is_missing_stripe_resource_error(exc: Exception) -> bool:
-        """Return True when Stripe reports a missing subscription/resource."""
-        code = str(getattr(exc, "code", "") or "").lower()
-        if code == "resource_missing":
-            return True
-        message = str(exc).lower()
-        return "no such subscription" in message or "resource missing" in message
+    def _pool_bound_subscription_repo(
+        pool: Any | None,
+    ) -> AuthNZBillingSubscriptionRepository | None:
+        if pool is None:
+            return None
+        return AuthNZBillingSubscriptionRepository(db_pool=pool)
 
-    async def _query_usage_for_date(self, pool: Any, target_date: str | date) -> list[dict[str, Any]]:
+    @staticmethod
+    def _pool_bound_sync_log_repo(
+        pool: Any | None,
+    ) -> AuthNZMeteringSyncLogRepository | None:
+        if pool is None:
+            return None
+        return AuthNZMeteringSyncLogRepository(db_pool=pool)
+
+    async def _query_usage_for_date(
+        self,
+        pool: Any | None,
+        target_date: str,
+    ) -> list[dict[str, Any]]:
         """Fetch usage_daily rows for *target_date*.
 
         Returns a list of dicts with keys: user_id, requests, errors,
         bytes_total, bytes_in_total, latency_avg_ms.
         """
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                pg_day = self._coerce_day(target_date)
-                try:
-                    rows = await conn.fetch(
-                        "SELECT user_id, requests, errors, bytes_total, "
-                        "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
-                        "FROM usage_daily WHERE day = $1",
-                        pg_day,
-                    )
-                    return [dict(r) for r in rows]
-                except Exception as exc:
-                    if not self._is_missing_usage_column_error(exc):
-                        raise
-                    rows = await conn.fetch(
-                        "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
-                        "FROM usage_daily WHERE day = $1",
-                        pg_day,
-                    )
-                    legacy_rows = [dict(r) for r in rows]
-                    for row in legacy_rows:
-                        row["bytes_in_total"] = 0
-                    return legacy_rows
-            else:
-                try:
-                    cur = await conn.execute(
-                        "SELECT user_id, requests, errors, bytes_total, "
-                        "COALESCE(bytes_in_total, 0) AS bytes_in_total, latency_avg_ms "
-                        "FROM usage_daily WHERE day = ?",
-                        (target_date,),
-                    )
-                    raw_rows = await cur.fetchall()
-                    return self._sqlite_rows_to_dicts(
-                        raw_rows,
-                        cur.description,
-                        include_bytes_in_total=True,
-                    )
-                except Exception as exc:
-                    if not self._is_missing_usage_column_error(exc):
-                        raise
-                    cur = await conn.execute(
-                        "SELECT user_id, requests, errors, bytes_total, latency_avg_ms "
-                        "FROM usage_daily WHERE day = ?",
-                        (target_date,),
-                    )
-                    raw_rows = await cur.fetchall()
-                    return self._sqlite_rows_to_dicts(
-                        raw_rows,
-                        cur.description,
-                        include_bytes_in_total=False,
-                    )
+        repo = self._pool_bound_usage_repo(pool) or self._usage_repo
+        return await repo.fetch_usage_for_date(target_date)
 
     async def _query_user_subscription(
-        self, pool: Any, user_id: int
+        self,
+        pool: Any | None,
+        user_id: int,
     ) -> dict[str, Any] | None:
         """Look up the active Stripe subscription for a user.
 
@@ -156,79 +147,8 @@ class StripeMeteringService:
         organisation subscription that has a Stripe subscription ID.
         Falls back to checking the ``organizations.owner_user_id`` path.
         """
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                row = await conn.fetchrow(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN org_members om ON om.org_id = os.org_id
-                    WHERE om.user_id = $1
-                      AND om.status = 'active'
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    user_id,
-                )
-                if row:
-                    return dict(row)
-                row = await conn.fetchrow(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN organizations o ON o.id = os.org_id
-                    WHERE o.owner_user_id = $1
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    user_id,
-                )
-                return dict(row) if row else None
-            else:
-                cur = await conn.execute(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN org_members om ON om.org_id = os.org_id
-                    WHERE om.user_id = ?
-                      AND om.status = 'active'
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    (user_id,),
-                )
-                row = await cur.fetchone()
-                if row:
-                    columns = [col[0] for col in cur.description]
-                    return dict(zip(columns, row))
-                cur = await conn.execute(
-                    """
-                    SELECT os.stripe_customer_id,
-                           os.stripe_subscription_id,
-                           os.org_id
-                    FROM org_subscriptions os
-                    JOIN organizations o ON o.id = os.org_id
-                    WHERE o.owner_user_id = ?
-                      AND os.status = 'active'
-                      AND os.stripe_subscription_id IS NOT NULL
-                    LIMIT 1
-                    """,
-                    (user_id,),
-                )
-                row = await cur.fetchone()
-                if not row:
-                    return None
-                columns = [col[0] for col in cur.description]
-                return dict(zip(columns, row))
+        repo = self._pool_bound_subscription_repo(pool) or self._subscription_repo
+        return await repo.get_active_subscription_for_user(user_id)
 
     async def _get_subscription_metered_item(
         self, subscription_id: str
@@ -254,110 +174,51 @@ class StripeMeteringService:
             # No metered item found — return None so caller can skip
             return None
         except Exception as exc:
-            if self._is_missing_stripe_resource_error(exc):
-                logger.warning(
-                    "Stripe subscription {} is missing; skipping metering sync",
-                    subscription_id,
-                )
-                return None
             logger.warning(
                 "Failed to retrieve subscription items for {}: {}",
                 subscription_id,
                 exc,
             )
-            raise
+            return None
 
-    async def _ensure_metering_sync_table(self, pool: Any) -> None:
+    async def _ensure_metering_sync_table(self, pool: Any | None) -> None:
         """Create the ``metering_sync_log`` tracking table if it does not exist."""
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                await conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS metering_sync_log (
-                        user_id INTEGER NOT NULL,
-                        day DATE NOT NULL,
-                        stripe_subscription_id TEXT NOT NULL,
-                        requests_synced INTEGER DEFAULT 0,
-                        bytes_synced BIGINT DEFAULT 0,
-                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        PRIMARY KEY (user_id, day, stripe_subscription_id)
-                    )
-                    """
-                )
-            else:
-                await conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS metering_sync_log (
-                        user_id INTEGER NOT NULL,
-                        day DATE NOT NULL,
-                        stripe_subscription_id TEXT NOT NULL,
-                        requests_synced INTEGER DEFAULT 0,
-                        bytes_synced INTEGER DEFAULT 0,
-                        synced_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                        PRIMARY KEY (user_id, day, stripe_subscription_id)
-                    )
-                    """
-                )
-                await conn.commit()
+        repo = self._pool_bound_sync_log_repo(pool) or self._sync_log_repo
+        await repo.ensure_schema()
 
     async def _already_synced(
-        self, pool: Any, user_id: int, day: str | date, subscription_id: str
+        self,
+        pool: Any | None,
+        user_id: int,
+        day: str,
+        subscription_id: str,
     ) -> bool:
         """Return True if usage for this user/day/subscription was already synced."""
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                pg_day = self._coerce_day(day)
-                row = await conn.fetchval(
-                    "SELECT 1 FROM metering_sync_log "
-                    "WHERE user_id = $1 AND day = $2 AND stripe_subscription_id = $3",
-                    user_id,
-                    pg_day,
-                    subscription_id,
-                )
-                return row is not None
-            else:
-                cur = await conn.execute(
-                    "SELECT 1 FROM metering_sync_log "
-                    "WHERE user_id = ? AND day = ? AND stripe_subscription_id = ?",
-                    (user_id, day, subscription_id),
-                )
-                return (await cur.fetchone()) is not None
+        repo = self._pool_bound_sync_log_repo(pool) or self._sync_log_repo
+        return await repo.already_synced(
+            user_id=user_id,
+            day=day,
+            subscription_id=subscription_id,
+        )
 
     async def _record_sync(
         self,
-        pool: Any,
+        pool: Any | None,
         user_id: int,
-        day: str | date,
+        day: str,
         subscription_id: str,
         requests: int,
         bytes_total: int,
     ) -> None:
         """Record a successful sync in metering_sync_log."""
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                pg_day = self._coerce_day(day)
-                await conn.execute(
-                    "INSERT INTO metering_sync_log "
-                    "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
-                    "VALUES ($1, $2, $3, $4, $5) "
-                    "ON CONFLICT (user_id, day, stripe_subscription_id) DO UPDATE "
-                    "SET requests_synced = EXCLUDED.requests_synced, "
-                    "    bytes_synced = EXCLUDED.bytes_synced, "
-                    "    synced_at = CURRENT_TIMESTAMP",
-                    user_id,
-                    pg_day,
-                    subscription_id,
-                    requests,
-                    bytes_total,
-                )
-            else:
-                await conn.execute(
-                    "INSERT OR REPLACE INTO metering_sync_log "
-                    "(user_id, day, stripe_subscription_id, requests_synced, bytes_synced) "
-                    "VALUES (?, ?, ?, ?, ?)",
-                    (user_id, day, subscription_id, requests, bytes_total),
-                )
-                await conn.commit()
+        repo = self._pool_bound_sync_log_repo(pool) or self._sync_log_repo
+        await repo.record_sync(
+            user_id=user_id,
+            day=day,
+            subscription_id=subscription_id,
+            requests=requests,
+            bytes_total=bytes_total,
+        )
 
     async def _report_usage_to_stripe(
         self, subscription_item_id: str, quantity: int, timestamp: int
@@ -378,28 +239,14 @@ class StripeMeteringService:
             action="set",
         )
 
-    async def _query_sync_totals(self, pool: Any, target_date: str | date) -> list[dict[str, Any]]:
+    async def _query_sync_totals(
+        self,
+        pool: Any | None,
+        target_date: str,
+    ) -> list[dict[str, Any]]:
         """Fetch synced totals from metering_sync_log for *target_date*."""
-        async with pool.acquire() as conn:
-            if self._is_postgres(conn):
-                pg_day = self._coerce_day(target_date)
-                rows = await conn.fetch(
-                    "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
-                    "FROM metering_sync_log WHERE day = $1",
-                    pg_day,
-                )
-                return [dict(r) for r in rows]
-            else:
-                cur = await conn.execute(
-                    "SELECT user_id, stripe_subscription_id, requests_synced, bytes_synced "
-                    "FROM metering_sync_log WHERE day = ?",
-                    (target_date,),
-                )
-                raw = await cur.fetchall()
-                if not raw:
-                    return []
-                cols = [c[0] for c in cur.description]
-                return [dict(zip(cols, r)) for r in raw]
+        repo = self._pool_bound_sync_log_repo(pool) or self._sync_log_repo
+        return await repo.fetch_sync_totals(target_date)
 
     # ------------------------------------------------------------------
     # Public API
@@ -429,16 +276,17 @@ class StripeMeteringService:
         # Configure stripe key (stripe is guaranteed non-None since STRIPE_AVAILABLE is True)
         stripe.api_key = self._stripe_key  # type: ignore[union-attr]
 
-        # Acquire DB pool
-        try:
-            pool = await self._get_db_pool()
-        except Exception as exc:
-            logger.error("Stripe metering sync: failed to get DB pool: {}", exc)
-            return {
-                "status": "error",
-                "date": target_date,
-                "error": f"db_pool_unavailable: {exc}",
-            }
+        pool = None
+        if not self._use_repository_owned_pool:
+            try:
+                pool = await self._get_db_pool()
+            except Exception as exc:
+                logger.error("Stripe metering sync: failed to get DB pool: {}", exc)
+                return {
+                    "status": "error",
+                    "date": target_date,
+                    "error": f"db_pool_unavailable: {exc}",
+                }
 
         # Ensure tracking table exists
         try:
@@ -609,17 +457,18 @@ class StripeMeteringService:
             datetime.now(timezone.utc) - timedelta(days=1)
         ).strftime("%Y-%m-%d")
 
-        # Acquire DB pool
-        try:
-            pool = await self._get_db_pool()
-        except Exception as exc:
-            logger.error("Reconciliation check: failed to get DB pool: {}", exc)
-            return {
-                "status": "error",
-                "date": target_date,
-                "error": f"db_pool_unavailable: {exc}",
-                "discrepancies": [],
-            }
+        pool = None
+        if not self._use_repository_owned_pool:
+            try:
+                pool = await self._get_db_pool()
+            except Exception as exc:
+                logger.error("Reconciliation check: failed to get DB pool: {}", exc)
+                return {
+                    "status": "error",
+                    "date": target_date,
+                    "error": f"db_pool_unavailable: {exc}",
+                    "discrepancies": [],
+                }
 
         # Fetch local usage totals
         try:
@@ -702,4 +551,4 @@ class StripeMeteringService:
     @property
     def is_enabled(self) -> bool:
         """Whether Stripe metering is enabled."""
-        return self._enabled and bool(self._stripe_key) and STRIPE_AVAILABLE
+        return self._enabled and bool(self._stripe_key)

--- a/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
+++ b/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _AcquireContext:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AcquireContext(self._conn)
+
+
+class _FakeSqliteConn:
+    def __init__(self, execute_side_effect=None):
+        self.execute = AsyncMock(side_effect=execute_side_effect)
+        self.commit = AsyncMock()
+
+
+class TestAuthNZUsageDailyRepository:
+    @pytest.mark.asyncio
+    async def test_fetch_usage_for_date_normalizes_legacy_rows(self):
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZUsageDailyRepository,
+        )
+
+        legacy_cursor = MagicMock()
+        legacy_cursor.description = [
+            ("user_id",),
+            ("requests",),
+            ("errors",),
+            ("bytes_total",),
+            ("latency_avg_ms",),
+        ]
+        legacy_cursor.fetchall = AsyncMock(return_value=[(7, 12, 1, 4096, 25.0)])
+
+        conn = _FakeSqliteConn(
+            [
+                sqlite3.OperationalError("no such column: bytes_in_total"),
+                legacy_cursor,
+            ]
+        )
+
+        repo = AuthNZUsageDailyRepository(db_pool=_FakePool(conn))
+        rows = await repo.fetch_usage_for_date("2026-03-13")
+
+        assert rows == [
+            {
+                "user_id": 7,
+                "requests": 12,
+                "errors": 1,
+                "bytes_total": 4096,
+                "bytes_in_total": 0,
+                "latency_avg_ms": 25.0,
+            }
+        ]
+
+
+class TestAuthNZBillingSubscriptionRepository:
+    @pytest.mark.asyncio
+    async def test_get_active_subscription_for_user_falls_back_to_org_owner(self):
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZBillingSubscriptionRepository,
+        )
+
+        miss_cursor = MagicMock()
+        miss_cursor.fetchone = AsyncMock(return_value=None)
+
+        owner_cursor = MagicMock()
+        owner_cursor.description = [
+            ("stripe_customer_id",),
+            ("stripe_subscription_id",),
+            ("org_id",),
+        ]
+        owner_cursor.fetchone = AsyncMock(return_value=("cus_owner", "sub_owner", 9))
+
+        conn = _FakeSqliteConn([miss_cursor, owner_cursor])
+
+        repo = AuthNZBillingSubscriptionRepository(db_pool=_FakePool(conn))
+        result = await repo.get_active_subscription_for_user(42)
+
+        assert result == {
+            "stripe_customer_id": "cus_owner",
+            "stripe_subscription_id": "sub_owner",
+            "org_id": 9,
+        }
+
+
+class TestAuthNZMeteringSyncLogRepository:
+    @pytest.mark.asyncio
+    async def test_ensure_schema_creates_sync_log_table_for_sqlite(self):
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZMeteringSyncLogRepository,
+        )
+
+        conn = _FakeSqliteConn()
+        repo = AuthNZMeteringSyncLogRepository(db_pool=_FakePool(conn))
+
+        await repo.ensure_schema()
+
+        conn.execute.assert_awaited_once()
+        assert "CREATE TABLE IF NOT EXISTS metering_sync_log" in conn.execute.await_args.args[0]
+        conn.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_log_repository_checks_records_and_reads_sync_state(self):
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZMeteringSyncLogRepository,
+        )
+
+        exists_cursor = MagicMock()
+        exists_cursor.fetchone = AsyncMock(return_value=(1,))
+
+        totals_cursor = MagicMock()
+        totals_cursor.description = [
+            ("user_id",),
+            ("stripe_subscription_id",),
+            ("requests_synced",),
+            ("bytes_synced",),
+        ]
+        totals_cursor.fetchall = AsyncMock(return_value=[(7, "sub_7", 12, 4096)])
+
+        conn = _FakeSqliteConn([exists_cursor, None, totals_cursor])
+        repo = AuthNZMeteringSyncLogRepository(db_pool=_FakePool(conn))
+
+        already_synced = await repo.already_synced(
+            user_id=7,
+            day="2026-03-13",
+            subscription_id="sub_7",
+        )
+        await repo.record_sync(
+            user_id=7,
+            day="2026-03-13",
+            subscription_id="sub_7",
+            requests=12,
+            bytes_total=4096,
+        )
+        rows = await repo.fetch_sync_totals("2026-03-13")
+
+        assert already_synced is True
+        assert rows == [
+            {
+                "user_id": 7,
+                "stripe_subscription_id": "sub_7",
+                "requests_synced": 12,
+                "bytes_synced": 4096,
+            }
+        ]
+        assert conn.commit.await_count == 1

--- a/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
+++ b/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
@@ -39,6 +39,37 @@ class _FakeSqliteConn:
 
 
 class TestAuthNZUsageDailyRepository:
+    def test_duplicate_subscription_error_is_exported_from_core_exceptions(self):
+        from tldw_Server_API.app.core import exceptions as core_exceptions
+
+        assert hasattr(core_exceptions, "DuplicateActiveSubscriptionError")
+
+    @pytest.mark.asyncio
+    async def test_get_db_pool_refreshes_global_pool_when_not_injected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import tldw_Server_API.app.core.AuthNZ.database as database_module
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZUsageDailyRepository,
+        )
+
+        first_pool = object()
+        second_pool = object()
+        pools = [first_pool, second_pool]
+
+        async def _fake_get_db_pool() -> object:
+            return pools.pop(0)
+
+        monkeypatch.setattr(database_module, "get_db_pool", _fake_get_db_pool)
+        repo = AuthNZUsageDailyRepository()
+
+        resolved_first = await repo._get_db_pool()
+        resolved_second = await repo._get_db_pool()
+
+        assert resolved_first is first_pool
+        assert resolved_second is second_pool
+
     @pytest.mark.asyncio
     async def test_fetch_usage_for_date_normalizes_legacy_rows(self):
         from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (

--- a/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
+++ b/tldw_Server_API/tests/Billing/test_authnz_metering_repository.py
@@ -1,32 +1,39 @@
 from __future__ import annotations
 
 import sqlite3
+from types import TracebackType
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 
 class _AcquireContext:
-    def __init__(self, conn):
+    def __init__(self, conn: Any) -> None:
         self._conn = conn
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> Any:
         return self._conn
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
         return False
 
 
 class _FakePool:
-    def __init__(self, conn):
+    def __init__(self, conn: Any) -> None:
         self._conn = conn
 
-    def acquire(self):
+    def acquire(self) -> _AcquireContext:
         return _AcquireContext(self._conn)
 
 
 class _FakeSqliteConn:
-    def __init__(self, execute_side_effect=None):
+    def __init__(self, execute_side_effect: Any | None = None) -> None:
         self.execute = AsyncMock(side_effect=execute_side_effect)
         self.commit = AsyncMock()
 
@@ -78,7 +85,12 @@ class TestAuthNZBillingSubscriptionRepository:
         )
 
         miss_cursor = MagicMock()
-        miss_cursor.fetchone = AsyncMock(return_value=None)
+        miss_cursor.description = [
+            ("stripe_customer_id",),
+            ("stripe_subscription_id",),
+            ("org_id",),
+        ]
+        miss_cursor.fetchall = AsyncMock(return_value=[])
 
         owner_cursor = MagicMock()
         owner_cursor.description = [
@@ -86,7 +98,7 @@ class TestAuthNZBillingSubscriptionRepository:
             ("stripe_subscription_id",),
             ("org_id",),
         ]
-        owner_cursor.fetchone = AsyncMock(return_value=("cus_owner", "sub_owner", 9))
+        owner_cursor.fetchall = AsyncMock(return_value=[("cus_owner", "sub_owner", 9)])
 
         conn = _FakeSqliteConn([miss_cursor, owner_cursor])
 
@@ -98,6 +110,36 @@ class TestAuthNZBillingSubscriptionRepository:
             "stripe_subscription_id": "sub_owner",
             "org_id": 9,
         }
+
+    @pytest.mark.asyncio
+    async def test_get_active_subscription_for_user_raises_on_duplicate_memberships(self):
+        from tldw_Server_API.app.core.DB_Management.AuthNZ_Metering_Repository import (
+            AuthNZBillingSubscriptionRepository,
+            DuplicateActiveSubscriptionError,
+        )
+
+        duplicate_cursor = MagicMock()
+        duplicate_cursor.description = [
+            ("stripe_customer_id",),
+            ("stripe_subscription_id",),
+            ("org_id",),
+        ]
+        duplicate_cursor.fetchall = AsyncMock(
+            return_value=[
+                ("cus_a", "sub_a", 1),
+                ("cus_b", "sub_b", 2),
+            ]
+        )
+
+        owner_cursor = MagicMock()
+        owner_cursor.description = duplicate_cursor.description
+        owner_cursor.fetchall = AsyncMock(return_value=[])
+
+        conn = _FakeSqliteConn([duplicate_cursor, owner_cursor])
+        repo = AuthNZBillingSubscriptionRepository(db_pool=_FakePool(conn))
+
+        with pytest.raises(DuplicateActiveSubscriptionError, match="multiple active subscriptions"):
+            await repo.get_active_subscription_for_user(42)
 
 
 class TestAuthNZMeteringSyncLogRepository:
@@ -112,8 +154,10 @@ class TestAuthNZMeteringSyncLogRepository:
 
         await repo.ensure_schema()
 
-        conn.execute.assert_awaited_once()
-        assert "CREATE TABLE IF NOT EXISTS metering_sync_log" in conn.execute.await_args.args[0]
+        assert conn.execute.await_count == 2
+        execute_calls = [call.args[0] for call in conn.execute.await_args_list]
+        assert "CREATE TABLE IF NOT EXISTS metering_sync_log" in execute_calls[0]
+        assert "CREATE INDEX IF NOT EXISTS idx_metering_sync_log_day" in execute_calls[1]
         conn.commit.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -9,11 +9,13 @@ Verifies that:
 """
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
-from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository, JobsSession
 from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 
@@ -175,18 +177,137 @@ class TestCountActiveJobs:
 
 
 class TrackingJobsRepository(JobsRepository):
-    def __init__(self, db_path):
-        super().__init__(backend="sqlite", db_path=db_path)
-        self.count_sessions = []
-        self.insert_sessions = []
+    def __init__(
+        self,
+        db_path: Path | None = None,
+        *,
+        backend: str = "sqlite",
+        db_url: str | None = None,
+        events: list[str] | None = None,
+    ) -> None:
+        super().__init__(
+            backend=backend,
+            db_path=db_path,
+            db_url=db_url,
+        )
+        self.count_sessions: list[JobsSession | None] = []
+        self.insert_sessions: list[JobsSession | None] = []
+        self.events = events if events is not None else []
 
-    def count_active_jobs_for_user(self, user_id: str, *, session=None) -> int:
+    def count_active_jobs_for_user(
+        self,
+        user_id: str,
+        *,
+        session: JobsSession | None = None,
+    ) -> int:
         self.count_sessions.append(session)
+        self.events.append("count_active_jobs")
+        if session is not None and session.backend == "postgres":
+            return 0
         return super().count_active_jobs_for_user(user_id, session=session)
 
-    def insert_job(self, *, session=None, **kwargs):
+    def insert_job(
+        self,
+        *,
+        domain: str,
+        queue: str,
+        job_type: str,
+        payload_json: str,
+        owner_user_id: str | None,
+        project_id: int | None,
+        batch_group: str | None,
+        idempotency_key: str | None,
+        priority: int,
+        max_retries: int,
+        available_at: Any,
+        request_id: str | None,
+        trace_id: str | None,
+        created_at: Any,
+        session: JobsSession | None = None,
+    ) -> dict[str, Any]:
         self.insert_sessions.append(session)
-        return super().insert_job(session=session, **kwargs)
+        self.events.append("insert_job")
+        if session is not None and session.backend == "postgres":
+            return {
+                "id": 1,
+                "uuid": "job-postgres-1",
+                "domain": domain,
+                "queue": queue,
+                "job_type": job_type,
+                "owner_user_id": owner_user_id,
+                "project_id": project_id,
+                "batch_group": batch_group,
+                "idempotency_key": idempotency_key,
+                "payload": payload_json,
+                "status": "queued",
+                "priority": priority,
+                "max_retries": max_retries,
+                "retry_count": 0,
+                "available_at": available_at,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "request_id": request_id,
+                "trace_id": trace_id,
+                "acquired_at": None,
+            }
+        return super().insert_job(
+            domain=domain,
+            queue=queue,
+            job_type=job_type,
+            payload_json=payload_json,
+            owner_user_id=owner_user_id,
+            project_id=project_id,
+            batch_group=batch_group,
+            idempotency_key=idempotency_key,
+            priority=priority,
+            max_retries=max_retries,
+            available_at=available_at,
+            request_id=request_id,
+            trace_id=trace_id,
+            created_at=created_at,
+            session=session,
+        )
+
+
+class _FakePostgresConnection:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def __enter__(self) -> "_FakePostgresConnection":
+        self._events.append("conn_enter")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self._events.append("conn_exit")
+        return False
+
+    def commit(self) -> None:
+        self._events.append("conn_commit")
+
+    def rollback(self) -> None:
+        self._events.append("conn_rollback")
+
+    def close(self) -> None:
+        self._events.append("conn_close")
+
+
+class _FakePostgresCursor:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def __enter__(self) -> "_FakePostgresCursor":
+        self._events.append("pg_cursor_enter")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self._events.append("pg_cursor_exit")
+        return False
+
+    def execute(self, query: str, params: tuple[Any, ...] | None = None) -> None:
+        self._events.append("pg_execute")
+
+    def fetchone(self) -> dict[str, int]:
+        return {"c": 0}
 
 
 class TestFairShareRepositoryIntegration:
@@ -216,3 +337,42 @@ class TestFairShareRepositoryIntegration:
         stored = job_manager.get_job(int(job["id"]))
         assert stored is not None
         assert stored["payload"] == {"test": True}
+
+    def test_postgres_fair_share_count_runs_after_pg_cursor_setup(self, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        monkeypatch.setenv("JOBS_PG_SKIP_SCHEMA_INIT", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        events: list[str] = []
+        repo = TrackingJobsRepository(
+            backend="postgres",
+            db_url="postgres://jobs.test/review_cleanup",
+            events=events,
+        )
+        job_manager = JobManager(
+            backend="postgres",
+            db_url="postgres://jobs.test/review_cleanup",
+            jobs_repository=repo,
+        )
+        fake_conn = _FakePostgresConnection(events)
+        monkeypatch.setattr(job_manager, "_connect", lambda: fake_conn)
+        monkeypatch.setattr(job_manager, "_pg_cursor", lambda conn: _FakePostgresCursor(events))
+
+        with patch.object(mgr_mod, "increment_created"), \
+             patch.object(mgr_mod, "emit_job_event"), \
+             patch.object(mgr_mod, "submit_job_audit_event"):
+            job = job_manager.create_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload={"test": True},
+                owner_user_id="42",
+                priority=5,
+            )
+
+        assert job is not None
+        assert repo.count_sessions
+        assert repo.insert_sessions
+        assert events.index("pg_cursor_enter") < events.index("count_active_jobs")
+        assert repo.count_sessions[0] is repo.insert_sessions[0]

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -315,6 +315,26 @@ class _FakePostgresCursor:
         return {"c": 0}
 
 
+class _FakePostgresIdempotencyCursor:
+    def __init__(self, existing_row: dict[str, Any]) -> None:
+        self._existing_row = existing_row
+        self._last_query = ""
+
+    def __enter__(self) -> "_FakePostgresIdempotencyCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def execute(self, query: str, params: tuple[Any, ...] | None = None) -> None:
+        self._last_query = query
+
+    def fetchone(self) -> dict[str, Any] | None:
+        if "SELECT * FROM jobs WHERE domain = %s" in self._last_query:
+            return self._existing_row
+        return None
+
+
 class _FakeSqliteConnection:
     is_fake_sqlite = True
 
@@ -343,6 +363,31 @@ class _FakeSqliteConnection:
 
 
 class TestFairShareRepositoryIntegration:
+    def test_idempotent_retry_returns_existing_job_even_when_at_limit(self, job_manager, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        first = job_manager.create_job(
+            domain="chatbooks",
+            queue="default",
+            job_type="export",
+            payload={"attempt": 1},
+            owner_user_id="42",
+            idempotency_key="idem-limit-replay",
+        )
+
+        replay = job_manager.create_job(
+            domain="chatbooks",
+            queue="default",
+            job_type="export",
+            payload={"attempt": 2},
+            owner_user_id="42",
+            idempotency_key="idem-limit-replay",
+        )
+
+        assert replay["id"] == first["id"]
+
     def test_create_job_reuses_repository_session_for_fair_share(self, tmp_path, monkeypatch):
         monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
         import tldw_Server_API.app.core.Jobs.manager as mgr_mod
@@ -431,6 +476,59 @@ class TestFairShareRepositoryIntegration:
         assert repo.insert_sessions
         assert events.index("pg_cursor_enter") < events.index("count_active_jobs")
         assert repo.count_sessions[0] is repo.insert_sessions[0]
+
+    def test_postgres_idempotent_retry_returns_existing_job_when_fair_share_blocks(
+        self,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
+        monkeypatch.setenv("JOBS_PG_SKIP_SCHEMA_INIT", "1")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        repo = TrackingJobsRepository(
+            backend="postgres",
+            db_url="postgres://jobs.test/review_cleanup",
+        )
+        job_manager = JobManager(
+            backend="postgres",
+            db_url="postgres://jobs.test/review_cleanup",
+            jobs_repository=repo,
+        )
+        fake_conn = _FakePostgresConnection([])
+        existing_row = {
+            "id": 321,
+            "uuid": "job-existing-321",
+            "domain": "chatbooks",
+            "queue": "default",
+            "job_type": "export",
+            "owner_user_id": "42",
+            "request_id": None,
+            "trace_id": None,
+            "retry_count": 0,
+        }
+        monkeypatch.setattr(repo, "_connect", lambda: fake_conn)
+        monkeypatch.setattr(
+            job_manager,
+            "_pg_cursor",
+            lambda conn: _FakePostgresIdempotencyCursor(existing_row),
+        )
+
+        with patch.object(
+            job_manager,
+            "_apply_fair_share_submission_policy",
+            side_effect=BadRequestError("User 42 has reached the maximum concurrent job limit (1)"),
+        ):
+            replay = job_manager.create_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload={"attempt": 2},
+                owner_user_id="42",
+                idempotency_key="idem-pg-limit-replay",
+            )
+
+        assert replay["id"] == existing_row["id"]
 
     def test_sqlite_fair_share_count_runs_inside_write_transaction(self, tmp_path, monkeypatch):
         monkeypatch.setenv("JOBS_MAX_PER_USER", "10")

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -13,14 +13,12 @@ from unittest.mock import patch
 
 import pytest
 
-from tldw_Server_API.app.core.exceptions import BadRequestError
-from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 
-pytestmark = pytest.mark.integration
 
-
-@pytest.fixture
+@pytest.fixture()
 def job_manager(tmp_path, monkeypatch):
     """Create a JobManager backed by a temporary SQLite database."""
     monkeypatch.delenv("JOBS_DISABLE_LEASE_ENFORCEMENT", raising=False)
@@ -64,7 +62,7 @@ class TestFairShareAdmissionControl:
         )
 
         # Third job should be blocked
-        with pytest.raises(BadRequestError, match="maximum concurrent job limit"):
+        with pytest.raises(ValueError, match="maximum concurrent job limit"):
             job_manager.create_job(
                 domain="chatbooks", queue="default", job_type="export",
                 payload={}, owner_user_id="42",
@@ -99,22 +97,10 @@ class TestFairShareAdmissionControl:
             domain="chatbooks", queue="default", job_type="export",
             payload={}, owner_user_id=None,
         )
-
-    def test_non_numeric_owner_user_id_does_not_require_int_cast(self, job_manager, monkeypatch):
-        monkeypatch.setenv("JOBS_MAX_PER_USER", "3")
-        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
-        mgr_mod._fair_share = None
-
-        job = job_manager.create_job(
-            domain="chatbooks",
-            queue="default",
-            job_type="export",
-            payload={},
-            owner_user_id="user-abc-123",
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id=None,
         )
-
-        assert job is not None
-        assert job.get("status") in ("queued", None) or "uuid" in job
 
 
 class TestFairSharePriorityAdjustment:
@@ -152,15 +138,24 @@ class TestFairSharePriorityAdjustment:
         assert job is not None
         mock_warning.assert_called_once()
 
-    def test_completing_a_job_restores_capacity(self, job_manager, monkeypatch):
-        monkeypatch.setenv("JOBS_MAX_PER_USER", "1")
-        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
-        mgr_mod._fair_share = None
 
+class TestCountActiveJobs:
+    """Verify the _count_active_jobs_for_user helper."""
+
+    def test_counts_queued_jobs(self, job_manager):
+        job_manager.create_job(
+            domain="chatbooks", queue="default", job_type="export",
+            payload={}, owner_user_id="99",
+        )
+        count = job_manager._count_active_jobs_for_user("99")
+        assert count == 1
+
+    def test_does_not_count_completed_jobs(self, job_manager):
         job = job_manager.create_job(
             domain="chatbooks", queue="default", job_type="export",
             payload={}, owner_user_id="99",
         )
+        # Acquire and complete the job
         acq = job_manager.acquire_next_job(
             domain="chatbooks", queue="default", lease_seconds=60, worker_id="w1",
         )
@@ -171,11 +166,53 @@ class TestFairSharePriorityAdjustment:
                 worker_id="w1",
                 lease_id=str(acq.get("lease_id")),
             )
+        count = job_manager._count_active_jobs_for_user("99")
+        assert count == 0
 
-        next_job = job_manager.create_job(
-            domain="chatbooks", queue="default", job_type="export",
-            payload={}, owner_user_id="99",
+    def test_counts_zero_for_unknown_user(self, job_manager):
+        count = job_manager._count_active_jobs_for_user("nonexistent")
+        assert count == 0
+
+
+class TrackingJobsRepository(JobsRepository):
+    def __init__(self, db_path):
+        super().__init__(backend="sqlite", db_path=db_path)
+        self.count_sessions = []
+        self.insert_sessions = []
+
+    def count_active_jobs_for_user(self, user_id: str, *, session=None) -> int:
+        self.count_sessions.append(session)
+        return super().count_active_jobs_for_user(user_id, session=session)
+
+    def insert_job(self, *, session=None, **kwargs):
+        self.insert_sessions.append(session)
+        return super().insert_job(session=session, **kwargs)
+
+
+class TestFairShareRepositoryIntegration:
+    def test_create_job_reuses_repository_session_for_fair_share(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        db_path = tmp_path / "jobs_repo_integration.db"
+        ensure_jobs_tables(db_path)
+        repo = TrackingJobsRepository(db_path)
+        job_manager = JobManager(db_path, jobs_repository=repo)
+
+        job = job_manager.create_job(
+            domain="chatbooks",
+            queue="default",
+            job_type="export",
+            payload={"test": True},
+            owner_user_id="42",
+            priority=5,
         )
 
         assert job is not None
-        assert next_job is not None
+        assert repo.count_sessions
+        assert repo.insert_sessions
+        assert repo.count_sessions[0] is repo.insert_sessions[0]
+        stored = job_manager.get_job(int(job["id"]))
+        assert stored is not None
+        assert stored["payload"] == {"test": True}

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -16,11 +16,12 @@ from unittest.mock import patch
 import pytest
 
 from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository, JobsSession
-from tldw_Server_API.app.core.Jobs.manager import JobManager, _get_fair_share
+from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+from tldw_Server_API.app.core.exceptions import BadRequestError
 
 
-@pytest.fixture()
+@pytest.fixture
 def job_manager(tmp_path, monkeypatch):
     """Create a JobManager backed by a temporary SQLite database."""
     monkeypatch.delenv("JOBS_DISABLE_LEASE_ENFORCEMENT", raising=False)
@@ -121,14 +122,15 @@ class TestFairSharePriorityAdjustment:
         assert stored is not None
         assert int(stored["priority"]) < 5
 
-    def test_warns_when_fair_share_check_is_skipped(self, job_manager, monkeypatch):
+    def test_fails_closed_when_fair_share_check_errors(self, job_manager, monkeypatch):
         monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
         import tldw_Server_API.app.core.Jobs.manager as mgr_mod
         mgr_mod._fair_share = None
 
         with patch.object(JobManager, "_count_active_jobs_for_user", side_effect=RuntimeError("boom")), \
-             patch.object(mgr_mod.logger, "warning") as mock_warning:
-            job = job_manager.create_job(
+             patch.object(mgr_mod.logger, "warning") as mock_warning, \
+             pytest.raises(BadRequestError, match="Unable to evaluate fair-share policy; please retry"):
+            job_manager.create_job(
                 domain="chatbooks",
                 queue="default",
                 job_type="export",
@@ -137,7 +139,6 @@ class TestFairSharePriorityAdjustment:
                 priority=5,
             )
 
-        assert job is not None
         mock_warning.assert_called_once()
 
 
@@ -202,7 +203,9 @@ class TrackingJobsRepository(JobsRepository):
     ) -> int:
         self.count_sessions.append(session)
         self.events.append("count_active_jobs")
-        if session is not None and session.backend == "postgres":
+        if session is not None and (
+            session.backend == "postgres" or getattr(session.conn, "is_fake_sqlite", False)
+        ):
             return 0
         return super().count_active_jobs_for_user(user_id, session=session)
 
@@ -227,10 +230,12 @@ class TrackingJobsRepository(JobsRepository):
     ) -> dict[str, Any]:
         self.insert_sessions.append(session)
         self.events.append("insert_job")
-        if session is not None and session.backend == "postgres":
+        if session is not None and (
+            session.backend == "postgres" or getattr(session.conn, "is_fake_sqlite", False)
+        ):
             return {
                 "id": 1,
-                "uuid": "job-postgres-1",
+                "uuid": "job-tracked-1",
                 "domain": domain,
                 "queue": queue,
                 "job_type": job_type,
@@ -310,6 +315,33 @@ class _FakePostgresCursor:
         return {"c": 0}
 
 
+class _FakeSqliteConnection:
+    is_fake_sqlite = True
+
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    def __enter__(self) -> "_FakeSqliteConnection":
+        self._events.append("conn_enter")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self._events.append("conn_exit")
+        return False
+
+    def execute(self, query: str, params: tuple[Any, ...] | None = None) -> None:
+        self._events.append("sqlite_execute")
+
+    def commit(self) -> None:
+        self._events.append("conn_commit")
+
+    def rollback(self) -> None:
+        self._events.append("conn_rollback")
+
+    def close(self) -> None:
+        self._events.append("conn_close")
+
+
 class TestFairShareRepositoryIntegration:
     def test_create_job_reuses_repository_session_for_fair_share(self, tmp_path, monkeypatch):
         monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
@@ -376,3 +408,55 @@ class TestFairShareRepositoryIntegration:
         assert repo.insert_sessions
         assert events.index("pg_cursor_enter") < events.index("count_active_jobs")
         assert repo.count_sessions[0] is repo.insert_sessions[0]
+
+    def test_sqlite_fair_share_count_runs_inside_write_transaction(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        db_path = tmp_path / "jobs_repo_sqlite_ordering.db"
+        ensure_jobs_tables(db_path)
+        events: list[str] = []
+        repo = TrackingJobsRepository(db_path, events=events)
+        job_manager = JobManager(db_path, jobs_repository=repo)
+        fake_conn = _FakeSqliteConnection(events)
+        monkeypatch.setattr(job_manager, "_connect", lambda: fake_conn)
+        monkeypatch.setattr(job_manager, "_update_gauges", lambda **kwargs: None)
+
+        with patch.object(mgr_mod, "increment_created"), \
+             patch.object(mgr_mod, "emit_job_event"), \
+             patch.object(mgr_mod, "submit_job_audit_event"):
+            job = job_manager.create_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload={"test": True},
+                owner_user_id="42",
+                priority=5,
+            )
+
+        assert job is not None
+        assert events.index("conn_enter") < events.index("count_active_jobs")
+        assert events.index("count_active_jobs") < events.index("insert_job")
+        assert repo.count_sessions[0] is repo.insert_sessions[0]
+
+    def test_constructor_rejects_backend_mismatch(self, tmp_path):
+        db_path = tmp_path / "jobs_repo_backend_mismatch.db"
+        ensure_jobs_tables(db_path)
+        repo = TrackingJobsRepository(
+            backend="postgres",
+            db_url="postgres://jobs.test/review_cleanup",
+        )
+
+        with pytest.raises(ValueError, match="does not match manager backend"):
+            JobManager(db_path, jobs_repository=repo)
+
+    def test_constructor_rejects_missing_repository_methods(self, tmp_path):
+        db_path = tmp_path / "jobs_repo_invalid_repo.db"
+        ensure_jobs_tables(db_path)
+
+        class InvalidJobsRepository:
+            backend = "sqlite"
+
+        with pytest.raises(TypeError, match="jobs_repository must expose"):
+            JobManager(db_path, jobs_repository=InvalidJobsRepository())

--- a/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
+++ b/tldw_Server_API/tests/Jobs/test_fair_share_integration.py
@@ -370,6 +370,29 @@ class TestFairShareRepositoryIntegration:
         assert stored is not None
         assert stored["payload"] == {"test": True}
 
+    def test_create_job_uses_repository_session_context(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
+        import tldw_Server_API.app.core.Jobs.manager as mgr_mod
+        mgr_mod._fair_share = None
+
+        db_path = tmp_path / "jobs_repo_session_context.db"
+        ensure_jobs_tables(db_path)
+        repo = TrackingJobsRepository(db_path)
+        job_manager = JobManager(db_path, jobs_repository=repo)
+
+        with patch.object(repo, "session", wraps=repo.session) as session_spy:
+            job = job_manager.create_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload={"test": True},
+                owner_user_id="42",
+                priority=5,
+            )
+
+        assert job is not None
+        session_spy.assert_called_once_with()
+
     def test_postgres_fair_share_count_runs_after_pg_cursor_setup(self, monkeypatch):
         monkeypatch.setenv("JOBS_MAX_PER_USER", "10")
         monkeypatch.setenv("JOBS_PG_SKIP_SCHEMA_INIT", "1")
@@ -388,7 +411,7 @@ class TestFairShareRepositoryIntegration:
             jobs_repository=repo,
         )
         fake_conn = _FakePostgresConnection(events)
-        monkeypatch.setattr(job_manager, "_connect", lambda: fake_conn)
+        monkeypatch.setattr(repo, "_connect", lambda: fake_conn)
         monkeypatch.setattr(job_manager, "_pg_cursor", lambda conn: _FakePostgresCursor(events))
 
         with patch.object(mgr_mod, "increment_created"), \
@@ -420,7 +443,7 @@ class TestFairShareRepositoryIntegration:
         repo = TrackingJobsRepository(db_path, events=events)
         job_manager = JobManager(db_path, jobs_repository=repo)
         fake_conn = _FakeSqliteConnection(events)
-        monkeypatch.setattr(job_manager, "_connect", lambda: fake_conn)
+        monkeypatch.setattr(repo, "_connect", lambda: fake_conn)
         monkeypatch.setattr(job_manager, "_update_gauges", lambda **kwargs: None)
 
         with patch.object(mgr_mod, "increment_created"), \

--- a/tldw_Server_API/tests/Jobs/test_jobs_repository.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_repository.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
+
+
+@pytest.fixture()
+def sqlite_jobs_repo(tmp_path):
+    from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+    db_path = tmp_path / "jobs_repo.db"
+    ensure_jobs_tables(db_path)
+    return JobsRepository.for_sqlite(db_path)
+
+
+class TestJobsRepositorySqlite:
+    def test_count_active_jobs_for_user_uses_existing_session(self, sqlite_jobs_repo):
+        with sqlite_jobs_repo.session() as session:
+            sqlite_jobs_repo.insert_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload_json='{"first": true}',
+                owner_user_id="42",
+                project_id=None,
+                batch_group=None,
+                idempotency_key=None,
+                priority=5,
+                max_retries=3,
+                available_at=None,
+                request_id="req-1",
+                trace_id="trace-1",
+                created_at=datetime(2026, 3, 17, 12, 0, tzinfo=timezone.utc),
+                session=session,
+            )
+            sqlite_jobs_repo.insert_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload_json='{"second": true}',
+                owner_user_id="42",
+                project_id=None,
+                batch_group=None,
+                idempotency_key=None,
+                priority=4,
+                max_retries=3,
+                available_at=None,
+                request_id="req-2",
+                trace_id="trace-2",
+                created_at=datetime(2026, 3, 17, 12, 1, tzinfo=timezone.utc),
+                session=session,
+            )
+
+            assert sqlite_jobs_repo.count_active_jobs_for_user("42", session=session) == 2
+            assert sqlite_jobs_repo.count_active_jobs_for_user("7", session=session) == 0
+
+    def test_insert_job_returns_created_row_from_same_session(self, sqlite_jobs_repo):
+        with sqlite_jobs_repo.session() as session:
+            row = sqlite_jobs_repo.insert_job(
+                domain="chatbooks",
+                queue="default",
+                job_type="export",
+                payload_json='{"created": true}',
+                owner_user_id="55",
+                project_id=9,
+                batch_group="batch-a",
+                idempotency_key="idem-1",
+                priority=3,
+                max_retries=7,
+                available_at=datetime(2026, 3, 18, 9, 30, tzinfo=timezone.utc),
+                request_id="req-55",
+                trace_id="trace-55",
+                created_at=datetime(2026, 3, 17, 12, 30, tzinfo=timezone.utc),
+                session=session,
+            )
+
+            counted = sqlite_jobs_repo.count_active_jobs_for_user("55", session=session)
+
+        assert row["owner_user_id"] == "55"
+        assert row["status"] == "queued"
+        assert row["queue"] == "default"
+        assert row["job_type"] == "export"
+        assert row["batch_group"] == "batch-a"
+        assert row["idempotency_key"] == "idem-1"
+        assert int(row["priority"]) == 3
+        assert int(row["max_retries"]) == 7
+        assert counted == 1

--- a/tldw_Server_API/tests/Jobs/test_jobs_repository.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_repository.py
@@ -1,13 +1,43 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 
 
-@pytest.fixture()
+class _PoolAcquireContext:
+    def __init__(self, pool: _FakeConnectionPool) -> None:
+        self._pool = pool
+
+    def __enter__(self) -> sqlite3.Connection:
+        self._pool.acquired += 1
+        return self._pool.conn
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self._pool.released += 1
+        return False
+
+
+class _FakeConnectionPool:
+    def __init__(self, db_path: Path) -> None:
+        self.conn = sqlite3.connect(db_path)
+        self.acquired = 0
+        self.released = 0
+        self.closed = 0
+
+    def acquire(self) -> _PoolAcquireContext:
+        return _PoolAcquireContext(self)
+
+    def close(self) -> None:
+        self.closed += 1
+        self.conn.close()
+
+
+@pytest.fixture
 def sqlite_jobs_repo(tmp_path):
     from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
 
@@ -88,3 +118,40 @@ class TestJobsRepositorySqlite:
         assert int(row["priority"]) == 3
         assert int(row["max_retries"]) == 7
         assert counted == 1
+
+    def test_session_uses_injected_connection_pool(self, tmp_path):
+        from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+        db_path = tmp_path / "jobs_repo_pool.db"
+        ensure_jobs_tables(db_path)
+        pool = _FakeConnectionPool(db_path)
+        repo = JobsRepository.for_sqlite(db_path, connection_pool=pool)
+
+        try:
+            with repo.session() as session:
+                row = repo.insert_job(
+                    domain="chatbooks",
+                    queue="default",
+                    job_type="export",
+                    payload_json='{"pooled": true}',
+                    owner_user_id="77",
+                    project_id=None,
+                    batch_group=None,
+                    idempotency_key=None,
+                    priority=4,
+                    max_retries=2,
+                    available_at=None,
+                    request_id="req-pool",
+                    trace_id="trace-pool",
+                    created_at=datetime(2026, 3, 17, 13, 0, tzinfo=timezone.utc),
+                    session=session,
+                )
+                counted = repo.count_active_jobs_for_user("77", session=session)
+        finally:
+            repo.close_pool()
+
+        assert row["owner_user_id"] == "77"
+        assert counted == 1
+        assert pool.acquired == 1
+        assert pool.released == 1
+        assert pool.closed == 1

--- a/tldw_Server_API/tests/Jobs/test_jobs_repository.py
+++ b/tldw_Server_API/tests/Jobs/test_jobs_repository.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from tldw_Server_API.app.core.exceptions import BadRequestError
 from tldw_Server_API.app.core.Jobs.migrations import ensure_jobs_tables
 
 
@@ -155,3 +156,29 @@ class TestJobsRepositorySqlite:
         assert pool.acquired == 1
         assert pool.released == 1
         assert pool.closed == 1
+
+
+class TestJobsRepositoryValidation:
+    def test_rejects_unsupported_backend(self):
+        from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+        with pytest.raises(BadRequestError, match="Unsupported jobs repository backend"):
+            JobsRepository(backend="mysql")
+
+    def test_requires_sqlite_db_path_without_pool(self):
+        from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+        with pytest.raises(BadRequestError, match="SQLite jobs repository requires db_path"):
+            JobsRepository(backend="sqlite")
+
+    def test_requires_postgres_db_url_without_pool(self):
+        from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+        with pytest.raises(BadRequestError, match="Postgres jobs repository requires db_url"):
+            JobsRepository(backend="postgres")
+
+    def test_rejects_pool_without_acquire(self, tmp_path):
+        from tldw_Server_API.app.core.DB_Management.Jobs_Repository import JobsRepository
+
+        with pytest.raises(BadRequestError, match="connection_pool must define an acquire"):
+            JobsRepository.for_sqlite(tmp_path / "jobs_repo_bad_pool.db", connection_pool=object())

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -481,7 +481,12 @@ class TestSyncDailyUsage:
     async def test_query_user_subscription_falls_back_to_org_owner(self, enabled_service, fake_pool, fake_sqlite_conn):
         svc = enabled_service
         miss_cursor = MagicMock()
-        miss_cursor.fetchone = AsyncMock(return_value=None)
+        miss_cursor.description = [
+            ("stripe_customer_id",),
+            ("stripe_subscription_id",),
+            ("org_id",),
+        ]
+        miss_cursor.fetchall = AsyncMock(return_value=[])
 
         owner_cursor = MagicMock()
         owner_cursor.description = [
@@ -489,7 +494,7 @@ class TestSyncDailyUsage:
             ("stripe_subscription_id",),
             ("org_id",),
         ]
-        owner_cursor.fetchone = AsyncMock(return_value=("cus_owner", "sub_owner", 9))
+        owner_cursor.fetchall = AsyncMock(return_value=[("cus_owner", "sub_owner", 9)])
 
         conn = fake_sqlite_conn([miss_cursor, owner_cursor])
 

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -20,6 +20,20 @@ import pytest
 from tldw_Server_API.app.services import stripe_metering_service as _sms_module
 from tldw_Server_API.app.services.stripe_metering_service import StripeMeteringService
 
+
+def _stripe_ok():
+    """Pretend Stripe is installed and provide a mock module when needed."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(patch.object(_sms_module, "STRIPE_AVAILABLE", True))
+    if _sms_module.stripe is None:
+        fake_stripe = MagicMock()
+        fake_stripe.api_key = None
+        stack.enter_context(patch.object(_sms_module, "stripe", fake_stripe))
+    return stack
+
+
 @pytest.fixture
 def mock_stripe() -> MagicMock:
     mock = MagicMock()

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -183,6 +183,59 @@ class TestSyncDailyUsage:
     """Tests for StripeMeteringService.sync_daily_usage."""
 
     @pytest.mark.asyncio
+    async def test_uses_injected_repositories_for_sync(self):
+        with patch.dict(
+            "os.environ",
+            {"BILLING_ENABLED": "true", "STRIPE_API_KEY": "sk_test_123"},
+        ):
+            svc = StripeMeteringService(
+                usage_repo=MagicMock(),
+                subscription_repo=MagicMock(),
+                sync_log_repo=MagicMock(),
+            )
+        svc._usage_repo.fetch_usage_for_date = AsyncMock(return_value=[
+            {
+                "user_id": 1,
+                "requests": 100,
+                "errors": 0,
+                "bytes_total": 5000,
+                "bytes_in_total": 3000,
+                "latency_avg_ms": 50.0,
+            },
+        ])
+        svc._subscription_repo.get_active_subscription_for_user = AsyncMock(return_value={
+            "stripe_customer_id": "cus_test1",
+            "stripe_subscription_id": "sub_test1",
+            "org_id": 10,
+        })
+        svc._sync_log_repo.ensure_schema = AsyncMock()
+        svc._sync_log_repo.already_synced = AsyncMock(return_value=False)
+        svc._sync_log_repo.record_sync = AsyncMock()
+        svc._get_subscription_metered_item = AsyncMock(return_value="si_item1")
+        svc._report_usage_to_stripe = AsyncMock()
+
+        with _stripe_ok():
+            result = await svc.sync_daily_usage(date="2026-03-13")
+
+        assert result["status"] == "completed"
+        assert result["synced_users"] == 1
+        svc._sync_log_repo.ensure_schema.assert_awaited_once()
+        svc._usage_repo.fetch_usage_for_date.assert_awaited_once_with("2026-03-13")
+        svc._subscription_repo.get_active_subscription_for_user.assert_awaited_once_with(1)
+        svc._sync_log_repo.already_synced.assert_awaited_once_with(
+            user_id=1,
+            day="2026-03-13",
+            subscription_id="sub_test1",
+        )
+        svc._sync_log_repo.record_sync.assert_awaited_once_with(
+            user_id=1,
+            day="2026-03-13",
+            subscription_id="sub_test1",
+            requests=100,
+            bytes_total=5000,
+        )
+
+    @pytest.mark.asyncio
     async def test_skips_when_disabled(self):
         """Returns skip status when billing is not enabled."""
         with patch.dict("os.environ", {}, clear=True):

--- a/tldw_Server_API/tests/test_stripe_metering.py
+++ b/tldw_Server_API/tests/test_stripe_metering.py
@@ -196,6 +196,15 @@ class _FakeSqliteConn:
 class TestSyncDailyUsage:
     """Tests for StripeMeteringService.sync_daily_usage."""
 
+    def test_rejects_partial_repository_injection_without_db_pool(self):
+        from tldw_Server_API.app.services.stripe_metering_service import StripeMeteringService
+
+        with pytest.raises(
+            ValueError,
+            match="Inject all metering repositories together or provide db_pool",
+        ):
+            StripeMeteringService(usage_repo=MagicMock())
+
     @pytest.mark.asyncio
     async def test_uses_injected_repositories_for_sync(self):
         with patch.dict(


### PR DESCRIPTION
## Summary
- add a dedicated Jobs persistence boundary with `JobsRepository` and `JobsSession` under `tldw_Server_API/app/core/DB_Management`
- route fair-share counting and create-time inserts through repository-backed sessions in `JobManager`
- add AuthNZ metering repositories for usage reads, subscription lookup, and sync-log ownership
- refactor `StripeMeteringService` into an orchestration layer with injectable repositories and thin persistence adapters
- finalize the design and execution docs with implementation notes, review rationale, and verification output

## Verification
- `python -m pytest tldw_Server_API/tests/AuthNZ/test_consent_endpoints.py tldw_Server_API/tests/AuthNZ/test_audit_chain_integration.py tldw_Server_API/tests/Billing/test_overage_enforcement_integration.py tldw_Server_API/tests/Billing/test_authnz_metering_repository.py tldw_Server_API/tests/Jobs/test_fair_share_integration.py tldw_Server_API/tests/Jobs/test_jobs_repository.py tldw_Server_API/tests/test_stripe_metering.py -v`
  - result: `67 passed`
- `python -m bandit -r tldw_Server_API/app/core/Jobs/manager.py tldw_Server_API/app/core/DB_Management/Jobs_Repository.py tldw_Server_API/app/core/DB_Management/AuthNZ_Metering_Repository.py tldw_Server_API/app/services/stripe_metering_service.py -f json -o /tmp/bandit_pr898_boundary_redesign.json`
  - result: `0 findings`, `0 errors`

## Notes
- This PR remains stacked on `feat/production-readiness-gaps` until PR 898 lands.
- The remaining known follow-up is the idempotent create branch in `JobManager.create_job()`, which still uses module-local SQL and can be moved behind the repository boundary in a later pass if desired.
