### PR TITLE
fix(embeddings): normalize jobs worker chunk type fallback

### DIFF
--- a/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
@@ -129,13 +129,18 @@ def _root_job_uuid(payload: dict[str, Any]) -> str | None:
 
 
 def _normalize_chunk_type(value: Any) -> str | None:
+    """Normalize a chunk-type candidate while surfacing non-fatal normalization failures."""
+
     try:
         return Chunker.normalize_chunk_type(value)
-    except _EMBEDDINGS_JOB_NONCRITICAL_EXCEPTIONS:
+    except _EMBEDDINGS_JOB_NONCRITICAL_EXCEPTIONS as exc:
+        logger.debug("Failed to normalize chunk type candidate {!r}: {}", value, exc)
         return None
 
 
 def _resolve_chunk_type(*candidates: Any) -> str:
+    """Return the first normalized chunk type from the candidate list, else fall back to ``text``."""
+
     for candidate in candidates:
         normalized = _normalize_chunk_type(candidate)
         if normalized:

--- a/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
+++ b/tldw_Server_API/app/core/Embeddings/services/jobs_worker.py
@@ -46,6 +46,7 @@ from tldw_Server_API.app.api.v1.endpoints.media_embeddings import (
     generate_embeddings_for_media,
 )
 from tldw_Server_API.app.api.v1.utils.rag_cache import invalidate_rag_caches
