### PR TITLE
feat: add Telegram bot governance integration

### DIFF
--- a/Docs/Plans/2026-03-19-telegram-bot-authnz-design.md
+++ b/Docs/Plans/2026-03-19-telegram-bot-authnz-design.md
@@ -277,6 +277,12 @@ This execution identity should be claim-first and usable by:
 - MCP tool execution
 - child agents
 
+Implementation note:
+
+- Telegram-originated Jobs should carry this brokered context in a top-level `execution_identity` payload field.
+- Parent Telegram identities should include the transport permissions needed to receive and reply on Telegram, plus the linked actor's resolved permissions.
+- Workspace, workflow, and tool allowlists should default to empty until an explicit policy or binding narrows them in.
+
 ### Downscoped child agents
 
 If a Telegram request spawns a workflow or child agent, each child receives a narrower identity.

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -14,6 +14,9 @@ from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigUpdate,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.services.telegram_execution_identity_service import (
+    get_telegram_execution_identity_service,
+)
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
@@ -45,4 +48,7 @@ async def telegram_admin_start_link(
 
 @router.post("/webhook")
 async def telegram_webhook(request: Request):
-    return await telegram_webhook_impl(request=request)
+    return await telegram_webhook_impl(
+        request=request,
+        get_execution_identity_service=get_telegram_execution_identity_service,
+    )

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -6,6 +6,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, re
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
+    telegram_webhook_impl,
 )
 from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigResponse,
@@ -31,3 +32,8 @@ async def telegram_admin_get_bot(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> TelegramBotConfigResponse:
     return await telegram_admin_get_bot_impl(principal=principal, request=request)
+
+
+@router.post("/webhook")
+async def telegram_webhook(request: Request):
+    return await telegram_webhook_impl(request=request)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
 
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import (
+    check_rate_limit,
+    get_auth_principal,
+    require_roles,
+)
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
@@ -46,7 +50,7 @@ async def telegram_admin_start_link(
     return await telegram_admin_start_link_impl(principal=principal, request=request)
 
 
-@router.post("/webhook")
+@router.post("/webhook", dependencies=[Depends(check_rate_limit)])
 async def telegram_webhook(request: Request):
     return await telegram_webhook_impl(
         request=request,

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_roles
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
@@ -14,6 +15,7 @@ from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigUpdate,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.Jobs.manager import JobManager
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
@@ -44,5 +46,8 @@ async def telegram_admin_start_link(
 
 
 @router.post("/webhook")
-async def telegram_webhook(request: Request):
-    return await telegram_webhook_impl(request=request)
+async def telegram_webhook(
+    request: Request,
+    job_manager: JobManager = Depends(get_job_manager),
+):
+    return await telegram_webhook_impl(request=request, job_manager=job_manager)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    telegram_admin_get_bot_impl,
+    telegram_admin_put_bot_impl,
+)
+from tldw_Server_API.app.api.v1.schemas.telegram_schemas import TelegramBotConfigUpdate
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+
+router = APIRouter(prefix="/telegram", tags=["telegram"])
+
+
+@router.put("/admin/bot", dependencies=[Depends(require_roles("admin"))])
+async def telegram_admin_put_bot(
+    payload: TelegramBotConfigUpdate,
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    return await telegram_admin_put_bot_impl(user=user, payload=payload)
+
+
+@router.get("/admin/bot", dependencies=[Depends(require_roles("admin"))])
+async def telegram_admin_get_bot(
+    user: User = Depends(get_request_user),
+) -> dict[str, Any]:
+    return await telegram_admin_get_bot_impl(user=user)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_roles
-from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
@@ -15,7 +14,6 @@ from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigUpdate,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
-from tldw_Server_API.app.core.Jobs.manager import JobManager
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
@@ -46,8 +44,5 @@ async def telegram_admin_start_link(
 
 
 @router.post("/webhook")
-async def telegram_webhook(
-    request: Request,
-    job_manager: JobManager = Depends(get_job_manager),
-):
-    return await telegram_webhook_impl(request=request, job_manager=job_manager)
+async def telegram_webhook(request: Request):
+    return await telegram_webhook_impl(request=request)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -6,6 +6,7 @@ from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, re
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
+    telegram_admin_start_link_impl,
     telegram_webhook_impl,
 )
 from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
@@ -32,6 +33,14 @@ async def telegram_admin_get_bot(
     principal: AuthPrincipal = Depends(get_auth_principal),
 ) -> TelegramBotConfigResponse:
     return await telegram_admin_get_bot_impl(principal=principal, request=request)
+
+
+@router.post("/admin/link/start", dependencies=[Depends(require_roles("admin"))])
+async def telegram_admin_start_link(
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+):
+    return await telegram_admin_start_link_impl(principal=principal, request=request)
 
 
 @router.post("/webhook")

--- a/tldw_Server_API/app/api/v1/endpoints/telegram.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram.py
@@ -1,30 +1,33 @@
 from __future__ import annotations
 
-from typing import Any
+from fastapi import APIRouter, Depends, Request
 
-from fastapi import APIRouter, Depends
-
-from tldw_Server_API.app.api.v1.API_Deps.auth_deps import require_roles
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal, require_roles
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     telegram_admin_get_bot_impl,
     telegram_admin_put_bot_impl,
 )
-from tldw_Server_API.app.api.v1.schemas.telegram_schemas import TelegramBotConfigUpdate
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User, get_request_user
+from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
+    TelegramBotConfigResponse,
+    TelegramBotConfigUpdate,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
 
-@router.put("/admin/bot", dependencies=[Depends(require_roles("admin"))])
+@router.put("/admin/bot", dependencies=[Depends(require_roles("admin"))], response_model=TelegramBotConfigResponse)
 async def telegram_admin_put_bot(
+    request: Request,
     payload: TelegramBotConfigUpdate,
-    user: User = Depends(get_request_user),
-) -> dict[str, Any]:
-    return await telegram_admin_put_bot_impl(user=user, payload=payload)
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> TelegramBotConfigResponse:
+    return await telegram_admin_put_bot_impl(principal=principal, payload=payload, request=request)
 
 
-@router.get("/admin/bot", dependencies=[Depends(require_roles("admin"))])
+@router.get("/admin/bot", dependencies=[Depends(require_roles("admin"))], response_model=TelegramBotConfigResponse)
 async def telegram_admin_get_bot(
-    user: User = Depends(get_request_user),
-) -> dict[str, Any]:
-    return await telegram_admin_get_bot_impl(user=user)
+    request: Request,
+    principal: AuthPrincipal = Depends(get_auth_principal),
+) -> TelegramBotConfigResponse:
+    return await telegram_admin_get_bot_impl(principal=principal, request=request)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
+from fastapi import HTTPException, Request, status
 from loguru import logger
 
-from tldw_Server_API.app.api.v1.schemas.telegram_schemas import TelegramBotConfigUpdate
-from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
+    TelegramBotConfigResponse,
+    TelegramBotConfigUpdate,
+)
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
-from tldw_Server_API.app.core.AuthNZ.repos.user_provider_secrets_repo import (
-    AuthnzUserProviderSecretsRepo,
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.repos.org_provider_secrets_repo import (
+    AuthnzOrgProviderSecretsRepo,
 )
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     decrypt_byok_payload,
@@ -24,6 +29,12 @@ _DEFAULT_BOT_USERNAME = "example_bot"
 _CREDENTIAL_VERSION = 1
 
 
+@dataclass(frozen=True)
+class TelegramScope:
+    scope_type: str
+    scope_id: int
+
+
 def _coerce_nonempty_string(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -31,9 +42,61 @@ def _coerce_nonempty_string(value: Any) -> str | None:
     return cleaned if cleaned else None
 
 
-async def _get_user_secret_repo() -> AuthnzUserProviderSecretsRepo:
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _collect_scope_ids(values: list[int] | None, active_id: int | None) -> list[int]:
+    out: set[int] = set()
+    for raw in values or []:
+        try:
+            out.add(int(raw))
+        except (TypeError, ValueError):
+            continue
+    if active_id is not None:
+        try:
+            out.add(int(active_id))
+        except (TypeError, ValueError):
+            pass
+    return sorted(out)
+
+
+def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    merged: dict[str, Any] = {
+        "provider": _PROVIDER,
+        "credential_version": _CREDENTIAL_VERSION,
+        "bot_username": _DEFAULT_BOT_USERNAME,
+        "enabled": False,
+    }
+    if isinstance(payload, dict):
+        merged.update(payload)
+    merged["bot_username"] = _coerce_nonempty_string(merged.get("bot_username")) or _DEFAULT_BOT_USERNAME
+    merged["enabled"] = bool(merged.get("enabled"))
+    return merged
+
+
+def _public_bot_config_record(
+    payload: dict[str, Any] | None,
+    *,
+    scope: TelegramScope,
+) -> TelegramBotConfigResponse:
+    normalized = _normalize_bot_config_payload(payload)
+    return TelegramBotConfigResponse(
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
+        bot_username=normalized["bot_username"],
+        enabled=normalized["enabled"],
+    )
+
+
+async def _get_org_secret_repo() -> AuthnzOrgProviderSecretsRepo:
     pool = await get_db_pool()
-    repo = AuthnzUserProviderSecretsRepo(pool)
+    repo = AuthnzOrgProviderSecretsRepo(pool)
     await repo.ensure_tables()
     return repo
 
@@ -53,46 +116,68 @@ def _decrypt_telegram_payload(encrypted_blob: str | None) -> dict[str, Any] | No
     return payload if isinstance(payload, dict) else None
 
 
-def _default_bot_config_payload() -> dict[str, Any]:
-    return {
-        "provider": _PROVIDER,
-        "credential_version": _CREDENTIAL_VERSION,
-        "bot_username": _DEFAULT_BOT_USERNAME,
-        "enabled": False,
-    }
+def _resolve_shared_scope(
+    *,
+    principal: AuthPrincipal,
+    request: Request | None = None,
+) -> TelegramScope:
+    request_active_team_id = _coerce_int(getattr(request.state, "active_team_id", None)) if request else None
+    request_active_org_id = _coerce_int(getattr(request.state, "active_org_id", None)) if request else None
 
+    active_team_id = _coerce_int(principal.active_team_id)
+    if active_team_id is None:
+        active_team_id = request_active_team_id
+    active_org_id = _coerce_int(principal.active_org_id)
+    if active_org_id is None:
+        active_org_id = request_active_org_id
 
-def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
-    merged = _default_bot_config_payload()
-    if isinstance(payload, dict):
-        merged.update(payload)
-    merged["bot_username"] = _coerce_nonempty_string(merged.get("bot_username")) or _DEFAULT_BOT_USERNAME
-    merged["enabled"] = bool(merged.get("enabled"))
-    return merged
+    team_ids = _collect_scope_ids(principal.team_ids, active_team_id)
+    org_ids = _collect_scope_ids(principal.org_ids, active_org_id)
 
+    if active_team_id is not None:
+        if active_team_id not in team_ids:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An active org/team scope is required",
+            )
+        return TelegramScope(scope_type="team", scope_id=active_team_id)
 
-def _public_bot_config_record(payload: dict[str, Any]) -> dict[str, Any]:
-    normalized = _normalize_bot_config_payload(payload)
-    return {
-        "ok": True,
-        "provider": _PROVIDER,
-        "bot_username": normalized["bot_username"],
-        "enabled": normalized["enabled"],
-    }
+    if active_org_id is not None:
+        if active_org_id not in org_ids:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="An active org/team scope is required",
+            )
+        return TelegramScope(scope_type="org", scope_id=active_org_id)
+
+    visible_scopes: list[TelegramScope] = [TelegramScope("team", team_id) for team_id in team_ids]
+    visible_scopes.extend(TelegramScope("org", org_id) for org_id in org_ids)
+    if len(visible_scopes) == 1:
+        return visible_scopes[0]
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="An active org/team scope is required",
+    )
 
 
 async def telegram_admin_put_bot_impl(
     *,
-    user: User,
+    principal: AuthPrincipal,
     payload: TelegramBotConfigUpdate,
-    get_user_secret_repo: Callable[[], Awaitable[Any]] = _get_user_secret_repo,
+    request: Request | None = None,
+    get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
     encrypt_telegram_payload: Callable[[dict[str, Any]], str] = _encrypt_telegram_payload,
-) -> dict[str, Any]:
+) -> TelegramBotConfigResponse:
     bot_token = _coerce_nonempty_string(payload.bot_token)
     webhook_secret = _coerce_nonempty_string(payload.webhook_secret)
     if not bot_token or not webhook_secret:
-        raise ValueError("bot_token and webhook_secret are required")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="bot_token and webhook_secret are required",
+        )
 
+    scope = _resolve_shared_scope(principal=principal, request=request)
     config_payload = _normalize_bot_config_payload(
         {
             "bot_token": bot_token,
@@ -101,10 +186,11 @@ async def telegram_admin_put_bot_impl(
         }
     )
 
-    repo = await get_user_secret_repo()
+    repo = await get_org_secret_repo()
     now = datetime.now(timezone.utc)
     await repo.upsert_secret(
-        user_id=int(user.id),
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
         provider=_PROVIDER,
         encrypted_blob=encrypt_telegram_payload(config_payload),
         key_hint=key_hint_for_api_key(bot_token),
@@ -114,19 +200,21 @@ async def telegram_admin_put_bot_impl(
             "credential_version": _CREDENTIAL_VERSION,
         },
         updated_at=now,
-        created_by=int(user.id),
-        updated_by=int(user.id),
+        created_by=int(principal.user_id) if principal.user_id is not None else None,
+        updated_by=int(principal.user_id) if principal.user_id is not None else None,
     )
-    return _public_bot_config_record(config_payload)
+    return _public_bot_config_record(config_payload, scope=scope)
 
 
 async def telegram_admin_get_bot_impl(
     *,
-    user: User,
-    get_user_secret_repo: Callable[[], Awaitable[Any]] = _get_user_secret_repo,
+    principal: AuthPrincipal,
+    request: Request | None = None,
+    get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
     decrypt_telegram_payload: Callable[[str | None], dict[str, Any] | None] = _decrypt_telegram_payload,
-) -> dict[str, Any]:
-    repo = await get_user_secret_repo()
-    row = await repo.fetch_secret_for_user(int(user.id), _PROVIDER)
+) -> TelegramBotConfigResponse:
+    scope = _resolve_shared_scope(principal=principal, request=request)
+    repo = await get_org_secret_repo()
+    row = await repo.fetch_secret(scope.scope_type, scope.scope_id, _PROVIDER)
     payload = decrypt_telegram_payload(row.get("encrypted_blob")) if row else None
-    return _public_bot_config_record(payload)
+    return _public_bot_config_record(payload, scope=scope)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import json
+import secrets
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from loguru import logger
 
+from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import TTLReceiptStore
 from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigResponse,
     TelegramBotConfigUpdate,
@@ -27,6 +31,8 @@ from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
 _PROVIDER = "telegram"
 _DEFAULT_BOT_USERNAME = "example_bot"
 _CREDENTIAL_VERSION = 1
+_WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
+_WEBHOOK_RECEIPTS = TTLReceiptStore()
 
 
 @dataclass(frozen=True)
@@ -154,6 +160,122 @@ def _resolve_shared_scope(
         status_code=status.HTTP_400_BAD_REQUEST,
         detail="An active org/team scope is required",
     )
+
+
+def _reset_telegram_webhook_state_for_tests() -> None:
+    """Reset webhook dedupe receipts for deterministic tests."""
+    _WEBHOOK_RECEIPTS.clear()
+
+
+def _telegram_webhook_error(
+    status_code: int,
+    error: str,
+    *,
+    detail: str | None = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "ok": False,
+            "error": error,
+            **({"detail": detail} if detail else {}),
+        },
+    )
+
+
+async def _resolve_webhook_scope_from_secret(
+    *,
+    repo: AuthnzOrgProviderSecretsRepo,
+    webhook_secret: str,
+) -> TelegramScope | None:
+    try:
+        rows = await repo.list_secrets(provider=_PROVIDER)
+    except Exception as exc:
+        logger.error("Failed to list Telegram bot configs for webhook resolution: {}", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Telegram bot configuration is unavailable",
+        ) from exc
+
+    matches: list[TelegramScope] = []
+    for row in rows:
+        scope_type = str(row.get("scope_type") or "").strip().lower()
+        scope_id = _coerce_int(row.get("scope_id"))
+        if scope_type not in {"org", "team"} or scope_id is None:
+            continue
+        try:
+            secret_row = await repo.fetch_secret(scope_type, scope_id, _PROVIDER)
+        except Exception as exc:
+            logger.error(
+                "Failed to load Telegram bot config for webhook resolution at {}:{}: {}",
+                scope_type,
+                scope_id,
+                exc,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Telegram bot configuration is unavailable",
+            ) from exc
+        if not secret_row:
+            continue
+        payload = _decrypt_telegram_payload(secret_row.get("encrypted_blob"))
+        if not isinstance(payload, dict):
+            continue
+        stored_secret = _coerce_nonempty_string(payload.get("webhook_secret"))
+        if not stored_secret or not secrets.compare_digest(stored_secret, webhook_secret):
+            continue
+        if not bool(payload.get("enabled")):
+            continue
+        matches.append(TelegramScope(scope_type=scope_type, scope_id=scope_id))
+        if len(matches) > 1:
+            logger.warning("Ambiguous Telegram webhook secret matched multiple scopes; rejecting request")
+            return None
+
+    return matches[0] if matches else None
+
+
+async def telegram_webhook_impl(
+    *,
+    request: Request,
+    get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
+    dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
+    dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
+) -> JSONResponse:
+    raw_body = await request.body()
+    try:
+        payload = json.loads(raw_body.decode("utf-8") or "{}")
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_json")
+
+    if not isinstance(payload, dict):
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
+
+    update_id = payload.get("update_id")
+    if not isinstance(update_id, int) or isinstance(update_id, bool):
+        return _telegram_webhook_error(
+            status.HTTP_400_BAD_REQUEST,
+            "invalid_payload",
+            detail="update_id is required",
+        )
+    update_id_int = update_id
+
+    webhook_secret = _coerce_nonempty_string(request.headers.get("X-Telegram-Bot-Api-Secret-Token"))
+    if not webhook_secret:
+        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
+
+    repo = await get_org_secret_repo()
+    scope = await _resolve_webhook_scope_from_secret(
+        repo=repo,
+        webhook_secret=webhook_secret,
+    )
+    if scope is None:
+        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
+
+    dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
+    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
+        return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
+
+    return JSONResponse(status_code=200, content={"ok": True, "status": "accepted"})
 
 
 async def telegram_admin_put_bot_impl(

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import secrets
 import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
@@ -29,6 +30,12 @@ from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     key_hint_for_api_key,
     loads_envelope,
 )
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.core.Telegram.session_mapper import (
+    build_telegram_session_key,
+    derive_telegram_assistant_conversation_id,
+)
+from tldw_Server_API.app.services.telegram_delivery_service import TelegramDeliveryService
 
 _PROVIDER = "telegram"
 _DEFAULT_BOT_USERNAME = "example_bot"
@@ -65,6 +72,9 @@ class TelegramMessagePolicy:
     should_process: bool
     reason: str | None = None
     command: TelegramCommand | None = None
+
+
+_TELEGRAM_REQUEST_NAMESPACE = uuid.UUID("f3b8b11f-6a65-4a2a-a7fd-8f9d9cf3f3d4")
 
 
 def _coerce_nonempty_string(value: Any) -> str | None:
@@ -258,6 +268,30 @@ def _extract_message_chat_type(payload: dict[str, Any]) -> str | None:
     return _coerce_nonempty_string(chat.get("type"))
 
 
