### PR TITLE
fix: isolate workspace installation repo tests

### DIFF
--- a/tldw_Server_API/tests/Integrations/test_workspace_provider_installations_repo.py
+++ b/tldw_Server_API/tests/Integrations/test_workspace_provider_installations_repo.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-pytest_plugins = ("tldw_Server_API.tests.AuthNZ.conftest",)
-
 
 async def _make_workspace_provider_installations_repo(tmp_path, monkeypatch):
     from tldw_Server_API.app.core.AuthNZ.database import reset_db_pool


### PR DESCRIPTION
## Summary
- remove the unnecessary AuthNZ pytest plugin import from the workspace installation repo test module
- stop that plugin from contaminating unrelated Telegram async tests with order-dependent event-loop failures
- keep the integrations and scheduled-tasks control-plane backend verification slice green

## Test Plan
- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Integrations/test_workspace_provider_installations_repo.py tldw_Server_API/tests/Telegram/test_telegram_admin_link_inventory.py -v
- source .venv/bin/activate && python -m pytest tldw_Server_API/tests/Integrations tldw_Server_API/tests/Telegram/test_telegram_admin_link_inventory.py tldw_Server_API/tests/Notifications/test_scheduled_tasks_control_plane.py -v
- bunx vitest run src/routes/__tests__/integrations-route.test.tsx src/routes/__tests__/scheduled-tasks-route.test.tsx src/components/Layouts/__tests__/HeaderShortcuts.test.tsx src/services/__tests__/ui-settings.header-shortcuts.test.ts --maxWorkers=1
- source .venv/bin/activate && python -m bandit -r tldw_Server_API/tests/Integrations/test_workspace_provider_installations_repo.py -f json -o /tmp/bandit_workspace_provider_installations_repo_test.json