+from tldw_Server_API.app.core.Chunking.chunker import Chunker
 from tldw_Server_API.app.core.DB_Management.db_path_utils import (
     DatabasePaths,
     get_user_media_db_path,
@@ -125,6 +126,21 @@ def _root_job_uuid(payload: dict[str, Any]) -> str | None:
     if root is None:
         return None
     return str(root)
+
+
+def _normalize_chunk_type(value: Any) -> str | None:
+    try:
+        return Chunker.normalize_chunk_type(value)
+    except _EMBEDDINGS_JOB_NONCRITICAL_EXCEPTIONS:
+        return None
+
+
+def _resolve_chunk_type(*candidates: Any) -> str:
+    for candidate in candidates:
+        normalized = _normalize_chunk_type(candidate)
+        if normalized:
+            return normalized
+    return "text"
 
 
 def _update_root_job(
@@ -643,11 +659,19 @@ async def _handle_storage_job(
         if text is None:
             raise EmbeddingsJobError("Chunk payload missing text for storage stage", retryable=False)
         chunk_texts.append(text)
+        chunk_metadata = chunk.get("metadata") if isinstance(chunk.get("metadata"), dict) else {}
         metadata = {
             "media_id": str(media_id),
             "chunk_index": chunk.get("index", idx),
             "chunk_start": chunk.get("start"),
             "chunk_end": chunk.get("end"),
+            "chunk_type": _resolve_chunk_type(
+                chunk.get("chunk_type"),
+                chunk_metadata.get("chunk_type"),
+                chunk_metadata.get("paragraph_kind"),
+                chunk_metadata.get("type"),
+                chunk_metadata.get("kind"),
+            ),
             "title": media_content["media_item"].get("title", ""),
             "author": media_content["media_item"].get("author", ""),
             "embedding_model": embedding_model,

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_jobs_worker.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_jobs_worker.py
@@ -370,6 +370,26 @@ async def test_embeddings_worker_storage_uses_first_normalized_chunk_type(monkey
     assert captured["metadatas"][0]["chunk_type"] == "code"
 
 
+def test_normalize_chunk_type_logs_noncritical_failures(monkeypatch):
+    debug_calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def fail_normalization(_value):
+        raise ValueError("bad chunk metadata")
+
+    monkeypatch.setattr(jobs_worker.Chunker, "normalize_chunk_type", fail_normalization)
+    monkeypatch.setattr(
+        jobs_worker.logger,
+        "debug",
+        lambda message, *args: debug_calls.append((message, args)),
+    )
+
+    result = jobs_worker._normalize_chunk_type({"bad": "metadata"})
+
+    assert result is None
+    assert debug_calls
+    assert "Failed to normalize chunk type candidate" in debug_calls[0][0]
+
+
 @pytest.mark.asyncio
 async def test_embeddings_worker_storage_rejects_malformed_idempotent_artifact(monkeypatch, tmp_path):
     artifact_dir = tmp_path / "artifacts"

--- a/tldw_Server_API/tests/Embeddings/test_embeddings_jobs_worker.py
+++ b/tldw_Server_API/tests/Embeddings/test_embeddings_jobs_worker.py
@@ -300,6 +300,74 @@ async def test_embeddings_worker_storage_uses_user_scoped_chroma_manager(monkeyp
     assert captured["collection_name"] == "user_user-42_media_embeddings"
     assert captured["ids"] == ["media_42_chunk_0"]
     assert captured["embedding_model_id_for_dim_check"] == "test-model"
+    assert captured["metadatas"][0]["chunk_type"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_embeddings_worker_storage_uses_first_normalized_chunk_type(monkeypatch, tmp_path):
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    chunks_path = artifact_dir / "chunks.json"
+    embeddings_path = artifact_dir / "embeddings.json"
+
+    chunks_path.write_text(
+        (
+            '[{"text": "hello embeddings", "chunk_type": "   ", "metadata": {"kind": "code_fence"}, '
+            '"index": 0, "start": 0, "end": 16}]'
+        ),
+        encoding="utf-8",
+    )
+    embeddings_path.write_text(
+        '{"embeddings": [[0.1, 0.2, 0.3]], "embedding_model": "test-model", "embedding_provider": "test-provider"}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(jobs_worker, "_artifact_dir", lambda *_, **__: artifact_dir)
+    monkeypatch.setattr(
+        jobs_worker,
+        "_load_media_content",
+        lambda *_: {"media_item": {"title": "Doc", "author": "A"}, "content": {"content": "hello embeddings"}},
+    )
+    monkeypatch.setattr(jobs_worker, "invalidate_rag_caches", lambda *_, **__: None)
+    monkeypatch.setattr(jobs_worker, "_embedding_config_for_user", lambda: {"USER_DB_BASE_DIR": str(tmp_path)})
+
+    captured: dict[str, object] = {}
+
+    class FakeChromaDBManager:
+        def __init__(self, *, user_id, user_embedding_config):
+            captured["user_id"] = user_id
+            captured["user_embedding_config"] = user_embedding_config
+
+        def store_in_chroma(
+            self,
+            collection_name,
+            texts,
+            embeddings,
+            ids,
+            metadatas,
+            embedding_model_id_for_dim_check=None,
+        ):
+            captured["collection_name"] = collection_name
+            captured["texts"] = texts
+            captured["embeddings"] = embeddings
+            captured["ids"] = ids
+            captured["metadatas"] = metadatas
+            captured["embedding_model_id_for_dim_check"] = embedding_model_id_for_dim_check
+
+    monkeypatch.setattr(jobs_worker, "ChromaDBManager", FakeChromaDBManager)
+
+    result = await jobs_worker._handle_storage_job(
+        job={"id": 1, "uuid": "job-1"},
+        payload={},
+        media_id=42,
+        user_id="user-42",
+        embedding_model="test-model",
+        embedding_provider="test-provider",
+        root_uuid=None,
+    )
+
+    assert result["embedding_count"] == 1
+    assert captured["metadatas"][0]["chunk_type"] == "code"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add chunk_type metadata generation to embeddings jobs worker storage records on dev
- normalize chunk type candidates in order so blank or invalid early values do not mask later valid fallbacks
- add regression coverage for both the default text case and the ordered fallback case

## Test Plan
- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Embeddings/test_embeddings_jobs_worker.py tldw_Server_API/tests/Embeddings/test_media_embeddings_storage_scope.py -q
- source .venv/bin/activate && python -m bandit -r tldw_Server_API/app/core/Embeddings/services/jobs_worker.py -f json -o /tmp/bandit_pr910_jobs_worker_followup.json