+def _extract_message_chat_id(payload: dict[str, Any]) -> int | None:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None
+    chat = message.get("chat")
+    if not isinstance(chat, dict):
+        return None
+    return _coerce_int(chat.get("id"))
+
+
+def _extract_message_thread_id(payload: dict[str, Any]) -> int | None:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None
+    return _coerce_int(message.get("message_thread_id"))
+
+
+def _extract_message_id(payload: dict[str, Any]) -> int | None:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None
+    return _coerce_int(message.get("message_id"))
+
+
 def _message_reply_to_bot(
     payload: dict[str, Any],
     *,
@@ -279,6 +313,70 @@ def _message_reply_to_bot(
     if reply_username is None or configured_username is None:
         return False
     return reply_username == configured_username
+
+
+def _build_telegram_tenant_id(scope: TelegramScope) -> str:
+    return f"{scope.scope_type}:{scope.scope_id}"
+
+
+def _build_telegram_request_id(scope: TelegramScope, update_id: int) -> str:
+    return str(uuid.uuid5(_TELEGRAM_REQUEST_NAMESPACE, f"{scope.scope_type}:{scope.scope_id}:{update_id}"))
+
+
+def _build_telegram_ask_job_payload(
+    *,
+    scope: TelegramScope,
+    update_id: int,
+    message_id: int | None,
+    telegram_user_id: int,
+    text: str,
+    chat_type: str | None,
+    reply_to_bot: bool,
+    configured_bot_username: str,
+    command: TelegramCommand,
+    linked_actor: dict[str, Any],
+    telegram_chat_id: int | None,
+    telegram_thread_id: int | None,
+    request_id: str,
+) -> dict[str, Any]:
+    tenant_id = _build_telegram_tenant_id(scope)
+    session_key = build_telegram_session_key(
+        tenant_id=tenant_id,
+        chat_type=chat_type or "private",
+        telegram_user_id=telegram_user_id,
+        telegram_chat_id=telegram_chat_id,
+        topic_or_thread_id=telegram_thread_id,
+    )
+    return {
+        "telegram": {
+            "scope_type": scope.scope_type,
+            "scope_id": scope.scope_id,
+            "update_id": update_id,
+            "message_id": message_id,
+            "chat_type": chat_type,
+            "telegram_user_id": telegram_user_id,
+            "telegram_chat_id": telegram_chat_id,
+            "topic_or_thread_id": telegram_thread_id,
+            "text": text,
+            "reply_to_bot": reply_to_bot,
+            "bot_username": configured_bot_username,
+            "command": {
+                "action": command.action,
+                "input": command.input,
+                "target_bot_username": command.target_bot_username,
+            },
+            "linked_actor": {
+                "auth_user_id": str(linked_actor["auth_user_id"]),
+                "telegram_user_id": telegram_user_id,
+            },
+        },
+        "session": {
+            "tenant_id": tenant_id,
+            "session_key": session_key,
+            "assistant_conversation_id": derive_telegram_assistant_conversation_id(session_key),
+        },
+        "request_id": request_id,
+    }
 
 
 def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -475,6 +573,7 @@ async def _resolve_webhook_scope_from_secret(
 async def telegram_webhook_impl(
     *,
     request: Request,
+    job_manager: JobManager | None = None,
     get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
     dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
@@ -517,6 +616,9 @@ async def telegram_webhook_impl(
 
     telegram_user_id, text = _extract_message_actor_and_text(payload)
     chat_type = _extract_message_chat_type(payload)
+    telegram_chat_id = _extract_message_chat_id(payload)
+    telegram_thread_id = _extract_message_thread_id(payload)
+    message_id = _extract_message_id(payload)
     reply_to_bot = _message_reply_to_bot(payload, configured_bot_username=configured_bot_username)
     message_policy = evaluate_telegram_message_policy(
         chat_type=chat_type,
@@ -527,9 +629,47 @@ async def telegram_webhook_impl(
     if not message_policy.should_process:
         return JSONResponse(status_code=200, content={"ok": True, "status": "ignored"})
 
+    linked_actor = _resolve_telegram_actor_link(scope, telegram_user_id) if telegram_user_id is not None else None
+
     if _is_privileged_telegram_command(message_policy.command):
-        if telegram_user_id is None or _resolve_telegram_actor_link(scope, telegram_user_id) is None:
+        if linked_actor is None:
             return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
+
+    if message_policy.command is not None and message_policy.command.action == "ask" and linked_actor is not None:
+        if job_manager is None:
+            from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+
+            job_manager = get_job_manager()
+        request_id = _build_telegram_request_id(scope, update_id_int)
+        payload = _build_telegram_ask_job_payload(
+            scope=scope,
+            update_id=update_id_int,
+            message_id=message_id,
+            telegram_user_id=telegram_user_id,
+            text=text or "",
+            chat_type=chat_type,
+            reply_to_bot=reply_to_bot,
+            configured_bot_username=configured_bot_username,
+            command=message_policy.command,
+            linked_actor=linked_actor,
+            telegram_chat_id=telegram_chat_id,
+            telegram_thread_id=telegram_thread_id,
+            request_id=request_id,
+        )
+        queued_job = TelegramDeliveryService(job_manager).queue_inbound_ask(
+            owner_user_id=str(linked_actor["auth_user_id"]),
+            request_id=request_id,
+            payload=payload,
+        )
+        return JSONResponse(
+            status_code=200,
+            content={
+                "ok": True,
+                "status": "queued",
+                "request_id": request_id,
+                "job_id": queued_job.get("id"),
+            },
+        )
 
     return JSONResponse(status_code=200, content={"ok": True, "status": "accepted"})
 

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import json
 import secrets
+import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Awaitable, Callable
 
 from fastapi import HTTPException, Request, status
@@ -34,6 +35,15 @@ _DEFAULT_BOT_USERNAME = "example_bot"
 _CREDENTIAL_VERSION = 1
 _WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
 _WEBHOOK_RECEIPTS = TTLReceiptStore()
+_TELEGRAM_LINK_LOCK = threading.Lock()
+_TELEGRAM_PAIRING_CODE_COUNTER = 0
+_TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
+_TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
+_TELEGRAM_PAIRING_CODE_TTL_SECONDS = 900
+_PRIVILEGED_ACTION_PREFIXES = (
+    "/persona set",
+    "/character set",
+)
 
 
 @dataclass(frozen=True)
@@ -66,6 +76,89 @@ def _collect_scope_ids(values: list[int] | None) -> list[int]:
         except (TypeError, ValueError):
             continue
     return sorted(out)
+
+
+def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tuple[str, int, int]:
+    return (scope.scope_type, scope.scope_id, telegram_user_id)
+
+
+def _generate_telegram_pairing_code() -> str:
+    global _TELEGRAM_PAIRING_CODE_COUNTER
+    with _TELEGRAM_LINK_LOCK:
+        while True:
+            _TELEGRAM_PAIRING_CODE_COUNTER += 1
+            code = f"tg-{_TELEGRAM_PAIRING_CODE_COUNTER:06d}"
+            if code not in _TELEGRAM_PAIRING_CODES:
+                return code
+
+
+def _store_telegram_pairing_code(
+    *,
+    scope: TelegramScope,
+    auth_user_id: int | None,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    code = _generate_telegram_pairing_code()
+    record = {
+        "pairing_code": code,
+        "scope_type": scope.scope_type,
+        "scope_id": scope.scope_id,
+        "auth_user_id": auth_user_id,
+        "created_at": now,
+        "expires_at": now + timedelta(seconds=_TELEGRAM_PAIRING_CODE_TTL_SECONDS),
+    }
+    with _TELEGRAM_LINK_LOCK:
+        _TELEGRAM_PAIRING_CODES[code] = record
+    return record
+
+
+def _register_telegram_actor_link_for_tests(
+    *,
+    scope_type: str,
+    scope_id: int,
+    telegram_user_id: int,
+    auth_user_id: int,
+    telegram_username: str | None = None,
+) -> None:
+    """Install a deterministic in-memory actor link for tests."""
+    record = {
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+        "telegram_user_id": telegram_user_id,
+        "auth_user_id": auth_user_id,
+        "telegram_username": telegram_username,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    with _TELEGRAM_LINK_LOCK:
+        _TELEGRAM_ACTOR_LINKS[(scope_type, scope_id, telegram_user_id)] = record
+
+
+def _resolve_telegram_actor_link(scope: TelegramScope, telegram_user_id: int) -> dict[str, Any] | None:
+    with _TELEGRAM_LINK_LOCK:
+        link = _TELEGRAM_ACTOR_LINKS.get(_telegram_actor_link_key(scope, telegram_user_id))
+        return dict(link) if link else None
+
+
+def _is_privileged_telegram_action(text: Any) -> bool:
+    normalized = _coerce_nonempty_string(text)
+    if not normalized:
+        return False
+    lowered = normalized.lower()
+    for prefix in _PRIVILEGED_ACTION_PREFIXES:
+        if lowered == prefix or lowered.startswith(f"{prefix} "):
+            return True
+    return False
+
+
+def _extract_message_actor_and_text(payload: dict[str, Any]) -> tuple[int | None, str | None]:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None, None
+    from_block = message.get("from")
+    telegram_user_id = _coerce_int(from_block.get("id")) if isinstance(from_block, dict) else None
+    text = _coerce_nonempty_string(message.get("text"))
+    return telegram_user_id, text
 
 
 def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -166,6 +259,15 @@ def _resolve_shared_scope(
 def _reset_telegram_webhook_state_for_tests() -> None:
     """Reset webhook dedupe receipts for deterministic tests."""
     _WEBHOOK_RECEIPTS.clear()
+
+
+def _reset_telegram_link_state_for_tests() -> None:
+    """Reset Telegram pairing/link state for deterministic tests."""
+    global _TELEGRAM_PAIRING_CODE_COUNTER
+    with _TELEGRAM_LINK_LOCK:
+        _TELEGRAM_PAIRING_CODE_COUNTER = 0
+        _TELEGRAM_PAIRING_CODES.clear()
+        _TELEGRAM_ACTOR_LINKS.clear()
 
 
 def _telegram_webhook_error(
@@ -283,11 +385,35 @@ async def telegram_webhook_impl(
         )
     update_id_int = update_id
 
+    telegram_user_id, text = _extract_message_actor_and_text(payload)
+    if _is_privileged_telegram_action(text):
+        if telegram_user_id is None or _resolve_telegram_actor_link(scope, telegram_user_id) is None:
+            return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
+
     dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
     if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
         return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
 
     return JSONResponse(status_code=200, content={"ok": True, "status": "accepted"})
+
+
+async def telegram_admin_start_link_impl(
+    *,
+    principal: AuthPrincipal,
+    request: Request | None = None,
+) -> dict[str, Any]:
+    scope = _resolve_shared_scope(principal=principal, request=request)
+    record = _store_telegram_pairing_code(
+        scope=scope,
+        auth_user_id=int(principal.user_id) if principal.user_id is not None else None,
+    )
+    return {
+        "ok": True,
+        "pairing_code": record["pairing_code"],
+        "scope_type": record["scope_type"],
+        "scope_id": record["scope_id"],
+        "expires_at": record["expires_at"].isoformat(),
+    }
 
 
 async def telegram_admin_put_bot_impl(

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import secrets
 import threading
@@ -379,6 +380,23 @@ def _build_telegram_ask_job_payload(
     }
 
 
+async def _resolve_job_manager_for_request(request: Request) -> JobManager:
+    from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+
+    resolver = get_job_manager
+    app = getattr(request, "app", None)
+    dependency_overrides = getattr(app, "dependency_overrides", None)
+    if isinstance(dependency_overrides, dict):
+        override = dependency_overrides.get(get_job_manager)
+        if override is not None:
+            resolver = override
+
+    resolved = resolver()
+    if inspect.isawaitable(resolved):
+        resolved = await resolved
+    return resolved
+
+
 def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     merged: dict[str, Any] = {
         "provider": _PROVIDER,
@@ -637,9 +655,7 @@ async def telegram_webhook_impl(
 
     if message_policy.command is not None and message_policy.command.action == "ask" and linked_actor is not None:
         if job_manager is None:
-            from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
-
-            job_manager = get_job_manager()
+            job_manager = await _resolve_job_manager_for_request(request)
         request_id = _build_telegram_request_id(scope, update_id_int)
         payload = _build_telegram_ask_job_payload(
             scope=scope,

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -24,6 +24,9 @@ from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.repos.org_provider_secrets_repo import (
     AuthnzOrgProviderSecretsRepo,
 )
+from tldw_Server_API.app.core.AuthNZ.repos.telegram_approvals_repo import (
+    get_telegram_approvals_repo,
+)
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     decrypt_byok_payload,
     dumps_envelope,
@@ -50,8 +53,6 @@ _TELEGRAM_APPROVAL_CALLBACK_MAX_LENGTH = 64
 _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS = 300
 _WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
 _WEBHOOK_RECEIPTS = TTLReceiptStore()
-_TELEGRAM_PENDING_APPROVAL_LOCK = threading.Lock()
-_TELEGRAM_PENDING_APPROVALS: dict[str, dict[str, Any]] = {}
 _TELEGRAM_LINK_LOCK = threading.Lock()
 _TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
 _TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
@@ -131,17 +132,7 @@ def _coerce_datetime(value: Any) -> datetime | None:
     return None
 
 
-def _prune_pending_telegram_approvals_locked(now: datetime) -> None:
-    stale_tokens: list[str] = []
-    for approval_token, record in _TELEGRAM_PENDING_APPROVALS.items():
-        expires_at = _coerce_datetime(record.get("expires_at"))
-        if expires_at is None or expires_at <= now:
-            stale_tokens.append(approval_token)
-    for approval_token in stale_tokens:
-        _TELEGRAM_PENDING_APPROVALS.pop(approval_token, None)
-
-
-def _store_pending_telegram_approval(
+async def build_telegram_approval_callback_data(
     *,
     approval_policy_id: int | None,
     context_key: str,
@@ -150,64 +141,36 @@ def _store_pending_telegram_approval(
     tool_args: Any,
     scope: TelegramScope,
     initiating_auth_user_id: int,
+    scope_payload: dict[str, Any] | None = None,
+    scope_key: str | None = None,
     expires_at: datetime | None = None,
     ttl_seconds: int = _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS,
-) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
+    repo: Any | None = None,
+) -> str:
+    """Build short callback data and persist the pending approval server-side."""
+    approval_token = secrets.token_urlsafe(12)
+    repo = repo if repo is not None else await get_telegram_approvals_repo()
     expiry = _coerce_datetime(expires_at)
+    now = datetime.now(timezone.utc)
     if expiry is None:
         expiry = now + timedelta(seconds=max(1, int(ttl_seconds)))
-    initiating_user_id = _coerce_int(initiating_auth_user_id)
-    if initiating_user_id is None:
-        raise ValueError("initiating_auth_user_id is required")
-    scope_fingerprint = _scope_key_for_tool_call(tool_name, tool_args)
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        _prune_pending_telegram_approvals_locked(now)
-        while True:
-            approval_token = secrets.token_urlsafe(12)
-            if approval_token not in _TELEGRAM_PENDING_APPROVALS:
-                break
-        record = {
-            "approval_token": approval_token,
-            "approval_policy_id": _coerce_int(approval_policy_id),
-            "context_key": str(context_key).strip(),
-            "conversation_id": _coerce_nonempty_string(conversation_id),
-            "tool_name": str(tool_name).strip(),
-            "scope_fingerprint": scope_fingerprint,
-            "scope_type": scope.scope_type,
-            "scope_id": scope.scope_id,
-            "initiating_auth_user_id": initiating_user_id,
-            "expires_at": expiry,
-            "created_at": now,
-            "reserved_at": None,
-        }
-        _TELEGRAM_PENDING_APPROVALS[approval_token] = record
-        return dict(record)
-
-
-def build_telegram_approval_callback_data(
-    *,
-    approval_policy_id: int | None,
-    context_key: str,
-    conversation_id: str | None,
-    tool_name: str,
-    tool_args: Any,
-    scope: TelegramScope,
-    initiating_auth_user_id: int,
-    expires_at: datetime | None = None,
-    ttl_seconds: int = _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS,
-) -> str:
-    """Build short callback data and register the approval server-side."""
-    record = _store_pending_telegram_approval(
+    scope_key_value = _coerce_nonempty_string(scope_key) or _scope_key_for_tool_call(
+        tool_name,
+        tool_args,
+        scope_payload=scope_payload,
+    )
+    record = await repo.create_pending_approval(
+        approval_token=approval_token,
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
         approval_policy_id=approval_policy_id,
         context_key=context_key,
         conversation_id=conversation_id,
         tool_name=tool_name,
-        tool_args=tool_args,
-        scope=scope,
+        scope_key=scope_key_value,
         initiating_auth_user_id=initiating_auth_user_id,
-        expires_at=expires_at,
-        ttl_seconds=ttl_seconds,
+        expires_at=expiry,
+        now=now,
     )
     callback_data = f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}{record['approval_token']}"
     if len(callback_data) > _TELEGRAM_APPROVAL_CALLBACK_MAX_LENGTH:
@@ -225,48 +188,11 @@ def _parse_telegram_approval_callback_data(callback_data: Any) -> dict[str, Any]
     return {"approval_token": approval_token}
 
 
-def _peek_pending_telegram_approval(approval_token: str, *, now: datetime | None = None) -> dict[str, Any] | None:
-    current = now or datetime.now(timezone.utc)
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        _prune_pending_telegram_approvals_locked(current)
-        record = _TELEGRAM_PENDING_APPROVALS.get(str(approval_token).strip())
-        return dict(record) if record else None
-
-
-def _reserve_pending_telegram_approval(approval_token: str, *, now: datetime | None = None) -> dict[str, Any] | None:
-    current = now or datetime.now(timezone.utc)
-    token = str(approval_token).strip()
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        _prune_pending_telegram_approvals_locked(current)
-        record = _TELEGRAM_PENDING_APPROVALS.get(token)
-        if not record:
-            return None
-        if record.get("reserved_at") is not None:
-            return None
-        record["reserved_at"] = current
-        return dict(record)
-
-
-def _release_pending_telegram_approval(approval_token: str) -> None:
-    token = str(approval_token).strip()
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        record = _TELEGRAM_PENDING_APPROVALS.get(token)
-        if not record:
-            return
-        record["reserved_at"] = None
-
-
-def _consume_pending_telegram_approval(approval_token: str) -> None:
-    token = str(approval_token).strip()
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        _TELEGRAM_PENDING_APPROVALS.pop(token, None)
-
-
-def _peek_pending_telegram_approval_for_tests(callback_data: Any) -> dict[str, Any] | None:
+async def _peek_pending_telegram_approval_for_tests(callback_data: Any, *, repo: Any) -> dict[str, Any] | None:
     parsed = _parse_telegram_approval_callback_data(callback_data)
     if parsed is None:
         return None
-    return _peek_pending_telegram_approval(parsed["approval_token"])
+    return await repo.get_pending_approval_by_token(parsed["approval_token"])
 
 
 def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tuple[str, int, int]:
@@ -683,6 +609,7 @@ async def _handle_telegram_approval_callback_query(
     *,
     scope: TelegramScope,
     payload: dict[str, Any],
+    get_telegram_approvals_repo: Callable[[], Awaitable[Any]],
     get_approval_service: Callable[[], Awaitable[Any]],
 ) -> JSONResponse:
     callback_data = _extract_callback_query_data(payload)
@@ -691,14 +618,22 @@ async def _handle_telegram_approval_callback_query(
         return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
 
     now = datetime.now(timezone.utc)
-    pending_approval = _reserve_pending_telegram_approval(
+    try:
+        approvals_repo = await get_telegram_approvals_repo()
+    except Exception as exc:
+        logger.error("Failed to resolve Telegram approvals repo: {}", exc)
+        return _telegram_webhook_error(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "approval_service_unavailable",
+        )
+
+    pending_approval = await approvals_repo.get_pending_approval_by_token(
         parsed_callback["approval_token"],
         now=now,
     )
     if pending_approval is None:
         return _telegram_webhook_error(status.HTTP_409_CONFLICT, "approval_unavailable")
 
-    should_release = True
     telegram_user_id = _extract_callback_query_actor_id(payload)
     if telegram_user_id is None:
         return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
@@ -723,6 +658,13 @@ async def _handle_telegram_approval_callback_query(
         ):
             return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "approval_not_authorized")
 
+        consumed_pending = await approvals_repo.consume_pending_approval(
+            parsed_callback["approval_token"],
+            now=now,
+        )
+        if consumed_pending is None:
+            return _telegram_webhook_error(status.HTTP_409_CONFLICT, "approval_unavailable")
+
         try:
             approval_service = await get_approval_service()
         except Exception as exc:
@@ -739,26 +681,24 @@ async def _handle_telegram_approval_callback_query(
             )
 
         decision = await approval_service.record_decision(
-            approval_policy_id=_coerce_int(pending_approval.get("approval_policy_id")),
-            context_key=str(pending_approval.get("context_key") or ""),
-            conversation_id=_coerce_nonempty_string(pending_approval.get("conversation_id")),
-            tool_name=str(pending_approval.get("tool_name") or ""),
-            scope_key=str(pending_approval.get("scope_fingerprint") or ""),
+            approval_policy_id=_coerce_int(consumed_pending.get("approval_policy_id")),
+            context_key=str(consumed_pending.get("context_key") or ""),
+            conversation_id=_coerce_nonempty_string(consumed_pending.get("conversation_id")),
+            tool_name=str(consumed_pending.get("tool_name") or ""),
+            scope_key=str(consumed_pending.get("scope_key") or ""),
             decision="approved",
             consume_on_match=True,
-            expires_at=_coerce_datetime(pending_approval.get("expires_at")),
+            expires_at=None,
             actor_id=linked_auth_user_id,
         )
-        should_release = False
-        _consume_pending_telegram_approval(parsed_callback["approval_token"])
         return JSONResponse(
             status_code=200,
             content={
                 "ok": True,
                 "status": "approved",
                 "approval_decision_id": decision.get("id") if isinstance(decision, dict) else None,
-                "approval_policy_id": pending_approval.get("approval_policy_id"),
-                "scope_key": pending_approval.get("scope_fingerprint"),
+                "approval_policy_id": consumed_pending.get("approval_policy_id"),
+                "scope_key": consumed_pending.get("scope_key"),
             },
         )
     except Exception as exc:
@@ -767,20 +707,11 @@ async def _handle_telegram_approval_callback_query(
             status.HTTP_503_SERVICE_UNAVAILABLE,
             "approval_service_unavailable",
         )
-    finally:
-        if should_release:
-            _release_pending_telegram_approval(parsed_callback["approval_token"])
 
 
 def _reset_telegram_webhook_state_for_tests() -> None:
     """Reset webhook dedupe receipts for deterministic tests."""
     _WEBHOOK_RECEIPTS.clear()
-
-
-def _reset_telegram_approval_state_for_tests() -> None:
-    """Reset Telegram approval callback state for deterministic tests."""
-    with _TELEGRAM_PENDING_APPROVAL_LOCK:
-        _TELEGRAM_PENDING_APPROVALS.clear()
 
 
 def _reset_telegram_link_state_for_tests() -> None:
@@ -879,6 +810,7 @@ async def telegram_webhook_impl(
     request: Request,
     job_manager: JobManager | None = None,
     get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
+    get_telegram_approvals_repo: Callable[[], Awaitable[Any]] = get_telegram_approvals_repo,
     get_approval_service: Callable[[], Awaitable[Any]] = get_mcp_hub_approval_service,
     dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
@@ -924,6 +856,7 @@ async def telegram_webhook_impl(
         return await _handle_telegram_approval_callback_query(
             scope=scope,
             payload=payload,
+            get_telegram_approvals_repo=get_telegram_approvals_repo,
             get_approval_service=get_approval_service,
         )
 

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -36,7 +36,6 @@ _CREDENTIAL_VERSION = 1
 _WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
 _WEBHOOK_RECEIPTS = TTLReceiptStore()
 _TELEGRAM_LINK_LOCK = threading.Lock()
-_TELEGRAM_PAIRING_CODE_COUNTER = 0
 _TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
 _TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
 _TELEGRAM_PAIRING_CODE_TTL_SECONDS = 900
@@ -83,11 +82,10 @@ def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tup
 
 
 def _generate_telegram_pairing_code() -> str:
-    global _TELEGRAM_PAIRING_CODE_COUNTER
+    alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
     with _TELEGRAM_LINK_LOCK:
         while True:
-            _TELEGRAM_PAIRING_CODE_COUNTER += 1
-            code = f"tg-{_TELEGRAM_PAIRING_CODE_COUNTER:06d}"
+            code = "".join(secrets.choice(alphabet) for _ in range(8))
             if code not in _TELEGRAM_PAIRING_CODES:
                 return code
 
@@ -263,9 +261,7 @@ def _reset_telegram_webhook_state_for_tests() -> None:
 
 def _reset_telegram_link_state_for_tests() -> None:
     """Reset Telegram pairing/link state for deterministic tests."""
-    global _TELEGRAM_PAIRING_CODE_COUNTER
     with _TELEGRAM_LINK_LOCK:
-        _TELEGRAM_PAIRING_CODE_COUNTER = 0
         _TELEGRAM_PAIRING_CODES.clear()
         _TELEGRAM_ACTOR_LINKS.clear()
 
@@ -385,14 +381,14 @@ async def telegram_webhook_impl(
         )
     update_id_int = update_id
 
+    dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
+    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
+        return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
+
     telegram_user_id, text = _extract_message_actor_and_text(payload)
     if _is_privileged_telegram_action(text):
         if telegram_user_id is None or _resolve_telegram_actor_link(scope, telegram_user_id) is None:
             return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
-
-    dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
-    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
-        return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
 
     return JSONResponse(status_code=200, content={"ok": True, "status": "accepted"})
 

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -44,6 +44,9 @@ from tldw_Server_API.app.services.mcp_hub_approval_service import (
     get_mcp_hub_approval_service,
 )
 from tldw_Server_API.app.services.telegram_delivery_service import TelegramDeliveryService
+from tldw_Server_API.app.services.telegram_execution_identity_service import (
+    get_telegram_execution_identity_service,
+)
 
 _PROVIDER = "telegram"
 _DEFAULT_BOT_USERNAME = "example_bot"
@@ -812,6 +815,7 @@ async def telegram_webhook_impl(
     get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
     get_telegram_approvals_repo: Callable[[], Awaitable[Any]] = get_telegram_approvals_repo,
     get_approval_service: Callable[[], Awaitable[Any]] = get_mcp_hub_approval_service,
+    get_execution_identity_service: Callable[[], Awaitable[Any]] = get_telegram_execution_identity_service,
     dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
 ) -> JSONResponse:
@@ -900,6 +904,26 @@ async def telegram_webhook_impl(
             telegram_thread_id=telegram_thread_id,
             request_id=request_id,
         )
+        try:
+            execution_identity_service = await get_execution_identity_service()
+            execution_identity = execution_identity_service.mint_telegram_identity(
+                tenant_id=str(payload["session"]["tenant_id"]),
+                auth_user_id=str(linked_actor["auth_user_id"]),
+                request_id=request_id,
+                conversation_id=str(payload["session"]["assistant_conversation_id"]),
+                telegram_user_id=telegram_user_id,
+                telegram_chat_id=telegram_chat_id,
+                telegram_thread_id=telegram_thread_id,
+                scope_type=scope.scope_type,
+                scope_id=scope.scope_id,
+            )
+        except Exception as exc:
+            logger.error("Failed to mint Telegram execution identity: {}", exc)
+            return _telegram_webhook_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "execution_identity_unavailable",
+            )
+        payload["execution_identity"] = execution_identity.to_payload()
         queued_job = TelegramDeliveryService(job_manager).queue_inbound_ask(
             owner_user_id=str(linked_actor["auth_user_id"]),
             request_id=request_id,

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -257,6 +257,14 @@ async def telegram_webhook_impl(
     if not webhook_secret:
         return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
 
+    repo = await get_org_secret_repo()
+    scope = await _resolve_webhook_scope_from_secret(
+        repo=repo,
+        webhook_secret=webhook_secret,
+    )
+    if scope is None:
+        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
+
     raw_body = await request.body()
     try:
         payload = json.loads(raw_body.decode("utf-8") or "{}")
@@ -274,14 +282,6 @@ async def telegram_webhook_impl(
             detail="update_id is required",
         )
     update_id_int = update_id
-
-    repo = await get_org_secret_repo()
-    scope = await _resolve_webhook_scope_from_secret(
-        repo=repo,
-        webhook_secret=webhook_secret,
-    )
-    if scope is None:
-        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
 
     dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
     if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from loguru import logger
+
+from tldw_Server_API.app.api.v1.schemas.telegram_schemas import TelegramBotConfigUpdate
+from tldw_Server_API.app.core.AuthNZ.User_DB_Handling import User
+from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
+from tldw_Server_API.app.core.AuthNZ.repos.user_provider_secrets_repo import (
+    AuthnzUserProviderSecretsRepo,
+)
+from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
+    decrypt_byok_payload,
+    dumps_envelope,
+    encrypt_byok_payload,
+    key_hint_for_api_key,
+    loads_envelope,
+)
+
+_PROVIDER = "telegram"
+_DEFAULT_BOT_USERNAME = "example_bot"
+_CREDENTIAL_VERSION = 1
+
+
+def _coerce_nonempty_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned else None
+
+
+async def _get_user_secret_repo() -> AuthnzUserProviderSecretsRepo:
+    pool = await get_db_pool()
+    repo = AuthnzUserProviderSecretsRepo(pool)
+    await repo.ensure_tables()
+    return repo
+
+
+def _encrypt_telegram_payload(payload: dict[str, Any]) -> str:
+    return dumps_envelope(encrypt_byok_payload(payload))
+
+
+def _decrypt_telegram_payload(encrypted_blob: str | None) -> dict[str, Any] | None:
+    if not encrypted_blob:
+        return None
+    try:
+        payload = decrypt_byok_payload(loads_envelope(encrypted_blob))
+    except Exception as exc:
+        logger.warning("Failed to decrypt Telegram bot config payload: {}", exc)
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _default_bot_config_payload() -> dict[str, Any]:
+    return {
+        "provider": _PROVIDER,
+        "credential_version": _CREDENTIAL_VERSION,
+        "bot_username": _DEFAULT_BOT_USERNAME,
+        "enabled": False,
+    }
+
+
+def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    merged = _default_bot_config_payload()
+    if isinstance(payload, dict):
+        merged.update(payload)
+    merged["bot_username"] = _coerce_nonempty_string(merged.get("bot_username")) or _DEFAULT_BOT_USERNAME
+    merged["enabled"] = bool(merged.get("enabled"))
+    return merged
+
+
+def _public_bot_config_record(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = _normalize_bot_config_payload(payload)
+    return {
+        "ok": True,
+        "provider": _PROVIDER,
+        "bot_username": normalized["bot_username"],
+        "enabled": normalized["enabled"],
+    }
+
+
+async def telegram_admin_put_bot_impl(
+    *,
+    user: User,
+    payload: TelegramBotConfigUpdate,
+    get_user_secret_repo: Callable[[], Awaitable[Any]] = _get_user_secret_repo,
+    encrypt_telegram_payload: Callable[[dict[str, Any]], str] = _encrypt_telegram_payload,
+) -> dict[str, Any]:
+    bot_token = _coerce_nonempty_string(payload.bot_token)
+    webhook_secret = _coerce_nonempty_string(payload.webhook_secret)
+    if not bot_token or not webhook_secret:
+        raise ValueError("bot_token and webhook_secret are required")
+
+    config_payload = _normalize_bot_config_payload(
+        {
+            "bot_token": bot_token,
+            "webhook_secret": webhook_secret,
+            "enabled": bool(payload.enabled),
+        }
+    )
+
+    repo = await get_user_secret_repo()
+    now = datetime.now(timezone.utc)
+    await repo.upsert_secret(
+        user_id=int(user.id),
+        provider=_PROVIDER,
+        encrypted_blob=encrypt_telegram_payload(config_payload),
+        key_hint=key_hint_for_api_key(bot_token),
+        metadata={
+            "bot_username": config_payload["bot_username"],
+            "enabled": config_payload["enabled"],
+            "credential_version": _CREDENTIAL_VERSION,
+        },
+        updated_at=now,
+        created_by=int(user.id),
+        updated_by=int(user.id),
+    )
+    return _public_bot_config_record(config_payload)
+
+
+async def telegram_admin_get_bot_impl(
+    *,
+    user: User,
+    get_user_secret_repo: Callable[[], Awaitable[Any]] = _get_user_secret_repo,
+    decrypt_telegram_payload: Callable[[str | None], dict[str, Any] | None] = _decrypt_telegram_payload,
+) -> dict[str, Any]:
+    repo = await get_user_secret_repo()
+    row = await repo.fetch_secret_for_user(int(user.id), _PROVIDER)
+    payload = decrypt_telegram_payload(row.get("encrypted_blob")) if row else None
+    return _public_bot_config_record(payload)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -39,10 +39,25 @@ _TELEGRAM_LINK_LOCK = threading.Lock()
 _TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
 _TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
 _TELEGRAM_PAIRING_CODE_TTL_SECONDS = 900
+
+
 @dataclass(frozen=True)
 class TelegramScope:
     scope_type: str
     scope_id: int
+
+
+@dataclass(frozen=True)
+class TelegramCommand:
+    action: str
+    input: str
+
+
+@dataclass(frozen=True)
+class TelegramMessagePolicy:
+    should_process: bool
+    reason: str | None = None
+    command: TelegramCommand | None = None
 
 
 def _coerce_nonempty_string(value: Any) -> str | None:
@@ -131,18 +146,53 @@ def _resolve_telegram_actor_link(scope: TelegramScope, telegram_user_id: int) ->
         return dict(link) if link else None
 
 
-def _is_privileged_telegram_action(text: Any) -> bool:
+def parse_telegram_command(text: Any) -> TelegramCommand | None:
     normalized = _coerce_nonempty_string(text)
     if not normalized:
+        return None
+    if not normalized.startswith("/"):
+        return None
+
+    parts = normalized.split(maxsplit=1)
+    command_token = parts[0][1:]
+    if not command_token:
+        return None
+    action = command_token.split("@", 1)[0].strip().lower()
+    if not action:
+        return None
+    argument = _coerce_nonempty_string(parts[1]) if len(parts) > 1 else ""
+    return TelegramCommand(action=action, input=argument or "")
+
+
+def evaluate_telegram_message_policy(
+    *,
+    chat_type: Any,
+    text: Any,
+    reply_to_bot: bool = False,
+) -> TelegramMessagePolicy:
+    command = parse_telegram_command(text)
+    if command is not None:
+        return TelegramMessagePolicy(should_process=True, command=command)
+
+    normalized_chat_type = _coerce_nonempty_string(chat_type)
+    if normalized_chat_type in {"group", "supergroup"} and not reply_to_bot:
+        return TelegramMessagePolicy(
+            should_process=False,
+            reason="group_freeform_requires_command_or_reply",
+        )
+
+    return TelegramMessagePolicy(should_process=True)
+
+
+def _is_privileged_telegram_command(command: TelegramCommand | None) -> bool:
+    if command is None:
         return False
-    tokens = normalized.lower().split()
-    if len(tokens) < 2:
+    if command.action not in {"persona", "character"}:
         return False
-    if tokens[0] not in {"/persona", "/character"}:
+    tokens = command.input.lower().split()
+    if not tokens:
         return False
-    if tokens[1] != "set":
-        return False
-    return True
+    return tokens[0] == "set"
 
 
 def _extract_message_actor_and_text(payload: dict[str, Any]) -> tuple[int | None, str | None]:
@@ -153,6 +203,29 @@ def _extract_message_actor_and_text(payload: dict[str, Any]) -> tuple[int | None
     telegram_user_id = _coerce_int(from_block.get("id")) if isinstance(from_block, dict) else None
     text = _coerce_nonempty_string(message.get("text"))
     return telegram_user_id, text
+
+
+def _extract_message_chat_type(payload: dict[str, Any]) -> str | None:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None
+    chat = message.get("chat")
+    if not isinstance(chat, dict):
+        return None
+    return _coerce_nonempty_string(chat.get("type"))
+
+
+def _message_reply_to_bot(payload: dict[str, Any]) -> bool:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return False
+    reply_to_message = message.get("reply_to_message")
+    if not isinstance(reply_to_message, dict):
+        return False
+    reply_from = reply_to_message.get("from")
+    if not isinstance(reply_from, dict):
+        return False
+    return bool(reply_from.get("is_bot"))
 
 
 def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -377,12 +450,22 @@ async def telegram_webhook_impl(
         )
     update_id_int = update_id
 
+    telegram_user_id, text = _extract_message_actor_and_text(payload)
+    chat_type = _extract_message_chat_type(payload)
+    reply_to_bot = _message_reply_to_bot(payload)
+    message_policy = evaluate_telegram_message_policy(
+        chat_type=chat_type,
+        text=text,
+        reply_to_bot=reply_to_bot,
+    )
+    if not message_policy.should_process:
+        return JSONResponse(status_code=200, content={"ok": True, "status": "ignored"})
+
     dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
     if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
         return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
 
-    telegram_user_id, text = _extract_message_actor_and_text(payload)
-    if _is_privileged_telegram_action(text):
+    if _is_privileged_telegram_command(message_policy.command):
         if telegram_user_id is None or _resolve_telegram_actor_link(scope, telegram_user_id) is None:
             return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
 

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -48,9 +48,16 @@ class TelegramScope:
 
 
 @dataclass(frozen=True)
+class TelegramWebhookContext:
+    scope: TelegramScope
+    bot_username: str
+
+
+@dataclass(frozen=True)
 class TelegramCommand:
     action: str
     input: str
+    target_bot_username: str | None = None
 
 
 @dataclass(frozen=True)
@@ -146,6 +153,30 @@ def _resolve_telegram_actor_link(scope: TelegramScope, telegram_user_id: int) ->
         return dict(link) if link else None
 
 
+def _normalize_telegram_bot_username(value: Any) -> str | None:
+    username = _coerce_nonempty_string(value)
+    if not username:
+        return None
+    if username.startswith("@"):
+        username = username[1:]
+    username = username.strip().lower()
+    return username or None
+
+
+def _command_targets_configured_bot(
+    command: TelegramCommand | None,
+    configured_bot_username: Any,
+) -> bool:
+    if command is None:
+        return False
+    if command.target_bot_username is None:
+        return True
+    normalized_bot_username = _normalize_telegram_bot_username(configured_bot_username)
+    if normalized_bot_username is None:
+        return False
+    return command.target_bot_username == normalized_bot_username
+
+
 def parse_telegram_command(text: Any) -> TelegramCommand | None:
     normalized = _coerce_nonempty_string(text)
     if not normalized:
@@ -157,20 +188,32 @@ def parse_telegram_command(text: Any) -> TelegramCommand | None:
     command_token = parts[0][1:]
     if not command_token:
         return None
-    action = command_token.split("@", 1)[0].strip().lower()
+    action_token, target_username = (command_token.split("@", 1) + [None])[:2]
+    action = action_token.strip().lower()
     if not action:
         return None
     argument = _coerce_nonempty_string(parts[1]) if len(parts) > 1 else ""
-    return TelegramCommand(action=action, input=argument or "")
+    return TelegramCommand(
+        action=action,
+        input=argument or "",
+        target_bot_username=_normalize_telegram_bot_username(target_username),
+    )
 
 
 def evaluate_telegram_message_policy(
     *,
     chat_type: Any,
     text: Any,
+    bot_username: Any = None,
     reply_to_bot: bool = False,
 ) -> TelegramMessagePolicy:
     command = parse_telegram_command(text)
+    if command is not None and not _command_targets_configured_bot(command, bot_username):
+        return TelegramMessagePolicy(
+            should_process=False,
+            reason="command_not_for_configured_bot",
+            command=command,
+        )
     if command is not None:
         return TelegramMessagePolicy(should_process=True, command=command)
 
@@ -215,7 +258,11 @@ def _extract_message_chat_type(payload: dict[str, Any]) -> str | None:
     return _coerce_nonempty_string(chat.get("type"))
 
 
-def _message_reply_to_bot(payload: dict[str, Any]) -> bool:
+def _message_reply_to_bot(
+    payload: dict[str, Any],
+    *,
+    configured_bot_username: Any = None,
+) -> bool:
     message = payload.get("message")
     if not isinstance(message, dict):
         return False
@@ -225,7 +272,13 @@ def _message_reply_to_bot(payload: dict[str, Any]) -> bool:
     reply_from = reply_to_message.get("from")
     if not isinstance(reply_from, dict):
         return False
-    return bool(reply_from.get("is_bot"))
+    if not bool(reply_from.get("is_bot")):
+        return False
+    reply_username = _normalize_telegram_bot_username(reply_from.get("username"))
+    configured_username = _normalize_telegram_bot_username(configured_bot_username)
+    if reply_username is None or configured_username is None:
+        return False
+    return reply_username == configured_username
 
 
 def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
@@ -366,7 +419,7 @@ async def _resolve_webhook_scope_from_secret(
     *,
     repo: AuthnzOrgProviderSecretsRepo,
     webhook_secret: str,
-) -> TelegramScope | None:
+) -> TelegramWebhookContext | None:
     try:
         rows = await repo.list_secrets(provider=_PROVIDER)
     except Exception as exc:
@@ -376,7 +429,7 @@ async def _resolve_webhook_scope_from_secret(
             detail="Telegram bot configuration is unavailable",
         ) from exc
 
-    matches: list[TelegramScope] = []
+    matches: list[TelegramWebhookContext] = []
     for row in rows:
         scope_type = str(row.get("scope_type") or "").strip().lower()
         scope_id = _coerce_int(row.get("scope_id"))
@@ -405,7 +458,13 @@ async def _resolve_webhook_scope_from_secret(
             continue
         if not bool(payload.get("enabled")):
             continue
-        matches.append(TelegramScope(scope_type=scope_type, scope_id=scope_id))
+        matches.append(
+            TelegramWebhookContext(
+                scope=TelegramScope(scope_type=scope_type, scope_id=scope_id),
+                bot_username=_normalize_telegram_bot_username(payload.get("bot_username"))
+                or _DEFAULT_BOT_USERNAME,
+            )
+        )
         if len(matches) > 1:
             logger.warning("Ambiguous Telegram webhook secret matched multiple scopes; rejecting request")
             return None
@@ -425,12 +484,14 @@ async def telegram_webhook_impl(
         return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
 
     repo = await get_org_secret_repo()
-    scope = await _resolve_webhook_scope_from_secret(
+    webhook_context = await _resolve_webhook_scope_from_secret(
         repo=repo,
         webhook_secret=webhook_secret,
     )
-    if scope is None:
+    if webhook_context is None:
         return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
+    scope = webhook_context.scope
+    configured_bot_username = webhook_context.bot_username
 
     raw_body = await request.body()
     try:
@@ -456,10 +517,11 @@ async def telegram_webhook_impl(
 
     telegram_user_id, text = _extract_message_actor_and_text(payload)
     chat_type = _extract_message_chat_type(payload)
-    reply_to_bot = _message_reply_to_bot(payload)
+    reply_to_bot = _message_reply_to_bot(payload, configured_bot_username=configured_bot_username)
     message_policy = evaluate_telegram_message_policy(
         chat_type=chat_type,
         text=text,
+        bot_username=configured_bot_username,
         reply_to_bot=reply_to_bot,
     )
     if not message_policy.should_process:

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -36,13 +36,22 @@ from tldw_Server_API.app.core.Telegram.session_mapper import (
     build_telegram_session_key,
     derive_telegram_assistant_conversation_id,
 )
+from tldw_Server_API.app.services.mcp_hub_approval_service import (
+    _scope_key_for_tool_call,
+    get_mcp_hub_approval_service,
+)
 from tldw_Server_API.app.services.telegram_delivery_service import TelegramDeliveryService
 
 _PROVIDER = "telegram"
 _DEFAULT_BOT_USERNAME = "example_bot"
 _CREDENTIAL_VERSION = 1
+_TELEGRAM_APPROVAL_CALLBACK_PREFIX = "tgapp1."
+_TELEGRAM_APPROVAL_CALLBACK_MAX_LENGTH = 64
+_TELEGRAM_PENDING_APPROVAL_TTL_SECONDS = 300
 _WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
 _WEBHOOK_RECEIPTS = TTLReceiptStore()
+_TELEGRAM_PENDING_APPROVAL_LOCK = threading.Lock()
+_TELEGRAM_PENDING_APPROVALS: dict[str, dict[str, Any]] = {}
 _TELEGRAM_LINK_LOCK = threading.Lock()
 _TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
 _TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
@@ -102,6 +111,162 @@ def _collect_scope_ids(values: list[int] | None) -> list[int]:
         except (TypeError, ValueError):
             continue
     return sorted(out)
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def _prune_pending_telegram_approvals_locked(now: datetime) -> None:
+    stale_tokens: list[str] = []
+    for approval_token, record in _TELEGRAM_PENDING_APPROVALS.items():
+        expires_at = _coerce_datetime(record.get("expires_at"))
+        if expires_at is None or expires_at <= now:
+            stale_tokens.append(approval_token)
+    for approval_token in stale_tokens:
+        _TELEGRAM_PENDING_APPROVALS.pop(approval_token, None)
+
+
+def _store_pending_telegram_approval(
+    *,
+    approval_policy_id: int | None,
+    context_key: str,
+    conversation_id: str | None,
+    tool_name: str,
+    tool_args: Any,
+    scope: TelegramScope,
+    initiating_auth_user_id: int,
+    expires_at: datetime | None = None,
+    ttl_seconds: int = _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    expiry = _coerce_datetime(expires_at)
+    if expiry is None:
+        expiry = now + timedelta(seconds=max(1, int(ttl_seconds)))
+    initiating_user_id = _coerce_int(initiating_auth_user_id)
+    if initiating_user_id is None:
+        raise ValueError("initiating_auth_user_id is required")
+    scope_fingerprint = _scope_key_for_tool_call(tool_name, tool_args)
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        _prune_pending_telegram_approvals_locked(now)
+        while True:
+            approval_token = secrets.token_urlsafe(12)
+            if approval_token not in _TELEGRAM_PENDING_APPROVALS:
+                break
+        record = {
+            "approval_token": approval_token,
+            "approval_policy_id": _coerce_int(approval_policy_id),
+            "context_key": str(context_key).strip(),
+            "conversation_id": _coerce_nonempty_string(conversation_id),
+            "tool_name": str(tool_name).strip(),
+            "scope_fingerprint": scope_fingerprint,
+            "scope_type": scope.scope_type,
+            "scope_id": scope.scope_id,
+            "initiating_auth_user_id": initiating_user_id,
+            "expires_at": expiry,
+            "created_at": now,
+            "reserved_at": None,
+        }
+        _TELEGRAM_PENDING_APPROVALS[approval_token] = record
+        return dict(record)
+
+
+def build_telegram_approval_callback_data(
+    *,
+    approval_policy_id: int | None,
+    context_key: str,
+    conversation_id: str | None,
+    tool_name: str,
+    tool_args: Any,
+    scope: TelegramScope,
+    initiating_auth_user_id: int,
+    expires_at: datetime | None = None,
+    ttl_seconds: int = _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS,
+) -> str:
+    """Build short callback data and register the approval server-side."""
+    record = _store_pending_telegram_approval(
+        approval_policy_id=approval_policy_id,
+        context_key=context_key,
+        conversation_id=conversation_id,
+        tool_name=tool_name,
+        tool_args=tool_args,
+        scope=scope,
+        initiating_auth_user_id=initiating_auth_user_id,
+        expires_at=expires_at,
+        ttl_seconds=ttl_seconds,
+    )
+    callback_data = f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}{record['approval_token']}"
+    if len(callback_data) > _TELEGRAM_APPROVAL_CALLBACK_MAX_LENGTH:
+        raise ValueError("Telegram approval callback_data exceeds Telegram limits")
+    return callback_data
+
+
+def _parse_telegram_approval_callback_data(callback_data: Any) -> dict[str, Any] | None:
+    text = _coerce_nonempty_string(callback_data)
+    if not text or not text.startswith(_TELEGRAM_APPROVAL_CALLBACK_PREFIX):
+        return None
+    approval_token = text[len(_TELEGRAM_APPROVAL_CALLBACK_PREFIX) :]
+    if not approval_token:
+        return None
+    return {"approval_token": approval_token}
+
+
+def _peek_pending_telegram_approval(approval_token: str, *, now: datetime | None = None) -> dict[str, Any] | None:
+    current = now or datetime.now(timezone.utc)
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        _prune_pending_telegram_approvals_locked(current)
+        record = _TELEGRAM_PENDING_APPROVALS.get(str(approval_token).strip())
+        return dict(record) if record else None
+
+
+def _reserve_pending_telegram_approval(approval_token: str, *, now: datetime | None = None) -> dict[str, Any] | None:
+    current = now or datetime.now(timezone.utc)
+    token = str(approval_token).strip()
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        _prune_pending_telegram_approvals_locked(current)
+        record = _TELEGRAM_PENDING_APPROVALS.get(token)
+        if not record:
+            return None
+        if record.get("reserved_at") is not None:
+            return None
+        record["reserved_at"] = current
+        return dict(record)
+
+
+def _release_pending_telegram_approval(approval_token: str) -> None:
+    token = str(approval_token).strip()
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        record = _TELEGRAM_PENDING_APPROVALS.get(token)
+        if not record:
+            return
+        record["reserved_at"] = None
+
+
+def _consume_pending_telegram_approval(approval_token: str) -> None:
+    token = str(approval_token).strip()
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        _TELEGRAM_PENDING_APPROVALS.pop(token, None)
+
+
+def _peek_pending_telegram_approval_for_tests(callback_data: Any) -> dict[str, Any] | None:
+    parsed = _parse_telegram_approval_callback_data(callback_data)
+    if parsed is None:
+        return None
+    return _peek_pending_telegram_approval(parsed["approval_token"])
 
 
 def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tuple[str, int, int]:
@@ -492,9 +657,130 @@ def _resolve_shared_scope(
     )
 
 
+def _extract_callback_query(payload: dict[str, Any]) -> dict[str, Any] | None:
+    callback_query = payload.get("callback_query")
+    return callback_query if isinstance(callback_query, dict) else None
+
+
+def _extract_callback_query_actor_id(payload: dict[str, Any]) -> int | None:
+    callback_query = _extract_callback_query(payload)
+    if callback_query is None:
+        return None
+    from_block = callback_query.get("from")
+    if not isinstance(from_block, dict):
+        return None
+    return _coerce_int(from_block.get("id"))
+
+
+def _extract_callback_query_data(payload: dict[str, Any]) -> str | None:
+    callback_query = _extract_callback_query(payload)
+    if callback_query is None:
+        return None
+    return _coerce_nonempty_string(callback_query.get("data"))
+
+
+async def _handle_telegram_approval_callback_query(
+    *,
+    scope: TelegramScope,
+    payload: dict[str, Any],
+    get_approval_service: Callable[[], Awaitable[Any]],
+) -> JSONResponse:
+    callback_data = _extract_callback_query_data(payload)
+    parsed_callback = _parse_telegram_approval_callback_data(callback_data)
+    if parsed_callback is None:
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
+
+    now = datetime.now(timezone.utc)
+    pending_approval = _reserve_pending_telegram_approval(
+        parsed_callback["approval_token"],
+        now=now,
+    )
+    if pending_approval is None:
+        return _telegram_webhook_error(status.HTTP_409_CONFLICT, "approval_unavailable")
+
+    should_release = True
+    telegram_user_id = _extract_callback_query_actor_id(payload)
+    if telegram_user_id is None:
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
+
+    try:
+        if (
+            pending_approval.get("scope_type") != scope.scope_type
+            or _coerce_int(pending_approval.get("scope_id")) != scope.scope_id
+        ):
+            return _telegram_webhook_error(status.HTTP_409_CONFLICT, "approval_unavailable")
+
+        linked_actor = _resolve_telegram_actor_link(scope, telegram_user_id)
+        if linked_actor is None:
+            return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
+
+        linked_auth_user_id = _coerce_int(linked_actor.get("auth_user_id"))
+        initiating_auth_user_id = _coerce_int(pending_approval.get("initiating_auth_user_id"))
+        if (
+            linked_auth_user_id is None
+            or initiating_auth_user_id is None
+            or linked_auth_user_id != initiating_auth_user_id
+        ):
+            return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "approval_not_authorized")
+
+        try:
+            approval_service = await get_approval_service()
+        except Exception as exc:
+            logger.error("Failed to resolve Telegram approval service: {}", exc)
+            return _telegram_webhook_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "approval_service_unavailable",
+            )
+
+        if not hasattr(approval_service, "record_decision"):
+            return _telegram_webhook_error(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "approval_service_unavailable",
+            )
+
+        decision = await approval_service.record_decision(
+            approval_policy_id=_coerce_int(pending_approval.get("approval_policy_id")),
+            context_key=str(pending_approval.get("context_key") or ""),
+            conversation_id=_coerce_nonempty_string(pending_approval.get("conversation_id")),
+            tool_name=str(pending_approval.get("tool_name") or ""),
+            scope_key=str(pending_approval.get("scope_fingerprint") or ""),
+            decision="approved",
+            consume_on_match=True,
+            expires_at=_coerce_datetime(pending_approval.get("expires_at")),
+            actor_id=linked_auth_user_id,
+        )
+        should_release = False
+        _consume_pending_telegram_approval(parsed_callback["approval_token"])
+        return JSONResponse(
+            status_code=200,
+            content={
+                "ok": True,
+                "status": "approved",
+                "approval_decision_id": decision.get("id") if isinstance(decision, dict) else None,
+                "approval_policy_id": pending_approval.get("approval_policy_id"),
+                "scope_key": pending_approval.get("scope_fingerprint"),
+            },
+        )
+    except Exception as exc:
+        logger.error("Failed to persist Telegram approval decision: {}", exc)
+        return _telegram_webhook_error(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "approval_service_unavailable",
+        )
+    finally:
+        if should_release:
+            _release_pending_telegram_approval(parsed_callback["approval_token"])
+
+
 def _reset_telegram_webhook_state_for_tests() -> None:
     """Reset webhook dedupe receipts for deterministic tests."""
     _WEBHOOK_RECEIPTS.clear()
+
+
+def _reset_telegram_approval_state_for_tests() -> None:
+    """Reset Telegram approval callback state for deterministic tests."""
+    with _TELEGRAM_PENDING_APPROVAL_LOCK:
+        _TELEGRAM_PENDING_APPROVALS.clear()
 
 
 def _reset_telegram_link_state_for_tests() -> None:
@@ -593,6 +879,7 @@ async def telegram_webhook_impl(
     request: Request,
     job_manager: JobManager | None = None,
     get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
+    get_approval_service: Callable[[], Awaitable[Any]] = get_mcp_hub_approval_service,
     dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
 ) -> JSONResponse:
@@ -631,6 +918,14 @@ async def telegram_webhook_impl(
     dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
     if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
         return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
+
+    callback_query = _extract_callback_query(payload)
+    if callback_query is not None:
+        return await _handle_telegram_approval_callback_query(
+            scope=scope,
+            payload=payload,
+            get_approval_service=get_approval_service,
+        )
 
     telegram_user_id, text = _extract_message_actor_and_text(payload)
     chat_type = _extract_message_chat_type(payload)

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -51,18 +51,13 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
-def _collect_scope_ids(values: list[int] | None, active_id: int | None) -> list[int]:
+def _collect_scope_ids(values: list[int] | None) -> list[int]:
     out: set[int] = set()
     for raw in values or []:
         try:
             out.add(int(raw))
         except (TypeError, ValueError):
             continue
-    if active_id is not None:
-        try:
-            out.add(int(active_id))
-        except (TypeError, ValueError):
-            pass
     return sorted(out)
 
 
@@ -131,8 +126,8 @@ def _resolve_shared_scope(
     if active_org_id is None:
         active_org_id = request_active_org_id
 
-    team_ids = _collect_scope_ids(principal.team_ids, active_team_id)
-    org_ids = _collect_scope_ids(principal.org_ids, active_org_id)
+    team_ids = _collect_scope_ids(principal.team_ids)
+    org_ids = _collect_scope_ids(principal.org_ids)
 
     if active_team_id is not None:
         if active_team_id not in team_ids:

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -39,12 +39,6 @@ _TELEGRAM_LINK_LOCK = threading.Lock()
 _TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
 _TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
 _TELEGRAM_PAIRING_CODE_TTL_SECONDS = 900
-_PRIVILEGED_ACTION_PREFIXES = (
-    "/persona set",
-    "/character set",
-)
-
-
 @dataclass(frozen=True)
 class TelegramScope:
     scope_type: str
@@ -83,11 +77,7 @@ def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tup
 
 def _generate_telegram_pairing_code() -> str:
     alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
-    with _TELEGRAM_LINK_LOCK:
-        while True:
-            code = "".join(secrets.choice(alphabet) for _ in range(8))
-            if code not in _TELEGRAM_PAIRING_CODES:
-                return code
+    return "".join(secrets.choice(alphabet) for _ in range(8))
 
 
 def _store_telegram_pairing_code(
@@ -96,18 +86,21 @@ def _store_telegram_pairing_code(
     auth_user_id: int | None,
 ) -> dict[str, Any]:
     now = datetime.now(timezone.utc)
-    code = _generate_telegram_pairing_code()
-    record = {
-        "pairing_code": code,
-        "scope_type": scope.scope_type,
-        "scope_id": scope.scope_id,
-        "auth_user_id": auth_user_id,
-        "created_at": now,
-        "expires_at": now + timedelta(seconds=_TELEGRAM_PAIRING_CODE_TTL_SECONDS),
-    }
     with _TELEGRAM_LINK_LOCK:
-        _TELEGRAM_PAIRING_CODES[code] = record
-    return record
+        while True:
+            code = _generate_telegram_pairing_code()
+            if code in _TELEGRAM_PAIRING_CODES:
+                continue
+            record = {
+                "pairing_code": code,
+                "scope_type": scope.scope_type,
+                "scope_id": scope.scope_id,
+                "auth_user_id": auth_user_id,
+                "created_at": now,
+                "expires_at": now + timedelta(seconds=_TELEGRAM_PAIRING_CODE_TTL_SECONDS),
+            }
+            _TELEGRAM_PAIRING_CODES[code] = record
+            return record
 
 
 def _register_telegram_actor_link_for_tests(
@@ -142,11 +135,14 @@ def _is_privileged_telegram_action(text: Any) -> bool:
     normalized = _coerce_nonempty_string(text)
     if not normalized:
         return False
-    lowered = normalized.lower()
-    for prefix in _PRIVILEGED_ACTION_PREFIXES:
-        if lowered == prefix or lowered.startswith(f"{prefix} "):
-            return True
-    return False
+    tokens = normalized.lower().split()
+    if len(tokens) < 2:
+        return False
+    if tokens[0] not in {"/persona", "/character"}:
+        return False
+    if tokens[1] != "set":
+        return False
+    return True
 
 
 def _extract_message_actor_and_text(payload: dict[str, Any]) -> tuple[int | None, str | None]:

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -14,6 +14,7 @@ from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import TTLReceiptSto
 from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigResponse,
     TelegramBotConfigUpdate,
+    TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthPrincipal
@@ -183,6 +184,17 @@ def _telegram_webhook_error(
     )
 
 
+def _coerce_valid_webhook_secret_header(request: Request) -> str | None:
+    webhook_secret = _coerce_nonempty_string(
+        request.headers.get("X-Telegram-Bot-Api-Secret-Token")
+    )
+    if not webhook_secret:
+        return None
+    if len(webhook_secret) < TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH:
+        return None
+    return webhook_secret
+
+
 async def _resolve_webhook_scope_from_secret(
     *,
     repo: AuthnzOrgProviderSecretsRepo,
@@ -241,6 +253,10 @@ async def telegram_webhook_impl(
     dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
 ) -> JSONResponse:
+    webhook_secret = _coerce_valid_webhook_secret_header(request)
+    if not webhook_secret:
+        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
+
     raw_body = await request.body()
     try:
         payload = json.loads(raw_body.decode("utf-8") or "{}")
@@ -258,10 +274,6 @@ async def telegram_webhook_impl(
             detail="update_id is required",
         )
     update_id_int = update_id
-
-    webhook_secret = _coerce_nonempty_string(request.headers.get("X-Telegram-Bot-Api-Secret-Token"))
-    if not webhook_secret:
-        return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
 
     repo = await get_org_secret_repo()
     scope = await _resolve_webhook_scope_from_secret(

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
-import json
 import secrets
-import threading
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -12,11 +11,12 @@ from typing import Any, Awaitable, Callable
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from loguru import logger
+from pydantic import ValidationError
 
-from tldw_Server_API.app.api.v1.endpoints._in_memory_limits import TTLReceiptStore
 from tldw_Server_API.app.api.v1.schemas.telegram_schemas import (
     TelegramBotConfigResponse,
     TelegramBotConfigUpdate,
+    TelegramWebhookUpdate,
     TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH,
 )
 from tldw_Server_API.app.core.AuthNZ.database import get_db_pool
@@ -26,6 +26,9 @@ from tldw_Server_API.app.core.AuthNZ.repos.org_provider_secrets_repo import (
 )
 from tldw_Server_API.app.core.AuthNZ.repos.telegram_approvals_repo import (
     get_telegram_approvals_repo,
+)
+from tldw_Server_API.app.core.AuthNZ.repos.telegram_runtime_repo import (
+    get_telegram_runtime_repo,
 )
 from tldw_Server_API.app.core.AuthNZ.user_provider_secrets import (
     decrypt_byok_payload,
@@ -55,10 +58,6 @@ _TELEGRAM_APPROVAL_CALLBACK_PREFIX = "tgapp1."
 _TELEGRAM_APPROVAL_CALLBACK_MAX_LENGTH = 64
 _TELEGRAM_PENDING_APPROVAL_TTL_SECONDS = 300
 _WEBHOOK_REPLAY_WINDOW_SECONDS = 3600
-_WEBHOOK_RECEIPTS = TTLReceiptStore()
-_TELEGRAM_LINK_LOCK = threading.Lock()
-_TELEGRAM_PAIRING_CODES: dict[str, dict[str, Any]] = {}
-_TELEGRAM_ACTOR_LINKS: dict[tuple[str, int, int], dict[str, Any]] = {}
 _TELEGRAM_PAIRING_CODE_TTL_SECONDS = 900
 
 
@@ -198,36 +197,52 @@ async def _peek_pending_telegram_approval_for_tests(callback_data: Any, *, repo:
     return await repo.get_pending_approval_by_token(parsed["approval_token"])
 
 
-def _telegram_actor_link_key(scope: TelegramScope, telegram_user_id: int) -> tuple[str, int, int]:
-    return (scope.scope_type, scope.scope_id, telegram_user_id)
-
-
 def _generate_telegram_pairing_code() -> str:
     alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
     return "".join(secrets.choice(alphabet) for _ in range(8))
 
 
-def _store_telegram_pairing_code(
+def _normalize_pairing_code(value: Any) -> str | None:
+    text = _coerce_nonempty_string(value)
+    if not text:
+        return None
+    return text.replace(" ", "").upper() or None
+
+
+async def _store_telegram_pairing_code(
     *,
+    auth_user_id: int,
     scope: TelegramScope,
-    auth_user_id: int | None,
+    runtime_repo: Any,
 ) -> dict[str, Any]:
     now = datetime.now(timezone.utc)
-    with _TELEGRAM_LINK_LOCK:
-        while True:
-            code = _generate_telegram_pairing_code()
-            if code in _TELEGRAM_PAIRING_CODES:
-                continue
-            record = {
-                "pairing_code": code,
-                "scope_type": scope.scope_type,
-                "scope_id": scope.scope_id,
-                "auth_user_id": auth_user_id,
-                "created_at": now,
-                "expires_at": now + timedelta(seconds=_TELEGRAM_PAIRING_CODE_TTL_SECONDS),
-            }
-            _TELEGRAM_PAIRING_CODES[code] = record
-            return record
+    return await runtime_repo.create_pairing_code(
+        pairing_code=_generate_telegram_pairing_code(),
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
+        auth_user_id=auth_user_id,
+        expires_at=now + timedelta(seconds=_TELEGRAM_PAIRING_CODE_TTL_SECONDS),
+        now=now,
+    )
+
+
+async def _register_telegram_actor_link_for_tests_async(
+    *,
+    scope_type: str,
+    scope_id: int,
+    telegram_user_id: int,
+    auth_user_id: int,
+    telegram_username: str | None = None,
+) -> None:
+    """Install a deterministic Telegram actor link for tests."""
+    runtime_repo = await get_telegram_runtime_repo()
+    await runtime_repo.upsert_actor_link(
+        scope_type=scope_type,
+        scope_id=scope_id,
+        telegram_user_id=telegram_user_id,
+        auth_user_id=auth_user_id,
+        telegram_username=telegram_username,
+    )
 
 
 def _register_telegram_actor_link_for_tests(
@@ -238,24 +253,15 @@ def _register_telegram_actor_link_for_tests(
     auth_user_id: int,
     telegram_username: str | None = None,
 ) -> None:
-    """Install a deterministic in-memory actor link for tests."""
-    record = {
-        "scope_type": scope_type,
-        "scope_id": scope_id,
-        "telegram_user_id": telegram_user_id,
-        "auth_user_id": auth_user_id,
-        "telegram_username": telegram_username,
-        "created_at": datetime.now(timezone.utc),
-        "updated_at": datetime.now(timezone.utc),
-    }
-    with _TELEGRAM_LINK_LOCK:
-        _TELEGRAM_ACTOR_LINKS[(scope_type, scope_id, telegram_user_id)] = record
-
-
-def _resolve_telegram_actor_link(scope: TelegramScope, telegram_user_id: int) -> dict[str, Any] | None:
-    with _TELEGRAM_LINK_LOCK:
-        link = _TELEGRAM_ACTOR_LINKS.get(_telegram_actor_link_key(scope, telegram_user_id))
-        return dict(link) if link else None
+    asyncio.run(
+        _register_telegram_actor_link_for_tests_async(
+            scope_type=scope_type,
+            scope_id=scope_id,
+            telegram_user_id=telegram_user_id,
+            auth_user_id=auth_user_id,
+            telegram_username=telegram_username,
+        )
+    )
 
 
 def _normalize_telegram_bot_username(value: Any) -> str | None:
@@ -351,6 +357,16 @@ def _extract_message_actor_and_text(payload: dict[str, Any]) -> tuple[int | None
     telegram_user_id = _coerce_int(from_block.get("id")) if isinstance(from_block, dict) else None
     text = _coerce_nonempty_string(message.get("text"))
     return telegram_user_id, text
+
+
+def _extract_message_actor_username(payload: dict[str, Any]) -> str | None:
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return None
+    from_block = message.get("from")
+    if not isinstance(from_block, dict):
+        return None
+    return _coerce_nonempty_string(from_block.get("username"))
 
 
 def _extract_message_chat_type(payload: dict[str, Any]) -> str | None:
@@ -500,7 +516,10 @@ def _normalize_bot_config_payload(payload: dict[str, Any] | None) -> dict[str, A
     }
     if isinstance(payload, dict):
         merged.update(payload)
-    merged["bot_username"] = _coerce_nonempty_string(merged.get("bot_username")) or _DEFAULT_BOT_USERNAME
+    merged["bot_username"] = (
+        _normalize_telegram_bot_username(merged.get("bot_username"))
+        or _DEFAULT_BOT_USERNAME
+    )
     merged["enabled"] = bool(merged.get("enabled"))
     return merged
 
@@ -612,6 +631,7 @@ async def _handle_telegram_approval_callback_query(
     *,
     scope: TelegramScope,
     payload: dict[str, Any],
+    runtime_repo: Any,
     get_telegram_approvals_repo: Callable[[], Awaitable[Any]],
     get_approval_service: Callable[[], Awaitable[Any]],
 ) -> JSONResponse:
@@ -648,7 +668,11 @@ async def _handle_telegram_approval_callback_query(
         ):
             return _telegram_webhook_error(status.HTTP_409_CONFLICT, "approval_unavailable")
 
-        linked_actor = _resolve_telegram_actor_link(scope, telegram_user_id)
+        linked_actor = await runtime_repo.get_actor_link(
+            scope_type=scope.scope_type,
+            scope_id=scope.scope_id,
+            telegram_user_id=telegram_user_id,
+        )
         if linked_actor is None:
             return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "account_link_required")
 
@@ -712,16 +736,19 @@ async def _handle_telegram_approval_callback_query(
         )
 
 
+async def _reset_telegram_runtime_state_for_tests_async() -> None:
+    runtime_repo = await get_telegram_runtime_repo()
+    await runtime_repo.clear_all_for_tests()
+
+
 def _reset_telegram_webhook_state_for_tests() -> None:
     """Reset webhook dedupe receipts for deterministic tests."""
-    _WEBHOOK_RECEIPTS.clear()
+    asyncio.run(_reset_telegram_runtime_state_for_tests_async())
 
 
 def _reset_telegram_link_state_for_tests() -> None:
     """Reset Telegram pairing/link state for deterministic tests."""
-    with _TELEGRAM_LINK_LOCK:
-        _TELEGRAM_PAIRING_CODES.clear()
-        _TELEGRAM_ACTOR_LINKS.clear()
+    asyncio.run(_reset_telegram_runtime_state_for_tests_async())
 
 
 def _telegram_webhook_error(
@@ -808,17 +835,59 @@ async def _resolve_webhook_scope_from_secret(
     return matches[0] if matches else None
 
 
+async def _handle_telegram_link_command(
+    *,
+    scope: TelegramScope,
+    payload: dict[str, Any],
+    command: TelegramCommand,
+    runtime_repo: Any,
+) -> JSONResponse:
+    telegram_user_id = _extract_message_actor_and_text(payload)[0]
+    if telegram_user_id is None:
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
+    pairing_code = _normalize_pairing_code(command.input)
+    if pairing_code is None:
+        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "pairing_code_required")
+
+    consumed_pairing = await runtime_repo.consume_pairing_code(pairing_code)
+    if consumed_pairing is None:
+        return _telegram_webhook_error(status.HTTP_403_FORBIDDEN, "invalid_pairing_code")
+
+    auth_user_id = _coerce_int(consumed_pairing.get("auth_user_id"))
+    if auth_user_id is None:
+        return _telegram_webhook_error(status.HTTP_409_CONFLICT, "invalid_pairing_code")
+
+    linked_actor = await runtime_repo.upsert_actor_link(
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
+        telegram_user_id=telegram_user_id,
+        auth_user_id=auth_user_id,
+        telegram_username=_extract_message_actor_username(payload),
+    )
+    return JSONResponse(
+        status_code=200,
+        content={
+            "ok": True,
+            "status": "linked",
+            "scope_type": linked_actor.get("scope_type", scope.scope_type),
+            "scope_id": linked_actor.get("scope_id", scope.scope_id),
+            "telegram_user_id": linked_actor.get("telegram_user_id", telegram_user_id),
+        },
+    )
+
+
 async def telegram_webhook_impl(
     *,
     request: Request,
     job_manager: JobManager | None = None,
     get_org_secret_repo: Callable[[], Awaitable[Any]] = _get_org_secret_repo,
     get_telegram_approvals_repo: Callable[[], Awaitable[Any]] = get_telegram_approvals_repo,
+    get_telegram_runtime_repo: Callable[[], Awaitable[Any]] = get_telegram_runtime_repo,
     get_approval_service: Callable[[], Awaitable[Any]] = get_mcp_hub_approval_service,
     get_execution_identity_service: Callable[[], Awaitable[Any]] = get_telegram_execution_identity_service,
-    dedupe_receipts: TTLReceiptStore = _WEBHOOK_RECEIPTS,
     dedupe_ttl_seconds: int = _WEBHOOK_REPLAY_WINDOW_SECONDS,
 ) -> JSONResponse:
+    """Validate, dedupe, and route a Telegram webhook update."""
     webhook_secret = _coerce_valid_webhook_secret_header(request)
     if not webhook_secret:
         return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
@@ -832,27 +901,28 @@ async def telegram_webhook_impl(
         return _telegram_webhook_error(status.HTTP_401_UNAUTHORIZED, "invalid_secret")
     scope = webhook_context.scope
     configured_bot_username = webhook_context.bot_username
+    runtime_repo = await get_telegram_runtime_repo()
 
     raw_body = await request.body()
     try:
-        payload = json.loads(raw_body.decode("utf-8") or "{}")
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_json")
-
-    if not isinstance(payload, dict):
+        webhook_update = TelegramWebhookUpdate.model_validate_json(raw_body or b"{}")
+    except ValidationError as exc:
+        if any(error.get("type") == "json_invalid" for error in exc.errors()):
+            return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_json")
         return _telegram_webhook_error(status.HTTP_400_BAD_REQUEST, "invalid_payload")
+    payload = webhook_update.model_dump(by_alias=True, exclude_none=True)
 
-    update_id = payload.get("update_id")
-    if not isinstance(update_id, int) or isinstance(update_id, bool):
-        return _telegram_webhook_error(
-            status.HTTP_400_BAD_REQUEST,
-            "invalid_payload",
-            detail="update_id is required",
-        )
-    update_id_int = update_id
+    update_id_int = int(webhook_update.update_id)
 
     dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
-    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
+    receipt_stored = await runtime_repo.store_webhook_receipt(
+        dedupe_key=dedupe_key,
+        scope_type=scope.scope_type,
+        scope_id=scope.scope_id,
+        update_id=update_id_int,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=max(1, dedupe_ttl_seconds)),
+    )
+    if not receipt_stored:
         return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
 
     callback_query = _extract_callback_query(payload)
@@ -860,6 +930,7 @@ async def telegram_webhook_impl(
         return await _handle_telegram_approval_callback_query(
             scope=scope,
             payload=payload,
+            runtime_repo=runtime_repo,
             get_telegram_approvals_repo=get_telegram_approvals_repo,
             get_approval_service=get_approval_service,
         )
@@ -879,7 +950,21 @@ async def telegram_webhook_impl(
     if not message_policy.should_process:
         return JSONResponse(status_code=200, content={"ok": True, "status": "ignored"})
 
-    linked_actor = _resolve_telegram_actor_link(scope, telegram_user_id) if telegram_user_id is not None else None
+    if message_policy.command is not None and message_policy.command.action == "link":
+        return await _handle_telegram_link_command(
+            scope=scope,
+            payload=payload,
+            command=message_policy.command,
+            runtime_repo=runtime_repo,
+        )
+
+    linked_actor = None
+    if telegram_user_id is not None:
+        linked_actor = await runtime_repo.get_actor_link(
+            scope_type=scope.scope_type,
+            scope_id=scope.scope_id,
+            telegram_user_id=telegram_user_id,
+        )
 
     if _is_privileged_telegram_command(message_policy.command):
         if linked_actor is None:
@@ -924,7 +1009,7 @@ async def telegram_webhook_impl(
                 "execution_identity_unavailable",
             )
         payload["execution_identity"] = execution_identity.to_payload()
-        queued_job = TelegramDeliveryService(job_manager).queue_inbound_ask(
+        queued_job = await TelegramDeliveryService(job_manager).queue_inbound_ask(
             owner_user_id=str(linked_actor["auth_user_id"]),
             request_id=request_id,
             payload=payload,
@@ -946,18 +1031,28 @@ async def telegram_admin_start_link_impl(
     *,
     principal: AuthPrincipal,
     request: Request | None = None,
+    get_telegram_runtime_repo: Callable[[], Awaitable[Any]] = get_telegram_runtime_repo,
 ) -> dict[str, Any]:
     scope = _resolve_shared_scope(principal=principal, request=request)
-    record = _store_telegram_pairing_code(
+    auth_user_id = _coerce_int(principal.user_id)
+    if auth_user_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Authenticated user id is required",
+        )
+    runtime_repo = await get_telegram_runtime_repo()
+    record = await _store_telegram_pairing_code(
         scope=scope,
-        auth_user_id=int(principal.user_id) if principal.user_id is not None else None,
+        auth_user_id=auth_user_id,
+        runtime_repo=runtime_repo,
     )
+    expires_at = _coerce_datetime(record.get("expires_at"))
     return {
         "ok": True,
         "pairing_code": record["pairing_code"],
         "scope_type": record["scope_type"],
         "scope_id": record["scope_id"],
-        "expires_at": record["expires_at"].isoformat(),
+        "expires_at": expires_at.isoformat() if expires_at is not None else str(record.get("expires_at") or ""),
     }
 
 
@@ -982,12 +1077,14 @@ async def telegram_admin_put_bot_impl(
         {
             "bot_token": bot_token,
             "webhook_secret": webhook_secret,
+            "bot_username": payload.bot_username,
             "enabled": bool(payload.enabled),
         }
     )
 
     repo = await get_org_secret_repo()
     now = datetime.now(timezone.utc)
+    actor_user_id = _coerce_int(principal.user_id)
     await repo.upsert_secret(
         scope_type=scope.scope_type,
         scope_id=scope.scope_id,
@@ -1000,8 +1097,8 @@ async def telegram_admin_put_bot_impl(
             "credential_version": _CREDENTIAL_VERSION,
         },
         updated_at=now,
-        created_by=int(principal.user_id) if principal.user_id is not None else None,
-        updated_by=int(principal.user_id) if principal.user_id is not None else None,
+        created_by=actor_user_id,
+        updated_by=actor_user_id,
     )
     return _public_bot_config_record(config_payload, scope=scope)
 

--- a/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
+++ b/tldw_Server_API/app/api/v1/endpoints/telegram_support.py
@@ -450,6 +450,10 @@ async def telegram_webhook_impl(
         )
     update_id_int = update_id
 
+    dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
+    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
+        return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
+
     telegram_user_id, text = _extract_message_actor_and_text(payload)
     chat_type = _extract_message_chat_type(payload)
     reply_to_bot = _message_reply_to_bot(payload)
@@ -460,10 +464,6 @@ async def telegram_webhook_impl(
     )
     if not message_policy.should_process:
         return JSONResponse(status_code=200, content={"ok": True, "status": "ignored"})
-
-    dedupe_key = f"{scope.scope_type}:{scope.scope_id}:{update_id_int}"
-    if dedupe_receipts.seen_or_store(dedupe_key, dedupe_ttl_seconds):
-        return JSONResponse(status_code=200, content={"ok": True, "status": "duplicate"})
 
     if _is_privileged_telegram_command(message_policy.command):
         if telegram_user_id is None or _resolve_telegram_actor_link(scope, telegram_user_id) is None:

--- a/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
@@ -1,8 +1,10 @@
 """Schemas for Telegram bot configuration."""
 
-from typing import Literal
+from __future__ import annotations
 
-from pydantic import BaseModel, Field, field_validator
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, field_validator
 
 TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH = 8
 
@@ -12,17 +14,33 @@ class TelegramBotConfigUpdate(BaseModel):
 
     bot_token: str = Field(...)
     webhook_secret: str = Field(..., min_length=TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH)
+    bot_username: str | None = None
     enabled: bool = True
 
     @field_validator("bot_token", "webhook_secret", mode="before")
     @classmethod
-    def _strip_and_require_nonempty(cls, value):
+    def _strip_and_require_nonempty(cls, value: Any) -> Any:
         if not isinstance(value, str):
             return value
         cleaned = value.strip()
         if not cleaned:
             raise ValueError("must not be blank")
         return cleaned
+
+    @field_validator("bot_username", mode="before")
+    @classmethod
+    def _normalize_bot_username(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return value
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        if cleaned.startswith("@"):
+            cleaned = cleaned[1:]
+        cleaned = cleaned.strip().lower()
+        return cleaned or None
 
 
 class TelegramBotConfigResponse(BaseModel):
@@ -34,3 +52,59 @@ class TelegramBotConfigResponse(BaseModel):
     scope_id: int
     bot_username: str
     enabled: bool
+
+
+class TelegramWebhookActor(BaseModel):
+    """Minimal Telegram actor payload used by webhook parsing."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: int | None = None
+    username: str | None = None
+    is_bot: bool | None = None
+
+
+class TelegramWebhookChat(BaseModel):
+    """Minimal Telegram chat payload used by webhook parsing."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    type: str | None = None
+
+
+class TelegramWebhookMessage(BaseModel):
+    """Telegram message envelope."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    message_id: int | None = None
+    chat: TelegramWebhookChat | None = None
+    from_user: TelegramWebhookActor | None = Field(default=None, alias="from")
+    text: str | None = None
+    message_thread_id: int | None = None
+    reply_to_message: TelegramWebhookMessage | None = None
+
+
+class TelegramWebhookCallbackQuery(BaseModel):
+    """Telegram callback query envelope."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    id: str | None = None
+    from_user: TelegramWebhookActor | None = Field(default=None, alias="from")
+    message: TelegramWebhookMessage | None = None
+    data: str | None = None
+
+
+class TelegramWebhookUpdate(BaseModel):
+    """Validated Telegram webhook payload."""
+
+    model_config = ConfigDict(extra="allow")
+
+    update_id: StrictInt
+    message: TelegramWebhookMessage | None = None
+    callback_query: TelegramWebhookCallbackQuery | None = None
+
+
+TelegramWebhookMessage.model_rebuild()

--- a/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
@@ -1,6 +1,8 @@
 """Schemas for Telegram bot configuration."""
 
-from pydantic import BaseModel, Field
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class TelegramBotConfigUpdate(BaseModel):
@@ -9,3 +11,24 @@ class TelegramBotConfigUpdate(BaseModel):
     bot_token: str = Field(...)
     webhook_secret: str = Field(...)
     enabled: bool = True
+
+    @field_validator("bot_token", "webhook_secret", mode="before")
+    @classmethod
+    def _strip_and_require_nonempty(cls, value):
+        if not isinstance(value, str):
+            return value
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("must not be blank")
+        return cleaned
+
+
+class TelegramBotConfigResponse(BaseModel):
+    """Public Telegram bot configuration response."""
+
+    ok: bool = True
+    provider: Literal["telegram"] = "telegram"
+    scope_type: Literal["org", "team"]
+    scope_id: int
+    bot_username: str
+    enabled: bool

--- a/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
@@ -1,0 +1,11 @@
+"""Schemas for Telegram bot configuration."""
+
+from pydantic import BaseModel, Field
+
+
+class TelegramBotConfigUpdate(BaseModel):
+    """Update payload for Telegram bot configuration."""
+
+    bot_token: str = Field(...)
+    webhook_secret: str = Field(...)
+    enabled: bool = True

--- a/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
+++ b/tldw_Server_API/app/api/v1/schemas/telegram_schemas.py
@@ -4,12 +4,14 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
+TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH = 8
+
 
 class TelegramBotConfigUpdate(BaseModel):
     """Update payload for Telegram bot configuration."""
 
     bot_token: str = Field(...)
-    webhook_secret: str = Field(...)
+    webhook_secret: str = Field(..., min_length=TELEGRAM_WEBHOOK_SECRET_MIN_LENGTH)
     enabled: bool = True
 
     @field_validator("bot_token", "webhook_secret", mode="before")

--- a/tldw_Server_API/app/core/AuthNZ/permissions.py
+++ b/tldw_Server_API/app/core/AuthNZ/permissions.py
@@ -296,6 +296,11 @@ API_GENERATE_KEYS = "api.generate_keys"
 API_MANAGE_WEBHOOKS = "api.manage_webhooks"
 API_RATE_LIMIT_OVERRIDE = "api.rate_limit_override"
 
+# Telegram permissions
+TELEGRAM_ADMIN = "telegram.admin"
+TELEGRAM_RECEIVE = "telegram.receive"
+TELEGRAM_REPLY = "telegram.reply"
+
 # Workflows permissions
 WORKFLOWS_RUNS_READ = "workflows.runs.read"
 WORKFLOWS_RUNS_CONTROL = "workflows.runs.control"

--- a/tldw_Server_API/app/core/AuthNZ/repos/telegram_approvals_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/telegram_approvals_repo.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
+
+
+def _normalize_scope_type(scope_type: str) -> str:
+    value = str(scope_type or "").strip().lower()
+    if not value:
+        raise ValueError("scope_type is required")
+    return value
+
+
+def _normalize_optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+@dataclass
+class TelegramApprovalsRepo:
+    """Persistence for pending Telegram approval button clicks."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                await self.db_pool.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telegram_pending_approvals (
+                        id BIGSERIAL PRIMARY KEY,
+                        approval_token TEXT NOT NULL UNIQUE,
+                        scope_type TEXT NOT NULL,
+                        scope_id BIGINT NOT NULL,
+                        approval_policy_id INTEGER NULL,
+                        context_key TEXT NOT NULL,
+                        conversation_id TEXT NULL,
+                        tool_name TEXT NOT NULL,
+                        scope_key TEXT NOT NULL,
+                        initiating_auth_user_id BIGINT NOT NULL,
+                        expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        consumed_at TIMESTAMP WITHOUT TIME ZONE NULL,
+                        created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+                    )
+                    """,
+                )
+                await self.db_pool.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_telegram_pending_approvals_active
+                    ON telegram_pending_approvals (approval_token, consumed_at, expires_at)
+                    """,
+                )
+                return
+
+            await self.db_pool.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_pending_approvals (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    approval_token TEXT NOT NULL UNIQUE,
+                    scope_type TEXT NOT NULL,
+                    scope_id INTEGER NOT NULL,
+                    approval_policy_id INTEGER NULL,
+                    context_key TEXT NOT NULL,
+                    conversation_id TEXT NULL,
+                    tool_name TEXT NOT NULL,
+                    scope_key TEXT NOT NULL,
+                    initiating_auth_user_id INTEGER NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    consumed_at TEXT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """,
+                (),
+            )
+            await self.db_pool.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_telegram_pending_approvals_active
+                ON telegram_pending_approvals (approval_token, consumed_at, expires_at)
+                """,
+                (),
+            )
+        except Exception as exc:
+            logger.error("TelegramApprovalsRepo.ensure_tables failed: {}", exc)
+            raise
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if row is None:
+            return {}
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return dict(row)
+        except Exception:
+            try:
+                keys = row.keys()
+                return {key: row[key] for key in keys}
+            except Exception:
+                return {}
+
+    async def create_pending_approval(
+        self,
+        *,
+        approval_token: str,
+        scope_type: str,
+        scope_id: int,
+        approval_policy_id: int | None,
+        context_key: str,
+        conversation_id: str | None,
+        tool_name: str,
+        scope_key: str,
+        initiating_auth_user_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        created_at = now or datetime.now(timezone.utc)
+        scope_type_value = _normalize_scope_type(scope_type)
+        conversation_value = _normalize_optional_text(conversation_id)
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                INSERT INTO telegram_pending_approvals (
+                    approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                    conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                    expires_at, consumed_at, created_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULL, $11)
+                RETURNING id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                          conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                          expires_at, consumed_at, created_at
+                """,
+                str(approval_token).strip(),
+                scope_type_value,
+                int(scope_id),
+                approval_policy_id,
+                str(context_key).strip(),
+                conversation_value,
+                str(tool_name).strip(),
+                str(scope_key).strip(),
+                int(initiating_auth_user_id),
+                self._normalize_datetime_for_postgres(expires_at),
+                self._normalize_datetime_for_postgres(created_at),
+            )
+            return self._row_to_dict(row)
+
+        await self.db_pool.execute(
+            """
+            INSERT INTO telegram_pending_approvals (
+                approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                expires_at, consumed_at, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+            """,
+            (
+                str(approval_token).strip(),
+                scope_type_value,
+                int(scope_id),
+                approval_policy_id,
+                str(context_key).strip(),
+                conversation_value,
+                str(tool_name).strip(),
+                str(scope_key).strip(),
+                int(initiating_auth_user_id),
+                expires_at.isoformat(),
+                created_at.isoformat(),
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                   conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                   expires_at, consumed_at, created_at
+            FROM telegram_pending_approvals
+            WHERE approval_token = ?
+            """,
+            (str(approval_token).strip(),),
+        )
+        return self._row_to_dict(row)
+
+    async def get_pending_approval_by_token(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        current = now or datetime.now(timezone.utc)
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                       conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                       expires_at, consumed_at, created_at
+                FROM telegram_pending_approvals
+                WHERE approval_token = $1
+                  AND consumed_at IS NULL
+                  AND expires_at > $2
+                LIMIT 1
+                """,
+                str(approval_token).strip(),
+                self._normalize_datetime_for_postgres(current),
+            )
+            return self._row_to_dict(row) if row else None
+
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                   conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                   expires_at, consumed_at, created_at
+            FROM telegram_pending_approvals
+            WHERE approval_token = ?
+              AND consumed_at IS NULL
+              AND datetime(expires_at) > datetime(?)
+            LIMIT 1
+            """,
+            (
+                str(approval_token).strip(),
+                current.isoformat(),
+            ),
+        )
+        return self._row_to_dict(row) if row else None
+
+    async def consume_pending_approval(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        current = now or datetime.now(timezone.utc)
+        token = str(approval_token).strip()
+        pending = await self.get_pending_approval_by_token(token, now=current)
+        if pending is None:
+            return None
+
+        if getattr(self.db_pool, "pool", None) is not None:
+            await self.db_pool.execute(
+                """
+                UPDATE telegram_pending_approvals
+                SET consumed_at = $1
+                WHERE approval_token = $2
+                  AND consumed_at IS NULL
+                  AND expires_at > $1
+                """,
+                self._normalize_datetime_for_postgres(current),
+                token,
+            )
+        else:
+            await self.db_pool.execute(
+                """
+                UPDATE telegram_pending_approvals
+                SET consumed_at = ?
+                WHERE approval_token = ?
+                  AND consumed_at IS NULL
+                  AND datetime(expires_at) > datetime(?)
+                """,
+                (
+                    current.isoformat(),
+                    token,
+                    current.isoformat(),
+                ),
+            )
+        pending["consumed_at"] = current
+        return pending
+
+
+async def get_telegram_approvals_repo() -> TelegramApprovalsRepo:
+    pool = await get_db_pool()
+    repo = TelegramApprovalsRepo(pool)
+    await repo.ensure_tables()
+    return repo

--- a/tldw_Server_API/app/core/AuthNZ/repos/telegram_approvals_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/telegram_approvals_repo.py
@@ -237,24 +237,26 @@ class TelegramApprovalsRepo:
     ) -> dict[str, Any] | None:
         current = now or datetime.now(timezone.utc)
         token = str(approval_token).strip()
-        pending = await self.get_pending_approval_by_token(token, now=current)
-        if pending is None:
-            return None
 
         if getattr(self.db_pool, "pool", None) is not None:
-            await self.db_pool.execute(
+            row = await self.db_pool.fetchone(
                 """
                 UPDATE telegram_pending_approvals
                 SET consumed_at = $1
                 WHERE approval_token = $2
                   AND consumed_at IS NULL
                   AND expires_at > $1
+                RETURNING id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                          conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                          expires_at, consumed_at, created_at
                 """,
                 self._normalize_datetime_for_postgres(current),
                 token,
             )
-        else:
-            await self.db_pool.execute(
+            return self._row_to_dict(row) if row else None
+
+        async with self.db_pool.transaction() as conn:
+            await conn.execute(
                 """
                 UPDATE telegram_pending_approvals
                 SET consumed_at = ?
@@ -268,8 +270,22 @@ class TelegramApprovalsRepo:
                     current.isoformat(),
                 ),
             )
-        pending["consumed_at"] = current
-        return pending
+            changes_row = await conn.execute("SELECT changes() AS changed")
+            changed = await changes_row.fetchone()
+            if int(self._row_to_dict(changed).get("changed") or 0) <= 0:
+                return None
+            row_cursor = await conn.execute(
+                """
+                SELECT id, approval_token, scope_type, scope_id, approval_policy_id, context_key,
+                       conversation_id, tool_name, scope_key, initiating_auth_user_id,
+                       expires_at, consumed_at, created_at
+                FROM telegram_pending_approvals
+                WHERE approval_token = ?
+                """,
+                (token,),
+            )
+            row = await row_cursor.fetchone()
+            return self._row_to_dict(row) if row else None
 
 
 async def get_telegram_approvals_repo() -> TelegramApprovalsRepo:

--- a/tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py
+++ b/tldw_Server_API/app/core/AuthNZ/repos/telegram_runtime_repo.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+from tldw_Server_API.app.core.AuthNZ.database import DatabasePool, get_db_pool
+
+
+def _normalize_scope_type(scope_type: str) -> str:
+    value = str(scope_type or "").strip().lower()
+    if not value:
+        raise ValueError("scope_type is required")
+    return value
+
+
+def _normalize_optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+@dataclass
+class TelegramRuntimeRepo:
+    """Persistence for Telegram webhook receipts, pairing codes, and actor links."""
+
+    db_pool: DatabasePool
+
+    async def ensure_tables(self) -> None:
+        try:
+            if getattr(self.db_pool, "pool", None) is not None:
+                await self.db_pool.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telegram_webhook_receipts (
+                        id BIGSERIAL PRIMARY KEY,
+                        dedupe_key TEXT NOT NULL UNIQUE,
+                        scope_type TEXT NOT NULL,
+                        scope_id BIGINT NOT NULL,
+                        update_id BIGINT NOT NULL,
+                        expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+                    )
+                    """,
+                )
+                await self.db_pool.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_telegram_webhook_receipts_expiry
+                    ON telegram_webhook_receipts (expires_at)
+                    """,
+                )
+                await self.db_pool.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telegram_pairing_codes (
+                        id BIGSERIAL PRIMARY KEY,
+                        pairing_code TEXT NOT NULL UNIQUE,
+                        scope_type TEXT NOT NULL,
+                        scope_id BIGINT NOT NULL,
+                        auth_user_id BIGINT NOT NULL,
+                        created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        consumed_at TIMESTAMP WITHOUT TIME ZONE NULL
+                    )
+                    """,
+                )
+                await self.db_pool.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_telegram_pairing_codes_active
+                    ON telegram_pairing_codes (pairing_code, consumed_at, expires_at)
+                    """,
+                )
+                await self.db_pool.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS telegram_actor_links (
+                        id BIGSERIAL PRIMARY KEY,
+                        scope_type TEXT NOT NULL,
+                        scope_id BIGINT NOT NULL,
+                        telegram_user_id BIGINT NOT NULL,
+                        auth_user_id BIGINT NOT NULL,
+                        telegram_username TEXT NULL,
+                        created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                        UNIQUE (scope_type, scope_id, telegram_user_id)
+                    )
+                    """,
+                )
+                return
+
+            await self.db_pool.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_webhook_receipts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    dedupe_key TEXT NOT NULL UNIQUE,
+                    scope_type TEXT NOT NULL,
+                    scope_id INTEGER NOT NULL,
+                    update_id INTEGER NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                )
+                """,
+                (),
+            )
+            await self.db_pool.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_telegram_webhook_receipts_expiry
+                ON telegram_webhook_receipts (expires_at)
+                """,
+                (),
+            )
+            await self.db_pool.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_pairing_codes (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    pairing_code TEXT NOT NULL UNIQUE,
+                    scope_type TEXT NOT NULL,
+                    scope_id INTEGER NOT NULL,
+                    auth_user_id INTEGER NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    consumed_at TEXT NULL
+                )
+                """,
+                (),
+            )
+            await self.db_pool.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_telegram_pairing_codes_active
+                ON telegram_pairing_codes (pairing_code, consumed_at, expires_at)
+                """,
+                (),
+            )
+            await self.db_pool.execute(
+                """
+                CREATE TABLE IF NOT EXISTS telegram_actor_links (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    scope_type TEXT NOT NULL,
+                    scope_id INTEGER NOT NULL,
+                    telegram_user_id INTEGER NOT NULL,
+                    auth_user_id INTEGER NOT NULL,
+                    telegram_username TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE (scope_type, scope_id, telegram_user_id)
+                )
+                """,
+                (),
+            )
+        except Exception as exc:
+            logger.error("TelegramRuntimeRepo.ensure_tables failed: {}", exc)
+            raise
+
+    @staticmethod
+    def _normalize_datetime_for_postgres(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+    @staticmethod
+    def _row_to_dict(row: Any) -> dict[str, Any]:
+        if row is None:
+            return {}
+        if isinstance(row, dict):
+            return dict(row)
+        try:
+            return dict(row)
+        except Exception:
+            try:
+                keys = row.keys()
+                return {key: row[key] for key in keys}
+            except Exception:
+                return {}
+
+    async def store_webhook_receipt(
+        self,
+        *,
+        dedupe_key: str,
+        scope_type: str,
+        scope_id: int,
+        update_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> bool:
+        current = now or datetime.now(timezone.utc)
+        scope_type_value = _normalize_scope_type(scope_type)
+        if getattr(self.db_pool, "pool", None) is not None:
+            async with self.db_pool.transaction() as conn:
+                await conn.execute(
+                    """
+                    DELETE FROM telegram_webhook_receipts
+                    WHERE dedupe_key = $1
+                      AND expires_at <= $2
+                    """,
+                    str(dedupe_key).strip(),
+                    self._normalize_datetime_for_postgres(current),
+                )
+                row = await conn.fetchrow(
+                    """
+                    INSERT INTO telegram_webhook_receipts (
+                        dedupe_key, scope_type, scope_id, update_id, expires_at, created_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6)
+                    ON CONFLICT (dedupe_key) DO NOTHING
+                    RETURNING dedupe_key
+                    """,
+                    str(dedupe_key).strip(),
+                    scope_type_value,
+                    int(scope_id),
+                    int(update_id),
+                    self._normalize_datetime_for_postgres(expires_at),
+                    self._normalize_datetime_for_postgres(current),
+                )
+                return row is not None
+
+        async with self.db_pool.transaction() as conn:
+            await conn.execute(
+                """
+                DELETE FROM telegram_webhook_receipts
+                WHERE dedupe_key = ?
+                  AND datetime(expires_at) <= datetime(?)
+                """,
+                (
+                    str(dedupe_key).strip(),
+                    current.isoformat(),
+                ),
+            )
+            await conn.execute(
+                """
+                INSERT OR IGNORE INTO telegram_webhook_receipts (
+                    dedupe_key, scope_type, scope_id, update_id, expires_at, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    str(dedupe_key).strip(),
+                    scope_type_value,
+                    int(scope_id),
+                    int(update_id),
+                    expires_at.isoformat(),
+                    current.isoformat(),
+                ),
+            )
+            changes_row = await conn.execute("SELECT changes() AS changed")
+            changed = await changes_row.fetchone()
+            return int(self._row_to_dict(changed).get("changed") or 0) > 0
+
+    async def create_pairing_code(
+        self,
+        *,
+        pairing_code: str,
+        scope_type: str,
+        scope_id: int,
+        auth_user_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        created_at = now or datetime.now(timezone.utc)
+        code = str(pairing_code or "").strip().upper()
+        scope_type_value = _normalize_scope_type(scope_type)
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                INSERT INTO telegram_pairing_codes (
+                    pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, NULL)
+                RETURNING id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                """,
+                code,
+                scope_type_value,
+                int(scope_id),
+                int(auth_user_id),
+                self._normalize_datetime_for_postgres(created_at),
+                self._normalize_datetime_for_postgres(expires_at),
+            )
+            return self._row_to_dict(row)
+
+        await self.db_pool.execute(
+            """
+            INSERT INTO telegram_pairing_codes (
+                pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, NULL)
+            """,
+            (
+                code,
+                scope_type_value,
+                int(scope_id),
+                int(auth_user_id),
+                created_at.isoformat(),
+                expires_at.isoformat(),
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+            FROM telegram_pairing_codes
+            WHERE pairing_code = ?
+            """,
+            (code,),
+        )
+        return self._row_to_dict(row)
+
+    async def consume_pairing_code(
+        self,
+        pairing_code: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        current = now or datetime.now(timezone.utc)
+        code = str(pairing_code or "").strip().upper()
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                UPDATE telegram_pairing_codes
+                SET consumed_at = $2
+                WHERE pairing_code = $1
+                  AND consumed_at IS NULL
+                  AND expires_at > $2
+                RETURNING id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                """,
+                code,
+                self._normalize_datetime_for_postgres(current),
+            )
+            return self._row_to_dict(row) if row else None
+
+        async with self.db_pool.transaction() as conn:
+            await conn.execute(
+                """
+                UPDATE telegram_pairing_codes
+                SET consumed_at = ?
+                WHERE pairing_code = ?
+                  AND consumed_at IS NULL
+                  AND datetime(expires_at) > datetime(?)
+                """,
+                (
+                    current.isoformat(),
+                    code,
+                    current.isoformat(),
+                ),
+            )
+            changes_row = await conn.execute("SELECT changes() AS changed")
+            changed = await changes_row.fetchone()
+            if int(self._row_to_dict(changed).get("changed") or 0) <= 0:
+                return None
+            row_cursor = await conn.execute(
+                """
+                SELECT id, pairing_code, scope_type, scope_id, auth_user_id, created_at, expires_at, consumed_at
+                FROM telegram_pairing_codes
+                WHERE pairing_code = ?
+                """,
+                (code,),
+            )
+            row = await row_cursor.fetchone()
+            return self._row_to_dict(row) if row else None
+
+    async def upsert_actor_link(
+        self,
+        *,
+        scope_type: str,
+        scope_id: int,
+        telegram_user_id: int,
+        auth_user_id: int,
+        telegram_username: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        current = now or datetime.now(timezone.utc)
+        scope_type_value = _normalize_scope_type(scope_type)
+        username = _normalize_optional_text(telegram_username)
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                INSERT INTO telegram_actor_links (
+                    scope_type, scope_id, telegram_user_id, auth_user_id, telegram_username, created_at, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT (scope_type, scope_id, telegram_user_id) DO UPDATE
+                SET auth_user_id = EXCLUDED.auth_user_id,
+                    telegram_username = EXCLUDED.telegram_username,
+                    updated_at = EXCLUDED.updated_at
+                RETURNING id, scope_type, scope_id, telegram_user_id, auth_user_id,
+                          telegram_username, created_at, updated_at
+                """,
+                scope_type_value,
+                int(scope_id),
+                int(telegram_user_id),
+                int(auth_user_id),
+                username,
+                self._normalize_datetime_for_postgres(current),
+                self._normalize_datetime_for_postgres(current),
+            )
+            return self._row_to_dict(row)
+
+        await self.db_pool.execute(
+            """
+            INSERT INTO telegram_actor_links (
+                scope_type, scope_id, telegram_user_id, auth_user_id, telegram_username, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(scope_type, scope_id, telegram_user_id) DO UPDATE SET
+                auth_user_id = excluded.auth_user_id,
+                telegram_username = excluded.telegram_username,
+                updated_at = excluded.updated_at
+            """,
+            (
+                scope_type_value,
+                int(scope_id),
+                int(telegram_user_id),
+                int(auth_user_id),
+                username,
+                current.isoformat(),
+                current.isoformat(),
+            ),
+        )
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, scope_type, scope_id, telegram_user_id, auth_user_id,
+                   telegram_username, created_at, updated_at
+            FROM telegram_actor_links
+            WHERE scope_type = ?
+              AND scope_id = ?
+              AND telegram_user_id = ?
+            """,
+            (
+                scope_type_value,
+                int(scope_id),
+                int(telegram_user_id),
+            ),
+        )
+        return self._row_to_dict(row)
+
+    async def get_actor_link(
+        self,
+        *,
+        scope_type: str,
+        scope_id: int,
+        telegram_user_id: int,
+    ) -> dict[str, Any] | None:
+        scope_type_value = _normalize_scope_type(scope_type)
+        if getattr(self.db_pool, "pool", None) is not None:
+            row = await self.db_pool.fetchone(
+                """
+                SELECT id, scope_type, scope_id, telegram_user_id, auth_user_id,
+                       telegram_username, created_at, updated_at
+                FROM telegram_actor_links
+                WHERE scope_type = $1
+                  AND scope_id = $2
+                  AND telegram_user_id = $3
+                LIMIT 1
+                """,
+                scope_type_value,
+                int(scope_id),
+                int(telegram_user_id),
+            )
+            return self._row_to_dict(row) if row else None
+
+        row = await self.db_pool.fetchone(
+            """
+            SELECT id, scope_type, scope_id, telegram_user_id, auth_user_id,
+                   telegram_username, created_at, updated_at
+            FROM telegram_actor_links
+            WHERE scope_type = ?
+              AND scope_id = ?
+              AND telegram_user_id = ?
+            LIMIT 1
+            """,
+            (
+                scope_type_value,
+                int(scope_id),
+                int(telegram_user_id),
+            ),
+        )
+        return self._row_to_dict(row) if row else None
+
+    async def clear_all_for_tests(self) -> None:
+        await self.db_pool.execute("DELETE FROM telegram_webhook_receipts")
+        await self.db_pool.execute("DELETE FROM telegram_pairing_codes")
+        await self.db_pool.execute("DELETE FROM telegram_actor_links")
+
+
+async def get_telegram_runtime_repo() -> TelegramRuntimeRepo:
+    pool = await get_db_pool()
+    repo = TelegramRuntimeRepo(pool)
+    await repo.ensure_tables()
+    return repo

--- a/tldw_Server_API/app/core/Telegram/session_mapper.py
+++ b/tldw_Server_API/app/core/Telegram/session_mapper.py
@@ -9,6 +9,8 @@ _CHARACTER_CONVERSATION_NAMESPACE = uuid.UUID("8f6d6df3-0b13-5c67-a1f4-5c62fa2d4
 
 
 def _coerce_nonempty_string(value: Any) -> str:
+    if value is None:
+        raise ValueError("value must be a non-empty string")
     text = str(value).strip()
     if not text:
         raise ValueError("value must be a non-empty string")
@@ -23,20 +25,21 @@ def _coerce_nonempty_id(value: Any, *, field_name: str) -> str:
 def build_telegram_session_key(
     *,
     tenant_id: Any,
+    chat_type: Any,
     telegram_user_id: Any,
     telegram_chat_id: Any | None = None,
     topic_or_thread_id: Any | None = None,
 ) -> str:
     tenant = _coerce_nonempty_string(tenant_id)
+    normalized_chat_type = _coerce_nonempty_string(chat_type).lower()
     user = _coerce_nonempty_string(telegram_user_id)
-    if telegram_chat_id is None:
+    if normalized_chat_type == "private":
         return f"{tenant}:dm:{user}"
+    if normalized_chat_type not in {"group", "supergroup"}:
+        raise ValueError("chat_type must be private, group, or supergroup")
 
     chat = _coerce_nonempty_string(telegram_chat_id)
-    if topic_or_thread_id is None:
-        return f"{tenant}:group:{chat}:user:{user}"
-
-    topic = _coerce_nonempty_string(topic_or_thread_id)
+    topic = _coerce_nonempty_string(topic_or_thread_id) if topic_or_thread_id is not None else "root"
     return f"{tenant}:group:{chat}:topic:{topic}:user:{user}"
 
 

--- a/tldw_Server_API/app/core/Telegram/session_mapper.py
+++ b/tldw_Server_API/app/core/Telegram/session_mapper.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+_ASSISTANT_CONVERSATION_NAMESPACE = uuid.UUID("1f5d8d1d-8d7d-5b0e-8c7f-7e6f6d6d5d5a")
+_PERSONA_SESSION_NAMESPACE = uuid.UUID("d7cf4f79-c4de-5b54-8d0c-6f989d8b2f11")
+_CHARACTER_CONVERSATION_NAMESPACE = uuid.UUID("8f6d6df3-0b13-5c67-a1f4-5c62fa2d4f22")
+
+
+def _coerce_nonempty_string(value: Any) -> str:
+    text = str(value).strip()
+    if not text:
+        raise ValueError("value must be a non-empty string")
+    return text
+
+
+def _coerce_nonempty_id(value: Any, *, field_name: str) -> str:
+    text = _coerce_nonempty_string(value)
+    return text if text else field_name
+
+
+def build_telegram_session_key(
+    *,
+    tenant_id: Any,
+    telegram_user_id: Any,
+    telegram_chat_id: Any | None = None,
+    topic_or_thread_id: Any | None = None,
+) -> str:
+    tenant = _coerce_nonempty_string(tenant_id)
+    user = _coerce_nonempty_string(telegram_user_id)
+    if telegram_chat_id is None:
+        return f"{tenant}:dm:{user}"
+
+    chat = _coerce_nonempty_string(telegram_chat_id)
+    if topic_or_thread_id is None:
+        return f"{tenant}:group:{chat}:user:{user}"
+
+    topic = _coerce_nonempty_string(topic_or_thread_id)
+    return f"{tenant}:group:{chat}:topic:{topic}:user:{user}"
+
+
+def derive_telegram_assistant_conversation_id(session_key: str) -> str:
+    key = _coerce_nonempty_string(session_key)
+    return str(uuid.uuid5(_ASSISTANT_CONVERSATION_NAMESPACE, key))
+
+
+def derive_telegram_persona_session_id(session_key: str, *, persona_id: Any) -> str:
+    key = _coerce_nonempty_string(session_key)
+    persona = _coerce_nonempty_id(persona_id, field_name="persona")
+    return str(uuid.uuid5(_PERSONA_SESSION_NAMESPACE, f"{key}:persona:{persona}"))
+
+
+def derive_telegram_character_conversation_id(session_key: str, *, character_id: Any) -> str:
+    key = _coerce_nonempty_string(session_key)
+    character = _coerce_nonempty_id(character_id, field_name="character")
+    return str(uuid.uuid5(_CHARACTER_CONVERSATION_NAMESPACE, f"{key}:character:{character}"))

--- a/tldw_Server_API/app/core/http_client.py
+++ b/tldw_Server_API/app/core/http_client.py
@@ -754,6 +754,7 @@ _SENSITIVE_HEADER_KEYS = {
     "api-key",
     "x-auth-token",
 }
+_TELEGRAM_BOT_PATH_PATTERN = re.compile(r"^/bot[^/]+(?P<suffix>/.*)?$")
 
 
 def _redact_headers(h: dict[str, str] | None) -> dict[str, str]:
@@ -824,6 +825,36 @@ def _sanitize_accept_encoding_for_backend(headers: dict[str, str] | None, backen
     return hdrs
 
 
+def _redact_path_for_logging(host: str, path: str) -> str:
+    if host == "api.telegram.org":
+        match = _TELEGRAM_BOT_PATH_PATTERN.match(path or "/")
+        if match:
+            suffix = match.group("suffix") or ""
+            return f"/bot<redacted>{suffix}"
+    return path or "/"
+
+
+def _sanitize_url_for_logs(u: str | Any) -> str:
+    try:
+        s = str(u)
+    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+        return ""
+    try:
+        parsed = urlparse(s)
+        scheme = (parsed.scheme or "").lower()
+        host = (parsed.hostname or "").lower()
+        if not scheme or not host:
+            return s
+        port = parsed.port
+        path = _redact_path_for_logging(host, parsed.path or "/")
+        authority = host
+        if port is not None:
+            authority = f"{host}:{port}"
+        return f"{scheme}://{authority}{path}"
+    except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
+        return s
+
+
 def _url_parts(u: str | Any) -> tuple[str, str, str]:
     """Return (scheme, host, path) for logging; redacts query by omission."""
     try:
@@ -834,7 +865,7 @@ def _url_parts(u: str | Any) -> tuple[str, str, str]:
         p = urlparse(s)
         scheme = (p.scheme or "").lower()
         host = (p.hostname or "").lower()
-        path = p.path or "/"
+        path = _redact_path_for_logging(host, p.path or "/")
         return scheme, host, path  # noqa: TRY300
     except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
         return "", "", ""
@@ -1371,7 +1402,7 @@ def _build_aiohttp_form(data: Any | None, files: Any | None) -> aiohttp.FormData
 def _decorrelated_jitter_sleep(prev: float, base_ms: int, cap_s: int) -> float:
     base = max(0.001, base_ms / 1000.0)
     cap = max(base, float(cap_s))
-    sleep = base if prev <= 0 else min(cap, random.uniform(base, prev * 3))
+    sleep = base if prev <= 0 else min(cap, random.uniform(base, prev * 3))  # nosec B311
     return sleep
 
 
@@ -2067,7 +2098,9 @@ async def _afetch_httpx(
         # Parity with other paths: drop 'zstd' from Accept-Encoding for httpx
         try:
             with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
-                logger.debug(f"afetch _do_once: method={method_upper} url={target_url}")
+                logger.debug(
+                    f"afetch _do_once: method={method_upper} url={_sanitize_url_for_logs(target_url)}"
+                )
             req_headers = _sanitize_accept_encoding_for_backend(req_headers, "httpx")
         except _HTTPCLIENT_NONCRITICAL_EXCEPTIONS:
             pass
@@ -2136,7 +2169,7 @@ async def _afetch_httpx(
             attributes={
                 "http.method": method.upper(),
                 "net.host.name": host_attr,
-                "url.full": url,
+                "url.full": _sanitize_url_for_logs(url),
             },
         ):
             for attempt in range(1, attempts + 1):
@@ -2288,7 +2321,8 @@ async def _afetch_httpx(
                             if delay <= 0:
                                 delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                             logger.debug(
-                                f"afetch retry attempt={attempt} reason={reason} delay={delay:.3f}s url={cur_url}"
+                                f"afetch retry attempt={attempt} reason={reason} delay={delay:.3f}s "
+                                f"url={_sanitize_url_for_logs(cur_url)}"
                             )
                             with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                                 tm.add_event("http.retry", {"attempt": attempt, "reason": reason})
@@ -2315,7 +2349,8 @@ async def _afetch_httpx(
                         get_metrics_registry().increment("http_client_retries_total", 1, labels={"reason": rsn})
                     delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                     logger.debug(
-                        f"afetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={cur_url}"
+                        f"afetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s "
+                        f"url={_sanitize_url_for_logs(cur_url)}"
                     )
                     with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                         tm.add_event("http.retry", {"attempt": attempt, "reason": rsn})
@@ -2436,7 +2471,7 @@ async def _afetch_aiohttp(
         attributes={
             "http.method": method.upper(),
             "net.host.name": host_attr,
-            "url.full": url,
+            "url.full": _sanitize_url_for_logs(url),
         },
     ):
         for attempt in range(1, attempts + 1):
@@ -2557,7 +2592,8 @@ async def _afetch_aiohttp(
                 if delay <= 0:
                     delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                 logger.debug(
-                    f"afetch retry attempt={attempt} reason={reason} delay={delay:.3f}s url={cur_url}"
+                    f"afetch retry attempt={attempt} reason={reason} delay={delay:.3f}s "
+                    f"url={_sanitize_url_for_logs(cur_url)}"
                 )
                 with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                     tm.add_event("http.retry", {"attempt": attempt, "reason": reason})
@@ -2582,7 +2618,8 @@ async def _afetch_aiohttp(
                     get_metrics_registry().increment("http_client_retries_total", 1, labels={"reason": rsn})
                 delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                 logger.debug(
-                    f"afetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={cur_url}"
+                    f"afetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s "
+                    f"url={_sanitize_url_for_logs(cur_url)}"
                 )
                 with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                     tm.add_event("http.retry", {"attempt": attempt, "reason": rsn})
@@ -2784,7 +2821,7 @@ def _fetch_httpx_response(
             attributes={
                 "http.method": method.upper(),
                 "net.host.name": host_attr,
-                "url.full": url,
+                "url.full": _sanitize_url_for_logs(url),
             },
         ):
             for attempt in range(1, attempts + 1):
@@ -2852,7 +2889,8 @@ def _fetch_httpx_response(
                             get_metrics_registry().increment("http_client_retries_total", 1, labels={"reason": rsn})
                         delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                         logger.debug(
-                            f"fetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={cur_url}"
+                            f"fetch network retry attempt={attempt} reason={rsn} delay={delay:.3f}s "
+                            f"url={_sanitize_url_for_logs(cur_url)}"
                         )
                         time.sleep(delay)
                         sleep_s = delay
@@ -2924,7 +2962,8 @@ def _fetch_httpx_response(
                     if delay <= 0:
                         delay = _decorrelated_jitter_sleep(sleep_s, retry.backoff_base_ms, retry.backoff_cap_s)
                     logger.debug(
-                        f"fetch retry attempt={attempt} reason={rsn} delay={delay:.3f}s url={cur_url}"
+                        f"fetch retry attempt={attempt} reason={rsn} delay={delay:.3f}s "
+                        f"url={_sanitize_url_for_logs(cur_url)}"
                     )
                     with suppress(_HTTPCLIENT_NONCRITICAL_EXCEPTIONS):
                         tm.add_event("http.retry", {"attempt": attempt, "reason": rsn})

--- a/tldw_Server_API/app/main.py
+++ b/tldw_Server_API/app/main.py
@@ -1021,6 +1021,13 @@ else:
         logger.warning(f"Discord endpoints unavailable; skipping import: {_discord_err}")
         _HAS_DISCORD = False
     try:
+        from tldw_Server_API.app.api.v1.endpoints.telegram import router as telegram_router
+
+        _HAS_TELEGRAM = True
+    except _IMPORT_EXCEPTIONS as _telegram_err:
+        logger.warning(f"Telegram endpoints unavailable; skipping import: {_telegram_err}")
+        _HAS_TELEGRAM = False
+    try:
         from tldw_Server_API.app.api.v1.endpoints.files import router as files_router
 
         _HAS_FILES = True
@@ -5745,6 +5752,12 @@ elif _MINIMAL_TEST_APP:
     except _IMPORT_EXCEPTIONS as _discord_min_err:
         logger.debug(f"Skipping discord router in minimal test app: {_discord_min_err}")
     try:
+        from tldw_Server_API.app.api.v1.endpoints.telegram import router as telegram_router
+
+        app.include_router(telegram_router, prefix=f"{API_V1_PREFIX}", tags=["telegram"])
+    except _IMPORT_EXCEPTIONS as _telegram_min_err:
+        logger.debug(f"Skipping telegram router in minimal test app: {_telegram_min_err}")
+    try:
         from tldw_Server_API.app.api.v1.endpoints.files import router as files_router
 
         app.include_router(files_router, prefix=f"{API_V1_PREFIX}", tags=["files"])
@@ -6340,6 +6353,10 @@ else:
         _include_if_enabled("slack", slack_router, prefix=f"{API_V1_PREFIX}", tags=["slack"], default_stable=False)
     if _HAS_DISCORD and "discord_router" in locals():
         _include_if_enabled("discord", discord_router, prefix=f"{API_V1_PREFIX}", tags=["discord"], default_stable=False)
+    if _HAS_TELEGRAM and "telegram_router" in locals():
+        _include_if_enabled(
+            "telegram", telegram_router, prefix=f"{API_V1_PREFIX}", tags=["telegram"], default_stable=False
+        )
     try:
         # Optional outputs artifacts endpoint
         from tldw_Server_API.app.api.v1.endpoints.outputs import router as _outputs_router

--- a/tldw_Server_API/app/services/telegram_delivery_service.py
+++ b/tldw_Server_API/app/services/telegram_delivery_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+
+@dataclass(slots=True)
+class TelegramDeliveryService:
+    """Minimal Telegram delivery service wrapper for job-backed execution."""
+
+    job_manager: JobManager
+
+    def queue_inbound_ask(
+        self,
+        *,
+        owner_user_id: str,
+        request_id: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self.job_manager.create_job(
+            domain="telegram",
+            queue="default",
+            job_type="telegram.ask",
+            payload=payload,
+            owner_user_id=owner_user_id,
+            request_id=request_id,
+            idempotency_key=request_id,
+        )

--- a/tldw_Server_API/app/services/telegram_delivery_service.py
+++ b/tldw_Server_API/app/services/telegram_delivery_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from collections.abc import Callable
@@ -64,7 +65,7 @@ class TelegramDeliveryService:
     job_manager: JobManager | None = None
     transport: Callable[..., Any] = fetch
 
-    def queue_inbound_ask(
+    async def queue_inbound_ask(
         self,
         *,
         owner_user_id: str,
@@ -73,7 +74,8 @@ class TelegramDeliveryService:
     ) -> dict[str, Any]:
         if self.job_manager is None:
             raise ValueError("job_manager is required for inbound ask queueing")  # noqa: TRY003
-        return self.job_manager.create_job(
+        return await asyncio.to_thread(
+            self.job_manager.create_job,
             domain="telegram",
             queue="default",
             job_type="telegram.ask",

--- a/tldw_Server_API/app/services/telegram_delivery_service.py
+++ b/tldw_Server_API/app/services/telegram_delivery_service.py
@@ -1,16 +1,68 @@
 from __future__ import annotations
 
+import json
+import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from tldw_Server_API.app.core.http_client import fetch
 from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+_TELEGRAM_DELIVERY_NAMESPACE = uuid.UUID("8c8d4c1f-c899-4d13-819b-8178818ed020")
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_send_message_url(bot_token: str) -> str:
+    return f"https://api.telegram.org/bot{bot_token}/sendMessage"
+
+
+def _build_delivery_correlation_id(
+    *,
+    request_id: str,
+    chat_id: int,
+    text: str,
+    message_thread_id: int | None = None,
+    reply_to_message_id: int | None = None,
+) -> str:
+    material = json.dumps(
+        {
+            "request_id": request_id,
+            "chat_id": chat_id,
+            "text": text,
+            "message_thread_id": message_thread_id,
+            "reply_to_message_id": reply_to_message_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return str(uuid.uuid5(_TELEGRAM_DELIVERY_NAMESPACE, material))
+
+
+def _extract_response_payload(response: Any) -> dict[str, Any] | None:
+    if response is None or not hasattr(response, "json"):
+        return None
+    try:
+        payload = response.json()
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 @dataclass(slots=True)
 class TelegramDeliveryService:
-    """Minimal Telegram delivery service wrapper for job-backed execution."""
+    """Job handoff and outbound Telegram reply delivery helpers."""
 
-    job_manager: JobManager
+    job_manager: JobManager | None = None
+    transport: Callable[..., Any] = fetch
 
     def queue_inbound_ask(
         self,
@@ -19,6 +71,8 @@ class TelegramDeliveryService:
         request_id: str,
         payload: dict[str, Any],
     ) -> dict[str, Any]:
+        if self.job_manager is None:
+            raise ValueError("job_manager is required for inbound ask queueing")  # noqa: TRY003
         return self.job_manager.create_job(
             domain="telegram",
             queue="default",
@@ -28,3 +82,74 @@ class TelegramDeliveryService:
             request_id=request_id,
             idempotency_key=request_id,
         )
+
+    def send_message(
+        self,
+        *,
+        bot_token: str,
+        chat_id: int,
+        text: str,
+        request_id: str,
+        message_thread_id: int | None = None,
+        reply_to_message_id: int | None = None,
+        parse_mode: str | None = None,
+        disable_notification: bool = False,
+        attempt: int = 1,
+        timeout: float = 10.0,
+    ) -> dict[str, Any]:
+        correlation_id = _build_delivery_correlation_id(
+            request_id=request_id,
+            chat_id=chat_id,
+            text=text,
+            message_thread_id=message_thread_id,
+            reply_to_message_id=reply_to_message_id,
+        )
+        payload: dict[str, Any] = {
+            "chat_id": chat_id,
+            "text": text,
+        }
+        if message_thread_id is not None:
+            payload["message_thread_id"] = message_thread_id
+        if reply_to_message_id is not None:
+            payload["reply_to_message_id"] = reply_to_message_id
+        if parse_mode:
+            payload["parse_mode"] = parse_mode
+        if disable_notification:
+            payload["disable_notification"] = True
+
+        delivery_record = {
+            "status": "failed",
+            "delivery_correlation_id": correlation_id,
+            "request_id": request_id,
+            "attempt": max(1, _coerce_int(attempt) or 1),
+            "chat_id": chat_id,
+            "message_thread_id": message_thread_id,
+            "reply_to_message_id": reply_to_message_id,
+            "telegram_message_id": None,
+            "status_code": None,
+            "response_body": None,
+        }
+        try:
+            response = self.transport(
+                method="POST",
+                url=_build_send_message_url(bot_token),
+                json=payload,
+                timeout=timeout,
+            )
+        except Exception as exc:
+            delivery_record["error"] = str(exc)
+            return delivery_record
+
+        status_code = _coerce_int(getattr(response, "status_code", None))
+        response_body = _extract_response_payload(response)
+        telegram_message_id = None
+        if isinstance(response_body, dict):
+            result = response_body.get("result")
+            if isinstance(result, dict):
+                telegram_message_id = _coerce_int(result.get("message_id"))
+        delivery_record["status_code"] = status_code
+        delivery_record["response_body"] = response_body
+        delivery_record["telegram_message_id"] = telegram_message_id
+        if status_code is not None and 200 <= status_code < 300:
+            delivery_record["status"] = "sent"
+        return delivery_record

--- a/tldw_Server_API/app/services/telegram_execution_identity_service.py
+++ b/tldw_Server_API/app/services/telegram_execution_identity_service.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from tldw_Server_API.app.core.AuthNZ.permissions import TELEGRAM_RECEIVE, TELEGRAM_REPLY
+from tldw_Server_API.app.core.AuthNZ.rbac import get_effective_permissions
+
+PermissionResolver = Callable[[int], list[str]]
+
+
+def _coerce_nonempty_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned else None
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_positive_ttl(value: Any, fallback_seconds: int) -> int:
+    try:
+        candidate = int(value)
+    except (TypeError, ValueError):
+        candidate = int(fallback_seconds)
+    return max(1, candidate)
+
+
+def _unique_strings(values: Sequence[Any] | None) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in values or []:
+        cleaned = str(raw or "").strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        out.append(cleaned)
+    return out
+
+
+def _normalize_capability_scopes(
+    scopes: Mapping[str, Sequence[Any]] | None,
+) -> dict[str, list[str]]:
+    if not isinstance(scopes, Mapping):
+        return {}
+    normalized: dict[str, list[str]] = {}
+    for raw_key, raw_values in scopes.items():
+        key = str(raw_key or "").strip()
+        values = _unique_strings(list(raw_values or []))
+        if key and values:
+            normalized[key] = values
+    return normalized
+
+
+def _intersect_values(parent_values: Sequence[str], requested_values: Sequence[Any] | None) -> list[str]:
+    if requested_values is None:
+        return list(parent_values)
+    requested_set = set(_unique_strings(list(requested_values or [])))
+    if not requested_set:
+        return []
+    return [value for value in parent_values if value in requested_set]
+
+
+def _intersect_capability_scopes(
+    parent_scopes: Mapping[str, list[str]],
+    requested_scopes: Mapping[str, Sequence[Any]] | None,
+) -> dict[str, list[str]]:
+    if requested_scopes is None:
+        return {key: list(values) for key, values in parent_scopes.items()}
+
+    normalized_requested = _normalize_capability_scopes(requested_scopes)
+    out: dict[str, list[str]] = {}
+    for key, requested_values in normalized_requested.items():
+        parent_values = parent_scopes.get(key) or []
+        intersected = _intersect_values(parent_values, requested_values)
+        if intersected:
+            out[key] = intersected
+    return out
+
+
+@dataclass(frozen=True, slots=True)
+class TelegramExecutionIdentity:
+    execution_id: str
+    parent_execution_id: str | None
+    tenant_id: str
+    auth_user_id: str
+    source: str
+    permissions: list[str]
+    capability_scopes: dict[str, list[str]]
+    allowed_workspace_ids: list[str]
+    allowed_workflow_ids: list[str]
+    allowed_tool_ids: list[str]
+    conversation_id: str | None
+    persona_id: str | None
+    character_id: str | None
+    request_id: str | None
+    telegram_user_id: int | None
+    telegram_chat_id: int | None
+    telegram_thread_id: int | None
+    scope_type: str | None
+    scope_id: int | None
+    issued_at: datetime
+    expires_at: datetime
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "execution_id": self.execution_id,
+            "parent_execution_id": self.parent_execution_id,
+            "tenant_id": self.tenant_id,
+            "auth_user_id": self.auth_user_id,
+            "source": self.source,
+            "permissions": list(self.permissions),
+            "capability_scopes": {
+                key: list(values) for key, values in self.capability_scopes.items()
+            },
+            "allowed_workspace_ids": list(self.allowed_workspace_ids),
+            "allowed_workflow_ids": list(self.allowed_workflow_ids),
+            "allowed_tool_ids": list(self.allowed_tool_ids),
+            "conversation_id": self.conversation_id,
+            "persona_id": self.persona_id,
+            "character_id": self.character_id,
+            "request_id": self.request_id,
+            "telegram_user_id": self.telegram_user_id,
+            "telegram_chat_id": self.telegram_chat_id,
+            "telegram_thread_id": self.telegram_thread_id,
+            "scope_type": self.scope_type,
+            "scope_id": self.scope_id,
+            "issued_at": self.issued_at.isoformat(),
+            "expires_at": self.expires_at.isoformat(),
+        }
+
+
+@dataclass(slots=True)
+class TelegramExecutionIdentityService:
+    permission_resolver: PermissionResolver = get_effective_permissions
+    default_ttl_seconds: int = 900
+
+    def mint_telegram_identity(
+        self,
+        *,
+        tenant_id: str,
+        auth_user_id: str | int,
+        permissions: Sequence[Any] | None = None,
+        capability_scopes: Mapping[str, Sequence[Any]] | None = None,
+        allowed_workspace_ids: Sequence[Any] | None = None,
+        allowed_workflow_ids: Sequence[Any] | None = None,
+        allowed_tool_ids: Sequence[Any] | None = None,
+        conversation_id: str | None = None,
+        persona_id: str | None = None,
+        character_id: str | None = None,
+        request_id: str | None = None,
+        telegram_user_id: int | None = None,
+        telegram_chat_id: int | None = None,
+        telegram_thread_id: int | None = None,
+        scope_type: str | None = None,
+        scope_id: int | None = None,
+        now: datetime | None = None,
+        ttl_seconds: int | None = None,
+    ) -> TelegramExecutionIdentity:
+        issued_at = now.astimezone(timezone.utc) if isinstance(now, datetime) else datetime.now(timezone.utc)
+        resolved_auth_user_id = str(auth_user_id).strip()
+        if not resolved_auth_user_id:
+            raise ValueError("auth_user_id is required")
+
+        resolved_permissions = _unique_strings(list(permissions or []))
+        if permissions is None:
+            auth_user_id_int = _coerce_int(resolved_auth_user_id)
+            if auth_user_id_int is None:
+                raise ValueError("auth_user_id must be an integer when permissions are unresolved")
+            resolved_permissions = _unique_strings(self.permission_resolver(auth_user_id_int))
+
+        effective_permissions = _unique_strings(
+            [TELEGRAM_RECEIVE, TELEGRAM_REPLY] + resolved_permissions
+        )
+        ttl = _coerce_positive_ttl(ttl_seconds, self.default_ttl_seconds)
+        expires_at = issued_at + timedelta(seconds=ttl)
+
+        return TelegramExecutionIdentity(
+            execution_id=str(uuid.uuid4()),
+            parent_execution_id=None,
+            tenant_id=str(tenant_id).strip(),
+            auth_user_id=resolved_auth_user_id,
+            source="telegram",
+            permissions=effective_permissions,
+            capability_scopes=_normalize_capability_scopes(capability_scopes),
+            allowed_workspace_ids=_unique_strings(list(allowed_workspace_ids or [])),
+            allowed_workflow_ids=_unique_strings(list(allowed_workflow_ids or [])),
+            allowed_tool_ids=_unique_strings(list(allowed_tool_ids or [])),
+            conversation_id=_coerce_nonempty_string(conversation_id),
+            persona_id=_coerce_nonempty_string(persona_id),
+            character_id=_coerce_nonempty_string(character_id),
+            request_id=_coerce_nonempty_string(request_id),
+            telegram_user_id=_coerce_int(telegram_user_id),
+            telegram_chat_id=_coerce_int(telegram_chat_id),
+            telegram_thread_id=_coerce_int(telegram_thread_id),
+            scope_type=_coerce_nonempty_string(scope_type),
+            scope_id=_coerce_int(scope_id),
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+
+    def mint_child_identity(
+        self,
+        parent: TelegramExecutionIdentity,
+        *,
+        permissions: Sequence[Any] | None = None,
+        capability_scopes: Mapping[str, Sequence[Any]] | None = None,
+        allowed_workspace_ids: Sequence[Any] | None = None,
+        allowed_workflow_ids: Sequence[Any] | None = None,
+        allowed_tool_ids: Sequence[Any] | None = None,
+        conversation_id: str | None = None,
+        persona_id: str | None = None,
+        character_id: str | None = None,
+        request_id: str | None = None,
+        now: datetime | None = None,
+        ttl_seconds: int | None = None,
+    ) -> TelegramExecutionIdentity:
+        issued_at = now.astimezone(timezone.utc) if isinstance(now, datetime) else datetime.now(timezone.utc)
+        ttl = _coerce_positive_ttl(ttl_seconds, self.default_ttl_seconds)
+        requested_expires_at = issued_at + timedelta(seconds=ttl)
+        expires_at = min(parent.expires_at, requested_expires_at)
+
+        child_permissions = _intersect_values(parent.permissions, permissions)
+        child_capability_scopes = _intersect_capability_scopes(parent.capability_scopes, capability_scopes)
+        child_workspace_ids = _intersect_values(parent.allowed_workspace_ids, allowed_workspace_ids)
+        child_workflow_ids = _intersect_values(parent.allowed_workflow_ids, allowed_workflow_ids)
+        child_tool_ids = _intersect_values(parent.allowed_tool_ids, allowed_tool_ids)
+
+        return TelegramExecutionIdentity(
+            execution_id=str(uuid.uuid4()),
+            parent_execution_id=parent.execution_id,
+            tenant_id=parent.tenant_id,
+            auth_user_id=parent.auth_user_id,
+            source=parent.source,
+            permissions=child_permissions,
+            capability_scopes=child_capability_scopes,
+            allowed_workspace_ids=child_workspace_ids,
+            allowed_workflow_ids=child_workflow_ids,
+            allowed_tool_ids=child_tool_ids,
+            conversation_id=_coerce_nonempty_string(conversation_id) or parent.conversation_id,
+            persona_id=_coerce_nonempty_string(persona_id) or parent.persona_id,
+            character_id=_coerce_nonempty_string(character_id) or parent.character_id,
+            request_id=_coerce_nonempty_string(request_id) or parent.request_id,
+            telegram_user_id=parent.telegram_user_id,
+            telegram_chat_id=parent.telegram_chat_id,
+            telegram_thread_id=parent.telegram_thread_id,
+            scope_type=parent.scope_type,
+            scope_id=parent.scope_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+
+
+async def get_telegram_execution_identity_service() -> TelegramExecutionIdentityService:
+    return TelegramExecutionIdentityService(permission_resolver=get_effective_permissions)

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approval_scope.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approval_scope.py
@@ -1,24 +1,102 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     TelegramScope,
     _peek_pending_telegram_approval_for_tests,
-    _reset_telegram_approval_state_for_tests,
     build_telegram_approval_callback_data,
 )
 from tldw_Server_API.app.services.mcp_hub_approval_service import _scope_key_for_tool_call
 
 
-@pytest.fixture(autouse=True)
-def _reset_state() -> None:
-    _reset_telegram_approval_state_for_tests()
+class _FakeTelegramApprovalsRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, object]] = {}
+
+    async def create_pending_approval(
+        self,
+        *,
+        approval_token: str,
+        scope_type: str,
+        scope_id: int,
+        approval_policy_id: int | None,
+        context_key: str,
+        conversation_id: str | None,
+        tool_name: str,
+        scope_key: str,
+        initiating_auth_user_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        row = {
+            "approval_token": approval_token,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "approval_policy_id": approval_policy_id,
+            "context_key": context_key,
+            "conversation_id": conversation_id,
+            "tool_name": tool_name,
+            "scope_key": scope_key,
+            "initiating_auth_user_id": initiating_auth_user_id,
+            "expires_at": expires_at,
+            "created_at": now or datetime.now(timezone.utc),
+            "consumed_at": None,
+        }
+        self.rows[approval_token] = row
+        return dict(row)
+
+    async def get_pending_approval_by_token(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, object] | None:
+        row = self.rows.get(approval_token)
+        if row is None:
+            return None
+        current = now or datetime.now(timezone.utc)
+        if row.get("consumed_at") is not None:
+            return None
+        expires_at = row.get("expires_at")
+        if isinstance(expires_at, datetime) and expires_at <= current:
+            return None
+        return dict(row)
+
+    async def consume_pending_approval(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, object] | None:
+        row = await self.get_pending_approval_by_token(approval_token, now=now)
+        if row is None:
+            return None
+        stored = self.rows[approval_token]
+        stored["consumed_at"] = now or datetime.now(timezone.utc)
+        row["consumed_at"] = stored["consumed_at"]
+        return row
 
 
-def test_telegram_approval_callback_data_preserves_exact_scope_fingerprint() -> None:
-    scope_key = _scope_key_for_tool_call("Bash", {"command": "git status", "args": ["--short"]})
-    callback_data = build_telegram_approval_callback_data(
+@pytest.mark.asyncio
+async def test_telegram_approval_callback_data_preserves_exact_scope_fingerprint() -> None:
+    repo = _FakeTelegramApprovalsRepo()
+    scope_payload = {
+        "path_scope_mode": "cwd_descendants",
+        "workspace_root": "/tmp/project",
+        "scope_root": "/tmp/project/src",
+        "normalized_paths": ["/tmp/project/README.md"],
+        "reason": "path_outside_current_folder_scope",
+    }
+    scope_key = _scope_key_for_tool_call(
+        "Bash",
+        {"command": "git status", "args": ["--short"]},
+        scope_payload=scope_payload,
+    )
+
+    callback_data = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
@@ -26,40 +104,62 @@ def test_telegram_approval_callback_data_preserves_exact_scope_fingerprint() -> 
         tool_args={"command": "git status", "args": ["--short"]},
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
+        scope_payload=scope_payload,
+        repo=repo,
     )
 
-    pending = _peek_pending_telegram_approval_for_tests(callback_data)
+    pending = await _peek_pending_telegram_approval_for_tests(callback_data, repo=repo)
 
     assert pending is not None
-    assert pending["scope_fingerprint"] == scope_key
+    assert pending["scope_key"] == scope_key
     assert pending["tool_name"] == "Bash"
     assert pending["context_key"] == "user:202|group:88|persona:researcher"
     assert len(callback_data) <= 64
 
 
-def test_telegram_approval_callback_data_changes_when_tool_scope_changes() -> None:
-    first = build_telegram_approval_callback_data(
+@pytest.mark.asyncio
+async def test_telegram_approval_callback_data_changes_when_scope_payload_changes() -> None:
+    repo = _FakeTelegramApprovalsRepo()
+
+    first = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
-        tool_name="Bash",
-        tool_args={"command": "git status"},
+        tool_name="files.read",
+        tool_args={"path": "../README.md"},
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
+        scope_payload={
+            "path_scope_mode": "cwd_descendants",
+            "workspace_root": "/tmp/project",
+            "scope_root": "/tmp/project/src",
+            "normalized_paths": ["/tmp/project/README.md"],
+            "reason": "path_outside_current_folder_scope",
+        },
+        repo=repo,
     )
-    second = build_telegram_approval_callback_data(
+    second = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
-        tool_name="Bash",
-        tool_args={"command": "git status --porcelain"},
+        tool_name="files.read",
+        tool_args={"path": "../README.md"},
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
+        scope_payload={
+            "path_scope_mode": "cwd_descendants",
+            "workspace_root": "/tmp/project",
+            "scope_root": "/tmp/project/src",
+            "normalized_paths": ["/tmp/project/docs/README.md"],
+            "reason": "path_outside_current_folder_scope",
+        },
+        repo=repo,
     )
 
-    first_pending = _peek_pending_telegram_approval_for_tests(first)
-    second_pending = _peek_pending_telegram_approval_for_tests(second)
+    first_pending = await _peek_pending_telegram_approval_for_tests(first, repo=repo)
+    second_pending = await _peek_pending_telegram_approval_for_tests(second, repo=repo)
 
     assert first_pending is not None
     assert second_pending is not None
-    assert first_pending["scope_fingerprint"] != second_pending["scope_fingerprint"]
+    assert first_pending["scope_key"] != second_pending["scope_key"]
+

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approval_scope.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approval_scope.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    TelegramScope,
+    _peek_pending_telegram_approval_for_tests,
+    _reset_telegram_approval_state_for_tests,
+    build_telegram_approval_callback_data,
+)
+from tldw_Server_API.app.services.mcp_hub_approval_service import _scope_key_for_tool_call
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    _reset_telegram_approval_state_for_tests()
+
+
+def test_telegram_approval_callback_data_preserves_exact_scope_fingerprint() -> None:
+    scope_key = _scope_key_for_tool_call("Bash", {"command": "git status", "args": ["--short"]})
+    callback_data = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status", "args": ["--short"]},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+    )
+
+    pending = _peek_pending_telegram_approval_for_tests(callback_data)
+
+    assert pending is not None
+    assert pending["scope_fingerprint"] == scope_key
+    assert pending["tool_name"] == "Bash"
+    assert pending["context_key"] == "user:202|group:88|persona:researcher"
+    assert len(callback_data) <= 64
+
+
+def test_telegram_approval_callback_data_changes_when_tool_scope_changes() -> None:
+    first = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+    )
+    second = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status --porcelain"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+    )
+
+    first_pending = _peek_pending_telegram_approval_for_tests(first)
+    second_pending = _peek_pending_telegram_approval_for_tests(second)
+
+    assert first_pending is not None
+    assert second_pending is not None
+    assert first_pending["scope_fingerprint"] != second_pending["scope_fingerprint"]

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approvals_repo.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approvals_repo.py
@@ -49,6 +49,10 @@ async def test_telegram_approvals_repo_persists_and_consumes_pending_approvals(t
 
     consumed = await repo.consume_pending_approval("tok-123")
     assert consumed is not None
+    assert consumed["consumed_at"] is not None
+
+    consumed_again = await repo.consume_pending_approval("tok-123")
+    assert consumed_again is None
 
     missing = await repo.get_pending_approval_by_token("tok-123")
     assert missing is None

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approvals_repo.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_approvals_repo.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+@pytest.mark.asyncio
+async def test_telegram_approvals_repo_persists_and_consumes_pending_approvals(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.telegram_approvals_repo import TelegramApprovalsRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = TelegramApprovalsRepo(pool)
+    await repo.ensure_tables()
+
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    created = await repo.create_pending_approval(
+        approval_token="tok-123",
+        scope_type="group",
+        scope_id=88,
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        scope_key="tool:Bash|args:abc123",
+        initiating_auth_user_id=202,
+        expires_at=expires_at,
+    )
+    assert created["approval_token"] == "tok-123"
+
+    fetched = await repo.get_pending_approval_by_token("tok-123")
+    assert fetched is not None
+    assert fetched["scope_key"] == "tool:Bash|args:abc123"
+
+    consumed = await repo.consume_pending_approval("tok-123")
+    assert consumed is not None
+
+    missing = await repo.get_pending_approval_by_token("tok-123")
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_telegram_approvals_repo_ignores_expired_approvals(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.telegram_approvals_repo import TelegramApprovalsRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = TelegramApprovalsRepo(pool)
+    await repo.ensure_tables()
+
+    expired_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await repo.create_pending_approval(
+        approval_token="tok-expired",
+        scope_type="group",
+        scope_id=88,
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        scope_key="tool:Bash|args:abc123",
+        initiating_auth_user_id=202,
+        expires_at=expired_at,
+    )
+
+    assert await repo.get_pending_approval_by_token("tok-expired") is None
+    assert await repo.consume_pending_approval("tok-expired") is None

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_downscoped_child_agents.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_downscoped_child_agents.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from tldw_Server_API.app.services.telegram_execution_identity_service import (
+    TelegramExecutionIdentityService,
+)
+
+
+def test_child_agent_identity_is_downscoped() -> None:
+    service = TelegramExecutionIdentityService(permission_resolver=lambda _user_id: [])
+    now = datetime(2026, 3, 19, 19, 30, tzinfo=timezone.utc)
+
+    parent = service.mint_telegram_identity(
+        tenant_id="tenant-a",
+        auth_user_id="42",
+        permissions=["telegram.reply", "email.read", "email.delete"],
+        capability_scopes={
+            "tool": ["email.read", "email.delete"],
+            "workflow": ["email.summary"],
+        },
+        allowed_workspace_ids=["workspace-mail"],
+        allowed_tool_ids=["email.read", "email.delete"],
+        allowed_workflow_ids=["email.summary"],
+        request_id="req-parent",
+        now=now,
+        ttl_seconds=300,
+    )
+
+    child = service.mint_child_identity(
+        parent,
+        permissions=["telegram.reply", "email.read", "email.create"],
+        capability_scopes={"tool": ["email.read", "email.create"]},
+        allowed_workspace_ids=["workspace-mail", "workspace-other"],
+        allowed_tool_ids=["email.read", "email.create"],
+        now=now + timedelta(seconds=30),
+        ttl_seconds=3600,
+    )
+
+    assert child.tenant_id == parent.tenant_id
+    assert child.auth_user_id == parent.auth_user_id
+    assert child.parent_execution_id == parent.execution_id
+    assert child.permissions == ["telegram.reply", "email.read"]
+    assert child.capability_scopes == {"tool": ["email.read"]}
+    assert child.allowed_workspace_ids == ["workspace-mail"]
+    assert child.allowed_tool_ids == ["email.read"]
+    assert child.allowed_workflow_ids == ["email.summary"]
+    assert child.expires_at == parent.expires_at
+

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_execution_identity_service.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_execution_identity_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from tldw_Server_API.app.core.AuthNZ.permissions import TELEGRAM_RECEIVE, TELEGRAM_REPLY
+from tldw_Server_API.app.services.telegram_execution_identity_service import (
+    TelegramExecutionIdentityService,
+)
+
+
+def test_mint_telegram_identity_adds_transport_permissions_and_fails_closed_on_workspace_scope() -> None:
+    captured: dict[str, int | None] = {"user_id": None}
+
+    def _resolve_permissions(user_id: int) -> list[str]:
+        captured["user_id"] = user_id
+        return ["email.read", "email.read", "email.delete", " "]
+
+    service = TelegramExecutionIdentityService(
+        permission_resolver=_resolve_permissions,
+        default_ttl_seconds=600,
+    )
+    now = datetime(2026, 3, 19, 19, 0, tzinfo=timezone.utc)
+
+    identity = service.mint_telegram_identity(
+        tenant_id="team:22",
+        auth_user_id="42",
+        telegram_user_id=77,
+        telegram_chat_id=100,
+        telegram_thread_id=None,
+        scope_type="team",
+        scope_id=22,
+        request_id="req-telegram-1",
+        conversation_id="conv-123",
+        now=now,
+    )
+
+    assert captured["user_id"] == 42
+    assert identity.source == "telegram"
+    assert identity.tenant_id == "team:22"
+    assert identity.auth_user_id == "42"
+    assert identity.request_id == "req-telegram-1"
+    assert identity.conversation_id == "conv-123"
+    assert identity.permissions == [TELEGRAM_RECEIVE, TELEGRAM_REPLY, "email.read", "email.delete"]
+    assert identity.capability_scopes == {}
+    assert identity.allowed_workspace_ids == []
+    assert identity.allowed_tool_ids == []
+    assert identity.allowed_workflow_ids == []
+    assert identity.parent_execution_id is None
+
+    payload = identity.to_payload()
+    assert payload["issued_at"] == now.isoformat()
+    assert payload["expires_at"] == (now + timedelta(seconds=600)).isoformat()
+

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_permission_constants.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_permission_constants.py
@@ -1,0 +1,7 @@
+from tldw_Server_API.app.core.AuthNZ import permissions as perms
+
+
+def test_telegram_permission_constants_exist():
+    assert perms.TELEGRAM_ADMIN == "telegram.admin"
+    assert perms.TELEGRAM_RECEIVE == "telegram.receive"
+    assert perms.TELEGRAM_REPLY == "telegram.reply"

--- a/tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py
+++ b/tldw_Server_API/tests/AuthNZ/unit/test_telegram_runtime_repo.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
+
+
+@pytest.mark.asyncio
+async def test_telegram_runtime_repo_persists_receipts_pairing_codes_and_links(tmp_path, monkeypatch) -> None:
+    from tldw_Server_API.app.core.AuthNZ.database import get_db_pool, reset_db_pool
+    from tldw_Server_API.app.core.AuthNZ.migrations import ensure_authnz_tables
+    from tldw_Server_API.app.core.AuthNZ.repos.telegram_runtime_repo import TelegramRuntimeRepo
+    from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+    db_path = tmp_path / "users.db"
+    monkeypatch.setenv("AUTH_MODE", "multi_user")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+
+    reset_settings()
+    await reset_db_pool()
+
+    pool = await get_db_pool()
+    ensure_authnz_tables(Path(str(db_path)))
+
+    repo = TelegramRuntimeRepo(pool)
+    await repo.ensure_tables()
+
+    now = datetime.now(timezone.utc)
+    first_store = await repo.store_webhook_receipt(
+        dedupe_key="team:22:9001",
+        scope_type="team",
+        scope_id=22,
+        update_id=9001,
+        expires_at=now + timedelta(minutes=5),
+        now=now,
+    )
+    second_store = await repo.store_webhook_receipt(
+        dedupe_key="team:22:9001",
+        scope_type="team",
+        scope_id=22,
+        update_id=9001,
+        expires_at=now + timedelta(minutes=5),
+        now=now,
+    )
+    third_store = await repo.store_webhook_receipt(
+        dedupe_key="team:22:9001",
+        scope_type="team",
+        scope_id=22,
+        update_id=9001,
+        expires_at=now + timedelta(minutes=10),
+        now=now + timedelta(minutes=6),
+    )
+    assert first_store is True
+    assert second_store is False
+    assert third_store is True
+
+    pairing = await repo.create_pairing_code(
+        pairing_code="ABCD1234",
+        scope_type="team",
+        scope_id=22,
+        auth_user_id=901,
+        expires_at=now + timedelta(minutes=5),
+        now=now,
+    )
+    assert pairing["pairing_code"] == "ABCD1234"
+
+    consumed_pairing = await repo.consume_pairing_code("abcd1234", now=now + timedelta(minutes=1))
+    missing_pairing = await repo.consume_pairing_code("ABCD1234", now=now + timedelta(minutes=1))
+    assert consumed_pairing is not None
+    assert consumed_pairing["auth_user_id"] == 901
+    assert missing_pairing is None
+
+    linked = await repo.upsert_actor_link(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=77,
+        auth_user_id=901,
+        telegram_username="linked-user",
+        now=now,
+    )
+    fetched = await repo.get_actor_link(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=77,
+    )
+    assert linked["auth_user_id"] == 901
+    assert fetched is not None
+    assert fetched["telegram_username"] == "linked-user"

--- a/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
@@ -82,6 +82,7 @@ def test_put_and_get_telegram_bot_config_uses_shared_scope(client, auth_header, 
     payload = {
         "bot_token": ":".join(["123", "abc"]),
         "webhook_secret": "-".join(["secret", "123"]),
+        "bot_username": "@ResearchBot",
         "enabled": True,
     }
     put_res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
@@ -89,7 +90,7 @@ def test_put_and_get_telegram_bot_config_uses_shared_scope(client, auth_header, 
     put_body = put_res.json()
     assert put_body["scope_type"] == "team"
     assert put_body["scope_id"] == 22
-    assert put_body["bot_username"] == "example_bot"
+    assert put_body["bot_username"] == "researchbot"
     assert put_body["enabled"] is True
 
     get_res = client.get("/api/v1/telegram/admin/bot", headers=auth_header)
@@ -97,7 +98,7 @@ def test_put_and_get_telegram_bot_config_uses_shared_scope(client, auth_header, 
     body = get_res.json()
     assert body["scope_type"] == "team"
     assert body["scope_id"] == 22
-    assert body["bot_username"] == "example_bot"
+    assert body["bot_username"] == "researchbot"
     assert body["enabled"] is True
 
 

--- a/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
@@ -118,6 +118,40 @@ def test_put_telegram_bot_config_rejects_missing_active_scope(client, auth_heade
     assert "active org/team scope" in res.json()["detail"]
 
 
+@pytest.mark.parametrize(
+    ("active_org_id", "active_team_id", "org_ids", "team_ids"),
+    [
+        (999, None, [11], []),
+        (None, 999, [], [22]),
+    ],
+)
+def test_put_telegram_bot_config_rejects_stale_active_scope_claim(
+    client,
+    auth_header,
+    principal_override,
+    active_org_id,
+    active_team_id,
+    org_ids,
+    team_ids,
+):
+    principal = _make_principal(
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+        org_ids=org_ids,
+        team_ids=team_ids,
+    )
+    principal_override(principal)
+
+    payload = {
+        "bot_token": ":".join(["123", "abc"]),
+        "webhook_secret": "-".join(["secret", "123"]),
+        "enabled": True,
+    }
+    res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
+    assert res.status_code == 400
+    assert "active org/team scope" in res.json()["detail"]
+
+
 def test_put_telegram_bot_config_rejects_whitespace_credentials(client, auth_header, principal_override):
     principal = _make_principal(active_org_id=11, org_ids=[11], team_ids=[])
     principal_override(principal)

--- a/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
@@ -3,12 +3,49 @@ from __future__ import annotations
 import base64
 
 import pytest
+from fastapi import Request
 
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 
 
 def _b64_key(byte_char: bytes) -> str:
     return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _make_principal(
+    *,
+    active_org_id: int | None = None,
+    active_team_id: int | None = None,
+    org_ids: list[int] | None = None,
+    team_ids: list[int] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=101,
+        api_key_id=None,
+        subject="test-admin",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=["system.configure"],
+        is_admin=True,
+        org_ids=org_ids or [],
+        team_ids=team_ids or [],
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+    )
+
+
+def _override_principal(client, principal: AuthPrincipal) -> None:
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.active_org_id = principal.active_org_id
+        request.state.active_team_id = principal.active_team_id
+        return principal
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
 
 
 @pytest.fixture()
@@ -24,21 +61,71 @@ def client(client_user_only, monkeypatch):
     return client_user_only
 
 
-def test_put_and_get_telegram_bot_config(client, auth_header, monkeypatch):
+@pytest.fixture()
+def principal_override(client):
+    def _install(principal: AuthPrincipal) -> None:
+        _override_principal(client, principal)
+
+    yield _install
+    client.app.dependency_overrides.pop(get_auth_principal, None)
+
+
+def test_put_and_get_telegram_bot_config_uses_shared_scope(client, auth_header, principal_override):
+    principal = _make_principal(
+        active_team_id=22,
+        active_org_id=11,
+        team_ids=[22, 23],
+        org_ids=[11, 12],
+    )
+    principal_override(principal)
+
     payload = {
         "bot_token": ":".join(["123", "abc"]),
         "webhook_secret": "-".join(["secret", "123"]),
         "enabled": True,
     }
     put_res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
-    if put_res.status_code != 200:
-        pytest.fail(f"expected 200 from PUT /api/v1/telegram/admin/bot, got {put_res.status_code}")
+    assert put_res.status_code == 200
+    put_body = put_res.json()
+    assert put_body["scope_type"] == "team"
+    assert put_body["scope_id"] == 22
+    assert put_body["bot_username"] == "example_bot"
+    assert put_body["enabled"] is True
 
     get_res = client.get("/api/v1/telegram/admin/bot", headers=auth_header)
-    if get_res.status_code != 200:
-        pytest.fail(f"expected 200 from GET /api/v1/telegram/admin/bot, got {get_res.status_code}")
+    assert get_res.status_code == 200
     body = get_res.json()
-    if body["bot_username"] is None:
-        pytest.fail("expected Telegram bot_username to be populated")
-    if body["enabled"] is not True:
-        pytest.fail("expected Telegram bot config to remain enabled")
+    assert body["scope_type"] == "team"
+    assert body["scope_id"] == 22
+    assert body["bot_username"] == "example_bot"
+    assert body["enabled"] is True
+
+
+def test_put_telegram_bot_config_rejects_missing_active_scope(client, auth_header, principal_override):
+    principal = _make_principal(
+        org_ids=[11, 12],
+        team_ids=[22],
+    )
+    principal_override(principal)
+
+    payload = {
+        "bot_token": ":".join(["123", "abc"]),
+        "webhook_secret": "-".join(["secret", "123"]),
+        "enabled": True,
+    }
+    res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
+    assert res.status_code == 400
+    assert "active org/team scope" in res.json()["detail"]
+
+
+def test_put_telegram_bot_config_rejects_whitespace_credentials(client, auth_header, principal_override):
+    principal = _make_principal(active_org_id=11, org_ids=[11], team_ids=[])
+    principal_override(principal)
+
+    payload = {
+        "bot_token": "   ",
+        "webhook_secret": "\t",
+        "enabled": True,
+    }
+    res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
+    assert res.status_code == 422

--- a/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+@pytest.fixture()
+def auth_header(auth_headers):
+    return auth_headers
+
+
+@pytest.fixture()
+def client(client_user_only, monkeypatch):
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"t"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    return client_user_only
+
+
+def test_put_and_get_telegram_bot_config(client, auth_header, monkeypatch):
+    payload = {
+        "bot_token": ":".join(["123", "abc"]),
+        "webhook_secret": "-".join(["secret", "123"]),
+        "enabled": True,
+    }
+    put_res = client.put("/api/v1/telegram/admin/bot", json=payload, headers=auth_header)
+    if put_res.status_code != 200:
+        pytest.fail(f"expected 200 from PUT /api/v1/telegram/admin/bot, got {put_res.status_code}")
+
+    get_res = client.get("/api/v1/telegram/admin/bot", headers=auth_header)
+    if get_res.status_code != 200:
+        pytest.fail(f"expected 200 from GET /api/v1/telegram/admin/bot, got {get_res.status_code}")
+    body = get_res.json()
+    if body["bot_username"] is None:
+        pytest.fail("expected Telegram bot_username to be populated")
+    if body["enabled"] is not True:
+        pytest.fail("expected Telegram bot config to remain enabled")

--- a/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import Request
+
+import tldw_Server_API.app.api.v1.endpoints.telegram_support as telegram_support
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    TelegramScope,
+    TelegramWebhookContext,
+    _register_telegram_actor_link_for_tests,
+    _reset_telegram_approval_state_for_tests,
+    _reset_telegram_link_state_for_tests,
+    _reset_telegram_webhook_state_for_tests,
+    build_telegram_approval_callback_data,
+    telegram_webhook_impl,
+)
+from tldw_Server_API.app.services.mcp_hub_approval_service import _scope_key_for_tool_call
+
+
+@dataclass
+class _RecordedApprovalDecision:
+    id: int
+    approval_policy_id: int | None
+    context_key: str
+    conversation_id: str | None
+    tool_name: str
+    scope_key: str
+    decision: str
+    consume_on_match: bool
+    expires_at: datetime | None
+    actor_id: int | None
+
+
+class _FakeApprovalService:
+    def __init__(self) -> None:
+        self.recorded: list[_RecordedApprovalDecision] = []
+
+    async def record_decision(
+        self,
+        *,
+        approval_policy_id: int | None,
+        context_key: str,
+        conversation_id: str | None,
+        tool_name: str,
+        scope_key: str,
+        decision: str,
+        consume_on_match: bool = False,
+        expires_at: datetime | None = None,
+        actor_id: int | None = None,
+    ) -> dict[str, object]:
+        row = _RecordedApprovalDecision(
+            id=len(self.recorded) + 1,
+            approval_policy_id=approval_policy_id,
+            context_key=context_key,
+            conversation_id=conversation_id,
+            tool_name=tool_name,
+            scope_key=scope_key,
+            decision=decision,
+            consume_on_match=consume_on_match,
+            expires_at=expires_at,
+            actor_id=actor_id,
+        )
+        self.recorded.append(row)
+        return {
+            "id": row.id,
+            "approval_policy_id": row.approval_policy_id,
+            "context_key": row.context_key,
+            "conversation_id": row.conversation_id,
+            "tool_name": row.tool_name,
+            "scope_key": row.scope_key,
+            "decision": row.decision,
+            "consume_on_match": row.consume_on_match,
+            "expires_at": row.expires_at,
+            "created_by": row.actor_id,
+        }
+
+
+def _build_request(*, update_id: int, telegram_user_id: int, callback_data: str) -> Request:
+    body = {
+        "update_id": update_id,
+        "callback_query": {
+            "id": f"cb-{update_id}",
+            "from": {"id": telegram_user_id, "is_bot": False, "username": f"user-{telegram_user_id}"},
+            "message": {
+                "message_id": 21,
+                "chat": {"id": -1001, "type": "group"},
+            },
+            "data": callback_data,
+        },
+    }
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"x-telegram-bot-api-secret-token", b"secret-123"),
+    ]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/telegram/webhook",
+        "query_string": b"",
+        "headers": headers,
+    }
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.request", "body": json.dumps(body).encode("utf-8"), "more_body": False}
+
+    return Request(scope, _receive)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    _reset_telegram_webhook_state_for_tests()
+    _reset_telegram_link_state_for_tests()
+    _reset_telegram_approval_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_rejects_approval_from_non_initiating_linked_user(monkeypatch):
+    _register_telegram_actor_link_for_tests(
+        scope_type="group",
+        scope_id=88,
+        telegram_user_id=303,
+        auth_user_id=303,
+    )
+
+    async def _fake_get_org_secret_repo() -> object:
+        return object()
+
+    async def _fake_resolve_webhook_scope_from_secret(*, repo: object, webhook_secret: str):
+        return TelegramWebhookContext(scope=TelegramScope(scope_type="group", scope_id=88), bot_username="example_bot")
+
+    service = _FakeApprovalService()
+
+    async def _fake_get_approval_service() -> _FakeApprovalService:
+        return service
+
+    monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
+
+    callback_data = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+    request = _build_request(update_id=9001, telegram_user_id=303, callback_data=callback_data)
+
+    response = await telegram_webhook_impl(
+        request=request,
+        get_org_secret_repo=_fake_get_org_secret_repo,
+        get_approval_service=_fake_get_approval_service,
+    )
+
+    assert response.status_code == 403
+    assert json.loads(response.body)["error"] == "approval_not_authorized"
+    assert service.recorded == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_approves_initiating_linked_user_and_is_single_use(monkeypatch):
+    _register_telegram_actor_link_for_tests(
+        scope_type="group",
+        scope_id=88,
+        telegram_user_id=202,
+        auth_user_id=202,
+    )
+
+    async def _fake_get_org_secret_repo() -> object:
+        return object()
+
+    async def _fake_resolve_webhook_scope_from_secret(*, repo: object, webhook_secret: str):
+        return TelegramWebhookContext(scope=TelegramScope(scope_type="group", scope_id=88), bot_username="example_bot")
+
+    service = _FakeApprovalService()
+
+    async def _fake_get_approval_service() -> _FakeApprovalService:
+        return service
+
+    monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
+
+    callback_data = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+    first = await telegram_webhook_impl(
+        request=_build_request(update_id=9003, telegram_user_id=202, callback_data=callback_data),
+        get_org_secret_repo=_fake_get_org_secret_repo,
+        get_approval_service=_fake_get_approval_service,
+    )
+    second = await telegram_webhook_impl(
+        request=_build_request(update_id=9004, telegram_user_id=202, callback_data=callback_data),
+        get_org_secret_repo=_fake_get_org_secret_repo,
+        get_approval_service=_fake_get_approval_service,
+    )
+
+    assert first.status_code == 200
+    assert json.loads(first.body)["status"] == "approved"
+    assert len(service.recorded) == 1
+    assert service.recorded[0].decision == "approved"
+    assert service.recorded[0].consume_on_match is True
+    assert service.recorded[0].actor_id == 202
+    assert service.recorded[0].scope_key == _scope_key_for_tool_call("Bash", {"command": "git status"})
+    assert second.status_code == 409
+    assert json.loads(second.body)["error"] == "approval_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypatch):
+    _register_telegram_actor_link_for_tests(
+        scope_type="group",
+        scope_id=88,
+        telegram_user_id=202,
+        auth_user_id=202,
+    )
+
+    async def _fake_get_org_secret_repo() -> object:
+        return object()
+
+    async def _fake_resolve_webhook_scope_from_secret(*, repo: object, webhook_secret: str):
+        return TelegramWebhookContext(scope=TelegramScope(scope_type="group", scope_id=99), bot_username="example_bot")
+
+    service = _FakeApprovalService()
+
+    async def _fake_get_approval_service() -> _FakeApprovalService:
+        return service
+
+    monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
+
+    callback_data = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status --porcelain"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+    request = _build_request(update_id=9002, telegram_user_id=202, callback_data=callback_data)
+
+    response = await telegram_webhook_impl(
+        request=request,
+        get_org_secret_repo=_fake_get_org_secret_repo,
+        get_approval_service=_fake_get_approval_service,
+    )
+
+    assert response.status_code == 409
+    assert json.loads(response.body)["error"] == "approval_unavailable"
+    assert service.recorded == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_callback_rejects_expired_approval(monkeypatch):
+    _register_telegram_actor_link_for_tests(
+        scope_type="group",
+        scope_id=88,
+        telegram_user_id=202,
+        auth_user_id=202,
+    )
+
+    async def _fake_get_org_secret_repo() -> object:
+        return object()
+
+    async def _fake_resolve_webhook_scope_from_secret(*, repo: object, webhook_secret: str):
+        return TelegramWebhookContext(scope=TelegramScope(scope_type="group", scope_id=88), bot_username="example_bot")
+
+    service = _FakeApprovalService()
+
+    async def _fake_get_approval_service() -> _FakeApprovalService:
+        return service
+
+    monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
+
+    callback_data = build_telegram_approval_callback_data(
+        approval_policy_id=17,
+        context_key="user:202|group:88|persona:researcher",
+        conversation_id="conv-1",
+        tool_name="Bash",
+        tool_args={"command": "git status"},
+        scope=TelegramScope(scope_type="group", scope_id=88),
+        initiating_auth_user_id=202,
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+    )
+
+    response = await telegram_webhook_impl(
+        request=_build_request(update_id=9005, telegram_user_id=202, callback_data=callback_data),
+        get_org_secret_repo=_fake_get_org_secret_repo,
+        get_approval_service=_fake_get_approval_service,
+    )
+
+    assert response.status_code == 409
+    assert json.loads(response.body)["error"] == "approval_unavailable"
+    assert service.recorded == []

--- a/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
@@ -11,9 +11,6 @@ import tldw_Server_API.app.api.v1.endpoints.telegram_support as telegram_support
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     TelegramScope,
     TelegramWebhookContext,
-    _register_telegram_actor_link_for_tests,
-    _reset_telegram_link_state_for_tests,
-    _reset_telegram_webhook_state_for_tests,
     build_telegram_approval_callback_data,
     telegram_webhook_impl,
 )
@@ -146,6 +143,59 @@ class _FakeTelegramApprovalsRepo:
         return row
 
 
+class _FakeTelegramRuntimeRepo:
+    def __init__(self) -> None:
+        self.links: dict[tuple[str, int, int], dict[str, object]] = {}
+        self.receipts: set[str] = set()
+
+    async def store_webhook_receipt(
+        self,
+        *,
+        dedupe_key: str,
+        scope_type: str,
+        scope_id: int,
+        update_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> bool:
+        _ = (scope_type, scope_id, update_id, expires_at, now)
+        if dedupe_key in self.receipts:
+            return False
+        self.receipts.add(dedupe_key)
+        return True
+
+    async def upsert_actor_link(
+        self,
+        *,
+        scope_type: str,
+        scope_id: int,
+        telegram_user_id: int,
+        auth_user_id: int,
+        telegram_username: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        row = {
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "telegram_user_id": telegram_user_id,
+            "auth_user_id": auth_user_id,
+            "telegram_username": telegram_username,
+            "updated_at": now or datetime.now(timezone.utc),
+        }
+        self.links[(scope_type, scope_id, telegram_user_id)] = row
+        return dict(row)
+
+    async def get_actor_link(
+        self,
+        *,
+        scope_type: str,
+        scope_id: int,
+        telegram_user_id: int,
+    ) -> dict[str, object] | None:
+        row = self.links.get((scope_type, scope_id, telegram_user_id))
+        return dict(row) if row is not None else None
+
+
 def _build_request(*, update_id: int, telegram_user_id: int, callback_data: str) -> Request:
     body = {
         "update_id": update_id,
@@ -177,16 +227,11 @@ def _build_request(*, update_id: int, telegram_user_id: int, callback_data: str)
     return Request(scope, _receive)
 
 
-@pytest.fixture(autouse=True)
-def _reset_state() -> None:
-    _reset_telegram_webhook_state_for_tests()
-    _reset_telegram_link_state_for_tests()
-
-
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_approval_from_non_initiating_linked_user(monkeypatch):
     repo = _FakeTelegramApprovalsRepo()
-    _register_telegram_actor_link_for_tests(
+    runtime_repo = _FakeTelegramRuntimeRepo()
+    await runtime_repo.upsert_actor_link(
         scope_type="group",
         scope_id=88,
         telegram_user_id=303,
@@ -207,6 +252,9 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
     async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
         return repo
 
+    async def _fake_get_telegram_runtime_repo() -> _FakeTelegramRuntimeRepo:
+        return runtime_repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
     callback_data = await build_telegram_approval_callback_data(
@@ -226,6 +274,7 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
         request=request,
         get_org_secret_repo=_fake_get_org_secret_repo,
         get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
+        get_telegram_runtime_repo=_fake_get_telegram_runtime_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -237,7 +286,8 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
 @pytest.mark.asyncio
 async def test_telegram_callback_approves_initiating_linked_user_and_is_single_use(monkeypatch):
     repo = _FakeTelegramApprovalsRepo()
-    _register_telegram_actor_link_for_tests(
+    runtime_repo = _FakeTelegramRuntimeRepo()
+    await runtime_repo.upsert_actor_link(
         scope_type="group",
         scope_id=88,
         telegram_user_id=202,
@@ -258,6 +308,9 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
     async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
         return repo
 
+    async def _fake_get_telegram_runtime_repo() -> _FakeTelegramRuntimeRepo:
+        return runtime_repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
     callback_data = await build_telegram_approval_callback_data(
@@ -276,12 +329,14 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
         request=_build_request(update_id=9003, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
         get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
+        get_telegram_runtime_repo=_fake_get_telegram_runtime_repo,
         get_approval_service=_fake_get_approval_service,
     )
     second = await telegram_webhook_impl(
         request=_build_request(update_id=9004, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
         get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
+        get_telegram_runtime_repo=_fake_get_telegram_runtime_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -300,7 +355,8 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypatch):
     repo = _FakeTelegramApprovalsRepo()
-    _register_telegram_actor_link_for_tests(
+    runtime_repo = _FakeTelegramRuntimeRepo()
+    await runtime_repo.upsert_actor_link(
         scope_type="group",
         scope_id=88,
         telegram_user_id=202,
@@ -321,6 +377,9 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
     async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
         return repo
 
+    async def _fake_get_telegram_runtime_repo() -> _FakeTelegramRuntimeRepo:
+        return runtime_repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
     callback_data = await build_telegram_approval_callback_data(
@@ -340,6 +399,7 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
         request=request,
         get_org_secret_repo=_fake_get_org_secret_repo,
         get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
+        get_telegram_runtime_repo=_fake_get_telegram_runtime_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -351,7 +411,8 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_expired_approval(monkeypatch):
     repo = _FakeTelegramApprovalsRepo()
-    _register_telegram_actor_link_for_tests(
+    runtime_repo = _FakeTelegramRuntimeRepo()
+    await runtime_repo.upsert_actor_link(
         scope_type="group",
         scope_id=88,
         telegram_user_id=202,
@@ -372,6 +433,9 @@ async def test_telegram_callback_rejects_expired_approval(monkeypatch):
     async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
         return repo
 
+    async def _fake_get_telegram_runtime_repo() -> _FakeTelegramRuntimeRepo:
+        return runtime_repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
     callback_data = await build_telegram_approval_callback_data(
@@ -390,6 +454,7 @@ async def test_telegram_callback_rejects_expired_approval(monkeypatch):
         request=_build_request(update_id=9005, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
         get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
+        get_telegram_runtime_repo=_fake_get_telegram_runtime_repo,
         get_approval_service=_fake_get_approval_service,
     )
 

--- a/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_approvals.py
@@ -12,7 +12,6 @@ from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     TelegramScope,
     TelegramWebhookContext,
     _register_telegram_actor_link_for_tests,
-    _reset_telegram_approval_state_for_tests,
     _reset_telegram_link_state_for_tests,
     _reset_telegram_webhook_state_for_tests,
     build_telegram_approval_callback_data,
@@ -79,6 +78,74 @@ class _FakeApprovalService:
         }
 
 
+class _FakeTelegramApprovalsRepo:
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, object]] = {}
+
+    async def create_pending_approval(
+        self,
+        *,
+        approval_token: str,
+        scope_type: str,
+        scope_id: int,
+        approval_policy_id: int | None,
+        context_key: str,
+        conversation_id: str | None,
+        tool_name: str,
+        scope_key: str,
+        initiating_auth_user_id: int,
+        expires_at: datetime,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        row = {
+            "approval_token": approval_token,
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "approval_policy_id": approval_policy_id,
+            "context_key": context_key,
+            "conversation_id": conversation_id,
+            "tool_name": tool_name,
+            "scope_key": scope_key,
+            "initiating_auth_user_id": initiating_auth_user_id,
+            "expires_at": expires_at,
+            "created_at": now or datetime.now(timezone.utc),
+            "consumed_at": None,
+        }
+        self.rows[approval_token] = row
+        return dict(row)
+
+    async def get_pending_approval_by_token(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, object] | None:
+        row = self.rows.get(approval_token)
+        if row is None:
+            return None
+        current = now or datetime.now(timezone.utc)
+        if row.get("consumed_at") is not None:
+            return None
+        expires_at = row.get("expires_at")
+        if isinstance(expires_at, datetime) and expires_at <= current:
+            return None
+        return dict(row)
+
+    async def consume_pending_approval(
+        self,
+        approval_token: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, object] | None:
+        row = await self.get_pending_approval_by_token(approval_token, now=now)
+        if row is None:
+            return None
+        stored = self.rows[approval_token]
+        stored["consumed_at"] = now or datetime.now(timezone.utc)
+        row["consumed_at"] = stored["consumed_at"]
+        return row
+
+
 def _build_request(*, update_id: int, telegram_user_id: int, callback_data: str) -> Request:
     body = {
         "update_id": update_id,
@@ -114,11 +181,11 @@ def _build_request(*, update_id: int, telegram_user_id: int, callback_data: str)
 def _reset_state() -> None:
     _reset_telegram_webhook_state_for_tests()
     _reset_telegram_link_state_for_tests()
-    _reset_telegram_approval_state_for_tests()
 
 
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_approval_from_non_initiating_linked_user(monkeypatch):
+    repo = _FakeTelegramApprovalsRepo()
     _register_telegram_actor_link_for_tests(
         scope_type="group",
         scope_id=88,
@@ -137,9 +204,12 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
     async def _fake_get_approval_service() -> _FakeApprovalService:
         return service
 
+    async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
+        return repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
-    callback_data = build_telegram_approval_callback_data(
+    callback_data = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
@@ -148,12 +218,14 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        repo=repo,
     )
     request = _build_request(update_id=9001, telegram_user_id=303, callback_data=callback_data)
 
     response = await telegram_webhook_impl(
         request=request,
         get_org_secret_repo=_fake_get_org_secret_repo,
+        get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -164,6 +236,7 @@ async def test_telegram_callback_rejects_approval_from_non_initiating_linked_use
 
 @pytest.mark.asyncio
 async def test_telegram_callback_approves_initiating_linked_user_and_is_single_use(monkeypatch):
+    repo = _FakeTelegramApprovalsRepo()
     _register_telegram_actor_link_for_tests(
         scope_type="group",
         scope_id=88,
@@ -182,9 +255,12 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
     async def _fake_get_approval_service() -> _FakeApprovalService:
         return service
 
+    async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
+        return repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
-    callback_data = build_telegram_approval_callback_data(
+    callback_data = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
@@ -193,16 +269,19 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        repo=repo,
     )
 
     first = await telegram_webhook_impl(
         request=_build_request(update_id=9003, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
+        get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
         get_approval_service=_fake_get_approval_service,
     )
     second = await telegram_webhook_impl(
         request=_build_request(update_id=9004, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
+        get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -212,6 +291,7 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
     assert service.recorded[0].decision == "approved"
     assert service.recorded[0].consume_on_match is True
     assert service.recorded[0].actor_id == 202
+    assert service.recorded[0].expires_at is None
     assert service.recorded[0].scope_key == _scope_key_for_tool_call("Bash", {"command": "git status"})
     assert second.status_code == 409
     assert json.loads(second.body)["error"] == "approval_unavailable"
@@ -219,6 +299,7 @@ async def test_telegram_callback_approves_initiating_linked_user_and_is_single_u
 
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypatch):
+    repo = _FakeTelegramApprovalsRepo()
     _register_telegram_actor_link_for_tests(
         scope_type="group",
         scope_id=88,
@@ -237,9 +318,12 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
     async def _fake_get_approval_service() -> _FakeApprovalService:
         return service
 
+    async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
+        return repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
-    callback_data = build_telegram_approval_callback_data(
+    callback_data = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
@@ -248,12 +332,14 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        repo=repo,
     )
     request = _build_request(update_id=9002, telegram_user_id=202, callback_data=callback_data)
 
     response = await telegram_webhook_impl(
         request=request,
         get_org_secret_repo=_fake_get_org_secret_repo,
+        get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
         get_approval_service=_fake_get_approval_service,
     )
 
@@ -264,6 +350,7 @@ async def test_telegram_callback_rejects_scope_mismatch_as_unavailable(monkeypat
 
 @pytest.mark.asyncio
 async def test_telegram_callback_rejects_expired_approval(monkeypatch):
+    repo = _FakeTelegramApprovalsRepo()
     _register_telegram_actor_link_for_tests(
         scope_type="group",
         scope_id=88,
@@ -282,9 +369,12 @@ async def test_telegram_callback_rejects_expired_approval(monkeypatch):
     async def _fake_get_approval_service() -> _FakeApprovalService:
         return service
 
+    async def _fake_get_telegram_approvals_repo() -> _FakeTelegramApprovalsRepo:
+        return repo
+
     monkeypatch.setattr(telegram_support, "_resolve_webhook_scope_from_secret", _fake_resolve_webhook_scope_from_secret)
 
-    callback_data = build_telegram_approval_callback_data(
+    callback_data = await build_telegram_approval_callback_data(
         approval_policy_id=17,
         context_key="user:202|group:88|persona:researcher",
         conversation_id="conv-1",
@@ -293,11 +383,13 @@ async def test_telegram_callback_rejects_expired_approval(monkeypatch):
         scope=TelegramScope(scope_type="group", scope_id=88),
         initiating_auth_user_id=202,
         expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        repo=repo,
     )
 
     response = await telegram_webhook_impl(
         request=_build_request(update_id=9005, telegram_user_id=202, callback_data=callback_data),
         get_org_secret_repo=_fake_get_org_secret_repo,
+        get_telegram_approvals_repo=_fake_get_telegram_approvals_repo,
         get_approval_service=_fake_get_approval_service,
     )
 

--- a/tldw_Server_API/tests/Telegram/test_telegram_commands.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_commands.py
@@ -112,6 +112,16 @@ def test_parse_telegram_command_ask():
     assert command == TelegramCommand(action="ask", input="summarize the last report")
 
 
+def test_parse_telegram_command_with_target_bot():
+    command = parse_telegram_command("/ask@ourbot summarize the last report")
+
+    assert command == TelegramCommand(
+        action="ask",
+        input="summarize the last report",
+        target_bot_username="ourbot",
+    )
+
+
 def test_group_freeform_message_without_reply_is_ignored():
     policy = evaluate_telegram_message_policy(chat_type="group", text="hello everyone", reply_to_bot=False)
 
@@ -166,6 +176,36 @@ def test_telegram_webhook_ignores_group_freeform_message_without_reply(client, p
     assert response.json() == {"ok": True, "status": "ignored"}
 
 
+def test_telegram_webhook_ignores_group_command_for_other_bot(client, principal_override):
+    principal = _make_principal(active_team_id=22, team_ids=[22], org_ids=[1])
+    principal_override(principal)
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 9003,
+            "message": {
+                "message_id": 7,
+                "chat": {"id": 123, "type": "group"},
+                "from": {"id": 77, "username": "unknown"},
+                "text": "/ask@otherbot summarize the last report",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "status": "ignored"}
+
+
 def test_replayed_ignored_group_freeform_message_is_deduped(client, principal_override):
     principal = _make_principal(active_team_id=22, team_ids=[22], org_ids=[1])
     principal_override(principal)
@@ -196,3 +236,38 @@ def test_replayed_ignored_group_freeform_message_is_deduped(client, principal_ov
     assert first.json() == {"ok": True, "status": "ignored"}
     assert second.status_code == 200
     assert second.json() == {"ok": True, "status": "duplicate"}
+
+
+def test_telegram_webhook_ignores_group_reply_to_different_bot(client, principal_override):
+    principal = _make_principal(active_team_id=22, team_ids=[22], org_ids=[1])
+    principal_override(principal)
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 9004,
+            "message": {
+                "message_id": 8,
+                "chat": {"id": 123, "type": "group"},
+                "from": {"id": 77, "username": "unknown"},
+                "reply_to_message": {
+                    "message_id": 2,
+                    "from": {"id": 88, "is_bot": True, "username": "otherbot"},
+                    "text": "previous bot message",
+                },
+                "text": "please summarize this",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "status": "ignored"}

--- a/tldw_Server_API/tests/Telegram/test_telegram_commands.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_commands.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import Request
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    TelegramCommand,
+    evaluate_telegram_message_policy,
+    parse_telegram_command,
+    _reset_telegram_webhook_state_for_tests,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _make_principal(
+    *,
+    active_org_id: int | None = None,
+    active_team_id: int | None = None,
+    org_ids: list[int] | None = None,
+    team_ids: list[int] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=404,
+        api_key_id=None,
+        subject="telegram-command-test",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=["system.configure"],
+        is_admin=True,
+        org_ids=org_ids or [],
+        team_ids=team_ids or [],
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+    )
+
+
+def _override_principal(client, principal: AuthPrincipal) -> None:
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.active_org_id = principal.active_org_id
+        request.state.active_team_id = principal.active_team_id
+        return principal
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+
+
+@pytest.fixture()
+def client(client_user_only, monkeypatch):
+    monkeypatch.setenv("BYOK_ENABLED", "1")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"c"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    _reset_telegram_webhook_state_for_tests()
+    return client_user_only
+
+
+@pytest.fixture()
+def principal_override(client):
+    def _install(principal: AuthPrincipal) -> None:
+        _override_principal(client, principal)
+
+    yield _install
+    client.app.dependency_overrides.pop(get_auth_principal, None)
+    _reset_telegram_webhook_state_for_tests()
+
+
+def _seed_telegram_bot(
+    client,
+    principal_override,
+    *,
+    scope_type: str,
+    scope_id: int,
+    bot_token: str,
+    webhook_secret: str,
+) -> None:
+    if scope_type == "team":
+        principal = _make_principal(active_team_id=scope_id, team_ids=[scope_id], org_ids=[1])
+    else:
+        principal = _make_principal(active_org_id=scope_id, org_ids=[scope_id], team_ids=[1])
+    principal_override(principal)
+
+    response = client.put(
+        "/api/v1/telegram/admin/bot",
+        json={
+            "bot_token": bot_token,
+            "webhook_secret": webhook_secret,
+            "enabled": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_parse_telegram_command_mode():
+    command = parse_telegram_command("/mode persona")
+
+    assert command == TelegramCommand(action="mode", input="persona")
+
+
+def test_parse_telegram_command_ask():
+    command = parse_telegram_command("/ask summarize the last report")
+
+    assert command == TelegramCommand(action="ask", input="summarize the last report")
+
+
+def test_group_freeform_message_without_reply_is_ignored():
+    policy = evaluate_telegram_message_policy(chat_type="group", text="hello everyone", reply_to_bot=False)
+
+    assert policy.should_process is False
+    assert policy.reason == "group_freeform_requires_command_or_reply"
+    assert policy.command is None
+
+
+def test_group_command_is_processed():
+    policy = evaluate_telegram_message_policy(chat_type="group", text="/ask summarize this", reply_to_bot=False)
+
+    assert policy.should_process is True
+    assert policy.reason is None
+    assert policy.command == TelegramCommand(action="ask", input="summarize this")
+
+
+def test_group_reply_to_bot_is_processed():
+    policy = evaluate_telegram_message_policy(chat_type="group", text="please summarize", reply_to_bot=True)
+
+    assert policy.should_process is True
+    assert policy.reason is None
+    assert policy.command is None
+
+
+def test_telegram_webhook_ignores_group_freeform_message_without_reply(client, principal_override):
+    principal = _make_principal(active_team_id=22, team_ids=[22], org_ids=[1])
+    principal_override(principal)
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 9001,
+            "message": {
+                "message_id": 5,
+                "chat": {"id": 123, "type": "group"},
+                "from": {"id": 77, "username": "unknown"},
+                "text": "hello everyone",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "status": "ignored"}

--- a/tldw_Server_API/tests/Telegram/test_telegram_commands.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_commands.py
@@ -164,3 +164,35 @@ def test_telegram_webhook_ignores_group_freeform_message_without_reply(client, p
 
     assert response.status_code == 200
     assert response.json() == {"ok": True, "status": "ignored"}
+
+
+def test_replayed_ignored_group_freeform_message_is_deduped(client, principal_override):
+    principal = _make_principal(active_team_id=22, team_ids=[22], org_ids=[1])
+    principal_override(principal)
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    payload = {
+        "update_id": 9002,
+        "message": {
+            "message_id": 6,
+            "chat": {"id": 123, "type": "group"},
+            "from": {"id": 77, "username": "unknown"},
+            "text": "hello everyone",
+        },
+    }
+    headers = {"X-Telegram-Bot-Api-Secret-Token": "secret-123"}
+
+    first = client.post("/api/v1/telegram/webhook", headers=headers, json=payload)
+    second = client.post("/api/v1/telegram/webhook", headers=headers, json=payload)
+
+    assert first.status_code == 200
+    assert first.json() == {"ok": True, "status": "ignored"}
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "status": "duplicate"}

--- a/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+from fastapi import Request
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    _register_telegram_actor_link_for_tests,
+    _reset_telegram_link_state_for_tests,
+    _reset_telegram_webhook_state_for_tests,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+from tldw_Server_API.app.core.Jobs.manager import JobManager
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _make_principal(
+    *,
+    active_org_id: int | None = None,
+    active_team_id: int | None = None,
+    org_ids: list[int] | None = None,
+    team_ids: list[int] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=404,
+        api_key_id=None,
+        subject="telegram-job-test",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=["system.configure"],
+        is_admin=True,
+        org_ids=org_ids or [],
+        team_ids=team_ids or [],
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+    )
+
+
+def _override_principal(client, principal: AuthPrincipal) -> None:
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.active_org_id = principal.active_org_id
+        request.state.active_team_id = principal.active_team_id
+        return principal
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+
+
+def _seed_telegram_bot(
+    client,
+    principal_override,
+    *,
+    scope_type: str,
+    scope_id: int,
+    bot_token: str,
+    webhook_secret: str,
+) -> None:
+    if scope_type == "team":
+        principal = _make_principal(active_team_id=scope_id, team_ids=[scope_id], org_ids=[1])
+    else:
+        principal = _make_principal(active_org_id=scope_id, org_ids=[scope_id], team_ids=[1])
+    principal_override(principal)
+
+    response = client.put(
+        "/api/v1/telegram/admin/bot",
+        json={
+            "bot_token": bot_token,
+            "webhook_secret": webhook_secret,
+            "enabled": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+@pytest.fixture()
+def client(client_user_only, monkeypatch):
+    monkeypatch.setenv("BYOK_ENABLED", "1")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"j"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    _reset_telegram_webhook_state_for_tests()
+    _reset_telegram_link_state_for_tests()
+    return client_user_only
+
+
+@pytest.fixture()
+def principal_override(client):
+    def _install(principal: AuthPrincipal) -> None:
+        _override_principal(client, principal)
+
+    yield _install
+    client.app.dependency_overrides.pop(get_auth_principal, None)
+    _reset_telegram_webhook_state_for_tests()
+    _reset_telegram_link_state_for_tests()
+
+
+@pytest.fixture()
+def job_manager_override(client, tmp_path):
+    job_manager = JobManager(tmp_path / "telegram_jobs.db")
+    client.app.dependency_overrides[get_job_manager] = lambda: job_manager
+    yield job_manager
+    client.app.dependency_overrides.pop(get_job_manager, None)
+
+
+def _post_ask(
+    client,
+    *,
+    update_id: int,
+    secret: str,
+    telegram_user_id: int,
+    text: str = "/ask summarize the last report",
+) -> object:
+    return client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": secret},
+        json={
+            "update_id": update_id,
+            "message": {
+                "message_id": 42,
+                "chat": {"id": 100, "type": "private"},
+                "from": {"id": telegram_user_id, "username": "linked-user"},
+                "text": text,
+            },
+        },
+    )
+
+
+def test_linked_ask_queues_job_and_returns_queued(client, principal_override, job_manager_override) -> None:
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+    _register_telegram_actor_link_for_tests(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=77,
+        auth_user_id=901,
+    )
+
+    response = _post_ask(client, update_id=12001, secret="secret-123", telegram_user_id=77)
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["status"] == "queued"
+    assert payload["request_id"]
+    assert uuid.UUID(payload["request_id"])
+    assert payload["job_id"] is not None
+
+    job = job_manager_override.get_job(int(payload["job_id"]))
+    assert job is not None
+    assert job["status"] == "queued"
+
+
+def test_replayed_linked_ask_is_deduped(client, principal_override, job_manager_override) -> None:
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+    _register_telegram_actor_link_for_tests(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=77,
+        auth_user_id=901,
+    )
+
+    first = _post_ask(client, update_id=12002, secret="secret-123", telegram_user_id=77)
+    second = _post_ask(client, update_id=12002, secret="secret-123", telegram_user_id=77)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["status"] == "queued"
+    assert second.status_code == 200, second.text
+    assert second.json() == {"ok": True, "status": "duplicate"}
+
+
+def test_linked_ask_job_payload_includes_owner_and_session_mapping(
+    client,
+    principal_override,
+    job_manager_override,
+) -> None:
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+    _register_telegram_actor_link_for_tests(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=77,
+        auth_user_id=901,
+    )
+
+    response = _post_ask(client, update_id=12003, secret="secret-123", telegram_user_id=77)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    job = job_manager_override.get_job(int(body["job_id"]))
+    assert job is not None
+    assert job["owner_user_id"] == "901"
+
+    telegram_payload = job["payload"]["telegram"]
+    session_payload = job["payload"]["session"]
+    assert telegram_payload["scope_type"] == "team"
+    assert telegram_payload["scope_id"] == 22
+    assert telegram_payload["update_id"] == 12003
+    assert telegram_payload["message_id"] == 42
+    assert telegram_payload["chat_type"] == "private"
+    assert telegram_payload["telegram_user_id"] == 77
+    assert telegram_payload["linked_actor"]["auth_user_id"] == "901"
+    assert session_payload["tenant_id"] == "team:22"
+    assert session_payload["session_key"] == "team:22:dm:77"
+    assert uuid.UUID(session_payload["assistant_conversation_id"])

--- a/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
@@ -14,9 +14,11 @@ from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     _reset_telegram_webhook_state_for_tests,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.permissions import TELEGRAM_RECEIVE, TELEGRAM_REPLY
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 from tldw_Server_API.app.core.Jobs.manager import JobManager
 from tldw_Server_API.app.services.telegram_delivery_service import TelegramDeliveryService
+from tldw_Server_API.app.services import telegram_execution_identity_service as telegram_identity_service
 
 
 def _b64_key(byte_char: bytes) -> str:
@@ -196,7 +198,13 @@ def test_linked_ask_job_payload_includes_owner_and_session_mapping(
     client,
     principal_override,
     job_manager_override,
+    monkeypatch,
 ) -> None:
+    monkeypatch.setattr(
+        telegram_identity_service,
+        "get_effective_permissions",
+        lambda user_id: ["email.read"] if int(user_id) == 901 else [],
+    )
     _seed_telegram_bot(
         client,
         principal_override,
@@ -232,6 +240,13 @@ def test_linked_ask_job_payload_includes_owner_and_session_mapping(
     assert session_payload["tenant_id"] == "team:22"
     assert session_payload["session_key"] == "team:22:dm:77"
     assert uuid.UUID(session_payload["assistant_conversation_id"])
+    execution_identity = job["payload"]["execution_identity"]
+    assert execution_identity["source"] == "telegram"
+    assert execution_identity["tenant_id"] == "team:22"
+    assert execution_identity["auth_user_id"] == "901"
+    assert execution_identity["conversation_id"] == session_payload["assistant_conversation_id"]
+    assert execution_identity["permissions"] == [TELEGRAM_RECEIVE, TELEGRAM_REPLY, "email.read"]
+    assert execution_identity["allowed_workspace_ids"] == []
 
 
 class _DummyResponse:

--- a/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py
@@ -16,6 +16,7 @@ from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
 from tldw_Server_API.app.core.Jobs.manager import JobManager
+from tldw_Server_API.app.services.telegram_delivery_service import TelegramDeliveryService
 
 
 def _b64_key(byte_char: bytes) -> str:
@@ -231,3 +232,83 @@ def test_linked_ask_job_payload_includes_owner_and_session_mapping(
     assert session_payload["tenant_id"] == "team:22"
     assert session_payload["session_key"] == "team:22:dm:77"
     assert uuid.UUID(session_payload["assistant_conversation_id"])
+
+
+class _DummyResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def test_send_message_wraps_telegram_api_and_returns_delivery_correlation() -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_transport(**kwargs):
+        captured.update(kwargs)
+        return _DummyResponse(
+            200,
+            {
+                "ok": True,
+                "result": {
+                    "message_id": 501,
+                },
+            },
+        )
+
+    service = TelegramDeliveryService(job_manager=None, transport=_fake_transport)
+
+    result = service.send_message(
+        bot_token="123:abc",
+        chat_id=100,
+        text="queued reply",
+        request_id="req-telegram-1",
+        message_thread_id=55,
+        reply_to_message_id=42,
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "https://api.telegram.org/bot123:abc/sendMessage"
+    assert captured["json"] == {
+        "chat_id": 100,
+        "text": "queued reply",
+        "message_thread_id": 55,
+        "reply_to_message_id": 42,
+    }
+    assert result["status"] == "sent"
+    assert result["telegram_message_id"] == 501
+    assert uuid.UUID(result["delivery_correlation_id"])
+
+
+def test_send_message_reuses_delivery_correlation_across_retries() -> None:
+    attempts: list[int] = []
+
+    def _fake_transport(**_kwargs):
+        attempts.append(1)
+        return _DummyResponse(500, {"ok": False, "description": "retry"})
+
+    service = TelegramDeliveryService(job_manager=None, transport=_fake_transport)
+
+    first = service.send_message(
+        bot_token="123:abc",
+        chat_id=100,
+        text="queued reply",
+        request_id="req-telegram-2",
+        attempt=1,
+    )
+    second = service.send_message(
+        bot_token="123:abc",
+        chat_id=100,
+        text="queued reply",
+        request_id="req-telegram-2",
+        attempt=2,
+    )
+
+    assert len(attempts) == 2
+    assert first["status"] == "failed"
+    assert second["status"] == "failed"
+    assert first["attempt"] == 1
+    assert second["attempt"] == 2
+    assert first["delivery_correlation_id"] == second["delivery_correlation_id"]

--- a/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
@@ -7,7 +7,6 @@ from fastapi import Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
-    _register_telegram_actor_link_for_tests,
     _reset_telegram_link_state_for_tests,
     _reset_telegram_webhook_state_for_tests,
 )
@@ -212,7 +211,14 @@ def test_replayed_denied_privileged_action_is_deduped(client, principal_override
     assert second.json() == {"ok": True, "status": "duplicate"}
 
 
-def test_linked_user_is_allowed_for_privileged_action(client, principal_override):
+def test_linked_user_is_allowed_for_privileged_action(client, auth_headers, principal_override):
+    principal = _make_principal(
+        active_team_id=22,
+        active_org_id=11,
+        team_ids=[22, 23],
+        org_ids=[11, 12],
+    )
+    principal_override(principal)
     _seed_telegram_bot(
         client,
         principal_override,
@@ -221,13 +227,25 @@ def test_linked_user_is_allowed_for_privileged_action(client, principal_override
         bot_token="123:abc",
         webhook_secret="secret-123",
     )
-    _register_telegram_actor_link_for_tests(
-        scope_type="team",
-        scope_id=22,
-        telegram_user_id=99,
-        auth_user_id=202,
-        telegram_username="linked",
+    start_link = client.post("/api/v1/telegram/admin/link/start", headers=auth_headers)
+    assert start_link.status_code == 200
+    pairing_code = start_link.json()["pairing_code"]
+
+    link_response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 7,
+            "message": {
+                "message_id": 4,
+                "chat": {"id": 1, "type": "private"},
+                "from": {"id": 99, "username": "linked"},
+                "text": f"/link {pairing_code}",
+            },
+        },
     )
+    assert link_response.status_code == 200
+    assert link_response.json()["status"] == "linked"
 
     response = client.post(
         "/api/v1/telegram/webhook",

--- a/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import Request
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    _register_telegram_actor_link_for_tests,
+    _reset_telegram_link_state_for_tests,
+    _reset_telegram_webhook_state_for_tests,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _make_principal(
+    *,
+    active_org_id: int | None = None,
+    active_team_id: int | None = None,
+    org_ids: list[int] | None = None,
+    team_ids: list[int] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=303,
+        api_key_id=None,
+        subject="telegram-link-test",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=["system.configure"],
+        is_admin=True,
+        org_ids=org_ids or [],
+        team_ids=team_ids or [],
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+    )
+
+
+def _override_principal(client, principal: AuthPrincipal) -> None:
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.active_org_id = principal.active_org_id
+        request.state.active_team_id = principal.active_team_id
+        return principal
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+
+
+@pytest.fixture()
+def client(client_user_only, monkeypatch):
+    monkeypatch.setenv("BYOK_ENABLED", "1")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"l"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    _reset_telegram_webhook_state_for_tests()
+    _reset_telegram_link_state_for_tests()
+    return client_user_only
+
+
+@pytest.fixture()
+def principal_override(client):
+    def _install(principal: AuthPrincipal) -> None:
+        _override_principal(client, principal)
+
+    yield _install
+    client.app.dependency_overrides.pop(get_auth_principal, None)
+    _reset_telegram_webhook_state_for_tests()
+    _reset_telegram_link_state_for_tests()
+
+
+def _seed_telegram_bot(
+    client,
+    principal_override,
+    *,
+    scope_type: str,
+    scope_id: int,
+    bot_token: str,
+    webhook_secret: str,
+) -> None:
+    if scope_type == "team":
+        principal = _make_principal(active_team_id=scope_id, team_ids=[scope_id], org_ids=[1])
+    else:
+        principal = _make_principal(active_org_id=scope_id, org_ids=[scope_id], team_ids=[1])
+    principal_override(principal)
+
+    response = client.put(
+        "/api/v1/telegram/admin/bot",
+        json={
+            "bot_token": bot_token,
+            "webhook_secret": webhook_secret,
+            "enabled": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_start_link_creates_pairing_code(client, auth_headers, principal_override):
+    principal = _make_principal(
+        active_team_id=22,
+        active_org_id=11,
+        team_ids=[22, 23],
+        org_ids=[11, 12],
+    )
+    principal_override(principal)
+
+    response = client.post("/api/v1/telegram/admin/link/start", headers=auth_headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope_type"] == "team"
+    assert body["scope_id"] == 22
+    assert len(body["pairing_code"]) >= 6
+
+
+def test_unknown_user_is_denied_for_privileged_action(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 7,
+            "message": {
+                "message_id": 4,
+                "chat": {"id": 1, "type": "private"},
+                "from": {"id": 99, "username": "unknown"},
+                "text": "/persona set analyst",
+            },
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"] == "account_link_required"
+
+
+def test_linked_user_is_allowed_for_privileged_action(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+    _register_telegram_actor_link_for_tests(
+        scope_type="team",
+        scope_id=22,
+        telegram_user_id=99,
+        auth_user_id=202,
+        telegram_username="linked",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 8,
+            "message": {
+                "message_id": 5,
+                "chat": {"id": 1, "type": "private"},
+                "from": {"id": 99, "username": "linked"},
+                "text": "/persona set analyst",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "status": "accepted"}

--- a/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
@@ -147,6 +147,41 @@ def test_unknown_user_is_denied_for_privileged_action(client, principal_override
     assert response.json()["error"] == "account_link_required"
 
 
+@pytest.mark.parametrize(
+    "message_text",
+    [
+        "/persona  set analyst",
+        "/character\tset analyst",
+    ],
+)
+def test_whitespace_variants_are_still_privileged_actions(client, principal_override, message_text):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        headers={"X-Telegram-Bot-Api-Secret-Token": "secret-123"},
+        json={
+            "update_id": 10,
+            "message": {
+                "message_id": 7,
+                "chat": {"id": 1, "type": "private"},
+                "from": {"id": 99, "username": "unknown"},
+                "text": message_text,
+            },
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"] == "account_link_required"
+
+
 def test_replayed_denied_privileged_action_is_deduped(client, principal_override):
     _seed_telegram_bot(
         client,

--- a/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py
@@ -147,6 +147,36 @@ def test_unknown_user_is_denied_for_privileged_action(client, principal_override
     assert response.json()["error"] == "account_link_required"
 
 
+def test_replayed_denied_privileged_action_is_deduped(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    payload = {
+        "update_id": 9,
+        "message": {
+            "message_id": 6,
+            "chat": {"id": 1, "type": "private"},
+            "from": {"id": 99, "username": "unknown"},
+            "text": "/persona set analyst",
+        },
+    }
+    headers = {"X-Telegram-Bot-Api-Secret-Token": "secret-123"}
+
+    first = client.post("/api/v1/telegram/webhook", headers=headers, json=payload)
+    second = client.post("/api/v1/telegram/webhook", headers=headers, json=payload)
+
+    assert first.status_code == 403
+    assert first.json()["error"] == "account_link_required"
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "status": "duplicate"}
+
+
 def test_linked_user_is_allowed_for_privileged_action(client, principal_override):
     _seed_telegram_bot(
         client,

--- a/tldw_Server_API/tests/Telegram/test_telegram_schemas.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_schemas.py
@@ -17,3 +17,8 @@ def test_telegram_bot_config_requires_bot_token_and_webhook_secret():
 
     with pytest.raises(ValidationError):
         TelegramBotConfigUpdate(bot_token="123:abc")
+
+
+def test_telegram_bot_config_rejects_short_webhook_secret():
+    with pytest.raises(ValidationError):
+        TelegramBotConfigUpdate(bot_token="123:abc", webhook_secret="short")

--- a/tldw_Server_API/tests/Telegram/test_telegram_schemas.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_schemas.py
@@ -1,0 +1,19 @@
+import pytest
+from pydantic import ValidationError
+
+from tldw_Server_API.app.api.v1.schemas.telegram_schemas import TelegramBotConfigUpdate
+
+
+def test_telegram_bot_config_defaults_enabled_true():
+    model = TelegramBotConfigUpdate(bot_token="123:abc", webhook_secret="secret-123")
+    assert model.enabled is True
+    assert model.bot_token == "123:abc"
+    assert model.webhook_secret == "secret-123"
+
+
+def test_telegram_bot_config_requires_bot_token_and_webhook_secret():
+    with pytest.raises(ValidationError):
+        TelegramBotConfigUpdate(webhook_secret="secret-123")
+
+    with pytest.raises(ValidationError):
+        TelegramBotConfigUpdate(bot_token="123:abc")

--- a/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import uuid
 
+import pytest
+
 from tldw_Server_API.app.core.Telegram.session_mapper import (
     build_telegram_session_key,
     derive_telegram_assistant_conversation_id,
@@ -11,7 +13,12 @@ from tldw_Server_API.app.core.Telegram.session_mapper import (
 
 
 def test_build_telegram_session_key_for_dm():
-    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="private",
+        telegram_chat_id=999,
+        telegram_user_id=200,
+    )
 
     assert key == "tenant-a:dm:200"
 
@@ -19,6 +26,7 @@ def test_build_telegram_session_key_for_dm():
 def test_build_telegram_session_key_for_group_topic():
     key = build_telegram_session_key(
         tenant_id="tenant-a",
+        chat_type="supergroup",
         telegram_chat_id=100,
         topic_or_thread_id=300,
         telegram_user_id=200,
@@ -27,8 +35,34 @@ def test_build_telegram_session_key_for_group_topic():
     assert key == "tenant-a:group:100:topic:300:user:200"
 
 
+def test_build_telegram_session_key_for_group_root_without_topic():
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="group",
+        telegram_chat_id=100,
+        telegram_user_id=200,
+    )
+
+    assert key == "tenant-a:group:100:topic:root:user:200"
+
+
+def test_build_telegram_session_key_rejects_missing_group_chat_id():
+    with pytest.raises(ValueError):
+        build_telegram_session_key(
+            tenant_id="tenant-a",
+            chat_type="group",
+            telegram_chat_id=None,
+            telegram_user_id=200,
+        )
+
+
 def test_assistant_conversation_id_is_stable_for_same_session_key():
-    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="private",
+        telegram_chat_id=999,
+        telegram_user_id=200,
+    )
 
     first = derive_telegram_assistant_conversation_id(key)
     second = derive_telegram_assistant_conversation_id(key)
@@ -38,7 +72,12 @@ def test_assistant_conversation_id_is_stable_for_same_session_key():
 
 
 def test_persona_session_ids_differ_for_different_persona_ids():
-    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="private",
+        telegram_chat_id=999,
+        telegram_user_id=200,
+    )
 
     first = derive_telegram_persona_session_id(key, persona_id="persona-a")
     second = derive_telegram_persona_session_id(key, persona_id="persona-b")
@@ -51,6 +90,7 @@ def test_persona_session_ids_differ_for_different_persona_ids():
 def test_character_conversation_ids_differ_for_different_character_ids():
     key = build_telegram_session_key(
         tenant_id="tenant-a",
+        chat_type="supergroup",
         telegram_chat_id=100,
         topic_or_thread_id=300,
         telegram_user_id=200,
@@ -65,7 +105,12 @@ def test_character_conversation_ids_differ_for_different_character_ids():
 
 
 def test_conversation_backed_ids_are_uuid_safe():
-    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        chat_type="private",
+        telegram_chat_id=999,
+        telegram_user_id=200,
+    )
 
     assistant_conversation_id = derive_telegram_assistant_conversation_id(key)
     persona_session_id = derive_telegram_persona_session_id(key, persona_id="persona-a")

--- a/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+
+from tldw_Server_API.app.core.Telegram.session_mapper import (
+    build_telegram_session_key,
+    derive_telegram_assistant_conversation_id,
+    derive_telegram_character_conversation_id,
+    derive_telegram_persona_session_id,
+)
+
+
+def test_build_telegram_session_key_for_dm():
+    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+
+    assert key == "tenant-a:dm:200"
+
+
+def test_build_telegram_session_key_for_group_topic():
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        telegram_chat_id=100,
+        topic_or_thread_id=300,
+        telegram_user_id=200,
+    )
+
+    assert key == "tenant-a:group:100:topic:300:user:200"
+
+
+def test_assistant_conversation_id_is_stable_for_same_session_key():
+    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+
+    first = derive_telegram_assistant_conversation_id(key)
+    second = derive_telegram_assistant_conversation_id(key)
+
+    assert first == second
+    assert uuid.UUID(first)
+
+
+def test_persona_session_ids_differ_for_different_persona_ids():
+    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+
+    first = derive_telegram_persona_session_id(key, persona_id="persona-a")
+    second = derive_telegram_persona_session_id(key, persona_id="persona-b")
+
+    assert first != second
+    assert uuid.UUID(first)
+    assert uuid.UUID(second)
+
+
+def test_character_conversation_ids_differ_for_different_character_ids():
+    key = build_telegram_session_key(
+        tenant_id="tenant-a",
+        telegram_chat_id=100,
+        topic_or_thread_id=300,
+        telegram_user_id=200,
+    )
+
+    first = derive_telegram_character_conversation_id(key, character_id="character-a")
+    second = derive_telegram_character_conversation_id(key, character_id="character-b")
+
+    assert first != second
+    assert uuid.UUID(first)
+    assert uuid.UUID(second)
+
+
+def test_conversation_backed_ids_are_uuid_safe():
+    key = build_telegram_session_key(tenant_id="tenant-a", telegram_user_id=200)
+
+    assistant_conversation_id = derive_telegram_assistant_conversation_id(key)
+    persona_session_id = derive_telegram_persona_session_id(key, persona_id="persona-a")
+    character_conversation_id = derive_telegram_character_conversation_id(key, character_id="character-a")
+
+    assert uuid.UUID(assistant_conversation_id)
+    assert uuid.UUID(persona_session_id)
+    assert uuid.UUID(character_conversation_id)

--- a/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+import tldw_Server_API.app.api.v1.endpoints.telegram_support as telegram_support
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     _reset_telegram_webhook_state_for_tests,
     telegram_webhook_impl,
@@ -211,6 +212,58 @@ def test_telegram_webhook_rejects_invalid_secret(client, principal_override):
 
     assert response.status_code == 401
     assert response.json()["error"] == "invalid_secret"
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_rejects_wrong_secret_before_body_parse(monkeypatch):
+    class _FakeRepo:
+        async def list_secrets(self, provider: str):
+            assert provider == "telegram"
+            return [{"scope_type": "team", "scope_id": 77}]
+
+        async def fetch_secret(self, scope_type: str, scope_id: int, provider: str):
+            assert provider == "telegram"
+            assert scope_type == "team"
+            assert scope_id == 77
+            return {"encrypted_blob": "ignored"}
+
+    monkeypatch.setattr(
+        telegram_support,
+        "_decrypt_telegram_payload",
+        lambda _encrypted_blob: {
+            "provider": "telegram",
+            "credential_version": 1,
+            "bot_username": "example_bot",
+            "enabled": True,
+            "bot_token": "123:abc",
+            "webhook_secret": "stored-secret-123",
+        },
+    )
+
+    async def _receive() -> dict[str, object]:
+        raise AssertionError("body should not be read before auth failure")
+
+    async def _get_repo() -> _FakeRepo:
+        return _FakeRepo()
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/telegram/webhook",
+            "query_string": b"",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"x-telegram-bot-api-secret-token", b"wrong-but-long-enough"),
+            ],
+        },
+        _receive,
+    )
+
+    response = await telegram_webhook_impl(request=request, get_org_secret_repo=_get_repo)
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {"ok": False, "error": "invalid_secret"}
 
 
 def test_telegram_webhook_rejects_malformed_payload(client, principal_override):

--- a/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import Request
 
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.API_Deps.jobs_deps import get_job_manager
 import tldw_Server_API.app.api.v1.endpoints.telegram_support as telegram_support
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     _reset_telegram_webhook_state_for_tests,
@@ -209,6 +210,33 @@ def test_telegram_webhook_rejects_invalid_secret(client, principal_override):
         json={"update_id": 5002, "message": {"message_id": 11, "chat": {"id": 333, "type": "private"}}},
         headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
     )
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "invalid_secret"
+
+
+def test_telegram_webhook_rejects_invalid_secret_before_job_manager_resolution(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="org",
+        scope_id=34,
+        bot_token="123:ghi",
+        webhook_secret="secret-790",
+    )
+
+    def _failing_job_manager():
+        raise AssertionError("job manager should not be resolved before secret validation")
+
+    client.app.dependency_overrides[get_job_manager] = _failing_job_manager
+    try:
+        response = client.post(
+            "/api/v1/telegram/webhook",
+            json={"update_id": 5004, "message": {"message_id": 13, "chat": {"id": 334, "type": "private"}}},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
+        )
+    finally:
+        client.app.dependency_overrides.pop(get_job_manager, None)
 
     assert response.status_code == 401
     assert response.json()["error"] == "invalid_secret"

--- a/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import Request
+
+from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
+from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
+    _reset_telegram_webhook_state_for_tests,
+)
+from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
+from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
+
+
+def _b64_key(byte_char: bytes) -> str:
+    return base64.b64encode(byte_char * 32).decode("ascii")
+
+
+def _make_principal(
+    *,
+    active_org_id: int | None = None,
+    active_team_id: int | None = None,
+    org_ids: list[int] | None = None,
+    team_ids: list[int] | None = None,
+) -> AuthPrincipal:
+    return AuthPrincipal(
+        kind="user",
+        user_id=202,
+        api_key_id=None,
+        subject="telegram-webhook-test",
+        token_type="access",
+        jti=None,
+        roles=["admin"],
+        permissions=["system.configure"],
+        is_admin=True,
+        org_ids=org_ids or [],
+        team_ids=team_ids or [],
+        active_org_id=active_org_id,
+        active_team_id=active_team_id,
+    )
+
+
+def _override_principal(client, principal: AuthPrincipal) -> None:
+    async def _fake_get_auth_principal(request: Request) -> AuthPrincipal:
+        request.state.auth = AuthContext(principal=principal, ip=None, user_agent=None, request_id=None)
+        request.state.active_org_id = principal.active_org_id
+        request.state.active_team_id = principal.active_team_id
+        return principal
+
+    client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+
+
+@pytest.fixture()
+def client(client_user_only, monkeypatch):
+    monkeypatch.setenv("BYOK_ENABLED", "1")
+    monkeypatch.setenv("BYOK_ENCRYPTION_KEY", _b64_key(b"t"))
+    monkeypatch.delenv("BYOK_SECONDARY_ENCRYPTION_KEY", raising=False)
+    reset_settings()
+    _reset_telegram_webhook_state_for_tests()
+    return client_user_only
+
+
+@pytest.fixture()
+def principal_override(client):
+    def _install(principal: AuthPrincipal) -> None:
+        _override_principal(client, principal)
+
+    yield _install
+    client.app.dependency_overrides.pop(get_auth_principal, None)
+    _reset_telegram_webhook_state_for_tests()
+
+
+def _seed_telegram_bot(
+    client, principal_override, *, scope_type: str, scope_id: int, bot_token: str, webhook_secret: str
+) -> None:
+    if scope_type == "team":
+        principal = _make_principal(active_team_id=scope_id, team_ids=[scope_id], org_ids=[1])
+    else:
+        principal = _make_principal(active_org_id=scope_id, org_ids=[scope_id], team_ids=[1])
+    principal_override(principal)
+
+    response = client.put(
+        "/api/v1/telegram/admin/bot",
+        json={
+            "bot_token": bot_token,
+            "webhook_secret": webhook_secret,
+            "enabled": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_telegram_webhook_accepts_and_dedupes_replayed_update(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=22,
+        bot_token="123:abc",
+        webhook_secret="secret-123",
+    )
+
+    payload = {
+        "update_id": 5001,
+        "message": {
+            "message_id": 10,
+            "chat": {"id": 222, "type": "private"},
+            "text": "hello",
+        },
+    }
+    headers = {"X-Telegram-Bot-Api-Secret-Token": "secret-123"}
+
+    first = client.post("/api/v1/telegram/webhook", json=payload, headers=headers)
+    second = client.post("/api/v1/telegram/webhook", json=payload, headers=headers)
+
+    assert first.status_code == 200
+    assert first.json() == {"ok": True, "status": "accepted"}
+    assert second.status_code == 200
+    assert second.json() == {"ok": True, "status": "duplicate"}
+
+
+def test_telegram_webhook_rejects_invalid_secret(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="org",
+        scope_id=33,
+        bot_token="123:def",
+        webhook_secret="secret-456",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        json={"update_id": 5002, "message": {"message_id": 11, "chat": {"id": 333, "type": "private"}}},
+        headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "invalid_secret"
+
+
+def test_telegram_webhook_rejects_malformed_payload(client, principal_override):
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=44,
+        bot_token="123:ghi",
+        webhook_secret="secret-789",
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        data="not-json",
+        headers={
+            "content-type": "application/json",
+            "X-Telegram-Bot-Api-Secret-Token": "secret-789",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_json"

--- a/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
+++ b/tldw_Server_API/tests/Telegram/test_telegram_webhook.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import json
 
 import pytest
 from fastapi import Request
@@ -8,6 +9,7 @@ from fastapi import Request
 from tldw_Server_API.app.api.v1.API_Deps.auth_deps import get_auth_principal
 from tldw_Server_API.app.api.v1.endpoints.telegram_support import (
     _reset_telegram_webhook_state_for_tests,
+    telegram_webhook_impl,
 )
 from tldw_Server_API.app.core.AuthNZ.principal_model import AuthContext, AuthPrincipal
 from tldw_Server_API.app.core.AuthNZ.settings import reset_settings
@@ -49,6 +51,24 @@ def _override_principal(client, principal: AuthPrincipal) -> None:
         return principal
 
     client.app.dependency_overrides[get_auth_principal] = _fake_get_auth_principal
+
+
+def _build_request(body: bytes, *, secret: str | None) -> Request:
+    headers: list[tuple[bytes, bytes]] = [(b"content-type", b"application/json")]
+    if secret is not None:
+        headers.append((b"x-telegram-bot-api-secret-token", secret.encode("utf-8")))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/telegram/webhook",
+        "query_string": b"",
+        "headers": headers,
+    }
+
+    async def _receive() -> dict[str, object]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, _receive)
 
 
 @pytest.fixture()
@@ -118,6 +138,59 @@ def test_telegram_webhook_accepts_and_dedupes_replayed_update(client, principal_
     assert first.json() == {"ok": True, "status": "accepted"}
     assert second.status_code == 200
     assert second.json() == {"ok": True, "status": "duplicate"}
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_rejects_short_secret_before_body_parse():
+    async def _failing_repo():
+        raise AssertionError("repo lookup should not happen before secret validation")
+
+    request = _build_request(b"not-json", secret="short")
+    response = await telegram_webhook_impl(request=request, get_org_secret_repo=_failing_repo)
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {"ok": False, "error": "invalid_secret"}
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_rejects_missing_secret_before_body_parse():
+    async def _failing_repo():
+        raise AssertionError("repo lookup should not happen before secret validation")
+
+    request = _build_request(b"not-json", secret=None)
+    response = await telegram_webhook_impl(request=request, get_org_secret_repo=_failing_repo)
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {"ok": False, "error": "invalid_secret"}
+
+
+def test_telegram_webhook_rejects_ambiguous_secret_collision(client, principal_override):
+    shared_secret = "shared-secret"
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="team",
+        scope_id=55,
+        bot_token="123:jkl",
+        webhook_secret=shared_secret,
+    )
+    _seed_telegram_bot(
+        client,
+        principal_override,
+        scope_type="org",
+        scope_id=66,
+        bot_token="123:mno",
+        webhook_secret=shared_secret,
+    )
+
+    response = client.post(
+        "/api/v1/telegram/webhook",
+        json={"update_id": 5003, "message": {"message_id": 12, "chat": {"id": 444, "type": "private"}}},
+        headers={"X-Telegram-Bot-Api-Secret-Token": shared_secret},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"] == "invalid_secret"
 
 
 def test_telegram_webhook_rejects_invalid_secret(client, principal_override):


### PR DESCRIPTION
## Summary
- add tenant-scoped Telegram bot admin and webhook support, including command routing, actor linking, session mapping, jobs handoff, and reply delivery correlation
- add exact-scope Telegram approval callbacks with persisted pending approvals so approvals survive worker restarts and preserve scope fidelity
- add Telegram execution identities and child downscoping so Telegram-triggered jobs and agents stay under MCP/AuthNZ-controlled least-privilege execution

## Test Plan
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m pytest /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_admin_api.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_webhook.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_linking_and_policy.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_commands.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_session_mapper.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_jobs_and_delivery.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/Telegram/test_telegram_approvals.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/AuthNZ/unit/test_telegram_execution_identity_service.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/tests/AuthNZ/unit/test_telegram_downscoped_child_agents.py -q`
- [x] `source /Users/macbook-dev/Documents/GitHub/tldw_server2/.venv/bin/activate && python -m bandit -r /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/app/api/v1/endpoints/telegram.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/app/api/v1/endpoints/telegram_support.py /Users/macbook-dev/Documents/GitHub/tldw_server2/.worktrees/telegram-bot-authnz/tldw_Server_API/app/services/telegram_execution_identity_service.py -f json -o /tmp/bandit_telegram_execution_identity.json`
